### PR TITLE
Fix lexing of the end of pp directives

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
@@ -684,7 +684,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     // don't consume EOL characters here
                     break;
                 }
-                else if (ch is SlidingTextWindow.InvalidCharacter && !textWindow.IsReallyAtEnd())
+                else if (ch is SlidingTextWindow.InvalidCharacter && textWindow.IsReallyAtEnd())
                 {
                     // don't consume EOF characters here
                     break;

--- a/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
@@ -671,40 +671,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
 
         private SyntaxToken ParseEndOfDirectiveWithOptionalPreprocessingMessage()
-        {
-            PooledStringBuilder builder = null;
-
-            // Skip the rest of the line until we hit a newline or EOF.  This follows the PP_Message portion of the specification.
-            var textWindow = this.lexer.TextWindow;
-            while (true)
-            {
-                var ch = this.lexer.TextWindow.PeekChar();
-                if (ch is '\r' or '\n' || SyntaxFacts.IsNewLine(ch))
-                {
-                    // don't consume EOL characters here
-                    break;
-                }
-                else if (ch is SlidingTextWindow.InvalidCharacter && textWindow.IsReallyAtEnd())
-                {
-                    // don't consume EOF characters here
-                    break;
-                }
-
-                builder ??= PooledStringBuilder.GetInstance();
-                builder.Builder.Append(ch);
-                textWindow.AdvanceChar();
-            }
-
-            var endOfDirective = SyntaxFactory.Token(SyntaxKind.EndOfDirectiveToken);
-
-            if (builder != null)
-            {
-                endOfDirective = endOfDirective.TokenWithLeadingTrivia(
-                    SyntaxFactory.PreprocessingMessage(builder.ToStringAndFree()));
-            }
-
-            return endOfDirective;
-        }
+            => this.lexer.LexEndOfDirectiveWithOptionalPreprocessingMessage();
 
         private SyntaxToken ParseEndOfDirective(bool ignoreErrors, bool afterPragma = false, bool afterLineNumber = false)
         {

--- a/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/DirectiveParser.cs
@@ -681,12 +681,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 var ch = this.lexer.TextWindow.PeekChar();
                 if (ch is '\r' or '\n' || SyntaxFacts.IsNewLine(ch))
                 {
-                    // don't consume end-of-line characters here
+                    // don't consume EOL characters here
                     break;
                 }
                 else if (ch is SlidingTextWindow.InvalidCharacter && !textWindow.IsReallyAtEnd())
                 {
-                    // don't consume end-of-line characters here
+                    // don't consume EOF characters here
                     break;
                 }
 

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -2854,7 +2854,7 @@ top:
             while (true)
             {
                 var ch = this.TextWindow.PeekChar();
-                if (ch is '\r' or '\n' || SyntaxFacts.IsNewLine(ch))
+                if (SyntaxFacts.IsNewLine(ch))
                 {
                     // don't consume EOL characters here
                     break;

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -11,6 +11,7 @@ using System.Text;
 using Microsoft.CodeAnalysis.Syntax.InternalSyntax;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 {
@@ -2843,6 +2844,41 @@ top:
             var errors = this.GetErrors(leadingTriviaWidth: 0);
             var trailing = this.LexDirectiveTrailingTrivia(info.Kind == SyntaxKind.EndOfDirectiveToken);
             return Create(in info, null, trailing, errors);
+        }
+
+        public SyntaxToken LexEndOfDirectiveWithOptionalPreprocessingMessage()
+        {
+            PooledStringBuilder? builder = null;
+
+            // Skip the rest of the line until we hit a EOL or EOF.  This follows the PP_Message portion of the specification.
+            while (true)
+            {
+                var ch = this.TextWindow.PeekChar();
+                if (ch is '\r' or '\n' || SyntaxFacts.IsNewLine(ch))
+                {
+                    // don't consume EOL characters here
+                    break;
+                }
+                else if (ch is SlidingTextWindow.InvalidCharacter && this.TextWindow.IsReallyAtEnd())
+                {
+                    // don't consume EOF characters here
+                    break;
+                }
+
+                builder ??= PooledStringBuilder.GetInstance();
+                builder.Builder.Append(ch);
+                this.TextWindow.AdvanceChar();
+            }
+
+            var leading = builder == null
+                ? null
+                : SyntaxFactory.PreprocessingMessage(builder.ToStringAndFree());
+
+            // now try to consume the EOL if there.
+            var trailing = this.LexDirectiveTrailingTrivia(includeEndOfLine: true)?.ToListNode();
+            var endOfDirective = SyntaxFactory.Token(leading, SyntaxKind.EndOfDirectiveToken, trailing);
+
+            return endOfDirective;
         }
 
         private bool ScanDirectiveToken(ref TokenInfo info)

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -2102,7 +2102,7 @@ return (i);
                 new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
 
             var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
-            Assert.Equal($"#region A//B{Environment.NewLine}", regionDirective.ToFullString());
+            Assert.Equal($"#region A//B", regionDirective.ToFullString());
             var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
             Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
             Assert.Equal("A//B", regionText.ToFullString());
@@ -2124,7 +2124,7 @@ return (i);
                 new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
 
             var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
-            Assert.Equal($"#region A/\\B{Environment.NewLine}", regionDirective.ToFullString());
+            Assert.Equal($"#region A/\\B", regionDirective.ToFullString());
             var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
             Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
             Assert.Equal("A/\\B", regionText.ToFullString());
@@ -2195,6 +2195,90 @@ class Test
             var node = Parse(text);
             TestRoundTripping(node, text);
             VerifyDirectives(node, SyntaxKind.RegionDirectiveTrivia, SyntaxKind.EndRegionDirectiveTrivia);
+        }
+
+        [Fact]
+        [Trait("Feature", "Directives")]
+        public void TestRegionWithMessage1()
+        {
+            var text =
+@"#region ""
+#endregion
+";
+            var node = Parse(text);
+            TestRoundTripping(node, text);
+            VerifyDirectivesSpecial(node,
+                new DirectiveInfo { Kind = SyntaxKind.RegionDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
+
+            var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
+            Assert.Equal($"#region \"", regionDirective.ToFullString());
+            var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
+            Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
+            Assert.Equal("\"", regionText.ToFullString());
+        }
+
+        [Fact]
+        [Trait("Feature", "Directives")]
+        public void TestRegionWithMessage2()
+        {
+            var text =
+@"#region ""goo""
+#endregion
+";
+            var node = Parse(text);
+            TestRoundTripping(node, text);
+            VerifyDirectivesSpecial(node,
+                new DirectiveInfo { Kind = SyntaxKind.RegionDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
+
+            var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
+            Assert.Equal($"#region \"goo\"", regionDirective.ToFullString());
+            var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
+            Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
+            Assert.Equal("\"goo\"", regionText.ToFullString());
+        }
+
+        [Fact]
+        [Trait("Feature", "Directives")]
+        public void TestRegionWithMessage3()
+        {
+            var text =
+@"#region """"
+#endregion
+";
+            var node = Parse(text);
+            TestRoundTripping(node, text);
+            VerifyDirectivesSpecial(node,
+                new DirectiveInfo { Kind = SyntaxKind.RegionDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
+
+            var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
+            Assert.Equal($"#region \"\"", regionDirective.ToFullString());
+            var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
+            Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
+            Assert.Equal("\"\"", regionText.ToFullString());
+        }
+
+        [Fact]
+        [Trait("Feature", "Directives")]
+        public void TestRegionWithMessage4()
+        {
+            var text =
+@"#region """"""
+#endregion
+";
+            var node = Parse(text);
+            TestRoundTripping(node, text);
+            VerifyDirectivesSpecial(node,
+                new DirectiveInfo { Kind = SyntaxKind.RegionDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
+
+            var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
+            Assert.Equal($"#region \"\"\"", regionDirective.ToFullString());
+            var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
+            Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
+            Assert.Equal("\"\"\"", regionText.ToFullString());
         }
 
         #endregion
@@ -3105,6 +3189,51 @@ class A { }
                 Diagnostic(ErrorCode.ERR_ErrorDirective, "version:A.B").WithArguments("version:A.B").WithLocation(1, 8)
                 );
         }
+
+        [Fact]
+        [Trait("Feature", "Directives")]
+        public void TestErrorWithStringMessage1()
+        {
+            var text = @"#error """;
+            var node = Parse(text);
+            TestRoundTripping(node, text, false);
+            VerifyErrorSpecial(node, new DirectiveInfo { Number = (int)ErrorCode.ERR_ErrorDirective, Text = "#error: '\"'" });
+            VerifyDirectivesSpecial(node, new DirectiveInfo { Kind = SyntaxKind.ErrorDirectiveTrivia, Status = NodeStatus.IsActive });
+        }
+
+        [Fact]
+        [Trait("Feature", "Directives")]
+        public void TestErrorWithStringMessage2()
+        {
+            var text = @"#error ""goo""";
+            var node = Parse(text);
+            TestRoundTripping(node, text, false);
+            VerifyErrorSpecial(node, new DirectiveInfo { Number = (int)ErrorCode.ERR_ErrorDirective, Text = "#error: '\"goo\"'" });
+            VerifyDirectivesSpecial(node, new DirectiveInfo { Kind = SyntaxKind.ErrorDirectiveTrivia, Status = NodeStatus.IsActive });
+        }
+
+        [Fact]
+        [Trait("Feature", "Directives")]
+        public void TestErrorWithStringMessage3()
+        {
+            var text = @"#error """"";
+            var node = Parse(text);
+            TestRoundTripping(node, text, false);
+            VerifyErrorSpecial(node, new DirectiveInfo { Number = (int)ErrorCode.ERR_ErrorDirective, Text = "#error: '\"\"'" });
+            VerifyDirectivesSpecial(node, new DirectiveInfo { Kind = SyntaxKind.ErrorDirectiveTrivia, Status = NodeStatus.IsActive });
+        }
+
+        [Fact]
+        [Trait("Feature", "Directives")]
+        public void TestErrorWithStringMessage4()
+        {
+            var text = @"#error """"""";
+            var node = Parse(text);
+            TestRoundTripping(node, text, false);
+            VerifyErrorSpecial(node, new DirectiveInfo { Number = (int)ErrorCode.ERR_ErrorDirective, Text = "#error: '\"\"\"'" });
+            VerifyDirectivesSpecial(node, new DirectiveInfo { Kind = SyntaxKind.ErrorDirectiveTrivia, Status = NodeStatus.IsActive });
+        }
+
         #endregion
 
         #region #line

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -2220,6 +2220,27 @@ class Test
 
         [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
         [Trait("Feature", "Directives")]
+        public void TestRegionWithMessage1B()
+        {
+            var text =
+@"#region "" 
+#endregion
+";
+            var node = Parse(text);
+            TestRoundTripping(node, text);
+            VerifyDirectivesSpecial(node,
+                new DirectiveInfo { Kind = SyntaxKind.RegionDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
+
+            var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
+            Assert.Equal($"#region \" {Environment.NewLine}", regionDirective.ToFullString());
+            var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
+            Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
+            Assert.Equal("\" ", regionText.ToFullString());
+        }
+
+        [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
+        [Trait("Feature", "Directives")]
         public void TestRegionWithMessage2()
         {
             var text =
@@ -2237,6 +2258,27 @@ class Test
             var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
             Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
             Assert.Equal("\"goo\"", regionText.ToFullString());
+        }
+
+        [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
+        [Trait("Feature", "Directives")]
+        public void TestRegionWithMessage2B()
+        {
+            var text =
+@"#region ""goo"" 
+#endregion
+";
+            var node = Parse(text);
+            TestRoundTripping(node, text);
+            VerifyDirectivesSpecial(node,
+                new DirectiveInfo { Kind = SyntaxKind.RegionDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
+
+            var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
+            Assert.Equal($"#region \"goo\" {Environment.NewLine}", regionDirective.ToFullString());
+            var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
+            Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
+            Assert.Equal("\"goo\" ", regionText.ToFullString());
         }
 
         [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
@@ -2262,6 +2304,27 @@ class Test
 
         [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
         [Trait("Feature", "Directives")]
+        public void TestRegionWithMessage3B()
+        {
+            var text =
+@"#region """" 
+#endregion
+";
+            var node = Parse(text);
+            TestRoundTripping(node, text);
+            VerifyDirectivesSpecial(node,
+                new DirectiveInfo { Kind = SyntaxKind.RegionDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
+
+            var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
+            Assert.Equal($"#region \"\" {Environment.NewLine}", regionDirective.ToFullString());
+            var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
+            Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
+            Assert.Equal("\"\" ", regionText.ToFullString());
+        }
+
+        [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
+        [Trait("Feature", "Directives")]
         public void TestRegionWithMessage4()
         {
             var text =
@@ -2279,6 +2342,27 @@ class Test
             var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
             Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
             Assert.Equal("\"\"\"", regionText.ToFullString());
+        }
+
+        [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
+        [Trait("Feature", "Directives")]
+        public void TestRegionWithMessage4B()
+        {
+            var text =
+@"#region """""" 
+#endregion
+";
+            var node = Parse(text);
+            TestRoundTripping(node, text);
+            VerifyDirectivesSpecial(node,
+                new DirectiveInfo { Kind = SyntaxKind.RegionDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
+
+            var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
+            Assert.Equal($"#region \"\"\" {Environment.NewLine}", regionDirective.ToFullString());
+            var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
+            Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
+            Assert.Equal("\"\"\" ", regionText.ToFullString());
         }
 
         [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -2281,6 +2281,24 @@ class Test
             Assert.Equal("\"\"\"", regionText.ToFullString());
         }
 
+        [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
+        [Trait("Feature", "Directives")]
+        public void TestRegionWithMessage5()
+        {
+            var text =
+@"#region Region Process Information after the Grid """"""""""""""""""""""""""""""""""""""""""""""""""
+class C
+{
+}
+#endregion
+";
+            var node = Parse(text);
+            TestRoundTripping(node, text, disallowErrors: true);
+
+            // ensure that we don't see those quotes as the start of a raw string that consumes the class decl.
+            var classDeclaration = node.ChildNodes().Single(n => n is ClassDeclarationSyntax);
+        }
+
         #endregion
 
         #region #define/#undefine

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -2102,7 +2102,7 @@ return (i);
                 new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
 
             var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
-            Assert.Equal($"#region A//B", regionDirective.ToFullString());
+            Assert.Equal($"#region A//B{Environment.NewLine}", regionDirective.ToFullString());
             var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
             Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
             Assert.Equal("A//B", regionText.ToFullString());
@@ -2124,7 +2124,7 @@ return (i);
                 new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
 
             var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
-            Assert.Equal($"#region A/\\B", regionDirective.ToFullString());
+            Assert.Equal($"#region A/\\B{Environment.NewLine}", regionDirective.ToFullString());
             var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
             Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
             Assert.Equal("A/\\B", regionText.ToFullString());
@@ -2212,7 +2212,7 @@ class Test
                 new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
 
             var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
-            Assert.Equal($"#region \"", regionDirective.ToFullString());
+            Assert.Equal($"#region \"{Environment.NewLine}", regionDirective.ToFullString());
             var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
             Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
             Assert.Equal("\"", regionText.ToFullString());
@@ -2233,7 +2233,7 @@ class Test
                 new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
 
             var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
-            Assert.Equal($"#region \"goo\"", regionDirective.ToFullString());
+            Assert.Equal($"#region \"goo\"{Environment.NewLine}", regionDirective.ToFullString());
             var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
             Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
             Assert.Equal("\"goo\"", regionText.ToFullString());
@@ -2254,7 +2254,7 @@ class Test
                 new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
 
             var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
-            Assert.Equal($"#region \"\"", regionDirective.ToFullString());
+            Assert.Equal($"#region \"\"{Environment.NewLine}", regionDirective.ToFullString());
             var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
             Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
             Assert.Equal("\"\"", regionText.ToFullString());
@@ -2275,7 +2275,7 @@ class Test
                 new DirectiveInfo { Kind = SyntaxKind.EndRegionDirectiveTrivia, Status = NodeStatus.IsActive });
 
             var regionDirective = (RegionDirectiveTriviaSyntax)node.GetFirstDirective();
-            Assert.Equal($"#region \"\"\"", regionDirective.ToFullString());
+            Assert.Equal($"#region \"\"\"{Environment.NewLine}", regionDirective.ToFullString());
             var regionText = regionDirective.EndOfDirectiveToken.LeadingTrivia.Single();
             Assert.Equal(SyntaxKind.PreprocessingMessageTrivia, regionText.Kind());
             Assert.Equal("\"\"\"", regionText.ToFullString());

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/PreprocessorTests.cs
@@ -2197,7 +2197,7 @@ class Test
             VerifyDirectives(node, SyntaxKind.RegionDirectiveTrivia, SyntaxKind.EndRegionDirectiveTrivia);
         }
 
-        [Fact]
+        [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
         [Trait("Feature", "Directives")]
         public void TestRegionWithMessage1()
         {
@@ -2218,7 +2218,7 @@ class Test
             Assert.Equal("\"", regionText.ToFullString());
         }
 
-        [Fact]
+        [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
         [Trait("Feature", "Directives")]
         public void TestRegionWithMessage2()
         {
@@ -2239,7 +2239,7 @@ class Test
             Assert.Equal("\"goo\"", regionText.ToFullString());
         }
 
-        [Fact]
+        [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
         [Trait("Feature", "Directives")]
         public void TestRegionWithMessage3()
         {
@@ -2260,7 +2260,7 @@ class Test
             Assert.Equal("\"\"", regionText.ToFullString());
         }
 
-        [Fact]
+        [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
         [Trait("Feature", "Directives")]
         public void TestRegionWithMessage4()
         {
@@ -3190,7 +3190,7 @@ class A { }
                 );
         }
 
-        [Fact]
+        [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
         [Trait("Feature", "Directives")]
         public void TestErrorWithStringMessage1()
         {
@@ -3201,7 +3201,7 @@ class A { }
             VerifyDirectivesSpecial(node, new DirectiveInfo { Kind = SyntaxKind.ErrorDirectiveTrivia, Status = NodeStatus.IsActive });
         }
 
-        [Fact]
+        [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
         [Trait("Feature", "Directives")]
         public void TestErrorWithStringMessage2()
         {
@@ -3212,7 +3212,7 @@ class A { }
             VerifyDirectivesSpecial(node, new DirectiveInfo { Kind = SyntaxKind.ErrorDirectiveTrivia, Status = NodeStatus.IsActive });
         }
 
-        [Fact]
+        [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
         [Trait("Feature", "Directives")]
         public void TestErrorWithStringMessage3()
         {
@@ -3223,7 +3223,7 @@ class A { }
             VerifyDirectivesSpecial(node, new DirectiveInfo { Kind = SyntaxKind.ErrorDirectiveTrivia, Status = NodeStatus.IsActive });
         }
 
-        [Fact]
+        [Fact, WorkItem(1549726, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726")]
         [Trait("Feature", "Directives")]
         public void TestErrorWithStringMessage4()
         {


### PR DESCRIPTION
Fixes for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549726

[Lexical specification](https://github.com/dotnet/csharpstandard/blob/draft-v6/standard/lexical-structure.md#656-diagnostic-directives) says that these directives end with PP_Message, which is defined simply as:

```
fragment PP_Start_Region
    : 'region' PP_Message?
    ;

fragment PP_End_Region
    : 'endregion' PP_Message?
    ;

fragment PP_Diagnostic
    : 'error' PP_Message?
    | 'warning' PP_Message?
    ;

fragment PP_Message
    : PP_Whitespace Input_Character*
    ;
```

So there should be no lexing of tokens/trivia in this section (unlike #if directives, etc.).