### PR TITLE
Use inline rename session options for all checkboxes directly

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
@@ -28,12 +28,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _session = session;
             _session.ReplacementTextChanged += OnReplacementTextChanged;
 
-            _previewChangesFlag = _session.PreviewChanges;
-            _renameFileFlag = _session.Options.RenameFile;
-            _renameInStringsFlag = _session.Options.RenameInStrings;
-            _renameInCommentsFlag = _session.Options.RenameInComments;
-            _renameOverloadsFlag = _session.Options.RenameOverloads;
-
             RegisterOleComponent();
         }
 
@@ -60,73 +54,53 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _ => EditorFeaturesResources.Rename_symbols_file
         };
 
-        private bool _renameInCommentsFlag;
         public bool RenameInCommentsFlag
         {
-            get => _renameInCommentsFlag;
+            get => _session.Options.RenameInComments;
             set
             {
-                if (Set(ref _renameInCommentsFlag, value))
-                {
-                    _session.RenameService.GlobalOptions.SetGlobalOption(new OptionKey(InlineRenameSessionOptionsStorage.RenameInComments), value);
-                    _session.RefreshRenameSessionWithOptionsChanged(_session.Options with { RenameInComments = value });
-                }
+                _session.RenameService.GlobalOptions.SetGlobalOption(new OptionKey(InlineRenameSessionOptionsStorage.RenameInComments), value);
+                _session.RefreshRenameSessionWithOptionsChanged(_session.Options with { RenameInComments = value });
             }
         }
 
-        private bool _renameInStringsFlag;
         public bool RenameInStringsFlag
         {
-            get => _renameInStringsFlag;
+            get => _session.Options.RenameInStrings;
             set
             {
-                if (Set(ref _renameInStringsFlag, value))
-                {
-                    _session.RenameService.GlobalOptions.SetGlobalOption(new OptionKey(InlineRenameSessionOptionsStorage.RenameInStrings), value);
-                    _session.RefreshRenameSessionWithOptionsChanged(_session.Options with { RenameInStrings = value });
-                }
+                _session.RenameService.GlobalOptions.SetGlobalOption(new OptionKey(InlineRenameSessionOptionsStorage.RenameInStrings), value);
+                _session.RefreshRenameSessionWithOptionsChanged(_session.Options with { RenameInStrings = value });
             }
         }
 
-        private bool _renameFileFlag;
         public bool RenameFileFlag
         {
-            get => _renameFileFlag;
+            get => _session.Options.RenameFile;
             set
             {
-                if (Set(ref _renameFileFlag, value))
-                {
-                    _session.RenameService.GlobalOptions.SetGlobalOption(new OptionKey(InlineRenameSessionOptionsStorage.RenameFile), value);
-                    _session.RefreshRenameSessionWithOptionsChanged(_session.Options with { RenameFile = value });
-                }
+                _session.RenameService.GlobalOptions.SetGlobalOption(new OptionKey(InlineRenameSessionOptionsStorage.RenameFile), value);
+                _session.RefreshRenameSessionWithOptionsChanged(_session.Options with { RenameFile = value });
             }
         }
 
-        private bool _previewChangesFlag;
         public bool PreviewChangesFlag
         {
-            get => _previewChangesFlag;
+            get => _session.PreviewChanges;
             set
             {
-                if (Set(ref _previewChangesFlag, value))
-                {
-                    _session.RenameService.GlobalOptions.SetGlobalOption(new OptionKey(InlineRenameSessionOptionsStorage.PreviewChanges), value);
-                    _session.SetPreviewChanges(value);
-                }
+                _session.RenameService.GlobalOptions.SetGlobalOption(new OptionKey(InlineRenameSessionOptionsStorage.PreviewChanges), value);
+                _session.SetPreviewChanges(value);
             }
         }
 
-        private bool _renameOverloadsFlag;
         public bool RenameOverloadsFlag
         {
-            get => _renameOverloadsFlag;
+            get => _session.Options.RenameOverloads;
             set
             {
-                if (Set(ref _renameOverloadsFlag, value))
-                {
-                    _session.RenameService.GlobalOptions.SetGlobalOption(new OptionKey(InlineRenameSessionOptionsStorage.RenameOverloads), value);
-                    _session.RefreshRenameSessionWithOptionsChanged(_session.Options with { RenameOverloads = value });
-                }
+                _session.RenameService.GlobalOptions.SetGlobalOption(new OptionKey(InlineRenameSessionOptionsStorage.RenameOverloads), value);
+                _session.RefreshRenameSessionWithOptionsChanged(_session.Options with { RenameOverloads = value });
             }
         }
 


### PR DESCRIPTION
Fixes #60294 

The flyout view model isn't recreated, so if the session options change in some way (such as being reset) it won't get updated between showing/hiding. This fixes so there's no intermediate variables and binds directly to the session options. 