### PR TITLE
Show rename flyout only on active view

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
@@ -71,6 +71,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 var useInlineAdornment = _globalOptionService.GetOption(InlineRenameExperimentationOptions.UseInlineAdornment);
                 if (useInlineAdornment)
                 {
+                    if (!_textView.HasAggregateFocus)
+                    {
+                        // For the rename flyout, the adornment is dismissed on focus lost. There's
+                        // no need to keep an adornment on every textview for show/hide behaviors
+                        return;
+                    }
+
                     var adornment = new RenameFlyout(
                         (RenameFlyoutViewModel)s_createdViewModels.GetValue(_renameService.ActiveSession, session => new RenameFlyoutViewModel(session)),
                         _textView);


### PR DESCRIPTION
Fixes #61357 and #60805

The flyout would appear on multiple textviews and then try to automatically focus, causing it to dismiss. The behavior for creating an adornment on multiple views is specifically for the dashboard to show/hide, since focus doesn't dismiss the session. 