### PR TITLE
IOperation: expose information about the type parameter that is going to be used as the ".constrained" type for invoking abstract static methods

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -917,6 +917,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
+        /// Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="MethodSymbol" />, if any.
+        /// Null if <see cref="MethodSymbol" /> is resolved statically, or is null.
+        /// </summary>
+        public ITypeSymbol? ConstrainedToType
+        {
+            get
+            {
+                return this.ConstrainedToTypeOpt.GetPublicSymbol();
+            }
+        }
+
+        /// <summary>
         /// Gives an indication of how successful the conversion was.
         /// Viable - found a best built-in or user-defined conversion.
         /// Empty - found no applicable built-in or user-defined conversions.
@@ -1044,8 +1056,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public CommonConversion ToCommonConversion()
         {
             // The MethodSymbol of CommonConversion only refers to UserDefined conversions, not method groups
-            var methodSymbol = IsUserDefined ? MethodSymbol : null;
-            return new CommonConversion(Exists, IsIdentity, IsNumeric, IsReference, IsImplicit, IsNullable, methodSymbol);
+            var (methodSymbol, constrainedToType) = IsUserDefined ? (MethodSymbol, ConstrainedToType) : (null, null);
+            return new CommonConversion(Exists, IsIdentity, IsNumeric, IsReference, IsImplicit, IsNullable, methodSymbol, constrainedToType);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -448,10 +448,22 @@ namespace Microsoft.CodeAnalysis.Operations
                 return new InvalidOperation(children, _semanticModel, syntax, type, constantValue, isImplicit);
             }
 
-            bool isVirtual = IsCallVirtual(targetMethod, boundCall.ReceiverOpt);
+            TypeParameterSymbol? constrainedToType = GetConstrainedToType(targetMethod, boundCall.ReceiverOpt);
+            bool isVirtual = constrainedToType is not null || IsCallVirtual(targetMethod, boundCall.ReceiverOpt);
             IOperation? receiver = CreateReceiverOperation(boundCall.ReceiverOpt, targetMethod);
             ImmutableArray<IArgumentOperation> arguments = DeriveArguments(boundCall);
-            return new InvocationOperation(targetMethod.GetPublicSymbol(), receiver, isVirtual, arguments, _semanticModel, syntax, type, isImplicit);
+            return new InvocationOperation(targetMethod.GetPublicSymbol(), constrainedToType.GetPublicSymbol(), receiver, isVirtual, arguments, _semanticModel, syntax, type, isImplicit);
+        }
+
+        private static TypeParameterSymbol? GetConstrainedToType(Symbol targetMember, BoundExpression? receiverOpt)
+        {
+            if (targetMember.IsStatic && (targetMember.IsAbstract || targetMember.IsVirtual) &&
+                receiverOpt is BoundTypeExpression { Type: TypeParameterSymbol typeParameter })
+            {
+                return typeParameter;
+            }
+
+            return null;
         }
 
         private IOperation CreateBoundFunctionPointerInvocationOperation(BoundFunctionPointerInvocation boundFunctionPointerInvocation)
@@ -581,7 +593,8 @@ namespace Microsoft.CodeAnalysis.Operations
             SyntaxNode syntax = boundPropertyAccess.Syntax;
             ITypeSymbol? type = boundPropertyAccess.GetPublicTypeSymbol();
             bool isImplicit = boundPropertyAccess.WasCompilerGenerated;
-            return new PropertyReferenceOperation(property, arguments, instance, _semanticModel, syntax, type, isImplicit);
+            TypeParameterSymbol? constrainedToType = GetConstrainedToType(boundPropertyAccess.PropertySymbol, boundPropertyAccess.ReceiverOpt);
+            return new PropertyReferenceOperation(property, constrainedToType.GetPublicSymbol(), arguments, instance, _semanticModel, syntax, type, isImplicit);
         }
 
         private IOperation CreateBoundIndexerAccessOperation(BoundIndexerAccess boundIndexerAccess)
@@ -599,7 +612,8 @@ namespace Microsoft.CodeAnalysis.Operations
 
             ImmutableArray<IArgumentOperation> arguments = DeriveArguments(boundIndexerAccess, isObjectOrCollectionInitializer: false);
             IOperation? instance = CreateReceiverOperation(boundIndexerAccess.ReceiverOpt, boundIndexerAccess.ExpressionSymbol);
-            return new PropertyReferenceOperation(property.GetPublicSymbol(), arguments, instance, _semanticModel, syntax, type, isImplicit);
+            TypeParameterSymbol? constrainedToType = GetConstrainedToType(property, boundIndexerAccess.ReceiverOpt);
+            return new PropertyReferenceOperation(property.GetPublicSymbol(), constrainedToType.GetPublicSymbol(), arguments, instance, _semanticModel, syntax, type, isImplicit);
         }
 
         private IEventReferenceOperation CreateBoundEventAccessOperation(BoundEventAccess boundEventAccess)
@@ -609,7 +623,8 @@ namespace Microsoft.CodeAnalysis.Operations
             SyntaxNode syntax = boundEventAccess.Syntax;
             ITypeSymbol? type = boundEventAccess.GetPublicTypeSymbol();
             bool isImplicit = boundEventAccess.WasCompilerGenerated;
-            return new EventReferenceOperation(@event, instance, _semanticModel, syntax, type, isImplicit);
+            TypeParameterSymbol? constrainedToType = GetConstrainedToType(boundEventAccess.EventSymbol, boundEventAccess.ReceiverOpt);
+            return new EventReferenceOperation(@event, constrainedToType.GetPublicSymbol(), instance, _semanticModel, syntax, type, isImplicit);
         }
 
         private IEventAssignmentOperation CreateBoundEventAssignmentOperatorOperation(BoundEventAssignmentOperator boundEventAssignmentOperator)
@@ -830,7 +845,7 @@ namespace Microsoft.CodeAnalysis.Operations
                     return new FieldReferenceOperation(field.GetPublicSymbol(), isDeclaration, createReceiver(), _semanticModel, syntax, type, constantValue: null, isImplicit);
                 case SymbolKind.Event:
                     var eventSymbol = (EventSymbol)memberSymbol;
-                    return new EventReferenceOperation(eventSymbol.GetPublicSymbol(), createReceiver(), _semanticModel, syntax, type, isImplicit);
+                    return new EventReferenceOperation(eventSymbol.GetPublicSymbol(), constrainedToType: null, createReceiver(), _semanticModel, syntax, type, isImplicit);
                 case SymbolKind.Property:
                     var property = (PropertySymbol)memberSymbol;
 
@@ -853,7 +868,7 @@ namespace Microsoft.CodeAnalysis.Operations
                         arguments = ImmutableArray<IArgumentOperation>.Empty;
                     }
 
-                    return new PropertyReferenceOperation(property.GetPublicSymbol(), arguments, createReceiver(), _semanticModel, syntax, type, isImplicit);
+                    return new PropertyReferenceOperation(property.GetPublicSymbol(), constrainedToType: null, arguments, createReceiver(), _semanticModel, syntax, type, isImplicit);
                 default:
                     throw ExceptionUtilities.UnexpectedValue(memberSymbol.Kind);
             }
@@ -893,7 +908,7 @@ namespace Microsoft.CodeAnalysis.Operations
             }
 
             bool isVirtual = IsCallVirtual(addMethod, boundCollectionElementInitializer.ImplicitReceiverOpt);
-            return new InvocationOperation(addMethod.GetPublicSymbol(), receiver, isVirtual, arguments, _semanticModel, syntax, type, isImplicit);
+            return new InvocationOperation(addMethod.GetPublicSymbol(), constrainedToType: null, receiver, isVirtual, arguments, _semanticModel, syntax, type, isImplicit);
         }
 
         private IDynamicMemberReferenceOperation CreateBoundDynamicMemberAccessOperation(BoundDynamicMemberAccess boundDynamicMemberAccess)
@@ -1107,12 +1122,13 @@ namespace Microsoft.CodeAnalysis.Operations
 
         private IMethodReferenceOperation CreateBoundMethodGroupSingleMethodOperation(BoundMethodGroup boundMethodGroup, MethodSymbol methodSymbol, bool suppressVirtualCalls)
         {
-            bool isVirtual = (methodSymbol.IsAbstract || methodSymbol.IsOverride || methodSymbol.IsVirtual) && !suppressVirtualCalls;
+            TypeParameterSymbol? constrainedToType = GetConstrainedToType(methodSymbol, boundMethodGroup.ReceiverOpt);
+            bool isVirtual = constrainedToType is not null || ((methodSymbol.IsAbstract || methodSymbol.IsOverride || methodSymbol.IsVirtual) && !suppressVirtualCalls);
             IOperation? instance = CreateReceiverOperation(boundMethodGroup.ReceiverOpt, methodSymbol);
             SyntaxNode bindingSyntax = boundMethodGroup.Syntax;
             ITypeSymbol? bindingType = null;
             bool isImplicit = boundMethodGroup.WasCompilerGenerated;
-            return new MethodReferenceOperation(methodSymbol.GetPublicSymbol(), isVirtual, instance, _semanticModel, bindingSyntax, bindingType, boundMethodGroup.WasCompilerGenerated);
+            return new MethodReferenceOperation(methodSymbol.GetPublicSymbol(), constrainedToType.GetPublicSymbol(), isVirtual, instance, _semanticModel, bindingSyntax, bindingType, isImplicit);
         }
 
         private IIsTypeOperation CreateBoundIsOperatorOperation(BoundIsOperator boundIsOperator)
@@ -1252,7 +1268,20 @@ namespace Microsoft.CodeAnalysis.Operations
             SyntaxNode syntax = boundCompoundAssignmentOperator.Syntax;
             ITypeSymbol? type = boundCompoundAssignmentOperator.GetPublicTypeSymbol();
             bool isImplicit = boundCompoundAssignmentOperator.WasCompilerGenerated;
-            return new CompoundAssignmentOperation(inConversion, outConversion, operatorKind, isLifted, isChecked, operatorMethod, target, value, _semanticModel, syntax, type, isImplicit);
+            return new CompoundAssignmentOperation(inConversion, outConversion, operatorKind, isLifted, isChecked, operatorMethod,
+                                                   GetConstrainedToTypeForOperator(method, boundCompoundAssignmentOperator.Operator.ConstrainedToTypeOpt).GetPublicSymbol(),
+                                                   target, value, _semanticModel, syntax, type, isImplicit);
+        }
+
+        private static TypeParameterSymbol? GetConstrainedToTypeForOperator(MethodSymbol? operatorMethod, TypeSymbol? constrainedToTypeOpt)
+        {
+            if (operatorMethod is not null && operatorMethod.IsStatic && (operatorMethod.IsAbstract || operatorMethod.IsVirtual) &&
+                constrainedToTypeOpt is TypeParameterSymbol typeParameter)
+            {
+                return typeParameter;
+            }
+
+            return null;
         }
 
         private IIncrementOrDecrementOperation CreateBoundIncrementOperatorOperation(BoundIncrementOperator boundIncrementOperator)
@@ -1266,7 +1295,9 @@ namespace Microsoft.CodeAnalysis.Operations
             SyntaxNode syntax = boundIncrementOperator.Syntax;
             ITypeSymbol? type = boundIncrementOperator.GetPublicTypeSymbol();
             bool isImplicit = boundIncrementOperator.WasCompilerGenerated;
-            return new IncrementOrDecrementOperation(isPostfix, isLifted, isChecked, target, operatorMethod, operationKind, _semanticModel, syntax, type, isImplicit);
+            return new IncrementOrDecrementOperation(isPostfix, isLifted, isChecked, target, operatorMethod,
+                                                     GetConstrainedToTypeForOperator(boundIncrementOperator.MethodOpt, boundIncrementOperator.ConstrainedToTypeOpt).GetPublicSymbol(),
+                                                     operationKind, _semanticModel, syntax, type, isImplicit);
         }
 
         private IInvalidOperation CreateBoundBadExpressionOperation(BoundBadExpression boundBadExpression)
@@ -1310,7 +1341,9 @@ namespace Microsoft.CodeAnalysis.Operations
             bool isLifted = boundUnaryOperator.OperatorKind.IsLifted();
             bool isChecked = boundUnaryOperator.OperatorKind.IsChecked() || (boundUnaryOperator.MethodOpt is not null && SyntaxFacts.IsCheckedOperator(boundUnaryOperator.MethodOpt.Name));
             bool isImplicit = boundUnaryOperator.WasCompilerGenerated;
-            return new UnaryOperation(unaryOperatorKind, operand, isLifted, isChecked, operatorMethod, _semanticModel, syntax, type, constantValue, isImplicit);
+            return new UnaryOperation(unaryOperatorKind, operand, isLifted, isChecked, operatorMethod,
+                                      GetConstrainedToTypeForOperator(boundUnaryOperator.MethodOpt, boundUnaryOperator.ConstrainedToTypeOpt).GetPublicSymbol(),
+                                      _semanticModel, syntax, type, constantValue, isImplicit);
         }
         private IOperation CreateBoundBinaryOperatorBase(BoundBinaryOperatorBase boundBinaryOperatorBase)
         {
@@ -1363,7 +1396,12 @@ namespace Microsoft.CodeAnalysis.Operations
                 bool isChecked = boundBinaryOperator.OperatorKind.IsChecked();
                 bool isCompareText = false;
                 bool isImplicit = boundBinaryOperator.WasCompilerGenerated;
-                return new BinaryOperation(operatorKind, left, right, isLifted, isChecked, isCompareText, operatorMethod, unaryOperatorMethod,
+                TypeSymbol? constrainedToTypeOpt = GetConstrainedToTypeForOperator(boundBinaryOperator.LogicalOperator, boundBinaryOperator.ConstrainedToTypeOpt) ??
+                                                   GetConstrainedToTypeForOperator(boundBinaryOperator.OperatorKind.Operator() == CSharp.BinaryOperatorKind.And ?
+                                                                                       boundBinaryOperator.FalseOperator :
+                                                                                       boundBinaryOperator.TrueOperator,
+                                                                                   boundBinaryOperator.ConstrainedToTypeOpt);
+                return new BinaryOperation(operatorKind, left, right, isLifted, isChecked, isCompareText, operatorMethod, constrainedToTypeOpt.GetPublicSymbol(), unaryOperatorMethod,
                                            _semanticModel, syntax, type, constantValue, isImplicit);
             }
         }
@@ -1390,7 +1428,10 @@ namespace Microsoft.CodeAnalysis.Operations
             bool isChecked = boundBinaryOperator.OperatorKind.IsChecked() || (boundBinaryOperator.Method is not null && SyntaxFacts.IsCheckedOperator(boundBinaryOperator.Method.Name));
             bool isCompareText = false;
             bool isImplicit = boundBinaryOperator.WasCompilerGenerated;
-            return new BinaryOperation(operatorKind, left, right, isLifted, isChecked, isCompareText, operatorMethod, unaryOperatorMethod,
+            return new BinaryOperation(operatorKind, left, right, isLifted, isChecked, isCompareText,
+                                       operatorMethod,
+                                       GetConstrainedToTypeForOperator(boundBinaryOperator.Method, boundBinaryOperator.ConstrainedToType).GetPublicSymbol(),
+                                       unaryOperatorMethod,
                                        _semanticModel, syntax, type, constantValue, isImplicit);
         }
 
@@ -2600,6 +2641,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 isLifted: boundIndex.Type.IsNullableType(),
                 isChecked: false,
                 operatorMethod: null,
+                constrainedToType: null,
                 _semanticModel,
                 boundIndex.Syntax,
                 boundIndex.GetPublicTypeSymbol(),
@@ -2686,7 +2728,7 @@ namespace Microsoft.CodeAnalysis.Operations
                         }
                     case PropertySymbol property:
                         {
-                            reference = new PropertyReferenceOperation(property.GetPublicSymbol(), ImmutableArray<IArgumentOperation>.Empty,
+                            reference = new PropertyReferenceOperation(property.GetPublicSymbol(), constrainedToType: null, ImmutableArray<IArgumentOperation>.Empty,
                                 createReceiver(), _semanticModel, nameSyntax, type: property.Type.GetPublicSymbol(), isImplicit: false);
                             break;
                         }

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory_Methods.cs
@@ -133,8 +133,9 @@ namespace Microsoft.CodeAnalysis.Operations
             IOperation? instance = CreateReceiverOperation(boundEventAssignmentOperator.ReceiverOpt, boundEventAssignmentOperator.Event);
             SyntaxNode eventAccessSyntax = ((AssignmentExpressionSyntax)syntax).Left;
             bool isImplicit = boundEventAssignmentOperator.WasCompilerGenerated;
+            TypeParameterSymbol? constrainedToType = GetConstrainedToType(boundEventAssignmentOperator.Event, boundEventAssignmentOperator.ReceiverOpt);
 
-            return new EventReferenceOperation(@event, instance, _semanticModel, eventAccessSyntax, @event.Type, isImplicit);
+            return new EventReferenceOperation(@event, constrainedToType.GetPublicSymbol(), instance, _semanticModel, eventAccessSyntax, @event.Type, isImplicit);
         }
 
         internal IOperation CreateDelegateTargetOperation(BoundNode delegateNode)
@@ -359,6 +360,7 @@ namespace Microsoft.CodeAnalysis.Operations
                     // No matching declaration, synthesize a property reference to be assigned.
                     target = new PropertyReferenceOperation(
                         property.GetPublicSymbol(),
+                        constrainedToType: null,
                         arguments: ImmutableArray<IArgumentOperation>.Empty,
                         instance,
                         semanticModel: _semanticModel,
@@ -370,6 +372,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 else
                 {
                     target = new PropertyReferenceOperation(anonymousProperty.Property.GetPublicSymbol(),
+                                                            constrainedToType: null,
                                                             ImmutableArray<IArgumentOperation>.Empty,
                                                             instance,
                                                             _semanticModel,

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+Microsoft.CodeAnalysis.CSharp.Conversion.ConstrainedToType.get -> Microsoft.CodeAnalysis.ITypeSymbol?
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.InterpolatedMultiLineRawStringStartToken = 9073 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.InterpolatedRawStringEndToken = 9074 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.InterpolatedSingleLineRawStringStartToken = 9072 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
@@ -8442,11 +8442,8 @@ class Test
 
             Assert.Equal("T.M01()", node.ToString());
             VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" qualifier is important for this invocation, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
-IInvocationOperation (virtual void I1.M01()) (OperationKind.Invocation, Type: System.Void) (Syntax: 'T.M01()')
+IInvocationOperation (virtual void I1.M01() ConstrainedToType: T) (OperationKind.Invocation, Type: System.Void) (Syntax: 'T.M01()')
   Instance Receiver: 
     null
   Arguments(0)
@@ -9040,11 +9037,8 @@ class Test
                     case ("", "++"):
                     case ("", "--"):
                         VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" constraint is important for this operator, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
-IIncrementOrDecrementOperation (" + (prefixOp != "" ? "Prefix" : "Postfix") + (isCheckedOperator && isCheckedContext ? ", Checked" : "") + @") (OperatorMethod: T I1<T>." + metadataName + @"(T x)) (OperationKind." + opKind + @", Type: T) (Syntax: '" + prefixOp + "x" + postfixOp + @"')
+IIncrementOrDecrementOperation (" + (prefixOp != "" ? "Prefix" : "Postfix") + (isCheckedOperator && isCheckedContext ? ", Checked" : "") + @") (OperatorMethod: T I1<T>." + metadataName + @"(T x) ConstrainedToType: T) (OperationKind." + opKind + @", Type: T) (Syntax: '" + prefixOp + "x" + postfixOp + @"')
   Target: 
     IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: T) (Syntax: 'x')
 ");
@@ -9052,11 +9046,8 @@ IIncrementOrDecrementOperation (" + (prefixOp != "" ? "Prefix" : "Postfix") + (i
 
                     default:
                         VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" constraint is important for this operator, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
-IUnaryOperation (UnaryOperatorKind." + opKind + (isCheckedOperator && isCheckedContext ? ", Checked" : "") + @") (OperatorMethod: T I1<T>." + metadataName + @"(T x)) (OperationKind.Unary, Type: T) (Syntax: '" + prefixOp + "x" + postfixOp + @"')
+IUnaryOperation (UnaryOperatorKind." + opKind + (isCheckedOperator && isCheckedContext ? ", Checked" : "") + @") (OperatorMethod: T I1<T>." + metadataName + @"(T x) ConstrainedToType: T) (OperationKind.Unary, Type: T) (Syntax: '" + prefixOp + "x" + postfixOp + @"')
   Operand: 
     IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: T) (Syntax: 'x')
 ");
@@ -9354,13 +9345,10 @@ class Test
 
             Assert.Equal("x ? true : false", node.ToString());
             VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" constraint is important for this operator, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
 IConditionalOperation (OperationKind.Conditional, Type: System.Boolean) (Syntax: 'x ? true : false')
   Condition: 
-    IUnaryOperation (UnaryOperatorKind.True) (OperatorMethod: System.Boolean I1<T>.op_True(T x)) (OperationKind.Unary, Type: System.Boolean, IsImplicit) (Syntax: 'x')
+    IUnaryOperation (UnaryOperatorKind.True) (OperatorMethod: System.Boolean I1<T>.op_True(T x) ConstrainedToType: T) (OperationKind.Unary, Type: System.Boolean, IsImplicit) (Syntax: 'x')
       Operand: 
         IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: T) (Syntax: 'x')
   WhenTrue: 
@@ -10754,11 +10742,8 @@ partial class Test
 
             Assert.Equal("x " + op + " 1", node.ToString());
             VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" constraint is important for this operator, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
-IBinaryOperation (BinaryOperatorKind." + BinaryOperatorKind(op) + (isCheckedOperator && isCheckedContext ? ", Checked" : "") + @") (OperatorMethod: T I1<T>." + metadataName + @"(T x, System.Int32 a)) (OperationKind.Binary, Type: T) (Syntax: 'x " + op + @" 1')
+IBinaryOperation (BinaryOperatorKind." + BinaryOperatorKind(op) + (isCheckedOperator && isCheckedContext ? ", Checked" : "") + @") (OperatorMethod: T I1<T>." + metadataName + @"(T x, System.Int32 a) ConstrainedToType: T) (OperationKind.Binary, Type: T) (Syntax: 'x " + op + @" 1')
   Left: 
     IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: T) (Syntax: 'x')
   Right: 
@@ -10950,11 +10935,8 @@ public partial interface I1<T0>
 
             Assert.Equal("x " + op + " 1", node.ToString());
             VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" constraint is important for this operator, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
-IBinaryOperation (BinaryOperatorKind." + BinaryOperatorKind(op) + @") (OperatorMethod: System.Boolean I1<T>." + metadataName + @"(T x, System.Int32 a)) (OperationKind.Binary, Type: System.Boolean) (Syntax: 'x " + op + @" 1')
+IBinaryOperation (BinaryOperatorKind." + BinaryOperatorKind(op) + @") (OperatorMethod: System.Boolean I1<T>." + metadataName + @"(T x, System.Int32 a) ConstrainedToType: T) (OperationKind.Binary, Type: System.Boolean) (Syntax: 'x " + op + @" 1')
   Left: 
     IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: T) (Syntax: 'x')
   Right: 
@@ -11143,11 +11125,8 @@ public partial interface I1<T0>
 
             Assert.Equal("x " + op + " y", node.ToString());
             VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" constraint is important for this operator, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
-IBinaryOperation (BinaryOperatorKind." + BinaryOperatorKind(op) + @", IsLifted) (OperatorMethod: System.Boolean I1<T>." + metadataName + @"(T x, T a)) (OperationKind.Binary, Type: System.Boolean) (Syntax: 'x " + op + @" y')
+IBinaryOperation (BinaryOperatorKind." + BinaryOperatorKind(op) + @", IsLifted) (OperatorMethod: System.Boolean I1<T>." + metadataName + @"(T x, T a) ConstrainedToType: T) (OperationKind.Binary, Type: System.Boolean) (Syntax: 'x " + op + @" y')
   Left: 
     IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: T?) (Syntax: 'x')
   Right: 
@@ -11341,11 +11320,8 @@ class Test
                 Assert.Equal("x " + op + op + " y", node1.ToString());
 
                 VerifyOperationTreeForNode(compilation1, model, node1,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" constraint is important for this operator, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
-IBinaryOperation (BinaryOperatorKind." + opKind + @") (OperatorMethod: T I1<T>." + binaryMetadataName + @"(T a, T x)) (OperationKind.Binary, Type: T) (Syntax: 'x " + op + op + @" y')
+IBinaryOperation (BinaryOperatorKind." + opKind + @") (OperatorMethod: T I1<T>." + binaryMetadataName + @"(T a, T x) ConstrainedToType: T) (OperationKind.Binary, Type: T) (Syntax: 'x " + op + op + @" y')
   Left: 
     IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: T) (Syntax: 'x')
   Right: 
@@ -11598,11 +11574,8 @@ class Test
                 Assert.Equal("x " + op + op + " y", node1.ToString());
 
                 VerifyOperationTreeForNode(compilation1, model, node1,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" constraint is important for this operator, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
-IBinaryOperation (BinaryOperatorKind." + opKind + @") (OperatorMethod: I1 I1." + binaryMetadataName + @"(I1 a, I1 x)) (OperationKind.Binary, Type: I1) (Syntax: 'x " + op + op + @" y')
+IBinaryOperation (BinaryOperatorKind." + opKind + @") (OperatorMethod: I1 I1." + binaryMetadataName + @"(I1 a, I1 x) ConstrainedToType: T) (OperationKind.Binary, Type: I1) (Syntax: 'x " + op + op + @" y')
   Left: 
     IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: I1, IsImplicit) (Syntax: 'x')
       Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
@@ -11977,11 +11950,8 @@ class Test
 
             Assert.Equal("x " + op + "= 1", node.ToString());
             VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" constraint is important for this operator, but it is not 
-//                                               reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                               to expose this information? 
 @"
-ICompoundAssignmentOperation (BinaryOperatorKind." + BinaryOperatorKind(op) + (isCheckedOperator && isCheckedContext ? ", Checked" : "") + @") (OperatorMethod: T I1<T>." + metadataName + @"(T x, System.Int32 a)) (OperationKind.CompoundAssignment, Type: T) (Syntax: 'x " + op + @"= 1')
+ICompoundAssignmentOperation (BinaryOperatorKind." + BinaryOperatorKind(op) + (isCheckedOperator && isCheckedContext ? ", Checked" : "") + @") (OperatorMethod: T I1<T>." + metadataName + @"(T x, System.Int32 a) ConstrainedToType: T) (OperationKind.CompoundAssignment, Type: T) (Syntax: 'x " + op + @"= 1')
   InConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
   OutConversion: CommonConversion (Exists: True, IsIdentity: True, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
   Left: 
@@ -13213,11 +13183,8 @@ class Test
 
             Assert.Equal("T.P01", node.ToString());
             VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" qualifier is important for this invocation, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
-IPropertyReferenceOperation: System.Int32 I1.P01 { get; set; } (Static) (OperationKind.PropertyReference, Type: System.Int32) (Syntax: 'T.P01')
+IPropertyReferenceOperation: System.Int32 I1.P01 { get; set; } (ConstrainedToType: T) (Static) (OperationKind.PropertyReference, Type: System.Int32) (Syntax: 'T.P01')
   Instance Receiver: 
     null
 ");
@@ -13302,11 +13269,8 @@ class Test
 
             Assert.Equal("T.P01", node.ToString());
             VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" qualifier is important for this invocation, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
-IPropertyReferenceOperation: System.Int32 I1.P01 { get; set; } (Static) (OperationKind.PropertyReference, Type: System.Int32) (Syntax: 'T.P01')
+IPropertyReferenceOperation: System.Int32 I1.P01 { get; set; } (ConstrainedToType: T) (Static) (OperationKind.PropertyReference, Type: System.Int32) (Syntax: 'T.P01')
   Instance Receiver: 
     null
 ");
@@ -13427,11 +13391,8 @@ class Test
 
             Assert.Equal("T.P01", node.ToString());
             VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" qualifier is important for this invocation, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
-IPropertyReferenceOperation: System.Int32 I1.P01 { get; set; } (Static) (OperationKind.PropertyReference, Type: System.Int32) (Syntax: 'T.P01')
+IPropertyReferenceOperation: System.Int32 I1.P01 { get; set; } (ConstrainedToType: T) (Static) (OperationKind.PropertyReference, Type: System.Int32) (Syntax: 'T.P01')
   Instance Receiver: 
     null
 ");
@@ -14143,11 +14104,17 @@ class Test
 
             Assert.Equal("T.E01", node.ToString());
             VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" qualifier is important for this invocation, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
-IEventReferenceOperation: event System.Action I1.E01 (Static) (OperationKind.EventReference, Type: System.Action) (Syntax: 'T.E01')
+IEventReferenceOperation: event System.Action I1.E01 (ConstrainedToType: T) (Static) (OperationKind.EventReference, Type: System.Action) (Syntax: 'T.E01')
+  Instance Receiver: 
+    null
+");
+            node = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().First().ArgumentList.Arguments[0].Expression;
+
+            Assert.Equal("T.E01", node.ToString());
+            VerifyOperationTreeForNode(compilation1, model, node,
+@"
+IEventReferenceOperation: event System.Action I1.E01 (ConstrainedToType: T) (Static) (OperationKind.EventReference, Type: System.Action) (Syntax: 'T.E01')
   Instance Receiver: 
     null
 ");
@@ -14762,11 +14729,8 @@ class Test
 
             Assert.Equal("T.M01", node.ToString());
             VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" qualifier is important for this invocation, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
-IMethodReferenceOperation: void I1.M01() (IsVirtual) (Static) (OperationKind.MethodReference, Type: null) (Syntax: 'T.M01')
+IMethodReferenceOperation: void I1.M01() (ConstrainedToType: T) (IsVirtual) (Static) (OperationKind.MethodReference, Type: null) (Syntax: 'T.M01')
   Instance Receiver: 
     null
 ");
@@ -15178,11 +15142,8 @@ class Test
 
             Assert.Equal("T.M01", node.ToString());
             VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" qualifier is important for this invocation, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
-IMethodReferenceOperation: void I1.M01() (IsVirtual) (Static) (OperationKind.MethodReference, Type: null) (Syntax: 'T.M01')
+IMethodReferenceOperation: void I1.M01() (ConstrainedToType: T) (IsVirtual) (Static) (OperationKind.MethodReference, Type: null) (Syntax: 'T.M01')
   Instance Receiver: 
     null
 ");
@@ -15449,11 +15410,8 @@ unsafe class Test
 
             Assert.Equal("T.M01", node.ToString());
             VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" qualifier is important for this invocation, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
-IMethodReferenceOperation: void I1.M01() (IsVirtual) (Static) (OperationKind.MethodReference, Type: null) (Syntax: 'T.M01')
+IMethodReferenceOperation: void I1.M01() (ConstrainedToType: T) (IsVirtual) (Static) (OperationKind.MethodReference, Type: null) (Syntax: 'T.M01')
   Instance Receiver: 
     null
 ");
@@ -30351,13 +30309,10 @@ class Test
             Assert.Equal("return " + (needCast ? "(int)" : "") + @"x;", node.ToString());
 
             VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" constraint is important for this operator, but it is not 
-//                                                reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                                to expose this information? 
 @"
 IReturnOperation (OperationKind.Return, Type: null) (Syntax: 'return " + (needCast ? "(int)" : "") + @"x;')
   ReturnedValue: 
-    IConversionOperation (TryCast: False, " + (isCheckedOperator && isCheckedContext ? "Checked" : "Unchecked") + @") (OperatorMethod: System.Int32 I1<T>." + metadataName + @"(T x)) (OperationKind.Conversion, Type: System.Int32" + (needCast ? "" : ", IsImplicit") + @") (Syntax: '" + (needCast ? "(int)" : "") + @"x')
+    IConversionOperation (TryCast: False, " + (isCheckedOperator && isCheckedContext ? "Checked" : "Unchecked") + @") (OperatorMethod: System.Int32 I1<T>." + metadataName + @"(T x) ConstrainedToType: T) (OperationKind.Conversion, Type: System.Int32" + (needCast ? "" : ", IsImplicit") + @") (Syntax: '" + (needCast ? "(int)" : "") + @"x')
       Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: True) (MethodSymbol: System.Int32 I1<T>." + metadataName + @"(T x))
       Operand: 
         IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: T) (Syntax: 'x')
@@ -31012,13 +30967,10 @@ class Test
             Assert.Equal("return " + (needCast ? "(T)" : "") + @"x;", node.ToString());
 
             VerifyOperationTreeForNode(compilation1, model, node,
-// https://github.com/dotnet/roslyn/issues/53803: It feels like the "T" constraint is important for this operator, but it is not 
-//                                               reflected in the IOperation tree. Should we change the shape of the tree in order
-//                                               to expose this information? 
 @"
 IReturnOperation (OperationKind.Return, Type: null) (Syntax: 'return " + (needCast ? "(T)" : "") + @"x;')
   ReturnedValue: 
-    IConversionOperation (TryCast: False, Unchecked) (OperatorMethod: T I1<T>." + metadataName + @"(System.Int32 x)) (OperationKind.Conversion, Type: T" + (needCast ? "" : ", IsImplicit") + @") (Syntax: '" + (needCast ? "(T)" : "") + @"x')
+    IConversionOperation (TryCast: False, Unchecked) (OperatorMethod: T I1<T>." + metadataName + @"(System.Int32 x) ConstrainedToType: T) (OperationKind.Conversion, Type: T" + (needCast ? "" : ", IsImplicit") + @") (Syntax: '" + (needCast ? "(T)" : "") + @"x')
       Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: True) (MethodSymbol: T I1<T>." + metadataName + @"(System.Int32 x))
       Operand: 
         IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: System.Int32) (Syntax: 'x')

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -4942,6 +4942,7 @@ namespace Microsoft.CodeAnalysis.Operations
             Instance = SetParentOperation(instance, this);
         }
         public IOperation? Instance { get; }
+        public abstract ITypeSymbol? ConstrainedToType { get; }
     }
     internal sealed partial class FieldReferenceOperation : BaseMemberReferenceOperation, IFieldReferenceOperation
     {
@@ -5009,7 +5010,7 @@ namespace Microsoft.CodeAnalysis.Operations
             Type = type;
         }
         public IMethodSymbol Method { get; }
-        public ITypeSymbol? ConstrainedToType { get; }
+        public override ITypeSymbol? ConstrainedToType { get; }
         public bool IsVirtual { get; }
         internal override int ChildOperationsCount =>
             (Instance is null ? 0 : 1);
@@ -5065,7 +5066,7 @@ namespace Microsoft.CodeAnalysis.Operations
             Type = type;
         }
         public IPropertySymbol Property { get; }
-        public ITypeSymbol? ConstrainedToType { get; }
+        public override ITypeSymbol? ConstrainedToType { get; }
         public ImmutableArray<IArgumentOperation> Arguments { get; }
         internal override int ChildOperationsCount =>
             Arguments.Length +
@@ -5133,7 +5134,7 @@ namespace Microsoft.CodeAnalysis.Operations
             Type = type;
         }
         public IEventSymbol Event { get; }
-        public ITypeSymbol? ConstrainedToType { get; }
+        public override ITypeSymbol? ConstrainedToType { get; }
         internal override int ChildOperationsCount =>
             (Instance is null ? 0 : 1);
         internal override IOperation GetCurrent(int slot, int index)

--- a/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
+++ b/src/Compilers/Core/Portable/Generated/Operations.Generated.cs
@@ -666,6 +666,11 @@ namespace Microsoft.CodeAnalysis.Operations
         /// </summary>
         IMethodSymbol? OperatorMethod { get; }
         /// <summary>
+        /// Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="OperatorMethod" />, if any.
+        /// Null if <see cref="OperatorMethod" /> is resolved statically, or is null.
+        /// </summary>
+        ITypeSymbol? ConstrainedToType { get; }
+        /// <summary>
         /// Gets the underlying common conversion information.
         /// </summary>
         /// <remarks>
@@ -713,6 +718,11 @@ namespace Microsoft.CodeAnalysis.Operations
         /// Method to be invoked.
         /// </summary>
         IMethodSymbol TargetMethod { get; }
+        /// <summary>
+        /// Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="TargetMethod" />.
+        /// Null if <see cref="TargetMethod" /> is resolved statically, or is an instance method.
+        /// </summary>
+        ITypeSymbol? ConstrainedToType { get; }
         /// <summary>
         /// 'This' or 'Me' instance to be supplied to the method, or null if the method is static.
         /// </summary>
@@ -830,6 +840,11 @@ namespace Microsoft.CodeAnalysis.Operations
         /// Referenced member.
         /// </summary>
         ISymbol Member { get; }
+        /// <summary>
+        /// Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="Member" />.
+        /// Null if <see cref="Member" /> is resolved statically, or is an instance member.
+        /// </summary>
+        ITypeSymbol? ConstrainedToType { get; }
     }
     /// <summary>
     /// Represents a reference to a field.
@@ -985,6 +1000,11 @@ namespace Microsoft.CodeAnalysis.Operations
         /// Operator method used by the operation, null if the operation does not use an operator method.
         /// </summary>
         IMethodSymbol? OperatorMethod { get; }
+        /// <summary>
+        /// Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="OperatorMethod" />, if any.
+        /// Null if <see cref="OperatorMethod" /> is resolved statically, or is null.
+        /// </summary>
+        ITypeSymbol? ConstrainedToType { get; }
     }
     /// <summary>
     /// Represents an operation with two operands and a binary operator that produces a result with a non-null type.
@@ -1036,6 +1056,12 @@ namespace Microsoft.CodeAnalysis.Operations
         /// Operator method used by the operation, null if the operation does not use an operator method.
         /// </summary>
         IMethodSymbol? OperatorMethod { get; }
+        /// <summary>
+        /// Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="OperatorMethod" />
+        /// or corresponding true/false operator, if any.
+        /// Null if operators are resolved statically, or are not used.
+        /// </summary>
+        ITypeSymbol? ConstrainedToType { get; }
     }
     /// <summary>
     /// Represents a conditional operation with:
@@ -1393,6 +1419,11 @@ namespace Microsoft.CodeAnalysis.Operations
         /// Operator method used by the operation, null if the operation does not use an operator method.
         /// </summary>
         IMethodSymbol? OperatorMethod { get; }
+        /// <summary>
+        /// Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="OperatorMethod" />, if any.
+        /// Null if <see cref="OperatorMethod" /> is resolved statically, or is null.
+        /// </summary>
+        ITypeSymbol? ConstrainedToType { get; }
     }
     /// <summary>
     /// Represents a parenthesized operation.
@@ -1999,6 +2030,11 @@ namespace Microsoft.CodeAnalysis.Operations
         /// Operator method used by the operation, null if the operation does not use an operator method.
         /// </summary>
         IMethodSymbol? OperatorMethod { get; }
+        /// <summary>
+        /// Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="OperatorMethod" />, if any.
+        /// Null if <see cref="OperatorMethod" /> is resolved statically, or is null.
+        /// </summary>
+        ITypeSymbol? ConstrainedToType { get; }
     }
     /// <summary>
     /// Represents an operation to throw an exception.
@@ -4719,16 +4755,18 @@ namespace Microsoft.CodeAnalysis.Operations
     }
     internal sealed partial class InvocationOperation : Operation, IInvocationOperation
     {
-        internal InvocationOperation(IMethodSymbol targetMethod, IOperation? instance, bool isVirtual, ImmutableArray<IArgumentOperation> arguments, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
+        internal InvocationOperation(IMethodSymbol targetMethod, ITypeSymbol? constrainedToType, IOperation? instance, bool isVirtual, ImmutableArray<IArgumentOperation> arguments, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
             : base(semanticModel, syntax, isImplicit)
         {
             TargetMethod = targetMethod;
+            ConstrainedToType = constrainedToType;
             Instance = SetParentOperation(instance, this);
             IsVirtual = isVirtual;
             Arguments = SetParentOperation(arguments, this);
             Type = type;
         }
         public IMethodSymbol TargetMethod { get; }
+        public ITypeSymbol? ConstrainedToType { get; }
         public IOperation? Instance { get; }
         public bool IsVirtual { get; }
         public ImmutableArray<IArgumentOperation> Arguments { get; }
@@ -4962,14 +5000,16 @@ namespace Microsoft.CodeAnalysis.Operations
     }
     internal sealed partial class MethodReferenceOperation : BaseMemberReferenceOperation, IMethodReferenceOperation
     {
-        internal MethodReferenceOperation(IMethodSymbol method, bool isVirtual, IOperation? instance, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
+        internal MethodReferenceOperation(IMethodSymbol method, ITypeSymbol? constrainedToType, bool isVirtual, IOperation? instance, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
             : base(instance, semanticModel, syntax, isImplicit)
         {
             Method = method;
+            ConstrainedToType = constrainedToType;
             IsVirtual = isVirtual;
             Type = type;
         }
         public IMethodSymbol Method { get; }
+        public ITypeSymbol? ConstrainedToType { get; }
         public bool IsVirtual { get; }
         internal override int ChildOperationsCount =>
             (Instance is null ? 0 : 1);
@@ -5016,14 +5056,16 @@ namespace Microsoft.CodeAnalysis.Operations
     }
     internal sealed partial class PropertyReferenceOperation : BaseMemberReferenceOperation, IPropertyReferenceOperation
     {
-        internal PropertyReferenceOperation(IPropertySymbol property, ImmutableArray<IArgumentOperation> arguments, IOperation? instance, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
+        internal PropertyReferenceOperation(IPropertySymbol property, ITypeSymbol? constrainedToType, ImmutableArray<IArgumentOperation> arguments, IOperation? instance, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
             : base(instance, semanticModel, syntax, isImplicit)
         {
             Property = property;
+            ConstrainedToType = constrainedToType;
             Arguments = SetParentOperation(arguments, this);
             Type = type;
         }
         public IPropertySymbol Property { get; }
+        public ITypeSymbol? ConstrainedToType { get; }
         public ImmutableArray<IArgumentOperation> Arguments { get; }
         internal override int ChildOperationsCount =>
             Arguments.Length +
@@ -5083,13 +5125,15 @@ namespace Microsoft.CodeAnalysis.Operations
     }
     internal sealed partial class EventReferenceOperation : BaseMemberReferenceOperation, IEventReferenceOperation
     {
-        internal EventReferenceOperation(IEventSymbol @event, IOperation? instance, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
+        internal EventReferenceOperation(IEventSymbol @event, ITypeSymbol? constrainedToType, IOperation? instance, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
             : base(instance, semanticModel, syntax, isImplicit)
         {
             Event = @event;
+            ConstrainedToType = constrainedToType;
             Type = type;
         }
         public IEventSymbol Event { get; }
+        public ITypeSymbol? ConstrainedToType { get; }
         internal override int ChildOperationsCount =>
             (Instance is null ? 0 : 1);
         internal override IOperation GetCurrent(int slot, int index)
@@ -5135,7 +5179,7 @@ namespace Microsoft.CodeAnalysis.Operations
     }
     internal sealed partial class UnaryOperation : Operation, IUnaryOperation
     {
-        internal UnaryOperation(UnaryOperatorKind operatorKind, IOperation operand, bool isLifted, bool isChecked, IMethodSymbol? operatorMethod, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, ConstantValue? constantValue, bool isImplicit)
+        internal UnaryOperation(UnaryOperatorKind operatorKind, IOperation operand, bool isLifted, bool isChecked, IMethodSymbol? operatorMethod, ITypeSymbol? constrainedToType, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, ConstantValue? constantValue, bool isImplicit)
             : base(semanticModel, syntax, isImplicit)
         {
             OperatorKind = operatorKind;
@@ -5143,6 +5187,7 @@ namespace Microsoft.CodeAnalysis.Operations
             IsLifted = isLifted;
             IsChecked = isChecked;
             OperatorMethod = operatorMethod;
+            ConstrainedToType = constrainedToType;
             OperationConstantValue = constantValue;
             Type = type;
         }
@@ -5151,6 +5196,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public bool IsLifted { get; }
         public bool IsChecked { get; }
         public IMethodSymbol? OperatorMethod { get; }
+        public ITypeSymbol? ConstrainedToType { get; }
         internal override int ChildOperationsCount =>
             (Operand is null ? 0 : 1);
         internal override IOperation GetCurrent(int slot, int index)
@@ -5196,7 +5242,7 @@ namespace Microsoft.CodeAnalysis.Operations
     }
     internal sealed partial class BinaryOperation : Operation, IBinaryOperation
     {
-        internal BinaryOperation(BinaryOperatorKind operatorKind, IOperation leftOperand, IOperation rightOperand, bool isLifted, bool isChecked, bool isCompareText, IMethodSymbol? operatorMethod, IMethodSymbol? unaryOperatorMethod, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, ConstantValue? constantValue, bool isImplicit)
+        internal BinaryOperation(BinaryOperatorKind operatorKind, IOperation leftOperand, IOperation rightOperand, bool isLifted, bool isChecked, bool isCompareText, IMethodSymbol? operatorMethod, ITypeSymbol? constrainedToType, IMethodSymbol? unaryOperatorMethod, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, ConstantValue? constantValue, bool isImplicit)
             : base(semanticModel, syntax, isImplicit)
         {
             OperatorKind = operatorKind;
@@ -5206,6 +5252,7 @@ namespace Microsoft.CodeAnalysis.Operations
             IsChecked = isChecked;
             IsCompareText = isCompareText;
             OperatorMethod = operatorMethod;
+            ConstrainedToType = constrainedToType;
             UnaryOperatorMethod = unaryOperatorMethod;
             OperationConstantValue = constantValue;
             Type = type;
@@ -5217,6 +5264,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public bool IsChecked { get; }
         public bool IsCompareText { get; }
         public IMethodSymbol? OperatorMethod { get; }
+        public ITypeSymbol? ConstrainedToType { get; }
         public IMethodSymbol? UnaryOperatorMethod { get; }
         internal override int ChildOperationsCount =>
             (LeftOperand is null ? 0 : 1) +
@@ -5858,7 +5906,7 @@ namespace Microsoft.CodeAnalysis.Operations
     }
     internal sealed partial class CompoundAssignmentOperation : BaseAssignmentOperation, ICompoundAssignmentOperation
     {
-        internal CompoundAssignmentOperation(IConvertibleConversion inConversion, IConvertibleConversion outConversion, BinaryOperatorKind operatorKind, bool isLifted, bool isChecked, IMethodSymbol? operatorMethod, IOperation target, IOperation value, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
+        internal CompoundAssignmentOperation(IConvertibleConversion inConversion, IConvertibleConversion outConversion, BinaryOperatorKind operatorKind, bool isLifted, bool isChecked, IMethodSymbol? operatorMethod, ITypeSymbol? constrainedToType, IOperation target, IOperation value, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
             : base(target, value, semanticModel, syntax, isImplicit)
         {
             InConversionConvertible = inConversion;
@@ -5867,6 +5915,7 @@ namespace Microsoft.CodeAnalysis.Operations
             IsLifted = isLifted;
             IsChecked = isChecked;
             OperatorMethod = operatorMethod;
+            ConstrainedToType = constrainedToType;
             Type = type;
         }
         internal IConvertibleConversion InConversionConvertible { get; }
@@ -5877,6 +5926,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public bool IsLifted { get; }
         public bool IsChecked { get; }
         public IMethodSymbol? OperatorMethod { get; }
+        public ITypeSymbol? ConstrainedToType { get; }
         internal override int ChildOperationsCount =>
             (Target is null ? 0 : 1) +
             (Value is null ? 0 : 1);
@@ -6806,7 +6856,7 @@ namespace Microsoft.CodeAnalysis.Operations
     }
     internal sealed partial class IncrementOrDecrementOperation : Operation, IIncrementOrDecrementOperation
     {
-        internal IncrementOrDecrementOperation(bool isPostfix, bool isLifted, bool isChecked, IOperation target, IMethodSymbol? operatorMethod, OperationKind kind, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
+        internal IncrementOrDecrementOperation(bool isPostfix, bool isLifted, bool isChecked, IOperation target, IMethodSymbol? operatorMethod, ITypeSymbol? constrainedToType, OperationKind kind, SemanticModel? semanticModel, SyntaxNode syntax, ITypeSymbol? type, bool isImplicit)
             : base(semanticModel, syntax, isImplicit)
         {
             IsPostfix = isPostfix;
@@ -6814,6 +6864,7 @@ namespace Microsoft.CodeAnalysis.Operations
             IsChecked = isChecked;
             Target = SetParentOperation(target, this);
             OperatorMethod = operatorMethod;
+            ConstrainedToType = constrainedToType;
             Type = type;
             Kind = kind;
         }
@@ -6822,6 +6873,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public bool IsChecked { get; }
         public IOperation Target { get; }
         public IMethodSymbol? OperatorMethod { get; }
+        public ITypeSymbol? ConstrainedToType { get; }
         internal override int ChildOperationsCount =>
             (Target is null ? 0 : 1);
         internal override IOperation GetCurrent(int slot, int index)
@@ -10224,7 +10276,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public override IOperation VisitInvocation(IInvocationOperation operation, object? argument)
         {
             var internalOperation = (InvocationOperation)operation;
-            return new InvocationOperation(internalOperation.TargetMethod, Visit(internalOperation.Instance), internalOperation.IsVirtual, VisitArray(internalOperation.Arguments), internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
+            return new InvocationOperation(internalOperation.TargetMethod, internalOperation.ConstrainedToType, Visit(internalOperation.Instance), internalOperation.IsVirtual, VisitArray(internalOperation.Arguments), internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
         }
         public override IOperation VisitArrayElementReference(IArrayElementReferenceOperation operation, object? argument)
         {
@@ -10249,27 +10301,27 @@ namespace Microsoft.CodeAnalysis.Operations
         public override IOperation VisitMethodReference(IMethodReferenceOperation operation, object? argument)
         {
             var internalOperation = (MethodReferenceOperation)operation;
-            return new MethodReferenceOperation(internalOperation.Method, internalOperation.IsVirtual, Visit(internalOperation.Instance), internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
+            return new MethodReferenceOperation(internalOperation.Method, internalOperation.ConstrainedToType, internalOperation.IsVirtual, Visit(internalOperation.Instance), internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
         }
         public override IOperation VisitPropertyReference(IPropertyReferenceOperation operation, object? argument)
         {
             var internalOperation = (PropertyReferenceOperation)operation;
-            return new PropertyReferenceOperation(internalOperation.Property, VisitArray(internalOperation.Arguments), Visit(internalOperation.Instance), internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
+            return new PropertyReferenceOperation(internalOperation.Property, internalOperation.ConstrainedToType, VisitArray(internalOperation.Arguments), Visit(internalOperation.Instance), internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
         }
         public override IOperation VisitEventReference(IEventReferenceOperation operation, object? argument)
         {
             var internalOperation = (EventReferenceOperation)operation;
-            return new EventReferenceOperation(internalOperation.Event, Visit(internalOperation.Instance), internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
+            return new EventReferenceOperation(internalOperation.Event, internalOperation.ConstrainedToType, Visit(internalOperation.Instance), internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
         }
         public override IOperation VisitUnaryOperator(IUnaryOperation operation, object? argument)
         {
             var internalOperation = (UnaryOperation)operation;
-            return new UnaryOperation(internalOperation.OperatorKind, Visit(internalOperation.Operand), internalOperation.IsLifted, internalOperation.IsChecked, internalOperation.OperatorMethod, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.OperationConstantValue, internalOperation.IsImplicit);
+            return new UnaryOperation(internalOperation.OperatorKind, Visit(internalOperation.Operand), internalOperation.IsLifted, internalOperation.IsChecked, internalOperation.OperatorMethod, internalOperation.ConstrainedToType, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.OperationConstantValue, internalOperation.IsImplicit);
         }
         public override IOperation VisitBinaryOperator(IBinaryOperation operation, object? argument)
         {
             var internalOperation = (BinaryOperation)operation;
-            return new BinaryOperation(internalOperation.OperatorKind, Visit(internalOperation.LeftOperand), Visit(internalOperation.RightOperand), internalOperation.IsLifted, internalOperation.IsChecked, internalOperation.IsCompareText, internalOperation.OperatorMethod, internalOperation.UnaryOperatorMethod, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.OperationConstantValue, internalOperation.IsImplicit);
+            return new BinaryOperation(internalOperation.OperatorKind, Visit(internalOperation.LeftOperand), Visit(internalOperation.RightOperand), internalOperation.IsLifted, internalOperation.IsChecked, internalOperation.IsCompareText, internalOperation.OperatorMethod, internalOperation.ConstrainedToType, internalOperation.UnaryOperatorMethod, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.OperationConstantValue, internalOperation.IsImplicit);
         }
         public override IOperation VisitConditional(IConditionalOperation operation, object? argument)
         {
@@ -10324,7 +10376,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public override IOperation VisitCompoundAssignment(ICompoundAssignmentOperation operation, object? argument)
         {
             var internalOperation = (CompoundAssignmentOperation)operation;
-            return new CompoundAssignmentOperation(internalOperation.InConversionConvertible, internalOperation.OutConversionConvertible, internalOperation.OperatorKind, internalOperation.IsLifted, internalOperation.IsChecked, internalOperation.OperatorMethod, Visit(internalOperation.Target), Visit(internalOperation.Value), internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
+            return new CompoundAssignmentOperation(internalOperation.InConversionConvertible, internalOperation.OutConversionConvertible, internalOperation.OperatorKind, internalOperation.IsLifted, internalOperation.IsChecked, internalOperation.OperatorMethod, internalOperation.ConstrainedToType, Visit(internalOperation.Target), Visit(internalOperation.Value), internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
         }
         public override IOperation VisitParenthesized(IParenthesizedOperation operation, object? argument)
         {
@@ -10419,7 +10471,7 @@ namespace Microsoft.CodeAnalysis.Operations
         public override IOperation VisitIncrementOrDecrement(IIncrementOrDecrementOperation operation, object? argument)
         {
             var internalOperation = (IncrementOrDecrementOperation)operation;
-            return new IncrementOrDecrementOperation(internalOperation.IsPostfix, internalOperation.IsLifted, internalOperation.IsChecked, Visit(internalOperation.Target), internalOperation.OperatorMethod, internalOperation.Kind, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
+            return new IncrementOrDecrementOperation(internalOperation.IsPostfix, internalOperation.IsLifted, internalOperation.IsChecked, Visit(internalOperation.Target), internalOperation.OperatorMethod, internalOperation.ConstrainedToType, internalOperation.Kind, internalOperation.OwningSemanticModel, internalOperation.Syntax, internalOperation.Type, internalOperation.IsImplicit);
         }
         public override IOperation VisitThrow(IThrowOperation operation, object? argument)
         {

--- a/src/Compilers/Core/Portable/Operations/CommonConversion.cs
+++ b/src/Compilers/Core/Portable/Operations/CommonConversion.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Operations
 
         private readonly ConversionKind _conversionKind;
 
-        internal CommonConversion(bool exists, bool isIdentity, bool isNumeric, bool isReference, bool isImplicit, bool isNullable, IMethodSymbol? methodSymbol)
+        internal CommonConversion(bool exists, bool isIdentity, bool isNumeric, bool isReference, bool isImplicit, bool isNullable, IMethodSymbol? methodSymbol, ITypeSymbol? constrainedToType)
         {
             _conversionKind = (exists ? ConversionKind.Exists : ConversionKind.None) |
                               (isIdentity ? ConversionKind.IsIdentity : ConversionKind.None) |
@@ -38,6 +38,7 @@ namespace Microsoft.CodeAnalysis.Operations
                               (isImplicit ? ConversionKind.IsImplicit : ConversionKind.None) |
                               (isNullable ? ConversionKind.IsNullable : ConversionKind.None);
             MethodSymbol = methodSymbol;
+            ConstrainedToType = constrainedToType;
         }
 
         /// <summary>
@@ -78,5 +79,10 @@ namespace Microsoft.CodeAnalysis.Operations
         /// Otherwise, returns null.
         /// </summary>
         public IMethodSymbol? MethodSymbol { get; }
+        /// <summary>
+        /// Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="MethodSymbol" />, if any.
+        /// Null if <see cref="MethodSymbol" /> is resolved statically, or is null.
+        /// </summary>
+        public ITypeSymbol? ConstrainedToType { get; }
     }
 }

--- a/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
+++ b/src/Compilers/Core/Portable/Operations/ControlFlowGraphBuilder.cs
@@ -2103,7 +2103,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             IOperation value = VisitRequired(compoundAssignment.Value);
 
             return PopStackFrame(frame, new CompoundAssignmentOperation(compoundAssignment.InConversionConvertible, compoundAssignment.OutConversionConvertible, operation.OperatorKind, operation.IsLifted,
-                operation.IsChecked, operation.OperatorMethod, PopOperand(), value, semanticModel: null,
+                operation.IsChecked, operation.OperatorMethod, operation.ConstrainedToType, PopOperand(), value, semanticModel: null,
                 syntax: operation.Syntax, type: operation.Type, isImplicit: IsImplicit(operation)));
         }
 
@@ -2185,8 +2185,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             PushOperand(VisitRequired(operation.LeftOperand));
             IOperation rightOperand = VisitRequired(operation.RightOperand);
             return PopStackFrame(frame, new BinaryOperation(operation.OperatorKind, PopOperand(), rightOperand, operation.IsLifted, operation.IsChecked, operation.IsCompareText,
-                                                            operation.OperatorMethod, ((BinaryOperation)operation).UnaryOperatorMethod, semanticModel: null,
-                                                            operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation)));
+                                                            operation.OperatorMethod, operation.ConstrainedToType, ((BinaryOperation)operation).UnaryOperatorMethod,
+                                                            semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation)));
         }
 
         public override IOperation VisitTupleBinaryOperator(ITupleBinaryOperation operation, int? captureIdForResult)
@@ -2203,8 +2203,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                 return VisitConditionalExpression(operation, sense: true, captureIdForResult, fallToTrueOpt: null, fallToFalseOpt: null);
             }
 
-            return new UnaryOperation(operation.OperatorKind, VisitRequired(operation.Operand), operation.IsLifted, operation.IsChecked, operation.OperatorMethod,
-                                               semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
+            return new UnaryOperation(operation.OperatorKind, VisitRequired(operation.Operand), operation.IsLifted, operation.IsChecked,
+                                      operation.OperatorMethod, operation.ConstrainedToType,
+                                      semanticModel: null, operation.Syntax, operation.Type, operation.GetConstantValue(), IsImplicit(operation));
         }
 
         private static bool IsBooleanLogicalNot(IUnaryOperation operation)
@@ -2346,8 +2347,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             IOperation negateNullable(IOperation operand)
             {
-                return new UnaryOperation(UnaryOperatorKind.Not, operand, isLifted: true, isChecked: false, operatorMethod: null,
-                                                   semanticModel: null, operand.Syntax, operand.Type, constantValue: null, isImplicit: true);
+                return new UnaryOperation(UnaryOperatorKind.Not, operand, isLifted: true, isChecked: false,
+                                          operatorMethod: null, constrainedToType: null,
+                                          semanticModel: null, operand.Syntax, operand.Type, constantValue: null, isImplicit: true);
 
             }
         }
@@ -2447,8 +2449,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
                      (ITypeSymbolHelpers.IsNullableType(left.Type) || !ITypeSymbolHelpers.IsNullableType(unaryOperatorMethod.Parameters[0].Type))))
                 {
                     condition = new UnaryOperation(isAndAlso ? UnaryOperatorKind.False : UnaryOperatorKind.True,
-                                                            condition, isLifted: false, isChecked: false, operatorMethod: unaryOperatorMethod,
-                                                            semanticModel: null, condition.Syntax, booleanType, constantValue: null, isImplicit: true);
+                                                   condition, isLifted: false, isChecked: false,
+                                                   operatorMethod: unaryOperatorMethod,
+                                                   constrainedToType: unaryOperatorMethod is not null && (unaryOperatorMethod.IsAbstract || unaryOperatorMethod.IsVirtual) ? binOp.ConstrainedToType : null,
+                                                   semanticModel: null, condition.Syntax, booleanType, constantValue: null, isImplicit: true);
                 }
                 else
                 {
@@ -2483,18 +2487,19 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             IOperation visitedRight = VisitRequired(right);
             AddStatement(new FlowCaptureOperation(resultId, binOp.Syntax,
                                          new BinaryOperation(isAndAlso ? BinaryOperatorKind.And : BinaryOperatorKind.Or,
-                                                                      PopOperand(),
-                                                                      visitedRight,
-                                                                      isLifted: false,
-                                                                      binOp.IsChecked,
-                                                                      binOp.IsCompareText,
-                                                                      binOp.OperatorMethod,
-                                                                      unaryOperatorMethod: null,
-                                                                      semanticModel: null,
-                                                                      binOp.Syntax,
-                                                                      binOp.Type,
-                                                                      binOp.GetConstantValue(),
-                                                                      IsImplicit(binOp))));
+                                                             PopOperand(),
+                                                             visitedRight,
+                                                             isLifted: false,
+                                                             binOp.IsChecked,
+                                                             binOp.IsCompareText,
+                                                             binOp.OperatorMethod,
+                                                             binOp.OperatorMethod is not null && (binOp.OperatorMethod.IsAbstract || binOp.OperatorMethod.IsVirtual) ? binOp.ConstrainedToType : null,
+                                                             unaryOperatorMethod: null,
+                                                             semanticModel: null,
+                                                             binOp.Syntax,
+                                                             binOp.Type,
+                                                             binOp.GetConstantValue(),
+                                                             IsImplicit(binOp))));
 
             PopStackFrameAndLeaveRegion(frame);
             LeaveRegionsUpTo(resultCaptureRegion);
@@ -2506,6 +2511,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
         private IOperation VisitUserDefinedBinaryConditionalOperator(IBinaryOperation binOp, int? captureIdForResult)
         {
+            Debug.Assert(binOp.OperatorMethod is not null);
+
             SpillEvalStack();
 
             var resultCaptureRegion = CurrentRegionRequired;
@@ -2545,8 +2552,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             if (unaryOperatorMethod != null && ITypeSymbolHelpers.IsBooleanType(unaryOperatorMethod.ReturnType))
             {
                 condition = new UnaryOperation(isAndAlso ? UnaryOperatorKind.False : UnaryOperatorKind.True,
-                                                        condition, isLifted: false, isChecked: false, operatorMethod: unaryOperatorMethod,
-                                                        semanticModel: null, condition.Syntax, unaryOperatorMethod.ReturnType, constantValue: null, isImplicit: true);
+                                               condition, isLifted: false, isChecked: false,
+                                               operatorMethod: unaryOperatorMethod,
+                                               constrainedToType: unaryOperatorMethod.IsAbstract || unaryOperatorMethod.IsVirtual ? binOp.ConstrainedToType : null,
+                                               semanticModel: null, condition.Syntax, unaryOperatorMethod.ReturnType, constantValue: null, isImplicit: true);
             }
             else
             {
@@ -2568,17 +2577,18 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
 
             AddStatement(new FlowCaptureOperation(resultId, binOp.Syntax,
                                          new BinaryOperation(isAndAlso ? BinaryOperatorKind.And : BinaryOperatorKind.Or,
-                                                                      PopOperand(),
-                                                                      visitedRight,
-                                                                      isLifted,
-                                                                      binOp.IsChecked,
-                                                                      binOp.IsCompareText,
-                                                                      binOp.OperatorMethod,
-                                                                      unaryOperatorMethod: null,
-                                                                      semanticModel: null,
-                                                                      binOp.Syntax,
-                                                                      binOp.Type,
-                                                                      binOp.GetConstantValue(), IsImplicit(binOp))));
+                                                             PopOperand(),
+                                                             visitedRight,
+                                                             isLifted,
+                                                             binOp.IsChecked,
+                                                             binOp.IsCompareText,
+                                                             binOp.OperatorMethod,
+                                                             binOp.OperatorMethod.IsAbstract || binOp.OperatorMethod.IsVirtual ? binOp.ConstrainedToType : null,
+                                                             unaryOperatorMethod: null,
+                                                             semanticModel: null,
+                                                             binOp.Syntax,
+                                                             binOp.Type,
+                                                             binOp.GetConstantValue(), IsImplicit(binOp))));
 
             PopStackFrameAndLeaveRegion(frame);
             LeaveRegionsUpTo(resultCaptureRegion);
@@ -2676,11 +2686,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
             {
                 return lastUnary != null
                     ? new UnaryOperation(lastUnary.OperatorKind, condition, lastUnary.IsLifted, lastUnary.IsChecked,
-                                                  lastUnary.OperatorMethod, semanticModel: null, lastUnary.Syntax,
-                                                  lastUnary.Type, lastUnary.GetConstantValue(), IsImplicit(lastUnary))
+                                         lastUnary.OperatorMethod, lastUnary.ConstrainedToType, semanticModel: null, lastUnary.Syntax,
+                                         lastUnary.Type, lastUnary.GetConstantValue(), IsImplicit(lastUnary))
                     : new UnaryOperation(UnaryOperatorKind.Not, condition, isLifted: false, isChecked: false,
-                                                  operatorMethod: null, semanticModel: null, condition.Syntax,
-                                                  condition.Type, constantValue: null, isImplicit: true);
+                                         operatorMethod: null, constrainedToType: null, semanticModel: null, condition.Syntax,
+                                         condition.Type, constantValue: null, isImplicit: true);
             }
 
             return condition;
@@ -3233,7 +3243,7 @@ oneMoreTime:
                     if (candidate.OriginalDefinition.Equals(method))
                     {
                         method = (IMethodSymbol)candidate;
-                        return new InvocationOperation(method, value, isVirtual: false,
+                        return new InvocationOperation(method, constrainedToType: null, value, isVirtual: false,
                                                        ImmutableArray<IArgumentOperation>.Empty, semanticModel: null, value.Syntax,
                                                        method.ReturnType, isImplicit: true);
                     }
@@ -4066,7 +4076,7 @@ oneMoreTime:
                         args = ImmutableArray<IArgumentOperation>.Empty;
                     }
 
-                    var invocation = new InvocationOperation(method, value, isVirtual: disposeMethod?.IsVirtual ?? true,
+                    var invocation = new InvocationOperation(method, constrainedToType: null, value, isVirtual: disposeMethod?.IsVirtual ?? true,
                                                              args, semanticModel: null, value.Syntax,
                                                              method.ReturnType, isImplicit: true);
 
@@ -4168,7 +4178,7 @@ oneMoreTime:
                 }
                 else
                 {
-                    AddStatement(new InvocationOperation(enterMethod, instance: null, isVirtual: false,
+                    AddStatement(new InvocationOperation(enterMethod, constrainedToType: null, instance: null, isVirtual: false,
                                                           ImmutableArray.Create<IArgumentOperation>(
                                                                     new ArgumentOperation(ArgumentKind.Explicit,
                                                                                           enterMethod.Parameters[0],
@@ -4196,7 +4206,7 @@ oneMoreTime:
                 Debug.Assert(enterMethod is not null);
                 lockTaken = new LocalReferenceOperation(lockStatement.LockTakenSymbol, isDeclaration: true, semanticModel: null, lockedValue.Syntax,
                                                          lockStatement.LockTakenSymbol.Type, constantValue: null, isImplicit: true);
-                AddStatement(new InvocationOperation(enterMethod, instance: null, isVirtual: false,
+                AddStatement(new InvocationOperation(enterMethod, constrainedToType: null, instance: null, isVirtual: false,
                                                       ImmutableArray.Create<IArgumentOperation>(
                                                                 new ArgumentOperation(ArgumentKind.Explicit,
                                                                                       enterMethod.Parameters[0],
@@ -4251,18 +4261,18 @@ oneMoreTime:
             }
             else
             {
-                AddStatement(new InvocationOperation(exitMethod, instance: null, isVirtual: false,
-                                                      ImmutableArray.Create<IArgumentOperation>(
-                                                                new ArgumentOperation(ArgumentKind.Explicit,
-                                                                                      exitMethod.Parameters[0],
-                                                                                      lockedValue,
-                                                                                      inConversion: OperationFactory.IdentityConversion,
-                                                                                      outConversion: OperationFactory.IdentityConversion,
-                                                                                      semanticModel: null,
-                                                                                      lockedValue.Syntax,
-                                                                                      isImplicit: true)),
-                                                      semanticModel: null, lockedValue.Syntax,
-                                                      exitMethod.ReturnType, isImplicit: true));
+                AddStatement(new InvocationOperation(exitMethod, constrainedToType: null, instance: null, isVirtual: false,
+                                                     ImmutableArray.Create<IArgumentOperation>(
+                                                               new ArgumentOperation(ArgumentKind.Explicit,
+                                                                                     exitMethod.Parameters[0],
+                                                                                     lockedValue,
+                                                                                     inConversion: OperationFactory.IdentityConversion,
+                                                                                     outConversion: OperationFactory.IdentityConversion,
+                                                                                     semanticModel: null,
+                                                                                     lockedValue.Syntax,
+                                                                                     isImplicit: true)),
+                                                     semanticModel: null, lockedValue.Syntax,
+                                                     exitMethod.ReturnType, isImplicit: true));
             }
 
             AppendNewBlock(endOfFinally);
@@ -4450,6 +4460,7 @@ oneMoreTime:
                     var instance = info.CurrentProperty.IsStatic ? null : enumeratorRef;
                     var visitedArguments = makeArguments(info.CurrentArguments, ref instance);
                     return new PropertyReferenceOperation(info.CurrentProperty,
+                                                          constrainedToType: null,
                                                           visitedArguments,
                                                           instance,
                                                           semanticModel: null,
@@ -4513,7 +4524,7 @@ oneMoreTime:
             {
                 Debug.Assert(method.IsStatic == (instanceOpt == null));
                 var visitedArguments = makeArguments(arguments, ref instanceOpt);
-                return new InvocationOperation(method, instanceOpt,
+                return new InvocationOperation(method, constrainedToType: null, instanceOpt,
                                                isVirtual: method.IsVirtual || method.IsAbstract || method.IsOverride,
                                                visitedArguments, semanticModel: null, syntax,
                                                method.ReturnType, isImplicit: true);
@@ -4642,7 +4653,7 @@ oneMoreTime:
 
                     Debug.Assert(builder.All(op => op is not null));
 
-                    return new InvocationOperation(method, instance: null, isVirtual: false, builder.ToImmutableAndFree(),
+                    return new InvocationOperation(method, constrainedToType: null, instance: null, isVirtual: false, builder.ToImmutableAndFree(),
                                                    semanticModel: null, operation.LimitValue.Syntax, method.ReturnType,
                                                    isImplicit: true);
                 }
@@ -4770,18 +4781,19 @@ oneMoreTime:
                                                                        isImplicit: true);
 
                             isUp = new BinaryOperation(BinaryOperatorKind.GreaterThanOrEqual,
-                                                                stepValue,
-                                                                literal,
-                                                                isLifted: false,
-                                                                isChecked: false,
-                                                                isCompareText: false,
-                                                                operatorMethod: null,
-                                                                unaryOperatorMethod: null,
-                                                                semanticModel: null,
-                                                                stepValue.Syntax,
-                                                                booleanType,
-                                                                constantValue: null,
-                                                                isImplicit: true);
+                                                       stepValue,
+                                                       literal,
+                                                       isLifted: false,
+                                                       isChecked: false,
+                                                       isCompareText: false,
+                                                       operatorMethod: null,
+                                                       constrainedToType: null,
+                                                       unaryOperatorMethod: null,
+                                                       semanticModel: null,
+                                                       stepValue.Syntax,
+                                                       booleanType,
+                                                       constantValue: null,
+                                                       isImplicit: true);
 
                             AddStatement(new FlowCaptureOperation(positiveFlagId, isUp.Syntax, isUp));
 
@@ -4923,18 +4935,19 @@ oneMoreTime:
                     if (comparisonKind != BinaryOperatorKind.None)
                     {
                         condition = new BinaryOperation(comparisonKind,
-                                                                 PopOperand(),
-                                                                 limitReference,
-                                                                 isLifted: false,
-                                                                 isChecked: false,
-                                                                 isCompareText: false,
-                                                                 operatorMethod: null,
-                                                                 unaryOperatorMethod: null,
-                                                                 semanticModel: null,
-                                                                 operation.LimitValue.Syntax,
-                                                                 booleanType,
-                                                                 constantValue: null,
-                                                                 isImplicit: true);
+                                                        PopOperand(),
+                                                        limitReference,
+                                                        isLifted: false,
+                                                        isChecked: false,
+                                                        isCompareText: false,
+                                                        operatorMethod: null,
+                                                        constrainedToType: null,
+                                                        unaryOperatorMethod: null,
+                                                        semanticModel: null,
+                                                        operation.LimitValue.Syntax,
+                                                        booleanType,
+                                                        constantValue: null,
+                                                        isImplicit: true);
 
                         ConditionalBranch(condition, jumpIfTrue: false, @break);
                         UnconditionalBranch(bodyBlock);
@@ -4959,18 +4972,19 @@ oneMoreTime:
                     if (ITypeSymbolHelpers.IsNullableType(operation.LimitValue.Type))
                     {
                         eitherLimitOrControlVariableIsNull = new BinaryOperation(BinaryOperatorKind.Or,
-                                                                                          MakeIsNullOperation(limitReference, booleanType),
-                                                                                          MakeIsNullOperation(PopOperand(), booleanType),
-                                                                                          isLifted: false,
-                                                                                          isChecked: false,
-                                                                                          isCompareText: false,
-                                                                                          operatorMethod: null,
-                                                                                          unaryOperatorMethod: null,
-                                                                                          semanticModel: null,
-                                                                                          operation.StepValue.Syntax,
-                                                                                          _compilation.GetSpecialType(SpecialType.System_Boolean),
-                                                                                          constantValue: null,
-                                                                                          isImplicit: true);
+                                                                                 MakeIsNullOperation(limitReference, booleanType),
+                                                                                 MakeIsNullOperation(PopOperand(), booleanType),
+                                                                                 isLifted: false,
+                                                                                 isChecked: false,
+                                                                                 isCompareText: false,
+                                                                                 operatorMethod: null,
+                                                                                 constrainedToType: null,
+                                                                                 unaryOperatorMethod: null,
+                                                                                 semanticModel: null,
+                                                                                 operation.StepValue.Syntax,
+                                                                                 _compilation.GetSpecialType(SpecialType.System_Boolean),
+                                                                                 constantValue: null,
+                                                                                 isImplicit: true);
 
                         // if either limit or control variable is null, we exit the loop
                         var whenBothNotNull = new BasicBlockBuilder(BasicBlockKind.Block);
@@ -4999,18 +5013,19 @@ oneMoreTime:
                     _currentBasicBlock = null;
 
                     condition = new BinaryOperation(BinaryOperatorKind.LessThanOrEqual,
-                                                             controlVariableReferenceforCondition,
-                                                             limitReference,
-                                                             isLifted: false,
-                                                             isChecked: false,
-                                                             isCompareText: false,
-                                                             operatorMethod: null,
-                                                             unaryOperatorMethod: null,
-                                                             semanticModel: null,
-                                                             operation.LimitValue.Syntax,
-                                                             booleanType,
-                                                             constantValue: null,
-                                                             isImplicit: true);
+                                                    controlVariableReferenceforCondition,
+                                                    limitReference,
+                                                    isLifted: false,
+                                                    isChecked: false,
+                                                    isCompareText: false,
+                                                    operatorMethod: null,
+                                                    constrainedToType: null,
+                                                    unaryOperatorMethod: null,
+                                                    semanticModel: null,
+                                                    operation.LimitValue.Syntax,
+                                                    booleanType,
+                                                    constantValue: null,
+                                                    isImplicit: true);
 
                     ConditionalBranch(condition, jumpIfTrue: false, @break);
                     UnconditionalBranch(bodyBlock);
@@ -5018,18 +5033,19 @@ oneMoreTime:
                     AppendNewBlock(notPositive);
 
                     condition = new BinaryOperation(BinaryOperatorKind.GreaterThanOrEqual,
-                                                             OperationCloner.CloneOperation(controlVariableReferenceforCondition),
-                                                             OperationCloner.CloneOperation(limitReference),
-                                                             isLifted: false,
-                                                             isChecked: false,
-                                                             isCompareText: false,
-                                                             operatorMethod: null,
-                                                             unaryOperatorMethod: null,
-                                                             semanticModel: null,
-                                                             operation.LimitValue.Syntax,
-                                                             booleanType,
-                                                             constantValue: null,
-                                                             isImplicit: true);
+                                                    OperationCloner.CloneOperation(controlVariableReferenceforCondition),
+                                                    OperationCloner.CloneOperation(limitReference),
+                                                    isLifted: false,
+                                                    isChecked: false,
+                                                    isCompareText: false,
+                                                    operatorMethod: null,
+                                                    constrainedToType: null,
+                                                    unaryOperatorMethod: null,
+                                                    semanticModel: null,
+                                                    operation.LimitValue.Syntax,
+                                                    booleanType,
+                                                    constantValue: null,
+                                                    isImplicit: true);
 
                     ConditionalBranch(condition, jumpIfTrue: false, @break);
                     UnconditionalBranch(bodyBlock);
@@ -5051,32 +5067,34 @@ oneMoreTime:
                                                        constantValue: ConstantValue.Create(bits), isImplicit: true);
 
                 var shiftedStep = new BinaryOperation(BinaryOperatorKind.RightShift,
-                                                               GetCaptureReference(stepValueId, operation.StepValue),
-                                                               shiftConst,
-                                                               isLifted: false,
-                                                               isChecked: false,
-                                                               isCompareText: false,
-                                                               operatorMethod: null,
-                                                               unaryOperatorMethod: null,
-                                                               semanticModel: null,
-                                                               operand.Syntax,
-                                                               operation.StepValue.Type,
-                                                               constantValue: null,
-                                                               isImplicit: true);
+                                                      GetCaptureReference(stepValueId, operation.StepValue),
+                                                      shiftConst,
+                                                      isLifted: false,
+                                                      isChecked: false,
+                                                      isCompareText: false,
+                                                      operatorMethod: null,
+                                                      constrainedToType: null,
+                                                      unaryOperatorMethod: null,
+                                                      semanticModel: null,
+                                                      operand.Syntax,
+                                                      operation.StepValue.Type,
+                                                      constantValue: null,
+                                                      isImplicit: true);
 
                 return new BinaryOperation(BinaryOperatorKind.ExclusiveOr,
-                                                    shiftedStep,
-                                                    operand,
-                                                    isLifted: false,
-                                                    isChecked: false,
-                                                    isCompareText: false,
-                                                    operatorMethod: null,
-                                                    unaryOperatorMethod: null,
-                                                    semanticModel: null,
-                                                    operand.Syntax,
-                                                    operand.Type,
-                                                    constantValue: null,
-                                                    isImplicit: true);
+                                           shiftedStep,
+                                           operand,
+                                           isLifted: false,
+                                           isChecked: false,
+                                           isCompareText: false,
+                                           operatorMethod: null,
+                                           constrainedToType: null,
+                                           unaryOperatorMethod: null,
+                                           semanticModel: null,
+                                           operand.Syntax,
+                                           operand.Type,
+                                           constantValue: null,
+                                           isImplicit: true);
             }
 
             void incrementLoopControlVariable()
@@ -5136,19 +5154,20 @@ oneMoreTime:
 
                         EvalStackFrame nullCheckFrame = PushStackFrame();
                         IOperation condition = new BinaryOperation(BinaryOperatorKind.Or,
-                                                                            MakeIsNullOperation(GetCaptureReference(stepValueId, operation.StepValue), booleanType),
-                                                                            MakeIsNullOperation(visitLoopControlVariableReference(forceImplicit: true), // Yes we are going to evaluate it again
-                                                                                                booleanType),
-                                                                            isLifted: false,
-                                                                            isChecked: false,
-                                                                            isCompareText: false,
-                                                                            operatorMethod: null,
-                                                                            unaryOperatorMethod: null,
-                                                                            semanticModel: null,
-                                                                            operation.StepValue.Syntax,
-                                                                            _compilation.GetSpecialType(SpecialType.System_Boolean),
-                                                                            constantValue: null,
-                                                                            isImplicit: true);
+                                                                   MakeIsNullOperation(GetCaptureReference(stepValueId, operation.StepValue), booleanType),
+                                                                   MakeIsNullOperation(visitLoopControlVariableReference(forceImplicit: true), // Yes we are going to evaluate it again
+                                                                                       booleanType),
+                                                                   isLifted: false,
+                                                                   isChecked: false,
+                                                                   isCompareText: false,
+                                                                   operatorMethod: null,
+                                                                   constrainedToType: null,
+                                                                   unaryOperatorMethod: null,
+                                                                   semanticModel: null,
+                                                                   operation.StepValue.Syntax,
+                                                                   _compilation.GetSpecialType(SpecialType.System_Boolean),
+                                                                   constantValue: null,
+                                                                   isImplicit: true);
 
                         ConditionalBranch(condition, jumpIfTrue: false, whenNotNull);
                         _currentBasicBlock = null;
@@ -5187,18 +5206,19 @@ oneMoreTime:
                     }
 
                     IOperation increment = new BinaryOperation(BinaryOperatorKind.Add,
-                                                                        controlVariableReferenceForIncrement,
-                                                                        stepValueForIncrement,
-                                                                        isLifted: false,
-                                                                        isChecked: operation.IsChecked,
-                                                                        isCompareText: false,
-                                                                        operatorMethod: null,
-                                                                        unaryOperatorMethod: null,
-                                                                        semanticModel: null,
-                                                                        operation.StepValue.Syntax,
-                                                                        controlVariableReferenceForIncrement.Type,
-                                                                        constantValue: null,
-                                                                        isImplicit: true);
+                                                               controlVariableReferenceForIncrement,
+                                                               stepValueForIncrement,
+                                                               isLifted: false,
+                                                               isChecked: operation.IsChecked,
+                                                               isCompareText: false,
+                                                               operatorMethod: null,
+                                                               constrainedToType: null,
+                                                               unaryOperatorMethod: null,
+                                                               semanticModel: null,
+                                                               operation.StepValue.Syntax,
+                                                               controlVariableReferenceForIncrement.Type,
+                                                               constantValue: null,
+                                                               isImplicit: true);
 
                     controlVariableReferenceForAssignment = PopOperand();
 
@@ -5380,18 +5400,19 @@ oneMoreTime:
                             }
 
                             condition = new BinaryOperation(BinaryOperatorKind.Equals,
-                                                                     leftOperand,
-                                                                     rightOperand,
-                                                                     isLifted,
-                                                                     isChecked: false,
-                                                                     isCompareText: false,
-                                                                     operatorMethod: null,
-                                                                     unaryOperatorMethod: null,
-                                                                     semanticModel: null,
-                                                                     compareWith.Syntax,
-                                                                     booleanType,
-                                                                     constantValue: null,
-                                                                     isImplicit: true);
+                                                            leftOperand,
+                                                            rightOperand,
+                                                            isLifted,
+                                                            isChecked: false,
+                                                            isCompareText: false,
+                                                            operatorMethod: null,
+                                                            constrainedToType: null,
+                                                            unaryOperatorMethod: null,
+                                                            semanticModel: null,
+                                                            compareWith.Syntax,
+                                                            booleanType,
+                                                            constantValue: null,
+                                                            isImplicit: true);
 
                             ConditionalBranch(condition, jumpIfTrue: false, nextCase);
 
@@ -5732,7 +5753,7 @@ oneMoreTime:
             IOperation? instance = operation.TargetMethod.IsStatic ? null : operation.Instance;
             (IOperation? visitedInstance, ImmutableArray<IArgumentOperation> visitedArguments) = VisitInstanceWithArguments(instance, operation.Arguments);
             PopStackFrame(frame);
-            return new InvocationOperation(operation.TargetMethod, visitedInstance, operation.IsVirtual, visitedArguments, semanticModel: null, operation.Syntax,
+            return new InvocationOperation(operation.TargetMethod, operation.ConstrainedToType, visitedInstance, operation.IsVirtual, visitedArguments, semanticModel: null, operation.Syntax,
                                            operation.Type, IsImplicit(operation));
         }
 
@@ -6021,13 +6042,13 @@ oneMoreTime:
                     case OperationKind.EventReference:
                         var eventReference = (IEventReferenceOperation)originalTarget;
                         instance = (!eventReference.Member.IsStatic && eventReference.Instance != null) ? PopOperand() : null;
-                        return new EventReferenceOperation(eventReference.Event, instance, semanticModel: null, eventReference.Syntax,
+                        return new EventReferenceOperation(eventReference.Event, eventReference.ConstrainedToType, instance, semanticModel: null, eventReference.Syntax,
                                                             eventReference.Type, IsImplicit(eventReference));
                     case OperationKind.PropertyReference:
                         var propertyReference = (IPropertyReferenceOperation)originalTarget;
                         instance = (!propertyReference.Member.IsStatic && propertyReference.Instance != null) ? PopOperand() : null;
                         ImmutableArray<IArgumentOperation> propertyArguments = PopArray(propertyReference.Arguments, RewriteArgumentFromArray);
-                        return new PropertyReferenceOperation(propertyReference.Property, propertyArguments, instance, semanticModel: null, propertyReference.Syntax,
+                        return new PropertyReferenceOperation(propertyReference.Property, propertyReference.ConstrainedToType, propertyArguments, instance, semanticModel: null, propertyReference.Syntax,
                                                                propertyReference.Type, IsImplicit(propertyReference));
                     case OperationKind.ArrayElementReference:
                         var arrayElementReference = (IArrayElementReferenceOperation)originalTarget;
@@ -6097,7 +6118,7 @@ oneMoreTime:
 
                 var visitedPropertyInstance = new InstanceReferenceOperation(InstanceReferenceKind.ImplicitReceiver, semanticModel: null,
                     propertyReference.Instance.Syntax, propertyReference.Instance.Type, IsImplicit(propertyReference.Instance));
-                IOperation visitedTarget = new PropertyReferenceOperation(propertyReference.Property, ImmutableArray<IArgumentOperation>.Empty, visitedPropertyInstance,
+                IOperation visitedTarget = new PropertyReferenceOperation(propertyReference.Property, propertyReference.ConstrainedToType, ImmutableArray<IArgumentOperation>.Empty, visitedPropertyInstance,
                     semanticModel: null, propertyReference.Syntax, propertyReference.Type, IsImplicit(propertyReference));
                 IOperation visitedValue = visitAndCaptureInitializer(propertyReference.Property, simpleAssignment.Value);
                 var visitedAssignment = new SimpleAssignmentOperation(isRef: simpleAssignment.IsRef, visitedTarget, visitedValue,
@@ -6792,7 +6813,7 @@ oneMoreTime:
         public override IOperation VisitMethodReference(IMethodReferenceOperation operation, int? captureIdForResult)
         {
             IOperation? visitedInstance = operation.Method.IsStatic ? null : Visit(operation.Instance);
-            return new MethodReferenceOperation(operation.Method, operation.IsVirtual, visitedInstance, semanticModel: null,
+            return new MethodReferenceOperation(operation.Method, operation.ConstrainedToType, operation.IsVirtual, visitedInstance, semanticModel: null,
                                                 operation.Syntax, operation.Type, IsImplicit(operation));
         }
 
@@ -6821,14 +6842,14 @@ oneMoreTime:
             IOperation? instance = operation.Property.IsStatic ? null : operation.Instance;
             (IOperation? visitedInstance, ImmutableArray<IArgumentOperation> visitedArguments) = VisitInstanceWithArguments(instance, operation.Arguments);
             PopStackFrame(frame);
-            return new PropertyReferenceOperation(operation.Property, visitedArguments, visitedInstance, semanticModel: null,
+            return new PropertyReferenceOperation(operation.Property, operation.ConstrainedToType, visitedArguments, visitedInstance, semanticModel: null,
                                                   operation.Syntax, operation.Type, IsImplicit(operation));
         }
 
         public override IOperation VisitEventReference(IEventReferenceOperation operation, int? captureIdForResult)
         {
             IOperation? visitedInstance = operation.Event.IsStatic ? null : Visit(operation.Instance);
-            return new EventReferenceOperation(operation.Event, visitedInstance, semanticModel: null,
+            return new EventReferenceOperation(operation.Event, operation.ConstrainedToType, visitedInstance, semanticModel: null,
                                                operation.Syntax, operation.Type, IsImplicit(operation));
         }
 
@@ -6924,7 +6945,7 @@ oneMoreTime:
                     arguments = ImmutableArray<IArgumentOperation>.Empty;
                 }
 
-                IOperation propertyRef = new PropertyReferenceOperation(propertySymbol, arguments, instance,
+                IOperation propertyRef = new PropertyReferenceOperation(propertySymbol, constrainedToType: null, arguments, instance,
                     semanticModel: null, operation.Syntax, propertySymbol.Type, isImplicit: true);
                 VisitInitializer(rewrittenTarget: propertyRef, initializer: operation);
             }
@@ -6965,7 +6986,7 @@ oneMoreTime:
                 visitedHandler = VisitRequired(operation.HandlerValue);
 
                 IOperation? visitedInstance = eventReferenceInstance == null ? null : PopOperand();
-                visitedEventReference = new EventReferenceOperation(eventReference.Event, visitedInstance,
+                visitedEventReference = new EventReferenceOperation(eventReference.Event, eventReference.ConstrainedToType, visitedInstance,
                     semanticModel: null, operation.EventReference.Syntax, operation.EventReference.Type, IsImplicit(operation.EventReference));
             }
             else
@@ -7011,7 +7032,7 @@ oneMoreTime:
 
             (IOperation? visitedInstance, ImmutableArray<IArgumentOperation> visitedArguments) =
                 VisitInstanceWithArguments(operation.EventReference.Event.IsStatic ? null : operation.EventReference.Instance, operation.Arguments);
-            var visitedEventReference = new EventReferenceOperation(operation.EventReference.Event, visitedInstance,
+            var visitedEventReference = new EventReferenceOperation(operation.EventReference.Event, operation.EventReference.ConstrainedToType, visitedInstance,
                 semanticModel: null, operation.EventReference.Syntax, operation.EventReference.Type, IsImplicit(operation.EventReference));
 
             PopStackFrame(frame);
@@ -7026,7 +7047,8 @@ oneMoreTime:
 
         public override IOperation VisitIncrementOrDecrement(IIncrementOrDecrementOperation operation, int? captureIdForResult)
         {
-            return new IncrementOrDecrementOperation(operation.IsPostfix, operation.IsLifted, operation.IsChecked, VisitRequired(operation.Target), operation.OperatorMethod,
+            return new IncrementOrDecrementOperation(operation.IsPostfix, operation.IsLifted, operation.IsChecked, VisitRequired(operation.Target),
+                                                     operation.OperatorMethod, operation.ConstrainedToType,
                                                      operation.Kind, semanticModel: null, operation.Syntax, operation.Type, IsImplicit(operation));
         }
 
@@ -7554,7 +7576,7 @@ oneMoreTime:
             {
                 cloned = operation.CloneMethod is null
                     ? MakeInvalidOperation(visitedInstance.Type, visitedInstance)
-                    : new InvocationOperation(operation.CloneMethod, visitedInstance,
+                    : new InvocationOperation(operation.CloneMethod, constrainedToType: null, visitedInstance,
                         isVirtual: true, arguments: ImmutableArray<IArgumentOperation>.Empty,
                         semanticModel: null, operation.Syntax, operation.Type, isImplicit: true);
             }
@@ -7657,7 +7679,7 @@ oneMoreTime:
                             operation.Operand.Type, constantValue: operation.Operand.GetConstantValue());
 
                         // `oldInstance.Property`
-                        var visitedValue = new PropertyReferenceOperation(property, ImmutableArray<IArgumentOperation>.Empty, oldInstance,
+                        var visitedValue = new PropertyReferenceOperation(property, constrainedToType: null, ImmutableArray<IArgumentOperation>.Empty, oldInstance,
                             semanticModel: null, operation.Syntax, property.Type, isImplicit: true);
 
                         int extraValueCaptureId = GetNextCaptureId(outerCaptureRegion);
@@ -7683,7 +7705,7 @@ oneMoreTime:
                     semanticModel: null, operation.Syntax, operation.Type, isImplicit: true);
 
                 // <implicitReceiver>.Property
-                var target = new PropertyReferenceOperation(property, ImmutableArray<IArgumentOperation>.Empty, implicitReceiver,
+                var target = new PropertyReferenceOperation(property, constrainedToType: null, ImmutableArray<IArgumentOperation>.Empty, implicitReceiver,
                     semanticModel: null, operation.Syntax, property.Type, isImplicit: true);
 
                 // <implicitReceiver>.Property = <capturedValue>

--- a/src/Compilers/Core/Portable/Operations/OperationFactory.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Operations
 
         private class IdentityConvertibleConversion : IConvertibleConversion
         {
-            public CommonConversion ToCommonConversion() => new CommonConversion(exists: true, isIdentity: true, isNumeric: false, isReference: false, methodSymbol: null, isImplicit: true, isNullable: false);
+            public CommonConversion ToCommonConversion() => new CommonConversion(exists: true, isIdentity: true, isNumeric: false, isReference: false, methodSymbol: null, constrainedToType: null, isImplicit: true, isNullable: false);
         }
     }
 }

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -616,6 +616,14 @@
         <summary>Operator method used by the operation, null if the operation does not use an operator method.</summary>
       </Comments>
     </Property>
+    <Property Name="ConstrainedToType" Type="ITypeSymbol?" SkipGeneration="true">
+      <Comments>
+        <summary>
+          Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="OperatorMethod" />, if any.
+          Null if <see cref="OperatorMethod" /> is resolved statically, or is null.
+        </summary>
+      </Comments>
+    </Property>
     <Property Name="Conversion" Type="CommonConversion">
       <Comments>
         <summary>Gets the underlying common conversion information.</summary>
@@ -661,6 +669,14 @@
     <Property Name="TargetMethod" Type="IMethodSymbol">
       <Comments>
         <summary>Method to be invoked.</summary>
+      </Comments>
+    </Property>
+    <Property Name="ConstrainedToType" Type="ITypeSymbol?">
+      <Comments>
+        <summary>
+          Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="TargetMethod" />.
+          Null if <see cref="TargetMethod" /> is resolved statically, or is an instance method.
+        </summary>
       </Comments>
     </Property>
     <Property Name="Instance" Type="IOperation?">
@@ -768,6 +784,14 @@
         <summary>Referenced member.</summary>
       </Comments>
     </Property>
+    <Property Name="ConstrainedToType" Type="ITypeSymbol?" SkipGeneration="true">
+      <Comments>
+        <summary>
+          Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="Member" />.
+          Null if <see cref="Member" /> is resolved statically, or is an instance member.
+        </summary>
+      </Comments>
+    </Property>
   </AbstractNode>
   <Node Name="IFieldReferenceOperation" Base="IMemberReferenceOperation" HasType="true" HasConstantValue="true">
     <Comments>
@@ -811,6 +835,14 @@
         <summary>Referenced method.</summary>
       </Comments>
     </Property>
+    <Property Name="ConstrainedToType" Type="ITypeSymbol?" Internal="true">
+      <Comments>
+        <summary>
+          Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="Method" />.
+          Null if <see cref="Method" /> is resolved statically, or is an instance method.
+        </summary>
+      </Comments>
+    </Property>
     <Property Name="IsVirtual" Type="bool">
       <Comments>
         <summary>Indicates whether the reference uses virtual semantics.</summary>
@@ -831,6 +863,14 @@
     <Property Name="Property" Type="IPropertySymbol">
       <Comments>
         <summary>Referenced property.</summary>
+      </Comments>
+    </Property>
+    <Property Name="ConstrainedToType" Type="ITypeSymbol?" Internal="true">
+      <Comments>
+        <summary>
+          Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="Property" />.
+          Null if <see cref="Property" /> is resolved statically, or is an instance property.
+        </summary>
       </Comments>
     </Property>
     <Property Name="Arguments" Type="ImmutableArray&lt;IArgumentOperation&gt;">
@@ -857,6 +897,14 @@
     <Property Name="Event" Type="IEventSymbol">
       <Comments>
         <summary>Referenced event.</summary>
+      </Comments>
+    </Property>
+    <Property Name="ConstrainedToType" Type="ITypeSymbol?" Internal="true">
+      <Comments>
+        <summary>
+          Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="Event" />.
+          Null if <see cref="Event" /> is resolved statically, or is an instance event.
+        </summary>
       </Comments>
     </Property>
   </Node>
@@ -905,6 +953,14 @@
     <Property Name="OperatorMethod" Type="IMethodSymbol?">
       <Comments>
         <summary>Operator method used by the operation, null if the operation does not use an operator method.</summary>
+      </Comments>
+    </Property>
+    <Property Name="ConstrainedToType" Type="ITypeSymbol?">
+      <Comments>
+        <summary>
+          Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="OperatorMethod" />, if any.
+          Null if <see cref="OperatorMethod" /> is resolved statically, or is null.
+        </summary>
       </Comments>
     </Property>
   </Node>
@@ -965,6 +1021,15 @@
     <Property Name="OperatorMethod" Type="IMethodSymbol?">
       <Comments>
         <summary>Operator method used by the operation, null if the operation does not use an operator method.</summary>
+      </Comments>
+    </Property>
+    <Property Name="ConstrainedToType" Type="ITypeSymbol?">
+      <Comments>
+        <summary>
+          Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="OperatorMethod" />
+          or corresponding true/false operator, if any.
+          Null if operators are resolved statically, or are not used.
+        </summary>
       </Comments>
     </Property>
     <Property Name="UnaryOperatorMethod" Type="IMethodSymbol?" Internal="true">
@@ -1302,6 +1367,14 @@
     <Property Name="OperatorMethod" Type="IMethodSymbol?">
       <Comments>
         <summary>Operator method used by the operation, null if the operation does not use an operator method.</summary>
+      </Comments>
+    </Property>
+    <Property Name="ConstrainedToType" Type="ITypeSymbol?">
+      <Comments>
+        <summary>
+          Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="OperatorMethod" />, if any.
+          Null if <see cref="OperatorMethod" /> is resolved statically, or is null.
+        </summary>
       </Comments>
     </Property>
   </Node>
@@ -1804,6 +1877,14 @@
     <Property Name="OperatorMethod" Type="IMethodSymbol?">
       <Comments>
         <summary>Operator method used by the operation, null if the operation does not use an operator method.</summary>
+      </Comments>
+    </Property>
+    <Property Name="ConstrainedToType" Type="ITypeSymbol?">
+      <Comments>
+        <summary>
+          Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="OperatorMethod" />, if any.
+          Null if <see cref="OperatorMethod" /> is resolved statically, or is null.
+        </summary>
       </Comments>
     </Property>
   </Node>

--- a/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
+++ b/src/Compilers/Core/Portable/Operations/OperationInterfaces.xml
@@ -784,7 +784,7 @@
         <summary>Referenced member.</summary>
       </Comments>
     </Property>
-    <Property Name="ConstrainedToType" Type="ITypeSymbol?" SkipGeneration="true">
+    <Property Name="ConstrainedToType" Type="ITypeSymbol?" MakeAbstract="true">
       <Comments>
         <summary>
           Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="Member" />.
@@ -835,14 +835,7 @@
         <summary>Referenced method.</summary>
       </Comments>
     </Property>
-    <Property Name="ConstrainedToType" Type="ITypeSymbol?" Internal="true">
-      <Comments>
-        <summary>
-          Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="Method" />.
-          Null if <see cref="Method" /> is resolved statically, or is an instance method.
-        </summary>
-      </Comments>
-    </Property>
+    <Property Name="ConstrainedToType" Type="ITypeSymbol?" Override="true"/>
     <Property Name="IsVirtual" Type="bool">
       <Comments>
         <summary>Indicates whether the reference uses virtual semantics.</summary>
@@ -865,14 +858,7 @@
         <summary>Referenced property.</summary>
       </Comments>
     </Property>
-    <Property Name="ConstrainedToType" Type="ITypeSymbol?" Internal="true">
-      <Comments>
-        <summary>
-          Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="Property" />.
-          Null if <see cref="Property" /> is resolved statically, or is an instance property.
-        </summary>
-      </Comments>
-    </Property>
+    <Property Name="ConstrainedToType" Type="ITypeSymbol?" Override="true"/>
     <Property Name="Arguments" Type="ImmutableArray&lt;IArgumentOperation&gt;">
       <Comments>
         <summary>Arguments of the indexer property reference, excluding the instance argument. Arguments are in evaluation order.</summary>
@@ -899,14 +885,7 @@
         <summary>Referenced event.</summary>
       </Comments>
     </Property>
-    <Property Name="ConstrainedToType" Type="ITypeSymbol?" Internal="true">
-      <Comments>
-        <summary>
-          Type parameter which runtime type will be used to resolve virtual invocation of the <see cref="Event" />.
-          Null if <see cref="Event" /> is resolved statically, or is an instance event.
-        </summary>
-      </Comments>
-    </Property>
+    <Property Name="ConstrainedToType" Type="ITypeSymbol?" Override="true"/>
   </Node>
   <Node Name="IUnaryOperation" Base="IOperation" VisitorName="VisitUnaryOperator" HasType="true" HasConstantValue="true">
     <OperationKind>

--- a/src/Compilers/Core/Portable/Operations/OperationNodes.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationNodes.cs
@@ -183,34 +183,27 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseMemberReferenceOperation : IMemberReferenceOperation
     {
         public abstract ISymbol Member { get; }
-
-        ITypeSymbol? IMemberReferenceOperation.ConstrainedToType => ConstrainedToTypeImpl;
-
-        protected abstract ITypeSymbol? ConstrainedToTypeImpl { get; }
     }
 
     internal sealed partial class MethodReferenceOperation
     {
         public override ISymbol Member => Method;
-        protected override ITypeSymbol? ConstrainedToTypeImpl => ConstrainedToType;
     }
 
     internal sealed partial class PropertyReferenceOperation
     {
         public override ISymbol Member => Property;
-        protected override ITypeSymbol? ConstrainedToTypeImpl => ConstrainedToType;
     }
 
     internal sealed partial class EventReferenceOperation
     {
         public override ISymbol Member => Event;
-        protected override ITypeSymbol? ConstrainedToTypeImpl => ConstrainedToType;
     }
 
     internal sealed partial class FieldReferenceOperation
     {
         public override ISymbol Member => Field;
-        protected override ITypeSymbol? ConstrainedToTypeImpl => null;
+        public override ITypeSymbol? ConstrainedToType => null;
     }
 
     internal sealed partial class RangeCaseClauseOperation

--- a/src/Compilers/Core/Portable/Operations/OperationNodes.cs
+++ b/src/Compilers/Core/Portable/Operations/OperationNodes.cs
@@ -79,6 +79,7 @@ namespace Microsoft.CodeAnalysis.Operations
     internal partial class ConversionOperation
     {
         public IMethodSymbol? OperatorMethod => Conversion.MethodSymbol;
+        public ITypeSymbol? ConstrainedToType => Conversion.ConstrainedToType;
     }
 
     internal sealed partial class InvalidOperation : Operation, IInvalidOperation
@@ -182,26 +183,34 @@ namespace Microsoft.CodeAnalysis.Operations
     internal abstract partial class BaseMemberReferenceOperation : IMemberReferenceOperation
     {
         public abstract ISymbol Member { get; }
+
+        ITypeSymbol? IMemberReferenceOperation.ConstrainedToType => ConstrainedToTypeImpl;
+
+        protected abstract ITypeSymbol? ConstrainedToTypeImpl { get; }
     }
 
     internal sealed partial class MethodReferenceOperation
     {
         public override ISymbol Member => Method;
+        protected override ITypeSymbol? ConstrainedToTypeImpl => ConstrainedToType;
     }
 
     internal sealed partial class PropertyReferenceOperation
     {
         public override ISymbol Member => Property;
+        protected override ITypeSymbol? ConstrainedToTypeImpl => ConstrainedToType;
     }
 
     internal sealed partial class EventReferenceOperation
     {
         public override ISymbol Member => Event;
+        protected override ITypeSymbol? ConstrainedToTypeImpl => ConstrainedToType;
     }
 
     internal sealed partial class FieldReferenceOperation
     {
         public override ISymbol Member => Field;
+        protected override ITypeSymbol? ConstrainedToTypeImpl => null;
     }
 
     internal sealed partial class RangeCaseClauseOperation

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -56,6 +56,14 @@ Microsoft.CodeAnalysis.IOperation.OperationList.Reversed.Count.get -> int
 Microsoft.CodeAnalysis.IOperation.OperationList.Reversed.GetEnumerator() -> Microsoft.CodeAnalysis.IOperation.OperationList.Reversed.Enumerator
 Microsoft.CodeAnalysis.IOperation.OperationList.Reversed.ToImmutableArray() -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IOperation!>
 Microsoft.CodeAnalysis.IPropertySymbol.IsRequired.get -> bool
+Microsoft.CodeAnalysis.Operations.CommonConversion.ConstrainedToType.get -> Microsoft.CodeAnalysis.ITypeSymbol?
+Microsoft.CodeAnalysis.Operations.IBinaryOperation.ConstrainedToType.get -> Microsoft.CodeAnalysis.ITypeSymbol?
+Microsoft.CodeAnalysis.Operations.ICompoundAssignmentOperation.ConstrainedToType.get -> Microsoft.CodeAnalysis.ITypeSymbol?
+Microsoft.CodeAnalysis.Operations.IConversionOperation.ConstrainedToType.get -> Microsoft.CodeAnalysis.ITypeSymbol?
+Microsoft.CodeAnalysis.Operations.IIncrementOrDecrementOperation.ConstrainedToType.get -> Microsoft.CodeAnalysis.ITypeSymbol?
+Microsoft.CodeAnalysis.Operations.IInvocationOperation.ConstrainedToType.get -> Microsoft.CodeAnalysis.ITypeSymbol?
+Microsoft.CodeAnalysis.Operations.IMemberReferenceOperation.ConstrainedToType.get -> Microsoft.CodeAnalysis.ITypeSymbol?
+Microsoft.CodeAnalysis.Operations.IUnaryOperation.ConstrainedToType.get -> Microsoft.CodeAnalysis.ITypeSymbol?
 Microsoft.CodeAnalysis.SemanticModel.GetImportScopes(int position, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IImportScope!>
 Microsoft.CodeAnalysis.ISymbol.Accept<TArgument, TResult>(Microsoft.CodeAnalysis.SymbolVisitor<TArgument, TResult>! visitor, TArgument argument) -> TResult
 Microsoft.CodeAnalysis.SymbolVisitor<TArgument, TResult>

--- a/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
+++ b/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
@@ -817,6 +817,12 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var spacing = !operation.IsVirtual && operation.Instance != null ? " " : string.Empty;
             LogString($" ({isVirtualStr}{spacing}");
             LogSymbol(operation.TargetMethod, header: string.Empty);
+
+            if (operation.ConstrainedToType is not null)
+            {
+                LogType(operation.ConstrainedToType, header: " ConstrainedToType");
+            }
+
             LogString(")");
             LogCommonPropertiesAndNewLine(operation);
 
@@ -1046,6 +1052,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 LogString($" (IsDeclaration: {operation.IsDeclaration})");
             }
 
+            Assert.Null(operation.ConstrainedToType);
+
             VisitMemberReferenceExpressionCommon(operation);
         }
 
@@ -1053,6 +1061,12 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             LogString(nameof(IMethodReferenceOperation));
             LogString($": {operation.Method.ToTestDisplayString()}");
+
+            if (operation.ConstrainedToType is not null)
+            {
+                LogType(operation.ConstrainedToType, header: " (ConstrainedToType");
+                LogString(")");
+            }
 
             if (operation.IsVirtual)
             {
@@ -1069,6 +1083,12 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             LogString(nameof(IPropertyReferenceOperation));
             LogString($": {operation.Property.ToTestDisplayString()}");
 
+            if (operation.ConstrainedToType is not null)
+            {
+                LogType(operation.ConstrainedToType, header: " (ConstrainedToType");
+                LogString(")");
+            }
+
             VisitMemberReferenceExpressionCommon(operation);
 
             if (operation.Arguments.Length > 0)
@@ -1081,6 +1101,12 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             LogString(nameof(IEventReferenceOperation));
             LogString($": {operation.Event.ToTestDisplayString()}");
+
+            if (operation.ConstrainedToType is not null)
+            {
+                LogType(operation.ConstrainedToType, header: " (ConstrainedToType");
+                LogString(")");
+            }
 
             VisitMemberReferenceExpressionCommon(operation);
         }
@@ -1135,7 +1161,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
 
             LogString($" ({kindStr})");
-            LogHasOperatorMethodExpressionCommon(operation.OperatorMethod);
+            LogHasOperatorMethodExpressionCommon(operation.OperatorMethod, operation.ConstrainedToType);
             LogCommonPropertiesAndNewLine(operation);
 
             Visit(operation.Operand, "Operand");
@@ -1162,7 +1188,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
 
             LogString($" ({kindStr})");
-            LogHasOperatorMethodExpressionCommon(operation.OperatorMethod);
+            LogHasOperatorMethodExpressionCommon(operation.OperatorMethod, operation.ConstrainedToType);
             var unaryOperatorMethod = ((BinaryOperation)operation).UnaryOperatorMethod;
             LogCommonPropertiesAndNewLine(operation);
 
@@ -1182,12 +1208,22 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             Visit(operation.RightOperand, "Right");
         }
 
-        private void LogHasOperatorMethodExpressionCommon(IMethodSymbol operatorMethodOpt)
+        private void LogHasOperatorMethodExpressionCommon(IMethodSymbol operatorMethodOpt, ITypeSymbol constrainedToTypeOpt)
         {
             if (operatorMethodOpt != null)
             {
                 LogSymbol(operatorMethodOpt, header: " (OperatorMethod");
+
+                if (constrainedToTypeOpt is not null)
+                {
+                    LogType(constrainedToTypeOpt, header: " ConstrainedToType");
+                }
+
                 LogString(")");
+            }
+            else
+            {
+                Assert.Null(constrainedToTypeOpt);
             }
         }
 
@@ -1199,7 +1235,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var isChecked = operation.IsChecked ? "Checked" : "Unchecked";
             LogString($" ({isTryCast}, {isChecked})");
 
-            LogHasOperatorMethodExpressionCommon(operation.OperatorMethod);
+            LogHasOperatorMethodExpressionCommon(operation.OperatorMethod, operation.ConstrainedToType);
             LogCommonPropertiesAndNewLine(operation);
             Indent();
             LogConversion(operation.Conversion);
@@ -1621,7 +1657,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
 
             LogString($" ({kindStr})");
-            LogHasOperatorMethodExpressionCommon(operation.OperatorMethod);
+            LogHasOperatorMethodExpressionCommon(operation.OperatorMethod, operation.ConstrainedToType);
             LogCommonPropertiesAndNewLine(operation);
             Indent();
             LogConversion(operation.InConversion, "InConversion");
@@ -1650,7 +1686,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
 
             LogString($" ({kindStr})");
-            LogHasOperatorMethodExpressionCommon(operation.OperatorMethod);
+            LogHasOperatorMethodExpressionCommon(operation.OperatorMethod, operation.ConstrainedToType);
             LogCommonPropertiesAndNewLine(operation);
 
             Visit(operation.Target, "Target");

--- a/src/Compilers/Test/Core/Compilation/TestOperationVisitor.cs
+++ b/src/Compilers/Test/Core/Compilation/TestOperationVisitor.cs
@@ -520,6 +520,12 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             Assert.NotNull(operation.TargetMethod);
             var isVirtual = operation.IsVirtual;
 
+            AssertConstrainedToType(operation.TargetMethod, operation.ConstrainedToType);
+            if (operation.ConstrainedToType is not null)
+            {
+                Assert.True(isVirtual);
+            }
+
             IEnumerable<IOperation> children;
             if (operation.Instance != null)
             {
@@ -628,6 +634,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         private void VisitMemberReference(IMemberReferenceOperation operation, IEnumerable<IOperation> additionalChildren)
         {
             Assert.NotNull(operation.Member);
+            AssertConstrainedToType(operation.Member, operation.ConstrainedToType);
 
             IEnumerable<IOperation> children;
 
@@ -655,6 +662,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             Assert.Equal(OperationKind.FieldReference, operation.Kind);
             VisitMemberReference(operation);
+            Assert.Null(operation.ConstrainedToType);
 
             Assert.Same(operation.Member, operation.Field);
             var isDeclaration = operation.IsDeclaration;
@@ -667,6 +675,11 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             Assert.Same(operation.Member, operation.Method);
             var isVirtual = operation.IsVirtual;
+
+            if (operation.ConstrainedToType is not null)
+            {
+                Assert.True(isVirtual);
+            }
         }
 
         public override void VisitPropertyReference(IPropertyReferenceOperation operation)
@@ -720,6 +733,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var isLifted = operation.IsLifted;
             var isChecked = operation.IsChecked;
 
+            AssertConstrainedToType(operatorMethod, operation.ConstrainedToType);
             Assert.Same(operation.Operand, operation.ChildOperations.Single());
         }
 
@@ -733,6 +747,25 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var isLifted = operation.IsLifted;
             var isChecked = operation.IsChecked;
             var isCompareText = operation.IsCompareText;
+            var constrainedToType = operation.ConstrainedToType;
+
+            if (binaryOperationKind is BinaryOperatorKind.ConditionalAnd or BinaryOperatorKind.ConditionalOr)
+            {
+                if ((operatorMethod is null || !operatorMethod.IsStatic || (!operatorMethod.IsVirtual && !operatorMethod.IsAbstract)) &&
+                    (unaryOperatorMethod is null || !unaryOperatorMethod.IsStatic || (!unaryOperatorMethod.IsVirtual && !unaryOperatorMethod.IsAbstract)))
+                {
+                    Assert.Null(constrainedToType);
+                }
+                else if (constrainedToType is not null) // In error cases we might not have the type parameter
+                {
+                    Assert.IsAssignableFrom<ITypeParameterSymbol>(constrainedToType);
+                }
+            }
+            else
+            {
+                Assert.Null(unaryOperatorMethod);
+                AssertConstrainedToType(operatorMethod, constrainedToType);
+            }
 
             AssertEx.Equal(new[] { operation.LeftOperand, operation.RightOperand }, operation.ChildOperations);
         }
@@ -754,6 +787,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var isChecked = operation.IsChecked;
             var isTryCast = operation.IsTryCast;
 
+            AssertConstrainedToType(operatorMethod, operation.ConstrainedToType);
+
             switch (operation.Language)
             {
                 case LanguageNames.CSharp:
@@ -770,6 +805,18 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
 
             Assert.Same(operation.Operand, operation.ChildOperations.Single());
+        }
+
+        private static void AssertConstrainedToType(ISymbol member, ITypeSymbol constrainedToType)
+        {
+            if (member is null || !member.IsStatic || (!member.IsVirtual && !member.IsAbstract))
+            {
+                Assert.Null(constrainedToType);
+            }
+            else if (constrainedToType is not null) // In error cases we might not have the type parameter
+            {
+                Assert.IsAssignableFrom<ITypeParameterSymbol>(constrainedToType);
+            }
         }
 
         public override void VisitConditional(IConditionalOperation operation)
@@ -1079,6 +1126,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             var isLifted = operation.IsLifted;
             var isChecked = operation.IsChecked;
+            AssertConstrainedToType(operatorMethod, operation.ConstrainedToType);
             VisitAssignment(operation);
         }
 
@@ -1090,6 +1138,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var isLifted = operation.IsLifted;
             var isChecked = operation.IsChecked;
 
+            AssertConstrainedToType(operatorMethod, operation.ConstrainedToType);
             Assert.Same(operation.Target, operation.ChildOperations.Single());
         }
 

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory.vb
@@ -450,7 +450,7 @@ Namespace Microsoft.CodeAnalysis.Operations
             Dim syntax As SyntaxNode = boundCall.Syntax
             Dim type As ITypeSymbol = boundCall.Type
             Dim isImplicit As Boolean = boundCall.WasCompilerGenerated
-            Return New InvocationOperation(targetMethod, receiver, isVirtual, arguments, _semanticModel, syntax, type, isImplicit)
+            Return New InvocationOperation(targetMethod, constrainedToType:=Nothing, receiver, isVirtual, arguments, _semanticModel, syntax, type, isImplicit)
         End Function
 
         Private Function CreateBoundOmittedArgumentOperation(boundOmittedArgument As BoundOmittedArgument) As IOmittedArgumentOperation
@@ -504,7 +504,7 @@ Namespace Microsoft.CodeAnalysis.Operations
             Dim isLifted As Boolean = (boundUnaryOperator.OperatorKind And VisualBasic.UnaryOperatorKind.Lifted) <> 0
             Dim isChecked As Boolean = boundUnaryOperator.Checked
             Dim isImplicit As Boolean = boundUnaryOperator.WasCompilerGenerated
-            Return New UnaryOperation(operatorKind, operand, isLifted, isChecked, operatorMethod, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New UnaryOperation(operatorKind, operand, isLifted, isChecked, operatorMethod, constrainedToType:=Nothing, _semanticModel, syntax, type, constantValue, isImplicit)
         End Function
 
         Private Function CreateBoundUserDefinedUnaryOperatorOperation(boundUserDefinedUnaryOperator As BoundUserDefinedUnaryOperator) As IUnaryOperation
@@ -517,7 +517,7 @@ Namespace Microsoft.CodeAnalysis.Operations
             Dim isLifted As Boolean = (boundUserDefinedUnaryOperator.OperatorKind And VisualBasic.UnaryOperatorKind.Lifted) <> 0
             Dim isChecked As Boolean = False
             Dim isImplicit As Boolean = boundUserDefinedUnaryOperator.WasCompilerGenerated
-            Return New UnaryOperation(operatorKind, operand, isLifted, isChecked, operatorMethod, _semanticModel, syntax, type, constantValue, isImplicit)
+            Return New UnaryOperation(operatorKind, operand, isLifted, isChecked, operatorMethod, constrainedToType:=Nothing, _semanticModel, syntax, type, constantValue, isImplicit)
         End Function
 
         Private Shared Function TryGetOperatorMethod(boundUserDefinedUnaryOperator As BoundUserDefinedUnaryOperator) As MethodSymbol
@@ -570,7 +570,7 @@ Namespace Microsoft.CodeAnalysis.Operations
                 Dim isImplicit As Boolean = currentBinary.WasCompilerGenerated
 
                 left = New BinaryOperation(binaryOperatorInfo.OperatorKind, left, right, binaryOperatorInfo.IsLifted,
-                                           binaryOperatorInfo.IsChecked, binaryOperatorInfo.IsCompareText, binaryOperatorInfo.OperatorMethod,
+                                           binaryOperatorInfo.IsChecked, binaryOperatorInfo.IsCompareText, binaryOperatorInfo.OperatorMethod, constrainedToType:=Nothing,
                                            unaryOperatorMethod:=Nothing, _semanticModel, syntax, type, constantValue, isImplicit)
             End While
 
@@ -588,7 +588,7 @@ Namespace Microsoft.CodeAnalysis.Operations
             Dim constantValue As ConstantValue = boundUserDefinedBinaryOperator.ConstantValueOpt
             Dim isImplicit As Boolean = boundUserDefinedBinaryOperator.WasCompilerGenerated
             Return New BinaryOperation(binaryOperatorInfo.OperatorKind, left, right, binaryOperatorInfo.IsLifted,
-                                       binaryOperatorInfo.IsChecked, binaryOperatorInfo.IsCompareText, binaryOperatorInfo.OperatorMethod,
+                                       binaryOperatorInfo.IsChecked, binaryOperatorInfo.IsCompareText, binaryOperatorInfo.OperatorMethod, constrainedToType:=Nothing,
                                        unaryOperatorMethod:=Nothing, _semanticModel, syntax, type, constantValue, isImplicit)
         End Function
 
@@ -641,7 +641,7 @@ Namespace Microsoft.CodeAnalysis.Operations
             End If
 
             Return New BinaryOperation(operatorKind, left, right, binaryOperatorInfo.IsLifted, isChecked, isCompareText,
-                                       binaryOperatorInfo.OperatorMethod, unaryOperatorMethod, _semanticModel, syntax, type, constantValue, isImplicit)
+                                       binaryOperatorInfo.OperatorMethod, constrainedToType:=Nothing, unaryOperatorMethod, _semanticModel, syntax, type, constantValue, isImplicit)
         End Function
 
         Private Function CreateBoundBadExpressionOperation(boundBadExpression As BoundBadExpression) As IInvalidOperation
@@ -753,7 +753,7 @@ Namespace Microsoft.CodeAnalysis.Operations
             Dim syntax As SyntaxNode = boundDelegateCreationExpression.Syntax
             Dim type As ITypeSymbol = Nothing
             Dim isImplicit As Boolean = boundDelegateCreationExpression.WasCompilerGenerated
-            Return New MethodReferenceOperation(method, isVirtual, receiverOpt, _semanticModel, syntax, type, isImplicit)
+            Return New MethodReferenceOperation(method, constrainedToType:=Nothing, isVirtual, receiverOpt, _semanticModel, syntax, type, isImplicit)
         End Function
 
         Private Function CreateBoundTernaryConditionalExpressionOperation(boundTernaryConditionalExpression As BoundTernaryConditionalExpression) As IConditionalOperation
@@ -868,7 +868,7 @@ Namespace Microsoft.CodeAnalysis.Operations
             Dim syntax As SyntaxNode = boundPropertyAccess.Syntax
             Dim type As ITypeSymbol = boundPropertyAccess.Type
             Dim isImplicit As Boolean = boundPropertyAccess.WasCompilerGenerated
-            Return New PropertyReferenceOperation([property], arguments, instance, _semanticModel, syntax, type, isImplicit)
+            Return New PropertyReferenceOperation([property], constrainedToType:=Nothing, arguments, instance, _semanticModel, syntax, type, isImplicit)
         End Function
 
         Private Function CreateBoundWithLValueExpressionPlaceholder(boundWithLValueExpressionPlaceholder As BoundWithLValueExpressionPlaceholder) As IInstanceReferenceOperation
@@ -894,7 +894,7 @@ Namespace Microsoft.CodeAnalysis.Operations
             Dim syntax As SyntaxNode = boundEventAccess.Syntax
             Dim type As ITypeSymbol = boundEventAccess.Type
             Dim isImplicit As Boolean = boundEventAccess.WasCompilerGenerated
-            Return New EventReferenceOperation([event], instance, _semanticModel, syntax, type, isImplicit)
+            Return New EventReferenceOperation([event], constrainedToType:=Nothing, instance, _semanticModel, syntax, type, isImplicit)
         End Function
 
         Private Function CreateBoundFieldAccessOperation(boundFieldAccess As BoundFieldAccess) As IFieldReferenceOperation
@@ -1477,7 +1477,7 @@ Namespace Microsoft.CodeAnalysis.Operations
             End If
 
             Dim instance = CreateReceiverOperation(receiverOpt, boundRaiseEventStatement.EventSymbol)
-            Return New EventReferenceOperation(boundRaiseEventStatement.EventSymbol,
+            Return New EventReferenceOperation(boundRaiseEventStatement.EventSymbol, constrainedToType:=Nothing,
                                                instance,
                                                _semanticModel,
                                                eventReferenceSyntax,
@@ -1589,7 +1589,7 @@ Namespace Microsoft.CodeAnalysis.Operations
             Dim syntax As SyntaxNode = boundAnonymousTypePropertyAccess.Syntax
             Dim type As ITypeSymbol = boundAnonymousTypePropertyAccess.Type
             Dim isImplicit As Boolean = boundAnonymousTypePropertyAccess.WasCompilerGenerated
-            Return New PropertyReferenceOperation([property], arguments, instance, _semanticModel, syntax, type, isImplicit)
+            Return New PropertyReferenceOperation([property], constrainedToType:=Nothing, arguments, instance, _semanticModel, syntax, type, isImplicit)
         End Function
 
         Private Function CreateAnonymousTypePropertyAccessImplicitReceiverOperation(propertySym As IPropertySymbol, syntax As SyntaxNode) As InstanceReferenceOperation
@@ -1641,7 +1641,7 @@ Namespace Microsoft.CodeAnalysis.Operations
 
             If method IsNot Nothing Then
                 Dim receiver as IOperation = CreateReceiverOperation(boundNullableIsTrueOperator.Operand, method)
-                Return New InvocationOperation(method.AsMember(DirectCast(boundNullableIsTrueOperator.Operand.Type, NamedTypeSymbol)),
+                Return New InvocationOperation(method.AsMember(DirectCast(boundNullableIsTrueOperator.Operand.Type, NamedTypeSymbol)), constrainedToType:=Nothing,
                                                               receiver,
                                                               isVirtual:=False,
                                                               arguments:=ImmutableArray(Of IArgumentOperation).Empty,

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
@@ -92,7 +92,7 @@ Namespace Microsoft.CodeAnalysis.Operations
             Dim isImplicit As Boolean = boundAssignment.WasCompilerGenerated
 
             Return New CompoundAssignmentOperation(inConversion, outConversion, operatorInfo.OperatorKind, operatorInfo.IsLifted,
-                                                   operatorInfo.IsChecked, operatorInfo.OperatorMethod, target, value,
+                                                   operatorInfo.IsChecked, operatorInfo.OperatorMethod, constrainedToType:=Nothing, target, value,
                                                    _semanticModel, syntax, type, isImplicit)
         End Function
 
@@ -326,7 +326,7 @@ Namespace Microsoft.CodeAnalysis.Operations
                     Dim [property] As IPropertySymbol = properties(i)
                     Dim instance As IInstanceReferenceOperation = CreateAnonymousTypePropertyAccessImplicitReceiverOperation([property], expression.Syntax)
                     target = New PropertyReferenceOperation(
-                        [property],
+                        [property], constrainedToType:=Nothing,
                         ImmutableArray(Of IArgumentOperation).Empty,
                         instance,
                         _semanticModel,

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -239,7 +239,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' from the <see cref="CommonConversion"/> struct.
         ''' </remarks>
         Public Function ToCommonConversion() As CommonConversion Implements IConvertibleConversion.ToCommonConversion
-            Return New CommonConversion(Exists, IsIdentity, IsNumeric, IsReference, IsWidening, IsNullableValueType, MethodSymbol)
+            Return New CommonConversion(Exists, IsIdentity, IsNumeric, IsReference, IsWidening, IsNullableValueType, MethodSymbol, constrainedToType:=Nothing)
         End Function
 
         ''' <summary>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.Verifier.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.Verifier.cs
@@ -43,7 +43,7 @@ namespace IOperationGenerator
 
                     foreach (var prop in abstractNode.Properties)
                     {
-                        if (prop.Comments?.Elements?[0].Name != "summary" && !prop.IsInternal)
+                        if (prop.Comments?.Elements?[0].Name != "summary" && !prop.IsInternal && !prop.IsOverride)
                         {
                             Console.WriteLine($"{abstractNode.Name}.{prop.Name} does not have correctly formatted comments, please ensure that there is a <summary> block for the property.");
                             error = true;

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/IOperationClassWriter.cs
@@ -288,7 +288,7 @@ namespace IOperationGenerator
 
         private void WriteInterfaceProperty(Property prop)
         {
-            if (prop.IsInternal)
+            if (prop.IsInternal || prop.IsOverride)
                 return;
             WriteComments(prop.Comments, operationKinds: Enumerable.Empty<string>(), writeReservedRemark: false);
             var modifiers = prop.IsNew ? "new " : "";
@@ -627,6 +627,10 @@ namespace IOperationGenerator
                     }
                     else
                     {
+                        if (prop.IsOverride)
+                        {
+                            propExtensibility += "override ";
+                        }
                         WriteLine($"public {propExtensibility}{prop.Type} {prop.Name} {{ get; }}");
                     }
                 }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/Model.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/IOperationGenerator/Model.cs
@@ -115,6 +115,10 @@ namespace IOperationGenerator
         public string? IsInternalText;
         public bool IsInternal => IsInternalText == "true";
 
+        [XmlAttribute(AttributeName = "Override")]
+        public string? IsOverrideText;
+        public bool IsOverride => IsOverrideText == "true";
+
         [XmlAttribute(AttributeName = "SkipGeneration")]
         public string? SkipGenerationText;
         public bool SkipGeneration => SkipGenerationText == "true";


### PR DESCRIPTION
Closes #53803.