### PR TITLE
Don't fault for failure to parse XML in SymbolSearch

### DIFF
--- a/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.Update.cs
+++ b/src/Features/Core/Portable/SymbolSearch/Windows/SymbolSearchUpdateEngine.Update.cs
@@ -554,9 +554,17 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
 
                 using var reader = XmlReader.Create(stream, settings);
 
-                var result = XElement.Load(reader);
-                await LogInfoAsync("Converting data to XElement completed", cancellationToken).ConfigureAwait(false);
-                return result;
+                try
+                {
+                    var result = XElement.Load(reader);
+                    await LogInfoAsync("Converting data to XElement completed", cancellationToken).ConfigureAwait(false);
+                    return result;
+                }
+                catch (XmlException e)
+                {
+                    await LogExceptionAsync(e, "Converting data to XElement failed", cancellationToken).ConfigureAwait(false);
+                    return null;
+                }
             }
 
             private async Task RepeatIOAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken)


### PR DESCRIPTION
Resolves [AB#1351953](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1351953)

We don't want to report faults for failure to parse the xml stream. Instead log a specific exception and continue as if the stream failed. 