### PR TITLE
[LSP] Add support for reporting project level diagnostics in workspace pull

### DIFF
--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -1473,7 +1473,7 @@ Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Analyzers\VisualBasic\CodeFixes\VisualBasicCodeFixes.projitems*{0141285d-8f6c-42c7-baf3-3c0ccd61c716}*SharedItemsImports = 5
 		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\VisualBasic\VisualBasicWorkspaceExtensions.projitems*{0141285d-8f6c-42c7-baf3-3c0ccd61c716}*SharedItemsImports = 5
-		src\Compilers\CSharp\CommandLine\CscCommandLine.projitems*{0161e25c-918a-4dc8-9648-30fdcc8e31e9}*SharedItemsImports = 5
+		src\Compilers\CSharp\csc\CscCommandLine.projitems*{0161e25c-918a-4dc8-9648-30fdcc8e31e9}*SharedItemsImports = 5
 		src\Analyzers\VisualBasic\Tests\VisualBasicAnalyzers.UnitTests.projitems*{0be66736-cdaa-4989-88b1-b3f46ebdca4a}*SharedItemsImports = 5
 		src\Analyzers\Core\CodeFixes\CodeFixes.projitems*{1b6c4a1a-413b-41fb-9f85-5c09118e541b}*SharedItemsImports = 13
 		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 5
@@ -1495,7 +1495,7 @@ Global
 		src\Analyzers\CSharp\CodeFixes\CSharpCodeFixes.projitems*{3973b09a-4fbf-44a5-8359-3d22ceb71f71}*SharedItemsImports = 5
 		src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{3973b09a-4fbf-44a5-8359-3d22ceb71f71}*SharedItemsImports = 5
 		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\CSharp\CSharpWorkspaceExtensions.projitems*{438db8af-f3f0-4ed9-80b5-13fddd5b8787}*SharedItemsImports = 13
-		src\Compilers\CSharp\CommandLine\CscCommandLine.projitems*{4b45ca0c-03a0-400f-b454-3d4bcb16af38}*SharedItemsImports = 5
+		src\Compilers\CSharp\csc\CscCommandLine.projitems*{4b45ca0c-03a0-400f-b454-3d4bcb16af38}*SharedItemsImports = 5
 		src\Analyzers\CSharp\Tests\CSharpAnalyzers.UnitTests.projitems*{5018d049-5870-465a-889b-c742ce1e31cb}*SharedItemsImports = 5
 		src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{54e08bf5-f819-404f-a18d-0ab9ea81ea04}*SharedItemsImports = 13
 		src\Workspaces\SharedUtilitiesAndExtensions\Compiler\VisualBasic\VisualBasicCompilerExtensions.projitems*{57ca988d-f010-4bf2-9a2e-07d6dcd2ff2c}*SharedItemsImports = 5
@@ -1513,8 +1513,8 @@ Global
 		src\Analyzers\Core\Analyzers\Analyzers.projitems*{76e96966-4780-4040-8197-bde2879516f4}*SharedItemsImports = 13
 		src\Analyzers\VisualBasic\Tests\VisualBasicAnalyzers.UnitTests.projitems*{7b7f4153-ae93-4908-b8f0-430871589f83}*SharedItemsImports = 13
 		src\Analyzers\VisualBasic\Analyzers\VisualBasicAnalyzers.projitems*{94faf461-2e74-4dbb-9813-6b2cde6f1880}*SharedItemsImports = 13
-		src\Compilers\Server\CommandLine\VBCSCompilerCommandLine.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 5
-		src\Compilers\VisualBasic\CommandLine\VbcCommandLine.projitems*{975cd834-45f4-4ea0-a395-cb60dbd0e214}*SharedItemsImports = 5
+		src\Compilers\Server\VBCSCompiler\VBCSCompilerCommandLine.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 5
+		src\Compilers\VisualBasic\vbc\VbcCommandLine.projitems*{975cd834-45f4-4ea0-a395-cb60dbd0e214}*SharedItemsImports = 5
 		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\Core\WorkspaceExtensions.projitems*{99f594b1-3916-471d-a761-a6731fc50e9a}*SharedItemsImports = 13
 		src\Analyzers\VisualBasic\CodeFixes\VisualBasicCodeFixes.projitems*{9f9ccc78-7487-4127-9d46-db23e501f001}*SharedItemsImports = 13
 		src\Analyzers\CSharp\CodeFixes\CSharpCodeFixes.projitems*{a07abcf5-bc43-4ee9-8fd8-b2d77fd54d73}*SharedItemsImports = 5
@@ -1535,9 +1535,9 @@ Global
 		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{d0bc9be7-24f6-40ca-8dc6-fcb93bd44b34}*SharedItemsImports = 13
 		src\Dependencies\CodeAnalysis.Debugging\Microsoft.CodeAnalysis.Debugging.projitems*{d73adf7d-2c1c-42ae-b2ab-edc9497e4b71}*SharedItemsImports = 13
 		src\Analyzers\CSharp\CodeFixes\CSharpCodeFixes.projitems*{da973826-c985-4128-9948-0b445e638bdb}*SharedItemsImports = 13
-		src\Compilers\Server\CommandLine\VBCSCompilerCommandLine.projitems*{dc8c78cc-b6fe-47bf-93b1-b65a1c67c08d}*SharedItemsImports = 5
+		src\Compilers\Server\VBCSCompiler\VBCSCompilerCommandLine.projitems*{dc8c78cc-b6fe-47bf-93b1-b65a1c67c08d}*SharedItemsImports = 5
 		src\Analyzers\VisualBasic\Tests\VisualBasicAnalyzers.UnitTests.projitems*{e512c6c1-f085-4ad7-b0d9-e8f1a0a2a510}*SharedItemsImports = 5
-		src\Compilers\VisualBasic\CommandLine\VbcCommandLine.projitems*{e58ee9d7-1239-4961-a0c1-f9ec3952c4c1}*SharedItemsImports = 5
+		src\Compilers\VisualBasic\vbc\VbcCommandLine.projitems*{e58ee9d7-1239-4961-a0c1-f9ec3952c4c1}*SharedItemsImports = 5
 		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{e8f0baa5-7327-43d1-9a51-644e81ae55f1}*SharedItemsImports = 13
 		src\Dependencies\Collections\Microsoft.CodeAnalysis.Collections.projitems*{e919dd77-34f8-4f57-8058-4d3ff4c2b241}*SharedItemsImports = 13
 		src\Workspaces\SharedUtilitiesAndExtensions\Workspace\VisualBasic\VisualBasicWorkspaceExtensions.projitems*{e9dbfa41-7a9c-49be-bd36-fd71b31aa9fe}*SharedItemsImports = 13

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -340,6 +340,12 @@ namespace Roslyn.Test.Utilities
                 solution = solution.WithDocumentText(document.Id, SourceText.From(documentText.ToString(), System.Text.Encoding.UTF8));
             }
 
+            foreach (var project in workspace.Projects)
+            {
+                // Ensure all the projects have a valid file path.
+                solution = solution.WithProjectFilePath(project.Id, GetDocumentFilePathFromName(project.FilePath));
+            }
+
             workspace.ChangeSolution(solution);
 
             // Important: We must wait for workspace creation operations to finish.

--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return documents[0];
         }
 
-        public static Project GetProject(this Solution solution, TextDocumentIdentifier projectIdentifier)
+        public static Project? GetProject(this Solution solution, TextDocumentIdentifier projectIdentifier)
             => solution.Projects.Where(project => project.FilePath == projectIdentifier.Uri.LocalPath).SingleOrDefault();
 
         public static async Task<int> GetPositionFromLinePositionAsync(this TextDocument document, LinePosition linePosition, CancellationToken cancellationToken)

--- a/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -100,6 +100,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return documents[0];
         }
 
+        public static Project GetProject(this Solution solution, TextDocumentIdentifier projectIdentifier)
+            => solution.Projects.Where(project => project.FilePath == projectIdentifier.Uri.LocalPath).SingleOrDefault();
+
         public static async Task<int> GetPositionFromLinePositionAsync(this TextDocument document, LinePosition linePosition, CancellationToken cancellationToken)
         {
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -85,7 +86,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
         /// <summary>
         /// Returns all the documents that should be processed in the desired order to process them in.
         /// </summary>
-        protected abstract ValueTask<ImmutableArray<Document>> GetOrderedDocumentsAsync(RequestContext context, CancellationToken cancellationToken);
+        protected abstract ValueTask<ImmutableArray<IDiagnosticSource>> GetOrderedDiagnosticSourcesAsync(RequestContext context, CancellationToken cancellationToken);
 
         /// <summary>
         /// Creates the <see cref="VSInternalDiagnosticReport"/> instance we'll report back to clients to let them know our
@@ -94,11 +95,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
         protected abstract TReport CreateReport(TextDocumentIdentifier identifier, LSP.Diagnostic[]? diagnostics, string? resultId);
 
         protected abstract TReturn? CreateReturn(BufferedProgress<TReport> progress);
-
-        /// <summary>
-        /// Produce the diagnostics for the specified document.
-        /// </summary>
-        protected abstract Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(RequestContext context, Document document, DiagnosticMode diagnosticMode, CancellationToken cancellationToken);
 
         /// <summary>
         /// Generate the right diagnostic tags for a particular diagnostic.
@@ -123,43 +119,44 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             var previousResults = GetPreviousResults(diagnosticsParams) ?? ImmutableArray<PreviousPullResult>.Empty;
             context.TraceInformation($"previousResults.Length={previousResults.Length}");
 
-            // First, let the client know if any workspace documents have gone away.  That way it can remove those for
-            // the user from squiggles or error-list.
-            HandleRemovedDocuments(context, previousResults, progress);
-
             // Create a mapping from documents to the previous results the client says it has for them.  That way as we
             // process documents we know if we should tell the client it should stay the same, or we can tell it what
             // the updated diagnostics are.
-            var documentToPreviousDiagnosticParams = GetDocumentToPreviousDiagnosticParams(context, previousResults);
+            var documentToPreviousDiagnosticParams = GetDocumentToPreviousDiagnosticParams(context, previousResults, out var removedResults);
+
+            // First, let the client know if any workspace documents have gone away.  That way it can remove those for
+            // the user from squiggles or error-list.
+            HandleRemovedDocuments(context, removedResults, progress);
 
             // Next process each file in priority order. Determine if diagnostics are changed or unchanged since the
             // last time we notified the client.  Report back either to the client so they can update accordingly.
-            var orderedDocuments = await GetOrderedDocumentsAsync(context, cancellationToken).ConfigureAwait(false);
-            context.TraceInformation($"Processing {orderedDocuments.Length} documents");
+            var orderedSources = await GetOrderedDiagnosticSourcesAsync(context, cancellationToken).ConfigureAwait(false);
+            context.TraceInformation($"Processing {orderedSources.Length} documents");
 
-            foreach (var document in orderedDocuments)
+            foreach (var diagnosticSource in orderedSources)
             {
                 var encVersion = _editAndContinueDiagnosticUpdateSource.Version;
 
-                var project = document.Project;
+                var project = diagnosticSource.GetProject();
                 var newResultId = await _versionedCache.GetNewResultIdAsync(
                     documentToPreviousDiagnosticParams,
-                    document,
+                    diagnosticSource.GetId(),
+                    project,
                     computeCheapVersionAsync: async () => (encVersion, await project.GetDependentVersionAsync(cancellationToken).ConfigureAwait(false)),
                     computeExpensiveVersionAsync: async () => (encVersion, await project.GetDependentChecksumAsync(cancellationToken).ConfigureAwait(false)),
                     cancellationToken).ConfigureAwait(false);
                 if (newResultId != null)
                 {
-                    progress.Report(await ComputeAndReportCurrentDiagnosticsAsync(context, document, newResultId, context.ClientCapabilities, diagnosticMode, cancellationToken).ConfigureAwait(false));
+                    progress.Report(await ComputeAndReportCurrentDiagnosticsAsync(context, diagnosticSource, newResultId, context.ClientCapabilities, diagnosticMode, cancellationToken).ConfigureAwait(false));
                 }
                 else
                 {
-                    context.TraceInformation($"Diagnostics were unchanged for document: {document.FilePath}");
+                    context.TraceInformation($"Diagnostics were unchanged for document: {diagnosticSource.GetUri()}");
 
                     // Nothing changed between the last request and this one.  Report a (null-diagnostics,
                     // same-result-id) response to the client as that means they should just preserve the current
                     // diagnostics they have for this file.
-                    var previousParams = documentToPreviousDiagnosticParams[document];
+                    var previousParams = documentToPreviousDiagnosticParams[diagnosticSource.GetId()];
                     progress.Report(CreateReport(previousParams.TextDocument, diagnostics: null, previousParams.PreviousResultId));
                 }
             }
@@ -170,23 +167,50 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             return CreateReturn(progress);
         }
 
-        private static Dictionary<Document, PreviousPullResult> GetDocumentToPreviousDiagnosticParams(
-            RequestContext context, ImmutableArray<PreviousPullResult> previousResults)
+        private static Dictionary<ProjectOrDocumentId, PreviousPullResult> GetDocumentToPreviousDiagnosticParams(
+            RequestContext context, ImmutableArray<PreviousPullResult> previousResults, out ImmutableArray<PreviousPullResult> removedDocuments)
         {
             Contract.ThrowIfNull(context.Solution);
 
-            var result = new Dictionary<Document, PreviousPullResult>();
+            var result = new Dictionary<ProjectOrDocumentId, PreviousPullResult>();
+            _ = ArrayBuilder<PreviousPullResult>.GetInstance(out var removedDocumentsBuilder);
             foreach (var diagnosticParams in previousResults)
             {
                 if (diagnosticParams.TextDocument != null)
                 {
-                    var document = context.Solution.GetDocument(diagnosticParams.TextDocument);
-                    if (document != null)
-                        result[document] = diagnosticParams;
+                    var id = GetIdForPreviousResult(diagnosticParams.TextDocument, context.Solution);
+                    if (id != null)
+                    {
+                        result[id.Value] = diagnosticParams;
+                    }
+                    else
+                    {
+                        // The client previously had a result from us for this document, but we no longer have it in our solution.
+                        // Record it so we can report to the client that it has been removed.
+                        removedDocumentsBuilder.Add(diagnosticParams);
+                    }
                 }
             }
 
+            removedDocuments = removedDocumentsBuilder.ToImmutable();
             return result;
+
+            static ProjectOrDocumentId? GetIdForPreviousResult(TextDocumentIdentifier textDocumentIdentifier, Solution solution)
+            {
+                var document = solution.GetDocument(textDocumentIdentifier);
+                if (document != null)
+                {
+                    return new ProjectOrDocumentId(document.Id);
+                }
+
+                var project = solution.GetProject(textDocumentIdentifier);
+                if (project != null)
+                {
+                    return new ProjectOrDocumentId(project.Id);
+                }
+
+                return null;
+            }
         }
 
         private DiagnosticMode GetDiagnosticMode(RequestContext context)
@@ -204,60 +228,42 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 
         private async Task<TReport> ComputeAndReportCurrentDiagnosticsAsync(
             RequestContext context,
-            Document document,
+            IDiagnosticSource diagnosticSource,
             string resultId,
             ClientCapabilities clientCapabilities,
             DiagnosticMode diagnosticMode,
             CancellationToken cancellationToken)
         {
             using var _ = ArrayBuilder<LSP.Diagnostic>.GetInstance(out var result);
-            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var diagnostics = await GetDiagnosticsAsync(context, document, diagnosticMode, cancellationToken).ConfigureAwait(false);
-            context.TraceInformation($"Found {diagnostics.Length} diagnostics for {document.FilePath}");
+            var diagnostics = await diagnosticSource.GetDiagnosticsAsync(DiagnosticAnalyzerService, context, diagnosticMode, cancellationToken).ConfigureAwait(false);
+            context.TraceInformation($"Found {diagnostics.Length} diagnostics for {diagnosticSource.GetUri()}");
 
             foreach (var diagnostic in diagnostics)
-                result.Add(ConvertDiagnostic(document, text, diagnostic, clientCapabilities));
+                result.Add(ConvertDiagnostic(diagnosticSource, diagnostic, clientCapabilities));
 
-            return CreateReport(ProtocolConversions.DocumentToTextDocumentIdentifier(document), result.ToArray(), resultId);
+            return CreateReport(new LSP.TextDocumentIdentifier { Uri = diagnosticSource.GetUri() }, result.ToArray(), resultId);
         }
 
-        private void HandleRemovedDocuments(RequestContext context, ImmutableArray<PreviousPullResult> previousResults, BufferedProgress<TReport> progress)
+        private void HandleRemovedDocuments(RequestContext context, ImmutableArray<PreviousPullResult> removedPreviousResults, BufferedProgress<TReport> progress)
         {
-            Contract.ThrowIfNull(context.Solution);
-
-            foreach (var previousResult in previousResults)
+            foreach (var removedResult in removedPreviousResults)
             {
-                var textDocument = previousResult.TextDocument;
-                if (textDocument != null)
-                {
-                    var document = context.Solution.GetDocument(textDocument);
-                    if (document == null)
-                    {
-                        context.TraceInformation($"Clearing diagnostics for removed document: {textDocument.Uri}");
+                context.TraceInformation($"Clearing diagnostics for removed document: {removedResult.TextDocument.Uri}");
 
-                        // Client is asking server about a document that no longer exists (i.e. was removed/deleted from
-                        // the workspace). Report a (null-diagnostics, null-result-id) response to the client as that
-                        // means they should just consider the file deleted and should remove all diagnostics
-                        // information they've cached for it.
-                        progress.Report(CreateReport(textDocument, diagnostics: null, resultId: null));
-                    }
-                }
+                // Client is asking server about a document that no longer exists (i.e. was removed/deleted from
+                // the workspace). Report a (null-diagnostics, null-result-id) response to the client as that
+                // means they should just consider the file deleted and should remove all diagnostics
+                // information they've cached for it.
+                progress.Report(CreateReport(removedResult.TextDocument, diagnostics: null, resultId: null));
             }
         }
 
-        private LSP.Diagnostic ConvertDiagnostic(Document document, SourceText text, DiagnosticData diagnosticData, ClientCapabilities capabilities)
+        private LSP.Diagnostic ConvertDiagnostic(IDiagnosticSource diagnosticSource, DiagnosticData diagnosticData, ClientCapabilities capabilities)
         {
             Contract.ThrowIfNull(diagnosticData.Message, $"Got a document diagnostic that did not have a {nameof(diagnosticData.Message)}");
-            Contract.ThrowIfNull(diagnosticData.DataLocation, $"Got a document diagnostic that did not have a {nameof(diagnosticData.DataLocation)}");
 
-            var project = document.Project;
+            var project = diagnosticSource.GetProject();
 
-            // We currently do not map diagnostics spans as
-            //   1.  Razor handles span mapping for razor files on their side.
-            //   2.  LSP does not allow us to report document pull diagnostics for a different file path.
-            //   3.  The VS LSP client does not support document pull diagnostics for files outside our content type.
-            //   4.  This matches classic behavior where we only squiggle the original location anyway.
-            var useMappedSpan = false;
             if (!capabilities.HasVisualStudioLspCapability())
             {
                 var diagnostic = CreateBaseLspDiagnostic();
@@ -283,15 +289,51 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             // would get automatically serialized.
             LSP.VSDiagnostic CreateBaseLspDiagnostic()
             {
-                return new LSP.VSDiagnostic
+                var diagnostic = new LSP.VSDiagnostic
                 {
                     Source = "Roslyn",
                     Code = diagnosticData.Id,
                     CodeDescription = ProtocolConversions.HelpLinkToCodeDescription(diagnosticData.GetValidHelpLinkUri()),
                     Message = diagnosticData.Message,
                     Severity = ConvertDiagnosticSeverity(diagnosticData.Severity),
-                    Range = ProtocolConversions.LinePositionToRange(DiagnosticData.GetLinePositionSpan(diagnosticData.DataLocation, text, useMappedSpan)),
                     Tags = ConvertTags(diagnosticData),
+                };
+                var range = GetRange(diagnosticData.DataLocation);
+                if (range != null)
+                {
+                    diagnostic.Range = range;
+                }
+
+                return diagnostic;
+            }
+
+            static Range? GetRange(DiagnosticDataLocation? dataLocation)
+            {
+                if (dataLocation == null)
+                {
+                    return null;
+                }
+
+                // We currently do not map diagnostics spans as
+                //   1.  Razor handles span mapping for razor files on their side.
+                //   2.  LSP does not allow us to report document pull diagnostics for a different file path.
+                //   3.  The VS LSP client does not support document pull diagnostics for files outside our content type.
+                //   4.  This matches classic behavior where we only squiggle the original location anyway.
+
+                // We also do not adjust the diagnostic locations to ensure they are in bounds because we've
+                // explicitly requested up to date diagnostics as of the snapshot we were passed in.
+                return new Range
+                {
+                    Start = new Position
+                    {
+                        Character = dataLocation.OriginalStartColumn,
+                        Line = dataLocation.OriginalStartLine,
+                    },
+                    End = new Position
+                    {
+                        Character = dataLocation.OriginalEndColumn,
+                        Line = dataLocation.OriginalEndLine,
+                    }
                 };
             }
         }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             // Create a mapping from documents to the previous results the client says it has for them.  That way as we
             // process documents we know if we should tell the client it should stay the same, or we can tell it what
             // the updated diagnostics are.
-            var documentToPreviousDiagnosticParams = GetDocumentToPreviousDiagnosticParams(context, previousResults, out var removedResults);
+            var documentToPreviousDiagnosticParams = GetIdToPreviousDiagnosticParams(context, previousResults, out var removedResults);
 
             // First, let the client know if any workspace documents have gone away.  That way it can remove those for
             // the user from squiggles or error-list.
@@ -167,13 +167,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             return CreateReturn(progress);
         }
 
-        private static Dictionary<ProjectOrDocumentId, PreviousPullResult> GetDocumentToPreviousDiagnosticParams(
+        private static Dictionary<ProjectOrDocumentId, PreviousPullResult> GetIdToPreviousDiagnosticParams(
             RequestContext context, ImmutableArray<PreviousPullResult> previousResults, out ImmutableArray<PreviousPullResult> removedDocuments)
         {
             Contract.ThrowIfNull(context.Solution);
 
             var result = new Dictionary<ProjectOrDocumentId, PreviousPullResult>();
-            _ = ArrayBuilder<PreviousPullResult>.GetInstance(out var removedDocumentsBuilder);
+            using var _ = ArrayBuilder<PreviousPullResult>.GetInstance(out var removedDocumentsBuilder);
             foreach (var diagnosticParams in previousResults)
             {
                 if (diagnosticParams.TextDocument != null)

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagnosticHandler.cs
@@ -97,6 +97,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 
         private record struct DocumentDiagnosticSource(Document Document) : IDiagnosticSource
         {
+            public ProjectOrDocumentId GetId() => new(Document.Id);
+
+            public Project GetProject() => Document.Project;
+
+            public Uri GetUri() => Document.GetURI();
+
             public async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(IDiagnosticAnalyzerService diagnosticAnalyzerService, RequestContext context, DiagnosticMode diagnosticMode, CancellationToken cancellationToken)
             {
                 // We call GetDiagnosticsForSpanAsync here instead of GetDiagnosticsForIdsAsync as it has faster perf characteristics.
@@ -104,11 +110,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
                 var allSpanDiagnostics = await diagnosticAnalyzerService.GetDiagnosticsForSpanAsync(Document, range: null, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return allSpanDiagnostics;
             }
-            public ProjectOrDocumentId GetId() => new(Document.Id);
-
-            public Project GetProject() => Document.Project;
-
-            public Uri GetUri() => Document.GetURI();
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DocumentPullDiagnosticHandler.cs
@@ -99,10 +99,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
         {
             public async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(IDiagnosticAnalyzerService diagnosticAnalyzerService, RequestContext context, DiagnosticMode diagnosticMode, CancellationToken cancellationToken)
             {
-                // For open documents, directly use the IDiagnosticAnalyzerService.  This will use the actual snapshots
-                // we're passing in.  If information is already cached for that snapshot, it will be returned.  Otherwise,
-                // it will be computed on demand.  Because it is always accurate as per this snapshot, all spans are correct
-                // and do not need to be adjusted.
+                // We call GetDiagnosticsForSpanAsync here instead of GetDiagnosticsForIdsAsync as it has faster perf characteristics.
+                // GetDiagnosticsForIdsAsync runs analyzers against the entire compilation whereas GetDiagnosticsForSpanAsync will only run analyzers against the request document.
                 var allSpanDiagnostics = await diagnosticAnalyzerService.GetDiagnosticsForSpanAsync(Document, range: null, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return allSpanDiagnostics;
             }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Experimental/ExperimentalDocumentPullDiagnosticsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Experimental/ExperimentalDocumentPullDiagnosticsHandler.cs
@@ -63,15 +63,7 @@ internal class ExperimentalDocumentPullDiagnosticsHandler : AbstractPullDiagnost
         return null;
     }
 
-    protected override Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(RequestContext context, Document document, DiagnosticMode diagnosticMode, CancellationToken cancellationToken)
-    {
-        // We are intentionally getting diagnostics for the up to date LSP snapshot instead of from the IDiagnosticService
-        // as the solution crawler does not run in VSCode.  When the solution crawler is removed from VS, the VS LSP diagnostics
-        // implementation will switch over to up to date calculation.
-        return DiagnosticAnalyzerService.GetDiagnosticsForSpanAsync(document, range: null, cancellationToken: cancellationToken);
-    }
-
-    protected override ValueTask<ImmutableArray<Document>> GetOrderedDocumentsAsync(RequestContext context, CancellationToken cancellationToken)
+    protected override ValueTask<ImmutableArray<IDiagnosticSource>> GetOrderedDiagnosticSourcesAsync(RequestContext context, CancellationToken cancellationToken)
     {
         return ValueTaskFactory.FromResult(DocumentPullDiagnosticHandler.GetRequestedDocument(context));
     }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Experimental/ExperimentalWorkspacePullDiagnosticsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Experimental/ExperimentalWorkspacePullDiagnosticsHandler.cs
@@ -54,13 +54,7 @@ internal class ExperimentalWorkspacePullDiagnosticsHandler : AbstractPullDiagnos
         return null;
     }
 
-    protected override async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(RequestContext context, Document document, DiagnosticMode diagnosticMode, CancellationToken cancellationToken)
-    {
-        var diagnostics = await DiagnosticAnalyzerService.GetDiagnosticsForSpanAsync(document, range: null, cancellationToken: cancellationToken).ConfigureAwait(false);
-        return diagnostics;
-    }
-
-    protected override ValueTask<ImmutableArray<Document>> GetOrderedDocumentsAsync(RequestContext context, CancellationToken cancellationToken)
+    protected override ValueTask<ImmutableArray<IDiagnosticSource>> GetOrderedDiagnosticSourcesAsync(RequestContext context, CancellationToken cancellationToken)
     {
         return WorkspacePullDiagnosticHandler.GetWorkspacePullDocumentsAsync(context, GlobalOptions, cancellationToken);
     }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/IDiagnosticDocument.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/IDiagnosticDocument.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
+internal interface IDiagnosticSource
+{
+    Project GetProject();
+
+    ProjectOrDocumentId GetId();
+
+    Uri GetUri();
+
+    Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
+        IDiagnosticAnalyzerService diagnosticAnalyzerService,
+        RequestContext context,
+        DiagnosticMode diagnosticMode,
+        CancellationToken cancellationToken);
+}

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/IDiagnosticDocument.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/IDiagnosticDocument.cs
@@ -9,6 +9,11 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
+
+/// <summary>
+/// Wrapper around a source for diagnostics (e.g. a <see cref="Project"/> or <see cref="Document"/>)
+/// so that we can share per file diagnostic reporting code in <see cref="AbstractPullDiagnosticHandler{TDiagnosticsParams, TReport, TReturn}"/>
+/// </summary>
 internal interface IDiagnosticSource
 {
     Project GetProject();

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/ProjectOrDocumentId.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/ProjectOrDocumentId.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
+
+internal struct ProjectOrDocumentId
+{
+    public object Id { get; }
+
+    public ProjectOrDocumentId(ProjectId projectId)
+    {
+        Id = projectId;
+    }
+
+    public ProjectOrDocumentId(DocumentId documentId)
+    {
+        Id = documentId;
+    }
+}

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/ProjectOrDocumentId.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/ProjectOrDocumentId.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 
 /// <summary>
@@ -11,17 +13,26 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 internal readonly struct ProjectOrDocumentId
 {
     /// <summary>
-    /// Holds the actual <see cref="DocumentId"/> or <see cref="ProjectId"/> for equality comparison.
+    /// Non-null if this represents a documentId.  Used for equality comparisons.
     /// </summary>
-    public object Id { get; }
+    [SuppressMessage("CodeQuality", "IDE0052:Remove unread private members", Justification = "Used for equality comparison.")]
+    private readonly DocumentId? _documentId;
+
+    /// <summary>
+    /// Non-null if this represents a projectId.  Used for equality comparisons.
+    /// </summary>
+    [SuppressMessage("CodeQuality", "IDE0052:Remove unread private members", Justification = "Used for equality comparison.")]
+    private readonly ProjectId? _projectId;
 
     public ProjectOrDocumentId(ProjectId projectId)
     {
-        Id = projectId;
+        _projectId = projectId;
+        _documentId = null;
     }
 
     public ProjectOrDocumentId(DocumentId documentId)
     {
-        Id = documentId;
+        _documentId = documentId;
+        _projectId = null;
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/ProjectOrDocumentId.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/ProjectOrDocumentId.cs
@@ -8,8 +8,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 /// Wrapper around project and document ids for convenience in caching diagnostic results and
 /// use in the <see cref="IDiagnosticSource"/>
 /// </summary>
-internal struct ProjectOrDocumentId
+internal readonly struct ProjectOrDocumentId
 {
+    /// <summary>
+    /// Holds the actual <see cref="DocumentId"/> or <see cref="ProjectId"/> for equality comparison.
+    /// </summary>
     public object Id { get; }
 
     public ProjectOrDocumentId(ProjectId projectId)

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/ProjectOrDocumentId.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/ProjectOrDocumentId.cs
@@ -4,6 +4,10 @@
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 
+/// <summary>
+/// Wrapper around project and document ids for convenience in caching diagnostic results and
+/// use in the <see cref="IDiagnosticSource"/>
+/// </summary>
 internal struct ProjectOrDocumentId
 {
     public object Id { get; }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/WorkspacePullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/WorkspacePullDiagnosticHandler.cs
@@ -163,6 +163,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 
         private record struct ProjectDiagnosticSource(Project Project) : IDiagnosticSource
         {
+            public ProjectOrDocumentId GetId() => new(Project.Id);
+
+            public Project GetProject() => Project;
+
+            public Uri GetUri()
+            {
+                Contract.ThrowIfNull(Project.FilePath);
+                return ProtocolConversions.GetUriFromFilePath(Project.FilePath);
+            }
+
             public async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
                 IDiagnosticAnalyzerService diagnosticAnalyzerService,
                 RequestContext context,
@@ -176,20 +186,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
                 var projectDiagnostics = await diagnosticAnalyzerService.GetProjectDiagnosticsForIdsAsync(Project.Solution, Project.Id, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return projectDiagnostics;
             }
-
-            public ProjectOrDocumentId GetId() => new(Project.Id);
-
-            public Project GetProject() => Project;
-
-            public Uri GetUri()
-            {
-                Contract.ThrowIfNull(Project.FilePath);
-                return ProtocolConversions.GetUriFromFilePath(Project.FilePath);
-            }
         }
 
         private record struct WorkspaceDocumentDiagnosticSource(Document Document) : IDiagnosticSource
         {
+            public ProjectOrDocumentId GetId() => new(Document.Id);
+
+            public Project GetProject() => Document.Project;
+
+            public Uri GetUri() => Document.GetURI();
+
             public async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
                 IDiagnosticAnalyzerService diagnosticAnalyzerService,
                 RequestContext context,
@@ -211,12 +217,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
                     return documentDiagnostics;
                 }
             }
-
-            public ProjectOrDocumentId GetId() => new(Document.Id);
-
-            public Project GetProject() => Document.Project;
-
-            public Uri GetUri() => Document.GetURI();
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/PullHandlers/VersionedPullCache`1.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/PullHandlers/VersionedPullCache`1.cs
@@ -4,8 +4,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler
@@ -28,8 +31,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             CancellationToken cancellationToken)
         {
             return GetNewResultIdAsync(
-                documentToPreviousDiagnosticParams,
-                document,
+                documentToPreviousDiagnosticParams.ToDictionary(kvp => new ProjectOrDocumentId(kvp.Key.Id), kvp => kvp.Value),
+                new ProjectOrDocumentId(document.Id),
+                document.Project,
                 computeVersionAsync,
                 computeExpensiveVersionAsync: SpecializedTasks.Null<object>,
                 cancellationToken);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
@@ -1,0 +1,272 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics.Experimental;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.SolutionCrawler;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
+{
+    using DocumentDiagnosticPartialReport = SumType<SumType<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>, DocumentDiagnosticPartialResult>;
+
+    public abstract class AbstractPullDiagnosticTestsBase : AbstractLanguageServerProtocolTests
+    {
+        protected virtual ImmutableDictionary<string, ImmutableArray<DiagnosticAnalyzer>> TestAnalyzers => DiagnosticExtensions.GetCompilerDiagnosticAnalyzersMap()
+            .Add(InternalLanguageNames.TypeScript, ImmutableArray.Create<DiagnosticAnalyzer>(new MockTypescriptDiagnosticAnalyzer()));
+
+        protected override TestComposition Composition => base.Composition.AddParts(typeof(MockTypescriptDiagnosticAnalyzer));
+
+        private protected static async Task<ImmutableArray<TestDiagnosticResult>> RunGetWorkspacePullDiagnosticsAsync(
+            TestLspServer testLspServer,
+            bool useVSDiagnostics,
+            ImmutableArray<(string resultId, Uri uri)>? previousResults = null,
+            bool useProgress = false)
+        {
+            await testLspServer.WaitForDiagnosticsAsync();
+
+            if (useVSDiagnostics)
+            {
+                BufferedProgress<VSInternalWorkspaceDiagnosticReport>? progress = useProgress ? BufferedProgress.Create<VSInternalWorkspaceDiagnosticReport>(null) : null;
+                var diagnostics = await testLspServer.ExecuteRequestAsync<VSInternalWorkspaceDiagnosticsParams, VSInternalWorkspaceDiagnosticReport[]>(
+                VSInternalMethods.WorkspacePullDiagnosticName,
+                CreateWorkspaceDiagnosticParams(previousResults, progress),
+                CancellationToken.None).ConfigureAwait(false);
+
+                if (useProgress)
+                {
+                    Assert.Null(diagnostics);
+                    diagnostics = progress!.Value.GetValues();
+                }
+
+                AssertEx.NotNull(diagnostics);
+                return diagnostics.Select(d => new TestDiagnosticResult(d.TextDocument!.Uri, d.ResultId!, d.Diagnostics)).ToImmutableArray();
+            }
+            else
+            {
+                BufferedProgress<WorkspaceDiagnosticReport>? progress = useProgress ? BufferedProgress.Create<WorkspaceDiagnosticReport>(null) : null;
+                var returnedResult = await testLspServer.ExecuteRequestAsync<WorkspaceDiagnosticParams, WorkspaceDiagnosticReport?>(
+                    ExperimentalMethods.WorkspaceDiagnostic,
+                    CreateProposedWorkspaceDiagnosticParams(previousResults, progress),
+                    CancellationToken.None).ConfigureAwait(false);
+
+                if (useProgress)
+                {
+                    Assert.Null(returnedResult);
+                    var progressValues = progress!.Value.GetValues();
+                    Assert.NotNull(progressValues);
+                    return progressValues.SelectMany(value => value.Items).Select(diagnostics => ConvertWorkspaceDiagnosticResult(diagnostics)).ToImmutableArray();
+
+                }
+
+                AssertEx.NotNull(returnedResult);
+                return returnedResult.Items.Select(diagnostics => ConvertWorkspaceDiagnosticResult(diagnostics)).ToImmutableArray();
+            }
+
+            static WorkspaceDiagnosticParams CreateProposedWorkspaceDiagnosticParams(
+                ImmutableArray<(string resultId, Uri uri)>? previousResults = null,
+                IProgress<WorkspaceDiagnosticReport[]>? progress = null)
+            {
+                var previousResultsLsp = previousResults?.Select(r => new PreviousResultId(r.uri, r.resultId)).ToArray() ?? Array.Empty<PreviousResultId>();
+                return new WorkspaceDiagnosticParams(identifier: null, previousResultsLsp, workDoneToken: null, partialResultToken: progress);
+            }
+
+            static TestDiagnosticResult ConvertWorkspaceDiagnosticResult(SumType<WorkspaceFullDocumentDiagnosticReport, WorkspaceUnchangedDocumentDiagnosticReport> workspaceReport)
+            {
+                if (workspaceReport.Value is WorkspaceFullDocumentDiagnosticReport fullReport)
+                {
+                    return new TestDiagnosticResult(fullReport.Uri, fullReport.ResultId!, fullReport.Items);
+                }
+                else
+                {
+                    var unchangedReport = (WorkspaceUnchangedDocumentDiagnosticReport)workspaceReport.Value!;
+                    return new TestDiagnosticResult(unchangedReport.Uri, unchangedReport.ResultId!, null);
+                }
+            }
+        }
+
+        private protected static Task CloseDocumentAsync(TestLspServer testLspServer, Document document) => testLspServer.CloseDocumentAsync(document.GetURI());
+
+        private protected static ImmutableArray<(string resultId, Uri uri)> CreateDiagnosticParamsFromPreviousReports(ImmutableArray<TestDiagnosticResult> results)
+        {
+            return results.Select(r => (r.ResultId, r.Uri)).ToImmutableArray();
+        }
+
+        private protected static VSInternalDocumentDiagnosticsParams CreateDocumentDiagnosticParams(
+            Uri uri,
+            string? previousResultId = null,
+            IProgress<VSInternalDiagnosticReport[]>? progress = null)
+        {
+            return new VSInternalDocumentDiagnosticsParams
+            {
+                TextDocument = new LSP.TextDocumentIdentifier { Uri = uri },
+                PreviousResultId = previousResultId,
+                PartialResultToken = progress,
+            };
+        }
+
+        private protected static VSInternalWorkspaceDiagnosticsParams CreateWorkspaceDiagnosticParams(
+            ImmutableArray<(string resultId, Uri uri)>? previousResults = null,
+            IProgress<VSInternalWorkspaceDiagnosticReport[]>? progress = null)
+        {
+            return new VSInternalWorkspaceDiagnosticsParams
+            {
+                PreviousResults = previousResults?.Select(r => new VSInternalDiagnosticParams { PreviousResultId = r.resultId, TextDocument = new TextDocumentIdentifier { Uri = r.uri } }).ToArray(),
+                PartialResultToken = progress,
+            };
+        }
+
+        private protected static async Task InsertTextAsync(
+            TestLspServer testLspServer,
+            Document document,
+            int position,
+            string text)
+        {
+            var sourceText = await document.GetTextAsync();
+            var lineInfo = sourceText.Lines.GetLinePositionSpan(new TextSpan(position, 0));
+
+            await testLspServer.InsertTextAsync(document.GetURI(), (lineInfo.Start.Line, lineInfo.Start.Character, text));
+        }
+
+        private protected static Task OpenDocumentAsync(TestLspServer testLspServer, Document document) => testLspServer.OpenDocumentAsync(document.GetURI());
+
+        private protected static async Task<ImmutableArray<TestDiagnosticResult>> RunGetDocumentPullDiagnosticsAsync(
+            TestLspServer testLspServer,
+            Uri uri,
+            bool useVSDiagnostics,
+            string? previousResultId = null,
+            bool useProgress = false)
+        {
+            await testLspServer.WaitForDiagnosticsAsync();
+
+            if (useVSDiagnostics)
+            {
+                BufferedProgress<VSInternalDiagnosticReport>? progress = useProgress ? BufferedProgress.Create<VSInternalDiagnosticReport>(null) : null;
+                var diagnostics = await testLspServer.ExecuteRequestAsync<VSInternalDocumentDiagnosticsParams, VSInternalDiagnosticReport[]>(
+                    VSInternalMethods.DocumentPullDiagnosticName,
+                    CreateDocumentDiagnosticParams(uri, previousResultId, progress),
+                    CancellationToken.None).ConfigureAwait(false);
+
+                if (useProgress)
+                {
+                    Assert.Null(diagnostics);
+                    diagnostics = progress!.Value.GetValues();
+                }
+
+                AssertEx.NotNull(diagnostics);
+                return diagnostics.Select(d => new TestDiagnosticResult(uri, d.ResultId!, d.Diagnostics)).ToImmutableArray();
+            }
+            else
+            {
+                BufferedProgress<DocumentDiagnosticPartialReport>? progress = useProgress ? BufferedProgress.Create<DocumentDiagnosticPartialReport>(null) : null;
+                var diagnostics = await testLspServer.ExecuteRequestAsync<DocumentDiagnosticParams, SumType<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>?>(
+                    ExperimentalMethods.TextDocumentDiagnostic,
+                    CreateProposedDocumentDiagnosticParams(uri, previousResultId, progress),
+                    CancellationToken.None).ConfigureAwait(false);
+                if (useProgress)
+                {
+                    Assert.Null(diagnostics);
+                    diagnostics = progress!.Value.GetValues().Single().First;
+                }
+
+                if (diagnostics == null)
+                {
+                    // The public LSP spec returns null when no diagnostics are available for a document wheres VS returns an empty array.
+                    return ImmutableArray<TestDiagnosticResult>.Empty;
+                }
+                else if (diagnostics.Value.Value is UnchangedDocumentDiagnosticReport)
+                {
+                    // The public LSP spec returns different types when unchanged in contrast to VS which just returns null diagnostic array.
+                    return ImmutableArray.Create(new TestDiagnosticResult(uri, diagnostics.Value.Second.ResultId!, null));
+                }
+                else
+                {
+                    return ImmutableArray.Create(new TestDiagnosticResult(uri, diagnostics.Value.First.ResultId!, diagnostics.Value.First.Items));
+                }
+            }
+
+            static DocumentDiagnosticParams CreateProposedDocumentDiagnosticParams(
+                Uri uri,
+                string? previousResultId = null,
+                IProgress<DocumentDiagnosticPartialReport[]>? progress = null)
+            {
+                return new DocumentDiagnosticParams(new TextDocumentIdentifier { Uri = uri }, null, previousResultId, progress, null);
+            }
+        }
+
+        private protected Task<TestLspServer> CreateTestWorkspaceWithDiagnosticsAsync(string markup, BackgroundAnalysisScope scope, bool useVSDiagnostics, bool pullDiagnostics = true)
+            => CreateTestWorkspaceWithDiagnosticsAsync(markup, scope, pullDiagnostics ? DiagnosticMode.Pull : DiagnosticMode.Push, useVSDiagnostics);
+
+        private protected async Task<TestLspServer> CreateTestWorkspaceFromXmlAsync(string xmlMarkup, BackgroundAnalysisScope scope, bool useVSDiagnostics, bool pullDiagnostics = true)
+        {
+            var testLspServer = await CreateXmlTestLspServerAsync(xmlMarkup, clientCapabilities: useVSDiagnostics ? CapabilitiesWithVSExtensions : new LSP.ClientCapabilities());
+            InitializeDiagnostics(scope, testLspServer, pullDiagnostics ? DiagnosticMode.Pull : DiagnosticMode.Push);
+            return testLspServer;
+        }
+
+        private protected async Task<TestLspServer> CreateTestWorkspaceWithDiagnosticsAsync(string markup, BackgroundAnalysisScope scope, DiagnosticMode mode, bool useVSDiagnostics, WellKnownLspServerKinds serverKind = WellKnownLspServerKinds.AlwaysActiveVSLspServer)
+        {
+            var testLspServer = await CreateTestLspServerAsync(markup, useVSDiagnostics ? CapabilitiesWithVSExtensions : new LSP.ClientCapabilities(), serverKind);
+            InitializeDiagnostics(scope, testLspServer, mode);
+            return testLspServer;
+        }
+
+        private protected Task<TestLspServer> CreateTestWorkspaceWithDiagnosticsAsync(string[] markups, BackgroundAnalysisScope scope, bool useVSDiagnostics, bool pullDiagnostics = true)
+            => CreateTestWorkspaceWithDiagnosticsAsync(markups, Array.Empty<string>(), scope, useVSDiagnostics, pullDiagnostics);
+
+        private protected async Task<TestLspServer> CreateTestWorkspaceWithDiagnosticsAsync(string[] markups, string[] sourceGeneratedMarkups, BackgroundAnalysisScope scope, bool useVSDiagnostics, bool pullDiagnostics = true)
+        {
+            var testLspServer = await CreateTestLspServerAsync(markups, sourceGeneratedMarkups, useVSDiagnostics ? CapabilitiesWithVSExtensions : new LSP.ClientCapabilities());
+            InitializeDiagnostics(scope, testLspServer, pullDiagnostics ? DiagnosticMode.Pull : DiagnosticMode.Push);
+            return testLspServer;
+        }
+
+        private void InitializeDiagnostics(BackgroundAnalysisScope scope, TestLspServer testLspServer, DiagnosticMode diagnosticMode)
+        {
+            var analyzerReference = new TestAnalyzerReferenceByLanguage(TestAnalyzers);
+            testLspServer.InitializeDiagnostics(scope, diagnosticMode, analyzerReference);
+        }
+
+        /// <summary>
+        /// Helper type to store unified LSP diagnostic results.
+        /// Diagnostics are null when unchanged.
+        /// </summary>
+        private protected record TestDiagnosticResult(Uri Uri, string ResultId, LSP.Diagnostic[]? Diagnostics)
+        {
+            public TextDocumentIdentifier TextDocument { get; } = new TextDocumentIdentifier { Uri = Uri };
+        }
+
+        [DiagnosticAnalyzer(InternalLanguageNames.TypeScript), PartNotDiscoverable]
+        private class MockTypescriptDiagnosticAnalyzer : DocumentDiagnosticAnalyzer
+        {
+            public static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+            "TS01", "TS error", "TS error", "Error", DiagnosticSeverity.Error, isEnabledByDefault: true);
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+            public override Task<ImmutableArray<Diagnostic>> AnalyzeSemanticsAsync(Document document, CancellationToken cancellationToken)
+                => SpecializedTasks.EmptyImmutableArray<Diagnostic>();
+
+            public override Task<ImmutableArray<Diagnostic>> AnalyzeSyntaxAsync(Document document, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(ImmutableArray.Create(
+                    Diagnostic.Create(Descriptor, Location.Create(document.FilePath!, default, default))));
+            }
+        }
+    }
+}

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/WorkspaceProjectDiagnosticsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/WorkspaceProjectDiagnosticsTests.cs
@@ -1,0 +1,88 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.SolutionCrawler;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics;
+public class WorkspaceProjectDiagnosticsTests : AbstractPullDiagnosticTestsBase
+{
+    [Theory, CombinatorialData]
+    public async Task TestWorkspaceDiagnosticsReportsProjectDiagnostic(bool useVSDiagnostics)
+    {
+        using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(string.Empty, BackgroundAnalysisScope.FullSolution, useVSDiagnostics);
+
+        var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
+
+        Assert.Equal(2, results.Length);
+        Assert.Empty(results[0].Diagnostics);
+        Assert.Equal(MockProjectDiagnosticAnalyzer.Id, results[1].Diagnostics.Single().Code);
+        Assert.Equal(ProtocolConversions.GetUriFromFilePath(testLspServer.GetCurrentSolution().Projects.First().FilePath!), results[1].Uri);
+
+        // Asking again should give us back an unchanged diagnostic.
+        var results2 = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics, previousResults: CreateDiagnosticParamsFromPreviousReports(results));
+        Assert.Null(results2[0].Diagnostics);
+        Assert.Null(results2[1].Diagnostics);
+        Assert.Equal(results[1].ResultId, results2[1].ResultId);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestWorkspaceDiagnosticsWithRemovedProject(bool useVSDiagnostics)
+    {
+        using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(string.Empty, BackgroundAnalysisScope.FullSolution, useVSDiagnostics);
+
+        var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
+
+        Assert.Equal(2, results.Length);
+        Assert.Empty(results[0].Diagnostics);
+        Assert.Equal(MockProjectDiagnosticAnalyzer.Id, results[1].Diagnostics.Single().Code);
+        Assert.Equal(ProtocolConversions.GetUriFromFilePath(testLspServer.GetCurrentSolution().Projects.First().FilePath!), results[1].Uri);
+
+        var initialSolution = testLspServer.GetCurrentSolution();
+        var newSolution = initialSolution.RemoveProject(initialSolution.Projects.First().Id);
+        await testLspServer.TestWorkspace.ChangeSolutionAsync(newSolution);
+
+        var results2 = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics, previousResults: CreateDiagnosticParamsFromPreviousReports(results));
+        Assert.Equal(2, results2.Length);
+        Assert.Null(results2[0].Diagnostics);
+        Assert.Null(results2[0].ResultId);
+        Assert.Null(results2[1].Diagnostics);
+        Assert.Null(results2[1].ResultId);
+    }
+
+    protected override TestComposition Composition => base.Composition.AddParts(typeof(MockProjectDiagnosticAnalyzer));
+
+    protected override ImmutableDictionary<string, ImmutableArray<DiagnosticAnalyzer>> TestAnalyzers
+        => ImmutableDictionary.Create<string, ImmutableArray<DiagnosticAnalyzer>>()
+        .Add(LanguageNames.CSharp, ImmutableArray.Create(DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.CSharp), new MockProjectDiagnosticAnalyzer()));
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp), PartNotDiscoverable]
+    private class MockProjectDiagnosticAnalyzer : DiagnosticAnalyzer
+    {
+        public const string Id = "MockProjectDiagnostic";
+        private readonly DiagnosticDescriptor _descriptor = new(Id, "MockProjectDiagnostic", "MockProjectDiagnostic", "InternalCategory", DiagnosticSeverity.Warning, isEnabledByDefault: true, helpLinkUri: "https://github.com/dotnet/roslyn");
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+            => ImmutableArray.Create(_descriptor);
+
+        public override void Initialize(AnalysisContext context)
+            => context.RegisterCompilationStartAction(CreateAnalyzerWithinCompilation);
+
+        public void CreateAnalyzerWithinCompilation(CompilationStartAnalysisContext context)
+            => context.RegisterCompilationEndAction(AnalyzeCompilation);
+
+        public void AnalyzeCompilation(CompilationAnalysisContext context)
+            => context.ReportDiagnostic(Diagnostic.Create(_descriptor, location: null, "args"));
+    }
+}


### PR DESCRIPTION
Previously we walked each document in the solution and reported diagnostics per document.  This of course doesn't work for project level diagnostics or additional file diagnostics.

In this PR I add support for project level diagnostics in LSP workspace pull when FSA is on.  Additional file diagnostics will come later (requires this to be fixed as well: https://github.com/dotnet/roslyn/issues/61789).

The general approach in this PR is to create diagnostic reports for project files as well.  The project reports will associate the set of project file diagnostics with the project file URI.  The main changes in this PR are adding abstractions around the diagnostic source (document or project) so we can re-use the same reporting code for both.

Looks like
![image](https://user-images.githubusercontent.com/5749229/173164549-f98a9b62-4f19-4106-9326-0af186382c1f.png)
