### PR TITLE
Use the complete branch name in DartLab yml

### DIFF
--- a/azure-pipelines-integration-dartlab.yml
+++ b/azure-pipelines-integration-dartlab.yml
@@ -20,7 +20,7 @@ resources:
     endpoint: dnceng/internal dotnet-roslyn
     type: git
     name: internal/dotnet-roslyn
-    ref: $(Build.SourceBranchName)
+    ref: $(Build.SourceBranch)
     trigger:
     - main
 


### PR DESCRIPTION
When branch names contain `/` the Build.SourceBranchName variable only includes the last part of the branch name. Build.SourceBranch includes the entire branch name.

Test Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6272677&view=results (microsoft)