### PR TITLE
Global options tests

### DIFF
--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
         {
             var syntaxTree = context.Node.SyntaxTree;
 
-            var fadeOutCode = context.GetIdeAnalyzerOptions().FadeOutComplexObjectInitialization;
+            var fadeOutCode = context.GetIdeAnalyzerOptions().FadeOutComplexCollectionInitialization;
             if (!fadeOutCode)
                 return;
 

--- a/src/EditorFeatures/Core/InlineHints/InlineHintsOptionsStorage.cs
+++ b/src/EditorFeatures/Core/InlineHints/InlineHintsOptionsStorage.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.InlineHints
             {
                 ParameterOptions = globalOptions.GetInlineParameterHintsOptions(language),
                 TypeOptions = globalOptions.GetInlineTypeHintsOptions(language),
-                DisplayOptions = globalOptions.GetSymbolDescriptionOptions(language)
+                DisplayOptions = globalOptions.GetSymbolDescriptionOptions(language),
             };
 
         public static InlineParameterHintsOptions GetInlineParameterHintsOptions(this IGlobalOptionService globalOptions, string language)
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.InlineHints
                 ForOtherParameters = globalOptions.GetOption(ForOtherParameters, language),
                 SuppressForParametersThatDifferOnlyBySuffix = globalOptions.GetOption(SuppressForParametersThatDifferOnlyBySuffix, language),
                 SuppressForParametersThatMatchMethodIntent = globalOptions.GetOption(SuppressForParametersThatMatchMethodIntent, language),
-                SuppressForParametersThatMatchArgumentName = globalOptions.GetOption(SuppressForParametersThatMatchArgumentName, language)
+                SuppressForParametersThatMatchArgumentName = globalOptions.GetOption(SuppressForParametersThatMatchArgumentName, language),
             };
 
         public static InlineTypeHintsOptions GetInlineTypeHintsOptions(this IGlobalOptionService globalOptions, string language)
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.InlineHints
               EnabledForTypes = globalOptions.GetOption(EnabledForTypes, language),
               ForImplicitVariableTypes = globalOptions.GetOption(ForImplicitVariableTypes, language),
               ForLambdaParameterTypes = globalOptions.GetOption(ForLambdaParameterTypes, language),
-              ForImplicitObjectCreation = globalOptions.GetOption(ForImplicitObjectCreation, language)
+              ForImplicitObjectCreation = globalOptions.GetOption(ForImplicitObjectCreation, language),
           };
 
         private const string FeatureName = "InlineHintsOptions";

--- a/src/EditorFeatures/Core/InlineHints/InlineHintsOptionsStorage.cs
+++ b/src/EditorFeatures/Core/InlineHints/InlineHintsOptionsStorage.cs
@@ -10,28 +10,34 @@ namespace Microsoft.CodeAnalysis.InlineHints
     internal static class InlineHintsOptionsStorage
     {
         public static InlineHintsOptions GetInlineHintsOptions(this IGlobalOptionService globalOptions, string language)
-            => new(
-                ParameterOptions: globalOptions.GetInlineParameterHintsOptions(language),
-                TypeOptions: globalOptions.GetInlineTypeHintsOptions(language),
-                DisplayOptions: globalOptions.GetSymbolDescriptionOptions(language));
+            => new()
+            {
+                ParameterOptions = globalOptions.GetInlineParameterHintsOptions(language),
+                TypeOptions = globalOptions.GetInlineTypeHintsOptions(language),
+                DisplayOptions = globalOptions.GetSymbolDescriptionOptions(language)
+            };
 
         public static InlineParameterHintsOptions GetInlineParameterHintsOptions(this IGlobalOptionService globalOptions, string language)
-            => new(
-                EnabledForParameters: globalOptions.GetOption(EnabledForParameters, language),
-                ForLiteralParameters: globalOptions.GetOption(ForLiteralParameters, language),
-                ForIndexerParameters: globalOptions.GetOption(ForIndexerParameters, language),
-                ForObjectCreationParameters: globalOptions.GetOption(ForObjectCreationParameters, language),
-                ForOtherParameters: globalOptions.GetOption(ForOtherParameters, language),
-                SuppressForParametersThatDifferOnlyBySuffix: globalOptions.GetOption(SuppressForParametersThatDifferOnlyBySuffix, language),
-                SuppressForParametersThatMatchMethodIntent: globalOptions.GetOption(SuppressForParametersThatMatchMethodIntent, language),
-                SuppressForParametersThatMatchArgumentName: globalOptions.GetOption(SuppressForParametersThatMatchArgumentName, language));
+            => new()
+            {
+                EnabledForParameters = globalOptions.GetOption(EnabledForParameters, language),
+                ForLiteralParameters = globalOptions.GetOption(ForLiteralParameters, language),
+                ForIndexerParameters = globalOptions.GetOption(ForIndexerParameters, language),
+                ForObjectCreationParameters = globalOptions.GetOption(ForObjectCreationParameters, language),
+                ForOtherParameters = globalOptions.GetOption(ForOtherParameters, language),
+                SuppressForParametersThatDifferOnlyBySuffix = globalOptions.GetOption(SuppressForParametersThatDifferOnlyBySuffix, language),
+                SuppressForParametersThatMatchMethodIntent = globalOptions.GetOption(SuppressForParametersThatMatchMethodIntent, language),
+                SuppressForParametersThatMatchArgumentName = globalOptions.GetOption(SuppressForParametersThatMatchArgumentName, language)
+            };
 
         public static InlineTypeHintsOptions GetInlineTypeHintsOptions(this IGlobalOptionService globalOptions, string language)
-          => new(
-                EnabledForTypes: globalOptions.GetOption(EnabledForTypes, language),
-                ForImplicitVariableTypes: globalOptions.GetOption(ForImplicitVariableTypes, language),
-                ForLambdaParameterTypes: globalOptions.GetOption(ForLambdaParameterTypes, language),
-                ForImplicitObjectCreation: globalOptions.GetOption(ForImplicitObjectCreation, language));
+          => new()
+          {
+              EnabledForTypes = globalOptions.GetOption(EnabledForTypes, language),
+              ForImplicitVariableTypes = globalOptions.GetOption(ForImplicitVariableTypes, language),
+              ForLambdaParameterTypes = globalOptions.GetOption(ForLambdaParameterTypes, language),
+              ForImplicitObjectCreation = globalOptions.GetOption(ForImplicitObjectCreation, language)
+          };
 
         private const string FeatureName = "InlineHintsOptions";
 

--- a/src/EditorFeatures/Core/QuickInfo/QuickInfoOptionsStorage.cs
+++ b/src/EditorFeatures/Core/QuickInfo/QuickInfoOptionsStorage.cs
@@ -9,9 +9,11 @@ namespace Microsoft.CodeAnalysis.QuickInfo
     internal static class QuickInfoOptionsStorage
     {
         public static QuickInfoOptions GetQuickInfoOptions(this IGlobalOptionService globalOptions, string? language)
-          => new(
-              ShowRemarksInQuickInfo: globalOptions.GetOption(ShowRemarksInQuickInfo, language),
-              IncludeNavigationHintsInQuickInfo: globalOptions.GetOption(IncludeNavigationHintsInQuickInfo));
+          => new()
+          {
+              ShowRemarksInQuickInfo = globalOptions.GetOption(ShowRemarksInQuickInfo, language),
+              IncludeNavigationHintsInQuickInfo = globalOptions.GetOption(IncludeNavigationHintsInQuickInfo)
+          };
 
         private const string FeatureName = "QuickInfoOptions";
 

--- a/src/EditorFeatures/Core/QuickInfo/QuickInfoOptionsStorage.cs
+++ b/src/EditorFeatures/Core/QuickInfo/QuickInfoOptionsStorage.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.QuickInfo
           => new()
           {
               ShowRemarksInQuickInfo = globalOptions.GetOption(ShowRemarksInQuickInfo, language),
-              IncludeNavigationHintsInQuickInfo = globalOptions.GetOption(IncludeNavigationHintsInQuickInfo)
+              IncludeNavigationHintsInQuickInfo = globalOptions.GetOption(IncludeNavigationHintsInQuickInfo),
           };
 
         private const string FeatureName = "QuickInfoOptions";

--- a/src/EditorFeatures/Core/SymbolDisplay/SymbolDescriptionOptionsStorage.cs
+++ b/src/EditorFeatures/Core/SymbolDisplay/SymbolDescriptionOptionsStorage.cs
@@ -11,8 +11,10 @@ namespace Microsoft.CodeAnalysis.LanguageServices
     internal static class SymbolDescriptionOptionsStorage
     {
         public static SymbolDescriptionOptions GetSymbolDescriptionOptions(this IGlobalOptionService globalOptions, string language)
-            => new(
-                QuickInfoOptions: globalOptions.GetQuickInfoOptions(language),
-                ClassificationOptions: globalOptions.GetClassificationOptions(language));
+            => new()
+            {
+                QuickInfoOptions = globalOptions.GetQuickInfoOptions(language),
+                ClassificationOptions = globalOptions.GetClassificationOptions(language)
+            };
     }
 }

--- a/src/EditorFeatures/Core/SymbolDisplay/SymbolDescriptionOptionsStorage.cs
+++ b/src/EditorFeatures/Core/SymbolDisplay/SymbolDescriptionOptionsStorage.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
             => new()
             {
                 QuickInfoOptions = globalOptions.GetQuickInfoOptions(language),
-                ClassificationOptions = globalOptions.GetClassificationOptions(language)
+                ClassificationOptions = globalOptions.GetClassificationOptions(language),
             };
     }
 }

--- a/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
+++ b/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
@@ -55,21 +55,9 @@ public class GlobalOptionsTests
             AccessedOptionKeys.Add(key);
         }
 
-        public T GetOption<T>(Option<T> option)
-        {
-            OnOptionAccessed(option);
-            return (T)GetNonEqualValue(typeof(T), option.DefaultValue);
-        }
-
         public T GetOption<T>(Option2<T> option)
         {
             OnOptionAccessed(new OptionKey(option));
-            return (T)GetNonEqualValue(typeof(T), option.DefaultValue);
-        }
-
-        public T GetOption<T>(PerLanguageOption<T> option, string? languageName)
-        {
-            OnOptionAccessed(new OptionKey(option, languageName));
             return (T)GetNonEqualValue(typeof(T), option.DefaultValue);
         }
 
@@ -99,12 +87,6 @@ public class GlobalOptionsTests
         public ImmutableArray<object?> GetOptions(ImmutableArray<OptionKey> optionKeys)
             => throw new NotImplementedException();
 
-        public IEnumerable<IOption> GetRegisteredOptions()
-            => throw new NotImplementedException();
-
-        public ImmutableHashSet<IOption> GetRegisteredSerializableOptions(ImmutableHashSet<string> languages)
-            => throw new NotImplementedException();
-
         public void RefreshOption(OptionKey optionKey, object? newValue)
             => throw new NotImplementedException();
 
@@ -115,9 +97,6 @@ public class GlobalOptionsTests
             => throw new NotImplementedException();
 
         public void SetOptions(OptionSet optionSet, IEnumerable<OptionKey> optionKeys)
-            => throw new NotImplementedException();
-
-        public bool TryMapEditorConfigKeyToOption(string key, string? language, [NotNullWhen(true)] out IEditorConfigStorageLocation2? storageLocation, out OptionKey optionKey)
             => throw new NotImplementedException();
 
         #endregion

--- a/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
+++ b/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
@@ -92,9 +92,6 @@ public class GlobalOptionsTests
         {
         }
 
-        public SerializableOptionSet GetSerializableOptionsSnapshot(ImmutableHashSet<string> languages, IOptionService optionService)
-            => new(optionService, ImmutableDictionary<OptionKey, object?>.Empty, ImmutableHashSet<OptionKey>.Empty);
-
 #pragma warning disable CS0067
         public event EventHandler<OptionChangedEventArgs>? OptionChanged;
 #pragma warning restore
@@ -117,7 +114,7 @@ public class GlobalOptionsTests
         public void SetGlobalOptions(ImmutableArray<OptionKey> optionKeys, ImmutableArray<object?> values)
             => throw new NotImplementedException();
 
-        public void SetOptions(OptionSet optionSet)
+        public void SetOptions(OptionSet optionSet, IEnumerable<OptionKey> optionKeys)
             => throw new NotImplementedException();
 
         public bool TryMapEditorConfigKeyToOption(string key, string? language, [NotNullWhen(true)] out IEditorConfigStorageLocation2? storageLocation, out OptionKey optionKey)

--- a/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
+++ b/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
@@ -246,6 +246,11 @@ public class GlobalOptionsTests
              property.DeclaringType == typeof(ClassificationOptions) && property.Name == nameof(ClassificationOptions.ForceFrozenPartialSemanticsForCrossProcessOperations) ||
              property.DeclaringType == typeof(BlockStructureOptions) && property.Name == nameof(BlockStructureOptions.IsMetadataAsSource));
 
+    /// <summary>
+    /// Our mock <see cref="IGlobalOptionService"/> implementation returns a non-default value for each option it reads.
+    /// Option objects initialized from this service thus should have all their data properties initialized to non-default values.
+    /// We then enumerate these properties via reflection and compare each property value with the default instance of the respective options type.
+    /// </summary>
     [Theory]
     [InlineData(LanguageNames.CSharp)]
     [InlineData(LanguageNames.VisualBasic)]

--- a/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
+++ b/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
@@ -1,0 +1,271 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Microsoft.CodeAnalysis.AddImport;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.DocumentationComments;
+using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.Editor.UnitTests;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.ExtractMethod;
+using Microsoft.CodeAnalysis.FindUsages;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.ImplementType;
+using Microsoft.CodeAnalysis.InlineHints;
+using Microsoft.CodeAnalysis.MetadataAsSource;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.SignatureHelp;
+using Microsoft.CodeAnalysis.Structure;
+using Microsoft.CodeAnalysis.SymbolSearch;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests;
+
+[UseExportProvider]
+public class GlobalOptionsTests
+{
+    [Export(typeof(IGlobalOptionService)), Shared, PartNotDiscoverable]
+    internal class TestGlobalOptions : IGlobalOptionService
+    {
+        public readonly List<OptionKey> AccessedOptionKeys = new();
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public TestGlobalOptions()
+        {
+        }
+
+        private void OnOptionAccessed(OptionKey key)
+        {
+            AccessedOptionKeys.Add(key);
+        }
+
+        public T GetOption<T>(Option<T> option)
+        {
+            OnOptionAccessed(option);
+            return (T)GetNonEqualValue(typeof(T), option.DefaultValue);
+        }
+
+        public T GetOption<T>(Option2<T> option)
+        {
+            OnOptionAccessed(new OptionKey(option));
+            return (T)GetNonEqualValue(typeof(T), option.DefaultValue);
+        }
+
+        public T GetOption<T>(PerLanguageOption<T> option, string? languageName)
+        {
+            OnOptionAccessed(new OptionKey(option, languageName));
+            return (T)GetNonEqualValue(typeof(T), option.DefaultValue);
+        }
+
+        public T GetOption<T>(PerLanguageOption2<T> option, string? languageName)
+        {
+            OnOptionAccessed(new OptionKey(option, languageName));
+            return (T)GetNonEqualValue(typeof(T), option.DefaultValue);
+        }
+
+        public object? GetOption(OptionKey optionKey)
+            => throw new NotImplementedException();
+
+        #region Unused
+
+        public void RegisterWorkspace(Workspace workspace)
+        {
+        }
+
+        public void UnregisterWorkspace(Workspace workspace)
+        {
+        }
+
+        public SerializableOptionSet GetSerializableOptionsSnapshot(ImmutableHashSet<string> languages, IOptionService optionService)
+            => new(optionService, ImmutableDictionary<OptionKey, object?>.Empty, ImmutableHashSet<OptionKey>.Empty);
+
+#pragma warning disable CS0067
+        public event EventHandler<OptionChangedEventArgs>? OptionChanged;
+#pragma warning restore
+
+        public ImmutableArray<object?> GetOptions(ImmutableArray<OptionKey> optionKeys)
+            => throw new NotImplementedException();
+
+        public IEnumerable<IOption> GetRegisteredOptions()
+            => throw new NotImplementedException();
+
+        public ImmutableHashSet<IOption> GetRegisteredSerializableOptions(ImmutableHashSet<string> languages)
+            => throw new NotImplementedException();
+
+        public void RefreshOption(OptionKey optionKey, object? newValue)
+            => throw new NotImplementedException();
+
+        public void SetGlobalOption(OptionKey optionKey, object? value)
+            => throw new NotImplementedException();
+
+        public void SetGlobalOptions(ImmutableArray<OptionKey> optionKeys, ImmutableArray<object?> values)
+            => throw new NotImplementedException();
+
+        public void SetOptions(OptionSet optionSet)
+            => throw new NotImplementedException();
+
+        public bool TryMapEditorConfigKeyToOption(string key, string? language, [NotNullWhen(true)] out IEditorConfigStorageLocation2? storageLocation, out OptionKey optionKey)
+            => throw new NotImplementedException();
+
+        #endregion
+    }
+
+    /// <summary>
+    /// True if the type is a type of an option value.
+    /// </summary>
+    private static bool IsOptionValueType(Type type)
+    {
+        type = GetNonNullableType(type);
+
+        return
+            type == typeof(bool) ||
+            type == typeof(int) ||
+            type == typeof(string) ||
+            type.IsEnum ||
+            type == typeof(NamingStylePreferences) ||
+            typeof(ICodeStyleOption).IsAssignableFrom(type);
+    }
+
+    private static Type GetNonNullableType(Type type)
+        => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>) ? type.GetGenericArguments()[0] : type;
+
+    /// <summary>
+    /// Returns another value of the same type that's not equal to the specified <paramref name="value"/>.
+    /// </summary>
+    private static object GetNonEqualValue(Type type, object? value)
+    {
+        Assert.True(IsOptionValueType(type));
+
+        switch (value)
+        {
+            case bool b:
+                return !b;
+
+            case int i:
+                return i == 0 ? 1 : 0;
+
+            case string s:
+                return "!" + s;
+
+            case ICodeStyleOption codeStyle:
+                return codeStyle
+                    .WithValue(GetNonEqualValue(codeStyle.GetType().GetGenericArguments()[0], codeStyle.Value))
+                    .WithNotification((codeStyle.Notification == NotificationOption2.Error) ? NotificationOption2.Warning : NotificationOption2.Error);
+
+            case NamingStylePreferences naming:
+                return naming.IsEmpty ? NamingStylePreferences.Default : NamingStylePreferences.Empty;
+
+            default:
+                if (value != null && type.IsEnum)
+                {
+                    var zero = Enum.ToObject(type, 0);
+                    return value.Equals(zero) ? Enum.ToObject(type, 1) : zero;
+                }
+
+                throw TestExceptionUtilities.UnexpectedValue(value);
+        }
+    }
+
+    private static void VerifyDataMembersHaveNonDefaultValues(object options, object defaultOptions, string language)
+    {
+        Assert.Equal(options.GetType(), defaultOptions.GetType());
+        Recurse(options.GetType(), options, defaultOptions, language);
+
+        static void Recurse(Type type, object options, object defaultOptions, string language)
+        {
+            foreach (var property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            {
+                if (property.GetCustomAttributes<DataMemberAttribute>().Any())
+                {
+                    // value initialized from global options:
+                    var value = property.GetValue(options);
+
+                    // default value for the option -- may be different then default(T):
+                    var defaultValue = property.GetValue(defaultOptions);
+
+                    if (IsOptionValueType(property.PropertyType))
+                    {
+                        if (IsStoredInGlobalOptions(property, language))
+                        {
+                            Assert.False(Equals(value, defaultValue), $"{type.FullName}.{property.Name} not initialized from global options");
+                        }
+                    }
+                    else
+                    {
+                        var propertyType = GetNonNullableType(property.PropertyType);
+
+                        if (propertyType != property.PropertyType)
+                        {
+                            var getValueOrDefault = property.PropertyType.GetMethod("GetValueOrDefault", Array.Empty<Type>());
+                            value = getValueOrDefault.Invoke(value, Array.Empty<object>());
+                            defaultValue = getValueOrDefault.Invoke(defaultValue, Array.Empty<object>());
+                        }
+
+                        Recurse(propertyType, value, defaultValue, language);
+                    }
+                }
+            }
+        }
+    }
+
+    private static TestWorkspace CreateWorkspace(out TestGlobalOptions globalOptions)
+    {
+        var composition = EditorTestCompositions.LanguageServerProtocol.
+            AddExcludedPartTypes(typeof(GlobalOptionService)).
+            AddParts(typeof(TestGlobalOptions));
+
+        var workspace = new TestWorkspace(composition: composition);
+        globalOptions = Assert.IsType<TestGlobalOptions>(workspace.ExportProvider.GetExportedValue<IGlobalOptionService>());
+        return workspace;
+    }
+
+    /// <summary>
+    /// Properties for options not stored in global options.
+    /// </summary>
+    private static bool IsStoredInGlobalOptions(PropertyInfo property, string language)
+        => !(property.DeclaringType == typeof(AddImportPlacementOptions) && property.Name == nameof(AddImportPlacementOptions.AllowInHiddenRegions) ||
+             property.DeclaringType == typeof(AddImportPlacementOptions) && property.Name == nameof(AddImportPlacementOptions.UsingDirectivePlacement) && language == LanguageNames.VisualBasic ||
+             property.DeclaringType == typeof(DocumentFormattingOptions) && property.Name == nameof(DocumentFormattingOptions.FileHeaderTemplate) ||
+             property.DeclaringType == typeof(DocumentFormattingOptions) && property.Name == nameof(DocumentFormattingOptions.InsertFinalNewLine) ||
+             property.DeclaringType == typeof(ClassificationOptions) && property.Name == nameof(ClassificationOptions.ForceFrozenPartialSemanticsForCrossProcessOperations) ||
+             property.DeclaringType == typeof(BlockStructureOptions) && property.Name == nameof(BlockStructureOptions.IsMetadataAsSource));
+
+    [Theory]
+    [InlineData(LanguageNames.CSharp)]
+    [InlineData(LanguageNames.VisualBasic)]
+    public void ReadingOptionsFromGlobalOptions(string language)
+    {
+        using var workspace = CreateWorkspace(out var globalOptions);
+        var languageServices = workspace.Services.GetLanguageServices(language);
+
+        VerifyDataMembersHaveNonDefaultValues(globalOptions.GetIdeAnalyzerOptions(languageServices), IdeAnalyzerOptions.GetDefault(languageServices), language);
+        VerifyDataMembersHaveNonDefaultValues(globalOptions.GetCodeActionOptions(languageServices), CodeActionOptions.GetDefault(languageServices), language);
+        VerifyDataMembersHaveNonDefaultValues(globalOptions.GetBraceMatchingOptions(language), BraceMatchingOptions.Default, language);
+        VerifyDataMembersHaveNonDefaultValues(globalOptions.GetFindUsagesOptions(language), FindUsagesOptions.Default, language);
+        VerifyDataMembersHaveNonDefaultValues(globalOptions.GetInlineHintsOptions(language), InlineHintsOptions.Default, language);
+        VerifyDataMembersHaveNonDefaultValues(globalOptions.GetAutoFormattingOptions(language), AutoFormattingOptions.Default, language);
+        VerifyDataMembersHaveNonDefaultValues(globalOptions.GetBlockStructureOptions(language, isMetadataAsSource: false), BlockStructureOptions.Default, language);
+        VerifyDataMembersHaveNonDefaultValues(globalOptions.GetDocumentationCommentOptions(globalOptions.GetLineFormattingOptions(language), language), DocumentationCommentOptions.Default, language);
+        VerifyDataMembersHaveNonDefaultValues(globalOptions.GetExtractMethodOptions(language), ExtractMethodOptions.Default, language);
+        VerifyDataMembersHaveNonDefaultValues(globalOptions.GetImplementTypeOptions(language), ImplementTypeOptions.Default, language);
+        VerifyDataMembersHaveNonDefaultValues(globalOptions.GetMetadataAsSourceOptions(languageServices), MetadataAsSourceOptions.GetDefault(languageServices), language);
+        VerifyDataMembersHaveNonDefaultValues(globalOptions.GetSignatureHelpOptions(language), SignatureHelpOptions.Default, language);
+        VerifyDataMembersHaveNonDefaultValues(globalOptions.GetSymbolSearchOptions(language), SymbolSearchOptions.Default, language);
+    }
+}

--- a/src/EditorFeatures/Test2/InlineHints/AbstractInlineHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineHints/AbstractInlineHintsTests.vb
@@ -19,15 +19,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InlineHints
             Using workspace = TestWorkspace.Create(test)
                 WpfTestRunner.RequireWpfFact($"{NameOf(AbstractInlineHintsTests)}.{NameOf(Me.VerifyParamHints)} creates asynchronous taggers")
 
-                Dim options = New InlineParameterHintsOptions(
-                    EnabledForParameters:=optionIsEnabled,
-                    ForLiteralParameters:=True,
-                    ForIndexerParameters:=True,
-                    ForObjectCreationParameters:=True,
-                    ForOtherParameters:=False,
-                    SuppressForParametersThatDifferOnlyBySuffix:=True,
-                    SuppressForParametersThatMatchMethodIntent:=True,
-                    SuppressForParametersThatMatchArgumentName:=True)
+                Dim options = New InlineParameterHintsOptions() With
+                {
+                    .EnabledForParameters = optionIsEnabled
+                }
 
                 Dim displayOptions = New SymbolDescriptionOptions()
 
@@ -84,11 +79,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.InlineHints
                 Dim globalOptions = workspace.GetService(Of IGlobalOptionService)
                 globalOptions.SetGlobalOption(New OptionKey(InlineHintsGlobalStateOption.DisplayAllOverride), ephemeral)
 
-                Dim options = New InlineTypeHintsOptions(
-                    EnabledForTypes:=optionIsEnabled AndAlso Not ephemeral,
-                    ForImplicitVariableTypes:=True,
-                    ForLambdaParameterTypes:=True,
-                    ForImplicitObjectCreation:=True)
+                Dim options = New InlineTypeHintsOptions() With
+                {
+                    .EnabledForTypes = optionIsEnabled AndAlso Not ephemeral
+                }
 
                 Dim displayOptions = New SymbolDescriptionOptions()
 

--- a/src/EditorFeatures/TestUtilities/Structure/AbstractSyntaxStructureProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Structure/AbstractSyntaxStructureProviderTests.cs
@@ -25,7 +25,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Structure
         protected virtual string WorkspaceKind => CodeAnalysis.WorkspaceKind.Host;
 
         internal virtual BlockStructureOptions GetDefaultOptions()
-            => new(MaximumBannerLength: 120, IsMetadataAsSource: WorkspaceKind == CodeAnalysis.WorkspaceKind.MetadataAsSource);
+            => new()
+            {
+                MaximumBannerLength = 120,
+                IsMetadataAsSource = WorkspaceKind == CodeAnalysis.WorkspaceKind.MetadataAsSource
+            };
 
         private Task<ImmutableArray<BlockSpan>> GetBlockSpansAsync(Document document, BlockStructureOptions options, int position)
             => GetBlockSpansWorkerAsync(document, options, position);

--- a/src/EditorFeatures/TestUtilities/Structure/AbstractSyntaxStructureProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Structure/AbstractSyntaxStructureProviderTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Structure
             => new()
             {
                 MaximumBannerLength = 120,
-                IsMetadataAsSource = WorkspaceKind == CodeAnalysis.WorkspaceKind.MetadataAsSource
+                IsMetadataAsSource = WorkspaceKind == CodeAnalysis.WorkspaceKind.MetadataAsSource,
             };
 
         private Task<ImmutableArray<BlockSpan>> GetBlockSpansAsync(Document document, BlockStructureOptions options, int position)

--- a/src/EditorFeatures/VisualBasicTest/Structure/CompilationUnitStructureTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Structure/CompilationUnitStructureTests.vb
@@ -36,7 +36,7 @@ Class C1
 End Class
 "
 
-            Dim options = New BlockStructureOptions(CollapseImportsWhenFirstOpened:=collapseUsingsByDefault)
+            Dim options = New BlockStructureOptions() With {.CollapseImportsWhenFirstOpened = collapseUsingsByDefault}
 
             Await VerifyBlockSpansAsync(code, options,
                 Region("span", "Imports ...", autoCollapse:=True, isDefaultCollapsed:=collapseUsingsByDefault))

--- a/src/EditorFeatures/VisualBasicTest/Structure/RegionDirectiveStructureTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Structure/RegionDirectiveStructureTests.vb
@@ -41,7 +41,7 @@ $$#Region ""Goo""
 #End Region|}
 "
 
-            Dim options = New BlockStructureOptions(CollapseRegionsWhenFirstOpened:=collapseRegionsByDefault)
+            Dim options = New BlockStructureOptions() With {.CollapseRegionsWhenFirstOpened = collapseRegionsByDefault}
 
             Await VerifyBlockSpansAsync(code, options,
                 Region("span", "Goo", autoCollapse:=False, isDefaultCollapsed:=collapseRegionsByDefault))

--- a/src/Features/Core/Portable/InlineHints/InlineHintsOptions.cs
+++ b/src/Features/Core/Portable/InlineHints/InlineHintsOptions.cs
@@ -5,11 +5,18 @@
 using System.Runtime.Serialization;
 using Microsoft.CodeAnalysis.LanguageServices;
 
-namespace Microsoft.CodeAnalysis.InlineHints
+namespace Microsoft.CodeAnalysis.InlineHints;
+
+[DataContract]
+internal readonly record struct InlineHintsOptions
 {
-    [DataContract]
-    internal readonly record struct InlineHintsOptions(
-        [property: DataMember(Order = 0)] InlineParameterHintsOptions ParameterOptions,
-        [property: DataMember(Order = 1)] InlineTypeHintsOptions TypeOptions,
-        [property: DataMember(Order = 2)] SymbolDescriptionOptions DisplayOptions);
+    [DataMember] public InlineParameterHintsOptions ParameterOptions { get; init; } = InlineParameterHintsOptions.Default;
+    [DataMember] public InlineTypeHintsOptions TypeOptions { get; init; } = InlineTypeHintsOptions.Default;
+    [DataMember] public SymbolDescriptionOptions DisplayOptions { get; init; } = SymbolDescriptionOptions.Default;
+
+    public InlineHintsOptions()
+    {
+    }
+
+    public static readonly InlineHintsOptions Default = new();
 }

--- a/src/Features/Core/Portable/InlineHints/InlineParameterHintsOptions.cs
+++ b/src/Features/Core/Portable/InlineHints/InlineParameterHintsOptions.cs
@@ -4,24 +4,23 @@
 
 using System.Runtime.Serialization;
 
-namespace Microsoft.CodeAnalysis.InlineHints
-{
-    [DataContract]
-    internal readonly record struct InlineParameterHintsOptions(
-        [property: DataMember(Order = 0)] bool EnabledForParameters = false,
-        [property: DataMember(Order = 1)] bool ForLiteralParameters = true,
-        [property: DataMember(Order = 2)] bool ForIndexerParameters = true,
-        [property: DataMember(Order = 3)] bool ForObjectCreationParameters = true,
-        [property: DataMember(Order = 4)] bool ForOtherParameters = false,
-        [property: DataMember(Order = 5)] bool SuppressForParametersThatDifferOnlyBySuffix = true,
-        [property: DataMember(Order = 6)] bool SuppressForParametersThatMatchMethodIntent = true,
-        [property: DataMember(Order = 7)] bool SuppressForParametersThatMatchArgumentName = true)
-    {
-        public InlineParameterHintsOptions()
-            : this(EnabledForParameters: false)
-        {
-        }
+namespace Microsoft.CodeAnalysis.InlineHints;
 
-        public static readonly InlineParameterHintsOptions Default = new();
+[DataContract]
+internal readonly record struct InlineParameterHintsOptions
+{
+    [DataMember] public bool EnabledForParameters { get; init; } = false;
+    [DataMember] public bool ForLiteralParameters { get; init; } = true;
+    [DataMember] public bool ForIndexerParameters { get; init; } = true;
+    [DataMember] public bool ForObjectCreationParameters { get; init; } = true;
+    [DataMember] public bool ForOtherParameters { get; init; } = false;
+    [DataMember] public bool SuppressForParametersThatDifferOnlyBySuffix { get; init; } = true;
+    [DataMember] public bool SuppressForParametersThatMatchMethodIntent { get; init; } = true;
+    [DataMember] public bool SuppressForParametersThatMatchArgumentName { get; init; } = true;
+
+    public InlineParameterHintsOptions()
+    {
     }
+
+    public static readonly InlineParameterHintsOptions Default = new();
 }

--- a/src/Features/Core/Portable/InlineHints/InlineTypeHintsOptions.cs
+++ b/src/Features/Core/Portable/InlineHints/InlineTypeHintsOptions.cs
@@ -4,20 +4,19 @@
 
 using System.Runtime.Serialization;
 
-namespace Microsoft.CodeAnalysis.InlineHints
-{
-    [DataContract]
-    internal readonly record struct InlineTypeHintsOptions(
-        [property: DataMember(Order = 0)] bool EnabledForTypes = false,
-        [property: DataMember(Order = 1)] bool ForImplicitVariableTypes = true,
-        [property: DataMember(Order = 2)] bool ForLambdaParameterTypes = true,
-        [property: DataMember(Order = 3)] bool ForImplicitObjectCreation = true)
-    {
-        public InlineTypeHintsOptions()
-            : this(EnabledForTypes: false)
-        {
-        }
+namespace Microsoft.CodeAnalysis.InlineHints;
 
-        public static readonly InlineTypeHintsOptions Default = new();
+[DataContract]
+internal readonly record struct InlineTypeHintsOptions
+{
+    [DataMember] public bool EnabledForTypes { get; init; } = false;
+    [DataMember] public bool ForImplicitVariableTypes { get; init; } = true;
+    [DataMember] public bool ForLambdaParameterTypes { get; init; } = true;
+    [DataMember] public bool ForImplicitObjectCreation { get; init; } = true;
+
+    public InlineTypeHintsOptions()
+    {
     }
+
+    public static readonly InlineTypeHintsOptions Default = new();
 }

--- a/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/SymbolDescriptionOptions.cs
+++ b/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/SymbolDescriptionOptions.cs
@@ -2,18 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Serialization;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.QuickInfo;
 
-namespace Microsoft.CodeAnalysis.LanguageServices
+namespace Microsoft.CodeAnalysis.LanguageServices;
+
+[DataContract]
+internal readonly record struct SymbolDescriptionOptions
 {
-    internal readonly record struct SymbolDescriptionOptions(
-        QuickInfoOptions QuickInfoOptions,
-        ClassificationOptions ClassificationOptions)
+    [DataMember] public QuickInfoOptions QuickInfoOptions { get; init; } = QuickInfoOptions.Default;
+    [DataMember] public ClassificationOptions ClassificationOptions { get; init; } = ClassificationOptions.Default;
+
+    public SymbolDescriptionOptions()
     {
-        public static readonly SymbolDescriptionOptions Default
-          = new(
-              QuickInfoOptions: QuickInfoOptions.Default,
-              ClassificationOptions: ClassificationOptions.Default);
     }
+
+    public static readonly SymbolDescriptionOptions Default = new();
 }

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceOptions.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceOptions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Serialization;
 using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.Host;
@@ -12,15 +13,24 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource;
 /// Options for metadata as source navigation
 /// </summary>
 /// <param name="GenerationOptions">Options to use to prettify the generated document.</param>
-/// <param name="NavigateToDecompiledSources"><see langword="false"/> to disallow decompiling code, which may
-/// result in signagures only being returned if there is no other non-decompilation option available</param>
-/// <param name="AlwaysUseDefaultSymbolServers">Whether navigation should try to use the default Microsoft and
-/// Nuget symbol servers regardless of debugger settings</param>
+[DataContract]
 internal readonly record struct MetadataAsSourceOptions(
-    CleanCodeGenerationOptions GenerationOptions,
-    bool NavigateToDecompiledSources = true,
-    bool AlwaysUseDefaultSymbolServers = true)
+    [property: DataMember] CleanCodeGenerationOptions GenerationOptions)
 {
+    /// <summary>
+    /// <see langword="false"/> to disallow decompiling code, which may
+    /// result in signagures only being returned if there is no other non-decompilation option available
+    /// </summary>
+    [DataMember]
+    public bool NavigateToDecompiledSources { get; init; } = true;
+
+    /// <summary>
+    /// Whether navigation should try to use the default Microsoft and
+    /// Nuget symbol servers regardless of debugger settings
+    /// </summary>
+    [DataMember]
+    public bool AlwaysUseDefaultSymbolServers { get; init; } = true;
+
     public static MetadataAsSourceOptions GetDefault(HostLanguageServices languageServices)
         => new(GenerationOptions: CleanCodeGenerationOptions.GetDefault(languageServices));
 }

--- a/src/Features/Core/Portable/QuickInfo/QuickInfoOptions.cs
+++ b/src/Features/Core/Portable/QuickInfo/QuickInfoOptions.cs
@@ -4,18 +4,17 @@
 
 using System.Runtime.Serialization;
 
-namespace Microsoft.CodeAnalysis.QuickInfo
-{
-    [DataContract]
-    internal readonly record struct QuickInfoOptions(
-        [property: DataMember(Order = 0)] bool ShowRemarksInQuickInfo = true,
-        [property: DataMember(Order = 1)] bool IncludeNavigationHintsInQuickInfo = true)
-    {
-        public QuickInfoOptions()
-            : this(ShowRemarksInQuickInfo: true)
-        {
-        }
+namespace Microsoft.CodeAnalysis.QuickInfo;
 
-        public static readonly QuickInfoOptions Default = new();
+[DataContract]
+internal readonly record struct QuickInfoOptions
+{
+    [DataMember] public bool ShowRemarksInQuickInfo { get; init; } = true;
+    [DataMember] public bool IncludeNavigationHintsInQuickInfo { get; init; } = true;
+
+    public QuickInfoOptions()
+    {
     }
+
+    public static readonly QuickInfoOptions Default = new();
 }

--- a/src/Features/Core/Portable/SignatureHelp/SignatureHelpOptions.cs
+++ b/src/Features/Core/Portable/SignatureHelp/SignatureHelpOptions.cs
@@ -3,12 +3,18 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.Completion;
+using System.Runtime.Serialization;
 
-namespace Microsoft.CodeAnalysis.SignatureHelp
+namespace Microsoft.CodeAnalysis.SignatureHelp;
+
+[DataContract]
+internal readonly record struct SignatureHelpOptions
 {
-    internal readonly record struct SignatureHelpOptions(
-        bool HideAdvancedMembers)
+    [DataMember] public bool HideAdvancedMembers { get; init; } = CompletionOptions.Default.HideAdvancedMembers;
+
+    public SignatureHelpOptions()
     {
-        public static readonly SignatureHelpOptions Default = new(CompletionOptions.Default.HideAdvancedMembers);
     }
+
+    public static readonly SignatureHelpOptions Default = new();
 }

--- a/src/Features/Core/Portable/Structure/BlockStructureOptions.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureOptions.cs
@@ -2,28 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.CodeAnalysis.Structure
-{
-    internal readonly record struct BlockStructureOptions(
-        bool ShowBlockStructureGuidesForCommentsAndPreprocessorRegions = false,
-        bool ShowBlockStructureGuidesForDeclarationLevelConstructs = true,
-        bool ShowBlockStructureGuidesForCodeLevelConstructs = true,
-        bool ShowOutliningForCommentsAndPreprocessorRegions = true,
-        bool ShowOutliningForDeclarationLevelConstructs = true,
-        bool ShowOutliningForCodeLevelConstructs = true,
-        bool CollapseRegionsWhenFirstOpened = true,
-        bool CollapseImportsWhenFirstOpened = false,
-        bool CollapseMetadataImplementationsWhenFirstOpened = false,
-        bool CollapseEmptyMetadataImplementationsWhenFirstOpened = true,
-        bool CollapseRegionsWhenCollapsingToDefinitions = false,
-        int MaximumBannerLength = 80,
-        bool IsMetadataAsSource = false)
-    {
-        public BlockStructureOptions()
-            : this(ShowBlockStructureGuidesForCommentsAndPreprocessorRegions: false)
-        {
-        }
+using System.Runtime.Serialization;
 
-        public static readonly BlockStructureOptions Default = new();
-    }
+namespace Microsoft.CodeAnalysis.Structure;
+
+[DataContract]
+internal sealed record class BlockStructureOptions
+{
+    [DataMember] public bool ShowBlockStructureGuidesForCommentsAndPreprocessorRegions { get; init; } = false;
+    [DataMember] public bool ShowBlockStructureGuidesForDeclarationLevelConstructs { get; init; } = true;
+    [DataMember] public bool ShowBlockStructureGuidesForCodeLevelConstructs { get; init; } = true;
+    [DataMember] public bool ShowOutliningForCommentsAndPreprocessorRegions { get; init; } = true;
+    [DataMember] public bool ShowOutliningForDeclarationLevelConstructs { get; init; } = true;
+    [DataMember] public bool ShowOutliningForCodeLevelConstructs { get; init; } = true;
+    [DataMember] public bool CollapseRegionsWhenFirstOpened { get; init; } = true;
+    [DataMember] public bool CollapseImportsWhenFirstOpened { get; init; } = false;
+    [DataMember] public bool CollapseMetadataImplementationsWhenFirstOpened { get; init; } = false;
+    [DataMember] public bool CollapseEmptyMetadataImplementationsWhenFirstOpened { get; init; } = true;
+    [DataMember] public bool CollapseRegionsWhenCollapsingToDefinitions { get; init; } = false;
+    [DataMember] public int MaximumBannerLength { get; init; } = 80;
+    [DataMember] public bool IsMetadataAsSource { get; init; } = false;
+
+    public static readonly BlockStructureOptions Default = new();
 }

--- a/src/Features/LanguageServer/Protocol/Features/Options/BlockStructureOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/BlockStructureOptionsStorage.cs
@@ -12,20 +12,22 @@ internal static class BlockStructureOptionsStorage
         => GetBlockStructureOptions(globalOptions, project.Language, isMetadataAsSource: project.Solution.Workspace.Kind == WorkspaceKind.MetadataAsSource);
 
     public static BlockStructureOptions GetBlockStructureOptions(this IGlobalOptionService globalOptions, string language, bool isMetadataAsSource)
-        => new(
-            ShowBlockStructureGuidesForCommentsAndPreprocessorRegions: globalOptions.GetOption(ShowBlockStructureGuidesForCommentsAndPreprocessorRegions, language),
-            ShowBlockStructureGuidesForDeclarationLevelConstructs: globalOptions.GetOption(ShowBlockStructureGuidesForDeclarationLevelConstructs, language),
-            ShowBlockStructureGuidesForCodeLevelConstructs: globalOptions.GetOption(ShowBlockStructureGuidesForCodeLevelConstructs, language),
-            ShowOutliningForCommentsAndPreprocessorRegions: globalOptions.GetOption(ShowOutliningForCommentsAndPreprocessorRegions, language),
-            ShowOutliningForDeclarationLevelConstructs: globalOptions.GetOption(ShowOutliningForDeclarationLevelConstructs, language),
-            ShowOutliningForCodeLevelConstructs: globalOptions.GetOption(ShowOutliningForCodeLevelConstructs, language),
-            CollapseRegionsWhenFirstOpened: globalOptions.GetOption(CollapseRegionsWhenFirstOpened, language),
-            CollapseImportsWhenFirstOpened: globalOptions.GetOption(CollapseImportsWhenFirstOpened, language),
-            CollapseMetadataImplementationsWhenFirstOpened: globalOptions.GetOption(CollapseSourceLinkEmbeddedDecompiledFilesWhenFirstOpened, language),
-            CollapseEmptyMetadataImplementationsWhenFirstOpened: globalOptions.GetOption(CollapseMetadataSignatureFilesWhenFirstOpened, language),
-            CollapseRegionsWhenCollapsingToDefinitions: globalOptions.GetOption(CollapseRegionsWhenCollapsingToDefinitions, language),
-            MaximumBannerLength: globalOptions.GetOption(MaximumBannerLength, language),
-            IsMetadataAsSource: isMetadataAsSource);
+        => new()
+        {
+            ShowBlockStructureGuidesForCommentsAndPreprocessorRegions = globalOptions.GetOption(ShowBlockStructureGuidesForCommentsAndPreprocessorRegions, language),
+            ShowBlockStructureGuidesForDeclarationLevelConstructs = globalOptions.GetOption(ShowBlockStructureGuidesForDeclarationLevelConstructs, language),
+            ShowBlockStructureGuidesForCodeLevelConstructs = globalOptions.GetOption(ShowBlockStructureGuidesForCodeLevelConstructs, language),
+            ShowOutliningForCommentsAndPreprocessorRegions = globalOptions.GetOption(ShowOutliningForCommentsAndPreprocessorRegions, language),
+            ShowOutliningForDeclarationLevelConstructs = globalOptions.GetOption(ShowOutliningForDeclarationLevelConstructs, language),
+            ShowOutliningForCodeLevelConstructs = globalOptions.GetOption(ShowOutliningForCodeLevelConstructs, language),
+            CollapseRegionsWhenFirstOpened = globalOptions.GetOption(CollapseRegionsWhenFirstOpened, language),
+            CollapseImportsWhenFirstOpened = globalOptions.GetOption(CollapseImportsWhenFirstOpened, language),
+            CollapseMetadataImplementationsWhenFirstOpened = globalOptions.GetOption(CollapseSourceLinkEmbeddedDecompiledFilesWhenFirstOpened, language),
+            CollapseEmptyMetadataImplementationsWhenFirstOpened = globalOptions.GetOption(CollapseMetadataSignatureFilesWhenFirstOpened, language),
+            CollapseRegionsWhenCollapsingToDefinitions = globalOptions.GetOption(CollapseRegionsWhenCollapsingToDefinitions, language),
+            MaximumBannerLength = globalOptions.GetOption(MaximumBannerLength, language),
+            IsMetadataAsSource = isMetadataAsSource
+        };
 
     private const string FeatureName = "BlockStructureOptions";
 

--- a/src/Features/LanguageServer/Protocol/Features/Options/BlockStructureOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/BlockStructureOptionsStorage.cs
@@ -26,7 +26,7 @@ internal static class BlockStructureOptionsStorage
             CollapseEmptyMetadataImplementationsWhenFirstOpened = globalOptions.GetOption(CollapseMetadataSignatureFilesWhenFirstOpened, language),
             CollapseRegionsWhenCollapsingToDefinitions = globalOptions.GetOption(CollapseRegionsWhenCollapsingToDefinitions, language),
             MaximumBannerLength = globalOptions.GetOption(MaximumBannerLength, language),
-            IsMetadataAsSource = isMetadataAsSource
+            IsMetadataAsSource = isMetadataAsSource,
         };
 
     private const string FeatureName = "BlockStructureOptions";

--- a/src/Features/LanguageServer/Protocol/Features/Options/ClassificationOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/ClassificationOptionsStorage.cs
@@ -9,10 +9,13 @@ namespace Microsoft.CodeAnalysis.Classification;
 internal static class ClassificationOptionsStorage
 {
     public static ClassificationOptions GetClassificationOptions(this IGlobalOptionService globalOptions, string language)
-        => new(
-            ClassifyReassignedVariables: globalOptions.GetOption(ClassifyReassignedVariables, language),
-            ColorizeRegexPatterns: globalOptions.GetOption(ColorizeRegexPatterns, language),
-            ColorizeJsonPatterns: globalOptions.GetOption(ColorizeJsonPatterns, language));
+        => new()
+        {
+            ClassifyReassignedVariables = globalOptions.GetOption(ClassifyReassignedVariables, language),
+            ColorizeRegexPatterns = globalOptions.GetOption(ColorizeRegexPatterns, language),
+            ColorizeJsonPatterns = globalOptions.GetOption(ColorizeJsonPatterns, language),
+            // ForceFrozenPartialSemanticsForCrossProcessOperations not stored in global options
+        };
 
     public static PerLanguageOption2<bool> ClassifyReassignedVariables =
         new("ClassificationOptions", "ClassifyReassignedVariables", ClassificationOptions.Default.ClassifyReassignedVariables,

--- a/src/Features/LanguageServer/Protocol/Features/Options/DocumentationCommentOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/DocumentationCommentOptionsStorage.cs
@@ -17,7 +17,7 @@ internal static class DocumentationCommentOptionsStorage
         return new()
         {
             LineFormatting = lineFormattingOptions,
-            AutoXmlDocCommentGeneration = globalOptions.GetOption(AutoXmlDocCommentGeneration, document.Project.Language)
+            AutoXmlDocCommentGeneration = globalOptions.GetOption(AutoXmlDocCommentGeneration, document.Project.Language),
         };
     }
 
@@ -25,7 +25,7 @@ internal static class DocumentationCommentOptionsStorage
       => new()
       {
           LineFormatting = lineFormatting,
-          AutoXmlDocCommentGeneration = globalOptions.GetOption(AutoXmlDocCommentGeneration, language)
+          AutoXmlDocCommentGeneration = globalOptions.GetOption(AutoXmlDocCommentGeneration, language),
       };
 
     public static readonly PerLanguageOption2<bool> AutoXmlDocCommentGeneration = new(

--- a/src/Features/LanguageServer/Protocol/Features/Options/DocumentationCommentOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/DocumentationCommentOptionsStorage.cs
@@ -21,10 +21,10 @@ internal static class DocumentationCommentOptionsStorage
         };
     }
 
-    public static DocumentationCommentOptions GetDocumentationCommentOptions(this IGlobalOptionService globalOptions, SyntaxFormattingOptions formattingOptions, string language)
+    public static DocumentationCommentOptions GetDocumentationCommentOptions(this IGlobalOptionService globalOptions, LineFormattingOptions lineFormatting, string language)
       => new()
       {
-          LineFormatting = formattingOptions.LineFormatting,
+          LineFormatting = lineFormatting,
           AutoXmlDocCommentGeneration = globalOptions.GetOption(AutoXmlDocCommentGeneration, language)
       };
 

--- a/src/Features/LanguageServer/Protocol/Features/Options/IdeAnalyzerOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/IdeAnalyzerOptionsStorage.cs
@@ -28,10 +28,12 @@ internal static class IdeAnalyzerOptionsStorage
             FadeOutUnusedImports = globalOptions.GetOption(FadeOutUnusedImports, language),
             FadeOutUnreachableCode = globalOptions.GetOption(FadeOutUnreachableCode, language),
             FadeOutComplexObjectInitialization = globalOptions.GetOption(FadeOutComplexObjectInitialization, language),
+            FadeOutComplexCollectionInitialization = globalOptions.GetOption(FadeOutComplexCollectionInitialization, language),
             ReportInvalidPlaceholdersInStringDotFormatCalls = globalOptions.GetOption(ReportInvalidPlaceholdersInStringDotFormatCalls, language),
             ReportInvalidRegexPatterns = globalOptions.GetOption(ReportInvalidRegexPatterns, language),
             ReportInvalidJsonPatterns = globalOptions.GetOption(ReportInvalidJsonPatterns, language),
             DetectAndOfferEditorFeaturesForProbableJsonStrings = globalOptions.GetOption(DetectAndOfferEditorFeaturesForProbableJsonStrings, language),
+            PreferSystemHashCode = globalOptions.GetOption(CodeStyleOptions2.PreferSystemHashCode, language),
             CleanCodeGenerationOptions = supportsLanguageSpecificOptions ? globalOptions.GetCleanCodeGenerationOptions(languageServices) : null,
             CodeStyleOptions = supportsLanguageSpecificOptions ? globalOptions.GetCodeStyleOptions(languageServices) : null,
         };

--- a/src/Features/LanguageServer/Protocol/Features/Options/MetadataAsSourceOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/MetadataAsSourceOptionsStorage.cs
@@ -13,10 +13,11 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource;
 internal static class MetadataAsSourceOptionsStorage
 {
     public static MetadataAsSourceOptions GetMetadataAsSourceOptions(this IGlobalOptionService globalOptions, HostLanguageServices languageServices)
-        => new(
-            GenerationOptions: globalOptions.GetCleanCodeGenerationOptions(languageServices),
-            NavigateToDecompiledSources: globalOptions.GetOption(NavigateToDecompiledSources),
-            AlwaysUseDefaultSymbolServers: globalOptions.GetOption(AlwaysUseDefaultSymbolServers));
+        => new(GenerationOptions: globalOptions.GetCleanCodeGenerationOptions(languageServices))
+        {
+            NavigateToDecompiledSources = globalOptions.GetOption(NavigateToDecompiledSources),
+            AlwaysUseDefaultSymbolServers = globalOptions.GetOption(AlwaysUseDefaultSymbolServers)
+        };
 
     public static Option2<bool> NavigateToDecompiledSources =
         new("FeatureOnOffOptions", "NavigateToDecompiledSources", defaultValue: true,

--- a/src/Features/LanguageServer/Protocol/Features/Options/MetadataAsSourceOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/MetadataAsSourceOptionsStorage.cs
@@ -16,7 +16,7 @@ internal static class MetadataAsSourceOptionsStorage
         => new(GenerationOptions: globalOptions.GetCleanCodeGenerationOptions(languageServices))
         {
             NavigateToDecompiledSources = globalOptions.GetOption(NavigateToDecompiledSources),
-            AlwaysUseDefaultSymbolServers = globalOptions.GetOption(AlwaysUseDefaultSymbolServers)
+            AlwaysUseDefaultSymbolServers = globalOptions.GetOption(AlwaysUseDefaultSymbolServers),
         };
 
     public static Option2<bool> NavigateToDecompiledSources =

--- a/src/Features/LanguageServer/Protocol/Features/Options/SignatureHelpOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/SignatureHelpOptionsStorage.cs
@@ -10,6 +10,8 @@ namespace Microsoft.CodeAnalysis.SignatureHelp;
 internal static class SignatureHelpOptionsStorage
 {
     public static SignatureHelpOptions GetSignatureHelpOptions(this IGlobalOptionService globalOptions, string language)
-      => new(
-          HideAdvancedMembers: globalOptions.GetOption(CompletionOptionsStorage.HideAdvancedMembers, language));
+      => new()
+      {
+          HideAdvancedMembers = globalOptions.GetOption(CompletionOptionsStorage.HideAdvancedMembers, language)
+      };
 }

--- a/src/Features/LanguageServer/Protocol/Handler/OnAutoInsert/OnAutoInsertHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/OnAutoInsert/OnAutoInsertHandler.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             // The editor calls this handler for C# and VB comment characters, but we only need to process the one for the language that matches the document
             if (request.Character == "\n" || request.Character == service.DocumentationCommentCharacter)
             {
-                var docCommentOptions = _globalOptions.GetDocumentationCommentOptions(formattingOptions, document.Project.Language);
+                var docCommentOptions = _globalOptions.GetDocumentationCommentOptions(formattingOptions.LineFormatting, document.Project.Language);
 
                 var documentationCommentResponse = await GetDocumentationCommentResponseAsync(
                     request, document, service, docCommentOptions, cancellationToken).ConfigureAwait(false);

--- a/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsOptions.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsOptions.cs
@@ -12,9 +12,11 @@ internal readonly record struct OmniSharpInlineHintsOptions(
     OmniSharpInlineTypeHintsOptions TypeOptions)
 {
     internal InlineHintsOptions ToInlineHintsOptions()
-        => new(ParameterOptions.ToInlineParameterHintsOptions(),
-               TypeOptions.ToInlineTypeHintsOptions(),
-               SymbolDescriptionOptions.Default);
+        => new()
+        {
+            ParameterOptions = ParameterOptions.ToInlineParameterHintsOptions(),
+            TypeOptions = TypeOptions.ToInlineTypeHintsOptions(),
+        };
 }
 internal readonly record struct OmniSharpInlineParameterHintsOptions(
     bool EnabledForParameters,
@@ -27,7 +29,17 @@ internal readonly record struct OmniSharpInlineParameterHintsOptions(
     bool SuppressForParametersThatMatchArgumentName)
 {
     internal InlineParameterHintsOptions ToInlineParameterHintsOptions()
-        => new(EnabledForParameters, ForLiteralParameters, ForIndexerParameters, ForObjectCreationParameters, ForOtherParameters, SuppressForParametersThatDifferOnlyBySuffix, SuppressForParametersThatMatchMethodIntent, SuppressForParametersThatMatchArgumentName);
+        => new()
+        {
+            EnabledForParameters = EnabledForParameters,
+            ForLiteralParameters = ForLiteralParameters,
+            ForIndexerParameters = ForIndexerParameters,
+            ForObjectCreationParameters = ForObjectCreationParameters,
+            ForOtherParameters = ForOtherParameters,
+            SuppressForParametersThatDifferOnlyBySuffix = SuppressForParametersThatDifferOnlyBySuffix,
+            SuppressForParametersThatMatchMethodIntent = SuppressForParametersThatMatchMethodIntent,
+            SuppressForParametersThatMatchArgumentName = SuppressForParametersThatMatchArgumentName
+        };
 }
 
 internal readonly record struct OmniSharpInlineTypeHintsOptions(
@@ -37,5 +49,11 @@ internal readonly record struct OmniSharpInlineTypeHintsOptions(
     bool ForImplicitObjectCreation)
 {
     internal InlineTypeHintsOptions ToInlineTypeHintsOptions()
-        => new(EnabledForTypes, ForImplicitVariableTypes, ForLambdaParameterTypes, ForImplicitObjectCreation);
+        => new()
+        {
+            EnabledForTypes = EnabledForTypes,
+            ForImplicitVariableTypes = ForImplicitVariableTypes,
+            ForLambdaParameterTypes = ForLambdaParameterTypes,
+            ForImplicitObjectCreation = ForImplicitObjectCreation
+        };
 }

--- a/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsOptions.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/InlineHints/OmniSharpInlineHintsOptions.cs
@@ -38,7 +38,7 @@ internal readonly record struct OmniSharpInlineParameterHintsOptions(
             ForOtherParameters = ForOtherParameters,
             SuppressForParametersThatDifferOnlyBySuffix = SuppressForParametersThatDifferOnlyBySuffix,
             SuppressForParametersThatMatchMethodIntent = SuppressForParametersThatMatchMethodIntent,
-            SuppressForParametersThatMatchArgumentName = SuppressForParametersThatMatchArgumentName
+            SuppressForParametersThatMatchArgumentName = SuppressForParametersThatMatchArgumentName,
         };
 }
 
@@ -54,6 +54,6 @@ internal readonly record struct OmniSharpInlineTypeHintsOptions(
             EnabledForTypes = EnabledForTypes,
             ForImplicitVariableTypes = ForImplicitVariableTypes,
             ForLambdaParameterTypes = ForLambdaParameterTypes,
-            ForImplicitObjectCreation = ForImplicitObjectCreation
+            ForImplicitObjectCreation = ForImplicitObjectCreation,
         };
 }

--- a/src/Workspaces/Core/Portable/Classification/ClassificationOptions.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassificationOptions.cs
@@ -4,20 +4,19 @@
 
 using System.Runtime.Serialization;
 
-namespace Microsoft.CodeAnalysis.Classification
-{
-    [DataContract]
-    internal readonly record struct ClassificationOptions(
-        [property: DataMember(Order = 0)] bool ClassifyReassignedVariables = false,
-        [property: DataMember(Order = 1)] bool ColorizeRegexPatterns = true,
-        [property: DataMember(Order = 2)] bool ColorizeJsonPatterns = true,
-        [property: DataMember(Order = 3)] bool ForceFrozenPartialSemanticsForCrossProcessOperations = false)
-    {
-        public ClassificationOptions()
-            : this(ClassifyReassignedVariables: false)
-        {
-        }
+namespace Microsoft.CodeAnalysis.Classification;
 
-        public static readonly ClassificationOptions Default = new();
+[DataContract]
+internal readonly record struct ClassificationOptions
+{
+    [DataMember] public bool ClassifyReassignedVariables { get; init; } = false;
+    [DataMember] public bool ColorizeRegexPatterns { get; init; } = true;
+    [DataMember] public bool ColorizeJsonPatterns { get; init; } = true;
+    [DataMember] public bool ForceFrozenPartialSemanticsForCrossProcessOperations { get; init; } = false;
+
+    public ClassificationOptions()
+    {
     }
+
+    public static readonly ClassificationOptions Default = new();
 }

--- a/src/Workspaces/Core/Portable/Options/IGlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/IGlobalOptionService.cs
@@ -12,12 +12,8 @@ using Microsoft.CodeAnalysis.Host;
 namespace Microsoft.CodeAnalysis.Options
 {
     /// <summary>
-    /// Provides services for reading and writing options.
-    /// This will provide support for options at the global level (i.e. shared among
-    /// all workspaces/services).
-    /// 
-    /// In general you should not import this type directly, and should instead get an
-    /// <see cref="ILegacyWorkspaceOptionService"/> from <see cref="Workspace.Services"/>
+    /// Provides services for reading and writing global client (in-proc) options
+    /// shared across all workspaces.
     /// </summary>
     internal interface IGlobalOptionService
     {

--- a/src/Workspaces/Core/Portable/OrganizeImports/OrganizeImportsOptions.cs
+++ b/src/Workspaces/Core/Portable/OrganizeImports/OrganizeImportsOptions.cs
@@ -15,9 +15,9 @@ namespace Microsoft.CodeAnalysis.OrganizeImports;
 [DataContract]
 internal readonly record struct OrganizeImportsOptions
 {
-    [property: DataMember(Order = 0)] public bool PlaceSystemNamespaceFirst { get; init; } = AddImportPlacementOptions.Default.PlaceSystemNamespaceFirst;
-    [property: DataMember(Order = 1)] public bool SeparateImportDirectiveGroups { get; init; } = SyntaxFormattingOptions.CommonOptions.Default.SeparateImportDirectiveGroups;
-    [property: DataMember(Order = 2)] public string NewLine { get; init; } = LineFormattingOptions.Default.NewLine;
+    [DataMember] public bool PlaceSystemNamespaceFirst { get; init; } = AddImportPlacementOptions.Default.PlaceSystemNamespaceFirst;
+    [DataMember] public bool SeparateImportDirectiveGroups { get; init; } = SyntaxFormattingOptions.CommonOptions.Default.SeparateImportDirectiveGroups;
+    [DataMember] public string NewLine { get; init; } = LineFormattingOptions.Default.NewLine;
 
     public OrganizeImportsOptions()
     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleOptions2.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         internal static readonly PerLanguageOption2<CodeStyleOption2<bool>> PreferSystemHashCode = CreateOption(
             CodeStyleOptionGroups.ExpressionLevelPreferences,
             nameof(PreferSystemHashCode),
-            IdeAnalyzerOptions.DefaultPreferSystemHashCode,
+            IdeAnalyzerOptions.CommonDefault.PreferSystemHashCode,
             new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferSystemHashCode"));
 
         public static readonly PerLanguageOption2<CodeStyleOption2<bool>> PreferNamespaceAndFolderMatchStructure = CreateOption(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Diagnostics/IdeAnalyzerOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Diagnostics/IdeAnalyzerOptions.cs
@@ -57,7 +57,7 @@ internal sealed record class IdeAnalyzerOptions
         => new()
         {
             CleanCodeGenerationOptions = CodeGeneration.CleanCodeGenerationOptions.GetDefault(languageServices),
-            CodeStyleOptions = IdeCodeStyleOptions.GetDefault(languageServices)
+            CodeStyleOptions = IdeCodeStyleOptions.GetDefault(languageServices),
         };
 #endif
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Diagnostics/IdeAnalyzerOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Diagnostics/IdeAnalyzerOptions.cs
@@ -16,7 +16,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics;
 [DataContract]
 internal sealed record class IdeAnalyzerOptions
 {
-    public static readonly CodeStyleOption2<bool> DefaultPreferSystemHashCode = new(value: true, notification: NotificationOption2.Suggestion);
+    private static readonly CodeStyleOption2<bool> s_defaultPreferSystemHashCode =
+        new(value: true, notification: NotificationOption2.Suggestion);
 
     public static readonly IdeAnalyzerOptions CodeStyleDefault = new()
     {
@@ -27,32 +28,36 @@ internal sealed record class IdeAnalyzerOptions
 
     public static readonly IdeAnalyzerOptions CommonDefault = new();
 
-    [DataMember(Order = 0)] public bool CrashOnAnalyzerException { get; init; } = false;
-    [DataMember(Order = 1)] public bool FadeOutUnusedImports { get; init; } = true;
-    [DataMember(Order = 2)] public bool FadeOutUnreachableCode { get; init; } = true;
-    [DataMember(Order = 3)] public bool FadeOutComplexObjectInitialization { get; init; } = false;
-    [DataMember(Order = 4)] public bool FadeOutComplexCollectionInitialization { get; init; } = false;
-    [DataMember(Order = 5)] public bool ReportInvalidPlaceholdersInStringDotFormatCalls { get; init; } = true;
-    [DataMember(Order = 6)] public bool ReportInvalidRegexPatterns { get; init; } = true;
-    [DataMember(Order = 7)] public bool ReportInvalidJsonPatterns { get; init; } = true;
-    [DataMember(Order = 8)] public bool DetectAndOfferEditorFeaturesForProbableJsonStrings { get; init; } = true;
-    [DataMember(Order = 9)] public CodeStyleOption2<bool> PreferSystemHashCode { get; init; } = DefaultPreferSystemHashCode;
+    [DataMember] public bool CrashOnAnalyzerException { get; init; } = false;
+    [DataMember] public bool FadeOutUnusedImports { get; init; } = true;
+    [DataMember] public bool FadeOutUnreachableCode { get; init; } = true;
+    [DataMember] public bool FadeOutComplexObjectInitialization { get; init; } = false;
+    [DataMember] public bool FadeOutComplexCollectionInitialization { get; init; } = false;
+    [DataMember] public bool ReportInvalidPlaceholdersInStringDotFormatCalls { get; init; } = true;
+    [DataMember] public bool ReportInvalidRegexPatterns { get; init; } = true;
+    [DataMember] public bool ReportInvalidJsonPatterns { get; init; } = true;
+    [DataMember] public bool DetectAndOfferEditorFeaturesForProbableJsonStrings { get; init; } = true;
+    [DataMember] public CodeStyleOption2<bool> PreferSystemHashCode { get; init; } = s_defaultPreferSystemHashCode;
 
     /// <summary>
     /// Default values for <see cref="CleanCodeGenerationOptions"/>, or null if not available (the project language does not support these options).
     /// </summary>
-    [DataMember(Order = 10)] public CleanCodeGenerationOptions? CleanCodeGenerationOptions { get; init; } = null;
+    [DataMember] public CleanCodeGenerationOptions? CleanCodeGenerationOptions { get; init; } = null;
 
     /// <summary>
     /// Default values for <see cref="IdeCodeStyleOptions"/>, or null if not available (the project language does not support these options).
     /// </summary>
-    [DataMember(Order = 11)] public IdeCodeStyleOptions? CodeStyleOptions { get; init; } = null;
+    [DataMember] public IdeCodeStyleOptions? CodeStyleOptions { get; init; } = null;
 
     public CodeCleanupOptions? CleanupOptions => CleanCodeGenerationOptions?.CleanupOptions;
     public CodeGenerationOptions? GenerationOptions => CleanCodeGenerationOptions?.GenerationOptions;
 
 #if !CODE_STYLE
     public static IdeAnalyzerOptions GetDefault(HostLanguageServices languageServices)
-        => new() { CleanCodeGenerationOptions = CodeGeneration.CleanCodeGenerationOptions.GetDefault(languageServices) };
+        => new()
+        {
+            CleanCodeGenerationOptions = CodeGeneration.CleanCodeGenerationOptions.GetDefault(languageServices),
+            CodeStyleOptions = IdeCodeStyleOptions.GetDefault(languageServices)
+        };
 #endif
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/AutoFormattingOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/AutoFormattingOptions.cs
@@ -12,10 +12,10 @@ namespace Microsoft.CodeAnalysis.Formatting;
 [DataContract]
 internal readonly record struct AutoFormattingOptions
 {
-    [DataMember(Order = 0)] public bool FormatOnReturn { get; init; } = true;
-    [DataMember(Order = 1)] public bool FormatOnTyping { get; init; } = true;
-    [DataMember(Order = 2)] public bool FormatOnSemicolon { get; init; } = true;
-    [DataMember(Order = 3)] public bool FormatOnCloseBrace { get; init; } = true;
+    [DataMember] public bool FormatOnReturn { get; init; } = true;
+    [DataMember] public bool FormatOnTyping { get; init; } = true;
+    [DataMember] public bool FormatOnSemicolon { get; init; } = true;
+    [DataMember] public bool FormatOnCloseBrace { get; init; } = true;
 
     public AutoFormattingOptions()
     {


### PR DESCRIPTION
Add test that validates that all properties of options objects are initialized when read from global options.

Use init-property pattern for all option types.

Fixes #61857
Fixes #61859