### PR TITLE
Add FixAll support to ConvertIfToSwitch refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchFixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchFixAllTests.cs
@@ -145,6 +145,56 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfTo
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task ConvertIfToSwitchStatement_Nested_FixAllInDocument()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    int M(int i, int j)
+    {
+        {|FixAllInDocument:|}if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (j == 6)
+            {
+                if (i == 6) return 1;
+                if (i == 7) return 2;
+                return 3;
+            }
+        }
+    }
+}",
+@"class C
+{
+    int M(int i, int j)
+    {
+        switch (i)
+        {
+            case 3:
+                return 0;
+            default:
+                if (j == 6)
+                {
+                    switch (i)
+                    {
+                        case 6:
+                            return 1;
+                        case 7:
+                            return 2;
+                        default:
+                            return 3;
+                    }
+                }
+                break;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public async Task ConvertIfToSwitchStatement_FixAllInProject()
         {
             await TestInRegularAndScriptAsync(

--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchFixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchFixAllTests.cs
@@ -1,0 +1,575 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.ConvertIfToSwitch;
+using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.ConvertIfToSwitch
+{
+    public class ConvertIfToSwitchFixAllTests : AbstractCSharpCodeActionTest
+    {
+        protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
+            => new CSharpConvertIfToSwitchCodeRefactoringProvider();
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task ConvertIfToSwitchStatement_FixAllInDocument()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    int M(int i)
+    {
+        {|FixAllInDocument:|}if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+
+    int M2(int i)
+    {
+        if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+}",
+@"class C
+{
+    int M(int i)
+    {
+        switch (i)
+        {
+            case 3:
+                return 0;
+            case 6:
+                return 1;
+            case 7:
+                return 1;
+            default:
+                return 0;
+        }
+    }
+
+    int M2(int i)
+    {
+        switch (i)
+        {
+            case 3:
+                return 0;
+            case 6:
+                return 1;
+            case 7:
+                return 1;
+            default:
+                return 0;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task ConvertIfToSwitchExpression_FixAllInDocument()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    int M(int i)
+    {
+        {|FixAllInDocument:|}if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+
+    int M2(int i)
+    {
+        if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+}",
+@"class C
+{
+    int M(int i)
+    {
+        return i switch
+        {
+            3 => 0,
+            6 => 1,
+            7 => 1,
+            _ => 0
+        };
+    }
+
+    int M2(int i)
+    {
+        return i switch
+        {
+            3 => 0,
+            6 => 1,
+            7 => 1,
+            _ => 0
+        };
+    }
+}", index: 1);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task ConvertIfToSwitchStatement_FixAllInProject()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+class C
+{
+    int M(int i)
+    {
+        {|FixAllInProject:|}if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+}
+        </Document>
+        <Document>
+class C2
+{
+    int M2(int i)
+    {
+        if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+class C3
+{
+    int M3(int i)
+    {
+        if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>",
+@"<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+class C
+{
+    int M(int i)
+    {
+        switch (i)
+        {
+            case 3:
+                return 0;
+            case 6:
+                return 1;
+            case 7:
+                return 1;
+            default:
+                return 0;
+        }
+    }
+}
+        </Document>
+        <Document>
+class C2
+{
+    int M2(int i)
+    {
+        switch (i)
+        {
+            case 3:
+                return 0;
+            case 6:
+                return 1;
+            case 7:
+                return 1;
+            default:
+                return 0;
+        }
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+class C3
+{
+    int M3(int i)
+    {
+        if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task ConvertIfToSwitchStatement_FixAllInSolution()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+class C
+{
+    int M(int i)
+    {
+        {|FixAllInSolution:|}if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+}
+        </Document>
+        <Document>
+class C2
+{
+    int M2(int i)
+    {
+        if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+class C3
+{
+    int M3(int i)
+    {
+        if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>",
+@"<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+class C
+{
+    int M(int i)
+    {
+        switch (i)
+        {
+            case 3:
+                return 0;
+            case 6:
+                return 1;
+            case 7:
+                return 1;
+            default:
+                return 0;
+        }
+    }
+}
+        </Document>
+        <Document>
+class C2
+{
+    int M2(int i)
+    {
+        switch (i)
+        {
+            case 3:
+                return 0;
+            case 6:
+                return 1;
+            case 7:
+                return 1;
+            default:
+                return 0;
+        }
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+class C3
+{
+    int M3(int i)
+    {
+        switch (i)
+        {
+            case 3:
+                return 0;
+            case 6:
+                return 1;
+            case 7:
+                return 1;
+            default:
+                return 0;
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task ConvertIfToSwitchStatement_FixAllInContainingMember()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    int M(int i)
+    {
+        {|FixAllInContainingMember:|}if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+
+    int M2(int i)
+    {
+        if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+}",
+@"class C
+{
+    int M(int i)
+    {
+        switch (i)
+        {
+            case 3:
+                return 0;
+            case 6:
+                return 1;
+            case 7:
+                return 1;
+            default:
+                return 0;
+        }
+    }
+
+    int M2(int i)
+    {
+        if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task ConvertIfToSwitchStatement_FixAllInContainingType()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    int M(int i)
+    {
+        {|FixAllInContainingType:|}if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+
+    int M2(int i)
+    {
+        if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+}
+
+class C2
+{
+    int M3(int i)
+    {
+        if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+}",
+@"class C
+{
+    int M(int i)
+    {
+        switch (i)
+        {
+            case 3:
+                return 0;
+            case 6:
+                return 1;
+            case 7:
+                return 1;
+            default:
+                return 0;
+        }
+    }
+
+    int M2(int i)
+    {
+        switch (i)
+        {
+            case 3:
+                return 0;
+            case 6:
+                return 1;
+            case 7:
+                return 1;
+            default:
+                return 0;
+        }
+    }
+}
+
+class C2
+{
+    int M3(int i)
+    {
+        if (i == 3)
+        {
+            return 0;
+        }
+        else
+        {
+            if (i == 6) return 1;
+            if (i == 7) return 1;
+            return 0;
+        }
+    }
+}");
+        }
+    }
+}

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchFixAllTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ConvertIfToSwitch/ConvertIfToSwitchFixAllTests.vb
@@ -1,0 +1,384 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.CodeAnalysis.CodeRefactorings
+Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
+Imports Microsoft.CodeAnalysis.VisualBasic.ConvertIfToSwitch
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.ConvertIfToSwitch
+    Public Class ConvertIfToSwitchFixAllTests
+        Inherits AbstractVisualBasicCodeActionTest
+
+        Protected Overrides Function CreateCodeRefactoringProvider(workspace As Workspace, parameters As TestParameters) As CodeRefactoringProvider
+            Return New VisualBasicConvertIfToSwitchCodeRefactoringProvider()
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)>
+        Public Async Function ConvertIfToSwitchStatement_FixAllInDocument() As Task
+            Await TestInRegularAndScriptAsync(
+"Class C
+    Sub M(i As Integer)
+        {|FixAllInDocument:|}If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+
+    Sub M2(i As Integer)
+        If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+End Class",
+"Class C
+    Sub M(i As Integer)
+        Select i
+            Case 1, 2, 3
+                M(0)
+            Case 4, 5, 6
+                M(1)
+            Case Else
+                M(2)
+        End Select
+    End Sub
+
+    Sub M2(i As Integer)
+        Select i
+            Case 1, 2, 3
+                M(0)
+            Case 4, 5, 6
+                M(1)
+            Case Else
+                M(2)
+        End Select
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)>
+        Public Async Function ConvertIfToSwitchStatement_FixAllInProject() As Task
+            Await TestInRegularAndScriptAsync(
+"
+<Workspace>
+    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+Class C
+    Sub M(i As Integer)
+        {|FixAllInProject:|}If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+End Class
+        </Document>
+        <Document>
+Class C2
+    Sub M2(i As Integer)
+        If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+End Class
+        </Document>
+    </Project>
+    <Project Language=""Visual Basic"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+Class C3
+    Sub M3(i As Integer)
+        If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>",
+"<Workspace>
+    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+Class C
+    Sub M(i As Integer)
+        Select i
+            Case 1, 2, 3
+                M(0)
+            Case 4, 5, 6
+                M(1)
+            Case Else
+                M(2)
+        End Select
+    End Sub
+End Class
+        </Document>
+        <Document>
+Class C2
+    Sub M2(i As Integer)
+        Select i
+            Case 1, 2, 3
+                M(0)
+            Case 4, 5, 6
+                M(1)
+            Case Else
+                M(2)
+        End Select
+    End Sub
+End Class
+        </Document>
+    </Project>
+    <Project Language=""Visual Basic"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+Class C3
+    Sub M3(i As Integer)
+        If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)>
+        Public Async Function ConvertIfToSwitchStatement_FixAllInSolution() As Task
+            Await TestInRegularAndScriptAsync(
+"
+<Workspace>
+    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+Class C
+    Sub M(i As Integer)
+        {|FixAllInSolution:|}If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+End Class
+        </Document>
+        <Document>
+Class C2
+    Sub M2(i As Integer)
+        If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+End Class
+        </Document>
+    </Project>
+    <Project Language=""Visual Basic"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+Class C3
+    Sub M3(i As Integer)
+        If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>",
+"<Workspace>
+    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+Class C
+    Sub M(i As Integer)
+        Select i
+            Case 1, 2, 3
+                M(0)
+            Case 4, 5, 6
+                M(1)
+            Case Else
+                M(2)
+        End Select
+    End Sub
+End Class
+        </Document>
+        <Document>
+Class C2
+    Sub M2(i As Integer)
+        Select i
+            Case 1, 2, 3
+                M(0)
+            Case 4, 5, 6
+                M(1)
+            Case Else
+                M(2)
+        End Select
+    End Sub
+End Class
+        </Document>
+    </Project>
+    <Project Language=""Visual Basic"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+Class C3
+    Sub M3(i As Integer)
+        Select i
+            Case 1, 2, 3
+                M(0)
+            Case 4, 5, 6
+                M(1)
+            Case Else
+                M(2)
+        End Select
+    End Sub
+End Class
+        </Document>
+    </Project>
+</Workspace>")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)>
+        Public Async Function ConvertIfToSwitchStatement_FixAllInContainingMember() As Task
+            Await TestInRegularAndScriptAsync(
+"Class C
+    Sub M(i As Integer)
+        {|FixAllInContainingMember:|}If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+
+    Sub M2(i As Integer)
+        If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+End Class",
+"Class C
+    Sub M(i As Integer)
+        Select i
+            Case 1, 2, 3
+                M(0)
+            Case 4, 5, 6
+                M(1)
+            Case Else
+                M(2)
+        End Select
+    End Sub
+
+    Sub M2(i As Integer)
+        If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertIfToSwitch)>
+        Public Async Function ConvertIfToSwitchStatement_FixAllInContainingType() As Task
+            Await TestInRegularAndScriptAsync(
+"Class C
+    Sub M(i As Integer)
+        {|FixAllInContainingType:|}If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+
+    Sub M2(i As Integer)
+        If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+End Class
+
+Class C2
+    Sub M3(i As Integer)
+        If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+End Class",
+"Class C
+    Sub M(i As Integer)
+        Select i
+            Case 1, 2, 3
+                M(0)
+            Case 4, 5, 6
+                M(1)
+            Case Else
+                M(2)
+        End Select
+    End Sub
+
+    Sub M2(i As Integer)
+        Select i
+            Case 1, 2, 3
+                M(0)
+            Case 4, 5, 6
+                M(1)
+            Case Else
+                M(2)
+        End Select
+    End Sub
+End Class
+
+Class C2
+    Sub M3(i As Integer)
+        If i = 1 OrElse 2 = i OrElse i = 3 Then
+            M(0)
+        ElseIf i = 4 OrElse 5 = i OrElse i = 6 Then
+            M(1)
+        Else
+            M(2)
+        End If
+    End Sub
+End Class")
+        End Function
+    End Class
+End Namespace

--- a/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertIfToSwitch/CSharpConvertIfToSwitchCodeRefactoringProvider.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Composition;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.ConvertIfToSwitch;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
@@ -19,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertIfToSwitch
         : AbstractConvertIfToSwitchCodeRefactoringProvider<IfStatementSyntax, ExpressionSyntax, BinaryExpressionSyntax, PatternSyntax>
     {
         [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
         public CSharpConvertIfToSwitchCodeRefactoringProvider()
         {
         }

--- a/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
         }
 
         private bool ShouldOfferRefactoring(
-            TIfStatementSyntax? ifStatement,
+            [NotNullWhen(true)] TIfStatementSyntax? ifStatement,
             SemanticModel semanticModel,
             ISyntaxFactsService syntaxFactsService,
             [NotNullWhen(true)] out Analyzer? analyzer,

--- a/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.cs
@@ -5,23 +5,32 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
 {
     internal abstract partial class AbstractConvertIfToSwitchCodeRefactoringProvider<
-        TIfStatementSyntax, TExpressionSyntax, TIsExpressionSyntax, TPatternSyntax> : CodeRefactoringProvider
+        TIfStatementSyntax, TExpressionSyntax, TIsExpressionSyntax, TPatternSyntax> : SyntaxEditorBasedCodeRefactoringProvider
     {
+        private const string SwitchStatementEquivalenceKey = "SwitchStatement";
+        private const string SwitchExpressionEquivalenceKey = "SwitchExpression";
+
         public abstract string GetTitle(bool forSwitchExpression);
         public abstract Analyzer CreateAnalyzer(ISyntaxFacts syntaxFacts, ParseOptions options);
+
+        protected sealed override ImmutableArray<FixAllScope> SupportedFixAllScopes => AllFixAllScopes;
 
         public sealed override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
@@ -32,31 +41,62 @@ namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
             }
 
             var ifStatement = await context.TryGetRelevantNodeAsync<TIfStatementSyntax>().ConfigureAwait(false);
-            if (ifStatement == null || ifStatement.GetDiagnostics().Any(d => d.Severity == DiagnosticSeverity.Error))
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var syntaxFactsService = document.GetRequiredLanguageService<ISyntaxFactsService>();
+            if (!ShouldOfferRefactoring(ifStatement, semanticModel, syntaxFactsService, out var analyzer, out var sections, out var target))
             {
                 return;
             }
 
-            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            context.RegisterRefactoring(
+                CodeAction.Create(
+                    GetTitle(forSwitchExpression: false),
+                    c => UpdateDocumentAsync(document, target, ifStatement, sections, analyzer.Features, convertToSwitchExpression: false, c),
+                    SwitchStatementEquivalenceKey),
+                ifStatement.Span);
+
+            if (analyzer.Supports(Feature.SwitchExpression) &&
+                CanConvertToSwitchExpression(analyzer.Supports(Feature.OrPattern), sections))
+            {
+                context.RegisterRefactoring(
+                    CodeAction.Create(
+                        GetTitle(forSwitchExpression: true),
+                        c => UpdateDocumentAsync(document, target, ifStatement, sections, analyzer.Features, convertToSwitchExpression: true, c),
+                        SwitchExpressionEquivalenceKey),
+                    ifStatement.Span);
+            }
+        }
+
+        private bool ShouldOfferRefactoring(
+            TIfStatementSyntax? ifStatement,
+            SemanticModel semanticModel,
+            ISyntaxFactsService syntaxFactsService,
+            [NotNullWhen(true)] out Analyzer? analyzer,
+            [NotNullWhen(true)] out ImmutableArray<AnalyzedSwitchSection> sections,
+            [NotNullWhen(true)] out SyntaxNode? target)
+        {
+            analyzer = null;
+            sections = default;
+            target = null;
+
+            if (ifStatement == null || ifStatement.GetDiagnostics().Any(d => d.Severity == DiagnosticSeverity.Error))
+            {
+                return false;
+            }
+
             var ifOperation = semanticModel.GetOperation(ifStatement);
             if (ifOperation is not IConditionalOperation { Parent: IBlockOperation parentBlock })
             {
-                return;
+                return false;
             }
 
             var operations = parentBlock.Operations;
             var index = operations.IndexOf(ifOperation);
-            var syntaxFactsService = document.GetLanguageService<ISyntaxFactsService>();
-            if (syntaxFactsService == null)
-            {
-                return;
-            }
-
-            var analyzer = CreateAnalyzer(syntaxFactsService, ifStatement.SyntaxTree.Options);
-            var (sections, target) = analyzer.AnalyzeIfStatementSequence(operations.AsSpan()[index..]);
+            analyzer = CreateAnalyzer(syntaxFactsService, ifStatement.SyntaxTree.Options);
+            (sections, target) = analyzer.AnalyzeIfStatementSequence(operations.AsSpan()[index..]);
             if (sections.IsDefaultOrEmpty)
             {
-                return;
+                return false;
             }
 
             // To prevent noisiness we don't offer this unless we're going to generate at least
@@ -74,26 +114,10 @@ namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
             var labelCount = sections.Sum(section => section.Labels.IsDefault ? 1 : section.Labels.Length);
             if (labelCount < 2)
             {
-                return;
+                return false;
             }
 
-            context.RegisterRefactoring(
-                CodeAction.Create(
-                    GetTitle(forSwitchExpression: false),
-                    c => UpdateDocumentAsync(document, target, ifStatement, sections, analyzer.Features, convertToSwitchExpression: false, c),
-                    "SwitchStatement"),
-                ifStatement.Span);
-
-            if (analyzer.Supports(Feature.SwitchExpression) &&
-                CanConvertToSwitchExpression(analyzer.Supports(Feature.OrPattern), sections))
-            {
-                context.RegisterRefactoring(
-                    CodeAction.Create(
-                        GetTitle(forSwitchExpression: true),
-                        c => UpdateDocumentAsync(document, target, ifStatement, sections, analyzer.Features, convertToSwitchExpression: true, c),
-                        "SwitchExpression"),
-                    ifStatement.Span);
-            }
+            return true;
         }
 
         private static bool CanConvertToSwitchExpression(
@@ -151,6 +175,52 @@ namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
                 // and as long as no label has any guards.
                 return supportsOrPattern && section.Labels.All(label => label.Guards.IsDefaultOrEmpty);
             }
+        }
+
+        protected sealed override async Task FixAllAsync(
+            Document document,
+            ImmutableArray<TextSpan> fixAllSpans,
+            SyntaxEditor editor,
+            CodeActionOptionsProvider optionsProvider,
+            string? equivalenceKey,
+            CancellationToken cancellationToken)
+        {
+            var convertToSwitchExpression = equivalenceKey == SwitchExpressionEquivalenceKey;
+            var syntaxFactsService = document.GetRequiredLanguageService<ISyntaxFactsService>();
+
+            // Get all the descendant if statements to process.
+            var ifStatements = editor.OriginalRoot.DescendantNodes().OfType<TIfStatementSyntax>();
+
+            // We're going to be continually editing this tree. Track all the nodes we
+            // care about so we can find them across each edit.
+            document = document.WithSyntaxRoot(editor.OriginalRoot.TrackNodes(ifStatements));
+
+            // Process the if statements.
+            foreach (var originalIfStatement in ifStatements)
+            {
+                // Only process if statements fully within a fixAllSpan
+                if (!fixAllSpans.Any(fixAllSpan => fixAllSpan.Contains(originalIfStatement.Span)))
+                    continue;
+
+                // Get current root, if statement and semantic model.
+                var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                var ifStatement = root.GetCurrentNodes(originalIfStatement).SingleOrDefault();
+                var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+                // Check if the refactoring is applicable for this if statement.
+                if (!ShouldOfferRefactoring(ifStatement, semanticModel, syntaxFactsService, out var analyzer, out var sections, out var target))
+                    continue;
+
+                // When converting to switch expression, we need to perform an additional check to ensure this conversion is possible.
+                if (convertToSwitchExpression && !CanConvertToSwitchExpression(analyzer.Supports(Feature.OrPattern), sections))
+                    continue;
+
+                document = await UpdateDocumentAsync(document, target, ifStatement, sections,
+                    analyzer.Features, convertToSwitchExpression, cancellationToken).ConfigureAwait(false);
+            }
+
+            var updatedRoot = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            editor.ReplaceNode(editor.OriginalRoot, updatedRoot);
         }
     }
 }


### PR DESCRIPTION
This was identified as a high value refactoring for FixAll support as it promotes a new language feature (C# switch expressions).