### PR TITLE
Fix Rune access issue on AspNetCoreVirtualChar

### DIFF
--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualChar.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualChar.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
         public override string ToString() => _virtualChar.ToString();
 
         /// <inheritdoc cref="VirtualChar.Equals(object)"/>
-        public override bool Equals(object? obj) => _virtualChar.Equals(obj);
+        public override bool Equals(object? obj) => obj is AspNetCoreVirtualChar vc && Equals(vc);
 
         /// <inheritdoc cref="VirtualChar.Equals(VirtualChar)"/>
         public bool Equals(AspNetCoreVirtualChar other) => _virtualChar.Equals(other._virtualChar);

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualChar.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualChar.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Text;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
 {
-    internal readonly struct AspNetCoreVirtualChar
+    internal readonly struct AspNetCoreVirtualChar : IEquatable<AspNetCoreVirtualChar>
     {
         private readonly VirtualChar _virtualChar;
 
@@ -17,8 +18,15 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
             _virtualChar = virtualChar;
         }
 
-        /// <inheritdoc cref="VirtualChar.Rune"/>
-        public Rune Rune => _virtualChar.Rune;
+        /// <summary>
+        /// Returns the Unicode scalar value as an integer.
+        /// </summary>
+        public int RuneValue
+        {
+            // Rune is an internal shim with netstandard2.0 and accessing it throws an internal access exception.
+            // Expose integer value. Can be converted back to Rune by caller.
+            get => _virtualChar.Rune.Value;
+        }
 
         /// <inheritdoc cref="VirtualChar.SurrogateChar"/>
         public char SurrogateChar => _virtualChar.SurrogateChar;
@@ -31,5 +39,14 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
 
         /// <inheritdoc cref="VirtualChar.ToString"/>
         public override string ToString() => _virtualChar.ToString();
+
+        /// <inheritdoc cref="VirtualChar.Equals(object)"/>
+        public override bool Equals(object? obj) => _virtualChar.Equals(obj);
+
+        /// <inheritdoc cref="VirtualChar.Equals(VirtualChar)"/>
+        public bool Equals(AspNetCoreVirtualChar other) => _virtualChar.Equals(other._virtualChar);
+
+        /// <inheritdoc cref="VirtualChar.GetHashCode"/>
+        public override int GetHashCode() => _virtualChar.GetHashCode();
     }
 }


### PR DESCRIPTION
Rune is an internal shim with netstandard2.0 and accessing it throws an internal access exception. Expose integer value as RuneValue instead. I'm not sure whether RuneValue is necessary when [Value](https://github.com/dotnet/roslyn/blob/06f579b06f045b831d715287561f748f8d919e03/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualChar.cs#L88) already exists. I don't have code that uses RuneValue and it could be removed from this PR.

Also added equality implementations. I wanted to test equality of virtual chars and [Equals](https://github.com/dotnet/roslyn/blob/06f579b06f045b831d715287561f748f8d919e03/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualChar.cs#L116-L119) uses Rune. Copying the Equals logic in my assembly is how I noticed this problem.