### PR TITLE
Parse single identifier as expression in some cases

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -17,6 +17,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 {
+    using System.Linq;
     using Microsoft.CodeAnalysis.Syntax.InternalSyntax;
 
     internal partial class LanguageParser : SyntaxParser
@@ -2661,7 +2662,8 @@ parse_member_name:;
                                 // Do not parse a single identifier as an expression statement in a Simple Program, this could be a beginning of a keyword and
                                 // we want completion to offer it.
                                 ((ExpressionStatementSyntax)statement) is var exprStatement &&
-                                exprStatement.Expression.Kind == SyntaxKind.IdentifierName &&
+                                exprStatement.Expression is IdentifierNameSyntax identifier &&
+                                !identifier.Identifier.Text.Any(char.IsUpper) && // C# keyword cannot contain upper case letters. In case our identifier does then it is definitely not a keyword start
                                 exprStatement.SemicolonToken.IsMissing:
 
                         return false;

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -8545,7 +8545,7 @@ class B<X, Y> : A<int
         [Fact, WorkItem(30102, "https://github.com/dotnet/roslyn/issues/30102")]
         public void TestExtraneousColonInBaseList()
         {
-            var tree = UsingNode(@"
+            UsingNode(@"
 class A : B : C
 {
 }
@@ -8559,17 +8559,17 @@ class A : B : C
                 // (2,13): error CS1022: Type or namespace definition, or end-of-file expected
                 // class A : B : C
                 Diagnostic(ErrorCode.ERR_EOFExpected, ":").WithLocation(2, 13),
-                // (2,15): error CS0116: A namespace cannot directly contain members such as fields or methods
+                // (2,15): error CS8370: Feature 'top-level statements' is not available in C# 7.3. Please use language version 9.0 or greater.
                 // class A : B : C
-                Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "C").WithLocation(2, 15),
-                // (3,1): error CS8370: Feature 'top-level statements' is not available in C# 7.3. Please use language version 9.0 or greater.
-                // {
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, @"{
-}").WithArguments("top-level statements", "9.0").WithLocation(3, 1),
-                // (3,1): error CS8803: Top-level statements must precede namespace and type declarations.
-                // {
-                Diagnostic(ErrorCode.ERR_TopLevelStatementAfterNamespaceOrType, @"{
-}").WithLocation(3, 1)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion7_3, @"C
+").WithArguments("top-level statements", "9.0").WithLocation(2, 15),
+                // (2,15): error CS8803: Top-level statements must precede namespace and type declarations.
+                // class A : B : C
+                Diagnostic(ErrorCode.ERR_TopLevelStatementAfterNamespaceOrType, @"C
+").WithLocation(2, 15),
+                // (2,16): error CS1002: ; expected
+                // class A : B : C
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(2, 16)
                 );
 
             N(SyntaxKind.CompilationUnit);
@@ -8592,13 +8592,17 @@ class A : B : C
                     M(SyntaxKind.OpenBraceToken);
                     M(SyntaxKind.CloseBraceToken);
                 }
-                N(SyntaxKind.IncompleteMember);
+                N(SyntaxKind.GlobalStatement);
                 {
-                    N(SyntaxKind.IdentifierName);
+                    N(SyntaxKind.ExpressionStatement);
                     {
-                        N(SyntaxKind.IdentifierToken, "C");
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "C");
+                        }
                     }
                 }
+                M(SyntaxKind.SemicolonToken);
                 N(SyntaxKind.GlobalStatement);
                 {
                     N(SyntaxKind.Block);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -2451,9 +2451,12 @@ Diagnostic(ErrorCode.ERR_EOFExpected, "}"));
                 // (1,27): error CS1002: ; expected
                 //  > Roslyn.Utilities.dll!  Basic
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "Basic").WithLocation(1, 27),
-                // (1,27): error CS0116: A namespace cannot directly contain members such as fields or methods
+                // (1,27): error CS0103: The name 'Basic' does not exist in the current context
                 //  > Roslyn.Utilities.dll!  Basic
-                Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "Basic").WithLocation(1, 27)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "Basic").WithArguments("Basic").WithLocation(1, 27),
+                // (1,32): error CS1002: ; expected
+                //  > Roslyn.Utilities.dll!  Basic
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(1, 32)
                 );
         }
 
@@ -3882,13 +3885,12 @@ namespace x
    // (1,15): error CS1022: Type or namespace definition, or end-of-file expected
    // public class S.D 
    Diagnostic(ErrorCode.ERR_EOFExpected, ".").WithLocation(1, 15),
-   // (1,16): error CS0116: A namespace cannot directly contain members such as fields or methods
+   // (1,16): error CS8803: Top-level statements must precede namespace and type declarations.
    // public class S.D 
-   Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "D").WithLocation(1, 16),
-   // (2,1): error CS8803: Top-level statements must precede namespace and type declarations.
-   // {
-   Diagnostic(ErrorCode.ERR_TopLevelStatementAfterNamespaceOrType, @"{
-").WithLocation(2, 1),
+   Diagnostic(ErrorCode.ERR_TopLevelStatementAfterNamespaceOrType, @"D 
+").WithLocation(1, 16),
+   // (1,17): error CS1002: ; expected
+   Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(1, 17),
    // (2,2): error CS1513: } expected
    // {
    Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(2, 2),

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/TopLevelStatementsParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/TopLevelStatementsParsingTests.cs
@@ -780,13 +780,13 @@ class Test : Itest
                 // (1,15): error CS1022: Type or namespace definition, or end-of-file expected
                 // public class S.D 
                 Diagnostic(ErrorCode.ERR_EOFExpected, ".").WithLocation(1, 15),
-                // (1,16): error CS0116: A namespace cannot directly contain members such as fields or methods
-                // public class S.D 
-                Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "D").WithLocation(1, 16),
-                // (2,1): error CS8803: Top-level statements must precede namespace and type declarations.
-                // {
-                Diagnostic(ErrorCode.ERR_TopLevelStatementAfterNamespaceOrType, @"{
-").WithLocation(2, 1),
+                // (1,16): error CS8803: Top-level statements must precede namespace and type declarations.
+                // public class S.D
+                Diagnostic(ErrorCode.ERR_TopLevelStatementAfterNamespaceOrType, @"D 
+").WithLocation(1, 16),
+                // (1,17): error CS1002: ; expected
+                // public class S.D
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(1, 17),
                 // (2,2): error CS1513: } expected
                 // {
                 Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(2, 2),
@@ -805,13 +805,17 @@ class Test : Itest
                     M(SyntaxKind.OpenBraceToken);
                     M(SyntaxKind.CloseBraceToken);
                 }
-                N(SyntaxKind.IncompleteMember);
+                N(SyntaxKind.GlobalStatement);
                 {
-                    N(SyntaxKind.IdentifierName);
+                    N(SyntaxKind.ExpressionStatement);
                     {
-                        N(SyntaxKind.IdentifierToken, "D");
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "D");
+                        }
                     }
                 }
+                M(SyntaxKind.SemicolonToken);
                 N(SyntaxKind.GlobalStatement);
                 {
                     N(SyntaxKind.Block);
@@ -868,9 +872,9 @@ class Test : Itest
                 // (1,27): error CS1002: ; expected
                 //  > Roslyn.Utilities.dll!  Basic
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "Basic").WithLocation(1, 27),
-                // (1,27): error CS0116: A namespace cannot directly contain members such as fields or methods
+                // (1,32): error CS1002: ; expected
                 //  > Roslyn.Utilities.dll!  Basic
-                Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "Basic").WithLocation(1, 27)
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(1, 32)
                 );
 
             N(SyntaxKind.CompilationUnit);
@@ -914,13 +918,17 @@ class Test : Itest
                         M(SyntaxKind.SemicolonToken);
                     }
                 }
-                N(SyntaxKind.IncompleteMember);
+                N(SyntaxKind.GlobalStatement);
                 {
-                    N(SyntaxKind.IdentifierName);
+                    N(SyntaxKind.ExpressionStatement);
                     {
-                        N(SyntaxKind.IdentifierToken, "Basic");
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "Basic");
+                        }
                     }
                 }
+                M(SyntaxKind.SemicolonToken);
                 N(SyntaxKind.EndOfFileToken);
             }
             EOF();
@@ -2641,6 +2649,58 @@ e
                     N(SyntaxKind.EmptyStatement);
                     {
                         N(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(61727, "https://github.com/dotnet/roslyn/issues/61727")]
+        public void SingleIdentifierDefinitelyNotAKeyword()
+        {
+            var test = "Identifier";
+
+            UsingTree(test,
+                // (1,11): error CS1002: ; expected
+                // Identifier
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(1, 11));
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.GlobalStatement);
+                {
+                    N(SyntaxKind.ExpressionStatement);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "Identifier");
+                        }
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Fact, WorkItem(61727, "https://github.com/dotnet/roslyn/issues/61727")]
+        public void SingleIdentifierCanBeAKeyword()
+        {
+            var test = "asy";
+
+            UsingTree(test,
+                // (1,1): error CS0116: A namespace cannot directly contain members such as fields or methods.
+                // asy
+                Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "asy").WithLocation(1, 1));
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.IncompleteMember);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "asy");
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/61727

As @CyrusNajmabadi suggested, the fix is implemented on compiler side. Previously `StringBuilder ` was parsed as incomplete member because while writing an identifier can be a start of a keyword and for completion engine it was better to have a syntax tree parsed this way. I added a check for an identifier to not have any uppercase letter, because if it has, then it cannot be a keyword "by definition". It is not a complicated change, it will cover 90+% of cases and the only existing tests I had to modify where some weird edge cases with wrong code, so I think it is rather good solution.

Now pictures of initial issue fixed:
![nSe3XncueO](https://user-images.githubusercontent.com/70431552/173694701-a3f0bc01-7a89-4203-827c-fe25b64d8512.png)

![qeglWQwDRX](https://user-images.githubusercontent.com/70431552/173694713-6fd04cf9-d324-478e-bd64-44fd43d544b9.png)
_Formatting problem is not in the scope of this PR. The end result is anyway better than it was before_