### PR TITLE
Add compliance pipeline for running APIScan

### DIFF
--- a/azure-pipelines-compliance.yml
+++ b/azure-pipelines-compliance.yml
@@ -23,7 +23,9 @@ steps:
 
 - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"
   displayName: Setting SourceBranchName variable
-  condition: succeeded()
+
+- powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
+  displayName: Setting VisualStudio.DropName variable
 
 - task: PowerShell@2
   displayName: Build
@@ -32,13 +34,14 @@ steps:
     arguments: -ci
                -restore
                -build
-               -pack
                -configuration $(BuildConfiguration)
                -officialBuildId $(Build.BuildNumber)
                -officialSkipTests true
                -officialSkipApplyOptimizationData true
                -officialSourceBranchName $(SourceBranchName)
                -officialVisualStudioDropAccessToken $(_DevDivDropAccessToken)
+               /p:RepositoryName=$(Build.Repository.Name)
+               /p:VisualStudioDropName=$(VisualStudio.DropName)
 
 - task: CopyFiles@2
   # APIScan can take a long time, so here we copy (mostly) just the product binaries and related .pdbs

--- a/azure-pipelines-compliance.yml
+++ b/azure-pipelines-compliance.yml
@@ -16,19 +16,14 @@ variables:
   TeamName: DotNet-Roslyn
   SignType: test
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  _DevDivDropAccessToken: $(System.AccessToken)
 
 steps:
 - template: eng/pipelines/checkout-windows-task.yml
 
-- task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
-  displayName: Install Signing Plugin
-  inputs:
-    signType: $(SignType)
-    esrpSigning: true
-  condition: and(succeeded(), ne(variables['SignType'], ''))
-
-- task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
-  displayName: Install Swix Plugin
+- powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"
+  displayName: Setting SourceBranchName variable
+  condition: succeeded()
 
 - task: PowerShell@2
   displayName: Build
@@ -38,10 +33,12 @@ steps:
                -restore
                -build
                -pack
-               -sign
                -configuration $(BuildConfiguration)
-               /p:DotNetSignType=$(SignType)
-               /p:PreReleaseVersionLabel=compliance
+               -officialBuildId $(Build.BuildNumber)
+               -officialSkipTests=true
+               -officialSkipApplyOptimizationData=true
+               -officialSourceBranchName $(SourceBranchName)
+               -officialVisualStudioDropAccessToken $(_DevDivDropAccessToken)
 
 - task: CopyFiles@2
   # APIScan can take a long time, so here we copy (mostly) just the product binaries and related .pdbs
@@ -51,7 +48,9 @@ steps:
     SourceFolder: '$(Build.SourcesDirectory)\artifacts\bin\Roslyn.VisualStudio.Setup\$(BuildConfiguration)\net472'  # Limit to (mostly) product binaries
     Contents: |
       Microsoft.CodeAnalysis*.dll
+      Microsoft.CodeAnalysis*.pdb
       Microsoft.VisualStudio.LanguageServices*.dll
+      Microsoft.VisualStudio.LanguageServices*.pdb
     TargetFolder: '$(Agent.TempDirectory)\APIScanFiles'
   continueOnError: true
 

--- a/azure-pipelines-compliance.yml
+++ b/azure-pipelines-compliance.yml
@@ -1,5 +1,5 @@
 # Name: DotNet-Roslyn-Compliance
-# URL: 
+# URL: https://devdiv.visualstudio.com/DevDiv/_build?definitionId=16722
 #
 # Responsible for running compliance checks.
 
@@ -14,7 +14,7 @@ queue:
 variables:
   BuildConfiguration: Release
   TeamName: DotNet-Roslyn
-  BuildPlatform: any cpu
+  SignType: test
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
 steps:
@@ -44,16 +44,11 @@ steps:
                -officialBuildId $(Build.BuildNumber)
                -officialSkipTests=true
                -officialSkipApplyOptimizationData=true
-               -officialSourceBranchName $(SourceBranchName)
-               -officialIbcDrop $(IbcDrop)
                /p:RepositoryName=$(Build.Repository.Name)
                /p:VisualStudioDropName=$(VisualStudio.DropName)
                /p:DotNetSignType=$(SignType)
                /p:DotNetPublishToBlobFeed=false
                /p:PublishToSymbolServer=false
-               /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-               /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-               /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                /p:DotnetPublishUsingPipelines=false
                /p:PreReleaseVersionLabel=compliance
                /p:IgnoreIbcMergeErrors=true

--- a/azure-pipelines-compliance.yml
+++ b/azure-pipelines-compliance.yml
@@ -18,8 +18,7 @@ variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
 steps:
-- checkout: self
-  clean: true
+- template: eng/pipelines/checkout-windows-task.yml
 
 - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
   displayName: Install Signing Plugin
@@ -41,16 +40,8 @@ steps:
                -pack
                -sign
                -configuration $(BuildConfiguration)
-               -officialBuildId $(Build.BuildNumber)
-               -officialSkipTests=true
-               -officialSkipApplyOptimizationData=true
-               /p:RepositoryName=$(Build.Repository.Name)
                /p:DotNetSignType=$(SignType)
-               /p:DotNetPublishToBlobFeed=false
-               /p:PublishToSymbolServer=false
-               /p:DotnetPublishUsingPipelines=false
                /p:PreReleaseVersionLabel=compliance
-               /p:IgnoreIbcMergeErrors=true
 
 - task: CopyFiles@2
   # APIScan can take a long time, so here we copy (mostly) just the product binaries and related .pdbs

--- a/azure-pipelines-compliance.yml
+++ b/azure-pipelines-compliance.yml
@@ -34,29 +34,29 @@ steps:
 - task: PowerShell@2
   displayName: Build
   inputs:
-  filePath: eng/build.ps1
-  arguments: -ci
-              -restore
-              -build
-              -pack
-              -sign
-              -configuration $(BuildConfiguration)
-              -officialBuildId $(Build.BuildNumber)
-              -officialSkipTests=true
-              -officialSkipApplyOptimizationData=true
-              -officialSourceBranchName $(SourceBranchName)
-              -officialIbcDrop $(IbcDrop)
-              /p:RepositoryName=$(Build.Repository.Name)
-              /p:VisualStudioDropName=$(VisualStudio.DropName)
-              /p:DotNetSignType=$(SignType)
-              /p:DotNetPublishToBlobFeed=false
-              /p:PublishToSymbolServer=false
-              /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-              /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-              /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-              /p:DotnetPublishUsingPipelines=false
-              /p:PreReleaseVersionLabel=compliance
-              /p:IgnoreIbcMergeErrors=true
+    filePath: eng/build.ps1
+    arguments: -ci
+               -restore
+               -build
+               -pack
+               -sign
+               -configuration $(BuildConfiguration)
+               -officialBuildId $(Build.BuildNumber)
+               -officialSkipTests=true
+               -officialSkipApplyOptimizationData=true
+               -officialSourceBranchName $(SourceBranchName)
+               -officialIbcDrop $(IbcDrop)
+               /p:RepositoryName=$(Build.Repository.Name)
+               /p:VisualStudioDropName=$(VisualStudio.DropName)
+               /p:DotNetSignType=$(SignType)
+               /p:DotNetPublishToBlobFeed=false
+               /p:PublishToSymbolServer=false
+               /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+               /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+               /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+               /p:DotnetPublishUsingPipelines=false
+               /p:PreReleaseVersionLabel=compliance
+               /p:IgnoreIbcMergeErrors=true
 
 - task: CopyFiles@2
   # APIScan can take a long time, so here we copy (mostly) just the product binaries and related .pdbs

--- a/azure-pipelines-compliance.yml
+++ b/azure-pipelines-compliance.yml
@@ -32,31 +32,31 @@ steps:
   displayName: Install Swix Plugin
 
 - task: PowerShell@2
-    displayName: Build
-    inputs:
-    filePath: eng/build.ps1
-    arguments: -ci
-                -restore
-                -build
-                -pack
-                -sign
-                -configuration $(BuildConfiguration)
-                -officialBuildId $(Build.BuildNumber)
-                -officialSkipTests=true
-                -officialSkipApplyOptimizationData=true
-                -officialSourceBranchName $(SourceBranchName)
-                -officialIbcDrop $(IbcDrop)
-                /p:RepositoryName=$(Build.Repository.Name)
-                /p:VisualStudioDropName=$(VisualStudio.DropName)
-                /p:DotNetSignType=$(SignType)
-                /p:DotNetPublishToBlobFeed=false
-                /p:PublishToSymbolServer=false
-                /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-                /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-                /p:DotnetPublishUsingPipelines=false
-                /p:PreReleaseVersionLabel=compliance
-                /p:IgnoreIbcMergeErrors=true
+  displayName: Build
+  inputs:
+  filePath: eng/build.ps1
+  arguments: -ci
+              -restore
+              -build
+              -pack
+              -sign
+              -configuration $(BuildConfiguration)
+              -officialBuildId $(Build.BuildNumber)
+              -officialSkipTests=true
+              -officialSkipApplyOptimizationData=true
+              -officialSourceBranchName $(SourceBranchName)
+              -officialIbcDrop $(IbcDrop)
+              /p:RepositoryName=$(Build.Repository.Name)
+              /p:VisualStudioDropName=$(VisualStudio.DropName)
+              /p:DotNetSignType=$(SignType)
+              /p:DotNetPublishToBlobFeed=false
+              /p:PublishToSymbolServer=false
+              /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+              /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+              /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+              /p:DotnetPublishUsingPipelines=false
+              /p:PreReleaseVersionLabel=compliance
+              /p:IgnoreIbcMergeErrors=true
 
 - task: CopyFiles@2
   # APIScan can take a long time, so here we copy (mostly) just the product binaries and related .pdbs

--- a/azure-pipelines-compliance.yml
+++ b/azure-pipelines-compliance.yml
@@ -19,7 +19,7 @@ variables:
   _DevDivDropAccessToken: $(System.AccessToken)
 
 steps:
-- template: eng/pipelines/checkout-windows-task.yml
+- template: eng/pipelines/checkout-task.yml
 
 - powershell: Write-Host "##vso[task.setvariable variable=SourceBranchName]$('$(Build.SourceBranch)'.Substring('refs/heads/'.Length))"
   displayName: Setting SourceBranchName variable

--- a/azure-pipelines-compliance.yml
+++ b/azure-pipelines-compliance.yml
@@ -57,6 +57,36 @@ steps:
     TargetFolder: '$(Agent.TempDirectory)\APIScanFiles'
   continueOnError: true
 
+- task: CopyFiles@2
+  displayName: Copy csc assemblies for APIScan
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)\artifacts\bin\csc\$(BuildConfiguration)\net472'
+    Contents: |
+      csc.dll
+      csc.pdb
+    TargetFolder: '$(Agent.TempDirectory)\APIScanFiles'
+  continueOnError: true
+
+- task: CopyFiles@2
+  displayName: Copy vbc assemblies for APIScan
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)\artifacts\bin\vbc\$(BuildConfiguration)\net472'
+    Contents: |
+      vbc.dll
+      vbc.pdb
+    TargetFolder: '$(Agent.TempDirectory)\APIScanFiles'
+  continueOnError: true
+
+- task: CopyFiles@2
+  displayName: Copy VBCSCompiler assemblies for APIScan
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)\artifacts\bin\VBCSCompiler\$(BuildConfiguration)\net472'
+    Contents: |
+      VBCSCompiler.dll
+      VBCSCompiler.pdb
+    TargetFolder: '$(Agent.TempDirectory)\APIScanFiles'
+  continueOnError: true
+
 - task: APIScan@2
   # Scan for the use of undocumented APIs.
   displayName: Run APIScan

--- a/azure-pipelines-compliance.yml
+++ b/azure-pipelines-compliance.yml
@@ -35,8 +35,8 @@ steps:
                -pack
                -configuration $(BuildConfiguration)
                -officialBuildId $(Build.BuildNumber)
-               -officialSkipTests=true
-               -officialSkipApplyOptimizationData=true
+               -officialSkipTests true
+               -officialSkipApplyOptimizationData true
                -officialSourceBranchName $(SourceBranchName)
                -officialVisualStudioDropAccessToken $(_DevDivDropAccessToken)
 

--- a/azure-pipelines-compliance.yml
+++ b/azure-pipelines-compliance.yml
@@ -1,0 +1,100 @@
+# Name: DotNet-Roslyn-Compliance
+# URL: 
+#
+# Responsible for running compliance checks.
+
+#
+# NOTE: triggers for this build are defined in the Web UI instead of here in the YAML file so they
+#       apply to all branches.
+
+queue:
+  name: VSEngSS-MicroBuild2022-1ES
+  demands: Cmd
+  timeoutInMinutes: 90
+variables:
+  BuildConfiguration: Release
+  TeamName: DotNet-Roslyn
+  BuildPlatform: any cpu
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+steps:
+- checkout: self
+  clean: true
+
+- task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
+  displayName: Install Signing Plugin
+  inputs:
+    signType: $(SignType)
+    esrpSigning: true
+  condition: and(succeeded(), ne(variables['SignType'], ''))
+
+- task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@1
+  displayName: Install Swix Plugin
+
+- task: PowerShell@2
+    displayName: Build
+    inputs:
+    filePath: eng/build.ps1
+    arguments: -ci
+                -restore
+                -build
+                -pack
+                -sign
+                -configuration $(BuildConfiguration)
+                -officialBuildId $(Build.BuildNumber)
+                -officialSkipTests=true
+                -officialSkipApplyOptimizationData=true
+                -officialSourceBranchName $(SourceBranchName)
+                -officialIbcDrop $(IbcDrop)
+                /p:RepositoryName=$(Build.Repository.Name)
+                /p:VisualStudioDropName=$(VisualStudio.DropName)
+                /p:DotNetSignType=$(SignType)
+                /p:DotNetPublishToBlobFeed=false
+                /p:PublishToSymbolServer=false
+                /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+                /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+                /p:DotnetPublishUsingPipelines=false
+                /p:PreReleaseVersionLabel=compliance
+                /p:IgnoreIbcMergeErrors=true
+
+- task: CopyFiles@2
+  # APIScan can take a long time, so here we copy (mostly) just the product binaries and related .pdbs
+  # in an effort to limit what it needs to work on.
+  displayName: Copy Roslyn assemblies for APIScan
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)\artifacts\bin\Roslyn.VisualStudio.Setup\$(BuildConfiguration)\net472'  # Limit to (mostly) product binaries
+    Contents: |
+      Microsoft.CodeAnalysis*.dll
+      Microsoft.VisualStudio.LanguageServices*.dll
+    TargetFolder: '$(Agent.TempDirectory)\APIScanFiles'
+  continueOnError: true
+
+- task: APIScan@2
+  # Scan for the use of undocumented APIs.
+  displayName: Run APIScan
+  inputs:
+    softwareFolder: '$(Agent.TempDirectory)\APIScanFiles' # Only examine the product binaries we previously copied.
+    softwareName: 'Dotnet-Roslyn'
+    softwareVersionNum: '17.0'
+    softwareBuildNum: '$(Build.BuildId)'
+    symbolsFolder: 'SRV*http://symweb'
+  env:
+    AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(ApiScanSecret)
+  continueOnError: true
+
+- task: TSAUpload@2
+  # Scan the output of previous steps and create bugs for any problems.
+  displayName: Upload results and create bugs
+  inputs:
+    GdnPublishTsaOnboard: true
+    GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\eng\TSAConfig.gdntsa'  # All relevant settings are in this file.
+  continueOnError: true
+
+- task: PublishSecurityAnalysisLogs@3
+  displayName: Publishing analysis artifacts
+  inputs:
+    ArtifactName: 'CodeAnalysisLogs'
+    ArtifactType: 'Container'           # Associate the artifacts with the build.
+    AllTools: true                      # Look for logs from all tools.
+    ToolLogsNotFoundAction: 'Standard'  # If a log is not found just output a message to that effect.

--- a/azure-pipelines-compliance.yml
+++ b/azure-pipelines-compliance.yml
@@ -45,7 +45,6 @@ steps:
                -officialSkipTests=true
                -officialSkipApplyOptimizationData=true
                /p:RepositoryName=$(Build.Repository.Name)
-               /p:VisualStudioDropName=$(VisualStudio.DropName)
                /p:DotNetSignType=$(SignType)
                /p:DotNetPublishToBlobFeed=false
                /p:PublishToSymbolServer=false

--- a/eng/TSAConfig.gdntsa
+++ b/eng/TSAConfig.gdntsa
@@ -1,0 +1,17 @@
+{
+    "codebaseName": "Roslyn-GitHub",
+    "notificationAliases": [
+        "mlinfraswat@microsoft.com"
+    ],
+    "codebaseAdmins": [
+        "REDMOND\\jaredpar",
+        "REDMOND\\vaagrawa"
+    ],
+    "instanceUrl": "https://devdiv.visualstudio.com",
+    "projectName": "DevDiv",
+    "areaPath": "DevDiv\\NET Developer Experience\\Productivity",
+    "iterationPath": "DevDiv",
+    "tools": [
+        "APIScan"
+    ]
+}


### PR DESCRIPTION
Added compliance yml for running APIScan on demand. Based on https://github.com/dotnet/project-system/blob/main/build/ci/compliance.yml

Pipeline: https://devdiv.visualstudio.com/DevDiv/_build?definitionId=16722&_a=summary (microsoft)