### PR TITLE
Filter symbol first before creating InheritanceMargin target

### DIFF
--- a/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
+++ b/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
@@ -124,6 +124,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.InheritanceMargin
 
         private static async Task VerifyInheritanceMemberAsync(TestWorkspace testWorkspace, TestInheritanceMemberItem expectedItem, InheritanceMarginItem actualItem)
         {
+            Assert.True(!actualItem.TargetItems.IsEmpty);
             Assert.Equal(expectedItem.LineNumber, actualItem.LineNumber);
             Assert.Equal(expectedItem.MemberName, actualItem.DisplayTexts.JoinText());
             Assert.Equal(expectedItem.Targets.Length, actualItem.TargetItems.Length);
@@ -2278,6 +2279,21 @@ using System.Collections;";
                 new[] { itemForBarInMarkup1 },
                 new[] { itemForIBar, itemForBarInMarkup2 },
                 testHost);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestHiddenLocationSymbol(TestHost testHost)
+        {
+            await VerifyNoItemForDocumentAsync(@"
+public class B : C
+{
+}
+
+#line hidden
+public class C
+{
+}",
+LanguageNames.CSharp, testHost);
         }
     }
 }

--- a/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
+++ b/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
@@ -2284,16 +2284,35 @@ using System.Collections;";
         [Theory, CombinatorialData]
         public async Task TestHiddenLocationSymbol(TestHost testHost)
         {
-            await VerifyNoItemForDocumentAsync(@"
-public class B : C
+            var itemForB = new TestInheritanceMemberItem(
+                lineNumber: 2,
+                memberName: "class B",
+                ImmutableArray.Create(new TargetInfo(
+                    targetSymbolDisplayName: "C",
+                    locationTag: "target1",
+                    relationship: InheritanceRelationship.BaseType)));
+
+            var itemForC = new TestInheritanceMemberItem(
+                lineNumber: 7,
+                memberName: "class C",
+                ImmutableArray.Create(new TargetInfo(
+                    targetSymbolDisplayName: "B",
+                    locationTag: "target2",
+                    relationship: InheritanceRelationship.DerivedType)));
+
+            await VerifyInSingleDocumentAsync(@"
+public class {|target2:B|} : C
 {
 }
 
 #line hidden
-public class C
+public class {|target1:C|}
 {
 }",
-LanguageNames.CSharp, testHost);
+                LanguageNames.CSharp,
+                testHost,
+                itemForB,
+                itemForC);
         }
     }
 }

--- a/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
+++ b/src/EditorFeatures/Test/InheritanceMargin/InheritanceMarginTests.cs
@@ -2284,23 +2284,7 @@ using System.Collections;";
         [Theory, CombinatorialData]
         public async Task TestHiddenLocationSymbol(TestHost testHost)
         {
-            var itemForB = new TestInheritanceMemberItem(
-                lineNumber: 2,
-                memberName: "class B",
-                ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "C",
-                    locationTag: "target1",
-                    relationship: InheritanceRelationship.BaseType)));
-
-            var itemForC = new TestInheritanceMemberItem(
-                lineNumber: 7,
-                memberName: "class C",
-                ImmutableArray.Create(new TargetInfo(
-                    targetSymbolDisplayName: "B",
-                    locationTag: "target2",
-                    relationship: InheritanceRelationship.DerivedType)));
-
-            await VerifyInSingleDocumentAsync(@"
+            await VerifyNoItemForDocumentAsync(@"
 public class {|target2:B|} : C
 {
 }
@@ -2310,9 +2294,7 @@ public class {|target1:C|}
 {
 }",
                 LanguageNames.CSharp,
-                testHost,
-                itemForB,
-                itemForC);
+                testHost);
         }
     }
 }

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -413,14 +413,12 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             var nonNullBaseSymbolItems = GetNonNullTargetItems(baseSymbolItems);
             var nonNullDerivedTypeItems = GetNonNullTargetItems(derivedTypeItems);
 
-            return nonNullBaseSymbolItems.IsEmpty && nonNullDerivedTypeItems.IsEmpty
-                ? null
-                : InheritanceMarginItem.CreateOrdered(
-                    lineNumber,
-                    topLevelDisplayText: null,
-                    FindUsagesHelpers.GetDisplayParts(interfaceSymbol),
-                    interfaceSymbol.GetGlyph(),
-                    nonNullBaseSymbolItems.Concat(nonNullDerivedTypeItems));
+            return InheritanceMarginItem.CreateOrdered(
+                lineNumber,
+                topLevelDisplayText: null,
+                FindUsagesHelpers.GetDisplayParts(interfaceSymbol),
+                interfaceSymbol.GetGlyph(),
+                nonNullBaseSymbolItems.Concat(nonNullDerivedTypeItems));
         }
 
         private static async ValueTask<InheritanceMarginItem?> CreateInheritanceMemberItemForInterfaceMemberAsync(
@@ -440,14 +438,12 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                     cancellationToken), cancellationToken).ConfigureAwait(false);
 
             var nonNullImplementedMemberItems = GetNonNullTargetItems(implementedMemberItems);
-            return nonNullImplementedMemberItems.IsEmpty
-                ? null
-                : InheritanceMarginItem.CreateOrdered(
-                    lineNumber,
-                    topLevelDisplayText: null,
-                    FindUsagesHelpers.GetDisplayParts(memberSymbol),
-                    memberSymbol.GetGlyph(),
-                    nonNullImplementedMemberItems);
+            return InheritanceMarginItem.CreateOrdered(
+                lineNumber,
+                topLevelDisplayText: null,
+                FindUsagesHelpers.GetDisplayParts(memberSymbol),
+                memberSymbol.GetGlyph(),
+                nonNullImplementedMemberItems);
         }
 
         private static async ValueTask<InheritanceMarginItem?> CreateInheritanceItemForClassAndStructureAsync(
@@ -481,14 +477,12 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             var nonNullBaseSymbolItems = GetNonNullTargetItems(baseSymbolItems);
             var nonNullDerivedTypeItems = GetNonNullTargetItems(derivedTypeItems);
 
-            return nonNullBaseSymbolItems.IsEmpty && nonNullDerivedTypeItems.IsEmpty
-                ? null
-                : InheritanceMarginItem.CreateOrdered(
-                    lineNumber,
-                    topLevelDisplayText: null,
-                    FindUsagesHelpers.GetDisplayParts(memberSymbol),
-                    memberSymbol.GetGlyph(),
-                    nonNullBaseSymbolItems.Concat(nonNullDerivedTypeItems));
+            return  InheritanceMarginItem.CreateOrdered(
+                lineNumber,
+                topLevelDisplayText: null,
+                FindUsagesHelpers.GetDisplayParts(memberSymbol),
+                memberSymbol.GetGlyph(),
+                nonNullBaseSymbolItems.Concat(nonNullDerivedTypeItems));
         }
 
         private static async ValueTask<InheritanceMarginItem?> CreateInheritanceMemberItemForClassOrStructMemberAsync(
@@ -531,9 +525,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             var nonNullOverriddenMemberItems = GetNonNullTargetItems(overriddenMemberItems);
             var nonNullOverridingMemberItems = GetNonNullTargetItems(overridingMemberItems);
 
-            return nonNullImplementedMemberItems.IsEmpty && nonNullOverriddenMemberItems.IsEmpty && nonNullOverridingMemberItems.IsEmpty
-                ? null
-                : InheritanceMarginItem.CreateOrdered(
+            return InheritanceMarginItem.CreateOrdered(
                     lineNumber,
                     topLevelDisplayText: null,
                     FindUsagesHelpers.GetDisplayParts(memberSymbol),

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -530,7 +530,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                 topLevelDisplayText: null,
                 FindUsagesHelpers.GetDisplayParts(memberSymbol),
                 memberSymbol.GetGlyph(),
-                nonNullImplementedMemberItems.Concat(nonNullOverriddenMemberItems).Concat(nonNullOverridingMemberItems));
+                nonNullImplementedMemberItems.Concat(nonNullOverriddenMemberItems, nonNullOverridingMemberItems));
         }
 
         private static async ValueTask<InheritanceTargetItem?> CreateInheritanceItemAsync(

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
 
             if (!targetsForBaseSymbols.IsEmpty || !targetsForDerivedSymbols.IsEmpty)
             {
-                var item = CreateInheritanceMemberItem(
+                var item = CreateInheritanceMarginItem(
                     memberSymbol,
                     lineNumber,
                     targetsForBaseSymbols.Concat(targetsForDerivedSymbols));
@@ -370,7 +370,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
 
                 if (!targetsForimplementingSymbols.IsEmpty)
                 {
-                    var item = CreateInheritanceMemberItem(memberSymbol, lineNumber, targetsForimplementingSymbols);
+                    var item = CreateInheritanceMarginItem(memberSymbol, lineNumber, targetsForimplementingSymbols);
                     builder.AddIfNotNull(item);
                 }
             }
@@ -410,7 +410,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
 
                 if (!targetsForOverriddenSymbols.IsEmpty || !targetsForImplementedSymbols.IsEmpty || !targetsForOverridingSymbols.IsEmpty)
                 {
-                    var item = CreateInheritanceMemberItem(
+                    var item = CreateInheritanceMarginItem(
                         memberSymbol,
                         lineNumber,
                         targetsForOverriddenSymbols.Concat(targetsForImplementedSymbols).Concat(targetsForOverridingSymbols));
@@ -419,7 +419,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             }
         }
 
-        private static InheritanceMarginItem CreateInheritanceMemberItem(
+        private static InheritanceMarginItem CreateInheritanceMarginItem(
             ISymbol memberSymbol,
             int lineNumber,
             ImmutableArray<InheritanceTargetItem> targetItems)

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -526,11 +526,11 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             var nonNullOverridingMemberItems = GetNonNullTargetItems(overridingMemberItems);
 
             return InheritanceMarginItem.CreateOrdered(
-                    lineNumber,
-                    topLevelDisplayText: null,
-                    FindUsagesHelpers.GetDisplayParts(memberSymbol),
-                    memberSymbol.GetGlyph(),
-                    nonNullImplementedMemberItems.Concat(nonNullOverriddenMemberItems).Concat(nonNullOverridingMemberItems));
+                lineNumber,
+                topLevelDisplayText: null,
+                FindUsagesHelpers.GetDisplayParts(memberSymbol),
+                memberSymbol.GetGlyph(),
+                nonNullImplementedMemberItems.Concat(nonNullOverriddenMemberItems).Concat(nonNullOverridingMemberItems));
         }
 
         private static async ValueTask<InheritanceTargetItem?> CreateInheritanceItemAsync(

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -477,7 +477,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             var nonNullBaseSymbolItems = GetNonNullTargetItems(baseSymbolItems);
             var nonNullDerivedTypeItems = GetNonNullTargetItems(derivedTypeItems);
 
-            return  InheritanceMarginItem.CreateOrdered(
+            return InheritanceMarginItem.CreateOrdered(
                 lineNumber,
                 topLevelDisplayText: null,
                 FindUsagesHelpers.GetDisplayParts(memberSymbol),

--- a/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs
@@ -607,18 +607,13 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
         /// </summary>
         private static DefinitionItem? ToSlimDefinitionItem(ISymbol symbol, Solution solution)
         {
-            if (!IsNavigableSymbol(symbol))
-            {
-                return null;
-            }
-
             var locations = symbol.Locations;
             if (locations.Length > 1)
             {
                 return symbol.ToNonClassifiedDefinitionItem(
                     solution,
                     FindReferencesSearchOptions.Default with { UnidirectionalHierarchyCascade = true },
-                    includeHiddenLocations: false);
+                    includeHiddenLocations: true);
             }
 
             if (locations.Length == 1)
@@ -633,7 +628,7 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
                         solution,
                         symbol);
                 }
-                else if (location.IsInSource && location.IsVisibleSourceLocation())
+                else if (location.IsInSource)
                 {
                     var document = solution.GetDocument(location.SourceTree);
                     if (document != null)
@@ -649,18 +644,6 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             }
 
             return null;
-
-            static bool IsNavigableSymbol(ISymbol symbol)
-            {
-                var locations = symbol.Locations;
-                if (locations.Length == 1)
-                {
-                    var location = locations[0];
-                    return location.IsInMetadata || (location.IsInSource && location.IsVisibleSourceLocation());
-                }
-
-                return !locations.IsEmpty;
-            }
         }
 
         private static (ImmutableArray<T> trueItems, ImmutableArray<T> falseItems) DivideIntoSubArrays<T>(ImmutableArray<T> items, Func<T, bool> predicate)

--- a/src/Features/Core/Portable/InheritanceMargin/InheritanceMarginItem.cs
+++ b/src/Features/Core/Portable/InheritanceMargin/InheritanceMarginItem.cs
@@ -58,15 +58,13 @@ namespace Microsoft.CodeAnalysis.InheritanceMargin
             TargetItems = targetItems;
         }
 
-        public static InheritanceMarginItem CreateOrdered(
+        public static InheritanceMarginItem? CreateOrdered(
             int lineNumber,
             string? topLevelDisplayText,
             ImmutableArray<TaggedText> displayTexts,
             Glyph glyph,
             ImmutableArray<InheritanceTargetItem> targetItems)
-        {
-            return new(lineNumber, topLevelDisplayText, displayTexts, glyph, Order(targetItems));
-        }
+            => targetItems.IsEmpty ? null : new(lineNumber, topLevelDisplayText, displayTexts, glyph, Order(targetItems));
 
         public static ImmutableArray<InheritanceTargetItem> Order(ImmutableArray<InheritanceTargetItem> targetItems)
             => targetItems.OrderBy(t => t.DisplayName).ThenByDescending(t => t.LanguageGlyph).ThenBy(t => t.ProjectName ?? "").ToImmutableArray();


### PR DESCRIPTION
Fixes [AB#1514769](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1514769)
The reason for the IndexOutOfRange exception is because there is no target for a given `InheritanceMarginItem`.
And it happens because 

*Code defects* [here](https://sourceroslyn.io/#Microsoft.CodeAnalysis.Features/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs,303)
 At all the similar places, it creates an InheritanceMarginItem when there are base type symbols or derived type symbols.
However, there is another [filtering](https://sourceroslyn.io/#Microsoft.CodeAnalysis.Features/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs,398) later, which is checking if the symbol could be navigable.
And if this filter gets all the symbols out, then we end up with an InheritanceMarginItem with no targets.
This really happens in cases like
```
public class B : C
{
}
#line hidden
public class C
{
}
```
here for `B`, `C` is a hidden place, so it would be filtered by [this line](https://sourceroslyn.io/#Microsoft.CodeAnalysis.Features/InheritanceMargin/AbstractInheritanceMarginService_Helpers.cs,743) And for `B`, it has an empty InheritanceMarginItem.

The fix is:
1. I did some code refactoring to make sure before `InheritanceMarginItem` is created, we should check the target items is not empty.
2. Hidden places should be included.
