### PR TITLE
Avoid accessing Document from formatter services

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/CSharpFormattingInteractionService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpFormattingInteractionService.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             var fallbackOptions = _globalOptions.GetCSharpSyntaxFormattingOptions();
             var options = await _indentationManager.GetInferredFormattingOptionsAsync(document, fallbackOptions, explicitFormat: true, cancellationToken).ConfigureAwait(false);
             var service = document.GetRequiredLanguageService<ISyntaxFormattingService>();
-            var documentSyntax = await DocumentSyntax.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            var documentSyntax = await ParsedDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
             return service.GetFormattingChangesOnPaste(documentSyntax, textSpan, options, cancellationToken);
         }
 
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         public async Task<ImmutableArray<TextChange>> GetFormattingChangesAsync(Document document, char typedChar, int position, CancellationToken cancellationToken)
         {
             var service = document.GetRequiredLanguageService<ISyntaxFormattingService>();
-            var documentSyntax = await DocumentSyntax.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            var documentSyntax = await ParsedDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
             if (service.ShouldFormatOnTypedCharacter(documentSyntax, typedChar, position, cancellationToken))
             {

--- a/src/EditorFeatures/CSharp/Formatting/CSharpFormattingInteractionService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpFormattingInteractionService.cs
@@ -107,7 +107,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             var fallbackOptions = _globalOptions.GetCSharpSyntaxFormattingOptions();
             var options = await _indentationManager.GetInferredFormattingOptionsAsync(document, fallbackOptions, explicitFormat: true, cancellationToken).ConfigureAwait(false);
             var service = document.GetRequiredLanguageService<ISyntaxFormattingService>();
-            return await service.GetFormattingChangesOnPasteAsync(document, textSpan, options, cancellationToken).ConfigureAwait(false);
+            var documentSyntax = await DocumentSyntax.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            return service.GetFormattingChangesOnPaste(documentSyntax, textSpan, options, cancellationToken);
         }
 
         Task<ImmutableArray<TextChange>> IFormattingInteractionService.GetFormattingChangesOnReturnAsync(
@@ -117,8 +118,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         public async Task<ImmutableArray<TextChange>> GetFormattingChangesAsync(Document document, char typedChar, int position, CancellationToken cancellationToken)
         {
             var service = document.GetRequiredLanguageService<ISyntaxFormattingService>();
+            var documentSyntax = await DocumentSyntax.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
-            if (await service.ShouldFormatOnTypedCharacterAsync(document, typedChar, position, cancellationToken).ConfigureAwait(false))
+            if (service.ShouldFormatOnTypedCharacter(documentSyntax, typedChar, position, cancellationToken))
             {
                 var fallbackOptions = _globalOptions.GetCSharpSyntaxFormattingOptions();
                 var formattingOptions = await _indentationManager.GetInferredFormattingOptionsAsync(document, fallbackOptions, explicitFormat: false, cancellationToken).ConfigureAwait(false);
@@ -129,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     IndentStyle = _globalOptions.GetOption(IndentationOptionsStorage.SmartIndent, LanguageNames.CSharp)
                 };
 
-                return await service.GetFormattingChangesOnTypedCharacterAsync(document, position, indentationOptions, cancellationToken).ConfigureAwait(false);
+                return service.GetFormattingChangesOnTypedCharacter(documentSyntax, position, indentationOptions, cancellationToken);
             }
 
             return ImmutableArray<TextChange>.Empty;

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/CSharpFormatterTestsBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/CSharpFormatterTestsBase.cs
@@ -72,20 +72,20 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
         private static async Task TokenFormatWorkerAsync(TestWorkspace workspace, ITextBuffer buffer, int indentationLine, char ch, bool useTabs)
         {
             var document = buffer.CurrentSnapshot.GetRelatedDocumentsWithChanges().First();
-            var root = (CompilationUnitSyntax)await document.GetSyntaxRootAsync();
+            var documentSyntax = await DocumentSyntax.CreateAsync(document, CancellationToken.None);
 
-            var line = root.GetText().Lines[indentationLine];
+            var line = documentSyntax.Text.Lines[indentationLine];
 
             var index = line.ToString().LastIndexOf(ch);
             Assert.InRange(index, 0, int.MaxValue);
 
             // get token
             var position = line.Start + index;
-            var token = root.FindToken(position);
+            var token = documentSyntax.Root.FindToken(position);
 
             var formattingRuleProvider = workspace.Services.GetService<IHostDependentFormattingRuleFactoryService>();
 
-            var rules = ImmutableArray.Create(formattingRuleProvider.CreateRule(document, position)).AddRange(Formatter.GetDefaultFormattingRules(document));
+            var rules = ImmutableArray.Create(formattingRuleProvider.CreateRule(documentSyntax, position)).AddRange(Formatter.GetDefaultFormattingRules(document));
 
             var options = new IndentationOptions(
                 new CSharpSyntaxFormattingOptions
@@ -96,8 +96,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
                     }
                 });
 
-            var formatter = new CSharpSmartTokenFormatter(options, rules, root);
-            var changes = await formatter.FormatTokenAsync(token, CancellationToken.None);
+            var formatter = new CSharpSmartTokenFormatter(options, rules, (CompilationUnitSyntax)documentSyntax.Root, documentSyntax.Text);
+            var changes = formatter.FormatToken(token, CancellationToken.None);
 
             ApplyChanges(buffer, changes);
         }

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/CSharpFormatterTestsBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/CSharpFormatterTestsBase.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
         private static async Task TokenFormatWorkerAsync(TestWorkspace workspace, ITextBuffer buffer, int indentationLine, char ch, bool useTabs)
         {
             var document = buffer.CurrentSnapshot.GetRelatedDocumentsWithChanges().First();
-            var documentSyntax = await DocumentSyntax.CreateAsync(document, CancellationToken.None);
+            var documentSyntax = await ParsedDocument.CreateAsync(document, CancellationToken.None);
 
             var line = documentSyntax.Text.Lines[indentationLine];
 

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
@@ -3576,7 +3576,7 @@ class Program{
             var position = testDocument.CursorPosition.Value;
 
             var document = workspace.CurrentSolution.GetDocument(testDocument.Id);
-            var documentSyntax = await DocumentSyntax.CreateAsync(document, CancellationToken.None);
+            var documentSyntax = await ParsedDocument.CreateAsync(document, CancellationToken.None);
             var rules = Formatter.GetDefaultFormattingRules(document);
 
             var root = (CompilationUnitSyntax)await document.GetSyntaxRootAsync();

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
@@ -3576,6 +3576,7 @@ class Program{
             var position = testDocument.CursorPosition.Value;
 
             var document = workspace.CurrentSolution.GetDocument(testDocument.Id);
+            var documentSyntax = await DocumentSyntax.CreateAsync(document, CancellationToken.None);
             var rules = Formatter.GetDefaultFormattingRules(document);
 
             var root = (CompilationUnitSyntax)await document.GetSyntaxRootAsync();
@@ -3590,7 +3591,7 @@ class Program{
             var options = new IndentationOptions(
                 CSharpSyntaxFormattingOptions.Default.With(new LineFormattingOptions { UseTabs = useTabs }));
 
-            var formatter = new CSharpSmartTokenFormatter(options, rules, root);
+            var formatter = new CSharpSmartTokenFormatter(options, rules, (CompilationUnitSyntax)documentSyntax.Root, documentSyntax.Text);
 
             var tokenRange = FormattingRangeHelper.FindAppropriateRange(endToken);
             if (tokenRange == null)

--- a/src/EditorFeatures/Core/Formatting/FormatCommandHandler.Paste.cs
+++ b/src/EditorFeatures/Core/Formatting/FormatCommandHandler.Paste.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
             var services = solution.Workspace.Services;
             var formattingRuleService = services.GetService<IHostDependentFormattingRuleFactoryService>();
-            if (formattingRuleService != null && formattingRuleService.ShouldNotFormatOrCommitOnPaste(document))
+            if (formattingRuleService != null && formattingRuleService.ShouldNotFormatOrCommitOnPaste(document.Id))
             {
                 return;
             }

--- a/src/EditorFeatures/Core/Formatting/FormatCommandHandler.cs
+++ b/src/EditorFeatures/Core/Formatting/FormatCommandHandler.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             {
                 var ruleFactory = document.Project.Solution.Workspace.Services.GetRequiredService<IHostDependentFormattingRuleFactoryService>();
 
-                changes = ruleFactory.FilterFormattedChanges(document, selectionOpt.Value, changes).ToList();
+                changes = ruleFactory.FilterFormattedChanges(document.Id, selectionOpt.Value, changes).ToList();
                 if (changes.Count == 0)
                 {
                     return;

--- a/src/EditorFeatures/Core/Shared/Extensions/ITextSnapshotExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/ITextSnapshotExtensions.cs
@@ -33,13 +33,13 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
                 return;
             }
 
-            var rules = document.GetFormattingRules(span, additionalRules: null);
+            var documentSyntax = DocumentSyntax.CreateSynchronously(document, cancellationToken);
+            var rules = FormattingRuleUtilities.GetFormattingRules(documentSyntax, document.Project.LanguageServices, span, additionalRules: null);
 
-            var root = document.GetRequiredSyntaxRootSynchronously(cancellationToken);
             var formatter = document.GetRequiredLanguageService<ISyntaxFormattingService>();
 
             var options = document.GetSyntaxFormattingOptionsAsync(globalOptions, cancellationToken).AsTask().WaitAndGetResult(cancellationToken);
-            var result = formatter.GetFormattingResult(root, SpecializedCollections.SingletonEnumerable(span), options, rules, cancellationToken);
+            var result = formatter.GetFormattingResult(documentSyntax.Root, SpecializedCollections.SingletonEnumerable(span), options, rules, cancellationToken);
             var changes = result.GetTextChanges(cancellationToken);
 
             using (Logger.LogBlock(FunctionId.Formatting_ApplyResultToBuffer, cancellationToken))

--- a/src/EditorFeatures/Core/Shared/Extensions/ITextSnapshotExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/ITextSnapshotExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
                 return;
             }
 
-            var documentSyntax = DocumentSyntax.CreateSynchronously(document, cancellationToken);
+            var documentSyntax = ParsedDocument.CreateSynchronously(document, cancellationToken);
             var rules = FormattingRuleUtilities.GetFormattingRules(documentSyntax, document.Project.LanguageServices, span, additionalRules: null);
 
             var formatter = document.GetRequiredLanguageService<ISyntaxFormattingService>();

--- a/src/EditorFeatures/TestUtilities/Formatting/CoreFormatterTestsBase.cs
+++ b/src/EditorFeatures/TestUtilities/Formatting/CoreFormatterTestsBase.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Formatting
             var buffer = hostdoc.GetTextBuffer();
 
             var document = workspace.CurrentSolution.GetDocument(hostdoc.Id);
-            var documentSyntax = await DocumentSyntax.CreateAsync(document, CancellationToken.None).ConfigureAwait(false);
+            var documentSyntax = await ParsedDocument.CreateAsync(document, CancellationToken.None).ConfigureAwait(false);
 
             // create new buffer with cloned content
             var clonedBuffer = EditorFactory.CreateBuffer(

--- a/src/EditorFeatures/TestUtilities/Formatting/CoreFormatterTestsBase.cs
+++ b/src/EditorFeatures/TestUtilities/Formatting/CoreFormatterTestsBase.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Formatting
             var buffer = hostdoc.GetTextBuffer();
 
             var document = workspace.CurrentSolution.GetDocument(hostdoc.Id);
-            var syntaxTree = await document.GetSyntaxTreeAsync();
+            var documentSyntax = await DocumentSyntax.CreateAsync(document, CancellationToken.None).ConfigureAwait(false);
 
             // create new buffer with cloned content
             var clonedBuffer = EditorFactory.CreateBuffer(
@@ -195,10 +195,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Formatting
             {
                 var factory = (TestFormattingRuleFactoryServiceFactory.Factory)formattingRuleProvider;
                 factory.BaseIndentation = baseIndentation.Value;
-                factory.TextSpan = spans?.First() ?? syntaxTree.GetRoot(CancellationToken.None).FullSpan;
+                factory.TextSpan = spans?.First() ?? documentSyntax.Root.FullSpan;
             }
-
-            var root = await syntaxTree.GetRootAsync();
 
             var formattingService = document.GetRequiredLanguageService<ISyntaxFormattingService>();
 
@@ -206,12 +204,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Formatting
                 formattingService.GetFormattingOptions(options.ToAnalyzerConfigOptions(document.Project.LanguageServices), fallbackOptions: null) :
                 formattingService.DefaultOptions;
 
-            document = workspace.CurrentSolution.GetDocument(syntaxTree);
-            var rules = formattingRuleProvider.CreateRule(document, 0).Concat(Formatter.GetDefaultFormattingRules(document));
-            AssertFormat(workspace, expected, formattingOptions, rules, clonedBuffer, root, spans);
+            var rules = formattingRuleProvider.CreateRule(documentSyntax, 0).Concat(Formatter.GetDefaultFormattingRules(document));
+            AssertFormat(workspace, expected, formattingOptions, rules, clonedBuffer, documentSyntax.Root, spans);
 
             // format with node and transform
-            AssertFormatWithTransformation(workspace, expected, formattingOptions, rules, root, spans);
+            AssertFormatWithTransformation(workspace, expected, formattingOptions, rules, documentSyntax.Root, spans);
         }
 
         internal void AssertFormatWithTransformation(Workspace workspace, string expected, SyntaxFormattingOptions options, IEnumerable<AbstractFormattingRule> rules, SyntaxNode root, IEnumerable<TextSpan> spans)

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestFormattingRuleFactoryServiceFactory.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestFormattingRuleFactoryServiceFactory.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             public bool ShouldNotFormatOrCommitOnPaste(DocumentId documentId)
                 => UseBaseIndentation;
 
-            public AbstractFormattingRule CreateRule(DocumentSyntax document, int position)
+            public AbstractFormattingRule CreateRule(ParsedDocument document, int position)
             {
                 if (BaseIndentation == 0)
                 {

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestFormattingRuleFactoryServiceFactory.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestFormattingRuleFactoryServiceFactory.cs
@@ -35,25 +35,24 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             public TextSpan TextSpan = default;
             public bool UseBaseIndentation = false;
 
-            public bool ShouldUseBaseIndentation(Document document)
+            public bool ShouldUseBaseIndentation(DocumentId documentId)
                 => UseBaseIndentation;
 
-            public AbstractFormattingRule CreateRule(Document document, int position)
+            public bool ShouldNotFormatOrCommitOnPaste(DocumentId documentId)
+                => UseBaseIndentation;
+
+            public AbstractFormattingRule CreateRule(DocumentSyntax document, int position)
             {
                 if (BaseIndentation == 0)
                 {
                     return NoOpFormattingRule.Instance;
                 }
 
-                var root = document.GetSyntaxRootAsync().Result;
-                return new BaseIndentationFormattingRule(root, TextSpan, BaseIndentation + 4);
+                return new BaseIndentationFormattingRule(document.Root, TextSpan, BaseIndentation + 4);
             }
 
-            public IEnumerable<TextChange> FilterFormattedChanges(Document document, TextSpan span, IList<TextChange> changes)
+            public IEnumerable<TextChange> FilterFormattedChanges(DocumentId document, TextSpan span, IList<TextChange> changes)
                 => changes;
-
-            public bool ShouldNotFormatOrCommitOnPaste(Document document)
-                => UseBaseIndentation;
         }
     }
 }

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitCommandHandler.vb
@@ -241,7 +241,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                 Dim document = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges()
                 If document IsNot Nothing Then
                     Dim formattingRuleService = document.Project.Solution.Workspace.Services.GetService(Of IHostDependentFormattingRuleFactoryService)()
-                    If formattingRuleService.ShouldNotFormatOrCommitOnPaste(document) Then
+                    If formattingRuleService.ShouldNotFormatOrCommitOnPaste(document.Id) Then
                         transaction.Complete()
                         Return
                     End If

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitFormatter.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitFormatter.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.CodeCleanup
 Imports Microsoft.CodeAnalysis.CodeCleanup.Providers
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Formatting.Rules
+Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Indentation
 Imports Microsoft.CodeAnalysis.Internal.Log
@@ -49,7 +50,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                                 baseTree As SyntaxTree,
                                 cancellationToken As CancellationToken) Implements ICommitFormatter.CommitRegion
 
-            Using (Logger.LogBlock(FunctionId.LineCommit_CommitRegion, cancellationToken))
+            Using Logger.LogBlock(FunctionId.LineCommit_CommitRegion, cancellationToken)
                 Dim buffer = spanToFormat.Snapshot.TextBuffer
                 Dim currentSnapshot = buffer.CurrentSnapshot
 
@@ -69,8 +70,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                     Return
                 End If
 
+                Dim tree = document.GetSyntaxTreeSynchronously(cancellationToken)
+
                 Dim textSpanToFormat = spanToFormat.Span.ToTextSpan()
-                If AbortForDiagnostics(document, cancellationToken) Then
+                If AbortForDiagnostics(tree, cancellationToken) Then
                     Return
                 End If
 
@@ -78,7 +81,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                 Dim fallbackOptions = _globalOptions.GetVisualBasicSyntaxFormattingOptions()
                 Dim formattingOptions = _indentationManager.GetInferredFormattingOptionsAsync(document, fallbackOptions, isExplicitFormat, cancellationToken).WaitAndGetResult(cancellationToken)
                 Dim commitFormattingCleanup = GetCommitFormattingCleanupProvider(
-                    document,
+                    document.Id,
+                    document.Project.LanguageServices,
                     formattingOptions,
                     spanToFormat,
                     baseSnapshot,
@@ -129,10 +133,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             End Using
         End Sub
 
-        Private Shared Function AbortForDiagnostics(document As Document, cancellationToken As CancellationToken) As Boolean
+        Private Shared Function AbortForDiagnostics(tree As SyntaxTree, cancellationToken As CancellationToken) As Boolean
             Const UnterminatedStringId = "BC30648"
-
-            Dim tree = document.GetSyntaxTreeSynchronously(cancellationToken)
 
             ' If we have any unterminated strings that overlap what we're trying to format, then
             ' bail out.  It's quite likely the unterminated string will cause a bunch of code to
@@ -144,7 +146,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
         End Function
 
         Private Shared Function GetCommitFormattingCleanupProvider(
-            document As Document,
+            documentId As DocumentId,
+            languageServices As HostLanguageServices,
             options As SyntaxFormattingOptions,
             spanToFormat As SnapshotSpan,
             oldSnapshot As ITextSnapshot,
@@ -156,13 +159,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             Dim oldDirtySpan = newDirtySpan.TranslateTo(oldSnapshot, SpanTrackingMode.EdgeInclusive)
 
             ' based on changes made to dirty spans, get right formatting rules to apply
-            Dim rules = GetFormattingRules(document, options, spanToFormat, oldDirtySpan, oldTree, newDirtySpan, newTree, cancellationToken)
+            Dim rules = GetFormattingRules(documentId, languageServices, options, spanToFormat, oldDirtySpan, oldTree, newDirtySpan, newTree, cancellationToken)
 
             Return New FormatCodeCleanupProvider(rules)
         End Function
 
         Private Shared Function GetFormattingRules(
-            document As Document,
+            documentId As DocumentId,
+            languageServices As HostLanguageServices,
             options As SyntaxFormattingOptions,
             spanToFormat As SnapshotSpan,
             oldDirtySpan As SnapshotSpan,
@@ -174,11 +178,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             ' if the span we are going to format is same as the span that got changed, don't bother to do anything special.
             ' just do full format of the span.
             If spanToFormat = newDirtySpan Then
-                Return Formatter.GetDefaultFormattingRules(document)
+                Return Formatter.GetDefaultFormattingRules(languageServices)
             End If
 
             If oldTree Is Nothing OrElse newTree Is Nothing Then
-                Return Formatter.GetDefaultFormattingRules(document)
+                Return Formatter.GetDefaultFormattingRules(languageServices)
             End If
 
             ' TODO: remove this in dev14
@@ -186,10 +190,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             ' workaround for VB razor case.
             ' if we are under VB razor, we always use anchor operation otherwise, due to our double formatting, everything will just get messed.
             ' this is really a hacky workaround we should remove this in dev14
-            Dim formattingRuleService = document.Project.Solution.Workspace.Services.GetService(Of IHostDependentFormattingRuleFactoryService)()
+            Dim formattingRuleService = languageServices.WorkspaceServices.GetService(Of IHostDependentFormattingRuleFactoryService)()
             If formattingRuleService IsNot Nothing Then
-                If formattingRuleService.ShouldUseBaseIndentation(document) Then
-                    Return Formatter.GetDefaultFormattingRules(document)
+                If formattingRuleService.ShouldUseBaseIndentation(documentId) Then
+                    Return Formatter.GetDefaultFormattingRules(languageServices)
                 End If
             End If
 
@@ -215,16 +219,16 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             ' for now, do very simple checking. basically, we see whether we get same number of indent operation for the give span. alternative, but little bit
             ' more expensive and complex, we can actually calculate indentation right after the span, and see whether that is changed. not sure whether that much granularity
             ' is needed.
-            If GetNumberOfIndentOperations(document, options, oldTree, oldDirtySpan, cancellationToken) =
-               GetNumberOfIndentOperations(document, options, newTree, newDirtySpan, cancellationToken) Then
-                Return (New NoAnchorFormatterRule()).Concat(Formatter.GetDefaultFormattingRules(document))
+            If GetNumberOfIndentOperations(languageServices, options, oldTree, oldDirtySpan, cancellationToken) =
+               GetNumberOfIndentOperations(languageServices, options, newTree, newDirtySpan, cancellationToken) Then
+                Return (New NoAnchorFormatterRule()).Concat(Formatter.GetDefaultFormattingRules(languageServices))
             End If
 
-            Return Formatter.GetDefaultFormattingRules(document)
+            Return Formatter.GetDefaultFormattingRules(languageServices)
         End Function
 
         Private Shared Function GetNumberOfIndentOperations(
-            document As Document,
+            languageServices As HostLanguageServices,
             options As SyntaxFormattingOptions,
             syntaxTree As SyntaxTree,
             span As SnapshotSpan,
@@ -243,7 +247,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             Dim operations = New List(Of IndentBlockOperation)()
             While node IsNot Nothing
                 operations.AddRange(FormattingOperations.GetIndentBlockOperations(
-                                    Formatter.GetDefaultFormattingRules(document), node, options))
+                                    Formatter.GetDefaultFormattingRules(languageServices), node, options))
                 node = node.Parent
             End While
 

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartTokenFormatter_FormatTokenTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartTokenFormatter_FormatTokenTests.vb
@@ -205,7 +205,7 @@ End Class
 
                 Dim formatOptions = VisualBasicSyntaxFormattingOptions.Default
                 Dim smartFormatter = New VisualBasicSmartTokenFormatter(formatOptions, formattingRules, root)
-                Dim changes = Await smartFormatter.FormatTokenAsync(token, Nothing)
+                Dim changes = smartFormatter.FormatToken(token, Nothing)
 
                 Using edit = buffer.CreateEdit()
                     For Each change In changes

--- a/src/EditorFeatures/VisualBasicTest/Formatting/VisualBasicFormatterTestBase.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/VisualBasicFormatterTestBase.vb
@@ -48,7 +48,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting
                 Dim clonedBuffer = EditorFactory.CreateBuffer(workspace.ExportProvider, buffer.ContentType, buffer.CurrentSnapshot.GetText())
 
                 Dim document = workspace.CurrentSolution.GetDocument(hostdoc.Id)
-                Dim docSyntax = Await DocumentSyntax.CreateAsync(document, CancellationToken.None)
+                Dim docSyntax = Await ParsedDocument.CreateAsync(document, CancellationToken.None)
 
                 ' Add Base IndentationRule that we had just set up.
                 Dim formattingRuleProvider = workspace.Services.GetService(Of IHostDependentFormattingRuleFactoryService)()

--- a/src/EditorFeatures/VisualBasicTest/Formatting/VisualBasicFormatterTestBase.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/VisualBasicFormatterTestBase.vb
@@ -48,7 +48,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting
                 Dim clonedBuffer = EditorFactory.CreateBuffer(workspace.ExportProvider, buffer.ContentType, buffer.CurrentSnapshot.GetText())
 
                 Dim document = workspace.CurrentSolution.GetDocument(hostdoc.Id)
-                Dim syntaxTree = Await document.GetSyntaxTreeAsync()
+                Dim docSyntax = Await DocumentSyntax.CreateAsync(document, CancellationToken.None)
 
                 ' Add Base IndentationRule that we had just set up.
                 Dim formattingRuleProvider = workspace.Services.GetService(Of IHostDependentFormattingRuleFactoryService)()
@@ -58,11 +58,11 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting
                     factory.TextSpan = span
                 End If
 
-                Dim rules = formattingRuleProvider.CreateRule(document, 0).Concat(Formatter.GetDefaultFormattingRules(document))
+                Dim rules = formattingRuleProvider.CreateRule(docSyntax, 0).Concat(Formatter.GetDefaultFormattingRules(document))
                 Dim options = VisualBasicSyntaxFormattingOptions.Default
 
                 Dim changes = Formatter.GetFormattedTextChanges(
-                    Await syntaxTree.GetRootAsync(),
+                    docSyntax.Root,
                     workspace.Documents.First(Function(d) d.SelectedSpans.Any()).SelectedSpans,
                     workspace.Services,
                     options,

--- a/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
@@ -213,8 +213,10 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
             // Annotate the original closing brace so we can find it after formatting.
             document = await GetDocumentWithAnnotatedClosingBraceAsync(document, closingPoint, cancellationToken).ConfigureAwait(false);
 
-            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var documentSyntax = await DocumentSyntax.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+            var text = documentSyntax.Text;
+            var root = documentSyntax.Root;
 
             var startPoint = openingPoint;
             var endPoint = AdjustFormattingEndPoint(text, root, startPoint, closingPoint);
@@ -238,7 +240,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
             }
 
             var spanToFormat = TextSpan.FromBounds(Math.Max(startPoint, 0), endPoint);
-            var rules = document.GetFormattingRules(spanToFormat, braceFormattingIndentationRules);
+            var rules = FormattingRuleUtilities.GetFormattingRules(documentSyntax, document.Project.LanguageServices, spanToFormat, braceFormattingIndentationRules);
             var services = document.Project.Solution.Workspace.Services;
             var result = Formatter.GetFormattingResult(
                 root, SpecializedCollections.SingletonEnumerable(spanToFormat), services, options.FormattingOptions, rules, cancellationToken);

--- a/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
 
         protected abstract ImmutableArray<AbstractFormattingRule> GetBraceFormattingIndentationRulesAfterReturn(IndentationOptions options);
 
-        protected abstract int AdjustFormattingEndPoint(DocumentSyntax document, int startPoint, int endPoint);
+        protected abstract int AdjustFormattingEndPoint(ParsedDocument document, int startPoint, int endPoint);
 
         public sealed override async Task<BraceCompletionResult?> GetTextChangesAfterCompletionAsync(BraceCompletionContext context, IndentationOptions options, CancellationToken cancellationToken)
         {
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
                 return null;
             }
 
-            var documentSyntax = await DocumentSyntax.CreateAsync(context.Document, cancellationToken).ConfigureAwait(false);
+            var documentSyntax = await ParsedDocument.CreateAsync(context.Document, cancellationToken).ConfigureAwait(false);
 
             var (formattingChanges, finalCurlyBraceEnd) = FormatTrackingSpan(
                 documentSyntax,
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
                 closingPoint += newLineString.Length;
             }
 
-            var documentSyntax = await DocumentSyntax.CreateAsync(document.WithText(textToFormat), cancellationToken).ConfigureAwait(false);
+            var documentSyntax = await ParsedDocument.CreateAsync(document.WithText(textToFormat), cancellationToken).ConfigureAwait(false);
 
             // Format the text that contains the newly inserted line.
             var (formattingChanges, newClosingPoint) = FormatTrackingSpan(
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
         /// get the formatted text and the end of the close curly brace in the formatted text.
         /// </summary>
         private (ImmutableArray<TextChange> textChanges, int finalBraceEnd) FormatTrackingSpan(
-            DocumentSyntax document,
+            ParsedDocument document,
             HostLanguageServices languageServices,
             int openingPoint,
             int closingPoint,

--- a/src/Features/CSharp/Portable/BraceCompletion/BracketBraceCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/BracketBraceCompletionService.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
 
         protected override bool IsValidClosingBraceToken(SyntaxToken token) => token.IsKind(SyntaxKind.CloseBracketToken);
 
-        protected override int AdjustFormattingEndPoint(DocumentSyntax document, int startPoint, int endPoint)
+        protected override int AdjustFormattingEndPoint(ParsedDocument document, int startPoint, int endPoint)
             => endPoint;
 
         protected override ImmutableArray<AbstractFormattingRule> GetBraceFormattingIndentationRulesAfterReturn(IndentationOptions options)

--- a/src/Features/CSharp/Portable/BraceCompletion/BracketBraceCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/BracketBraceCompletionService.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
 
         protected override bool IsValidClosingBraceToken(SyntaxToken token) => token.IsKind(SyntaxKind.CloseBracketToken);
 
-        protected override int AdjustFormattingEndPoint(SourceText text, SyntaxNode root, int startPoint, int endPoint)
+        protected override int AdjustFormattingEndPoint(DocumentSyntax document, int startPoint, int endPoint)
             => endPoint;
 
         protected override ImmutableArray<AbstractFormattingRule> GetBraceFormattingIndentationRulesAfterReturn(IndentationOptions options)

--- a/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
         protected override bool IsValidClosingBraceToken(SyntaxToken token)
             => token.IsKind(SyntaxKind.CloseBraceToken);
 
-        protected override int AdjustFormattingEndPoint(SourceText text, SyntaxNode root, int startPoint, int endPoint)
+        protected override int AdjustFormattingEndPoint(DocumentSyntax document, int startPoint, int endPoint)
         {
             // Only format outside of the completed braces if they're on the same line for array/collection/object initializer expressions.
             // Example:   `var x = new int[]{}`:
@@ -66,9 +66,9 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
             // Incorrect: `var x = new int[] { }`
             // This is a heuristic to prevent brace completion from breaking user expectation/muscle memory in common scenarios.
             // see bug Devdiv:823958
-            if (text.Lines.GetLineFromPosition(startPoint) == text.Lines.GetLineFromPosition(endPoint))
+            if (document.Text.Lines.GetLineFromPosition(startPoint) == document.Text.Lines.GetLineFromPosition(endPoint))
             {
-                var startToken = root.FindToken(startPoint, findInsideTrivia: true);
+                var startToken = document.Root.FindToken(startPoint, findInsideTrivia: true);
                 if (IsValidOpeningBraceToken(startToken) &&
                     (startToken.Parent?.IsInitializerForArrayOrCollectionCreationExpression() == true ||
                      startToken.Parent is AnonymousObjectCreationExpressionSyntax))

--- a/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
         protected override bool IsValidClosingBraceToken(SyntaxToken token)
             => token.IsKind(SyntaxKind.CloseBraceToken);
 
-        protected override int AdjustFormattingEndPoint(DocumentSyntax document, int startPoint, int endPoint)
+        protected override int AdjustFormattingEndPoint(ParsedDocument document, int startPoint, int endPoint)
         {
             // Only format outside of the completed braces if they're on the same line for array/collection/object initializer expressions.
             // Example:   `var x = new int[]{}`:

--- a/src/Features/Core/Portable/Formatting/FormattingRuleUtilities.cs
+++ b/src/Features/Core/Portable/Formatting/FormattingRuleUtilities.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules;
 
 internal static class FormattingRuleUtilities
 {
-    public static ImmutableArray<AbstractFormattingRule> GetFormattingRules(DocumentSyntax document, HostLanguageServices languageServices, TextSpan span, IEnumerable<AbstractFormattingRule>? additionalRules)
+    public static ImmutableArray<AbstractFormattingRule> GetFormattingRules(ParsedDocument document, HostLanguageServices languageServices, TextSpan span, IEnumerable<AbstractFormattingRule>? additionalRules)
     {
         var formattingRuleFactory = languageServices.WorkspaceServices.GetRequiredService<IHostDependentFormattingRuleFactoryService>();
         // Not sure why this is being done... there aren't any docs on CreateRule either.

--- a/src/Features/Core/Portable/Formatting/FormattingRuleUtilities.cs
+++ b/src/Features/Core/Portable/Formatting/FormattingRuleUtilities.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Formatting.Rules;
+
+internal static class FormattingRuleUtilities
+{
+    public static ImmutableArray<AbstractFormattingRule> GetFormattingRules(DocumentSyntax document, HostLanguageServices languageServices, TextSpan span, IEnumerable<AbstractFormattingRule>? additionalRules)
+    {
+        var formattingRuleFactory = languageServices.WorkspaceServices.GetRequiredService<IHostDependentFormattingRuleFactoryService>();
+        // Not sure why this is being done... there aren't any docs on CreateRule either.
+        var position = (span.Start + span.End) / 2;
+
+        var rules = ImmutableArray.Create(formattingRuleFactory.CreateRule(document, position));
+        if (additionalRules != null)
+        {
+            rules = rules.AddRange(additionalRules);
+        }
+
+        return rules.AddRange(Formatter.GetDefaultFormattingRules(languageServices));
+    }
+}

--- a/src/Features/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -147,21 +147,5 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
             throw ExceptionUtilities.Unreachable;
         }
-
-        public static ImmutableArray<AbstractFormattingRule> GetFormattingRules(this Document document, TextSpan span, IEnumerable<AbstractFormattingRule>? additionalRules)
-        {
-            var workspace = document.Project.Solution.Workspace;
-            var formattingRuleFactory = workspace.Services.GetRequiredService<IHostDependentFormattingRuleFactoryService>();
-            // Not sure why this is being done... there aren't any docs on CreateRule either.
-            var position = (span.Start + span.End) / 2;
-
-            var rules = ImmutableArray.Create(formattingRuleFactory.CreateRule(document, position));
-            if (additionalRules != null)
-            {
-                rules = rules.AddRange(additionalRules);
-            }
-
-            return rules.AddRange(Formatter.GetDefaultFormattingRules(document));
-        }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             }
 
             var formattingService = document.Project.LanguageServices.GetRequiredService<ISyntaxFormattingService>();
-            var documentSyntax = await DocumentSyntax.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            var documentSyntax = await ParsedDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
             if (!formattingService.ShouldFormatOnTypedCharacter(documentSyntax, request.Character[0], position, cancellationToken))
             {

--- a/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Formatting/FormatDocumentOnTypeHandler.cs
@@ -56,8 +56,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             }
 
             var formattingService = document.Project.LanguageServices.GetRequiredService<ISyntaxFormattingService>();
+            var documentSyntax = await DocumentSyntax.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
-            if (!await formattingService.ShouldFormatOnTypedCharacterAsync(document, request.Character[0], position, cancellationToken).ConfigureAwait(false))
+            if (!formattingService.ShouldFormatOnTypedCharacter(documentSyntax, request.Character[0], position, cancellationToken))
             {
                 return Array.Empty<TextEdit>();
             }
@@ -69,15 +70,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 AutoFormattingOptions = _globalOptions.GetAutoFormattingOptions(document.Project.Language)
             };
 
-            var textChanges = await formattingService.GetFormattingChangesOnTypedCharacterAsync(document, position, indentationOptions, cancellationToken).ConfigureAwait(false);
+            var textChanges = formattingService.GetFormattingChangesOnTypedCharacter(documentSyntax, position, indentationOptions, cancellationToken);
             if (textChanges.IsEmpty)
             {
                 return Array.Empty<TextEdit>();
             }
 
             var edits = new ArrayBuilder<TextEdit>();
-            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            edits.AddRange(textChanges.Select(change => ProtocolConversions.TextChangeToTextEdit(change, text)));
+            edits.AddRange(textChanges.Select(change => ProtocolConversions.TextChangeToTextEdit(change, documentSyntax.Text)));
             return edits.ToArrayAndFree();
         }
     }

--- a/src/Tools/ExternalAccess/Razor/RazorCSharpFormattingInteractionService.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorCSharpFormattingInteractionService.cs
@@ -38,8 +38,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
         {
             Contract.ThrowIfFalse(document.Project.Language is LanguageNames.CSharp);
             var formattingService = document.GetRequiredLanguageService<ISyntaxFormattingService>();
+            var documentSyntax = await DocumentSyntax.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
-            if (!await formattingService.ShouldFormatOnTypedCharacterAsync(document, typedChar, position, cancellationToken).ConfigureAwait(false))
+            if (!formattingService.ShouldFormatOnTypedCharacter(documentSyntax, typedChar, position, cancellationToken))
             {
                 return ImmutableArray<TextChange>.Empty;
             }
@@ -58,7 +59,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
                 AutoFormattingOptions = globalOptions.GetAutoFormattingOptions(languageServices)
             };
 
-            return await formattingService.GetFormattingChangesOnTypedCharacterAsync(document, position, indentationOptions, cancellationToken).ConfigureAwait(false);
+            return formattingService.GetFormattingChangesOnTypedCharacter(documentSyntax, position, indentationOptions, cancellationToken);
         }
 
         /// <summary>
@@ -77,8 +78,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
         {
             Contract.ThrowIfFalse(document.Project.Language is LanguageNames.CSharp);
             var formattingService = document.GetRequiredLanguageService<ISyntaxFormattingService>();
+            var documentSyntax = await DocumentSyntax.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
-            if (!await formattingService.ShouldFormatOnTypedCharacterAsync(document, typedChar, position, cancellationToken).ConfigureAwait(false))
+            if (!formattingService.ShouldFormatOnTypedCharacter(documentSyntax, typedChar, position, cancellationToken))
             {
                 return ImmutableArray<TextChange>.Empty;
             }
@@ -90,7 +92,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
                 IndentStyle = (FormattingOptions2.IndentStyle)indentStyle
             };
 
-            return await formattingService.GetFormattingChangesOnTypedCharacterAsync(document, position, roslynIndentationOptions, cancellationToken).ConfigureAwait(false);
+            return formattingService.GetFormattingChangesOnTypedCharacter(documentSyntax, position, roslynIndentationOptions, cancellationToken);
         }
 
         public static IList<TextChange> GetFormattedTextChanges(

--- a/src/Tools/ExternalAccess/Razor/RazorCSharpFormattingInteractionService.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorCSharpFormattingInteractionService.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
         {
             Contract.ThrowIfFalse(document.Project.Language is LanguageNames.CSharp);
             var formattingService = document.GetRequiredLanguageService<ISyntaxFormattingService>();
-            var documentSyntax = await DocumentSyntax.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            var documentSyntax = await ParsedDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
             if (!formattingService.ShouldFormatOnTypedCharacter(documentSyntax, typedChar, position, cancellationToken))
             {
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
         {
             Contract.ThrowIfFalse(document.Project.Language is LanguageNames.CSharp);
             var formattingService = document.GetRequiredLanguageService<ISyntaxFormattingService>();
-            var documentSyntax = await DocumentSyntax.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+            var documentSyntax = await ParsedDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
             if (!formattingService.ShouldFormatOnTypedCharacter(documentSyntax, typedChar, position, cancellationToken))
             {

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 return VSConstants.E_FAIL;
             }
 
-            var documentSyntax = DocumentSyntax.CreateSynchronously(document, cancellationToken);
+            var documentSyntax = ParsedDocument.CreateSynchronously(document, cancellationToken);
             var text = documentSyntax.Text;
             var root = documentSyntax.Root;
             var formattingOptions = document.GetSyntaxFormattingOptionsAsync(GlobalOptions, cancellationToken).AsTask().WaitAndGetResult(cancellationToken);

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsLanguageTextOps.cs
@@ -53,8 +53,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 return VSConstants.E_FAIL;
             }
 
-            var root = document.GetSyntaxRootSynchronously(cancellationToken);
-            var text = root.SyntaxTree.GetText(cancellationToken);
+            var documentSyntax = DocumentSyntax.CreateSynchronously(document, cancellationToken);
+            var text = documentSyntax.Text;
+            var root = documentSyntax.Root;
             var formattingOptions = document.GetSyntaxFormattingOptionsAsync(GlobalOptions, cancellationToken).AsTask().WaitAndGetResult(cancellationToken);
 
             var ts = selections.Single();
@@ -65,7 +66,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             // Since we know we are on the UI thread, lets get the base indentation now, so that there is less
             // cleanup work to do later in Venus.
             var ruleFactory = Workspace.Services.GetService<IHostDependentFormattingRuleFactoryService>();
-            var rules = ruleFactory.CreateRule(document, start).Concat(Formatter.GetDefaultFormattingRules(document));
+            var rules = ruleFactory.CreateRule(documentSyntax, start).Concat(Formatter.GetDefaultFormattingRules(document.Project.LanguageServices));
 
             // use formatting that return text changes rather than tree rewrite which is more expensive
             var formatter = document.GetRequiredLanguageService<ISyntaxFormattingService>();
@@ -73,7 +74,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 .GetTextChanges(cancellationToken);
 
             var originalSpan = RoslynTextSpan.FromBounds(start, end);
-            var formattedChanges = ruleFactory.FilterFormattedChanges(document, originalSpan, originalChanges);
+            var formattedChanges = ruleFactory.FilterFormattedChanges(document.Id, originalSpan, originalChanges);
             if (formattedChanges.IsEmpty())
             {
                 return VSConstants.S_OK;

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
@@ -22,119 +22,99 @@ using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
-    [ExportWorkspaceServiceFactory(typeof(IHostDependentFormattingRuleFactoryService), ServiceLayer.Host), Shared]
-    internal sealed class VisualStudioFormattingRuleFactoryServiceFactory : IWorkspaceServiceFactory
+    [ExportWorkspaceService(typeof(IHostDependentFormattingRuleFactoryService), ServiceLayer.Host), Shared]
+    internal sealed class VisualStudioFormattingRuleFactoryService : IHostDependentFormattingRuleFactoryService
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public VisualStudioFormattingRuleFactoryServiceFactory()
+        public VisualStudioFormattingRuleFactoryService()
         {
         }
+        public bool ShouldUseBaseIndentation(DocumentId documentId)
+            => IsContainedDocument(documentId);
 
-        public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-            => new Factory();
+        public bool ShouldNotFormatOrCommitOnPaste(DocumentId documentId)
+            => IsContainedDocument(documentId);
 
-        private sealed class Factory : IHostDependentFormattingRuleFactoryService
+        private static bool IsContainedDocument(DocumentId documentId)
+            => ContainedDocument.TryGetContainedDocument(documentId) != null;
+
+        public AbstractFormattingRule CreateRule(DocumentSyntax document, int position)
         {
-            public bool ShouldUseBaseIndentation(Document document)
-                => IsContainedDocument(document);
-
-            public bool ShouldNotFormatOrCommitOnPaste(Document document)
-                => IsContainedDocument(document);
-
-            private static bool IsContainedDocument(Document document)
+            var containedDocument = ContainedDocument.TryGetContainedDocument(document.Id);
+            if (containedDocument == null)
             {
-                var visualStudioWorkspace = document.Project.Solution.Workspace as VisualStudioWorkspaceImpl;
-                return visualStudioWorkspace?.TryGetContainedDocument(document.Id) != null;
+                return NoOpFormattingRule.Instance;
             }
 
-            public AbstractFormattingRule CreateRule(Document document, int position)
+            var textContainer = document.Text.Container;
+            if (textContainer.TryGetTextBuffer() is not IProjectionBuffer)
             {
-                if (document.Project.Solution.Workspace is not VisualStudioWorkspaceImpl visualStudioWorkspace)
+                return NoOpFormattingRule.Instance;
+            }
+
+            using var pooledObject = SharedPools.Default<List<TextSpan>>().GetPooledObject();
+            var spans = pooledObject.Object;
+
+            var root = document.Root;
+            var text = document.Text;
+
+            spans.AddRange(containedDocument.GetEditorVisibleSpans());
+
+            for (var i = 0; i < spans.Count; i++)
+            {
+                var visibleSpan = spans[i];
+                if (visibleSpan.IntersectsWith(position) || visibleSpan.End == position)
                 {
-                    return NoOpFormattingRule.Instance;
+                    return containedDocument.GetBaseIndentationRule(root, text, spans, i);
                 }
+            }
 
-                var containedDocument = visualStudioWorkspace.TryGetContainedDocument(document.Id);
-                if (containedDocument == null)
-                {
-                    return NoOpFormattingRule.Instance;
-                }
+            // in razor (especially in @helper tag), it is possible for us to be asked for next line of visible span
+            var line = text.Lines.GetLineFromPosition(position);
+            if (line.LineNumber > 0)
+            {
+                line = text.Lines[line.LineNumber - 1];
 
-                var textContainer = document.GetTextSynchronously(CancellationToken.None).Container;
-                if (textContainer.TryGetTextBuffer() is not IProjectionBuffer)
-                {
-                    return NoOpFormattingRule.Instance;
-                }
-
-                using var pooledObject = SharedPools.Default<List<TextSpan>>().GetPooledObject();
-                var spans = pooledObject.Object;
-
-                var root = document.GetSyntaxRootSynchronously(CancellationToken.None);
-                var text = root.SyntaxTree.GetText(CancellationToken.None);
-
-                spans.AddRange(containedDocument.GetEditorVisibleSpans());
-
+                // find one that intersects with previous line
                 for (var i = 0; i < spans.Count; i++)
                 {
                     var visibleSpan = spans[i];
-                    if (visibleSpan.IntersectsWith(position) || visibleSpan.End == position)
+                    if (visibleSpan.IntersectsWith(line.Span))
                     {
                         return containedDocument.GetBaseIndentationRule(root, text, spans, i);
                     }
                 }
-
-                // in razor (especially in @helper tag), it is possible for us to be asked for next line of visible span
-                var line = text.Lines.GetLineFromPosition(position);
-                if (line.LineNumber > 0)
-                {
-                    line = text.Lines[line.LineNumber - 1];
-
-                    // find one that intersects with previous line
-                    for (var i = 0; i < spans.Count; i++)
-                    {
-                        var visibleSpan = spans[i];
-                        if (visibleSpan.IntersectsWith(line.Span))
-                        {
-                            return containedDocument.GetBaseIndentationRule(root, text, spans, i);
-                        }
-                    }
-                }
-
-                FatalError.ReportAndCatch(
-                    new InvalidOperationException($"Can't find an intersection. Visible spans count: {spans.Count}"));
-
-                return NoOpFormattingRule.Instance;
             }
 
-            public IEnumerable<TextChange> FilterFormattedChanges(Document document, TextSpan span, IList<TextChange> changes)
+            FatalError.ReportAndCatch(
+                new InvalidOperationException($"Can't find an intersection. Visible spans count: {spans.Count}"));
+
+            return NoOpFormattingRule.Instance;
+        }
+
+        public IEnumerable<TextChange> FilterFormattedChanges(DocumentId documentId, TextSpan span, IList<TextChange> changes)
+        {
+            var containedDocument = ContainedDocument.TryGetContainedDocument(documentId);
+            if (containedDocument == null)
             {
-                if (document.Project.Solution.Workspace is not VisualStudioWorkspaceImpl visualStudioWorkspace)
-                {
-                    return changes;
-                }
-
-                var containedDocument = visualStudioWorkspace.TryGetContainedDocument(document.Id);
-                if (containedDocument == null)
-                {
-                    return changes;
-                }
-
-                // in case of a Venus, when format document command is issued, Venus will call format API with each script block spans.
-                // in that case, we need to make sure formatter doesn't overstep other script blocks content. in actual format selection case,
-                // we need to format more than given selection otherwise, we will not adjust indentation of first token of the given selection.
-                foreach (var visibleSpan in containedDocument.GetEditorVisibleSpans())
-                {
-                    if (visibleSpan != span)
-                    {
-                        continue;
-                    }
-
-                    return changes.Where(c => span.IntersectsWith(c.Span));
-                }
-
                 return changes;
             }
+
+            // in case of a Venus, when format document command is issued, Venus will call format API with each script block spans.
+            // in that case, we need to make sure formatter doesn't overstep other script blocks content. in actual format selection case,
+            // we need to format more than given selection otherwise, we will not adjust indentation of first token of the given selection.
+            foreach (var visibleSpan in containedDocument.GetEditorVisibleSpans())
+            {
+                if (visibleSpan != span)
+                {
+                    continue;
+                }
+
+                return changes.Where(c => span.IntersectsWith(c.Span));
+            }
+
+            return changes;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioFormattingRuleFactoryServiceFactory.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         private static bool IsContainedDocument(DocumentId documentId)
             => ContainedDocument.TryGetContainedDocument(documentId) != null;
 
-        public AbstractFormattingRule CreateRule(DocumentSyntax document, int position)
+        public AbstractFormattingRule CreateRule(ParsedDocument document, int position)
         {
             var containedDocument = ContainedDocument.TryGetContainedDocument(document.Id);
             if (containedDocument == null)

--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpSyntaxFormattingService.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpSyntaxFormattingService.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             => _services = languageServices;
 
         public bool ShouldFormatOnTypedCharacter(
-            DocumentSyntax documentSyntax,
+            ParsedDocument documentSyntax,
             char typedChar,
             int caretPosition,
             CancellationToken cancellationToken)
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         public ImmutableArray<TextChange> GetFormattingChangesOnTypedCharacter(
-            DocumentSyntax document,
+            ParsedDocument document,
             int caretPosition,
             IndentationOptions indentationOptions,
             CancellationToken cancellationToken)
@@ -167,14 +167,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         }
 
         private static IList<TextChange> FormatToken(
-            DocumentSyntax document, IndentationOptions options, SyntaxToken token, ImmutableArray<AbstractFormattingRule> formattingRules, CancellationToken cancellationToken)
+            ParsedDocument document, IndentationOptions options, SyntaxToken token, ImmutableArray<AbstractFormattingRule> formattingRules, CancellationToken cancellationToken)
         {
             var formatter = new CSharpSmartTokenFormatter(options, formattingRules, (CompilationUnitSyntax)document.Root, document.Text);
             return formatter.FormatToken(token, cancellationToken);
         }
 
         private static ImmutableArray<TextChange> FormatRange(
-            DocumentSyntax document,
+            ParsedDocument document,
             IndentationOptions options,
             SyntaxToken endToken,
             ImmutableArray<AbstractFormattingRule> formattingRules,
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                    token.IsKind(SyntaxKind.EndOfFileToken);
         }
 
-        private ImmutableArray<AbstractFormattingRule> GetFormattingRules(DocumentSyntax document, int position, SyntaxToken tokenBeforeCaret)
+        private ImmutableArray<AbstractFormattingRule> GetFormattingRules(ParsedDocument document, int position, SyntaxToken tokenBeforeCaret)
         {
             var formattingRuleFactory = _services.WorkspaceServices.GetRequiredService<IHostDependentFormattingRuleFactoryService>();
             return ImmutableArray.Create(formattingRuleFactory.CreateRule(document, position))
@@ -322,7 +322,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                                  .AddRange(Formatter.GetDefaultFormattingRules(_services));
         }
 
-        public ImmutableArray<TextChange> GetFormattingChangesOnPaste(DocumentSyntax document, TextSpan textSpan, SyntaxFormattingOptions options, CancellationToken cancellationToken)
+        public ImmutableArray<TextChange> GetFormattingChangesOnPaste(ParsedDocument document, TextSpan textSpan, SyntaxFormattingOptions options, CancellationToken cancellationToken)
         {
             var formattingSpan = CommonFormattingHelpers.GetFormattingSpan(document.Root, textSpan);
             var service = _services.GetRequiredService<ISyntaxFormattingService>();

--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpSyntaxFormattingService.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpSyntaxFormattingService.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Indentation;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -24,29 +25,38 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting
 {
-    [ExportLanguageService(typeof(ISyntaxFormattingService), LanguageNames.CSharp), Shared]
     internal sealed class CSharpSyntaxFormattingService : CSharpSyntaxFormatting, ISyntaxFormattingService
     {
-        [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public CSharpSyntaxFormattingService()
+        private readonly HostLanguageServices _services;
+
+        [ExportLanguageServiceFactory(typeof(ISyntaxFormattingService), LanguageNames.CSharp), Shared]
+        internal sealed class Factory : ILanguageServiceFactory
         {
+            [ImportingConstructor]
+            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+            public Factory()
+            {
+            }
+
+            public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+                => new CSharpSyntaxFormattingService(languageServices);
         }
 
-        public async Task<bool> ShouldFormatOnTypedCharacterAsync(
-            Document document,
+        private CSharpSyntaxFormattingService(HostLanguageServices languageServices)
+            => _services = languageServices;
+
+        public bool ShouldFormatOnTypedCharacter(
+            DocumentSyntax documentSyntax,
             char typedChar,
             int caretPosition,
             CancellationToken cancellationToken)
         {
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
             // first, find the token user just typed.
-            var token = root.FindToken(Math.Max(0, caretPosition - 1), findInsideTrivia: true);
+            var token = documentSyntax.Root.FindToken(Math.Max(0, caretPosition - 1), findInsideTrivia: true);
             if (token.IsMissing ||
                 !ValidSingleOrMultiCharactersTokenKind(typedChar, token.Kind()) ||
                 token.IsKind(SyntaxKind.EndOfFileToken, SyntaxKind.None) ||
-                root.SyntaxTree.IsInNonUserCode(caretPosition, cancellationToken))
+                documentSyntax.SyntaxTree.IsInNonUserCode(caretPosition, cancellationToken))
             {
                 return false;
             }
@@ -71,8 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // mess with it if it's inside a line.
             if (token.IsKind(SyntaxKind.OpenBraceToken))
             {
-                var text = await root.SyntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
-                if (!token.IsFirstTokenOnLine(text))
+                if (!token.IsFirstTokenOnLine(documentSyntax.Text))
                 {
                     return false;
                 }
@@ -81,13 +90,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return true;
         }
 
-        public async Task<ImmutableArray<TextChange>> GetFormattingChangesOnTypedCharacterAsync(
-            Document document,
+        public ImmutableArray<TextChange> GetFormattingChangesOnTypedCharacter(
+            DocumentSyntax document,
             int caretPosition,
             IndentationOptions indentationOptions,
             CancellationToken cancellationToken)
         {
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var root = document.Root;
             var token = root.FindToken(Math.Max(0, caretPosition - 1), findInsideTrivia: true);
             var formattingRules = GetFormattingRules(document, caretPosition, token);
 
@@ -128,18 +137,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 // if we're only doing smart indent, then ignore all edits to this token that occur before
                 // the span of the token. They're irrelevant and may screw up other code the user doesn't 
                 // want touched.
-                var tokenEdits = await FormatTokenAsync(root, indentationOptions, token, formattingRules, cancellationToken).ConfigureAwait(false);
+                var tokenEdits = FormatToken(document, indentationOptions, token, formattingRules, cancellationToken);
                 return tokenEdits.Where(t => t.Span.Start >= token.FullSpan.Start).ToImmutableArray();
             }
 
             // if formatting range fails, do format token one at least
-            var changes = FormatRange(root, indentationOptions, token, formattingRules, cancellationToken);
+            var changes = FormatRange(document, indentationOptions, token, formattingRules, cancellationToken);
             if (changes.Length > 0)
             {
                 return changes;
             }
 
-            return (await FormatTokenAsync(root, indentationOptions, token, formattingRules, cancellationToken).ConfigureAwait(false)).ToImmutableArray();
+            return FormatToken(document, indentationOptions, token, formattingRules, cancellationToken).ToImmutableArray();
         }
 
         private static bool OnlySmartIndentCloseBrace(in AutoFormattingOptions options)
@@ -157,15 +166,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return !options.FormatOnTyping;
         }
 
-        private static async Task<IList<TextChange>> FormatTokenAsync(
-            SyntaxNode root, IndentationOptions options, SyntaxToken token, ImmutableArray<AbstractFormattingRule> formattingRules, CancellationToken cancellationToken)
+        private static IList<TextChange> FormatToken(
+            DocumentSyntax document, IndentationOptions options, SyntaxToken token, ImmutableArray<AbstractFormattingRule> formattingRules, CancellationToken cancellationToken)
         {
-            var formatter = new CSharpSmartTokenFormatter(options, formattingRules, (CompilationUnitSyntax)root);
-            return await formatter.FormatTokenAsync(token, cancellationToken).ConfigureAwait(false);
+            var formatter = new CSharpSmartTokenFormatter(options, formattingRules, (CompilationUnitSyntax)document.Root, document.Text);
+            return formatter.FormatToken(token, cancellationToken);
         }
 
         private static ImmutableArray<TextChange> FormatRange(
-            SyntaxNode root,
+            DocumentSyntax document,
             IndentationOptions options,
             SyntaxToken endToken,
             ImmutableArray<AbstractFormattingRule> formattingRules,
@@ -187,7 +196,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return ImmutableArray<TextChange>.Empty;
             }
 
-            var formatter = new CSharpSmartTokenFormatter(options, formattingRules, (CompilationUnitSyntax)root);
+            var formatter = new CSharpSmartTokenFormatter(options, formattingRules, (CompilationUnitSyntax)document.Root, document.Text);
 
             var changes = formatter.FormatRange(tokenRange.Value.Item1, tokenRange.Value.Item2, cancellationToken);
             return changes.ToImmutableArray();
@@ -305,26 +314,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                    token.IsKind(SyntaxKind.EndOfFileToken);
         }
 
-        private static ImmutableArray<AbstractFormattingRule> GetFormattingRules(Document document, int position, SyntaxToken tokenBeforeCaret)
+        private ImmutableArray<AbstractFormattingRule> GetFormattingRules(DocumentSyntax document, int position, SyntaxToken tokenBeforeCaret)
         {
-            var workspace = document.Project.Solution.Workspace;
-            var formattingRuleFactory = workspace.Services.GetRequiredService<IHostDependentFormattingRuleFactoryService>();
+            var formattingRuleFactory = _services.WorkspaceServices.GetRequiredService<IHostDependentFormattingRuleFactoryService>();
             return ImmutableArray.Create(formattingRuleFactory.CreateRule(document, position))
                                  .AddRange(GetTypingRules(tokenBeforeCaret))
-                                 .AddRange(Formatter.GetDefaultFormattingRules(document));
+                                 .AddRange(Formatter.GetDefaultFormattingRules(_services));
         }
 
-        public async Task<ImmutableArray<TextChange>> GetFormattingChangesOnPasteAsync(Document document, TextSpan textSpan, SyntaxFormattingOptions options, CancellationToken cancellationToken)
+        public ImmutableArray<TextChange> GetFormattingChangesOnPaste(DocumentSyntax document, TextSpan textSpan, SyntaxFormattingOptions options, CancellationToken cancellationToken)
         {
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-            var formattingSpan = CommonFormattingHelpers.GetFormattingSpan(root, textSpan);
-            var service = document.GetRequiredLanguageService<ISyntaxFormattingService>();
+            var formattingSpan = CommonFormattingHelpers.GetFormattingSpan(document.Root, textSpan);
+            var service = _services.GetRequiredService<ISyntaxFormattingService>();
 
             var rules = new List<AbstractFormattingRule>() { new PasteFormattingRule() };
             rules.AddRange(service.GetDefaultFormattingRules());
 
-            var result = service.GetFormattingResult(root, SpecializedCollections.SingletonEnumerable(formattingSpan), options, rules, cancellationToken);
+            var result = service.GetFormattingResult(document.Root, SpecializedCollections.SingletonEnumerable(formattingSpan), options, rules, cancellationToken);
             return result.GetTextChanges(cancellationToken).ToImmutableArray();
         }
 

--- a/src/Workspaces/Core/Portable/Formatting/Formatter.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Formatter.cs
@@ -34,22 +34,10 @@ namespace Microsoft.CodeAnalysis.Formatting
         /// Gets the formatting rules that would be applied if left unspecified.
         /// </summary>
         internal static ImmutableArray<AbstractFormattingRule> GetDefaultFormattingRules(Document document)
-        {
-            if (document == null)
-            {
-                throw new ArgumentNullException(nameof(document));
-            }
+            => GetDefaultFormattingRules(document.Project.LanguageServices);
 
-            var service = document.GetLanguageService<ISyntaxFormattingService>();
-            if (service != null)
-            {
-                return service.GetDefaultFormattingRules();
-            }
-            else
-            {
-                return ImmutableArray<AbstractFormattingRule>.Empty;
-            }
-        }
+        internal static ImmutableArray<AbstractFormattingRule> GetDefaultFormattingRules(HostLanguageServices languageServices)
+            => languageServices.GetService<ISyntaxFormattingService>()?.GetDefaultFormattingRules() ?? ImmutableArray<AbstractFormattingRule>.Empty;
 
         /// <summary>
         /// Formats the whitespace in a document.

--- a/src/Workspaces/Core/Portable/Formatting/ISyntaxFormattingService.cs
+++ b/src/Workspaces/Core/Portable/Formatting/ISyntaxFormattingService.cs
@@ -14,8 +14,8 @@ namespace Microsoft.CodeAnalysis.Formatting
 {
     internal interface ISyntaxFormattingService : ISyntaxFormatting, ILanguageService
     {
-        bool ShouldFormatOnTypedCharacter(DocumentSyntax document, char typedChar, int caretPosition, CancellationToken cancellationToken);
-        ImmutableArray<TextChange> GetFormattingChangesOnTypedCharacter(DocumentSyntax document, int caretPosition, IndentationOptions indentationOptions, CancellationToken cancellationToken);
-        ImmutableArray<TextChange> GetFormattingChangesOnPaste(DocumentSyntax document, TextSpan textSpan, SyntaxFormattingOptions options, CancellationToken cancellationToken);
+        bool ShouldFormatOnTypedCharacter(ParsedDocument document, char typedChar, int caretPosition, CancellationToken cancellationToken);
+        ImmutableArray<TextChange> GetFormattingChangesOnTypedCharacter(ParsedDocument document, int caretPosition, IndentationOptions indentationOptions, CancellationToken cancellationToken);
+        ImmutableArray<TextChange> GetFormattingChangesOnPaste(ParsedDocument document, TextSpan textSpan, SyntaxFormattingOptions options, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/ISyntaxFormattingService.cs
+++ b/src/Workspaces/Core/Portable/Formatting/ISyntaxFormattingService.cs
@@ -14,8 +14,8 @@ namespace Microsoft.CodeAnalysis.Formatting
 {
     internal interface ISyntaxFormattingService : ISyntaxFormatting, ILanguageService
     {
-        Task<bool> ShouldFormatOnTypedCharacterAsync(Document document, char typedChar, int caretPosition, CancellationToken cancellationToken);
-        Task<ImmutableArray<TextChange>> GetFormattingChangesOnTypedCharacterAsync(Document document, int caretPosition, IndentationOptions indentationOptions, CancellationToken cancellationToken);
-        Task<ImmutableArray<TextChange>> GetFormattingChangesOnPasteAsync(Document document, TextSpan textSpan, SyntaxFormattingOptions options, CancellationToken cancellationToken);
+        bool ShouldFormatOnTypedCharacter(DocumentSyntax document, char typedChar, int caretPosition, CancellationToken cancellationToken);
+        ImmutableArray<TextChange> GetFormattingChangesOnTypedCharacter(DocumentSyntax document, int caretPosition, IndentationOptions indentationOptions, CancellationToken cancellationToken);
+        ImmutableArray<TextChange> GetFormattingChangesOnPaste(DocumentSyntax document, TextSpan textSpan, SyntaxFormattingOptions options, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/DefaultFormattingRuleFactoryServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/DefaultFormattingRuleFactoryServiceFactory.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
         public bool ShouldUseBaseIndentation(DocumentId documentId)
             => false;
 
-        public AbstractFormattingRule CreateRule(DocumentSyntax document, int position)
+        public AbstractFormattingRule CreateRule(ParsedDocument document, int position)
             => NoOpFormattingRule.Instance;
 
         public IEnumerable<TextChange> FilterFormattedChanges(DocumentId document, TextSpan span, IList<TextChange> changes)

--- a/src/Workspaces/Core/Portable/Formatting/Rules/DefaultFormattingRuleFactoryServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/DefaultFormattingRuleFactoryServiceFactory.cs
@@ -11,31 +11,25 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Formatting.Rules
 {
-    [ExportWorkspaceServiceFactory(typeof(IHostDependentFormattingRuleFactoryService), ServiceLayer.Default), Shared]
-    internal sealed class DefaultFormattingRuleFactoryServiceFactory : IWorkspaceServiceFactory
+    [ExportWorkspaceService(typeof(IHostDependentFormattingRuleFactoryService), ServiceLayer.Default), Shared]
+    internal sealed class DefaultFormattingRuleFactoryService : IHostDependentFormattingRuleFactoryService
     {
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public DefaultFormattingRuleFactoryServiceFactory()
+        public DefaultFormattingRuleFactoryService()
         {
         }
 
-        public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-            => new Factory();
+        public bool ShouldNotFormatOrCommitOnPaste(DocumentId documentId)
+            => false;
 
-        private sealed class Factory : IHostDependentFormattingRuleFactoryService
-        {
-            public bool ShouldUseBaseIndentation(Document document)
-                => false;
+        public bool ShouldUseBaseIndentation(DocumentId documentId)
+            => false;
 
-            public AbstractFormattingRule CreateRule(Document document, int position)
-                => NoOpFormattingRule.Instance;
+        public AbstractFormattingRule CreateRule(DocumentSyntax document, int position)
+            => NoOpFormattingRule.Instance;
 
-            public IEnumerable<TextChange> FilterFormattedChanges(Document document, TextSpan span, IList<TextChange> changes)
-                => changes;
-
-            public bool ShouldNotFormatOrCommitOnPaste(Document document)
-                => false;
-        }
+        public IEnumerable<TextChange> FilterFormattedChanges(DocumentId document, TextSpan span, IList<TextChange> changes)
+            => changes;
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/IHostDependentFormattingRuleFactoryService.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/IHostDependentFormattingRuleFactoryService.cs
@@ -10,9 +10,9 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 {
     internal interface IHostDependentFormattingRuleFactoryService : IWorkspaceService
     {
-        bool ShouldNotFormatOrCommitOnPaste(Document document);
-        bool ShouldUseBaseIndentation(Document document);
-        AbstractFormattingRule CreateRule(Document document, int position);
-        IEnumerable<TextChange> FilterFormattedChanges(Document document, TextSpan span, IList<TextChange> changes);
+        bool ShouldNotFormatOrCommitOnPaste(DocumentId documentId);
+        bool ShouldUseBaseIndentation(DocumentId documentId);
+        AbstractFormattingRule CreateRule(DocumentSyntax document, int position);
+        IEnumerable<TextChange> FilterFormattedChanges(DocumentId documentId, TextSpan span, IList<TextChange> changes);
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Rules/IHostDependentFormattingRuleFactoryService.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/IHostDependentFormattingRuleFactoryService.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
     {
         bool ShouldNotFormatOrCommitOnPaste(DocumentId documentId);
         bool ShouldUseBaseIndentation(DocumentId documentId);
-        AbstractFormattingRule CreateRule(DocumentSyntax document, int position);
+        AbstractFormattingRule CreateRule(ParsedDocument document, int position);
         IEnumerable<TextChange> FilterFormattedChanges(DocumentId documentId, TextSpan span, IList<TextChange> changes);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Indentation/CSharpSmartTokenFormatter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Indentation/CSharpSmartTokenFormatter.cs
@@ -25,11 +25,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
         private readonly ImmutableArray<AbstractFormattingRule> _formattingRules;
 
         private readonly CompilationUnitSyntax _root;
+        private readonly SourceText _text;
 
         public CSharpSmartTokenFormatter(
             IndentationOptions options,
             ImmutableArray<AbstractFormattingRule> formattingRules,
-            CompilationUnitSyntax root)
+            CompilationUnitSyntax root,
+            SourceText text)
         {
             Contract.ThrowIfNull(root);
 
@@ -37,6 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
             _formattingRules = formattingRules;
 
             _root = root;
+            _text = text;
         }
 
         public IList<TextChange> FormatRange(
@@ -72,8 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
                 (endToken.Parent.IsParentKind(SyntaxKind.TryStatement) || endToken.Parent.IsParentKind(SyntaxKind.DoStatement));
         }
 
-        public async Task<IList<TextChange>> FormatTokenAsync(
-            SyntaxToken token, CancellationToken cancellationToken)
+        public IList<TextChange> FormatToken(SyntaxToken token, CancellationToken cancellationToken)
         {
             Contract.ThrowIfTrue(token.Kind() is SyntaxKind.None or SyntaxKind.EndOfFileToken);
 
@@ -108,8 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
                 _options.IndentStyle != FormattingOptions2.IndentStyle.Smart)
             {
                 RoslynDebug.AssertNotNull(token.SyntaxTree);
-                var text = await token.SyntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
-                if (token.IsFirstTokenOnLine(text))
+                if (token.IsFirstTokenOnLine(_text))
                 {
                     adjustedStartPosition = token.SpanStart;
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Indentation/AbstractIndentation.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Indentation/AbstractIndentation.Indenter.cs
@@ -167,14 +167,9 @@ namespace Microsoft.CodeAnalysis.Indentation
             {
                 if (_service.ShouldUseTokenIndenter(this, out var token))
                 {
-                    // var root = document.GetSyntaxRootSynchronously(cancellationToken);
-                    var sourceText = Tree.GetText(CancellationToken);
+                    var changes = SmartTokenFormatter.FormatToken(token, CancellationToken);
 
-                    var changes = this.SmartTokenFormatter
-                        .FormatTokenAsync(token, CancellationToken)
-                        .WaitAndGetResult_CanCallOnBackground(CancellationToken);
-
-                    var updatedSourceText = sourceText.WithChanges(changes);
+                    var updatedSourceText = Text.WithChanges(changes);
                     if (LineToBeIndented.LineNumber < updatedSourceText.Lines.Count)
                     {
                         var updatedLine = updatedSourceText.Lines[LineToBeIndented.LineNumber];

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Indentation/AbstractIndentation.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Indentation/AbstractIndentation.cs
@@ -21,12 +21,12 @@ namespace Microsoft.CodeAnalysis.Indentation
         /// <summary>
         /// Returns <see langword="true"/> if the language specific <see
         /// cref="ISmartTokenFormatter"/> should be deferred to figure out indentation.  If so, it
-        /// will be asked to <see cref="ISmartTokenFormatter.FormatTokenAsync"/> the resultant
+        /// will be asked to <see cref="ISmartTokenFormatter.FormatToken"/> the resultant
         /// <paramref name="token"/> provided by this method.
         /// </summary>
         protected abstract bool ShouldUseTokenIndenter(Indenter indenter, out SyntaxToken token);
         protected abstract ISmartTokenFormatter CreateSmartTokenFormatter(
-            TSyntaxRoot root, TextLine lineToBeIndented, IndentationOptions options, AbstractFormattingRule baseFormattingRule);
+            TSyntaxRoot root, SourceText text, TextLine lineToBeIndented, IndentationOptions options, AbstractFormattingRule baseFormattingRule);
 
         protected abstract IndentationResult? GetDesiredIndentationWorker(
             Indenter indenter, SyntaxToken? token, SyntaxTrivia? trivia);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Indentation/ISmartTokenFormatter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Indentation/ISmartTokenFormatter.cs
@@ -11,6 +11,6 @@ namespace Microsoft.CodeAnalysis.Indentation
 {
     internal interface ISmartTokenFormatter
     {
-        Task<IList<TextChange>> FormatTokenAsync(SyntaxToken token, CancellationToken cancellationToken);
+        IList<TextChange> FormatToken(SyntaxToken token, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Indentation/VisualBasicSmartTokenFormatter.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Indentation/VisualBasicSmartTokenFormatter.vb
@@ -27,13 +27,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
                        root As CompilationUnitSyntax)
             Contract.ThrowIfNull(root)
 
-            Me._options = options
-            Me._formattingRules = formattingRules
+            _options = options
+            _formattingRules = formattingRules
 
-            Me._root = root
+            _root = root
         End Sub
 
-        Public Function FormatTokenAsync(token As SyntaxToken, cancellationToken As CancellationToken) As Tasks.Task(Of IList(Of TextChange)) Implements ISmartTokenFormatter.FormatTokenAsync
+        Public Function FormatToken(token As SyntaxToken, cancellationToken As CancellationToken) As IList(Of TextChange) Implements ISmartTokenFormatter.FormatToken
             Contract.ThrowIfTrue(token.Kind = SyntaxKind.None OrElse token.Kind = SyntaxKind.EndOfFileToken)
 
             ' get previous token
@@ -42,7 +42,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
             Dim spans = SpecializedCollections.SingletonEnumerable(TextSpan.FromBounds(previousToken.SpanStart, token.Span.End))
             Dim formatter = VisualBasicSyntaxFormatting.Instance
             Dim result = formatter.GetFormattingResult(_root, spans, _options, _formattingRules, cancellationToken)
-            Return Task.FromResult(result.GetTextChanges(cancellationToken))
+            Return result.GetTextChanges(cancellationToken)
         End Function
     End Class
 End Namespace

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Indentation/CSharpIndentationService.Indenter.cs
@@ -26,11 +26,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
                 indenter.Rules, indenter.Root, indenter.LineToBeIndented, indenter.Options, out syntaxToken);
 
         protected override ISmartTokenFormatter CreateSmartTokenFormatter(
-            CompilationUnitSyntax root, TextLine lineToBeIndented,
+            CompilationUnitSyntax root, SourceText text, TextLine lineToBeIndented,
             IndentationOptions options, AbstractFormattingRule baseIndentationRule)
         {
             var rules = ImmutableArray.Create(baseIndentationRule).AddRange(CSharpSyntaxFormatting.Instance.GetDefaultFormattingRules());
-            return new CSharpSmartTokenFormatter(options, rules, root);
+            return new CSharpSmartTokenFormatter(options, rules, root, text);
         }
 
         protected override IndentationResult? GetDesiredIndentationWorker(Indenter indenter, SyntaxToken? tokenOpt, SyntaxTrivia? triviaOpt)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Indentation/AbstractIndentationService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Indentation/AbstractIndentationService.cs
@@ -44,21 +44,19 @@ namespace Microsoft.CodeAnalysis.Indentation
             var syntaxFormatting = this.SyntaxFormatting;
 
 #if CODE_STYLE
-            var tree = document.GetSyntaxTreeAsync(cancellationToken).WaitAndGetResult_CanCallOnBackground(cancellationToken);
-            Contract.ThrowIfNull(tree);
+            var documentSyntax = DocumentSyntax.CreateAsync(document, cancellationToken).AsTask().WaitAndGetResult_CanCallOnBackground(cancellationToken);
 #else
-            var tree = document.GetRequiredSyntaxTreeSynchronously(cancellationToken);
+            var documentSyntax = DocumentSyntax.CreateSynchronously(document, cancellationToken);
 #endif
 
-            var sourceText = tree.GetText(cancellationToken);
-            var lineToBeIndented = sourceText.Lines[lineNumber];
+            var lineToBeIndented = documentSyntax.Text.Lines[lineNumber];
 
 #if CODE_STYLE
             var baseIndentationRule = NoOpFormattingRule.Instance;
 #else
             var workspace = document.Project.Solution.Workspace;
             var formattingRuleFactory = workspace.Services.GetRequiredService<IHostDependentFormattingRuleFactoryService>();
-            var baseIndentationRule = formattingRuleFactory.CreateRule(document, lineToBeIndented.Start);
+            var baseIndentationRule = formattingRuleFactory.CreateRule(documentSyntax, lineToBeIndented.Start);
 #endif
 
             var formattingRules = ImmutableArray.Create(
@@ -67,8 +65,8 @@ namespace Microsoft.CodeAnalysis.Indentation
                 syntaxFormatting.GetDefaultFormattingRules());
 
             var smartTokenFormatter = CreateSmartTokenFormatter(
-                (TSyntaxRoot)tree.GetRoot(cancellationToken), lineToBeIndented, options, baseIndentationRule);
-            return new Indenter(this, tree, formattingRules, options, lineToBeIndented, smartTokenFormatter, cancellationToken);
+                (TSyntaxRoot)documentSyntax.Root, documentSyntax.Text, lineToBeIndented, options, baseIndentationRule);
+            return new Indenter(this, documentSyntax.SyntaxTree, formattingRules, options, lineToBeIndented, smartTokenFormatter, cancellationToken);
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Indentation/AbstractIndentationService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Indentation/AbstractIndentationService.cs
@@ -44,9 +44,9 @@ namespace Microsoft.CodeAnalysis.Indentation
             var syntaxFormatting = this.SyntaxFormatting;
 
 #if CODE_STYLE
-            var documentSyntax = DocumentSyntax.CreateAsync(document, cancellationToken).AsTask().WaitAndGetResult_CanCallOnBackground(cancellationToken);
+            var documentSyntax = ParsedDocument.CreateAsync(document, cancellationToken).AsTask().WaitAndGetResult_CanCallOnBackground(cancellationToken);
 #else
-            var documentSyntax = DocumentSyntax.CreateSynchronously(document, cancellationToken);
+            var documentSyntax = ParsedDocument.CreateSynchronously(document, cancellationToken);
 #endif
 
             var lineToBeIndented = documentSyntax.Text.Lines[lineNumber];

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/DocumentSyntax.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/DocumentSyntax.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis;
+
+internal readonly record struct DocumentSyntax(DocumentId Id, SourceText Text, SyntaxNode Root)
+{
+    public SyntaxTree SyntaxTree => Root.SyntaxTree;
+
+    public static async ValueTask<DocumentSyntax> CreateAsync(Document document, CancellationToken cancellationToken)
+    {
+        var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        return new DocumentSyntax(document.Id, text, root);
+    }
+
+#if !CODE_STYLE
+    public static DocumentSyntax CreateSynchronously(Document document, CancellationToken cancellationToken)
+    {
+        var text = document.GetTextSynchronously(cancellationToken);
+        var root = document.GetRequiredSyntaxRootSynchronously(cancellationToken);
+        return new DocumentSyntax(document.Id, text, root);
+    }
+#endif
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/ParsedDocument.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/ParsedDocument.cs
@@ -9,23 +9,23 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis;
 
-internal readonly record struct DocumentSyntax(DocumentId Id, SourceText Text, SyntaxNode Root)
+internal readonly record struct ParsedDocument(DocumentId Id, SourceText Text, SyntaxNode Root)
 {
     public SyntaxTree SyntaxTree => Root.SyntaxTree;
 
-    public static async ValueTask<DocumentSyntax> CreateAsync(Document document, CancellationToken cancellationToken)
+    public static async ValueTask<ParsedDocument> CreateAsync(Document document, CancellationToken cancellationToken)
     {
         var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        return new DocumentSyntax(document.Id, text, root);
+        return new ParsedDocument(document.Id, text, root);
     }
 
 #if !CODE_STYLE
-    public static DocumentSyntax CreateSynchronously(Document document, CancellationToken cancellationToken)
+    public static ParsedDocument CreateSynchronously(Document document, CancellationToken cancellationToken)
     {
         var text = document.GetTextSynchronously(cancellationToken);
         var root = document.GetRequiredSyntaxRootSynchronously(cancellationToken);
-        return new DocumentSyntax(document.Id, text, root);
+        return new ParsedDocument(document.Id, text, root);
     }
 #endif
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/SemanticDocument.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/SemanticDocument.cs
@@ -14,8 +14,8 @@ namespace Microsoft.CodeAnalysis
     {
         public readonly SemanticModel SemanticModel;
 
-        private SemanticDocument(Document document, SourceText text, SyntaxTree tree, SyntaxNode root, SemanticModel semanticModel)
-            : base(document, text, tree, root)
+        private SemanticDocument(Document document, SourceText text, SyntaxNode root, SemanticModel semanticModel)
+            : base(document, text, root)
         {
             this.SemanticModel = semanticModel;
         }
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            return new SemanticDocument(document, text, root.SyntaxTree, root, model);
+            return new SemanticDocument(document, text, root, model);
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/SyntacticDocument.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/SyntacticDocument.cs
@@ -9,27 +9,6 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis
 {
-    internal readonly record struct DocumentSyntax(DocumentId Id, SourceText Text, SyntaxNode Root)
-    {
-        public SyntaxTree SyntaxTree => Root.SyntaxTree;
-
-        public static async ValueTask<DocumentSyntax> CreateAsync(Document document, CancellationToken cancellationToken)
-        {
-            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            return new DocumentSyntax(document.Id, text, root);
-        }
-
-#if !CODE_STYLE
-        public static DocumentSyntax CreateSynchronously(Document document, CancellationToken cancellationToken)
-        {
-            var text = document.GetTextSynchronously(cancellationToken);
-            var root = document.GetRequiredSyntaxRootSynchronously(cancellationToken);
-            return new DocumentSyntax(document.Id, text, root);
-        }
-#endif
-    }
-
     internal class SyntacticDocument
     {
         public readonly Document Document;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/SyntacticDocument.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/SyntacticDocument.cs
@@ -2,37 +2,55 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis
 {
+    internal readonly record struct DocumentSyntax(DocumentId Id, SourceText Text, SyntaxNode Root)
+    {
+        public SyntaxTree SyntaxTree => Root.SyntaxTree;
+
+        public static async ValueTask<DocumentSyntax> CreateAsync(Document document, CancellationToken cancellationToken)
+        {
+            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            return new DocumentSyntax(document.Id, text, root);
+        }
+
+#if !CODE_STYLE
+        public static DocumentSyntax CreateSynchronously(Document document, CancellationToken cancellationToken)
+        {
+            var text = document.GetTextSynchronously(cancellationToken);
+            var root = document.GetRequiredSyntaxRootSynchronously(cancellationToken);
+            return new DocumentSyntax(document.Id, text, root);
+        }
+#endif
+    }
+
     internal class SyntacticDocument
     {
         public readonly Document Document;
         public readonly SourceText Text;
-        public readonly SyntaxTree SyntaxTree;
         public readonly SyntaxNode Root;
 
-        protected SyntacticDocument(Document document, SourceText text, SyntaxTree tree, SyntaxNode root)
+        protected SyntacticDocument(Document document, SourceText text, SyntaxNode root)
         {
-            this.Document = document;
-            this.Text = text;
-            this.SyntaxTree = tree;
-            this.Root = root;
+            Document = document;
+            Text = text;
+            Root = root;
         }
 
-        public Project Project => this.Document.Project;
+        public Project Project => Document.Project;
+        public SyntaxTree SyntaxTree => Root.SyntaxTree;
 
-        public static async Task<SyntacticDocument> CreateAsync(
-            Document document, CancellationToken cancellationToken)
+        public static async ValueTask<SyntacticDocument> CreateAsync(Document document, CancellationToken cancellationToken)
         {
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            return new SyntacticDocument(document, text, root.SyntaxTree, root);
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            return new SyntacticDocument(document, text, root);
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/WorkspaceExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/WorkspaceExtensions.projitems
@@ -69,6 +69,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Simplification\SimplifierOptionsProviders.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\AsyncSymbolVisitor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\AsyncSymbolVisitor`1.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities\ParsedDocument.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\IProgressTracker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\NoOpProgressTracker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\SemanticDocument.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Indentation/VisualBasicIndentationService.Indenter.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/Indentation/VisualBasicIndentationService.Indenter.vb
@@ -39,6 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
 
         Protected Overrides Function CreateSmartTokenFormatter(
                 root As CompilationUnitSyntax,
+                text As SourceText,
                 lineToBeIndented As TextLine,
                 options As IndentationOptions,
                 baseIndentationRule As AbstractFormattingRule) As ISmartTokenFormatter

--- a/src/Workspaces/VisualBasic/Portable/Formatting/VisualBasicSyntaxFormattingService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/VisualBasicSyntaxFormattingService.vb
@@ -21,15 +21,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Public Sub New()
         End Sub
 
-        Public Function ShouldFormatOnTypedCharacterAsync(document As Document, typedChar As Char, caretPosition As Integer, cancellationToken As CancellationToken) As Task(Of Boolean) Implements ISyntaxFormattingService.ShouldFormatOnTypedCharacterAsync
-            Return Task.FromResult(False)
+        Public Function ShouldFormatOnTypedCharacter(document As DocumentSyntax, typedChar As Char, caretPosition As Integer, cancellationToken As CancellationToken) As Boolean Implements ISyntaxFormattingService.ShouldFormatOnTypedCharacter
+            Return False
         End Function
 
-        Public Function GetFormattingChangesOnTypedCharacterAsync(document As Document, caretPosition As Integer, indentationOptions As IndentationOptions, cancellationToken As CancellationToken) As Task(Of ImmutableArray(Of TextChange)) Implements ISyntaxFormattingService.GetFormattingChangesOnTypedCharacterAsync
+        Public Function GetFormattingChangesOnTypedCharacter(document As DocumentSyntax, caretPosition As Integer, indentationOptions As IndentationOptions, cancellationToken As CancellationToken) As ImmutableArray(Of TextChange) Implements ISyntaxFormattingService.GetFormattingChangesOnTypedCharacter
             Throw ExceptionUtilities.Unreachable
         End Function
 
-        Public Function GetFormattingChangesOnPasteAsync(document As Document, textSpan As TextSpan, options As SyntaxFormattingOptions, cancellationToken As CancellationToken) As Task(Of ImmutableArray(Of TextChange)) Implements ISyntaxFormattingService.GetFormattingChangesOnPasteAsync
+        Public Function GetFormattingChangesOnPaste(document As DocumentSyntax, textSpan As TextSpan, options As SyntaxFormattingOptions, cancellationToken As CancellationToken) As ImmutableArray(Of TextChange) Implements ISyntaxFormattingService.GetFormattingChangesOnPaste
             Throw ExceptionUtilities.Unreachable
         End Function
     End Class

--- a/src/Workspaces/VisualBasic/Portable/Formatting/VisualBasicSyntaxFormattingService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/VisualBasicSyntaxFormattingService.vb
@@ -21,15 +21,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Public Sub New()
         End Sub
 
-        Public Function ShouldFormatOnTypedCharacter(document As DocumentSyntax, typedChar As Char, caretPosition As Integer, cancellationToken As CancellationToken) As Boolean Implements ISyntaxFormattingService.ShouldFormatOnTypedCharacter
+        Public Function ShouldFormatOnTypedCharacter(document As ParsedDocument, typedChar As Char, caretPosition As Integer, cancellationToken As CancellationToken) As Boolean Implements ISyntaxFormattingService.ShouldFormatOnTypedCharacter
             Return False
         End Function
 
-        Public Function GetFormattingChangesOnTypedCharacter(document As DocumentSyntax, caretPosition As Integer, indentationOptions As IndentationOptions, cancellationToken As CancellationToken) As ImmutableArray(Of TextChange) Implements ISyntaxFormattingService.GetFormattingChangesOnTypedCharacter
+        Public Function GetFormattingChangesOnTypedCharacter(document As ParsedDocument, caretPosition As Integer, indentationOptions As IndentationOptions, cancellationToken As CancellationToken) As ImmutableArray(Of TextChange) Implements ISyntaxFormattingService.GetFormattingChangesOnTypedCharacter
             Throw ExceptionUtilities.Unreachable
         End Function
 
-        Public Function GetFormattingChangesOnPaste(document As DocumentSyntax, textSpan As TextSpan, options As SyntaxFormattingOptions, cancellationToken As CancellationToken) As ImmutableArray(Of TextChange) Implements ISyntaxFormattingService.GetFormattingChangesOnPaste
+        Public Function GetFormattingChangesOnPaste(document As ParsedDocument, textSpan As TextSpan, options As SyntaxFormattingOptions, cancellationToken As CancellationToken) As ImmutableArray(Of TextChange) Implements ISyntaxFormattingService.GetFormattingChangesOnPaste
             Throw ExceptionUtilities.Unreachable
         End Function
     End Class


### PR DESCRIPTION
Formatting services have async methods that are asynchronous only because they need to retrieve `SourceText` and `SyntaxTree`. Some callers of the services are truly async (e.g. code fixes), but others (e.g. typing command handler) are synchronous and running on UI thread. This creates potential for undesirable scheduling of parser execution and blocking of the UI thread in the latter case. 

Instead of passing `Document` to various formatting services and then retrieving `SourceText` and `SyntaxTree` asynchronously in these services, retrieve the text and tree upfront and make the formatting services synchronous. The text and the syntax root are packaged in `DocumentSyntax` struct to simplify passing them both along.

Unlike `SyntacticDocument` the `ParsedDocument` struct does not have a reference to `Document`. This makes the formatting code completely independent of solution snapshot and prevents from potential accidental async reads of data from `Document`. If in future we end up removing Solution snapshot from in-proc this approach will also allow us to keep the synchronous formatter calls in-proc as long as we have the text and trees in-proc.

Contributes to https://github.com/dotnet/roslyn/issues/57554

Follow ups:
- [ ] Apply this pattern for brace completion and other blocking command handlers
- [ ] Avoid reading options asynchronously when they are available from the editor buffer
- [ ] Consider replacing `SyntacticDocument`, doc difference from `ParsedDocument` if we keep it