### PR TITLE
Fix post init trees parsing when parse options change

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -3173,6 +3173,10 @@ public static readonly string F = ""a""
             parseOptions = parseOptions.WithLanguageVersion(LanguageVersion.CSharp1);
             compilation = CreateCompilation(source, options: TestOptions.DebugDll, parseOptions: parseOptions);
             driver = driver.WithUpdatedParseOptions(parseOptions);
+
+            // change some other options to ensure the parseOption change tracking flows correctly
+            driver = driver.AddAdditionalTexts(ImmutableArray<AdditionalText>.Empty);
+
             driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out compilation, out diagnostics);
             diagnostics.Verify();
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -1021,7 +1021,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
                     SyntaxStore.Empty,
                     disabledOutputs: IncrementalGeneratorOutputKind.None,
                     runtime: TimeSpan.Zero,
-                    trackIncrementalGeneratorSteps: trackIncrementalGeneratorSteps);
+                    trackIncrementalGeneratorSteps: trackIncrementalGeneratorSteps,
+                    parseOptionsChanged: false);
 
             return new DriverStateTable.Builder(c, state, SyntaxStore.Empty.ToBuilder(c, ImmutableArray<SyntaxInputNode>.Empty, trackIncrementalGeneratorSteps, cancellationToken: default));
         }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis
         public GeneratorDriver ReplaceAdditionalTexts(ImmutableArray<AdditionalText> newTexts) => FromState(_state.With(additionalTexts: newTexts));
 
         public GeneratorDriver WithUpdatedParseOptions(ParseOptions newOptions) => newOptions is object
-                                                                                   ? FromState(_state.With(parseOptions: newOptions))
+                                                                                   ? FromState(_state.With(parseOptions: newOptions, parseOptionsChanged: true))
                                                                                    : throw new ArgumentNullException(nameof(newOptions));
 
         public GeneratorDriver WithUpdatedAnalyzerConfigOptions(AnalyzerConfigOptionsProvider newOptions) => newOptions is object
@@ -304,7 +304,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            state = state.With(stateTable: driverStateBuilder.ToImmutable(), syntaxStore: syntaxStoreBuilder.ToImmutable(), generatorStates: stateBuilder.ToImmutableAndFree(), runTime: timer.Elapsed);
+            state = state.With(stateTable: driverStateBuilder.ToImmutable(), syntaxStore: syntaxStoreBuilder.ToImmutable(), generatorStates: stateBuilder.ToImmutableAndFree(), runTime: timer.Elapsed, parseOptionsChanged: false);
             return state;
         }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis
         internal GeneratorDriver(ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, AnalyzerConfigOptionsProvider optionsProvider, ImmutableArray<AdditionalText> additionalTexts, GeneratorDriverOptions driverOptions)
         {
             var incrementalGenerators = GetIncrementalGenerators(generators, SourceExtension);
-            _state = new GeneratorDriverState(parseOptions, optionsProvider, generators, incrementalGenerators, additionalTexts, ImmutableArray.Create(new GeneratorState[generators.Length]), DriverStateTable.Empty, SyntaxStore.Empty, driverOptions.DisabledOutputs, runtime: TimeSpan.Zero, driverOptions.TrackIncrementalGeneratorSteps);
+            _state = new GeneratorDriverState(parseOptions, optionsProvider, generators, incrementalGenerators, additionalTexts, ImmutableArray.Create(new GeneratorState[generators.Length]), DriverStateTable.Empty, SyntaxStore.Empty, driverOptions.DisabledOutputs, runtime: TimeSpan.Zero, driverOptions.TrackIncrementalGeneratorSteps, parseOptionsChanged: true);
         }
 
         public GeneratorDriver RunGenerators(Compilation compilation, CancellationToken cancellationToken = default)
@@ -247,6 +247,12 @@ namespace Microsoft.CodeAnalysis
                     generatorState = ex is null
                                      ? new GeneratorState(postInitSources, inputNodes, outputNodes)
                                      : SetGeneratorException(MessageProvider, GeneratorState.Empty, sourceGenerator, ex, diagnosticsBag, isInit: true);
+                }
+                else if (state.ParseOptionsChanged && generatorState.PostInitTrees.Length > 0)
+                {
+                    // the generator is initalized, but we need to reparse the post-init trees as the parse options have changed
+                    var reparsedInitSources = ParseAdditionalSources(sourceGenerator, generatorState.PostInitTrees.SelectAsArray(t => new GeneratedSourceText(t.HintName, t.Text)), cancellationToken);
+                    generatorState = new GeneratorState(reparsedInitSources, generatorState.InputNodes, generatorState.OutputNodes);
                 }
 
                 // if the pipeline registered any syntax input nodes, record them

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriverState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriverState.cs
@@ -21,7 +21,8 @@ namespace Microsoft.CodeAnalysis
                                       SyntaxStore syntaxStore,
                                       IncrementalGeneratorOutputKind disabledOutputs,
                                       TimeSpan runtime,
-                                      bool trackIncrementalGeneratorSteps)
+                                      bool trackIncrementalGeneratorSteps,
+                                      bool parseOptionsChanged)
         {
             Generators = sourceGenerators;
             IncrementalGenerators = incrementalGenerators;
@@ -34,6 +35,7 @@ namespace Microsoft.CodeAnalysis
             DisabledOutputs = disabledOutputs;
             RunTime = runtime;
             TrackIncrementalSteps = trackIncrementalGeneratorSteps;
+            ParseOptionsChanged = parseOptionsChanged;
             Debug.Assert(Generators.Length == GeneratorStates.Length);
             Debug.Assert(IncrementalGenerators.Length == GeneratorStates.Length);
         }
@@ -93,6 +95,8 @@ namespace Microsoft.CodeAnalysis
 
         internal readonly bool TrackIncrementalSteps;
 
+        internal readonly bool ParseOptionsChanged;
+
         internal GeneratorDriverState With(
             ImmutableArray<ISourceGenerator>? sourceGenerators = null,
             ImmutableArray<IIncrementalGenerator>? incrementalGenerators = null,
@@ -116,7 +120,8 @@ namespace Microsoft.CodeAnalysis
                 syntaxStore ?? this.SyntaxStore,
                 disabledOutputs ?? this.DisabledOutputs,
                 runTime ?? this.RunTime,
-                this.TrackIncrementalSteps
+                this.TrackIncrementalSteps,
+                parseOptions is not null
                 );
         }
     }

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriverState.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriverState.cs
@@ -95,6 +95,9 @@ namespace Microsoft.CodeAnalysis
 
         internal readonly bool TrackIncrementalSteps;
 
+        /// <summary>
+        /// Tracks if the <see cref="ParseOptions"/> have been changed meaning post init trees will need to be re-parsed.
+        /// </summary>
         internal readonly bool ParseOptionsChanged;
 
         internal GeneratorDriverState With(
@@ -107,7 +110,8 @@ namespace Microsoft.CodeAnalysis
             ParseOptions? parseOptions = null,
             AnalyzerConfigOptionsProvider? optionsProvider = null,
             IncrementalGeneratorOutputKind? disabledOutputs = null,
-            TimeSpan? runTime = null)
+            TimeSpan? runTime = null,
+            bool? parseOptionsChanged = null)
         {
             return new GeneratorDriverState(
                 parseOptions ?? this.ParseOptions,
@@ -121,7 +125,7 @@ namespace Microsoft.CodeAnalysis
                 disabledOutputs ?? this.DisabledOutputs,
                 runTime ?? this.RunTime,
                 this.TrackIncrementalSteps,
-                parseOptions is not null
+                parseOptionsChanged ?? this.ParseOptionsChanged
                 );
         }
     }


### PR DESCRIPTION
If the parse options change after initialize has been called, we were not re-parsing the post init trees, leading to `System.ArgumentException: Inconsistent language versions` being thrown.

This tracks when the parse options change, and re-parses the init trees in the next generation pass if they have. 