### PR TITLE
Actually return filtered items for default implementation

### DIFF
--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis.Completion
         {
             // Default implementation just drops the pattern matches and builder, and
             // calls the public overload of FilterItems instead for compatibility.
-            FilterItems(document, itemsWithPatternMatch.SelectAsArray(item => item.Item1), filterText);
+            builder.AddRange(FilterItems(document, itemsWithPatternMatch.SelectAsArray(item => item.Item1), filterText));
         }
 
         // The FilterItems method might need to handle a large list of items when import completion is enabled and filter text is


### PR DESCRIPTION
Regression introduced in https://github.com/dotnet/roslyn/pull/61620
This didn't affect C#/VB since we don't use the default implementation, but presumably it would impact TS/F# selection.