### PR TITLE
Don't use exceptions for flow control

### DIFF
--- a/src/Features/Core/Portable/DecompiledSource/IDecompiledSourceService.cs
+++ b/src/Features/Core/Portable/DecompiledSource/IDecompiledSourceService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Formatting;
@@ -24,7 +22,7 @@ namespace Microsoft.CodeAnalysis.DecompiledSource
         /// <param name="metadataReference">The reference that contains the symbol</param>
         /// <param name="assemblyLocation">The location of the implementation assembly to decompile</param>
         /// <param name="cancellationToken">To cancel document operations</param>
-        /// <returns>The updated document</returns>
-        Task<Document> AddSourceToAsync(Document document, Compilation symbolCompilation, ISymbol symbol, MetadataReference metadataReference, string assemblyLocation, SyntaxFormattingOptions formattingOptions, CancellationToken cancellationToken);
+        /// <returns>The updated document, or null if the decompilation could not be performed</returns>
+        Task<Document?> AddSourceToAsync(Document document, Compilation symbolCompilation, ISymbol symbol, MetadataReference? metadataReference, string? assemblyLocation, SyntaxFormattingOptions formattingOptions, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/MetadataAsSource/DecompilationMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/DecompilationMetadataAsSourceFileProvider.cs
@@ -92,7 +92,15 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
                         if (decompiledSourceService != null)
                         {
-                            temporaryDocument = await decompiledSourceService.AddSourceToAsync(temporaryDocument, compilation, symbol, refInfo.metadataReference, refInfo.assemblyLocation, options.GenerationOptions.CleanupOptions.FormattingOptions, cancellationToken).ConfigureAwait(false);
+                            var decompilationDocument = await decompiledSourceService.AddSourceToAsync(temporaryDocument, compilation, symbol, refInfo.metadataReference, refInfo.assemblyLocation, options.GenerationOptions.CleanupOptions.FormattingOptions, cancellationToken).ConfigureAwait(false);
+                            if (decompilationDocument is not null)
+                            {
+                                temporaryDocument = decompilationDocument;
+                            }
+                            else
+                            {
+                                useDecompiler = false;
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
Fixes [AB#1514770](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1514770)

I suspect this exception used to bubble all the way up to a command handler that would show its message in the UI, but at some point in the past N years that changed, and the exception now just gets reported via telemetry. This is undesirable, as its a totally expected thing for ILSpy to not be able to decompile in some circumstances, and we gracefully fall back to metadata in those cases.