### PR TITLE
Fix race condition in FixAll tests based off TrackNodes functionality

### DIFF
--- a/src/Features/CSharp/Portable/CodeRefactorings/UseRecursivePatterns/UseRecursivePatternsCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/UseRecursivePatterns/UseRecursivePatternsCodeRefactoringProvider.cs
@@ -528,7 +528,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.UseRecursivePatterns
             CancellationToken cancellationToken)
         {
             // Get all the descendant nodes to refactor.
-            var nodes = editor.OriginalRoot.DescendantNodes().Where(IsFixableNode);
+            // NOTE: We need to realize the nodes with 'ToArray' call here
+            // to ensure we strongly hold onto the nodes so that 'TrackNodes'
+            // invoked below, which does tracking based off a ConditionalWeakTable,
+            // tracks the nodes for the entire duration of this method.
+            var nodes = editor.OriginalRoot.DescendantNodes().Where(IsFixableNode).ToArray();
 
             // We're going to be continually editing this tree. Track all the nodes we
             // care about so we can find them across each edit.

--- a/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
@@ -247,13 +247,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                 bool useExpressionBody,
                 CancellationToken cancellationToken)
             {
-                // Process all declaration nodes in reverse to handle nested declaration updates properly.
-                declarationsToFix = declarationsToFix.Reverse().ToImmutableArray();
-
                 // Track all the declaration nodes to be fixed so we can get the latest declaration node in the current root during updates.
                 var currentRoot = root.TrackNodes(declarationsToFix);
 
-                foreach (var declaration in declarationsToFix)
+                // Process all declaration nodes in reverse to handle nested declaration updates properly.
+                foreach (var declaration in declarationsToFix.Reverse())
                 {
                     // Get the current document, root, semanticModel and declaration.
                     document = document.WithSyntaxRoot(currentRoot);

--- a/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
@@ -248,7 +248,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                 CancellationToken cancellationToken)
             {
                 // Process all declaration nodes in reverse to handle nested declaration updates properly.
-                declarationsToFix = declarationsToFix.Reverse();
+                // NOTE: We need to realize the declarations with 'ToArray' call here
+                // to ensure we strongly hold onto the nodes so that 'TrackNodes'
+                // invoked below, which does tracking based off a ConditionalWeakTable,
+                // tracks the nodes for the entire duration of this method.
+                declarationsToFix = declarationsToFix.Reverse().ToArray();
 
                 // Track all the declaration nodes to be fixed so we can get the latest declaration node in the current root during updates.
                 var currentRoot = root.TrackNodes(declarationsToFix);

--- a/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/UseExpressionBodyCodeRefactoringProvider.cs
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var options = (CSharpCodeGenerationOptions)await document.GetCodeGenerationOptionsAsync(optionsProvider, cancellationToken).ConfigureAwait(false);
             var declarationsToFix = GetDeclarationsToFix(fixAllSpans, root, helper, useExpressionBody, options);
-            await FixDeclarationsAsync(document, editor, root, declarationsToFix, helper, useExpressionBody, cancellationToken).ConfigureAwait(false);
+            await FixDeclarationsAsync(document, editor, root, declarationsToFix.ToImmutableArray(), helper, useExpressionBody, cancellationToken).ConfigureAwait(false);
             return;
 
             // Local functions.
@@ -242,17 +242,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                 Document document,
                 SyntaxEditor editor,
                 SyntaxNode root,
-                IEnumerable<SyntaxNode> declarationsToFix,
+                ImmutableArray<SyntaxNode> declarationsToFix,
                 UseExpressionBodyHelper helper,
                 bool useExpressionBody,
                 CancellationToken cancellationToken)
             {
                 // Process all declaration nodes in reverse to handle nested declaration updates properly.
-                // NOTE: We need to realize the declarations with 'ToArray' call here
-                // to ensure we strongly hold onto the nodes so that 'TrackNodes'
-                // invoked below, which does tracking based off a ConditionalWeakTable,
-                // tracks the nodes for the entire duration of this method.
-                declarationsToFix = declarationsToFix.Reverse().ToArray();
+                declarationsToFix = declarationsToFix.Reverse().ToImmutableArray();
 
                 // Track all the declaration nodes to be fixed so we can get the latest declaration node in the current root during updates.
                 var currentRoot = root.TrackNodes(declarationsToFix);

--- a/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertIfToSwitch/AbstractConvertIfToSwitchCodeRefactoringProvider.cs
@@ -189,7 +189,11 @@ namespace Microsoft.CodeAnalysis.ConvertIfToSwitch
             var syntaxFactsService = document.GetRequiredLanguageService<ISyntaxFactsService>();
 
             // Get all the descendant if statements to process.
-            var ifStatements = editor.OriginalRoot.DescendantNodes().OfType<TIfStatementSyntax>();
+            // NOTE: We need to realize the nodes with 'ToArray' call here
+            // to ensure we strongly hold onto the nodes so that 'TrackNodes'
+            // invoked below, which does tracking based off a ConditionalWeakTable,
+            // tracks the nodes for the entire duration of this method.
+            var ifStatements = editor.OriginalRoot.DescendantNodes().OfType<TIfStatementSyntax>().ToArray();
 
             // We're going to be continually editing this tree. Track all the nodes we
             // care about so we can find them across each edit.


### PR DESCRIPTION
Recently we enabled FixAll functionality for a bunch of code refactorings. We have been seen intermittent failures in CI for the FixAll tests added for this. I was able to reproduce the failures locally quite consistently by running the test under a loop with thousands of iterations.

Upon investigation it was found that when the test fails, the [underlying CWT](https://github.com/dotnet/roslyn/blob/73de4e98d3020c72a2eef479d267357c15332d80/src/Compilers/Core/Portable/Syntax/SyntaxNodeExtensions_Tracking.cs#L18) used by [TrackNodes](https://github.com/dotnet/roslyn/blob/73de4e98d3020c72a2eef479d267357c15332d80/src/Compilers/Core/Portable/Syntax/SyntaxNodeExtensions_Tracking.cs#L26-L34) functionality seems to have cleared the entries for nodes requested to be tracked by this FixAll operations. Adding a `ToArray` invocation to the tracked nodes to realize the nodes into an array seems to ensure that this doesn't happen and the test passes consistently after this change.

Ideally, we would have expected the `SyntaxEditor.OriginalRoot` to keep all the nodes in the original tree alive, but that doesn't seem to be the case. Long term, we may want to consider adding a new TrackNodes API that does the tracking using dictionaries instead of CWTs and returns a disposable tracker object, such that the caller explicitly controls the lifetime of the tracking.