### PR TITLE
Support virtual conversion and equality operators

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1704,7 +1704,7 @@ If such a class is used as a base class and if the deriving class defines a dest
     <value>The first operand of an overloaded shift operator must have the same type as the containing type</value>
   </data>
   <data name="ERR_InterfacesCantContainConversionOrEqualityOperators" xml:space="preserve">
-    <value>Conversion, equality, or inequality operators declared in interfaces must be abstract</value>
+    <value>Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual</value>
   </data>
   <data name="ERR_EnumsCantContainDefaultConstructor" xml:space="preserve">
     <value>Enums cannot contain explicit parameterless constructors</value>
@@ -7129,5 +7129,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_ScriptsAndSubmissionsCannotHaveRequiredMembers" xml:space="preserve">
     <value>Required members are not allowed on the top level of a script or submission.</value>
+  </data>
+  <data name="ERR_BadAbstractEqualityOperatorSignature" xml:space="preserve">
+    <value>One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2090,6 +2090,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_RefReturningPropertiesCannotBeRequired = 9043,
         ERR_ImplicitImplementationOfInaccessibleInterfaceMember = 9044,
         ERR_ScriptsAndSubmissionsCannotHaveRequiredMembers = 9045,
+        ERR_BadAbstractEqualityOperatorSignature = 9046,
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedConversionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedConversionSymbol.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_OvlUnaryOperatorExpected, syntax.ParameterList.GetLocation());
             }
 
-            if (IsStatic && IsAbstract)
+            if (IsStatic && (IsAbstract || IsVirtual))
             {
                 CheckFeatureAvailabilityAndRuntimeSupport(syntax, location, hasBody: syntax.Body != null || syntax.ExpressionBody != null, diagnostics: diagnostics);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbol.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             CheckForBlockAndExpressionBody(
                 syntax.Body, syntax.ExpressionBody, syntax, diagnostics);
 
-            if (IsAbstract || (name != WellKnownMemberNames.EqualityOperatorName && name != WellKnownMemberNames.InequalityOperatorName))
+            if (IsAbstract || IsVirtual || (name != WellKnownMemberNames.EqualityOperatorName && name != WellKnownMemberNames.InequalityOperatorName))
             {
                 CheckFeatureAvailabilityAndRuntimeSupport(syntax, location, hasBody: syntax.Body != null || syntax.ExpressionBody != null, diagnostics: diagnostics);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             this.MakeFlags(methodKind, declarationModifiers, returnsVoid: false, isExtensionMethod: false, isNullableAnalysisEnabled: isNullableAnalysisEnabled);
 
             if (this.ContainingType.IsInterface &&
-                !IsAbstract &&
+                !(IsAbstract || IsVirtual) && !IsExplicitInterfaceImplementation &&
                 !(syntax is OperatorDeclarationSyntax { OperatorToken: var opToken } && opToken.Kind() is not (SyntaxKind.EqualsEqualsToken or SyntaxKind.ExclamationEqualsToken)))
             {
                 diagnostics.Add(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, this.Locations[0]);
@@ -134,11 +134,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (inInterface)
                 {
-                    allowedModifiers |= DeclarationModifiers.Abstract;
+                    allowedModifiers |= DeclarationModifiers.Abstract | DeclarationModifiers.Virtual;
 
                     if (syntax is OperatorDeclarationSyntax { OperatorToken: var opToken } && opToken.Kind() is not (SyntaxKind.EqualsEqualsToken or SyntaxKind.ExclamationEqualsToken))
                     {
-                        allowedModifiers |= DeclarationModifiers.Sealed | DeclarationModifiers.Virtual;
+                        allowedModifiers |= DeclarationModifiers.Sealed;
                     }
                 }
             }
@@ -386,6 +386,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     CheckShiftSignature(diagnostics);
                     break;
 
+                case WellKnownMemberNames.EqualityOperatorName:
+                case WellKnownMemberNames.InequalityOperatorName:
+                    if (IsAbstract || IsVirtual)
+                    {
+                        CheckAbstractEqualitySignature(diagnostics);
+                    }
+                    else
+                    {
+                        CheckBinarySignature(diagnostics);
+                    }
+
+                    break;
+
                 default:
                     CheckBinarySignature(diagnostics);
                     break;
@@ -418,11 +431,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private void CheckUserDefinedConversionSignature(BindingDiagnosticBag diagnostics)
         {
-            if (this.ReturnsVoid)
-            {
-                // CS0590: User-defined operators cannot return void
-                diagnostics.Add(ErrorCode.ERR_OperatorCantReturnVoid, this.Locations[0]);
-            }
+            CheckReturnIsNotVoid(diagnostics);
 
             // SPEC: For a given source type S and target type T, if S or T are
             // SPEC: nullable types let S0 and T0 refer to their underlying types,
@@ -455,7 +464,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 !MatchesContainingType(target))
             {
                 // CS0556: User-defined conversion must convert to or from the enclosing type
-                diagnostics.Add(IsAbstract ? ErrorCode.ERR_AbstractConversionNotInvolvingContainedType : ErrorCode.ERR_ConversionNotInvolvingContainedType, this.Locations[0]);
+                diagnostics.Add(IsAbstract || IsVirtual ? ErrorCode.ERR_AbstractConversionNotInvolvingContainedType : ErrorCode.ERR_ConversionNotInvolvingContainedType, this.Locations[0]);
                 return;
             }
 
@@ -574,6 +583,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        private void CheckReturnIsNotVoid(BindingDiagnosticBag diagnostics)
+        {
+            if (this.ReturnsVoid)
+            {
+                // CS0590: User-defined operators cannot return void
+                diagnostics.Add(ErrorCode.ERR_OperatorCantReturnVoid, this.Locations[0]);
+            }
+        }
+
         private void CheckUnarySignature(BindingDiagnosticBag diagnostics)
         {
             // SPEC: A unary + - ! ~ operator must take a single parameter of type
@@ -585,12 +603,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add((IsAbstract || IsVirtual) ? ErrorCode.ERR_BadAbstractUnaryOperatorSignature : ErrorCode.ERR_BadUnaryOperatorSignature, this.Locations[0]);
             }
 
-            if (this.ReturnsVoid)
-            {
-                // The Roslyn parser does not detect this error.
-                // CS0590: User-defined operators cannot return void
-                diagnostics.Add(ErrorCode.ERR_OperatorCantReturnVoid, this.Locations[0]);
-            }
+            CheckReturnIsNotVoid(diagnostics);
         }
 
         private void CheckTrueFalseSignature(BindingDiagnosticBag diagnostics)
@@ -714,12 +727,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Binder.CheckFeatureAvailability(location.SourceTree, MessageID.IDS_FeatureRelaxedShiftOperator, diagnostics, location);
             }
 
-            if (this.ReturnsVoid)
-            {
-                // The Roslyn parser does not detect this error.
-                // CS0590: User-defined operators cannot return void
-                diagnostics.Add(ErrorCode.ERR_OperatorCantReturnVoid, this.Locations[0]);
-            }
+            CheckReturnIsNotVoid(diagnostics);
         }
 
         private void CheckBinarySignature(BindingDiagnosticBag diagnostics)
@@ -733,12 +741,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add((IsAbstract || IsVirtual) ? ErrorCode.ERR_BadAbstractBinaryOperatorSignature : ErrorCode.ERR_BadBinaryOperatorSignature, this.Locations[0]);
             }
 
-            if (this.ReturnsVoid)
+            CheckReturnIsNotVoid(diagnostics);
+        }
+
+        private void CheckAbstractEqualitySignature(BindingDiagnosticBag diagnostics)
+        {
+            if (!IsSelfConstrainedTypeParameter(this.GetParameterType(0).StrippedType()) &&
+                !IsSelfConstrainedTypeParameter(this.GetParameterType(1).StrippedType()))
             {
-                // The parser does not detect this error.
-                // CS0590: User-defined operators cannot return void
-                diagnostics.Add(ErrorCode.ERR_OperatorCantReturnVoid, this.Locations[0]);
+                diagnostics.Add(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, this.Locations[0]);
             }
+
+            CheckReturnIsNotVoid(diagnostics);
         }
 
         public sealed override string Name

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Jeden z parametrů binárního operátoru musí být nadřazeného typu nebo jeho parametrem obecného typu, který se na něj omezuje.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadAbstractEqualityOperatorSignature">
+        <source>One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</source>
+        <target state="new">One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadAbstractIncDecRetType">
         <source>The return type for ++ or -- operator must either match the parameter type, or be derived from the parameter type, or be the containing type's type parameter constrained to it unless the parameter type is a different type parameter.</source>
         <target state="translated">Návratový typ pro operátor ++ nebo -- musí odpovídat typu parametru nebo od něj musí být odvozený, nebo musí být obecným parametrem nadřazeného typu, který se na něj omezuje, pokud se nejedná o jiný parametr obecného typu.</target>
@@ -11673,8 +11678,8 @@ Pokud chcete odstranit toto varování, můžete místo toho použít /reference
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfacesCantContainConversionOrEqualityOperators">
-        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract</source>
-        <target state="translated">Operátory převodu, rovnosti nebo nerovnosti deklarované v rozhraních musí být abstraktní.</target>
+        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual</source>
+        <target state="needs-review-translation">Operátory převodu, rovnosti nebo nerovnosti deklarované v rozhraních musí být abstraktní.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Einer der Parameter eines binären Operators muss der enthaltende Typ sein oder sein zugehöriger Typparameter, der darauf beschränkt ist.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadAbstractEqualityOperatorSignature">
+        <source>One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</source>
+        <target state="new">One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadAbstractIncDecRetType">
         <source>The return type for ++ or -- operator must either match the parameter type, or be derived from the parameter type, or be the containing type's type parameter constrained to it unless the parameter type is a different type parameter.</source>
         <target state="translated">Der Rückgabetyp für den „++“- oder „--“-Operator muss entweder mit dem Parametertyp übereinstimmen, vom Parametertyp abgeleitet werden oder der Typparameter des enthaltenden Typs sein, der beschränkt ist, sofern der Parametertyp kein anderer Typparameter ist.</target>
@@ -11673,8 +11678,8 @@ Um die Warnung zu beheben, können Sie stattdessen /reference verwenden (Einbett
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfacesCantContainConversionOrEqualityOperators">
-        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract</source>
-        <target state="translated">Konvertierungs-, Gleichheits- oder Ungleichheitsoperatoren, die in Schnittstellen deklariert sind, müssen abstrakt sein.</target>
+        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual</source>
+        <target state="needs-review-translation">Konvertierungs-, Gleichheits- oder Ungleichheitsoperatoren, die in Schnittstellen deklariert sind, müssen abstrakt sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Uno de los parámetros de un operador binario debe ser el tipo contenedor o su parámetro de tipo restringido a él.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadAbstractEqualityOperatorSignature">
+        <source>One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</source>
+        <target state="new">One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadAbstractIncDecRetType">
         <source>The return type for ++ or -- operator must either match the parameter type, or be derived from the parameter type, or be the containing type's type parameter constrained to it unless the parameter type is a different type parameter.</source>
         <target state="translated">El tipo de valor devuelto para el operador ++ o -- debe coincidir con el tipo de parámetro, o bien debe derivarse del tipo de parámetro, o ser el parámetro de tipo del tipo contenedor restringido a él, a menos que el tipo de parámetro sea un parámetro de tipo diferente.</target>
@@ -11673,8 +11678,8 @@ Para eliminar la advertencia puede usar /reference (establezca la propiedad Embe
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfacesCantContainConversionOrEqualityOperators">
-        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract</source>
-        <target state="translated">Los operadores de conversión, igualdad o desigualdad declarados en interfaces deben ser abstractos</target>
+        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual</source>
+        <target state="needs-review-translation">Los operadores de conversión, igualdad o desigualdad declarados en interfaces deben ser abstractos</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -122,6 +122,11 @@
         <target state="translated">L’un des paramètres d’un opérateur binaire doit être le type conteneur ou son paramètre de type lui être contraint.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadAbstractEqualityOperatorSignature">
+        <source>One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</source>
+        <target state="new">One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadAbstractIncDecRetType">
         <source>The return type for ++ or -- operator must either match the parameter type, or be derived from the parameter type, or be the containing type's type parameter constrained to it unless the parameter type is a different type parameter.</source>
         <target state="translated">Le type de retour pour l’opérateur + + ou--doit correspondre au type de paramètre ou être dérivé du type de paramètre ou être le paramètre de type du type conteneur qui lui est contraint, sauf si le paramètre est de type différent.</target>
@@ -11673,8 +11678,8 @@ Pour supprimer l'avertissement, vous pouvez utiliser la commande /reference (dé
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfacesCantContainConversionOrEqualityOperators">
-        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract</source>
-        <target state="translated">Les opérateurs de conversion, d’égalité ou d’inégalité déclarés dans les interfaces doivent être abstract</target>
+        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual</source>
+        <target state="needs-review-translation">Les opérateurs de conversion, d’égalité ou d’inégalité déclarés dans les interfaces doivent être abstract</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Uno dei parametri di un operatore binario deve essere il tipo che lo contiene o il relativo parametro di tipo vincolato ad esso.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadAbstractEqualityOperatorSignature">
+        <source>One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</source>
+        <target state="new">One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadAbstractIncDecRetType">
         <source>The return type for ++ or -- operator must either match the parameter type, or be derived from the parameter type, or be the containing type's type parameter constrained to it unless the parameter type is a different type parameter.</source>
         <target state="translated">Il tipo restituito per l'operatore ++ o -- deve corrispondere al tipo di parametro, essere derivato dal tipo di parametro oppure essere il parametro di tipo del tipo che lo contiene, a meno che il tipo di parametro non sia un parametro di tipo diverso.</target>
@@ -11673,8 +11678,8 @@ Per rimuovere l'avviso, è invece possibile usare /reference (impostare la propr
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfacesCantContainConversionOrEqualityOperators">
-        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract</source>
-        <target state="translated">Gli operatori di conversione, uguaglianza o disuguaglianza dichiarati nelle interfacce devono essere astratti</target>
+        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual</source>
+        <target state="needs-review-translation">Gli operatori di conversione, uguaglianza o disuguaglianza dichiarati nelle interfacce devono essere astratti</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -122,6 +122,11 @@
         <target state="translated">バイナリ演算子のパラメーターの 1 つは、それを含む型であるか、それに制約された型パラメーターである必要があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadAbstractEqualityOperatorSignature">
+        <source>One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</source>
+        <target state="new">One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadAbstractIncDecRetType">
         <source>The return type for ++ or -- operator must either match the parameter type, or be derived from the parameter type, or be the containing type's type parameter constrained to it unless the parameter type is a different type parameter.</source>
         <target state="translated">++ または -- 演算子の戻り値の型は、パラメーター型と一致するか、パラメーター型から派生しているか、またはパラメーター型が異なる型パラメーターでない限りそれに制約された含んでいる型の型パラメーターである必要があります。</target>
@@ -11673,8 +11678,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfacesCantContainConversionOrEqualityOperators">
-        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract</source>
-        <target state="translated">インターフェイスで宣言された変換演算子、等値演算子、または非等値演算子は抽象的である必要があります</target>
+        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual</source>
+        <target state="needs-review-translation">インターフェイスで宣言された変換演算子、等値演算子、または非等値演算子は抽象的である必要があります</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -122,6 +122,11 @@
         <target state="translated">이진 연산자의 매개 변수 중 하나는 포함하는 유형이거나 이에 제한되는 유형 매개 변수여야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadAbstractEqualityOperatorSignature">
+        <source>One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</source>
+        <target state="new">One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadAbstractIncDecRetType">
         <source>The return type for ++ or -- operator must either match the parameter type, or be derived from the parameter type, or be the containing type's type parameter constrained to it unless the parameter type is a different type parameter.</source>
         <target state="translated">++ 또는 -- 연산자에 대한 반환 유형은 매개 변수 유형과 일치하거나 매개 변수 유형에서 파생되거나 매개 변수 유형이 다른 유형 매개 변수가 아닌 경우 포함하는 유형의 유형 매개 변수로 제한됩니다.</target>
@@ -11672,8 +11677,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfacesCantContainConversionOrEqualityOperators">
-        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract</source>
-        <target state="translated">인터페이스에 선언된 변환, 같음 또는 부등식 연산자는 추상이어야 합니다.</target>
+        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual</source>
+        <target state="needs-review-translation">인터페이스에 선언된 변환, 같음 또는 부등식 연산자는 추상이어야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Jeden z parametrów operatora binarnego musi być typem otaczającym lub jest parametrem typu ograniczonym do niego.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadAbstractEqualityOperatorSignature">
+        <source>One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</source>
+        <target state="new">One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadAbstractIncDecRetType">
         <source>The return type for ++ or -- operator must either match the parameter type, or be derived from the parameter type, or be the containing type's type parameter constrained to it unless the parameter type is a different type parameter.</source>
         <target state="translated">Zwracany typ dla operatora ++ lub -- musi być zgodny z typem parametru lub być pochodną od typu parametru, bądź musi być parametrem typu typu zawierającego ograniczonego do niego, chyba że typ parametru jest innym parametrem typu.</target>
@@ -11673,8 +11678,8 @@ Aby usunąć ostrzeżenie, możesz zamiast tego użyć opcji /reference (ustaw w
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfacesCantContainConversionOrEqualityOperators">
-        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract</source>
-        <target state="translated">Operatory konwersji, równości lub nierówności zadeklarowane w interfejsach muszą być abstrakcyjne</target>
+        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual</source>
+        <target state="needs-review-translation">Operatory konwersji, równości lub nierówności zadeklarowane w interfejsach muszą być abstrakcyjne</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Um dos parâmetros de um operador binário deve ser o tipo recipiente ou seu parâmetro de tipo restrito a ele.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadAbstractEqualityOperatorSignature">
+        <source>One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</source>
+        <target state="new">One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadAbstractIncDecRetType">
         <source>The return type for ++ or -- operator must either match the parameter type, or be derived from the parameter type, or be the containing type's type parameter constrained to it unless the parameter type is a different type parameter.</source>
         <target state="translated">O tipo de retorno para o operador ++ ou -- deve corresponder ao tipo de parâmetro, ser derivado do tipo de parâmetro ou ser o parâmetro de tipo do tipo recipiente restrito a ele a menos que o tipo de parâmetro seja um parâmetro de tipo diferente.</target>
@@ -11673,8 +11678,8 @@ Para incorporar informações de tipo de interoperabilidade para os dois assembl
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfacesCantContainConversionOrEqualityOperators">
-        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract</source>
-        <target state="translated">Operadores de conversão, igualdade ou desigualdade declarados em interfaces devem ser abstratos</target>
+        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual</source>
+        <target state="needs-review-translation">Operadores de conversão, igualdade ou desigualdade declarados em interfaces devem ser abstratos</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Один из параметров бинарного оператора должен быть содержащего типа, или его параметр типа должен ограничиваться содержащим типом.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadAbstractEqualityOperatorSignature">
+        <source>One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</source>
+        <target state="new">One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadAbstractIncDecRetType">
         <source>The return type for ++ or -- operator must either match the parameter type, or be derived from the parameter type, or be the containing type's type parameter constrained to it unless the parameter type is a different type parameter.</source>
         <target state="translated">Возвращаемый тип для оператора + + или-- должен либо совпадать с типом параметра, либо быть производным от типа параметра, либо быть содержащим типом для типа параметра, ограниченного им, кроме случаев, когда параметр типа является параметром другого типа.</target>
@@ -11673,8 +11678,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfacesCantContainConversionOrEqualityOperators">
-        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract</source>
-        <target state="translated">Операторы преобразования, равенства или неравенства, объявленные в интерфейсах, должны быть абстрактными</target>
+        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual</source>
+        <target state="needs-review-translation">Операторы преобразования, равенства или неравенства, объявленные в интерфейсах, должны быть абстрактными</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -122,6 +122,11 @@
         <target state="translated">İkili işlecin parametrelerinden biri, içeren tür veya tür parametresi ile kısıtlanmış olmalıdır.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadAbstractEqualityOperatorSignature">
+        <source>One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</source>
+        <target state="new">One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadAbstractIncDecRetType">
         <source>The return type for ++ or -- operator must either match the parameter type, or be derived from the parameter type, or be the containing type's type parameter constrained to it unless the parameter type is a different type parameter.</source>
         <target state="translated">++ veya -- işlecinin dönüş türü parametre türüyle eşleşmeli veya parametre türünden türetilemez ya da parametre türü farklı bir tür parametresi olmadığı sürece, içeren türün tür parametresiyle kısıtlanmış olmalıdır.</target>
@@ -11673,8 +11678,8 @@ Uyarıyı kaldırmak için, /reference kullanabilirsiniz (Birlikte Çalışma T�
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfacesCantContainConversionOrEqualityOperators">
-        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract</source>
-        <target state="translated">Arabirimlerde bildirilen dönüştürme, eşitlik veya eşitsizlik işleçleri soyut olmalıdır</target>
+        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual</source>
+        <target state="needs-review-translation">Arabirimlerde bildirilen dönüştürme, eşitlik veya eşitsizlik işleçleri soyut olmalıdır</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -122,6 +122,11 @@
         <target state="translated">二元运算符的参数之一必须是包含类型或被其约束的类型参数。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadAbstractEqualityOperatorSignature">
+        <source>One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</source>
+        <target state="new">One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadAbstractIncDecRetType">
         <source>The return type for ++ or -- operator must either match the parameter type, or be derived from the parameter type, or be the containing type's type parameter constrained to it unless the parameter type is a different type parameter.</source>
         <target state="translated">++ 或 -- 运算符的返回类型必须与参数类型匹配，或者必须从参数类型派生，或者必须是包含类型的被其约束的类型参数，除非该参数类型是不同的类型参数。</target>
@@ -11678,8 +11683,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfacesCantContainConversionOrEqualityOperators">
-        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract</source>
-        <target state="translated">在接口中声明的转换、等式或不等式运算符必须是抽象的</target>
+        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual</source>
+        <target state="needs-review-translation">在接口中声明的转换、等式或不等式运算符必须是抽象的</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -122,6 +122,11 @@
         <target state="translated">二元運算子的其中一個參數必須是包含類型，或其型別參數受其限制。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_BadAbstractEqualityOperatorSignature">
+        <source>One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</source>
+        <target state="new">One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_BadAbstractIncDecRetType">
         <source>The return type for ++ or -- operator must either match the parameter type, or be derived from the parameter type, or be the containing type's type parameter constrained to it unless the parameter type is a different type parameter.</source>
         <target state="translated">++ 或 -- 運算子的傳回型別必須符合參數類型，或是衍生自參數類型，或為包含類型的型別參數受其限制，除非參數類型是不同的型別參數。</target>
@@ -11673,8 +11678,8 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
         <note />
       </trans-unit>
       <trans-unit id="ERR_InterfacesCantContainConversionOrEqualityOperators">
-        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract</source>
-        <target state="translated">在介面中宣告的轉換、等式或不等式運算子必須為抽象</target>
+        <source>Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual</source>
+        <target state="needs-review-translation">在介面中宣告的轉換、等式或不等式運算子必須為抽象</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_RuntimeDoesNotSupportDefaultInterfaceImplementation">

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -46720,10 +46720,10 @@ class Test2 : I1
             var compilation1 = CreateCompilation(source1 + source2, options: TestOptions.DebugExe, targetFramework: TargetFramework.NetCoreApp,
                                                  parseOptions: TestOptions.Regular9);
             compilation1.VerifyDiagnostics(
-                // (4,31): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (4,31): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     public static I1 operator ==(I1 x, I1 y)
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "==").WithLocation(4, 31),
-                // (10,31): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (10,31): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     public static I1 operator !=(I1 x, I1 y)
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "!=").WithLocation(10, 31),
                 // (24,13): error CS8652: The feature 'static abstract members in interfaces' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
@@ -46736,10 +46736,10 @@ class Test2 : I1
 
             CreateCompilation(source1 + source2, options: TestOptions.DebugExe, targetFramework: TargetFramework.NetCoreApp,
                               parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
-                // (4,31): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (4,31): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     public static I1 operator ==(I1 x, I1 y)
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "==").WithLocation(4, 31),
-                // (10,31): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (10,31): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     public static I1 operator !=(I1 x, I1 y)
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "!=").WithLocation(10, 31)
                 );
@@ -46884,13 +46884,13 @@ public interface I1
                 // (4,37): error CS0552: 'I1.implicit operator int(I1)': user-defined conversions to or from an interface are not allowed
                 //     public static implicit operator int(I1 x)
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "int").WithArguments("I1.implicit operator int(I1)").WithLocation(4, 37),
-                // (4,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (4,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     public static implicit operator int(I1 x)
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(4, 37),
                 // (8,37): error CS0552: 'I1.explicit operator byte(I1)': user-defined conversions to or from an interface are not allowed
                 //     public static explicit operator byte(I1 x)
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "byte").WithArguments("I1.explicit operator byte(I1)").WithLocation(8, 37),
-                // (8,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (8,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     public static explicit operator byte(I1 x)
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "byte").WithLocation(8, 37),
                 // (15,17): error CS0029: Cannot implicitly convert type 'I1' to 'int'
@@ -49313,13 +49313,13 @@ public interface I1
                 // (4,30): error CS0552: 'I1.implicit operator int(I1)': user-defined conversions to or from an interface are not allowed
                 //     static implicit operator int(I1 x)
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "int").WithArguments("I1.implicit operator int(I1)").WithLocation(4, 30),
-                // (4,30): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (4,30): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     static implicit operator int(I1 x)
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(4, 30),
                 // (9,30): error CS0552: 'I1.explicit operator byte(I1)': user-defined conversions to or from an interface are not allowed
                 //     static explicit operator byte(I1 x)
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "byte").WithArguments("I1.explicit operator byte(I1)").WithLocation(9, 30),
-                // (9,30): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (9,30): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     static explicit operator byte(I1 x)
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "byte").WithLocation(9, 30)
                 );
@@ -67883,9 +67883,14 @@ C1.get_P2
             return StaticAbstractMembersInInterfacesTests.GetUnaryOperatorName(op, isChecked, out checkedKeyword);
         }
 
+        private static string GetConversionOperatorName(string op, bool isChecked, out string checkedKeyword)
+        {
+            return StaticAbstractMembersInInterfacesTests.GetConversionOperatorName(op, isChecked, out checkedKeyword);
+        }
+
         [Theory]
         [CombinatorialData]
-        public void OperatorImplementation_Binary_011([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=")] string op, bool isChecked)
+        public void OperatorImplementation_Binary_011([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=", "==", "!=")] string op, bool isChecked)
         {
             string opName = GetBinaryOperatorName(op, isChecked, out string checkedKeyword);
 
@@ -67898,7 +67903,7 @@ C1.get_P2
 @"
 public partial interface I1<T> where T : I1<T>
 {
-    virtual static I1<T> operator " + checkedKeyword + op + @"(I1<T> x, int y)
+    virtual static I1<T> operator " + checkedKeyword + op + @"(T x, int y)
     {
         System.Console.WriteLine(""operator"");
         return x;
@@ -67913,12 +67918,12 @@ public partial interface I1<T> where T : I1<T>
 @"
 public partial interface I1<T>
 {
-    static I1<T> operator" + matchingOp + @"(I1<T> x, int y) => x;
+    virtual static I1<T> operator" + matchingOp + @"(T x, int y) => x;
 }
 ";
             }
 
-            ValidateOperatorImplementation_011(source1, "_ = checked(x " + op + " 1);", opName, "{0} {0}." + opName + "({0} x, System.Int32 y)");
+            ValidateOperatorImplementation_011(source1, "_ = checked(x " + op + " 1);", opName, "{0} {0}." + opName + "({1} x, System.Int32 y)");
         }
 
         private void ValidateOperatorImplementation_011(string source, string access, string opName, string expectedImplementationDisplayFormat)
@@ -68056,7 +68061,43 @@ public partial interface I1<T> where T : I1<T>
 
         [Theory]
         [CombinatorialData]
-        public void OperatorImplementationInDerived_Binary([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=")] string op, bool isChecked)
+        public void OperatorImplementation_Conversion_011([CombinatorialValues("implicit", "explicit")] string op, bool isChecked)
+        {
+            string opName = GetConversionOperatorName(op, isChecked, out string checkedKeyword);
+
+            if (opName is null)
+            {
+                return;
+            }
+
+            var source1 =
+@"
+public partial interface I1<T> where T : I1<T>
+{
+    virtual static " + op + @" operator " + checkedKeyword + @"int(T x)
+    {
+        System.Console.WriteLine(""operator"");
+        return 0;
+    }
+}
+";
+            if (isChecked)
+            {
+                source1 +=
+@"
+public partial interface I1<T>
+{
+    virtual static " + op + @" operator int(T x) => 1;
+}
+";
+            }
+
+            ValidateOperatorImplementation_011(source1, "_ = checked((int)x);", opName, "System.Int32 {0}." + opName + "({1} x)");
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void OperatorImplementationInDerived_Binary([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=", "==", "!=")] string op, bool isChecked)
         {
             string opName = GetBinaryOperatorName(op, isChecked, out string checkedKeyword);
 
@@ -68067,7 +68108,7 @@ public partial interface I1<T> where T : I1<T>
 
             string matchingOp = isChecked ? op : MatchingBinaryOperator(op);
 
-            const string signatureTemplate = "{0} {1}operator {2}({0} x, int y)";
+            const string signatureTemplate = "{0} {1}operator {2}{3}({0} x, int y)";
 
             OperatorImplementationInDerived_01(op, opName, checkedKeyword, matchingOp,
                 signatureTemplate: signatureTemplate,
@@ -68125,12 +68166,12 @@ public partial interface I1<T> where T : I1<T>
 @"
 public partial interface I2<T2> where T2 : I2<T2>
 {
-    static abstract " + string.Format(signatureTemplate, "T2", "", checkedKeyword + op) + @";
+    static abstract " + string.Format(signatureTemplate, "T2", "", checkedKeyword, op) + @";
 }
 
 public partial interface I4<T4> where T4 : I4<T4>
 {
-    static abstract " + string.Format(signatureTemplate, "T4", "", checkedKeyword + op) + @";
+    static abstract " + string.Format(signatureTemplate, "T4", "", checkedKeyword, op) + @";
 }
 
 public interface I5<T5> : I4<T5> where T5 : I5<T5>
@@ -68139,12 +68180,12 @@ public interface I5<T5> : I4<T5> where T5 : I5<T5>
 
 public interface I1<T1> : I2<T1>, I5<T1> where T1 : I1<T1>
 {
-    static " + string.Format(signatureTemplate, "T1", "I2<T1>.", checkedKeyword + op) + @"
+    static " + string.Format(signatureTemplate, "T1", "I2<T1>.", checkedKeyword, op) + @"
     {
         System.Console.WriteLine(""I2.M1"");
         return " + string.Format(returnTemplate, "x") + @";
     }
-    static " + string.Format(signatureTemplate, "T1", "I4<T1>.", checkedKeyword + op) + @"
+    static " + string.Format(signatureTemplate, "T1", "I4<T1>.", checkedKeyword, op) + @"
     {
         System.Console.WriteLine(""I4.M1"");
         return " + string.Format(returnTemplate, "x") + @";
@@ -68161,12 +68202,12 @@ public interface I3<T3> : I1<T3> where T3 : I1<T3>
 @"
 public partial interface I2<T2>
 {
-    static virtual " + string.Format(signatureTemplate, "T2", "", matchingOp) + @" => throw null;
+    static virtual " + string.Format(signatureTemplate, "T2", "", "", matchingOp) + @" => throw null;
 }
 
 public partial interface I4<T4>
 {
-    static virtual " + string.Format(signatureTemplate, "T4", "", matchingOp) + @" => throw null;
+    static virtual " + string.Format(signatureTemplate, "T4", "", "", matchingOp) + @" => throw null;
 }
 ";
             }
@@ -68235,20 +68276,40 @@ class Test1 : I1<Test1>
                                                      parseOptions: TestOptions.Regular10,
                                                      targetFramework: TargetFramework.Net60);
 
-                compilation1.VerifyDiagnostics(
-                    // (4,33): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
-                    //     static abstract T2 operator +(T2 x, int y);
-                    Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, op).WithArguments("abstract", "10.0", "preview").WithLocation(4, 33),
-                    // (9,33): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
-                    //     static abstract T4 operator +(T4 x, int y);
-                    Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, op).WithArguments("abstract", "10.0", "preview").WithLocation(9, 33),
-                    // (18,15): error CS8652: The feature 'static abstract members in interfaces' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                    //     static T1 I2<T1>.operator +(T1 x, int y)
-                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "I2<T1>.").WithArguments("static abstract members in interfaces").WithLocation(18, 15),
-                    // (23,15): error CS8652: The feature 'static abstract members in interfaces' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
-                    //     static T1 I4<T1>.operator +(T1 x, int y)
-                    Diagnostic(ErrorCode.ERR_FeatureInPreview, "I4<T1>.").WithArguments("static abstract members in interfaces").WithLocation(23, 15)
-                    );
+                if (op is not ("implicit" or "explicit"))
+                {
+                    compilation1.VerifyDiagnostics(
+                        // (4,33): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
+                        //     static abstract T2 operator +(T2 x, int y);
+                        Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, op).WithArguments("abstract", "10.0", "preview").WithLocation(4, 33),
+                        // (9,33): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
+                        //     static abstract T4 operator +(T4 x, int y);
+                        Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, op).WithArguments("abstract", "10.0", "preview").WithLocation(9, 33),
+                        // (18,15): error CS8652: The feature 'static abstract members in interfaces' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                        //     static T1 I2<T1>.operator +(T1 x, int y)
+                        Diagnostic(ErrorCode.ERR_FeatureInPreview, "I2<T1>.").WithArguments("static abstract members in interfaces").WithLocation(18, 15),
+                        // (23,15): error CS8652: The feature 'static abstract members in interfaces' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                        //     static T1 I4<T1>.operator +(T1 x, int y)
+                        Diagnostic(ErrorCode.ERR_FeatureInPreview, "I4<T1>.").WithArguments("static abstract members in interfaces").WithLocation(23, 15)
+                        );
+                }
+                else
+                {
+                    compilation1.VerifyDiagnostics(
+                        // (4,39): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
+                        //     static abstract implicit operator int(T2 x);
+                        Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments("abstract", "10.0", "preview").WithLocation(4, 39),
+                        // (9,39): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
+                        //     static abstract implicit operator int(T4 x);
+                        Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments("abstract", "10.0", "preview").WithLocation(9, 39),
+                        // (18,21): error CS8652: The feature 'static abstract members in interfaces' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                        //     static implicit I2<T1>.operator int(T1 x)
+                        Diagnostic(ErrorCode.ERR_FeatureInPreview, "I2<T1>.").WithArguments("static abstract members in interfaces").WithLocation(18, 21),
+                        // (23,21): error CS8652: The feature 'static abstract members in interfaces' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+                        //     static implicit I4<T1>.operator int(T1 x)
+                        Diagnostic(ErrorCode.ERR_FeatureInPreview, "I4<T1>.").WithArguments("static abstract members in interfaces").WithLocation(23, 21)
+                        );
+                }
 
                 var source3 = @"
 class Test1 : I1<Test1>
@@ -68284,20 +68345,40 @@ public interface I3<T3> : I1<T3> where T3 : I1<T3>
                 compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll, targetFramework: TargetFramework.Net50,
                                                  parseOptions: TestOptions.RegularPreview, skipUsesIsNullable: true);
 
-                compilation1.VerifyDiagnostics(
-                    // (4,33): error CS8919: Target runtime doesn't support static abstract members in interfaces.
-                    //     static abstract T2 operator +(T2 x, int y);
-                    Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, op).WithLocation(4, 33),
-                    // (9,33): error CS8919: Target runtime doesn't support static abstract members in interfaces.
-                    //     static abstract T4 operator +(T4 x, int y);
-                    Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, op).WithLocation(9, 33),
-                    // (18,31): error CS8919: Target runtime doesn't support static abstract members in interfaces.
-                    //     static T1 I2<T1>.operator +(T1 x, int y)
-                    Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, op).WithLocation(18, 31),
-                    // (23,31): error CS8919: Target runtime doesn't support static abstract members in interfaces.
-                    //     static T1 I4<T1>.operator +(T1 x, int y)
-                    Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, op).WithLocation(23, 31)
-                    );
+                if (op is not ("implicit" or "explicit"))
+                {
+                    compilation1.VerifyDiagnostics(
+                        // (4,33): error CS8919: Target runtime doesn't support static abstract members in interfaces.
+                        //     static abstract T2 operator +(T2 x, int y);
+                        Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, op).WithLocation(4, 33),
+                        // (9,33): error CS8919: Target runtime doesn't support static abstract members in interfaces.
+                        //     static abstract T4 operator +(T4 x, int y);
+                        Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, op).WithLocation(9, 33),
+                        // (18,31): error CS8919: Target runtime doesn't support static abstract members in interfaces.
+                        //     static T1 I2<T1>.operator +(T1 x, int y)
+                        Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, op).WithLocation(18, 31),
+                        // (23,31): error CS8919: Target runtime doesn't support static abstract members in interfaces.
+                        //     static T1 I4<T1>.operator +(T1 x, int y)
+                        Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, op).WithLocation(23, 31)
+                        );
+                }
+                else
+                {
+                    compilation1.VerifyDiagnostics(
+                        // (4,39): error CS8919: Target runtime doesn't support static abstract members in interfaces.
+                        //     static abstract explicit operator int(T2 x);
+                        Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, "int").WithLocation(4, 39),
+                        // (9,39): error CS8919: Target runtime doesn't support static abstract members in interfaces.
+                        //     static abstract explicit operator int(T4 x);
+                        Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, "int").WithLocation(9, 39),
+                        // (18,37): error CS8919: Target runtime doesn't support static abstract members in interfaces.
+                        //     static explicit I2<T1>.operator int(T1 x)
+                        Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, "int").WithLocation(18, 37),
+                        // (23,37): error CS8919: Target runtime doesn't support static abstract members in interfaces.
+                        //     static explicit I4<T1>.operator int(T1 x)
+                        Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, "int").WithLocation(23, 37)
+                        );
+                }
 
                 compilation3 = CreateCompilation(source3, new[] { compilation1.ToMetadataReference() },
                                                  options: TestOptions.DebugDll, targetFramework: TargetFramework.Net50,
@@ -68352,12 +68433,12 @@ public interface I3<T3> : I1<T3> where T3 : I1<T3>
 @"
 public partial interface I1<T1> where T1 : I1<T1>
 {
-    static abstract " + string.Format(signatureTemplate, "T1", "", checkedKeyword + op) + @";
+    static abstract " + string.Format(signatureTemplate, "T1", "", checkedKeyword, op) + @";
 }
 
 public partial interface I2<T2> : I1<T2> where T2 : I2<T2>
 {
-    static " + string.Format(signatureTemplate, "T2", "I1<T2>.", checkedKeyword + op) + @"
+    static " + string.Format(signatureTemplate, "T2", "I1<T2>.", checkedKeyword, op) + @"
     {
         throw null;
     }
@@ -68365,7 +68446,7 @@ public partial interface I2<T2> : I1<T2> where T2 : I2<T2>
 
 public partial interface I3<T3> : I1<T3> where T3 : I3<T3>
 {
-    static " + string.Format(signatureTemplate, "T3", "I1<T3>.", checkedKeyword + op) + @"
+    static " + string.Format(signatureTemplate, "T3", "I1<T3>.", checkedKeyword, op) + @"
     {
         throw null;
     }
@@ -68377,7 +68458,7 @@ public partial interface I3<T3> : I1<T3> where T3 : I3<T3>
 @"
 public partial interface I1<T1>
 {
-    static virtual " + string.Format(signatureTemplate, "T1", "", matchingOp) + @" => throw null;
+    static virtual " + string.Format(signatureTemplate, "T1", "", "", matchingOp) + @" => throw null;
 }
 ";
             }
@@ -68442,12 +68523,12 @@ class Test1 : I2<Test1>, I3<Test1>
 @"
 public partial interface I1<T1> where T1 : I1<T1>
 {
-    static virtual " + string.Format(signatureTemplate, "T1", "", checkedKeyword + op) + @" => throw null;
+    static virtual " + string.Format(signatureTemplate, "T1", "", checkedKeyword, op) + @" => throw null;
 }
 
 public partial interface I2<T2> : I1<T2> where T2 : I2<T2>
 {
-    static abstract " + string.Format(signatureTemplate, "T2", "I1<T2>.", checkedKeyword + op) + @";
+    static abstract " + string.Format(signatureTemplate, "T2", "I1<T2>.", checkedKeyword, op) + @";
 }
 ";
             if (matchingOp is object)
@@ -68456,7 +68537,7 @@ public partial interface I2<T2> : I1<T2> where T2 : I2<T2>
 @"
 public partial interface I1<T1>
 {
-    static virtual " + string.Format(signatureTemplate, "T1", "", matchingOp) + @" => throw null;
+    static virtual " + string.Format(signatureTemplate, "T1", "", "", matchingOp) + @" => throw null;
 }
 ";
             }
@@ -68484,7 +68565,7 @@ class Test1 : I2<Test1>
 
             string matchingOp = isChecked ? op : null;
 
-            const string signatureTemplate = "{0} {1}operator {2}({0} x)";
+            const string signatureTemplate = "{0} {1}operator {2}{3}({0} x)";
 
             OperatorImplementationInDerived_01(op, opName, checkedKeyword, matchingOp,
                 signatureTemplate: signatureTemplate,
@@ -68506,7 +68587,7 @@ class Test1 : I2<Test1>
             string opName = GetUnaryOperatorName(op, isChecked: false, out _);
             string matchingOp = op switch { "true" => "false", "false" => "true", _ => null };
 
-            const string signatureTemplate = "bool {1}operator {2}({0} x)";
+            const string signatureTemplate = "bool {1}operator {2}{3}({0} x)";
 
             OperatorImplementationInDerived_01(op, opName, checkedKeyword: "", matchingOp,
                 signatureTemplate: signatureTemplate,
@@ -68687,6 +68768,34 @@ class Test1 : I2<Test1>
 
                 Assert.Equal(3, count);
             }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void OperatorImplementationInDerived_Conversion([CombinatorialValues("implicit", "explicit")] string op, bool isChecked)
+        {
+            string opName = GetConversionOperatorName(op, isChecked, out string checkedKeyword);
+
+            if (opName is null)
+            {
+                return;
+            }
+
+            string matchingOp = isChecked ? op : null;
+
+            const string signatureTemplate = "{3} {1}operator {2}int({0} x)";
+
+            OperatorImplementationInDerived_01(op, opName, checkedKeyword, matchingOp,
+                signatureTemplate: signatureTemplate,
+                accessTemplate: "(int){0}",
+                extraOpTemplate: null,
+                returnTemplate: "0");
+
+            OperatorImplementationInDerived_13(op, checkedKeyword, matchingOp,
+                signatureTemplate: signatureTemplate);
+
+            OperatorReAbstraction_02(op, opName, checkedKeyword, matchingOp,
+                signatureTemplate: signatureTemplate);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
@@ -4014,7 +4014,7 @@ public interface I3
                                                  parseOptions: TestOptions.Regular7_3,
                                                  targetFramework: _supportingFramework);
 
-            compilation1.VerifyDiagnostics(
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature).Verify(
                 // (4,34): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
                 //     abstract static bool operator== (I1 x, I1 y); 
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "==").WithArguments("abstract", "7.3", "preview").WithLocation(4, 34),
@@ -4027,13 +4027,13 @@ public interface I3
                 // (11,32): error CS0106: The modifier 'sealed' is not valid for this item
                 //     sealed static bool operator== (I2 x, I2 y);
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "==").WithArguments("sealed").WithLocation(11, 32),
-                // (11,32): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (11,32): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     sealed static bool operator== (I2 x, I2 y);
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "==").WithLocation(11, 32),
                 // (13,32): error CS0106: The modifier 'sealed' is not valid for this item
                 //     sealed static bool operator!= (I2 x, I2 y) {return false;} 
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "!=").WithArguments("sealed").WithLocation(13, 32),
-                // (13,32): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (13,32): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     sealed static bool operator!= (I2 x, I2 y) {return false;} 
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "!=").WithLocation(13, 32),
                 // (18,41): error CS0106: The modifier 'sealed' is not valid for this item
@@ -4059,7 +4059,7 @@ public interface I3
                                                  parseOptions: TestOptions.Regular10,
                                                  targetFramework: _supportingFramework);
 
-            compilation1.VerifyDiagnostics(
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature).Verify(
                 // (4,34): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     abstract static bool operator== (I1 x, I1 y); 
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "==").WithArguments("abstract", "10.0", "preview").WithLocation(4, 34),
@@ -4072,13 +4072,13 @@ public interface I3
                 // (11,32): error CS0106: The modifier 'sealed' is not valid for this item
                 //     sealed static bool operator== (I2 x, I2 y);
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "==").WithArguments("sealed").WithLocation(11, 32),
-                // (11,32): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (11,32): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     sealed static bool operator== (I2 x, I2 y);
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "==").WithLocation(11, 32),
                 // (13,32): error CS0106: The modifier 'sealed' is not valid for this item
                 //     sealed static bool operator!= (I2 x, I2 y) {return false;} 
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "!=").WithArguments("sealed").WithLocation(13, 32),
-                // (13,32): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (13,32): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     sealed static bool operator!= (I2 x, I2 y) {return false;} 
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "!=").WithLocation(13, 32),
                 // (18,41): error CS0106: The modifier 'sealed' is not valid for this item
@@ -4104,20 +4104,20 @@ public interface I3
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: _supportingFramework);
 
-            compilation1.VerifyDiagnostics(
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature).Verify(
                 // (6,34): error CS0500: 'I1.operator !=(I1, I1)' cannot declare a body because it is marked abstract
                 //     abstract static bool operator!= (I1 x, I1 y) {return false;} 
                 Diagnostic(ErrorCode.ERR_AbstractHasBody, "!=").WithArguments("I1.operator !=(I1, I1)").WithLocation(6, 34),
                 // (11,32): error CS0106: The modifier 'sealed' is not valid for this item
                 //     sealed static bool operator== (I2 x, I2 y);
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "==").WithArguments("sealed").WithLocation(11, 32),
-                // (11,32): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (11,32): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     sealed static bool operator== (I2 x, I2 y);
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "==").WithLocation(11, 32),
                 // (13,32): error CS0106: The modifier 'sealed' is not valid for this item
                 //     sealed static bool operator!= (I2 x, I2 y) {return false;} 
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "!=").WithArguments("sealed").WithLocation(13, 32),
-                // (13,32): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (13,32): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     sealed static bool operator!= (I2 x, I2 y) {return false;} 
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "!=").WithLocation(13, 32),
                 // (18,41): error CS0106: The modifier 'sealed' is not valid for this item
@@ -4228,7 +4228,7 @@ public interface I3
                 // (11,37): error CS0552: 'I2.implicit operator int(I2)': user-defined conversions to or from an interface are not allowed
                 //     sealed static implicit operator int(I2 x);
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "int").WithArguments("I2.implicit operator int(I2)").WithLocation(11, 37),
-                // (11,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (11,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     sealed static implicit operator int(I2 x);
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(11, 37),
                 // (13,37): error CS0106: The modifier 'sealed' is not valid for this item
@@ -4237,7 +4237,7 @@ public interface I3
                 // (13,37): error CS0552: 'I2.explicit operator I2(bool)': user-defined conversions to or from an interface are not allowed
                 //     sealed static explicit operator I2(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "I2").WithArguments("I2.explicit operator I2(bool)").WithLocation(13, 37),
-                // (13,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (13,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     sealed static explicit operator I2(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "I2").WithLocation(13, 37),
                 // (18,46): error CS0106: The modifier 'sealed' is not valid for this item
@@ -4291,7 +4291,7 @@ public interface I3
                 // (11,37): error CS0552: 'I2.implicit operator int(I2)': user-defined conversions to or from an interface are not allowed
                 //     sealed static implicit operator int(I2 x);
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "int").WithArguments("I2.implicit operator int(I2)").WithLocation(11, 37),
-                // (11,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (11,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     sealed static implicit operator int(I2 x);
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(11, 37),
                 // (13,37): error CS0106: The modifier 'sealed' is not valid for this item
@@ -4300,7 +4300,7 @@ public interface I3
                 // (13,37): error CS0552: 'I2.explicit operator I2(bool)': user-defined conversions to or from an interface are not allowed
                 //     sealed static explicit operator I2(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "I2").WithArguments("I2.explicit operator I2(bool)").WithLocation(13, 37),
-                // (13,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (13,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     sealed static explicit operator I2(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "I2").WithLocation(13, 37),
                 // (18,46): error CS0106: The modifier 'sealed' is not valid for this item
@@ -4348,7 +4348,7 @@ public interface I3
                 // (11,37): error CS0552: 'I2.implicit operator int(I2)': user-defined conversions to or from an interface are not allowed
                 //     sealed static implicit operator int(I2 x);
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "int").WithArguments("I2.implicit operator int(I2)").WithLocation(11, 37),
-                // (11,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (11,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     sealed static implicit operator int(I2 x);
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(11, 37),
                 // (13,37): error CS0106: The modifier 'sealed' is not valid for this item
@@ -4357,7 +4357,7 @@ public interface I3
                 // (13,37): error CS0552: 'I2.explicit operator I2(bool)': user-defined conversions to or from an interface are not allowed
                 //     sealed static explicit operator I2(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "I2").WithArguments("I2.explicit operator I2(bool)").WithLocation(13, 37),
-                // (13,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (13,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     sealed static explicit operator I2(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "I2").WithLocation(13, 37),
                 // (18,46): error CS0106: The modifier 'sealed' is not valid for this item
@@ -4452,52 +4452,43 @@ public interface I3
                                                  parseOptions: TestOptions.Regular7_3,
                                                  targetFramework: _supportingFramework);
 
-            compilation1.VerifyDiagnostics(
-                // (4,33): error CS0106: The modifier 'virtual' is not valid for this item
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature).Verify(
+                // (4,33): error CS8703: The modifier 'virtual' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
                 //     virtual static bool operator== (I1 x, I1 y); 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "==").WithArguments("virtual").WithLocation(4, 33),
-                // (4,33): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "==").WithArguments("virtual", "7.3", "preview").WithLocation(4, 33),
+                // (4,33): error CS0501: 'I1.operator ==(I1, I1)' must declare a body because it is not marked abstract, extern, or partial
                 //     virtual static bool operator== (I1 x, I1 y); 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "==").WithLocation(4, 33),
-                // (6,33): error CS0106: The modifier 'virtual' is not valid for this item
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "==").WithArguments("I1.operator ==(I1, I1)").WithLocation(4, 33),
+                // (6,33): error CS8703: The modifier 'virtual' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
                 //     virtual static bool operator!= (I1 x, I1 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "!=").WithArguments("virtual").WithLocation(6, 33),
-                // (6,33): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual static bool operator!= (I1 x, I1 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "!=").WithLocation(6, 33),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "!=").WithArguments("virtual", "7.3", "preview").WithLocation(6, 33),
                 // (11,40): error CS0106: The modifier 'sealed' is not valid for this item
                 //     virtual sealed static bool operator== (I2 x, I2 y);
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "==").WithArguments("sealed").WithLocation(11, 40),
-                // (11,40): error CS0106: The modifier 'virtual' is not valid for this item
+                // (11,40): error CS8703: The modifier 'virtual' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
                 //     virtual sealed static bool operator== (I2 x, I2 y);
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "==").WithArguments("virtual").WithLocation(11, 40),
-                // (11,40): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "==").WithArguments("virtual", "7.3", "preview").WithLocation(11, 40),
+                // (11,40): error CS0501: 'I2.operator ==(I2, I2)' must declare a body because it is not marked abstract, extern, or partial
                 //     virtual sealed static bool operator== (I2 x, I2 y);
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "==").WithLocation(11, 40),
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "==").WithArguments("I2.operator ==(I2, I2)").WithLocation(11, 40),
                 // (13,40): error CS0106: The modifier 'sealed' is not valid for this item
                 //     virtual sealed static bool operator!= (I2 x, I2 y) {return false;} 
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "!=").WithArguments("sealed").WithLocation(13, 40),
-                // (13,40): error CS0106: The modifier 'virtual' is not valid for this item
+                // (13,40): error CS8703: The modifier 'virtual' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
                 //     virtual sealed static bool operator!= (I2 x, I2 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "!=").WithArguments("virtual").WithLocation(13, 40),
-                // (13,40): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual sealed static bool operator!= (I2 x, I2 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "!=").WithLocation(13, 40),
-                // (18,42): error CS0106: The modifier 'virtual' is not valid for this item
-                //     abstract virtual static bool operator== (I3 x, I3 y);
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "==").WithArguments("virtual").WithLocation(18, 42),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "!=").WithArguments("virtual", "7.3", "preview").WithLocation(13, 40),
                 // (18,42): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
                 //     abstract virtual static bool operator== (I3 x, I3 y);
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "==").WithArguments("abstract", "7.3", "preview").WithLocation(18, 42),
-                // (20,42): error CS0106: The modifier 'virtual' is not valid for this item
-                //     abstract virtual static bool operator!= (I3 x, I3 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "!=").WithArguments("virtual").WithLocation(20, 42),
+                // (18,42): error CS0503: The abstract method 'I3.operator ==(I3, I3)' cannot be marked virtual
+                //     abstract virtual static bool operator== (I3 x, I3 y);
+                Diagnostic(ErrorCode.ERR_AbstractNotVirtual, "==").WithArguments("method", "I3.operator ==(I3, I3)").WithLocation(18, 42),
                 // (20,42): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
                 //     abstract virtual static bool operator!= (I3 x, I3 y) {return false;} 
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "!=").WithArguments("abstract", "7.3", "preview").WithLocation(20, 42),
-                // (20,42): error CS0500: 'I3.operator !=(I3, I3)' cannot declare a body because it is marked abstract
+                // (20,42): error CS0503: The abstract method 'I3.operator !=(I3, I3)' cannot be marked virtual
                 //     abstract virtual static bool operator!= (I3 x, I3 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_AbstractHasBody, "!=").WithArguments("I3.operator !=(I3, I3)").WithLocation(20, 42)
+                Diagnostic(ErrorCode.ERR_AbstractNotVirtual, "!=").WithArguments("method", "I3.operator !=(I3, I3)").WithLocation(20, 42)
                 );
 
             validate();
@@ -4506,52 +4497,43 @@ public interface I3
                                              parseOptions: TestOptions.Regular10,
                                              targetFramework: _supportingFramework);
 
-            compilation1.VerifyDiagnostics(
-                // (4,33): error CS0106: The modifier 'virtual' is not valid for this item
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature).Verify(
+                // (4,33): error CS8703: The modifier 'virtual' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     virtual static bool operator== (I1 x, I1 y); 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "==").WithArguments("virtual").WithLocation(4, 33),
-                // (4,33): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "==").WithArguments("virtual", "10.0", "preview").WithLocation(4, 33),
+                // (4,33): error CS0501: 'I1.operator ==(I1, I1)' must declare a body because it is not marked abstract, extern, or partial
                 //     virtual static bool operator== (I1 x, I1 y); 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "==").WithLocation(4, 33),
-                // (6,33): error CS0106: The modifier 'virtual' is not valid for this item
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "==").WithArguments("I1.operator ==(I1, I1)").WithLocation(4, 33),
+                // (6,33): error CS8703: The modifier 'virtual' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     virtual static bool operator!= (I1 x, I1 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "!=").WithArguments("virtual").WithLocation(6, 33),
-                // (6,33): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual static bool operator!= (I1 x, I1 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "!=").WithLocation(6, 33),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "!=").WithArguments("virtual", "10.0", "preview").WithLocation(6, 33),
                 // (11,40): error CS0106: The modifier 'sealed' is not valid for this item
                 //     virtual sealed static bool operator== (I2 x, I2 y);
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "==").WithArguments("sealed").WithLocation(11, 40),
-                // (11,40): error CS0106: The modifier 'virtual' is not valid for this item
+                // (11,40): error CS8703: The modifier 'virtual' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     virtual sealed static bool operator== (I2 x, I2 y);
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "==").WithArguments("virtual").WithLocation(11, 40),
-                // (11,40): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "==").WithArguments("virtual", "10.0", "preview").WithLocation(11, 40),
+                // (11,40): error CS0501: 'I2.operator ==(I2, I2)' must declare a body because it is not marked abstract, extern, or partial
                 //     virtual sealed static bool operator== (I2 x, I2 y);
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "==").WithLocation(11, 40),
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "==").WithArguments("I2.operator ==(I2, I2)").WithLocation(11, 40),
                 // (13,40): error CS0106: The modifier 'sealed' is not valid for this item
                 //     virtual sealed static bool operator!= (I2 x, I2 y) {return false;} 
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "!=").WithArguments("sealed").WithLocation(13, 40),
-                // (13,40): error CS0106: The modifier 'virtual' is not valid for this item
+                // (13,40): error CS8703: The modifier 'virtual' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     virtual sealed static bool operator!= (I2 x, I2 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "!=").WithArguments("virtual").WithLocation(13, 40),
-                // (13,40): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual sealed static bool operator!= (I2 x, I2 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "!=").WithLocation(13, 40),
-                // (18,42): error CS0106: The modifier 'virtual' is not valid for this item
-                //     abstract virtual static bool operator== (I3 x, I3 y);
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "==").WithArguments("virtual").WithLocation(18, 42),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "!=").WithArguments("virtual", "10.0", "preview").WithLocation(13, 40),
                 // (18,42): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     abstract virtual static bool operator== (I3 x, I3 y);
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "==").WithArguments("abstract", "10.0", "preview").WithLocation(18, 42),
-                // (20,42): error CS0106: The modifier 'virtual' is not valid for this item
-                //     abstract virtual static bool operator!= (I3 x, I3 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "!=").WithArguments("virtual").WithLocation(20, 42),
+                // (18,42): error CS0503: The abstract method 'I3.operator ==(I3, I3)' cannot be marked virtual
+                //     abstract virtual static bool operator== (I3 x, I3 y);
+                Diagnostic(ErrorCode.ERR_AbstractNotVirtual, "==").WithArguments("method", "I3.operator ==(I3, I3)").WithLocation(18, 42),
                 // (20,42): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     abstract virtual static bool operator!= (I3 x, I3 y) {return false;} 
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "!=").WithArguments("abstract", "10.0", "preview").WithLocation(20, 42),
-                // (20,42): error CS0500: 'I3.operator !=(I3, I3)' cannot declare a body because it is marked abstract
+                // (20,42): error CS0503: The abstract method 'I3.operator !=(I3, I3)' cannot be marked virtual
                 //     abstract virtual static bool operator!= (I3 x, I3 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_AbstractHasBody, "!=").WithArguments("I3.operator !=(I3, I3)").WithLocation(20, 42)
+                Diagnostic(ErrorCode.ERR_AbstractNotVirtual, "!=").WithArguments("method", "I3.operator !=(I3, I3)").WithLocation(20, 42)
                 );
 
             validate();
@@ -4560,46 +4542,25 @@ public interface I3
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: _supportingFramework);
 
-            compilation1.VerifyDiagnostics(
-                // (4,33): error CS0106: The modifier 'virtual' is not valid for this item
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature).Verify(
+                // (4,33): error CS0501: 'I1.operator ==(I1, I1)' must declare a body because it is not marked abstract, extern, or partial
                 //     virtual static bool operator== (I1 x, I1 y); 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "==").WithArguments("virtual").WithLocation(4, 33),
-                // (4,33): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual static bool operator== (I1 x, I1 y); 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "==").WithLocation(4, 33),
-                // (6,33): error CS0106: The modifier 'virtual' is not valid for this item
-                //     virtual static bool operator!= (I1 x, I1 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "!=").WithArguments("virtual").WithLocation(6, 33),
-                // (6,33): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual static bool operator!= (I1 x, I1 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "!=").WithLocation(6, 33),
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "==").WithArguments("I1.operator ==(I1, I1)").WithLocation(4, 33),
                 // (11,40): error CS0106: The modifier 'sealed' is not valid for this item
                 //     virtual sealed static bool operator== (I2 x, I2 y);
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "==").WithArguments("sealed").WithLocation(11, 40),
-                // (11,40): error CS0106: The modifier 'virtual' is not valid for this item
+                // (11,40): error CS0501: 'I2.operator ==(I2, I2)' must declare a body because it is not marked abstract, extern, or partial
                 //     virtual sealed static bool operator== (I2 x, I2 y);
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "==").WithArguments("virtual").WithLocation(11, 40),
-                // (11,40): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual sealed static bool operator== (I2 x, I2 y);
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "==").WithLocation(11, 40),
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "==").WithArguments("I2.operator ==(I2, I2)").WithLocation(11, 40),
                 // (13,40): error CS0106: The modifier 'sealed' is not valid for this item
                 //     virtual sealed static bool operator!= (I2 x, I2 y) {return false;} 
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "!=").WithArguments("sealed").WithLocation(13, 40),
-                // (13,40): error CS0106: The modifier 'virtual' is not valid for this item
-                //     virtual sealed static bool operator!= (I2 x, I2 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "!=").WithArguments("virtual").WithLocation(13, 40),
-                // (13,40): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual sealed static bool operator!= (I2 x, I2 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "!=").WithLocation(13, 40),
-                // (18,42): error CS0106: The modifier 'virtual' is not valid for this item
+                // (18,42): error CS0503: The abstract method 'I3.operator ==(I3, I3)' cannot be marked virtual
                 //     abstract virtual static bool operator== (I3 x, I3 y);
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "==").WithArguments("virtual").WithLocation(18, 42),
-                // (20,42): error CS0106: The modifier 'virtual' is not valid for this item
+                Diagnostic(ErrorCode.ERR_AbstractNotVirtual, "==").WithArguments("method", "I3.operator ==(I3, I3)").WithLocation(18, 42),
+                // (20,42): error CS0503: The abstract method 'I3.operator !=(I3, I3)' cannot be marked virtual
                 //     abstract virtual static bool operator!= (I3 x, I3 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "!=").WithArguments("virtual").WithLocation(20, 42),
-                // (20,42): error CS0500: 'I3.operator !=(I3, I3)' cannot declare a body because it is marked abstract
-                //     abstract virtual static bool operator!= (I3 x, I3 y) {return false;} 
-                Diagnostic(ErrorCode.ERR_AbstractHasBody, "!=").WithArguments("I3.operator !=(I3, I3)").WithLocation(20, 42)
+                Diagnostic(ErrorCode.ERR_AbstractNotVirtual, "!=").WithArguments("method", "I3.operator !=(I3, I3)").WithLocation(20, 42)
                 );
 
             validate();
@@ -4609,33 +4570,33 @@ public interface I3
                 foreach (MethodSymbol m01 in compilation1.GetTypeByMetadataName("I1").GetMembers())
                 {
                     Assert.False(m01.IsAbstract);
-                    Assert.False(m01.IsVirtual);
-                    Assert.False(m01.IsMetadataVirtual());
+                    Assert.True(m01.IsVirtual);
+                    Assert.True(m01.IsMetadataVirtual());
                     Assert.False(m01.IsSealed);
                     Assert.True(m01.IsStatic);
                     Assert.False(m01.IsExtern);
                     Assert.False(m01.IsAsync);
                     Assert.False(m01.IsOverride);
-                    Assert.Null(m01.ContainingType.FindImplementationForInterfaceMember(m01));
+                    Assert.Same(m01, m01.ContainingType.FindImplementationForInterfaceMember(m01));
                 }
 
                 foreach (MethodSymbol m01 in compilation1.GetTypeByMetadataName("I2").GetMembers())
                 {
                     Assert.False(m01.IsAbstract);
-                    Assert.False(m01.IsVirtual);
-                    Assert.False(m01.IsMetadataVirtual());
+                    Assert.True(m01.IsVirtual);
+                    Assert.True(m01.IsMetadataVirtual());
                     Assert.False(m01.IsSealed);
                     Assert.True(m01.IsStatic);
                     Assert.False(m01.IsExtern);
                     Assert.False(m01.IsAsync);
                     Assert.False(m01.IsOverride);
-                    Assert.Null(m01.ContainingType.FindImplementationForInterfaceMember(m01));
+                    Assert.Same(m01, m01.ContainingType.FindImplementationForInterfaceMember(m01));
                 }
 
                 foreach (MethodSymbol m01 in compilation1.GetTypeByMetadataName("I3").GetMembers())
                 {
                     Assert.True(m01.IsAbstract);
-                    Assert.False(m01.IsVirtual);
+                    Assert.True(m01.IsVirtual);
                     Assert.True(m01.IsMetadataVirtual());
                     Assert.False(m01.IsSealed);
                     Assert.True(m01.IsStatic);
@@ -4678,66 +4639,57 @@ public interface I3
                                                  targetFramework: _supportingFramework);
 
             compilation1.VerifyDiagnostics(
-                // (4,38): error CS0106: The modifier 'virtual' is not valid for this item
+                // (4,38): error CS8703: The modifier 'virtual' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
                 //     virtual static implicit operator int(I1 x); 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "int").WithArguments("virtual").WithLocation(4, 38),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments("virtual", "7.3", "preview").WithLocation(4, 38),
+                // (4,38): error CS0501: 'I1.implicit operator int(I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual static implicit operator int(I1 x); 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "int").WithArguments("I1.implicit operator int(I1)").WithLocation(4, 38),
                 // (4,38): error CS0552: 'I1.implicit operator int(I1)': user-defined conversions to or from an interface are not allowed
                 //     virtual static implicit operator int(I1 x); 
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "int").WithArguments("I1.implicit operator int(I1)").WithLocation(4, 38),
-                // (4,38): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual static implicit operator int(I1 x); 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(4, 38),
-                // (6,38): error CS0106: The modifier 'virtual' is not valid for this item
+                // (6,38): error CS8703: The modifier 'virtual' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
                 //     virtual static explicit operator I1(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "I1").WithArguments("virtual").WithLocation(6, 38),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "I1").WithArguments("virtual", "7.3", "preview").WithLocation(6, 38),
                 // (6,38): error CS0552: 'I1.explicit operator I1(bool)': user-defined conversions to or from an interface are not allowed
                 //     virtual static explicit operator I1(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "I1").WithArguments("I1.explicit operator I1(bool)").WithLocation(6, 38),
-                // (6,38): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual static explicit operator I1(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "I1").WithLocation(6, 38),
                 // (11,45): error CS0106: The modifier 'sealed' is not valid for this item
                 //     virtual sealed static implicit operator int(I2 x);
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "int").WithArguments("sealed").WithLocation(11, 45),
-                // (11,45): error CS0106: The modifier 'virtual' is not valid for this item
+                // (11,45): error CS8703: The modifier 'virtual' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
                 //     virtual sealed static implicit operator int(I2 x);
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "int").WithArguments("virtual").WithLocation(11, 45),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments("virtual", "7.3", "preview").WithLocation(11, 45),
+                // (11,45): error CS0501: 'I2.implicit operator int(I2)' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual sealed static implicit operator int(I2 x);
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "int").WithArguments("I2.implicit operator int(I2)").WithLocation(11, 45),
                 // (11,45): error CS0552: 'I2.implicit operator int(I2)': user-defined conversions to or from an interface are not allowed
                 //     virtual sealed static implicit operator int(I2 x);
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "int").WithArguments("I2.implicit operator int(I2)").WithLocation(11, 45),
-                // (11,45): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual sealed static implicit operator int(I2 x);
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(11, 45),
                 // (13,45): error CS0106: The modifier 'sealed' is not valid for this item
                 //     virtual sealed static explicit operator I2(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "I2").WithArguments("sealed").WithLocation(13, 45),
-                // (13,45): error CS0106: The modifier 'virtual' is not valid for this item
+                // (13,45): error CS8703: The modifier 'virtual' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
                 //     virtual sealed static explicit operator I2(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "I2").WithArguments("virtual").WithLocation(13, 45),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "I2").WithArguments("virtual", "7.3", "preview").WithLocation(13, 45),
                 // (13,45): error CS0552: 'I2.explicit operator I2(bool)': user-defined conversions to or from an interface are not allowed
                 //     virtual sealed static explicit operator I2(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "I2").WithArguments("I2.explicit operator I2(bool)").WithLocation(13, 45),
-                // (13,45): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual sealed static explicit operator I2(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "I2").WithLocation(13, 45),
-                // (18,47): error CS0106: The modifier 'virtual' is not valid for this item
-                //     abstract virtual static implicit operator int(I3 x);
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "int").WithArguments("virtual").WithLocation(18, 47),
                 // (18,47): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
                 //     abstract virtual static implicit operator int(I3 x);
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments("abstract", "7.3", "preview").WithLocation(18, 47),
+                // (18,47): error CS0503: The abstract method 'I3.implicit operator int(I3)' cannot be marked virtual
+                //     abstract virtual static implicit operator int(I3 x);
+                Diagnostic(ErrorCode.ERR_AbstractNotVirtual, "int").WithArguments("method", "I3.implicit operator int(I3)").WithLocation(18, 47),
                 // (18,47): error CS0552: 'I3.implicit operator int(I3)': user-defined conversions to or from an interface are not allowed
                 //     abstract virtual static implicit operator int(I3 x);
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "int").WithArguments("I3.implicit operator int(I3)").WithLocation(18, 47),
-                // (20,47): error CS0106: The modifier 'virtual' is not valid for this item
-                //     abstract virtual static explicit operator I3(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "I3").WithArguments("virtual").WithLocation(20, 47),
                 // (20,47): error CS8703: The modifier 'abstract' is not valid for this item in C# 7.3. Please use language version 'preview' or greater.
                 //     abstract virtual static explicit operator I3(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "I3").WithArguments("abstract", "7.3", "preview").WithLocation(20, 47),
-                // (20,47): error CS0500: 'I3.explicit operator I3(bool)' cannot declare a body because it is marked abstract
+                // (20,47): error CS0503: The abstract method 'I3.explicit operator I3(bool)' cannot be marked virtual
                 //     abstract virtual static explicit operator I3(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_AbstractHasBody, "I3").WithArguments("I3.explicit operator I3(bool)").WithLocation(20, 47),
+                Diagnostic(ErrorCode.ERR_AbstractNotVirtual, "I3").WithArguments("method", "I3.explicit operator I3(bool)").WithLocation(20, 47),
                 // (20,47): error CS0552: 'I3.explicit operator I3(bool)': user-defined conversions to or from an interface are not allowed
                 //     abstract virtual static explicit operator I3(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "I3").WithArguments("I3.explicit operator I3(bool)").WithLocation(20, 47)
@@ -4750,66 +4702,57 @@ public interface I3
                                              targetFramework: _supportingFramework);
 
             compilation1.VerifyDiagnostics(
-                // (4,38): error CS0106: The modifier 'virtual' is not valid for this item
+                // (4,38): error CS8703: The modifier 'virtual' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     virtual static implicit operator int(I1 x); 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "int").WithArguments("virtual").WithLocation(4, 38),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments("virtual", "10.0", "preview").WithLocation(4, 38),
+                // (4,38): error CS0501: 'I1.implicit operator int(I1)' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual static implicit operator int(I1 x); 
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "int").WithArguments("I1.implicit operator int(I1)").WithLocation(4, 38),
                 // (4,38): error CS0552: 'I1.implicit operator int(I1)': user-defined conversions to or from an interface are not allowed
                 //     virtual static implicit operator int(I1 x); 
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "int").WithArguments("I1.implicit operator int(I1)").WithLocation(4, 38),
-                // (4,38): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual static implicit operator int(I1 x); 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(4, 38),
-                // (6,38): error CS0106: The modifier 'virtual' is not valid for this item
+                // (6,38): error CS8703: The modifier 'virtual' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     virtual static explicit operator I1(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "I1").WithArguments("virtual").WithLocation(6, 38),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "I1").WithArguments("virtual", "10.0", "preview").WithLocation(6, 38),
                 // (6,38): error CS0552: 'I1.explicit operator I1(bool)': user-defined conversions to or from an interface are not allowed
                 //     virtual static explicit operator I1(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "I1").WithArguments("I1.explicit operator I1(bool)").WithLocation(6, 38),
-                // (6,38): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual static explicit operator I1(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "I1").WithLocation(6, 38),
                 // (11,45): error CS0106: The modifier 'sealed' is not valid for this item
                 //     virtual sealed static implicit operator int(I2 x);
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "int").WithArguments("sealed").WithLocation(11, 45),
-                // (11,45): error CS0106: The modifier 'virtual' is not valid for this item
+                // (11,45): error CS8703: The modifier 'virtual' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     virtual sealed static implicit operator int(I2 x);
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "int").WithArguments("virtual").WithLocation(11, 45),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments("virtual", "10.0", "preview").WithLocation(11, 45),
+                // (11,45): error CS0501: 'I2.implicit operator int(I2)' must declare a body because it is not marked abstract, extern, or partial
+                //     virtual sealed static implicit operator int(I2 x);
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "int").WithArguments("I2.implicit operator int(I2)").WithLocation(11, 45),
                 // (11,45): error CS0552: 'I2.implicit operator int(I2)': user-defined conversions to or from an interface are not allowed
                 //     virtual sealed static implicit operator int(I2 x);
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "int").WithArguments("I2.implicit operator int(I2)").WithLocation(11, 45),
-                // (11,45): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual sealed static implicit operator int(I2 x);
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(11, 45),
                 // (13,45): error CS0106: The modifier 'sealed' is not valid for this item
                 //     virtual sealed static explicit operator I2(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "I2").WithArguments("sealed").WithLocation(13, 45),
-                // (13,45): error CS0106: The modifier 'virtual' is not valid for this item
+                // (13,45): error CS8703: The modifier 'virtual' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     virtual sealed static explicit operator I2(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "I2").WithArguments("virtual").WithLocation(13, 45),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "I2").WithArguments("virtual", "10.0", "preview").WithLocation(13, 45),
                 // (13,45): error CS0552: 'I2.explicit operator I2(bool)': user-defined conversions to or from an interface are not allowed
                 //     virtual sealed static explicit operator I2(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "I2").WithArguments("I2.explicit operator I2(bool)").WithLocation(13, 45),
-                // (13,45): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual sealed static explicit operator I2(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "I2").WithLocation(13, 45),
-                // (18,47): error CS0106: The modifier 'virtual' is not valid for this item
-                //     abstract virtual static implicit operator int(I3 x);
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "int").WithArguments("virtual").WithLocation(18, 47),
                 // (18,47): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     abstract virtual static implicit operator int(I3 x);
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments("abstract", "10.0", "preview").WithLocation(18, 47),
+                // (18,47): error CS0503: The abstract method 'I3.implicit operator int(I3)' cannot be marked virtual
+                //     abstract virtual static implicit operator int(I3 x);
+                Diagnostic(ErrorCode.ERR_AbstractNotVirtual, "int").WithArguments("method", "I3.implicit operator int(I3)").WithLocation(18, 47),
                 // (18,47): error CS0552: 'I3.implicit operator int(I3)': user-defined conversions to or from an interface are not allowed
                 //     abstract virtual static implicit operator int(I3 x);
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "int").WithArguments("I3.implicit operator int(I3)").WithLocation(18, 47),
-                // (20,47): error CS0106: The modifier 'virtual' is not valid for this item
-                //     abstract virtual static explicit operator I3(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "I3").WithArguments("virtual").WithLocation(20, 47),
                 // (20,47): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     abstract virtual static explicit operator I3(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "I3").WithArguments("abstract", "10.0", "preview").WithLocation(20, 47),
-                // (20,47): error CS0500: 'I3.explicit operator I3(bool)' cannot declare a body because it is marked abstract
+                // (20,47): error CS0503: The abstract method 'I3.explicit operator I3(bool)' cannot be marked virtual
                 //     abstract virtual static explicit operator I3(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_AbstractHasBody, "I3").WithArguments("I3.explicit operator I3(bool)").WithLocation(20, 47),
+                Diagnostic(ErrorCode.ERR_AbstractNotVirtual, "I3").WithArguments("method", "I3.explicit operator I3(bool)").WithLocation(20, 47),
                 // (20,47): error CS0552: 'I3.explicit operator I3(bool)': user-defined conversions to or from an interface are not allowed
                 //     abstract virtual static explicit operator I3(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "I3").WithArguments("I3.explicit operator I3(bool)").WithLocation(20, 47)
@@ -4822,60 +4765,39 @@ public interface I3
                                                  targetFramework: _supportingFramework);
 
             compilation1.VerifyDiagnostics(
-                // (4,38): error CS0106: The modifier 'virtual' is not valid for this item
+                // (4,38): error CS0501: 'I1.implicit operator int(I1)' must declare a body because it is not marked abstract, extern, or partial
                 //     virtual static implicit operator int(I1 x); 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "int").WithArguments("virtual").WithLocation(4, 38),
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "int").WithArguments("I1.implicit operator int(I1)").WithLocation(4, 38),
                 // (4,38): error CS0552: 'I1.implicit operator int(I1)': user-defined conversions to or from an interface are not allowed
                 //     virtual static implicit operator int(I1 x); 
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "int").WithArguments("I1.implicit operator int(I1)").WithLocation(4, 38),
-                // (4,38): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual static implicit operator int(I1 x); 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(4, 38),
-                // (6,38): error CS0106: The modifier 'virtual' is not valid for this item
-                //     virtual static explicit operator I1(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "I1").WithArguments("virtual").WithLocation(6, 38),
                 // (6,38): error CS0552: 'I1.explicit operator I1(bool)': user-defined conversions to or from an interface are not allowed
                 //     virtual static explicit operator I1(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "I1").WithArguments("I1.explicit operator I1(bool)").WithLocation(6, 38),
-                // (6,38): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual static explicit operator I1(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "I1").WithLocation(6, 38),
                 // (11,45): error CS0106: The modifier 'sealed' is not valid for this item
                 //     virtual sealed static implicit operator int(I2 x);
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "int").WithArguments("sealed").WithLocation(11, 45),
-                // (11,45): error CS0106: The modifier 'virtual' is not valid for this item
+                // (11,45): error CS0501: 'I2.implicit operator int(I2)' must declare a body because it is not marked abstract, extern, or partial
                 //     virtual sealed static implicit operator int(I2 x);
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "int").WithArguments("virtual").WithLocation(11, 45),
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "int").WithArguments("I2.implicit operator int(I2)").WithLocation(11, 45),
                 // (11,45): error CS0552: 'I2.implicit operator int(I2)': user-defined conversions to or from an interface are not allowed
                 //     virtual sealed static implicit operator int(I2 x);
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "int").WithArguments("I2.implicit operator int(I2)").WithLocation(11, 45),
-                // (11,45): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual sealed static implicit operator int(I2 x);
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(11, 45),
                 // (13,45): error CS0106: The modifier 'sealed' is not valid for this item
                 //     virtual sealed static explicit operator I2(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, "I2").WithArguments("sealed").WithLocation(13, 45),
-                // (13,45): error CS0106: The modifier 'virtual' is not valid for this item
-                //     virtual sealed static explicit operator I2(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "I2").WithArguments("virtual").WithLocation(13, 45),
                 // (13,45): error CS0552: 'I2.explicit operator I2(bool)': user-defined conversions to or from an interface are not allowed
                 //     virtual sealed static explicit operator I2(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "I2").WithArguments("I2.explicit operator I2(bool)").WithLocation(13, 45),
-                // (13,45): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     virtual sealed static explicit operator I2(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "I2").WithLocation(13, 45),
-                // (18,47): error CS0106: The modifier 'virtual' is not valid for this item
+                // (18,47): error CS0503: The abstract method 'I3.implicit operator int(I3)' cannot be marked virtual
                 //     abstract virtual static implicit operator int(I3 x);
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "int").WithArguments("virtual").WithLocation(18, 47),
+                Diagnostic(ErrorCode.ERR_AbstractNotVirtual, "int").WithArguments("method", "I3.implicit operator int(I3)").WithLocation(18, 47),
                 // (18,47): error CS0552: 'I3.implicit operator int(I3)': user-defined conversions to or from an interface are not allowed
                 //     abstract virtual static implicit operator int(I3 x);
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "int").WithArguments("I3.implicit operator int(I3)").WithLocation(18, 47),
-                // (20,47): error CS0106: The modifier 'virtual' is not valid for this item
+                // (20,47): error CS0503: The abstract method 'I3.explicit operator I3(bool)' cannot be marked virtual
                 //     abstract virtual static explicit operator I3(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "I3").WithArguments("virtual").WithLocation(20, 47),
-                // (20,47): error CS0500: 'I3.explicit operator I3(bool)' cannot declare a body because it is marked abstract
-                //     abstract virtual static explicit operator I3(bool x) {return null;} 
-                Diagnostic(ErrorCode.ERR_AbstractHasBody, "I3").WithArguments("I3.explicit operator I3(bool)").WithLocation(20, 47),
+                Diagnostic(ErrorCode.ERR_AbstractNotVirtual, "I3").WithArguments("method", "I3.explicit operator I3(bool)").WithLocation(20, 47),
                 // (20,47): error CS0552: 'I3.explicit operator I3(bool)': user-defined conversions to or from an interface are not allowed
                 //     abstract virtual static explicit operator I3(bool x) {return null;} 
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "I3").WithArguments("I3.explicit operator I3(bool)").WithLocation(20, 47)
@@ -4888,33 +4810,33 @@ public interface I3
                 foreach (MethodSymbol m01 in compilation1.GetTypeByMetadataName("I1").GetMembers())
                 {
                     Assert.False(m01.IsAbstract);
-                    Assert.False(m01.IsVirtual);
-                    Assert.False(m01.IsMetadataVirtual());
+                    Assert.True(m01.IsVirtual);
+                    Assert.True(m01.IsMetadataVirtual());
                     Assert.False(m01.IsSealed);
                     Assert.True(m01.IsStatic);
                     Assert.False(m01.IsExtern);
                     Assert.False(m01.IsAsync);
                     Assert.False(m01.IsOverride);
-                    Assert.Null(m01.ContainingType.FindImplementationForInterfaceMember(m01));
+                    Assert.Same(m01, m01.ContainingType.FindImplementationForInterfaceMember(m01));
                 }
 
                 foreach (MethodSymbol m01 in compilation1.GetTypeByMetadataName("I2").GetMembers())
                 {
                     Assert.False(m01.IsAbstract);
-                    Assert.False(m01.IsVirtual);
-                    Assert.False(m01.IsMetadataVirtual());
+                    Assert.True(m01.IsVirtual);
+                    Assert.True(m01.IsMetadataVirtual());
                     Assert.False(m01.IsSealed);
                     Assert.True(m01.IsStatic);
                     Assert.False(m01.IsExtern);
                     Assert.False(m01.IsAsync);
                     Assert.False(m01.IsOverride);
-                    Assert.Null(m01.ContainingType.FindImplementationForInterfaceMember(m01));
+                    Assert.Same(m01, m01.ContainingType.FindImplementationForInterfaceMember(m01));
                 }
 
                 foreach (MethodSymbol m01 in compilation1.GetTypeByMetadataName("I3").GetMembers())
                 {
                     Assert.True(m01.IsAbstract);
-                    Assert.False(m01.IsVirtual);
+                    Assert.True(m01.IsVirtual);
                     Assert.True(m01.IsMetadataVirtual());
                     Assert.False(m01.IsSealed);
                     Assert.True(m01.IsStatic);
@@ -5646,16 +5568,16 @@ partial interface I1
         {
             var source1 =
 @"
-interface I1
+interface I1<T> where T : I1<T>
 {
-    abstract static bool operator true (I1 x);
-    abstract static bool operator false (I1 x);
-    abstract static I1 operator > (I1 x, I1 y);
-    abstract static I1 operator < (I1 x, I1 y);
-    abstract static I1 operator >= (I1 x, I1 y);
-    abstract static I1 operator <= (I1 x, I1 y);
-    abstract static I1 operator == (I1 x, I1 y);
-    abstract static I1 operator != (I1 x, I1 y);
+    abstract static bool operator true (I1<T> x);
+    abstract static bool operator false (I1<T> x);
+    abstract static I1<T> operator > (I1<T> x, I1<T> y);
+    abstract static I1<T> operator < (I1<T> x, I1<T> y);
+    abstract static I1<T> operator >= (I1<T> x, I1<T> y);
+    abstract static I1<T> operator <= (I1<T> x, I1<T> y);
+    abstract static T operator == (T x, T y);
+    abstract static T operator != (T x, T y);
 }
 ";
             var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
@@ -5690,14 +5612,16 @@ interface I1
         {
             var source1 =
 @"
-interface I1
+interface I1<T> where T : I1<T>
 {
-    virtual  static bool operator true (I1 x) => throw null;
-    virtual  static bool operator false (I1 x) => throw null;
-    virtual  static I1 operator > (I1 x, I1 y) => throw null;
-    virtual  static I1 operator < (I1 x, I1 y) => throw null;
-    virtual  static I1 operator >= (I1 x, I1 y) => throw null;
-    virtual  static I1 operator <= (I1 x, I1 y) => throw null;
+    virtual  static bool operator true (I1<T> x) => throw null;
+    virtual  static bool operator false (I1<T> x) => throw null;
+    virtual  static I1<T> operator > (I1<T> x, I1<T> y) => throw null;
+    virtual  static I1<T> operator < (I1<T> x, I1<T> y) => throw null;
+    virtual  static I1<T> operator >= (I1<T> x, I1<T> y) => throw null;
+    virtual  static I1<T> operator <= (I1<T> x, I1<T> y) => throw null;
+    virtual  static T operator == (T x, T y) => throw null;
+    virtual  static T operator != (T x, T y) => throw null;
 }
 ";
             var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
@@ -5723,7 +5647,7 @@ interface I1
                     count++;
                 }
 
-                Assert.Equal(6, count);
+                Assert.Equal(8, count);
             }
         }
 
@@ -5842,7 +5766,7 @@ interface I1
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: TargetFramework.DesktopLatestExtended);
 
-            compilation1.VerifyDiagnostics(
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature).Verify(
                 // (4,35): error CS8919: Target runtime doesn't support static abstract members in interfaces.
                 //     abstract static bool operator true (I1 x);
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, "true").WithLocation(4, 35),
@@ -5883,13 +5807,15 @@ interface I1
     virtual  static I1 operator < (I1 x, I1 y) => throw null;
     virtual  static I1 operator >= (I1 x, I1 y) => throw null;
     virtual  static I1 operator <= (I1 x, I1 y) => throw null;
+    virtual  static I1 operator == (I1 x, I1 y) => throw null;
+    virtual  static I1 operator != (I1 x, I1 y) => throw null;
 }
 ";
             var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: TargetFramework.DesktopLatestExtended);
 
-            compilation1.VerifyDiagnostics(
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature).Verify(
                 // (4,35): error CS8919: Target runtime doesn't support static abstract members in interfaces.
                 //     virtual  static bool operator true (I1 x);
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, "true").WithLocation(4, 35),
@@ -5907,7 +5833,13 @@ interface I1
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, ">=").WithLocation(8, 33),
                 // (9,33): error CS8919: Target runtime doesn't support static abstract members in interfaces.
                 //     virtual  static I1 operator <= (I1 x, I1 y);
-                Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, "<=").WithLocation(9, 33)
+                Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, "<=").WithLocation(9, 33),
+                // (10,33): error CS8919: Target runtime doesn't support static abstract members in interfaces.
+                //     virtual  static I1 operator == (I1 x, I1 y) => throw null;
+                Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, "==").WithLocation(10, 33),
+                // (11,33): error CS8919: Target runtime doesn't support static abstract members in interfaces.
+                //     virtual  static I1 operator != (I1 x, I1 y) => throw null;
+                Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, "!=").WithLocation(11, 33)
                 );
         }
 
@@ -5951,15 +5883,57 @@ interface I1<T> where T : I1<T>
         }
 
         [Fact]
-        public void DefineAbstractStaticConversion_03()
+        public void DefineVirtualStaticConversion_01()
         {
             var source1 =
 @"
 interface I1<T> where T : I1<T>
 {
-    abstract static implicit operator int(T x);
-    abstract static explicit operator T(int x);
-    abstract static explicit operator checked T(int x);
+    virtual static implicit operator int(T x) => default;
+    virtual static explicit operator T(int x) => default;
+    virtual static explicit operator checked T(int x) => default;
+}
+";
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+            CompileAndVerify(compilation1, sourceSymbolValidator: validate, symbolValidator: validate, verify: Verification.Skipped).VerifyDiagnostics();
+
+            void validate(ModuleSymbol module)
+            {
+                int count = 0;
+                foreach (var m01 in module.GlobalNamespace.GetTypeMember("I1").GetMembers().OfType<MethodSymbol>())
+                {
+                    Assert.False(m01.IsMetadataNewSlot());
+                    Assert.False(m01.IsAbstract);
+                    Assert.True(m01.IsMetadataVirtual());
+                    Assert.False(m01.IsMetadataFinal);
+                    Assert.True(m01.IsVirtual);
+                    Assert.False(m01.IsSealed);
+                    Assert.True(m01.IsStatic);
+                    Assert.False(m01.IsOverride);
+
+                    count++;
+                }
+
+                Assert.Equal(3, count);
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void DefineAbstractStaticConversion_03(bool isVirtual)
+        {
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
+            var source1 =
+@"
+interface I1<T> where T : I1<T>
+{
+    " + modifier + @" static implicit operator int(T x)" + body + @"
+    " + modifier + @" static explicit operator T(int x)" + body + @"
+    " + modifier + @" static explicit operator checked T(int x)" + body + @"
 }
 ";
             var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
@@ -7491,13 +7465,8 @@ interface I15<T151, T152> where T151 : I15<T151, T152> where T152 : I15<T151, T1
 
         [Theory]
         [CombinatorialData]
-        public void OperatorSignature_04([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<", ">", "<=", ">=", "==", "!=")] string op, bool isVirtual)
+        public void OperatorSignature_04([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<", ">", "<=", ">=")] string op, bool isVirtual)
         {
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
-
             var (modifier, body) = GetModifierAndBody(isVirtual);
 
             var source1 =
@@ -7590,13 +7559,8 @@ interface I13
 
         [Theory]
         [CombinatorialData]
-        public void OperatorSignature_05([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<", ">", "<=", ">=", "==", "!=")] string op, bool isVirtual)
+        public void OperatorSignature_05([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<", ">", "<=", ">=")] string op, bool isVirtual)
         {
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
-
             var (modifier, body) = GetModifierAndBody(isVirtual);
 
             var source1 =
@@ -7788,70 +7752,72 @@ interface I14
 
         [Theory]
         [CombinatorialData]
-        public void OperatorSignature_07([CombinatorialValues("implicit", "explicit")] string op)
+        public void OperatorSignature_07([CombinatorialValues("implicit", "explicit")] string op, bool isVirtual)
         {
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
             var source1 =
 @"
 interface I1<T1> where T1 : I1<T1>
 {
-    abstract static " + op + @" operator T1(T1 y);
+    " + modifier + @" static " + op + @" operator T1(T1 y)" + body + @"
 }
 
 interface I2<T2> where T2 : I2<T2>
 {
-    abstract static " + op + @" operator dynamic(T2 y);
+    " + modifier + @" static " + op + @" operator dynamic(T2 y)" + body + @"
 }
 
 interface I3<T3> where T3 : I3<T3>
 {
-    static abstract " + op + @" operator T3(bool y);
+    static " + modifier + @" " + op + @" operator T3(bool y)" + body + @"
 }
 
 interface I4<T4> where T4 : struct, I4<T4>
 {
-    static abstract " + op + @" operator T4?(bool y);
+    static " + modifier + @" " + op + @" operator T4?(bool y)" + body + @"
 }
 
 class C5<T5> where T5 : C5<T5>.I6
 {
     public interface I6
     {
-        static abstract " + op + @" operator T5 (bool y);
+        static " + modifier + @" " + op + @" operator T5 (bool y)" + body + @"
     }
 }
 
 interface I7<T71, T72> where T72 : I7<T71, T72> where T71 : T72
 {
-    static abstract " + op + @" operator T71 (bool y);
+    static " + modifier + @" " + op + @" operator T71 (bool y)" + body + @"
 }
 
 interface I8<T8> where T8 : I9<T8>
 {
-    static abstract " + op + @" operator T8(bool y);
+    static " + modifier + @" " + op + @" operator T8(bool y)" + body + @"
 }
 
 interface I9<T9> : I8<T9> where T9 : I9<T9> {}
 
 interface I10<T10> where T10 : C11<T10>
 {
-    static abstract " + op + @" operator T10(bool y);
+    static " + modifier + @" " + op + @" operator T10(bool y)" + body + @"
 }
 
 class C11<T11> : I10<T11> where T11 : C11<T11> {}
 
 interface I12
 {
-    static abstract " + op + @" operator int(bool y);
+    static " + modifier + @" " + op + @" operator int(bool y)" + body + @"
 }
 
 interface I13
 {
-    static abstract " + op + @" operator I13(bool y);
+    static " + modifier + @" " + op + @" operator I13(bool y)" + body + @"
 }
 
 interface I14<T14> where T14 : I14<T14>
 {
-    abstract static " + op + @" operator object(T14 y);
+    " + modifier + @" static " + op + @" operator object(T14 y)" + body + @"
 }
 
 class C15 {}
@@ -7859,24 +7825,24 @@ class C16 : C15 {}
 
 interface I17<T17> where T17 : C15, I17<T17>
 {
-    abstract static " + op + @" operator C16(T17 y);
+    " + modifier + @" static " + op + @" operator C16(T17 y)" + body + @"
 }
 
 interface I18<T18> where T18 : C16, I18<T18>
 {
-    abstract static " + op + @" operator C15(T18 y);
+    " + modifier + @" static " + op + @" operator C15(T18 y)" + body + @"
 }
 
 interface I19<T19_1, T19_2> where T19_1 : I19<T19_1, T19_2>, T19_2
 {
-    abstract static " + op + @" operator T19_1(T19_2 y);
+    " + modifier + @" static " + op + @" operator T19_1(T19_2 y)" + body + @"
 }
 ";
 
             var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: _supportingFramework);
-            compilation1.VerifyDiagnostics(
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_UnimplementedInterfaceMember).Verify(
                 // (4,39): error CS0555: User-defined operator cannot convert a type to itself
                 //     abstract static explicit operator T1(T1 y);
                 Diagnostic(ErrorCode.ERR_IdentityConversion, "T1").WithLocation(4, 39),
@@ -7895,9 +7861,6 @@ interface I19<T19_1, T19_2> where T19_1 : I19<T19_1, T19_2>, T19_2
                 // (44,39): error CS8931: User-defined conversion in an interface must convert to or from a type parameter on the enclosing type constrained to the enclosing type
                 //     static abstract explicit operator T10(bool y);
                 Diagnostic(ErrorCode.ERR_AbstractConversionNotInvolvingContainedType, "T10").WithLocation(44, 39),
-                // (47,18): error CS0535: 'C11<T11>' does not implement interface member 'I10<T11>.explicit operator T11(bool)'
-                // class C11<T11> : I10<T11> where T11 : C11<T11> {}
-                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I10<T11>").WithArguments("C11<T11>", "I10<T11>." + op + " operator T11(bool)").WithLocation(47, 18),
                 // (51,39): error CS8931: User-defined conversion in an interface must convert to or from a type parameter on the enclosing type constrained to the enclosing type
                 //     static abstract explicit operator int(bool y);
                 Diagnostic(ErrorCode.ERR_AbstractConversionNotInvolvingContainedType, "int").WithLocation(51, 39),
@@ -7909,70 +7872,72 @@ interface I19<T19_1, T19_2> where T19_1 : I19<T19_1, T19_2>, T19_2
 
         [Theory]
         [CombinatorialData]
-        public void OperatorSignature_08([CombinatorialValues("implicit", "explicit")] string op)
+        public void OperatorSignature_08([CombinatorialValues("implicit", "explicit")] string op, bool isVirtual)
         {
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
             var source1 =
 @"
 interface I1<T1> where T1 : I1<T1>
 {
-    abstract static " + op + @" operator T1(T1 y);
+    " + modifier + @" static " + op + @" operator T1(T1 y)" + body + @"
 }
 
 interface I2<T2> where T2 : I2<T2>
 {
-    abstract static " + op + @" operator T2(dynamic y);
+    " + modifier + @" static " + op + @" operator T2(dynamic y)" + body + @"
 }
 
 interface I3<T3> where T3 : I3<T3>
 {
-    static abstract " + op + @" operator bool(T3 y);
+    static " + modifier + @" " + op + @" operator bool(T3 y)" + body + @"
 }
 
 interface I4<T4> where T4 : struct, I4<T4>
 {
-    static abstract " + op + @" operator bool(T4? y);
+    static " + modifier + @" " + op + @" operator bool(T4? y)" + body + @"
 }
 
 class C5<T5> where T5 : C5<T5>.I6
 {
     public interface I6
     {
-        static abstract " + op + @" operator bool(T5 y);
+        static " + modifier + @" " + op + @" operator bool(T5 y)" + body + @"
     }
 }
 
 interface I7<T71, T72> where T72 : I7<T71, T72> where T71 : T72
 {
-    static abstract " + op + @" operator bool(T71 y);
+    static " + modifier + @" " + op + @" operator bool(T71 y)" + body + @"
 }
 
 interface I8<T8> where T8 : I9<T8>
 {
-    static abstract " + op + @" operator bool(T8 y);
+    static " + modifier + @" " + op + @" operator bool(T8 y)" + body + @"
 }
 
 interface I9<T9> : I8<T9> where T9 : I9<T9> {}
 
 interface I10<T10> where T10 : C11<T10>
 {
-    static abstract " + op + @" operator bool(T10 y);
+    static " + modifier + @" " + op + @" operator bool(T10 y)" + body + @"
 }
 
 class C11<T11> : I10<T11> where T11 : C11<T11> {}
 
 interface I12
 {
-    static abstract " + op + @" operator bool(int y);
+    static " + modifier + @" " + op + @" operator bool(int y)" + body + @"
 }
 
 interface I13
 {
-    static abstract " + op + @" operator bool(I13 y);
+    static " + modifier + @" " + op + @" operator bool(I13 y)" + body + @"
 }
 
 interface I14<T14> where T14 : I14<T14>
 {
-    abstract static " + op + @" operator T14(object y);
+    " + modifier + @" static " + op + @" operator T14(object y)" + body + @"
 }
 
 class C15 {}
@@ -7980,24 +7945,24 @@ class C16 : C15 {}
 
 interface I17<T17> where T17 : C15, I17<T17>
 {
-    abstract static " + op + @" operator T17(C16 y);
+    " + modifier + @" static " + op + @" operator T17(C16 y)" + body + @"
 }
 
 interface I18<T18> where T18 : C16, I18<T18>
 {
-    abstract static " + op + @" operator T18(C15 y);
+    " + modifier + @" static " + op + @" operator T18(C15 y)" + body + @"
 }
 
 interface I19<T19_1, T19_2> where T19_1 : I19<T19_1, T19_2>, T19_2
 {
-    abstract static " + op + @" operator T19_2(T19_1 y);
+    " + modifier + @" static " + op + @" operator T19_2(T19_1 y)" + body + @"
 }
 ";
 
             var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: _supportingFramework);
-            compilation1.VerifyDiagnostics(
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_UnimplementedInterfaceMember).Verify(
                 // (4,39): error CS0555: User-defined operator cannot convert a type to itself
                 //     abstract static explicit operator T1(T1 y);
                 Diagnostic(ErrorCode.ERR_IdentityConversion, "T1").WithLocation(4, 39),
@@ -8016,15 +7981,206 @@ interface I19<T19_1, T19_2> where T19_1 : I19<T19_1, T19_2>, T19_2
                 // (44,39): error CS8931: User-defined conversion in an interface must convert to or from a type parameter on the enclosing type constrained to the enclosing type
                 //     static abstract explicit operator bool(T10 y);
                 Diagnostic(ErrorCode.ERR_AbstractConversionNotInvolvingContainedType, "bool").WithLocation(44, 39),
-                // (47,18): error CS0535: 'C11<T11>' does not implement interface member 'I10<T11>.explicit operator bool(T11)'
-                // class C11<T11> : I10<T11> where T11 : C11<T11> {}
-                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I10<T11>").WithArguments("C11<T11>", "I10<T11>." + op + " operator bool(T11)").WithLocation(47, 18),
                 // (51,39): error CS8931: User-defined conversion in an interface must convert to or from a type parameter on the enclosing type constrained to the enclosing type
                 //     static abstract explicit operator bool(int y);
                 Diagnostic(ErrorCode.ERR_AbstractConversionNotInvolvingContainedType, "bool").WithLocation(51, 39),
                 // (56,39): error CS0552: 'I13.explicit operator bool(I13)': user-defined conversions to or from an interface are not allowed
                 //     static abstract explicit operator bool(I13 y);
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "bool").WithArguments("I13." + op + " operator bool(I13)").WithLocation(56, 39)
+                );
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void OperatorSignature_09([CombinatorialValues("==", "!=")] string op, bool isVirtual)
+        {
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
+            var source1 =
+@"
+interface I1<T1> where T1 : I1<T1>
+{
+    static bool operator " + op + @"(T1 x, bool y) => throw null;
+}
+
+interface I2<T2> where T2 : struct, I2<T2>
+{
+    static bool operator " + op + @"(T2? x, bool y) => throw null;
+}
+
+interface I3<T3> where T3 : I3<T3>
+{
+    static " + modifier + @" bool operator " + op + @"(T3 x, bool y)" + body + @"
+}
+
+interface I4<T4> where T4 : struct, I4<T4>
+{
+    static " + modifier + @" bool operator " + op + @"(T4? x, bool y)" + body + @"
+}
+
+class C5<T5> where T5 : C5<T5>.I6
+{
+    public interface I6
+    {
+        static " + modifier + @" bool operator " + op + @"(T5 x, bool y)" + body + @"
+    }
+}
+
+interface I7<T71, T72> where T72 : I7<T71, T72> where T71 : T72
+{
+    static " + modifier + @" bool operator " + op + @"(T71 x, bool y)" + body + @"
+}
+
+interface I8<T8> where T8 : I9<T8>
+{
+    static " + modifier + @" bool operator " + op + @"(T8 x, bool y)" + body + @"
+}
+
+interface I9<T9> : I8<T9> where T9 : I9<T9> {}
+
+interface I10<T10> where T10 : C11<T10>
+{
+    static " + modifier + @" bool operator " + op + @"(T10 x, bool y)" + body + @"
+}
+
+class C11<T11> : I10<T11> where T11 : C11<T11> {}
+
+interface I12
+{
+    static " + modifier + @" bool operator " + op + @"(int x, bool y)" + body + @"
+}
+
+interface I13
+{
+    static " + modifier + @" bool operator " + op + @"(I13 x, bool y)" + body + @"
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+            compilation1.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_OperatorNeedsMatch or (int)ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators or (int)ErrorCode.ERR_UnimplementedInterfaceMember)).Verify(
+                // (4,26): error CS0563: One of the parameters of a binary operator must be the containing type
+                //     static bool operator ==(T1 x, bool y) => throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOperatorSignature, op).WithLocation(4, 26),
+                // (9,26): error CS0563: One of the parameters of a binary operator must be the containing type
+                //     static bool operator ==(T2? x, bool y) => throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOperatorSignature, op).WithLocation(9, 26),
+                // (26,39): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                //         static abstract bool operator ==(T5 x, bool y);
+                Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(26, 39),
+                // (32,35): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                //     static abstract bool operator ==(T71 x, bool y);
+                Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(32, 35),
+                // (37,35): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                //     static abstract bool operator ==(T8 x, bool y);
+                Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(37, 35),
+                // (44,35): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                //     static abstract bool operator ==(T10 x, bool y);
+                Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(44, 35),
+                // (51,35): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                //     static abstract bool operator ==(int x, bool y);
+                Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(51, 35),
+                // (56,35): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                //     static abstract bool operator ==(I13 x, bool y);
+                Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(56, 35)
+                );
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void OperatorSignature_10([CombinatorialValues("==", "!=")] string op, bool isVirtual)
+        {
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
+            var source1 =
+@"
+interface I1<T1> where T1 : I1<T1>
+{
+    static bool operator " + op + @"(bool y, T1 x) => throw null;
+}
+
+interface I2<T2> where T2 : struct, I2<T2>
+{
+    static bool operator " + op + @"(bool y, T2? x) => throw null;
+}
+
+interface I3<T3> where T3 : I3<T3>
+{
+    static " + modifier + @" bool operator " + op + @"(bool y, T3 x)" + body + @"
+}
+
+interface I4<T4> where T4 : struct, I4<T4>
+{
+    static " + modifier + @" bool operator " + op + @"(bool y, T4? x)" + body + @"
+}
+
+class C5<T5> where T5 : C5<T5>.I6
+{
+    public interface I6
+    {
+        static " + modifier + @" bool operator " + op + @"(bool y, T5 x)" + body + @"
+    }
+}
+
+interface I7<T71, T72> where T72 : I7<T71, T72> where T71 : T72
+{
+    static " + modifier + @" bool operator " + op + @"(bool y, T71 x)" + body + @"
+}
+
+interface I8<T8> where T8 : I9<T8>
+{
+    static " + modifier + @" bool operator " + op + @"(bool y, T8 x)" + body + @"
+}
+
+interface I9<T9> : I8<T9> where T9 : I9<T9> {}
+
+interface I10<T10> where T10 : C11<T10>
+{
+    static " + modifier + @" bool operator " + op + @"(bool y, T10 x)" + body + @"
+}
+
+class C11<T11> : I10<T11> where T11 : C11<T11> {}
+
+interface I12
+{
+    static " + modifier + @" bool operator " + op + @"(bool y, int x)" + body + @"
+}
+
+interface I13
+{
+    static " + modifier + @" bool operator " + op + @"(bool y, I13 x)" + body + @"
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+            compilation1.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_OperatorNeedsMatch or (int)ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators or (int)ErrorCode.ERR_UnimplementedInterfaceMember)).Verify(
+                // (4,26): error CS0563: One of the parameters of a binary operator must be the containing type
+                //     static bool operator ==(bool y, T1 x) => throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOperatorSignature, op).WithLocation(4, 26),
+                // (9,26): error CS0563: One of the parameters of a binary operator must be the containing type
+                //     static bool operator ==(bool y, T2? x) => throw null;
+                Diagnostic(ErrorCode.ERR_BadBinaryOperatorSignature, op).WithLocation(9, 26),
+                // (26,39): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                //         static abstract bool operator ==(bool y, T5 x);
+                Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(26, 39),
+                // (32,35): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                //     static abstract bool operator ==(bool y, T71 x);
+                Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(32, 35),
+                // (37,35): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                //     static abstract bool operator ==(bool y, T8 x);
+                Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(37, 35),
+                // (44,35): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                //     static abstract bool operator ==(bool y, T10 x);
+                Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(44, 35),
+                // (51,35): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                //     static abstract bool operator ==(bool y, int x);
+                Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(51, 35),
+                // (56,35): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                //     static abstract bool operator ==(bool y, I13 x);
+                Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(56, 35)
                 );
         }
 
@@ -9740,11 +9896,6 @@ class C<T>
         [CombinatorialData]
         public void ConsumeAbstractBinaryOperator_01([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=", "==", "!=")] string op, bool isChecked, bool isVirtual)
         {
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
-
             if (GetBinaryOperatorName(op, isChecked, out string checkedKeyword) is null)
             {
                 return;
@@ -9839,7 +9990,7 @@ public partial interface I1
             }
             else
             {
-                compilation1.VerifyDiagnostics(
+                compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature).Verify(
                     // (8,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
                     //         _ = x - 1;
                     Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "x " + op + " 1").WithLocation(8, 13),
@@ -10221,17 +10372,19 @@ class Test
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractBinaryOperatorForTupleEquality_01([CombinatorialValues("==", "!=")] string op)
+        public void ConsumeAbstractBinaryOperatorForTupleEquality_01([CombinatorialValues("==", "!=")] string op, bool isVirtual)
         {
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
             var source1 =
 @"
 interface I1<T> where T : I1<T>
 {
-    abstract static bool operator == (T x, T y);
-    abstract static bool operator != (T x, T y);
+    " + modifier + @" static bool operator == (T x, T y)" + body + @"
+    " + modifier + @" static bool operator != (T x, T y)" + body + @"
 
-    abstract static bool operator == (I1<T> x, I1<T> y);
-    abstract static bool operator != (I1<T> x, I1<T> y);
+    " + modifier + @" static bool operator == (I1<T> x, I1<T> y)" + body + @"
+    " + modifier + @" static bool operator != (I1<T> x, I1<T> y)" + body + @"
 
     static void M02((int, I1<T>) x)
     {
@@ -10261,43 +10414,16 @@ class Test
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: _supportingFramework);
 
-            compilation1.VerifyDiagnostics(
-                // (10,34): error CS8920: The interface 'I1<T>' cannot be used as type argument. Static member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
-                //     static void M02((int, I1<T>) x)
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "x").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(10, 34),
+            compilation1.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature or (int)ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers)).Verify(
                 // (12,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
                 //         _ = x != x;
                 Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "x " + op + " x").WithLocation(12, 13),
-                // (12,13): error CS8920: The interface 'I1<T>' cannot be used as type argument. Static member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
-                //         _ = x != x;
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "x").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(12, 13),
-                // (12,18): error CS8920: The interface 'I1<T>' cannot be used as type argument. Static member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
-                //         _ = x != x;
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "x").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(12, 18),
-                // (15,27): error CS8920: The interface 'I1<T>' cannot be used as type argument. Static member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
-                //     void M03((int, I1<T>) y)
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(15, 27),
                 // (17,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
                 //         _ = y != y;
                 Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "y " + op + " y").WithLocation(17, 13),
-                // (17,13): error CS8920: The interface 'I1<T>' cannot be used as type argument. Static member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
-                //         _ = y != y;
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(17, 13),
-                // (17,18): error CS8920: The interface 'I1<T>' cannot be used as type argument. Static member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
-                //         _ = y != y;
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(17, 18),
-                // (23,37): error CS8920: The interface 'I1<T>' cannot be used as type argument. Static member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
-                //     static void MT1<T>((int, I1<T>) a) where T : I1<T>
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "a").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(23, 37),
                 // (25,13): error CS8926: A static virtual or abstract interface member can be accessed only on a type parameter.
                 //         _ = a != a;
                 Diagnostic(ErrorCode.ERR_BadAbstractStaticMemberAccess, "a " + op + " a").WithLocation(25, 13),
-                // (25,13): error CS8920: The interface 'I1<T>' cannot be used as type argument. Static member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
-                //         _ = a != a;
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "a").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(25, 13),
-                // (25,18): error CS8920: The interface 'I1<T>' cannot be used as type argument. Static member 'I1<T>.operator ==(T, T)' does not have a most specific implementation in the interface.
-                //         _ = a != a;
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "a").WithArguments("I1<T>", "I1<T>.operator ==(T, T)").WithLocation(25, 18),
                 // (30,92): error CS8382: An expression tree may not contain a tuple == or != operator
                 //         _ = (System.Linq.Expressions.Expression<System.Action<(int, T)>>)(((int, T) b) => (b != b).ToString());
                 Diagnostic(ErrorCode.ERR_ExpressionTreeContainsTupleBinOp, "b " + op + " b").WithLocation(30, 92)
@@ -10645,11 +10771,6 @@ IBinaryOperation (BinaryOperatorKind." + BinaryOperatorKind(op) + (isCheckedOper
         [CombinatorialData]
         public void ConsumeAbstractComparisonBinaryOperator_03([CombinatorialValues("<", ">", "<=", ">=", "==", "!=")] string op, bool isVirtual)
         {
-            if (isVirtual && op is ("==" or "!="))
-            {
-                return;
-            }
-
             string metadataName = BinaryOperatorName(op);
             var (modifier, body) = GetModifierAndBody(isVirtual);
 
@@ -10846,11 +10967,6 @@ IBinaryOperation (BinaryOperatorKind." + BinaryOperatorKind(op) + @") (OperatorM
         [CombinatorialData]
         public void ConsumeAbstractLiftedComparisonBinaryOperator_03([CombinatorialValues("<", ">", "<=", ">=", "==", "!=")] string op, bool isVirtual)
         {
-            if (isVirtual && op is ("==" or "!="))
-            {
-                return;
-            }
-
             string metadataName = BinaryOperatorName(op);
             var (modifier, body) = GetModifierAndBody(isVirtual);
 
@@ -11878,14 +11994,16 @@ ICompoundAssignmentOperation (BinaryOperatorKind." + BinaryOperatorKind(op) + (i
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractBinaryOperatorForTupleEquality_03([CombinatorialValues("==", "!=")] string op)
+        public void ConsumeAbstractBinaryOperatorForTupleEquality_03([CombinatorialValues("==", "!=")] string op, bool isVirtual)
         {
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
             var source1 =
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static bool operator == (T x, T y);
-    abstract static bool operator != (T x, T y);
+    " + modifier + @" static bool operator == (T x, T y)" + body + @"
+    " + modifier + @" static bool operator != (T x, T y)" + body + @"
 }
 
 class Test
@@ -12057,11 +12175,6 @@ ITupleBinaryOperation (BinaryOperatorKind." + (op == "==" ? "Equals" : "NotEqual
         [CombinatorialData]
         public void ConsumeAbstractBinaryOperator_04([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=", "==", "!=")] string op, bool isChecked, bool isVirtual)
         {
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
-
             if (GetBinaryOperatorName(op, isChecked, out string checkedKeyword) is null)
             {
                 return;
@@ -12105,7 +12218,7 @@ class Test
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: TargetFramework.DesktopLatestExtended);
 
-            compilation3.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_OperatorNeedsMatch or (int)ErrorCode.ERR_CheckedOperatorNeedsMatch)).Verify(
+            compilation3.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_OperatorNeedsMatch or (int)ErrorCode.ERR_CheckedOperatorNeedsMatch or (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature)).Verify(
                 // (12,33): error CS8919: Target runtime doesn't support static abstract members in interfaces.
                 //     abstract static I1 operator - (I1 x, int y);
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, op).WithLocation(12, 33 + checkedKeyword.Length)
@@ -12264,14 +12377,16 @@ class Test
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractBinaryOperatorForTupleEquality_04([CombinatorialValues("==", "!=")] string op)
+        public void ConsumeAbstractBinaryOperatorForTupleEquality_04([CombinatorialValues("==", "!=")] string op, bool isVirtual)
         {
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
             var source1 =
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static bool operator == (T x, T y);
-    abstract static bool operator != (T x, T y);
+    " + modifier + @" static bool operator == (T x, T y)" + body + @"
+    " + modifier + @" static bool operator != (T x, T y)" + body + @"
 }
 ";
             var source2 =
@@ -12317,11 +12432,6 @@ class Test
         [CombinatorialData]
         public void ConsumeAbstractBinaryOperator_06([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=", "==", "!=")] string op, bool isChecked, bool isVirtual)
         {
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
-
             if (GetBinaryOperatorName(op, isChecked, out string checkedKeyword) is null)
             {
                 return;
@@ -12403,7 +12513,7 @@ class Test
             }
             else if (op != ">>>")
             {
-                compilation3.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_OperatorNeedsMatch).Verify(
+                compilation3.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_OperatorNeedsMatch or (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature)).Verify(
                     // (12,33): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                     //     abstract static I1 operator - (I1 x, int y);
                     Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, op).WithArguments(modifier.Trim(), "10.0", "preview").WithLocation(12, 33)
@@ -12624,14 +12734,16 @@ class Test
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractBinaryOperatorForTupleEquality_06([CombinatorialValues("==", "!=")] string op)
+        public void ConsumeAbstractBinaryOperatorForTupleEquality_06([CombinatorialValues("==", "!=")] string op, bool isVirtual)
         {
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
             var source1 =
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static bool operator == (T x, T y);
-    abstract static bool operator != (T x, T y);
+    " + modifier + @" static bool operator == (T x, T y)" + body + @"
+    " + modifier + @" static bool operator != (T x, T y)" + body + @"
 }
 ";
             var source2 =
@@ -12666,10 +12778,10 @@ class Test
             compilation3.VerifyDiagnostics(
                 // (12,35): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     abstract static bool operator == (T x, T y);
-                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "==").WithArguments("abstract", "10.0", "preview").WithLocation(12, 35),
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "==").WithArguments(modifier.Trim(), "10.0", "preview").WithLocation(12, 35),
                 // (13,35): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     abstract static bool operator != (T x, T y);
-                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "!=").WithArguments("abstract", "10.0", "preview").WithLocation(13, 35)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "!=").WithArguments(modifier.Trim(), "10.0", "preview").WithLocation(13, 35)
                 );
         }
 
@@ -17897,7 +18009,7 @@ public interface I2<T> where T : I2<T>
 
         [Theory]
         [CombinatorialData]
-        public void ImplementVirtualStaticBinaryOperator_01([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=")] string op, bool structure, bool isChecked)
+        public void ImplementVirtualStaticBinaryOperator_01([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=", "==", "!=")] string op, bool structure, bool isChecked)
         {
             string opName = GetBinaryOperatorName(op, isChecked, out string checkedKeyword);
 
@@ -18406,9 +18518,6 @@ interface I14 : I1
                 // (22,20): error CS0539: 'I5.operator |(I1, int)' in explicit interface declaration is not found among members of the interface that can be implemented
                 //     I1 I1.operator |(I1 x, int y) => default;
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, op).WithArguments("I5.operator " + checkedKeyword + op + "(I1, int)").WithLocation(22, 20 + checkedKeyword.Length),
-                // (32,33): error CS8924: One of the parameters of a binary operator must be the containing type, or its type parameter constrained to it.
-                //     abstract static I1 operator |(I1 x, int y);
-                Diagnostic(badAbstractSignatureError, op).WithLocation(32, 33 + checkedKeyword.Length),
                 // (42,16): error CS0563: One of the parameters of a binary operator must be the containing type
                 //     T operator |(T x, int y) => default;
                 Diagnostic(badSignatureError, op).WithLocation(42, 16 + checkedKeyword.Length),
@@ -18421,27 +18530,27 @@ interface I14 : I1
             {
                 expected = expected.Concat(
                     new[] {
-                        // (12,17): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                        // (4,33): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                        //     abstract static I1 operator ==(I1 x, int y);
+                        Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(4, 33),
+                        // (12,17): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                         //     I1 operator ==(I1 x, int y) => default;
                         Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, op).WithLocation(12, 17 + checkedKeyword.Length),
-                        // (17,24): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                        // (17,24): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                         //     static I1 operator ==(I1 x, int y) => default;
                         Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, op).WithLocation(17, 24 + checkedKeyword.Length),
-                        // (22,20): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                        // (22,20): error CS8930: Explicit implementation of a user-defined operator 'I5.operator ==(I1, int)' must be declared static
                         //     I1 I1.operator ==(I1 x, int y) => default;
-                        Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, op).WithLocation(22, 20),
-                        // (27,27): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                        //     static I1 I1.operator ==(I1 x, int y) => default;
-                        Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, op).WithLocation(27, 27),
-                        // (42,16): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                        Diagnostic(ErrorCode.ERR_ExplicitImplementationOfOperatorsMustBeStatic, op).WithArguments("I5.operator " + op + "(I1, int)").WithLocation(22, 20),
+                        // (32,33): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                        //     abstract static I1 operator ==(I1 x, int y);
+                        Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(32, 33),
+                        // (42,16): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                         //     T operator ==(T x, int y) => default;
                         Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, op).WithLocation(42, 16 + checkedKeyword.Length),
-                        // (47,23): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                        // (47,23): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                         //     static T operator ==(T x, int y) => default;
-                        Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, op).WithLocation(47, 23 + checkedKeyword.Length),
-                        // (57,30): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                        //     static T I11<T>.operator ==(T x, int y) => default;
-                        Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, op).WithLocation(57, 30),
+                        Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, op).WithLocation(47, 23 + checkedKeyword.Length)
                         }
                     ).ToArray();
             }
@@ -18455,6 +18564,9 @@ interface I14 : I1
                         // (22,20): error CS8930: Explicit implementation of a user-defined operator 'I5.operator |(I1, int)' must be declared static
                         //     I1 I1.operator |(I1 x, int y) => default;
                         Diagnostic(ErrorCode.ERR_ExplicitImplementationOfOperatorsMustBeStatic, op).WithArguments("I5.operator " + checkedKeyword + op + "(I1, int)").WithLocation(22, 20 + checkedKeyword.Length),
+                        // (32,33): error CS8924: One of the parameters of a binary operator must be the containing type, or its type parameter constrained to it.
+                        //     abstract static I1 operator |(I1 x, int y);
+                        Diagnostic(badAbstractSignatureError, op).WithLocation(32, 33 + checkedKeyword.Length),
                         // (42,16): error CS0558: User-defined operator 'I8<T>.operator |(T, int)' must be declared static and public
                         //     T operator |(T x, int y) => default;
                         Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, op).WithArguments("I8<T>.operator " + checkedKeyword + op + "(T, int)").WithLocation(42, 16 + checkedKeyword.Length)
@@ -18496,7 +18608,7 @@ interface I14 : I1
 
         [Theory]
         [CombinatorialData]
-        public void ImplementVirtualStaticBinaryOperator_03([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=")] string op, bool isChecked)
+        public void ImplementVirtualStaticBinaryOperator_03([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=", "==", "!=")] string op, bool isChecked)
         {
             if (GetBinaryOperatorName(op, isChecked, out string checkedKeyword) is null)
             {
@@ -18589,15 +18701,9 @@ interface I14 : I1
                 // (17,24): error CS0563: One of the parameters of a binary operator must be the containing type
                 //     static I1 operator |(I1 x, int y) => default;
                 Diagnostic(badSignatureError, op).WithLocation(17, 24 + checkedKeyword.Length),
-                // (22,20): error CS8930: Explicit implementation of a user-defined operator 'I5.operator |(I1, int)' must be declared static
-                //     I1 I1.operator |(I1 x, int y) => default;
-                Diagnostic(ErrorCode.ERR_ExplicitImplementationOfOperatorsMustBeStatic, op).WithArguments("I5.operator " + checkedKeyword + op + "(I1, int)").WithLocation(22, 20 + checkedKeyword.Length),
                 // (22,20): error CS0539: 'I5.operator |(I1, int)' in explicit interface declaration is not found among members of the interface that can be implemented
                 //     I1 I1.operator |(I1 x, int y) => default;
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, op).WithArguments("I5.operator " + checkedKeyword + op + "(I1, int)").WithLocation(22, 20 + checkedKeyword.Length),
-                // (32,33): error CS8924: One of the parameters of a binary operator must be the containing type, or its type parameter constrained to it.
-                //     virtual  static I1 operator |(I1 x, int y);
-                Diagnostic(badAbstractSignatureError, op).WithLocation(32, 33 + checkedKeyword.Length),
                 // (42,16): error CS0563: One of the parameters of a binary operator must be the containing type
                 //     T operator |(T x, int y) => default;
                 Diagnostic(badSignatureError, op).WithLocation(42, 16 + checkedKeyword.Length),
@@ -18609,14 +18715,56 @@ interface I14 : I1
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, op).WithArguments("virtual").WithLocation(62, 39 + checkedKeyword.Length),
                 // (67,36): error CS0106: The modifier 'virtual' is not valid for this item
                 //     virtual  static I1 I1.operator |(I1 x, int y);
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, op).WithArguments("virtual").WithLocation(67, 36 + checkedKeyword.Length),
-                // (12,17): error CS0558: User-defined operator 'I3.operator |(I1, int)' must be declared static and public
-                //     I1 operator |(I1 x, int y) => default;
-                Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, op).WithArguments("I3.operator " + checkedKeyword + op + "(I1, int)").WithLocation(12, 17 + checkedKeyword.Length),
-                // (42,16): error CS0558: User-defined operator 'I8<T>.operator |(T, int)' must be declared static and public
-                //     T operator |(T x, int y) => default;
-                Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, op).WithArguments("I8<T>.operator " + checkedKeyword + op + "(T, int)").WithLocation(42, 16 + checkedKeyword.Length)
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, op).WithArguments("virtual").WithLocation(67, 36 + checkedKeyword.Length)
                 };
+
+            if (op is "==" or "!=")
+            {
+                expected = expected.Concat(
+                    new[] {
+                        // (4,33): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                        //     virtual  static I1 operator ==(I1 x, int y);
+                        Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(4, 33),
+                        // (12,17): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
+                        //     I1 operator ==(I1 x, int y) => default;
+                        Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, op).WithLocation(12, 17 + checkedKeyword.Length),
+                        // (17,24): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
+                        //     static I1 operator ==(I1 x, int y) => default;
+                        Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, op).WithLocation(17, 24 + checkedKeyword.Length),
+                        // (22,20): error CS8930: Explicit implementation of a user-defined operator 'I5.operator ==(I1, int)' must be declared static
+                        //     I1 I1.operator ==(I1 x, int y) => default;
+                        Diagnostic(ErrorCode.ERR_ExplicitImplementationOfOperatorsMustBeStatic, op).WithArguments("I5.operator " + op + "(I1, int)").WithLocation(22, 20),
+                        // (32,33): error CS9045: One of the parameters of an equality, or inequality operator declared in interfaces must be a type parameter on the enclosing type constrained to the enclosing type
+                        //     virtual  static I1 operator ==(I1 x, int y);
+                        Diagnostic(ErrorCode.ERR_BadAbstractEqualityOperatorSignature, op).WithLocation(32, 33),
+                        // (42,16): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
+                        //     T operator ==(T x, int y) => default;
+                        Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, op).WithLocation(42, 16 + checkedKeyword.Length),
+                        // (47,23): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
+                        //     static T operator ==(T x, int y) => default;
+                        Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, op).WithLocation(47, 23 + checkedKeyword.Length)
+                        }
+                    ).ToArray();
+            }
+            else
+            {
+                expected = expected.Concat(
+                    new[] {
+                        // (12,17): error CS0558: User-defined operator 'I3.operator |(I1, int)' must be declared static and public
+                        //     I1 operator |(I1 x, int y) => default;
+                        Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, op).WithArguments("I3.operator " + checkedKeyword + op + "(I1, int)").WithLocation(12, 17 + checkedKeyword.Length),
+                        // (22,20): error CS8930: Explicit implementation of a user-defined operator 'I5.operator |(I1, int)' must be declared static
+                        //     I1 I1.operator |(I1 x, int y) => default;
+                        Diagnostic(ErrorCode.ERR_ExplicitImplementationOfOperatorsMustBeStatic, op).WithArguments("I5.operator " + checkedKeyword + op + "(I1, int)").WithLocation(22, 20 + checkedKeyword.Length),
+                        // (32,33): error CS8924: One of the parameters of a binary operator must be the containing type, or its type parameter constrained to it.
+                        //     virtual  static I1 operator |(I1 x, int y);
+                        Diagnostic(badAbstractSignatureError, op).WithLocation(32, 33 + checkedKeyword.Length),
+                        // (42,16): error CS0558: User-defined operator 'I8<T>.operator |(T, int)' must be declared static and public
+                        //     T operator |(T x, int y) => default;
+                        Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, op).WithArguments("I8<T>.operator " + checkedKeyword + op + "(T, int)").WithLocation(42, 16 + checkedKeyword.Length)
+                        }
+                    ).ToArray();
+            }
 
             compilation1.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_OperatorNeedsMatch or (int)ErrorCode.ERR_CheckedOperatorNeedsMatch)).Verify(expected);
 
@@ -18782,11 +18930,6 @@ typeKeyword + @"
         [CombinatorialData]
         public void ImplementAbstractStaticBinaryOperator_04([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=", "==", "!=")] string op, bool structure, bool isChecked, bool isVirtual)
         {
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
-
             if (GetBinaryOperatorName(op, isChecked, out string checkedKeyword) is null)
             {
                 return;
@@ -18885,7 +19028,8 @@ typeKeyword + @"
             {
                 if (op != ">>>")
                 {
-                    compilation3.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_OperatorNeedsMatch or (int)ErrorCode.WRN_EqualityOpWithoutEquals or (int)ErrorCode.WRN_EqualityOpWithoutGetHashCode)).Verify(
+                    compilation3.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_OperatorNeedsMatch or (int)ErrorCode.WRN_EqualityOpWithoutEquals or
+                                                                            (int)ErrorCode.WRN_EqualityOpWithoutGetHashCode or (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature)).Verify(
                         // (4,15): error CS8652: The feature 'static abstract members in interfaces' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
                         //     static I1 I1.operator +(I1 x, int y) => default;
                         Diagnostic(ErrorCode.ERR_FeatureInPreview, "I1.").WithArguments("static abstract members in interfaces").WithLocation(4, 15),
@@ -19008,11 +19152,6 @@ typeKeyword + @"
         [CombinatorialData]
         public void ImplementAbstractStaticBinaryOperator_05([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=", "==", "!=")] string op, bool structure, bool isChecked, bool isVirtual)
         {
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
-
             if (GetBinaryOperatorName(op, isChecked, out string checkedKeyword) is null)
             {
                 return;
@@ -19120,11 +19259,6 @@ typeKeyword + @"
         [CombinatorialData]
         public void ImplementAbstractStaticBinaryOperator_06([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=", "==", "!=")] string op, bool structure, bool isChecked, bool isVirtual)
         {
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
-
             if (GetBinaryOperatorName(op, isChecked, out string checkedKeyword) is null)
             {
                 return;
@@ -19166,7 +19300,7 @@ typeKeyword + @"
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: TargetFramework.DesktopLatestExtended);
 
-            compilation3.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_OperatorNeedsMatch or (int)ErrorCode.ERR_CheckedOperatorNeedsMatch)).Verify(
+            compilation3.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_OperatorNeedsMatch or (int)ErrorCode.ERR_CheckedOperatorNeedsMatch or (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature)).Verify(
                 // (4,27): error CS8919: Target runtime doesn't support static abstract members in interfaces.
                 //     static I1 I1.operator +(I1 x, int y) => default;
                 Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportStaticAbstractMembersInInterfaces, op).WithLocation(4, 27 + checkedKeyword.Length),
@@ -19350,11 +19484,6 @@ partial " + typeKeyword + @"
         public void ImplementAbstractStaticBinaryOperator_07([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=", "==", "!=")] string op, bool structure, bool isChecked, bool isVirtual)
         {
             // Basic implicit implementation scenario, MethodImpl is emitted
-
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
 
             string opName = GetBinaryOperatorName(op, isChecked, out string checkedKeyword);
             var (modifier, body) = GetModifierAndBody(isVirtual);
@@ -19617,14 +19746,9 @@ partial " + typeKeyword + @"
 
         [Theory]
         [CombinatorialData]
-        public void ImplementAbstractStaticBinaryOperator_08([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=", "==", "!=")] string op, bool structure, bool isChecked, bool isVirtual)
+        public void ImplementAbstractStaticBinaryOperator_08([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=")] string op, bool structure, bool isChecked, bool isVirtual)
         {
             // Basic explicit implementation scenario
-
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
 
             string opName = GetBinaryOperatorName(op, isChecked, out string checkedKeyword);
 
@@ -19710,6 +19834,96 @@ partial " + typeKeyword + @"
 
                 Assert.Equal("I1 C.I1." + opName + "(I1 x, System.Int32 y)", cM01.ToTestDisplayString());
                 Assert.Same(m01, cM01.ExplicitInterfaceImplementations.Single());
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void ImplementAbstractStaticEqualityOperator_08([CombinatorialValues("==", "!=")] string op, bool structure, bool isVirtual)
+        {
+            // Basic explicit implementation scenario
+
+            string opName = GetBinaryOperatorName(op, isChecked: false, checkedKeyword: out _);
+
+            if (opName is null)
+            {
+                return;
+            }
+
+            var typeKeyword = structure ? "struct" : "class";
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
+            var source1 =
+@"
+public partial interface I1<T> where T : I1<T>
+{
+    " + modifier + @" static T operator " + op + @"(T x, int y)" + body + @"
+}
+
+partial " + typeKeyword + @"
+    C : I1<C>
+{
+    static C I1<C>.operator " + op + @"(C x, int y) => default;
+}
+";
+            string matchingOp = MatchingBinaryOperator(op);
+
+            source1 +=
+@"
+public partial interface I1<T>
+{
+    " + modifier + @" static T operator " + matchingOp + @"(T x, int y)" + body + @"
+}
+
+partial " + typeKeyword + @"
+    C
+{
+    static C I1<C>.operator " + matchingOp + @"(C x, int y) => default;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+
+            var tree = compilation1.SyntaxTrees.Single();
+            var model = compilation1.GetSemanticModel(tree);
+            var node = tree.GetRoot().DescendantNodes().OfType<LiteralExpressionSyntax>().Where(l => l.ToString() == "default").First();
+
+            Assert.Equal("default", node.ToString());
+            Assert.Equal("C", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString());
+
+            var declaredSymbol = model.GetDeclaredSymbol(node.FirstAncestorOrSelf<OperatorDeclarationSyntax>());
+            Assert.Equal("C C.I1<C>." + opName + "(C x, System.Int32 y)", declaredSymbol.ToTestDisplayString());
+            Assert.DoesNotContain(opName, declaredSymbol.ContainingType.MemberNames);
+
+            CompileAndVerify(compilation1, sourceSymbolValidator: validate, symbolValidator: validate, verify: Verification.Skipped).VerifyDiagnostics();
+
+            CompileAndVerify(compilation1, sourceSymbolValidator: validate, symbolValidator: validate, verify: Verification.Skipped,
+                             emitOptions: EmitOptions.Default.WithEmitMetadataOnly(true).WithIncludePrivateMembers(false)).VerifyDiagnostics();
+
+            void validate(ModuleSymbol module)
+            {
+                var c = module.GlobalNamespace.GetTypeMember("C");
+                var m01 = c.Interfaces().Single().GetMembers(opName).OfType<MethodSymbol>().Single();
+
+                Assert.Equal(matchingOp is null ? 1 : 2, c.GetMembers().OfType<MethodSymbol>().Where(m => !m.IsConstructor()).Count());
+
+                var cM01 = (MethodSymbol)c.FindImplementationForInterfaceMember(m01);
+
+                Assert.True(cM01.IsStatic);
+                Assert.False(cM01.IsAbstract);
+                Assert.False(cM01.IsVirtual);
+                Assert.False(cM01.IsMetadataVirtual());
+                Assert.False(cM01.IsMetadataFinal);
+                Assert.False(cM01.IsMetadataNewSlot());
+                Assert.Equal(MethodKind.ExplicitInterfaceImplementation, cM01.MethodKind);
+                Assert.False(cM01.HasRuntimeSpecialName);
+                Assert.False(cM01.HasSpecialName);
+
+                Assert.Equal("C C.I1<C>." + opName + "(C x, System.Int32 y)", cM01.ToTestDisplayString());
+                Assert.Equal(m01, cM01.ExplicitInterfaceImplementations.Single());
             }
         }
 
@@ -19870,14 +20084,9 @@ public class C3 : C2, I1
 
         [Theory]
         [CombinatorialData]
-        public void ImplementAbstractStaticBinaryOperator_09([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=", "==", "!=")] string op, bool isChecked, bool isVirtual)
+        public void ImplementAbstractStaticBinaryOperator_09([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>", ">>>", "<", ">", "<=", ">=")] string op, bool isChecked, bool isVirtual)
         {
             // Explicit implementation from base is treated as an implementation
-
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
 
             string opName = GetBinaryOperatorName(op, isChecked, out string checkedKeyword);
 
@@ -19953,6 +20162,86 @@ public class C3 : C2, I1
 
                 Assert.Equal("I1 C2.I1." + opName + "(I1 x, System.Int32 y)", cM01.ToTestDisplayString());
                 Assert.Same(m01, cM01.ExplicitInterfaceImplementations.Single());
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void ImplementAbstractStaticEqualityOperator_09([CombinatorialValues("==", "!=")] string op, bool isVirtual)
+        {
+            // Explicit implementation from base is treated as an implementation
+
+            string opName = GetBinaryOperatorName(op, isChecked: false, checkedKeyword: out _);
+
+            if (opName is null)
+            {
+                return;
+            }
+
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
+            var source1 =
+@"
+public partial interface I1<T> where T : I1<T>
+{
+    " + modifier + @" static T operator " + op + @"(T x, int y)" + body + @"
+}
+
+public partial class C2<T> : I1<T> where T : I1<T>
+{
+    static T I1<T>.operator " + op + @"(T x, int y) => default;
+}
+";
+            string matchingOp = MatchingBinaryOperator(op);
+
+            source1 +=
+@"
+public partial interface I1<T>
+{
+    " + modifier + @" static T operator " + matchingOp + @"(T x, int y)" + body + @"
+}
+
+public partial class C2<T>
+{
+    static T I1<T>.operator " + matchingOp + @"(T x, int y) => default;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+            compilation1.VerifyDiagnostics();
+
+            var source2 =
+@"
+public class C3 : C2<C3>, I1<C3>
+{
+}
+";
+
+            foreach (var reference in new[] { compilation1.ToMetadataReference(), compilation1.EmitToImageReference() })
+            {
+                foreach (var parseOptions in new[] { TestOptions.Regular10, TestOptions.RegularPreview })
+                {
+                    var compilation2 = CreateCompilation(source2, options: TestOptions.DebugDll,
+                                                     parseOptions: parseOptions,
+                                                     targetFramework: _supportingFramework,
+                                                     references: new[] { reference });
+                    CompileAndVerify(compilation2, sourceSymbolValidator: validate, symbolValidator: validate, verify: Verification.Skipped).VerifyDiagnostics();
+                }
+            }
+
+            void validate(ModuleSymbol module)
+            {
+                var c3 = module.GlobalNamespace.GetTypeMember("C3");
+                Assert.Empty(c3.GetMembers().OfType<MethodSymbol>().Where(m => !m.IsConstructor()));
+                var m01 = c3.Interfaces().Single().GetMembers(opName).OfType<MethodSymbol>().Single();
+
+                var cM01 = (MethodSymbol)c3.FindImplementationForInterfaceMember(m01);
+
+                Assert.Equal("C3 C2<C3>.I1<C3>." + opName + "(C3 x, System.Int32 y)", cM01.ToTestDisplayString());
+                Assert.Equal(m01, cM01.ExplicitInterfaceImplementations.Single());
             }
         }
 
@@ -20518,11 +20807,6 @@ public class C1 : I2
         public void ImplementAbstractStaticBinaryOperator_13([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<", ">", "<=", ">=", "==", "!=")] string op, bool isChecked, bool isVirtual)
         {
             // A forwarding method is added for an implicit implementation declared in base class. 
-
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
 
             string opName = GetBinaryOperatorName(op, isChecked, out string checkedKeyword);
 
@@ -21160,10 +21444,6 @@ public class C3 : C2, I1
         public void ImplementAbstractStaticBinaryOperator_15([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<", ">", "<=", ">=", "==", "!=")] string op, bool isChecked, bool isVirtual)
         {
             // A forwarding method isn't created if base class implements interface exactly the same way. 
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
 
             string opName = GetBinaryOperatorName(op, isChecked, out string checkedKeyword);
 
@@ -21287,10 +21567,6 @@ public class C3 : C2, I1<C2>
         public void ImplementAbstractStaticBinaryOperator_16([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<", ">", "<=", ">=", "==", "!=")] string op, bool isChecked, bool isVirtual)
         {
             // A new implicit implementation is properly considered.
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
 
             string opName = GetBinaryOperatorName(op, isChecked, out string checkedKeyword);
 
@@ -21412,10 +21688,6 @@ public class C3 : C2, I1<C2>
         public void ImplementAbstractStaticBinaryOperator_18([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<", ">", "<=", ">=", "==", "!=")] string op, bool genericFirst, bool isChecked, bool isVirtual)
         {
             // An "ambiguity" in implicit implementation declared in generic base class plus interface is generic too.
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
 
             string opName = GetBinaryOperatorName(op, isChecked, out string checkedKeyword);
 
@@ -21527,11 +21799,6 @@ public class C2 : C1<int, int>, I1<C1<int, int>, int>
         public void ImplementAbstractStaticBinaryOperator_20([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<", ">", "<=", ">=", "==", "!=")] string op, bool genericFirst, bool isChecked, bool isVirtual)
         {
             // Same as ImplementAbstractStaticBinaryOperator_18 only implementation is explicit in source.
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
-
             string opName = GetBinaryOperatorName(op, isChecked, out string checkedKeyword);
 
             if (opName is null)
@@ -21630,11 +21897,6 @@ public class C2 : C1<int, int>, I1<C1<int, int>, int>
         public void ImplementAbstractStaticBinaryOperator_22([CombinatorialValues("+", "-", "*", "/", "%", "&", "|", "^", "<", ">", "<=", ">=", "==", "!=")] string op, bool genericFirst, bool isChecked, bool isVirtual)
         {
             // Same as ImplementAbstractStaticMethod_18 only implicit implementation is in an intermediate base.
-            if (isVirtual && op is "==" or "!=")
-            {
-                return;
-            }
-
             string opName = GetBinaryOperatorName(op, isChecked, out string checkedKeyword);
 
             if (opName is null)
@@ -22004,7 +22266,7 @@ struct
 
             Assert.Equal(Accessibility.Private, c1.GetMembers().OfType<MethodSymbol>().Where(m => !m.IsConstructor()).Single().DeclaredAccessibility);
 
-            compilation1.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.WRN_ExternMethodNoImplementation or (int)ErrorCode.ERR_OperatorNeedsMatch)).Verify(
+            compilation1.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.WRN_ExternMethodNoImplementation or (int)ErrorCode.ERR_OperatorNeedsMatch or (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature)).Verify(
                 // (16,35): error CS0106: The modifier 'private' is not valid for this item
                 //     private static I1 I1.operator ^(I1 x, int y) => default;
                 Diagnostic(ErrorCode.ERR_BadMemberFlag, op).WithArguments("private").WithLocation(16, 35),
@@ -22070,7 +22332,7 @@ class C2 : I1<C2>
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: _supportingFramework);
 
-            compilation1.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_OpTFRetType or (int)ErrorCode.ERR_OperatorNeedsMatch)).Verify(
+            compilation1.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_OpTFRetType or (int)ErrorCode.ERR_OperatorNeedsMatch or (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature)).Verify(
                 // (9,20): error CS0540: 'C1.I1<int>.operator -(I1<int>)': containing type does not implement interface 'I1<int>'
                 //     static I1<int> I1<int>.operator -(I1<int> x) => default;
                 Diagnostic(ErrorCode.ERR_ClassDoesntImplementInterface, "I1<int>").WithArguments("C1.I1<int>.operator " + op + "(I1<int>)", "I1<int>").WithLocation(9, 20),
@@ -22115,7 +22377,7 @@ struct C2 : I1<C2>
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: _supportingFramework);
 
-            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_OperatorNeedsMatch).Verify(
+            compilation1.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_OperatorNeedsMatch or (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature)).Verify(
                 // (9,23): error CS0540: 'C1.I1<string>.operator %(I1<string>, int)': containing type does not implement interface 'I1<string>'
                 //     static I1<string> I1<string>.operator %(I1<string> x, int y) => default;
                 Diagnostic(ErrorCode.ERR_ClassDoesntImplementInterface, "I1<string>").WithArguments("C1.I1<string>.operator " + op + "(I1<string>, int)", "I1<string>").WithLocation(9, 23),
@@ -27589,7 +27851,7 @@ public class C2 : C1<int>, I1<int>
                 _ => throw TestExceptionUtilities.UnexpectedValue(op)
             };
 
-        private static string GetConversionOperatorName(string op, bool isChecked, out string checkedKeyword)
+        internal static string GetConversionOperatorName(string op, bool isChecked, out string checkedKeyword)
         {
             string opName = ConversionOperatorName(op, isChecked: false);
             checkedKeyword = "";
@@ -27757,6 +28019,119 @@ public interface I2<T> where T : I2<T>
 
         [Theory]
         [CombinatorialData]
+        public void ImplementVirtualStaticConversionOperator_01([CombinatorialValues("implicit", "explicit")] string op, bool structure, bool isChecked)
+        {
+            string opName = GetConversionOperatorName(op, isChecked, out string checkedKeyword);
+
+            if (opName is null)
+            {
+                return;
+            }
+
+            var typeKeyword = structure ? "struct" : "class";
+
+            var source1 =
+@"
+public interface I1<T> where T : I1<T>
+{
+    virtual static " + op + @" operator " + checkedKeyword + @"int(T x) => default;
+}
+
+" + typeKeyword + @"
+    C1 : I1<C1>
+{}
+
+" + typeKeyword + @"
+    C2 : I1<C2>
+{
+    public " + op + @" operator " + checkedKeyword + @"int(C2 x) => throw null;
+}
+
+" + typeKeyword + @"
+    C3 : I1<C3>
+{
+    static " + op + @" operator " + checkedKeyword + @"int(C3 x) => throw null;
+}
+
+" + typeKeyword + @"
+    C4 : I1<C4>
+{
+    " + op + @" I1<C4>.operator " + checkedKeyword + @"int(C4 x) => throw null;
+}
+
+" + typeKeyword + @"
+    C5 : I1<C5>
+{
+    public static " + op + @" operator " + checkedKeyword + @"long(C5 x) => throw null;
+}
+
+" + typeKeyword + @"
+    C6 : I1<C6>
+{
+    static " + op + @" I1<C6>.operator " + checkedKeyword + @"long(C6 x) => throw null;
+}
+
+" + typeKeyword + @"
+    C7 : I1<C7>
+{
+    public static int " + opName + @"(C7 x) => throw null;
+}
+
+" + typeKeyword + @"
+    C8 : I1<C8>
+{
+    static int I1<C8>." + opName + @"(C8 x) => throw null;
+}
+
+public interface I2<T> where T : I2<T>
+{
+    virtual static int " + opName + @"(T x) => default;
+}
+
+" + typeKeyword + @"
+    C9 : I2<C9>
+{
+    public static " + op + @" operator " + checkedKeyword + @"int(C9 x) => throw null;
+}
+
+" + typeKeyword + @"
+    C10 : I2<C10>
+{
+    static " + op + @" I2<C10>.operator " + checkedKeyword + @"int(C10 x) => throw null;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_CheckedOperatorNeedsMatch).Verify(
+                // (14,30): error CS0558: User-defined operator 'C2.explicit operator int(C2)' must be declared static and public
+                //     public explicit operator int(C2 x) => throw null;
+                Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, "int").WithArguments("C2." + op + " operator " + checkedKeyword + "int(C2)").WithLocation(14, 30 + checkedKeyword.Length),
+                // (20,30): error CS0558: User-defined operator 'C3.explicit operator int(C3)' must be declared static and public
+                //     static explicit operator int(C3 x) => throw null;
+                Diagnostic(ErrorCode.ERR_OperatorsMustBeStatic, "int").WithArguments("C3." + op + " operator " + checkedKeyword + "int(C3)").WithLocation(20, 30 + checkedKeyword.Length),
+                // (26,30): error CS8930: Explicit implementation of a user-defined operator 'C4.explicit operator int(C4)' must be declared static
+                //     explicit I1<C4>.operator int(C4 x) => throw null;
+                Diagnostic(ErrorCode.ERR_ExplicitImplementationOfOperatorsMustBeStatic, "int").WithArguments("C4." + op + " operator " + checkedKeyword + "int(C4)").WithLocation(26, 30 + checkedKeyword.Length),
+                // (26,30): error CS0539: 'C4.explicit operator int(C4)' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     explicit I1<C4>.operator int(C4 x) => throw null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "int").WithArguments("C4." + op + " operator " + checkedKeyword + "int(C4)").WithLocation(26, 30 + checkedKeyword.Length),
+                // (38,37): error CS0539: 'C6.explicit operator long(C6)' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     static explicit I1<C6>.operator long(C6 x) => throw null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "long").WithArguments("C6." + op + " operator " + checkedKeyword + "long(C6)").WithLocation(38, 37 + checkedKeyword.Length),
+                // (50,23): error CS0539: 'C8.op_Explicit(C8)' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     static int I1<C8>.op_Explicit(C8 x) => throw null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, opName).WithArguments("C8." + opName + "(C8)").WithLocation(50, 23),
+                // (67,38): error CS0539: 'C10.explicit operator int(C10)' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     static explicit I2<C10>.operator int(C10 x) => throw null;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "int").WithArguments("C10." + op + " operator " + checkedKeyword + "int(C10)").WithLocation(67, 38 + checkedKeyword.Length)
+                );
+        }
+
+        [Theory]
+        [CombinatorialData]
         public void ImplementAbstractStaticConversionOperator_03([CombinatorialValues("implicit", "explicit")] string op, bool isChecked)
         {
             if (GetConversionOperatorName(op, isChecked, out string checkedKeyword) is null)
@@ -27843,42 +28218,36 @@ interface I14<T> : I1<T> where T : I1<T>
                 // (12,23): error CS0556: User-defined conversion must convert to or from the enclosing type
                 //     implicit operator int(T x) => default;
                 Diagnostic(ErrorCode.ERR_ConversionNotInvolvingContainedType, "int").WithLocation(12, 23 + checkedKeyword.Length),
-                // (12,23): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (12,23): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     implicit operator int(T x) => default;
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(12, 23 + checkedKeyword.Length),
                 // (17,30): error CS0556: User-defined conversion must convert to or from the enclosing type
                 //     static implicit operator int(T x) => default;
                 Diagnostic(ErrorCode.ERR_ConversionNotInvolvingContainedType, "int").WithLocation(17, 30 + checkedKeyword.Length),
-                // (17,30): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (17,30): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     static implicit operator int(T x) => default;
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(17, 30 + checkedKeyword.Length),
-                // (22,29): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (22,29): error CS8930: Explicit implementation of a user-defined operator 'I5<T>.implicit operator int(T)' must be declared static
                 //     implicit I1<T>.operator int(T x) => default;
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(22, 29 + checkedKeyword.Length),
+                Diagnostic(ErrorCode.ERR_ExplicitImplementationOfOperatorsMustBeStatic, "int").WithArguments("I5<T>." + op + " operator " + checkedKeyword + "int(T)").WithLocation(22, 29 + checkedKeyword.Length),
                 // (22,29): error CS0539: 'I5<T>.implicit operator int(T)' in explicit interface declaration is not found among members of the interface that can be implemented
                 //     implicit I1<T>.operator int(T x) => default;
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "int").WithArguments("I5<T>." + op + " operator " + checkedKeyword + "int(T)").WithLocation(22, 29 + checkedKeyword.Length),
-                // (27,36): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     static implicit I1<T>.operator int(T x) => default;
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(27, 36 + checkedKeyword.Length),
                 // (32,39): error CS8931: User-defined conversion in an interface must convert to or from a type parameter on the enclosing type constrained to the enclosing type
                 //     abstract static implicit operator int(T x);
                 Diagnostic(ErrorCode.ERR_AbstractConversionNotInvolvingContainedType, "int").WithLocation(32, 39 + checkedKeyword.Length),
                 // (42,23): error CS0556: User-defined conversion must convert to or from the enclosing type
                 //     implicit operator int(T x) => default;
                 Diagnostic(ErrorCode.ERR_ConversionNotInvolvingContainedType, "int").WithLocation(42, 23 + checkedKeyword.Length),
-                // (42,23): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (42,23): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     implicit operator int(T x) => default;
                 Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(42, 23 + checkedKeyword.Length),
                 // (47,30): error CS0556: User-defined conversion must convert to or from the enclosing type
                 //     static implicit operator int(T x) => default;
                 Diagnostic(ErrorCode.ERR_ConversionNotInvolvingContainedType, "int").WithLocation(47, 30 + checkedKeyword.Length),
-                // (47,30): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
+                // (47,30): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
                 //     static implicit operator int(T x) => default;
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(47, 30 + checkedKeyword.Length),
-                // (57,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                //     static implicit I11<T>.operator int(T x) => default;
-                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(57, 37 + checkedKeyword.Length)
+                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(47, 30 + checkedKeyword.Length)
                 );
 
             var i2 = compilation1.GlobalNamespace.GetTypeMember("I2");
@@ -27920,20 +28289,188 @@ interface I14<T> : I1<T> where T : I1<T>
 
         [Theory]
         [CombinatorialData]
-        public void ImplementAbstractStaticConversionOperator_04([CombinatorialValues("implicit", "explicit")] string op, bool structure, bool isChecked)
+        public void ImplementVirtualStaticConversionOperator_03([CombinatorialValues("implicit", "explicit")] string op, bool isChecked)
         {
             if (GetConversionOperatorName(op, isChecked, out string checkedKeyword) is null)
             {
                 return;
             }
 
+            var source1 =
+@"
+public interface I1<T> where T : I1<T>
+{
+    virtual  static " + op + @" operator " + checkedKeyword + @"int(T x) => default;
+}
+
+interface I2<T> : I1<T> where T : I1<T>
+{}
+
+interface I3<T> : I1<T> where T : I1<T>
+{
+    " + op + @" operator " + checkedKeyword + @"int(T x) => default;
+}
+
+interface I4<T> : I1<T> where T : I1<T>
+{
+    static " + op + @" operator " + checkedKeyword + @"int(T x) => default;
+}
+
+interface I5<T> : I1<T> where T : I1<T>
+{
+    " + op + @" I1<T>.operator " + checkedKeyword + @"int(T x) => default;
+}
+
+interface I6<T> : I1<T> where T : I1<T>
+{
+    static " + op + @" I1<T>.operator " + checkedKeyword + @"int(T x) => default;
+}
+
+interface I7<T> : I1<T> where T : I1<T>
+{
+    virtual  static " + op + @" operator " + checkedKeyword + @"int(T x) => default;
+}
+
+public interface I11<T> where T : I11<T>
+{
+    virtual  static " + op + @" operator " + checkedKeyword + @"int(T x) => default;
+}
+
+interface I8<T> : I11<T> where T : I8<T>
+{
+    " + op + @" operator " + checkedKeyword + @"int(T x) => default;
+}
+
+interface I9<T> : I11<T> where T : I9<T>
+{
+    static " + op + @" operator " + checkedKeyword + @"int(T x) => default;
+}
+
+interface I10<T> : I11<T> where T : I10<T>
+{
+    virtual  static " + op + @" operator " + checkedKeyword + @"int(T x) => default;
+}
+
+interface I12<T> : I11<T> where T : I12<T>
+{
+    static " + op + @" I11<T>.operator " + checkedKeyword + @"int(T x) => default;
+}
+
+interface I13<T> : I11<T> where T : I13<T>
+{
+    virtual  static " + op + @" I11<T>.operator " + checkedKeyword + @"int(T x) => default;
+}
+
+interface I14<T> : I1<T> where T : I1<T>
+{
+    virtual  static " + op + @" I1<T>.operator " + checkedKeyword + @"int(T x) => default;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_CheckedOperatorNeedsMatch).Verify(
+                // (12,23): error CS0556: User-defined conversion must convert to or from the enclosing type
+                //     implicit operator int(T x) => default;
+                Diagnostic(ErrorCode.ERR_ConversionNotInvolvingContainedType, "int").WithLocation(12, 23 + checkedKeyword.Length),
+                // (12,23): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
+                //     implicit operator int(T x) => default;
+                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(12, 23 + checkedKeyword.Length),
+                // (17,30): error CS0556: User-defined conversion must convert to or from the enclosing type
+                //     static implicit operator int(T x) => default;
+                Diagnostic(ErrorCode.ERR_ConversionNotInvolvingContainedType, "int").WithLocation(17, 30 + checkedKeyword.Length),
+                // (17,30): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
+                //     static implicit operator int(T x) => default;
+                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(17, 30 + checkedKeyword.Length),
+                // (22,29): error CS8930: Explicit implementation of a user-defined operator 'I5<T>.implicit operator int(T)' must be declared static
+                //     implicit I1<T>.operator int(T x) => default;
+                Diagnostic(ErrorCode.ERR_ExplicitImplementationOfOperatorsMustBeStatic, "int").WithArguments("I5<T>." + op + " operator " + checkedKeyword + "int(T)").WithLocation(22, 29 + checkedKeyword.Length),
+                // (22,29): error CS0539: 'I5<T>.implicit operator int(T)' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     implicit I1<T>.operator int(T x) => default;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "int").WithArguments("I5<T>." + op + " operator " + checkedKeyword + "int(T)").WithLocation(22, 29 + checkedKeyword.Length),
+                // (32,39): error CS8931: User-defined conversion in an interface must convert to or from a type parameter on the enclosing type constrained to the enclosing type
+                //     virtual  static implicit operator int(T x) => default;
+                Diagnostic(ErrorCode.ERR_AbstractConversionNotInvolvingContainedType, "int").WithLocation(32, 39 + checkedKeyword.Length),
+                // (42,23): error CS0556: User-defined conversion must convert to or from the enclosing type
+                //     implicit operator int(T x) => default;
+                Diagnostic(ErrorCode.ERR_ConversionNotInvolvingContainedType, "int").WithLocation(42, 23 + checkedKeyword.Length),
+                // (42,23): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
+                //     implicit operator int(T x) => default;
+                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(42, 23 + checkedKeyword.Length),
+                // (47,30): error CS0556: User-defined conversion must convert to or from the enclosing type
+                //     static implicit operator int(T x) => default;
+                Diagnostic(ErrorCode.ERR_ConversionNotInvolvingContainedType, "int").WithLocation(47, 30 + checkedKeyword.Length),
+                // (47,30): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract or virtual
+                //     static implicit operator int(T x) => default;
+                Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(47, 30 + checkedKeyword.Length),
+                // (62,46): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual  static implicit I11<T>.operator int(T x) => default;
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "int").WithArguments("virtual").WithLocation(62, 46 + checkedKeyword.Length),
+                // (67,45): error CS0106: The modifier 'virtual' is not valid for this item
+                //     virtual  static implicit I1<T>.operator int(T x) => default;
+                Diagnostic(ErrorCode.ERR_BadMemberFlag, "int").WithArguments("virtual").WithLocation(67, 45 + checkedKeyword.Length)
+                );
+
+            var i2 = compilation1.GlobalNamespace.GetTypeMember("I2");
+            var m01 = i2.Interfaces().Single().GetMembers().OfType<MethodSymbol>().Single();
+            Assert.Equal(m01, i2.FindImplementationForInterfaceMember(m01));
+
+            var i3 = compilation1.GlobalNamespace.GetTypeMember("I3");
+            m01 = i3.Interfaces().Single().GetMembers().OfType<MethodSymbol>().Single();
+            Assert.Equal(m01, i3.FindImplementationForInterfaceMember(m01));
+
+            var i4 = compilation1.GlobalNamespace.GetTypeMember("I4");
+            m01 = i4.Interfaces().Single().GetMembers().OfType<MethodSymbol>().Single();
+            Assert.Equal(m01, i4.FindImplementationForInterfaceMember(m01));
+
+            var i5 = compilation1.GlobalNamespace.GetTypeMember("I5");
+            m01 = i5.Interfaces().Single().GetMembers().OfType<MethodSymbol>().Single();
+            Assert.Equal(m01, i5.FindImplementationForInterfaceMember(m01));
+
+            var i6 = compilation1.GlobalNamespace.GetTypeMember("I6");
+            Assert.Same(i6.GetMembers().OfType<MethodSymbol>().Single(), i6.FindImplementationForInterfaceMember(i6.Interfaces().Single().GetMembers().OfType<MethodSymbol>().Single()));
+
+            var i7 = compilation1.GlobalNamespace.GetTypeMember("I7");
+            m01 = i7.Interfaces().Single().GetMembers().OfType<MethodSymbol>().Single();
+            Assert.Equal(m01, i7.FindImplementationForInterfaceMember(m01));
+
+            foreach (var name in new[] { "I8", "I9", "I10" })
+            {
+                var iX = compilation1.GlobalNamespace.GetTypeMember(name);
+                var iXM = iX.Interfaces().Single().GetMembers().OfType<MethodSymbol>().Single();
+                Assert.Equal(iXM, iX.FindImplementationForInterfaceMember(iXM));
+            }
+
+            foreach (var name in new[] { "I12", "I13" })
+            {
+                var iX = compilation1.GlobalNamespace.GetTypeMember(name);
+                var iXM = iX.Interfaces().Single().GetMembers().OfType<MethodSymbol>().Single();
+                Assert.Equal(iX.GetMembers().OfType<MethodSymbol>().Single(), iX.FindImplementationForInterfaceMember(iXM));
+            }
+
+            var i14 = compilation1.GlobalNamespace.GetTypeMember("I14");
+            Assert.Same(i14.GetMembers().OfType<MethodSymbol>().Single(), i14.FindImplementationForInterfaceMember(i14.Interfaces().Single().GetMembers().OfType<MethodSymbol>().Single()));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void ImplementAbstractStaticConversionOperator_04([CombinatorialValues("implicit", "explicit")] string op, bool structure, bool isChecked, bool isVirtual)
+        {
+            if (GetConversionOperatorName(op, isChecked, out string checkedKeyword) is null)
+            {
+                return;
+            }
+
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             var typeKeyword = structure ? "struct" : "class";
 
             var source1 =
 @"
 public interface I2<T> where T : I2<T>
 {
-    abstract static " + op + @" operator " + checkedKeyword + @"int(T x);
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"int(T x)" + body + @"
 }
 ";
             var source2 =
@@ -27998,7 +28535,7 @@ typeKeyword + @"
                     Diagnostic(ErrorCode.ERR_FeatureInPreview, "I2<Test1>.").WithArguments("static abstract members in interfaces").WithLocation(4, 21),
                     // (14,39): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                     //     abstract static explicit operator int(T x);
-                    Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments("abstract", "10.0", "preview").WithLocation(14, 39)
+                    Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments(modifier.Trim(), "10.0", "preview").WithLocation(14, 39)
                     );
             }
             else
@@ -28018,27 +28555,28 @@ typeKeyword + @"
                     Diagnostic(ErrorCode.ERR_FeatureInPreview, "checked").WithArguments("checked user-defined operators").WithLocation(14, 39),
                     // (14,47): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                     //     abstract static explicit operator checked int(T x);
-                    Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments("abstract", "10.0", "preview").WithLocation(14, 47)
+                    Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments(modifier.Trim(), "10.0", "preview").WithLocation(14, 47)
                     );
             }
         }
 
         [Theory]
         [CombinatorialData]
-        public void ImplementAbstractStaticConversionOperator_05([CombinatorialValues("implicit", "explicit")] string op, bool structure, bool isChecked)
+        public void ImplementAbstractStaticConversionOperator_05([CombinatorialValues("implicit", "explicit")] string op, bool structure, bool isChecked, bool isVirtual)
         {
             if (GetConversionOperatorName(op, isChecked, out string checkedKeyword) is null)
             {
                 return;
             }
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             var typeKeyword = structure ? "struct" : "class";
 
             var source1 =
 @"
 public partial interface I1<T> where T : I1<T> 
 {
-    abstract static " + op + @" operator " + checkedKeyword + @"int(T x);
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"int(T x)" + body + @"
 }
 ";
             var source2 =
@@ -28076,20 +28614,21 @@ public partial interface I1<T> where T : I1<T>
 
         [Theory]
         [CombinatorialData]
-        public void ImplementAbstractStaticConversionOperator_06([CombinatorialValues("implicit", "explicit")] string op, bool structure, bool isChecked)
+        public void ImplementAbstractStaticConversionOperator_06([CombinatorialValues("implicit", "explicit")] string op, bool structure, bool isChecked, bool isVirtual)
         {
             if (GetConversionOperatorName(op, isChecked, out string checkedKeyword) is null)
             {
                 return;
             }
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             var typeKeyword = structure ? "struct" : "class";
 
             var source1 =
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator " + checkedKeyword + @"int(T x);
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"int(T x)" + body + @"
 }
 ";
             var source2 =
@@ -28130,7 +28669,7 @@ typeKeyword + @"
 
         [Theory]
         [CombinatorialData]
-        public void ImplementAbstractStaticConversionOperator_07([CombinatorialValues("implicit", "explicit")] string op, bool structure, bool isChecked)
+        public void ImplementAbstractStaticConversionOperator_07([CombinatorialValues("implicit", "explicit")] string op, bool structure, bool isChecked, bool isVirtual)
         {
             // Basic implicit implementation scenario, MethodImpl is emitted
 
@@ -28141,14 +28680,15 @@ typeKeyword + @"
                 return;
             }
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             var typeKeyword = structure ? "struct" : "class";
 
             var source1 =
 @"
 public partial interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator " + checkedKeyword + @"int(T x);
-    abstract static " + op + @" operator " + checkedKeyword + @"long(T x);
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"int(T x)" + body + @"
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"long(T x)" + body + @"
 }
 
 partial " + typeKeyword + @"
@@ -28164,8 +28704,8 @@ partial " + typeKeyword + @"
 @"
 public partial interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator int(T x);
-    abstract static " + op + @" operator long(T x);
+    " + modifier + @" static " + op + @" operator int(T x)" + body + @"
+    " + modifier + @" static " + op + @" operator long(T x)" + body + @"
 }
 
 partial " + typeKeyword + @"
@@ -28246,7 +28786,7 @@ partial " + typeKeyword + @"
 
         [Theory]
         [CombinatorialData]
-        public void ImplementAbstractStaticConversionOperator_08([CombinatorialValues("implicit", "explicit")] string op, bool structure, bool isChecked)
+        public void ImplementAbstractStaticConversionOperator_08([CombinatorialValues("implicit", "explicit")] string op, bool structure, bool isChecked, bool isVirtual)
         {
             // Basic explicit implementation scenario
 
@@ -28257,14 +28797,15 @@ partial " + typeKeyword + @"
                 return;
             }
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             var typeKeyword = structure ? "struct" : "class";
 
             var source1 =
 @"
 partial interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator " + checkedKeyword + @"C(T x);
-    abstract static " + op + @" operator " + checkedKeyword + @"int(T x);
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"C(T x)" + body + @"
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"int(T x)" + body + @"
 }
 
 partial " + typeKeyword + @"
@@ -28280,8 +28821,8 @@ partial " + typeKeyword + @"
 @"
 partial interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator C(T x);
-    abstract static " + op + @" operator int(T x);
+    " + modifier + @" static " + op + @" operator C(T x)" + body + @"
+    " + modifier + @" static " + op + @" operator int(T x)" + body + @"
 }
 
 partial " + typeKeyword + @"
@@ -28299,7 +28840,7 @@ partial " + typeKeyword + @"
 
             var tree = compilation1.SyntaxTrees.Single();
             var model = compilation1.GetSemanticModel(tree);
-            var node = tree.GetRoot().DescendantNodes().OfType<LiteralExpressionSyntax>().First();
+            var node = tree.GetRoot().DescendantNodes().OfType<LiteralExpressionSyntax>().Where(l => l.ToString() == "default").First();
 
             Assert.Equal("default", node.ToString());
             Assert.Equal("C", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString());
@@ -28354,7 +28895,7 @@ partial " + typeKeyword + @"
 
         [Theory]
         [CombinatorialData]
-        public void ImplementAbstractStaticConversionOperator_09([CombinatorialValues("implicit", "explicit")] string op, bool isChecked)
+        public void ImplementAbstractStaticConversionOperator_09([CombinatorialValues("implicit", "explicit")] string op, bool isChecked, bool isVirtual)
         {
             // Explicit implementation from base is treated as an implementation
 
@@ -28365,11 +28906,13 @@ partial " + typeKeyword + @"
                 return;
             }
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
             var source1 =
 @"
 public partial interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator " + checkedKeyword + @"int(T x);
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"int(T x)" + body + @"
 }
 
 public partial class C2 : I1<C2>
@@ -28383,7 +28926,7 @@ public partial class C2 : I1<C2>
 @"
 public partial interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator int(T x);
+    " + modifier + @" static " + op + @" operator int(T x)" + body + @"
 }
 
 public partial class C2 : I1<C2>
@@ -28727,7 +29270,7 @@ public class C1 : I2<C1>
 
         [Theory]
         [CombinatorialData]
-        public void ImplementAbstractStaticConversionOperator_13([CombinatorialValues("implicit", "explicit")] string op, bool isChecked)
+        public void ImplementAbstractStaticConversionOperator_13([CombinatorialValues("implicit", "explicit")] string op, bool isChecked, bool isVirtual)
         {
             // A forwarding method is added for an implicit implementation declared in base class. 
 
@@ -28738,11 +29281,13 @@ public class C1 : I2<C1>
                 return;
             }
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
             var source1 =
 @"
 public partial interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator " + checkedKeyword + @"C1<T>(T x);
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"C1<T>(T x)" + body + @"
 }
 
 public partial class C1<T>
@@ -28759,7 +29304,7 @@ public class C2 : C1<C2>, I1<C2>
                 source1 += @"
 public partial interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator C1<T>(T x);
+    " + modifier + @" static " + op + @" operator C1<T>(T x)" + body + @"
 }
 
 public partial class C1<T>
@@ -28963,7 +29508,7 @@ partial class C1 : I1<C1>
 
         [Theory]
         [CombinatorialData]
-        public void ImplementAbstractStaticConversionOperator_15([CombinatorialValues("implicit", "explicit")] string op, bool isChecked)
+        public void ImplementAbstractStaticConversionOperator_15([CombinatorialValues("implicit", "explicit")] string op, bool isChecked, bool isVirtual)
         {
             // A forwarding method isn't created if base class implements interface exactly the same way. 
 
@@ -28974,12 +29519,14 @@ partial class C1 : I1<C1>
                 return;
             }
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
             var source1 =
 @"
 public partial interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator " + checkedKeyword + @"C1<T>(T x);
-    abstract static " + op + @" operator " + checkedKeyword + @"T(int x);
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"C1<T>(T x)" + body + @"
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"T(int x)" + body + @"
 }
 
 public partial class C1<T>
@@ -28998,8 +29545,8 @@ public partial class C2 : C1<C2>, I1<C2>
 @"
 public partial interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator C1<T>(T x);
-    abstract static " + op + @" operator T(int x);
+    " + modifier + @" static " + op + @" operator C1<T>(T x)" + body + @"
+    " + modifier + @" static " + op + @" operator T(int x)" + body + @"
 }
 
 public partial class C1<T>
@@ -29079,7 +29626,7 @@ public class C3 : C2, I1<C2>
 
         [Theory]
         [CombinatorialData]
-        public void ImplementAbstractStaticConversionOperator_18([CombinatorialValues("implicit", "explicit")] string op, bool genericFirst, bool isChecked)
+        public void ImplementAbstractStaticConversionOperator_18([CombinatorialValues("implicit", "explicit")] string op, bool genericFirst, bool isChecked, bool isVirtual)
         {
             // An "ambiguity" in implicit implementation declared in generic base class plus interface is generic too.
 
@@ -29089,6 +29636,8 @@ public class C3 : C2, I1<C2>
             {
                 return;
             }
+
+            var (modifier, body) = GetModifierAndBody(isVirtual);
 
             var generic =
 @"
@@ -29102,7 +29651,7 @@ public class C3 : C2, I1<C2>
 @"
 public partial interface I1<T, U> where T : I1<T, U>
 {
-    abstract static " + op + @" operator " + checkedKeyword + @"U(T x);
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"U(T x)" + body + @"
 }
 
 public partial class C1<T, U> : I1<C1<T, U>, U>
@@ -29116,7 +29665,7 @@ public partial class C1<T, U> : I1<C1<T, U>, U>
 @"
 public partial interface I1<T, U> where T : I1<T, U>
 {
-    abstract static " + op + @" operator U(T x);
+    " + modifier + @" static " + op + @" operator U(T x)" + body + @"
 }
 
 public partial class C1<T, U> : I1<C1<T, U>, U>
@@ -29183,7 +29732,7 @@ public class C2 : C1<int, int>, I1<C1<int, int>, int>
 
         [Theory]
         [CombinatorialData]
-        public void ImplementAbstractStaticConversionOperator_20([CombinatorialValues("implicit", "explicit")] string op, bool genericFirst, bool isChecked)
+        public void ImplementAbstractStaticConversionOperator_20([CombinatorialValues("implicit", "explicit")] string op, bool genericFirst, bool isChecked, bool isVirtual)
         {
             // Same as ImplementAbstractStaticConversionOperator_18 only implementation is explicit in source.
 
@@ -29193,6 +29742,8 @@ public class C2 : C1<int, int>, I1<C1<int, int>, int>
             {
                 return;
             }
+
+            var (modifier, body) = GetModifierAndBody(isVirtual);
 
             var generic =
 @"
@@ -29206,7 +29757,7 @@ public class C2 : C1<int, int>, I1<C1<int, int>, int>
 @"
 public partial interface I1<T, U> where T : I1<T, U>
 {
-    abstract static " + op + @" operator " + checkedKeyword + @"U(T x);
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"U(T x)" + body + @"
 }
 
 public partial class C1<T, U> : I1<C1<T, U>, U>
@@ -29220,7 +29771,7 @@ public partial class C1<T, U> : I1<C1<T, U>, U>
 @"
 public partial interface I1<T, U> where T : I1<T, U>
 {
-    abstract static " + op + @" operator U(T x);
+    " + modifier + @" static " + op + @" operator U(T x)" + body + @"
 }
 
 public partial class C1<T, U> : I1<C1<T, U>, U>
@@ -29459,7 +30010,7 @@ class C2 : I1<C2>
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperator_01([CombinatorialValues("implicit", "explicit")] string op, bool isChecked)
+        public void ConsumeAbstractConversionOperator_01([CombinatorialValues("implicit", "explicit")] string op, bool isChecked, bool isVirtual)
         {
             bool isExplicit = op == "explicit";
 
@@ -29468,6 +30019,7 @@ class C2 : I1<C2>
                 return;
             }
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             string checkedKeyword = isChecked ? " checked " : "";
             string cast = (isExplicit ? "(int)" : "");
 
@@ -29475,7 +30027,7 @@ class C2 : I1<C2>
 @"
 interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator " + checkedKeyword + @"int(T x);
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"int(T x)" + body + @"
 
     static int M02(I1<T> x)
     {" + checkedKeyword + @"{
@@ -29525,13 +30077,15 @@ class Test<T> where T : I1<T>
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperatorForTupleEquality_01([CombinatorialValues("==", "!=")] string op)
+        public void ConsumeAbstractConversionOperatorForTupleEquality_01([CombinatorialValues("==", "!=")] string op, bool isVirtual)
         {
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
             var source1 =
 @"
 interface I1
 {
-    abstract static implicit operator bool(I1 x);
+    " + modifier + @" static implicit operator bool(I1 x)" + body + @"
 
 
     static void M02((int, C<I1>) x)
@@ -29571,25 +30125,16 @@ class C<T>
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: _supportingFramework);
 
-            compilation1.VerifyDiagnostics(
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers).Verify(
                 // (4,39): error CS0552: 'I1.implicit operator bool(I1)': user-defined conversions to or from an interface are not allowed
                 //     abstract static implicit operator bool(I1 x);
                 Diagnostic(ErrorCode.ERR_ConversionWithInterface, "bool").WithArguments("I1.implicit operator bool(I1)").WithLocation(4, 39),
-                // (7,34): error CS8920: The interface 'I1' cannot be used as type argument. Static member 'I1.implicit operator bool(I1)' does not have a most specific implementation in the interface.
-                //     static void M02((int, C<I1>) x)
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "x").WithArguments("I1", "I1.implicit operator bool(I1)").WithLocation(7, 34),
                 // (9,13): error CS0029: Cannot implicitly convert type 'I1' to 'bool'
                 //         _ = x == x;
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "x " + op + " x").WithArguments("I1", "bool").WithLocation(9, 13),
-                // (12,27): error CS8920: The interface 'I1' cannot be used as type argument. Static member 'I1.implicit operator bool(I1)' does not have a most specific implementation in the interface.
-                //     void M03((int, C<I1>) y)
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "y").WithArguments("I1", "I1.implicit operator bool(I1)").WithLocation(12, 27),
                 // (14,13): error CS0029: Cannot implicitly convert type 'I1' to 'bool'
                 //         _ = y == y;
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "y " + op + " y").WithArguments("I1", "bool").WithLocation(14, 13),
-                // (20,34): error CS8920: The interface 'I1' cannot be used as type argument. Static member 'I1.implicit operator bool(I1)' does not have a most specific implementation in the interface.
-                //     static void MT1((int, C<I1>) a)
-                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedInterfaceWithStaticAbstractMembers, "a").WithArguments("I1", "I1.implicit operator bool(I1)").WithLocation(20, 34),
                 // (22,13): error CS0029: Cannot implicitly convert type 'I1' to 'bool'
                 //         _ = a == a;
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "a " + op + " a").WithArguments("I1", "bool").WithLocation(22, 13),
@@ -29601,7 +30146,7 @@ class C<T>
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperator_03([CombinatorialValues("implicit", "explicit")] string op, bool isCheckedOperator, bool isCheckedContext)
+        public void ConsumeAbstractConversionOperator_03([CombinatorialValues("implicit", "explicit")] string op, bool isCheckedOperator, bool isCheckedContext, bool isVirtual)
         {
             string metadataName = GetConversionOperatorName(op, isCheckedOperator, out string checkedKeyword);
 
@@ -29615,6 +30160,7 @@ class C<T>
                 metadataName = ConversionOperatorName(op, isChecked: false);
             }
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             string contextKeyword = isCheckedContext ? " checked " : " unchecked ";
             bool needCast = op == "explicit";
 
@@ -29622,14 +30168,14 @@ class C<T>
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator int(T x);
+    " + modifier + @" static " + op + @" operator int(T x)" + body + @"
 "
 ;
             if (isCheckedOperator)
             {
                 source1 +=
 @"
-    abstract static " + op + @" operator checked int(T x);
+    " + modifier + @" static " + op + @" operator checked int(T x)" + body + @"
 "
 ;
             }
@@ -29821,13 +30367,15 @@ IReturnOperation (OperationKind.Return, Type: null) (Syntax: 'return " + (needCa
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperatorForTupleEquality_03([CombinatorialValues("==", "!=")] string op)
+        public void ConsumeAbstractConversionOperatorForTupleEquality_03([CombinatorialValues("==", "!=")] string op, bool isVirtual)
         {
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
             var source1 =
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static implicit operator bool (T x);
+    " + modifier + @" static implicit operator bool (T x)" + body + @"
 }
 
 class Test
@@ -30010,7 +30558,7 @@ ITupleBinaryOperation (BinaryOperatorKind." + (op == "==" ? "Equals" : "NotEqual
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperator_04([CombinatorialValues("implicit", "explicit")] string op, bool isChecked)
+        public void ConsumeAbstractConversionOperator_04([CombinatorialValues("implicit", "explicit")] string op, bool isChecked, bool isVirtual)
         {
             bool needCast = op == "explicit";
 
@@ -30019,13 +30567,14 @@ ITupleBinaryOperation (BinaryOperatorKind." + (op == "==" ? "Equals" : "NotEqual
                 return;
             }
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             string checkedKeyword = isChecked ? " checked " : "";
 
             var source1 =
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator " + checkedKeyword + @"int(T x);
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"int(T x)" + body + @"
 }
 ";
             var source2 =
@@ -30066,13 +30615,15 @@ class Test
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperatorForTupleEquality_04([CombinatorialValues("==", "!=")] string op)
+        public void ConsumeAbstractConversionOperatorForTupleEquality_04([CombinatorialValues("==", "!=")] string op, bool isVirtual)
         {
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
             var source1 =
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static implicit operator bool(T x);
+    " + modifier + @" static implicit operator bool(T x)" + body + @"
 }
 ";
             var source2 =
@@ -30122,7 +30673,7 @@ class C<T>
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperator_06([CombinatorialValues("implicit", "explicit")] string op, bool isChecked)
+        public void ConsumeAbstractConversionOperator_06([CombinatorialValues("implicit", "explicit")] string op, bool isChecked, bool isVirtual)
         {
             bool needCast = op == "explicit";
 
@@ -30131,13 +30682,14 @@ class C<T>
                 return;
             }
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             string checkedKeyword = isChecked ? " checked " : "";
 
             var source1 =
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator " + checkedKeyword + @"int(T x);
+    " + modifier + @" static " + op + @" operator " + checkedKeyword + @"int(T x)" + body + @"
 }
 ";
             var source2 =
@@ -30191,7 +30743,7 @@ class Test
                     Diagnostic(ErrorCode.ERR_FeatureInPreview, "checked").WithArguments("checked user-defined operators").WithLocation(12, 40),
                     // (12,48): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                     //     abstract static explicit operator  checked int(T x);
-                    Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments("abstract", "10.0", "preview").WithLocation(12, 48)
+                    Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments(modifier.Trim(), "10.0", "preview").WithLocation(12, 48)
                     );
             }
             else
@@ -30199,20 +30751,22 @@ class Test
                 compilation3.VerifyDiagnostics(
                     // (12,39): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                     //     abstract static implicit operator int(T x);
-                    Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments("abstract", "10.0", "preview").WithLocation(12, 39)
+                    Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "int").WithArguments(modifier.Trim(), "10.0", "preview").WithLocation(12, 39)
                     );
             }
         }
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperatorForTupleEquality_06([CombinatorialValues("==", "!=")] string op)
+        public void ConsumeAbstractConversionOperatorForTupleEquality_06([CombinatorialValues("==", "!=")] string op, bool isVirtual)
         {
+            var (modifier, body) = GetModifierAndBody(isVirtual);
+
             var source1 =
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static implicit operator bool(T x);
+    " + modifier + @" static implicit operator bool(T x)" + body + @"
 }
 ";
             var source2 =
@@ -30256,16 +30810,17 @@ class C<T>
             compilation3.VerifyDiagnostics(
                 // (21,39): error CS8703: The modifier 'abstract' is not valid for this item in C# 10.0. Please use language version 'preview' or greater.
                 //     abstract static implicit operator bool(T x);
-                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "bool").WithArguments("abstract", "10.0", "preview").WithLocation(21, 39)
+                Diagnostic(ErrorCode.ERR_InvalidModifierForLanguageVersion, "bool").WithArguments(modifier.Trim(), "10.0", "preview").WithLocation(21, 39)
                 );
         }
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperator_07([CombinatorialValues("implicit", "explicit")] string op)
+        public void ConsumeAbstractConversionOperator_07([CombinatorialValues("implicit", "explicit")] string op, bool isVirtual)
         {
             // Same as ConsumeAbstractConversionOperator_03 only direction of conversion is flipped
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             string metadataName = ConversionOperatorName(op);
             bool needCast = op == "explicit";
 
@@ -30273,7 +30828,7 @@ class C<T>
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator T(int x);
+    " + modifier + @" static " + op + @" operator T(int x)" + body + @"
 }
 
 class Test
@@ -30473,10 +31028,11 @@ IReturnOperation (OperationKind.Return, Type: null) (Syntax: 'return " + (needCa
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperator_08([CombinatorialValues("implicit", "explicit")] string op)
+        public void ConsumeAbstractConversionOperator_08([CombinatorialValues("implicit", "explicit")] string op, bool isVirtual)
         {
             // Don't look in interfaces of the effective base
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             string metadataName = ConversionOperatorName(op);
             bool needCast = op == "explicit";
 
@@ -30484,7 +31040,7 @@ IReturnOperation (OperationKind.Return, Type: null) (Syntax: 'return " + (needCa
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator int(T x);
+    " + modifier + @" static " + op + @" operator int(T x)" + body + @"
 }
 
 class C1<T> : I1<C1<T>>
@@ -30523,10 +31079,11 @@ class Test
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperator_09([CombinatorialValues("implicit", "explicit")] string op)
+        public void ConsumeAbstractConversionOperator_09([CombinatorialValues("implicit", "explicit")] string op, bool isVirtual)
         {
             // Same as ConsumeAbstractConversionOperator_08 only direction of conversion is flipped
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             string metadataName = ConversionOperatorName(op);
             bool needCast = op == "explicit";
 
@@ -30534,7 +31091,7 @@ class Test
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator T(int x);
+    " + modifier + @" static " + op + @" operator T(int x)" + body + @"
 }
 
 class C1<T> : I1<C1<T>>
@@ -30573,10 +31130,11 @@ class Test
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperator_10([CombinatorialValues("implicit", "explicit")] string op)
+        public void ConsumeAbstractConversionOperator_10([CombinatorialValues("implicit", "explicit")] string op, bool isVirtual)
         {
             // Look in base interfaces for source 
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             string metadataName = ConversionOperatorName(op);
             bool needCast = op == "explicit";
 
@@ -30584,7 +31142,7 @@ class Test
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator int(T x);
+    " + modifier + @" static " + op + @" operator int(T x)" + body + @"
 }
 
 public interface I2<T> : I1<T> where T : I1<T>
@@ -30689,10 +31247,11 @@ class Test
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperator_12([CombinatorialValues("implicit", "explicit")] string op)
+        public void ConsumeAbstractConversionOperator_12([CombinatorialValues("implicit", "explicit")] string op, bool isVirtual)
         {
             // Ignore duplicate candidates
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             string metadataName = ConversionOperatorName(op);
             bool needCast = op == "explicit";
 
@@ -30700,7 +31259,7 @@ class Test
 @"
 public interface I1<T, U> where T : I1<T, U> where U : I1<T, U>
 {
-    abstract static " + op + @" operator U(T x);
+    " + modifier + @" static " + op + @" operator U(T x)" + body + @"
 }
 
 class Test
@@ -30828,10 +31387,11 @@ class Test
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperator_15([CombinatorialValues("implicit", "explicit")] string op)
+        public void ConsumeAbstractConversionOperator_15([CombinatorialValues("implicit", "explicit")] string op, bool isVirtual)
         {
             // If there is an applicable candidate in effective base class, interfaces are not looked at.
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             string metadataName = ConversionOperatorName(op);
             bool needCast = op == "explicit";
 
@@ -30839,7 +31399,7 @@ class Test
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator int(T x);
+    " + modifier + @" static " + op + @" operator int(T x)" + body + @"
 }
 
 public class C1 : I1<C1>
@@ -30930,17 +31490,18 @@ class Test
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperator_17([CombinatorialValues("implicit", "explicit")] string op)
+        public void ConsumeAbstractConversionOperator_17([CombinatorialValues("implicit", "explicit")] string op, bool isVirtual)
         {
             // If there is no applicable candidate in effective base class, look in interfaces.
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             bool needCast = op == "explicit";
 
             var source1 =
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator int(T x);
+    " + modifier + @"  static " + op + @" operator int(T x)" + body + @"
 }
 
 public class C1 
@@ -30980,7 +31541,7 @@ public class C2 : C1, I1<C2>
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: _supportingFramework);
 
-            CompileAndVerify(compilation1, verify: Verification.Skipped, expectedOutput: !Execute(isVirtual: false) ? null : @"
+            CompileAndVerify(compilation1, verify: Verification.Skipped, expectedOutput: !Execute(isVirtual) ? null : @"
 C2 conversion
 C2 conversion
 ").VerifyDiagnostics();
@@ -30988,17 +31549,18 @@ C2 conversion
 
         [Theory]
         [CombinatorialData]
-        public void ConsumeAbstractConversionOperator_18([CombinatorialValues("implicit", "explicit")] string op)
+        public void ConsumeAbstractConversionOperator_18([CombinatorialValues("implicit", "explicit")] string op, bool isVirtual)
         {
             // Same as ConsumeAbstractConversionOperator_17 only direction of conversion is flipped
 
+            var (modifier, body) = GetModifierAndBody(isVirtual);
             bool needCast = op == "explicit";
 
             var source1 =
 @"
 public interface I1<T> where T : I1<T>
 {
-    abstract static " + op + @" operator T(int x);
+    " + modifier + @" static " + op + @" operator T(int x)" + body + @"
 }
 
 public class C1 
@@ -31037,7 +31599,7 @@ public class C2 : C1, I1<C2>
                                                  parseOptions: TestOptions.RegularPreview,
                                                  targetFramework: _supportingFramework);
 
-            CompileAndVerify(compilation1, verify: Verification.Skipped, expectedOutput: !Execute(isVirtual: false) ? null : @"
+            CompileAndVerify(compilation1, verify: Verification.Skipped, expectedOutput: !Execute(isVirtual) ? null : @"
 C2 conversion
 C2 conversion
 ").VerifyDiagnostics();
@@ -31583,8 +32145,8 @@ public interface I1<T> where T : I1<T>
     " + modifier + @" static void M1()" + body + @"
     " + modifier + @" static int operator +(T x)" + body + @"
     " + modifier + @" static int operator +(T x, T y)" + body + @"
-    abstract static implicit operator int(T i);
-    abstract static explicit operator T(int i);
+    " + modifier + @" static implicit operator int(T i)" + body + @"
+    " + modifier + @" static explicit operator T(int i)" + body + @"
 }
 
 class C : I1<C>
@@ -31634,8 +32196,8 @@ public interface I1<T> where T : I1<T>
     " + modifier + @" static void M1()" + body + @"
     " + modifier + @" static int operator +(T x)" + body + @"
     " + modifier + @" static int operator +(T x, T y)" + body + @"
-    abstract static implicit operator int(T i);
-    abstract static explicit operator T(int i);
+    " + modifier + @" static implicit operator int(T i)" + body + @"
+    " + modifier + @" static explicit operator T(int i)" + body + @"
 }
 
 class C : I1<C>
@@ -31925,11 +32487,7 @@ public class C2 : I1<C2>
         public void BinaryOperators_Checked_Unsupported_01(string op, string name)
         {
             binaryOperators_Checked_Unsupported_01(op, name, isVirtual: false);
-
-            if (op is not ("==" or "!="))
-            {
-                binaryOperators_Checked_Unsupported_01(op, name, isVirtual: true);
-            }
+            binaryOperators_Checked_Unsupported_01(op, name, isVirtual: true);
 
             void binaryOperators_Checked_Unsupported_01(string op, string name, bool isVirtual)
             {
@@ -31947,7 +32505,8 @@ interface C
                                                      parseOptions: TestOptions.RegularPreview,
                                                      targetFramework: _supportingFramework);
 
-                compilation1.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_OperatorNeedsMatch or (int)ErrorCode.WRN_EqualityOpWithoutEquals or (int)ErrorCode.WRN_EqualityOpWithoutGetHashCode)).Verify(
+                compilation1.GetDiagnostics().Where(d => d.Code is not ((int)ErrorCode.ERR_OperatorNeedsMatch or (int)ErrorCode.WRN_EqualityOpWithoutEquals or
+                                                                        (int)ErrorCode.WRN_EqualityOpWithoutGetHashCode or (int)ErrorCode.ERR_BadAbstractEqualityOperatorSignature)).Verify(
                     // (4,39): error CS9150: User-defined operator '%' cannot be declared checked
                     //     public static abstract C operator checked %(C x, int y);
                     Diagnostic(ErrorCode.ERR_OperatorCantBeChecked, "checked").WithArguments(op).WithLocation(4, 39)
@@ -32188,6 +32747,38 @@ public class C2 : I1<C2>
         }
 
         [Fact]
+        public void ImplementVirtualStaticConversionOperator_21()
+        {
+            var source1 =
+@"
+public interface I1<T> where T : I1<T>
+{
+    virtual static explicit operator checked int(T x) => default;
+}
+
+public class C1 : I1<C1>
+{
+    public static explicit operator int(C1 x) => default;
+}
+
+public class C2 : I1<C2>
+{
+    static explicit I1<C2>.operator int(C2 x) => default;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_CheckedOperatorNeedsMatch).Verify(
+                // (14,37): error CS0539: 'C2.explicit operator int(C2)' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     static explicit I1<C2>.operator int(C2 x) => default;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "int").WithArguments("C2.explicit operator int(C2)").WithLocation(14, 37)
+                );
+        }
+
+        [Fact]
         public void ImplementAbstractStaticConversionOperator_22()
         {
             var source1 =
@@ -32219,6 +32810,38 @@ public class C2 : I1<C2>
                 // (12,19): error CS0535: 'C2' does not implement interface member 'I1<C2>.explicit operator int(C2)'
                 // public class C2 : I1<C2>
                 Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I1<C2>").WithArguments("C2", "I1<C2>.explicit operator int(C2)").WithLocation(12, 19),
+                // (14,45): error CS0539: 'C2.explicit operator checked int(C2)' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     static explicit I1<C2>.operator checked int(C2 x) => default;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "int").WithArguments("C2.explicit operator checked int(C2)").WithLocation(14, 45)
+                );
+        }
+
+        [Fact]
+        public void ImplementVirtualStaticConversionOperator_22()
+        {
+            var source1 =
+@"
+public interface I1<T> where T : I1<T>
+{
+    virtual static explicit operator int(T x) => default;
+}
+
+public class C1 : I1<C1>
+{
+    public static explicit operator checked int(C1 x) => default;
+}
+
+public class C2 : I1<C2>
+{
+    static explicit I1<C2>.operator checked int(C2 x) => default;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_CheckedOperatorNeedsMatch).Verify(
                 // (14,45): error CS0539: 'C2.explicit operator checked int(C2)' in explicit interface declaration is not found among members of the interface that can be implemented
                 //     static explicit I1<C2>.operator checked int(C2 x) => default;
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "int").WithArguments("C2.explicit operator checked int(C2)").WithLocation(14, 45)
@@ -32264,6 +32887,38 @@ public class C2 : I1<C2>
         }
 
         [Fact]
+        public void ImplementVirtualStaticConversionOperator_23()
+        {
+            var source1 =
+@"
+public interface I1<T> where T : I1<T>
+{
+    virtual static explicit operator checked int(T x) => default;
+}
+
+public class C1 : I1<C1>
+{
+    public static implicit operator int(C1 x) => default;
+}
+
+public class C2 : I1<C2>
+{
+    static implicit I1<C2>.operator int(C2 x) => default;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_CheckedOperatorNeedsMatch).Verify(
+                // (14,37): error CS0539: 'C2.implicit operator int(C2)' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     static implicit I1<C2>.operator int(C2 x) => default;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "int").WithArguments("C2.implicit operator int(C2)").WithLocation(14, 37)
+                );
+        }
+
+        [Fact]
         public void ImplementAbstractStaticConversionOperator_24()
         {
             var source1 =
@@ -32295,6 +32950,38 @@ public class C2 : I1<C2>
                 // (12,19): error CS0535: 'C2' does not implement interface member 'I1<C2>.implicit operator int(C2)'
                 // public class C2 : I1<C2>
                 Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I1<C2>").WithArguments("C2", "I1<C2>.implicit operator int(C2)").WithLocation(12, 19),
+                // (14,45): error CS0539: 'C2.explicit operator checked int(C2)' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     static explicit I1<C2>.operator checked int(C2 x) => default;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "int").WithArguments("C2.explicit operator checked int(C2)").WithLocation(14, 45)
+                );
+        }
+
+        [Fact]
+        public void ImplementVirtualStaticConversionOperator_24()
+        {
+            var source1 =
+@"
+public interface I1<T> where T : I1<T>
+{
+    virtual static implicit operator int(T x) => default;
+}
+
+public class C1 : I1<C1>
+{
+    public static explicit operator checked int(C1 x) => default;
+}
+
+public class C2 : I1<C2>
+{
+    static explicit I1<C2>.operator checked int(C2 x) => default;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_CheckedOperatorNeedsMatch).Verify(
                 // (14,45): error CS0539: 'C2.explicit operator checked int(C2)' in explicit interface declaration is not found among members of the interface that can be implemented
                 //     static explicit I1<C2>.operator checked int(C2 x) => default;
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "int").WithArguments("C2.explicit operator checked int(C2)").WithLocation(14, 45)
@@ -32340,6 +33027,38 @@ public class C2 : I1<C2>
         }
 
         [Fact]
+        public void ImplementVirtualStaticConversionOperator_25()
+        {
+            var source1 =
+@"
+public interface I1<T> where T : I1<T>
+{
+    virtual static explicit operator int(T x) => default;
+}
+
+public class C1 : I1<C1>
+{
+    public static implicit operator int(C1 x) => default;
+}
+
+public class C2 : I1<C2>
+{
+    static implicit I1<C2>.operator int(C2 x) => default;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_CheckedOperatorNeedsMatch).Verify(
+                // (14,37): error CS0539: 'C2.implicit operator int(C2)' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     static implicit I1<C2>.operator int(C2 x) => default;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "int").WithArguments("C2.implicit operator int(C2)").WithLocation(14, 37)
+                );
+        }
+
+        [Fact]
         public void ImplementAbstractStaticConversionOperator_26()
         {
             var source1 =
@@ -32371,6 +33090,38 @@ public class C2 : I1<C2>
                 // (12,19): error CS0535: 'C2' does not implement interface member 'I1<C2>.implicit operator int(C2)'
                 // public class C2 : I1<C2>
                 Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I1<C2>").WithArguments("C2", "I1<C2>.implicit operator int(C2)").WithLocation(12, 19),
+                // (14,37): error CS0539: 'C2.explicit operator int(C2)' in explicit interface declaration is not found among members of the interface that can be implemented
+                //     static explicit I1<C2>.operator int(C2 x) => default;
+                Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "int").WithArguments("C2.explicit operator int(C2)").WithLocation(14, 37)
+                );
+        }
+
+        [Fact]
+        public void ImplementVirtualStaticConversionOperator_26()
+        {
+            var source1 =
+@"
+public interface I1<T> where T : I1<T>
+{
+    virtual static implicit operator int(T x) => default;
+}
+
+public class C1 : I1<C1>
+{
+    public static explicit operator int(C1 x) => default;
+}
+
+public class C2 : I1<C2>
+{
+    static explicit I1<C2>.operator int(C2 x) => default;
+}
+";
+
+            var compilation1 = CreateCompilation(source1, options: TestOptions.DebugDll,
+                                                 parseOptions: TestOptions.RegularPreview,
+                                                 targetFramework: _supportingFramework);
+
+            compilation1.GetDiagnostics().Where(d => d.Code is not (int)ErrorCode.ERR_CheckedOperatorNeedsMatch).Verify(
                 // (14,37): error CS0539: 'C2.explicit operator int(C2)' in explicit interface declaration is not found among members of the interface that can be implemented
                 //     static explicit I1<C2>.operator int(C2 x) => default;
                 Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "int").WithArguments("C2.explicit operator int(C2)").WithLocation(14, 37)
@@ -32629,9 +33380,6 @@ public class C5 : I1<C5>
                     // (4,46): error CS0539: 'I2<T2>.implicit operator int(T2)' in explicit interface declaration is not found among members of the interface that can be implemented
                     //     abstract static implicit I1<T2>.operator int(T2 x);
                     Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "int").WithArguments("I2<T2>.implicit operator int(T2)").WithLocation(4, 46),
-                    // (9,37): error CS0567: Conversion, equality, or inequality operators declared in interfaces must be abstract
-                    //     static implicit I1<T3>.operator int(T3 x) => throw null;
-                    Diagnostic(ErrorCode.ERR_InterfacesCantContainConversionOrEqualityOperators, "int").WithLocation(9, 37),
                     // (9,37): error CS0539: 'I3<T3>.implicit operator int(T3)' in explicit interface declaration is not found among members of the interface that can be implemented
                     //     static implicit I1<T3>.operator int(T3 x) => throw null;
                     Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "int").WithArguments("I3<T3>.implicit operator int(T3)").WithLocation(9, 37),


### PR DESCRIPTION
https://github.com/dotnet/csharplang/blob/main/proposals/static-abstracts-in-interfaces.md#equality-operators-and-conversions

Virtual declarations of `==` and `!=` operators, as well as virtual declarations of implicit and explicit conversion operators are allowed in interfaces. Derived interfaces are allowed to implement them too.

For `==` and `!=` operators, at least one parameter type must be a type parameter that counts as "the instance type of the enclosing type".