### PR TITLE
Do not add cast to object when converting string.Format to interpolated string

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -12870,11 +12870,7 @@ class C
     }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestCode = code,
-                FixedCode = fixedCode,
-            }.RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
         }
 
         [WorkItem(64346, "https://github.com/dotnet/roslyn/issues/61346")]

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -12843,5 +12843,71 @@ namespace ConsoleApp1
                 LanguageVersion = LanguageVersion.CSharp10,
             }.RunAsync();
         }
+
+        [WorkItem(64346, "https://github.com/dotnet/roslyn/issues/61346")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task CanRemoveCastToObjectInStringInterpolation_NullableDisable()
+        {
+            var code = @"
+#nullable disable
+
+class C
+{
+    void M()
+    {
+        var v = $""{[|(object)|]0}"";
+    }
+}
+";
+            var fixedCode = @"
+#nullable disable
+
+class C
+{
+    void M()
+    {
+        var v = $""{0}"";
+    }
+}
+";
+            await new VerifyCS.Test
+            {
+                TestCode = code,
+                FixedCode = fixedCode,
+            }.RunAsync();
+        }
+
+        [WorkItem(64346, "https://github.com/dotnet/roslyn/issues/61346")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task CanRemoveCastToObjectInStringInterpolation_NullableEnable()
+        {
+            var code = @"
+#nullable enable
+
+class C
+{
+    void M()
+    {
+        var v = $""{[|(object)|]0}"";
+    }
+}
+";
+            var fixedCode = @"
+#nullable enable
+
+class C
+{
+    void M()
+    {
+        var v = $""{0}"";
+    }
+}
+";
+            await new VerifyCS.Test
+            {
+                TestCode = code,
+                FixedCode = fixedCode,
+            }.RunAsync();
+        }
     }
 }

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -12901,5 +12901,34 @@ class C
 ";
             await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
         }
+
+        [WorkItem(64346, "https://github.com/dotnet/roslyn/issues/61346")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task CanRemoveCastToNullableObjectInStringInterpolation()
+        {
+            var code = @"
+#nullable enable
+
+class C
+{
+    void M()
+    {
+        var v = $""{[|(object?)|]0}"";
+    }
+}
+";
+            var fixedCode = @"
+#nullable enable
+
+class C
+{
+    void M()
+    {
+        var v = $""{0}"";
+    }
+}
+";
+            await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+        }
     }
 }

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -12903,11 +12903,7 @@ class C
     }
 }
 ";
-            await new VerifyCS.Test
-            {
-                TestCode = code,
-                FixedCode = fixedCode,
-            }.RunAsync();
+            await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertPlaceholderToInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertPlaceholderToInterpolatedStringTests.cs
@@ -286,7 +286,7 @@ class T
 {
     void M()
     {
-        var a = $""{new object}"";
+        var a = $""{(object)new object}"";
     }
 }");
         }

--- a/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertPlaceholderToInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertToInterpolatedString/ConvertPlaceholderToInterpolatedStringTests.cs
@@ -286,7 +286,7 @@ class T
 {
     void M()
     {
-        var a = $""{(object)new object}"";
+        var a = $""{new object}"";
     }
 }");
         }
@@ -890,6 +890,35 @@ class T
     }
 }",
 @"using System;
+
+class T
+{
+    void M()
+    {
+        var a = $""{1}"";
+    }
+}");
+        }
+
+        [WorkItem(61346, "https://github.com/dotnet/roslyn/issues/61346")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestNoCastToObjectWhenNullableEnabled()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+#nullable enable
+
+class T
+{
+    void M()
+    {
+        var a = string.Format([|""{0}"", 1|]);
+    }
+}",
+@"using System;
+
+#nullable enable
 
 class T
 {

--- a/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertPlaceholderToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertPlaceholderToInterpolatedStringRefactoringProvider.cs
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
             {
                 var argumentExpression = syntaxFacts.GetExpressionOfArgument(GetArgument(arguments, i, syntaxFacts));
                 var convertedType = semanticModel.GetTypeInfo(argumentExpression).ConvertedType;
-                if (convertedType == null)
+                if (convertedType is null || convertedType.SpecialType is SpecialType.System_Object)
                 {
                     builder.Add((TExpressionSyntax)syntaxGenerator.AddParentheses(argumentExpression));
                 }

--- a/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertPlaceholderToInterpolatedStringRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ConvertToInterpolatedString/AbstractConvertPlaceholderToInterpolatedStringRefactoringProvider.cs
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.ConvertToInterpolatedString
             {
                 var argumentExpression = syntaxFacts.GetExpressionOfArgument(GetArgument(arguments, i, syntaxFacts));
                 var convertedType = semanticModel.GetTypeInfo(argumentExpression).ConvertedType;
-                if (convertedType is null || convertedType.SpecialType is SpecialType.System_Object)
+                if (convertedType is null)
                 {
                     builder.Add((TExpressionSyntax)syntaxGenerator.AddParentheses(argumentExpression));
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
@@ -456,6 +456,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
             if (originalConvertedType.Equals(rewrittenConvertedType, SymbolEqualityComparer.IncludeNullability))
                 return true;
 
+            // We can safely remove convertion to object in interpolated strings regardless of nullability
+            if (castNode.IsParentKind(SyntaxKind.Interpolation) && originalConversionOperation.Type?.SpecialType is SpecialType.System_Object)
+                return true;
+
             // There are cases where the types change but things may still be safe to remove.
 
             // Case1.  A value type casted to `object` is safe if it's now getting converted to `dynamic`.


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/61346