### PR TITLE
Shadow Copy all analyzer dependencies

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -53,6 +53,13 @@ namespace Microsoft.CodeAnalysis
                     _knownAssemblyPathsBySimpleName[simpleName] = paths.Add(fullPath);
                 }
             }
+
+            AddDependencyLocationInternal(fullPath);
+        }
+
+        protected virtual void AddDependencyLocationInternal(string fullPath)
+        {
+            return;
         }
 
         public Assembly LoadFromPath(string fullPath)


### PR DESCRIPTION
Previously we just copied the assembly and its resources. Most analyzers have dependencies that live next to the assembly that are also necessary

fixes https://developercommunity.visualstudio.com/t/Several-CS8032-warnings-appears-in-Error/10043881