### PR TITLE
Point workitems to the PR & clarification comment

### DIFF
--- a/src/Analyzers/CSharp/Tests/PopulateSwitch/PopulateSwitchStatementTests.cs
+++ b/src/Analyzers/CSharp/Tests/PopulateSwitch/PopulateSwitchStatementTests.cs
@@ -1224,7 +1224,7 @@ enum MyEnum
 }");
         }
 
-        [Fact, WorkItem(61281, "https://github.com/dotnet/roslyn/pull/61809")]
+        [Fact, WorkItem(61809, "https://github.com/dotnet/roslyn/pull/61809")]
         public async Task TestNotInSwitchWithUnknownType1()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -1237,7 +1237,7 @@ enum MyEnum
 }");
         }
 
-        [Fact, WorkItem(61281, "https://github.com/dotnet/roslyn/pull/61809")]
+        [Fact, WorkItem(61809, "https://github.com/dotnet/roslyn/pull/61809")]
         public async Task TestNotInSwitchWithUnknownType2()
         {
             // Parser currently treats "var v = null switch" as:

--- a/src/Analyzers/CSharp/Tests/PopulateSwitch/PopulateSwitchStatementTests.cs
+++ b/src/Analyzers/CSharp/Tests/PopulateSwitch/PopulateSwitchStatementTests.cs
@@ -1224,7 +1224,7 @@ enum MyEnum
 }");
         }
 
-        [Fact, WorkItem(61281, "https://github.com/dotnet/roslyn/issues/61281")]
+        [Fact, WorkItem(61281, "https://github.com/dotnet/roslyn/pull/61809")]
         public async Task TestNotInSwitchWithUnknownType1()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -1237,9 +1237,15 @@ enum MyEnum
 }");
         }
 
-        [Fact, WorkItem(61281, "https://github.com/dotnet/roslyn/issues/61281")]
+        [Fact, WorkItem(61281, "https://github.com/dotnet/roslyn/pull/61809")]
         public async Task TestNotInSwitchWithUnknownType2()
         {
+            // Parser currently treats "var v = null switch" as:
+            //
+            // var v = null <- ';' is "missing"
+            // switch
+            //
+            // So switch is a statement here.
             await TestMissingInRegularAndScriptAsync(
 @"class C
 {


### PR DESCRIPTION
Follow up to https://github.com/dotnet/roslyn/pull/61809

Switched `WorkItem`s to point to the PR, not to the issue they don't test. Added a clarification comment about why case that looks like a switch expression was put into switch statement section