### PR TITLE
Add FixAll support for ConvertNamespace refactoring

### DIFF
--- a/src/EditorFeatures/CSharpTest/ConvertNamespace/ConvertNamespaceRefactoringFixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertNamespace/ConvertNamespaceRefactoringFixAllTests.cs
@@ -1,0 +1,307 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.ConvertNamespace;
+using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertNamespace
+{
+    public class ConvertNamespaceRefactoringFixAllTests : AbstractCSharpCodeActionTest
+    {
+        protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
+            => new ConvertNamespaceCodeRefactoringProvider();
+
+        private OptionsCollection PreferBlockScopedNamespace =>
+            this.Option(CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.BlockScoped, NotificationOption2.Warning);
+
+        private OptionsCollection PreferFileScopedNamespace =>
+            this.Option(CSharpCodeStyleOptions.NamespaceDeclarations, NamespaceDeclarationPreference.FileScoped, NotificationOption2.Warning);
+
+        [Fact]
+        public async Task TestConvertToFileScope_FixAllInProject()
+        {
+            await TestInRegularAndScript1Async(@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+namespace {|FixAllInProject:|}N1
+{
+}
+        </Document>
+        <Document>
+namespace N2
+{
+    class C { }
+}
+        </Document>
+        <Document>
+namespace N3.N4
+{
+    class C2 { }
+}
+        </Document>
+        <Document>
+namespace N5;
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+namespace N6
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+", @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+namespace N1;
+        </Document>
+        <Document>
+namespace N2;
+
+class C { }
+    </Document>
+        <Document>
+namespace N3.N4;
+
+class C2 { }
+    </Document>
+        <Document>
+namespace N5;
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+namespace N6
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+", new TestParameters(options: PreferBlockScopedNamespace));
+        }
+
+        [Fact]
+        public async Task TestConvertToFileScope_FixAllInSolution()
+        {
+            await TestInRegularAndScript1Async(@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+namespace {|FixAllInSolution:|}N1
+{
+}
+        </Document>
+        <Document>
+namespace N2
+{
+    class C { }
+}
+        </Document>
+        <Document>
+namespace N3.N4
+{
+    class C2 { }
+}
+        </Document>
+        <Document>
+namespace N5;
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+namespace N6
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+", @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+namespace N1;
+        </Document>
+        <Document>
+namespace N2;
+
+class C { }
+    </Document>
+        <Document>
+namespace N3.N4;
+
+class C2 { }
+    </Document>
+        <Document>
+namespace N5;
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+namespace N6;
+        </Document>
+    </Project>
+</Workspace>
+", new TestParameters(options: PreferBlockScopedNamespace));
+        }
+
+        [Theory]
+        [InlineData("FixAllInDocument")]
+        [InlineData("FixAllInContainingType")]
+        [InlineData("FixAllInContainingMember")]
+        public async Task TestConvertToFileScope_UnsupportedFixAllScopes(string fixAllScope)
+        {
+            await TestMissingInRegularAndScriptAsync($@"
+namespace {{|{fixAllScope}:|}}N1
+{{
+}}", new TestParameters(options: PreferBlockScopedNamespace));
+        }
+
+        [Fact]
+        public async Task TestConvertToBlockScope_FixAllInProject()
+        {
+            await TestInRegularAndScript1Async(@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+namespace {|FixAllInProject:|}N1;
+        </Document>
+        <Document>
+namespace N2;
+
+class C { }
+        </Document>
+        <Document>
+namespace N3.N4;
+
+class C2 { }
+        </Document>
+        <Document>
+namespace N5
+{
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+namespace N6;
+        </Document>
+    </Project>
+</Workspace>
+", @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+namespace N1
+{
+}</Document>
+        <Document>
+namespace N2
+{
+    class C { }
+}</Document>
+        <Document>
+namespace N3.N4
+{
+    class C2 { }
+}</Document>
+        <Document>
+namespace N5
+{
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+namespace N6;
+        </Document>
+    </Project>
+</Workspace>
+", new TestParameters(options: PreferFileScopedNamespace));
+        }
+
+        [Fact]
+        public async Task TestConvertToBlockScope_FixAllInSolution()
+        {
+            await TestInRegularAndScript1Async(@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+namespace {|FixAllInSolution:|}N1;
+        </Document>
+        <Document>
+namespace N2;
+
+class C { }
+        </Document>
+        <Document>
+namespace N3.N4;
+
+class C2 { }
+        </Document>
+        <Document>
+namespace N5
+{
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+namespace N6;
+        </Document>
+    </Project>
+</Workspace>
+", @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+namespace N1
+{
+}</Document>
+        <Document>
+namespace N2
+{
+    class C { }
+}</Document>
+        <Document>
+namespace N3.N4
+{
+    class C2 { }
+}</Document>
+        <Document>
+namespace N5
+{
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+namespace N6
+{
+}</Document>
+    </Project>
+</Workspace>
+", new TestParameters(options: PreferFileScopedNamespace));
+        }
+
+        [Theory]
+        [InlineData("FixAllInDocument")]
+        [InlineData("FixAllInContainingType")]
+        [InlineData("FixAllInContainingMember")]
+        public async Task TestConvertToBlockScope_UnsupportedFixAllScopes(string fixAllScope)
+        {
+            await TestMissingInRegularAndScriptAsync($@"
+namespace {{|{fixAllScope}:|}}N1;
+", new TestParameters(options: PreferFileScopedNamespace));
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/ConvertNamespace/ConvertNamespaceCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertNamespace/ConvertNamespaceCodeRefactoringProvider.cs
@@ -3,16 +3,22 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
@@ -21,13 +27,16 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
     using static ConvertNamespaceTransform;
 
     [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.ConvertNamespace), Shared]
-    internal class ConvertNamespaceCodeRefactoringProvider : CodeRefactoringProvider
+    internal class ConvertNamespaceCodeRefactoringProvider : SyntaxEditorBasedCodeRefactoringProvider
     {
         [ImportingConstructor]
-        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
         public ConvertNamespaceCodeRefactoringProvider()
         {
         }
+
+        protected override ImmutableArray<FixAllScope> SupportedFixAllScopes
+            => ImmutableArray.Create(FixAllScope.Project, FixAllScope.Solution);
 
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
@@ -46,16 +55,24 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
                 return;
 
             var options = await document.GetCSharpCodeFixOptionsProviderAsync(context.Options, cancellationToken).ConfigureAwait(false);
-
-            var info =
-                CanOfferUseBlockScoped(options.NamespaceDeclarations, namespaceDecl, forAnalyzer: false) ? GetInfo(NamespaceDeclarationPreference.BlockScoped) :
-                CanOfferUseFileScoped(options.NamespaceDeclarations, root, namespaceDecl, forAnalyzer: false) ? GetInfo(NamespaceDeclarationPreference.FileScoped) :
-                ((string title, string equivalenceKey)?)null;
-            if (info == null)
+            if (!CanOfferRefactoring(namespaceDecl, root, options, out var info))
                 return;
 
             context.RegisterRefactoring(CodeAction.Create(
                 info.Value.title, c => ConvertAsync(document, namespaceDecl, options.GetFormattingOptions(), c), info.Value.equivalenceKey));
+        }
+
+        private static bool CanOfferRefactoring(
+            BaseNamespaceDeclarationSyntax namespaceDecl,
+            CompilationUnitSyntax root,
+            CSharpCodeFixOptionsProvider options,
+            [NotNullWhen(true)] out (string title, string equivalenceKey)? info)
+        {
+            info =
+                CanOfferUseBlockScoped(options.NamespaceDeclarations, namespaceDecl, forAnalyzer: false) ? GetInfo(NamespaceDeclarationPreference.BlockScoped) :
+                CanOfferUseFileScoped(options.NamespaceDeclarations, root, namespaceDecl, forAnalyzer: false) ? GetInfo(NamespaceDeclarationPreference.FileScoped) :
+                null;
+            return info != null;
         }
 
         private static bool IsValidPosition(BaseNamespaceDeclarationSyntax baseDeclaration, int position)
@@ -70,6 +87,28 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
                 return position <= namespaceDeclaration.Name.Span.End;
 
             throw ExceptionUtilities.UnexpectedValue(baseDeclaration.Kind());
+        }
+
+        protected override async Task FixAllAsync(
+            Document document,
+            ImmutableArray<TextSpan> fixAllSpans,
+            SyntaxEditor editor,
+            CodeActionOptionsProvider optionsProvider,
+            string? equivalenceKey,
+            CancellationToken cancellationToken)
+        {
+            var root = (CompilationUnitSyntax)await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var options = await document.GetCSharpCodeFixOptionsProviderAsync(optionsProvider, cancellationToken).ConfigureAwait(false);
+            var namespaceDecl = root.DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>().FirstOrDefault();
+            if (!CanOfferRefactoring(namespaceDecl, root, options, out var info)
+                || info.Value.equivalenceKey != equivalenceKey)
+            {
+                return;
+            }
+
+            document = await ConvertAsync(document, namespaceDecl, options.GetFormattingOptions(), cancellationToken).ConfigureAwait(false);
+            var newRoot = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            editor.ReplaceNode(editor.OriginalRoot, newRoot);
         }
     }
 }


### PR DESCRIPTION
Closes #62018

This was identified as a high priority refactoring for FixAll support as it promotes a new language feature (File scoped namespaces). We also have a customer request for FixAll support for this refactoring: #62018