### PR TITLE
Add Razor external access for VS MEF host services

### DIFF
--- a/src/Tools/ExternalAccess/Razor/RazorVisualStudioMefHostServicesAccessor.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorVisualStudioMefHostServicesAccessor.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
+{
+    internal class RazorVisualStudioMefHostServicesAccessor
+    {
+        public static HostServices Create(ExportProvider exportProvider)
+            => VisualStudioMefHostServices.Create(exportProvider);
+    }
+}


### PR DESCRIPTION
- Razor is currently in the process of transitioning its tests to use a real C# LSP server for tests instead of using Mocks.
- Part of the above process involves generating a C# test workspace in Razor. We need the workspace to have the proper HostServices so it can have access to all of the relevant MEF exports, e.g. `IEditorInlineRenameService` for rename tests.
- This PR adds an accessor so Razor can now create a proper VS HostServices and pass it into the C# test workspace constructor.