### PR TITLE
Create VS insertions after artifacts have been published.

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -299,7 +299,7 @@ stages:
 
 - stage: insert
   dependsOn:
-  - build
+  - publish_using_darc
   displayName: Insert to VS
 
   jobs:


### PR DESCRIPTION
Symbols are published during the 'Publish using Darc' stage. We should wait for publishing to complete before generating VS insertion PRs.