### PR TITLE
Cover additional cases where nullable directives can be removed

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryNullableDirective/CSharpRemoveRedundantNullableDirectiveTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryNullableDirective/CSharpRemoveRedundantNullableDirectiveTests.cs
@@ -189,6 +189,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers.UnitTests.RemoveUnnecessaryNul
                 """);
         }
 
+        [Fact]
+        public async Task TestRedundantDirectiveWithNamespaceAndDerivedType()
+        {
+            await VerifyCodeFixAsync(
+                NullableContextOptions.Enable,
+                """
+                [|#nullable enable|]
+
+                using System;
+
+                namespace X.Y
+                {
+                    class ProgramException : Exception
+                    {
+                    }
+                }
+                """,
+                """
+
+                using System;
+
+                namespace X.Y
+                {
+                    class ProgramException : Exception
+                    {
+                    }
+                }
+                """);
+        }
+
         private static string GetDisableDirectiveContext(NullableContextOptions options)
         {
             return options switch

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryNullableDirective/CSharpRemoveUnnecessaryNullableDirectiveTests.cs
@@ -95,6 +95,84 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers.UnitTests.RemoveUnnecessaryNul
                 """);
         }
 
+        [Fact]
+        public async Task TestUnnecessaryDirectiveWithNamespaceAndDerivedType()
+        {
+            await VerifyCodeFixAsync(
+                NullableContextOptions.Enable,
+                """
+                [|#nullable disable|]
+
+                using System;
+
+                namespace X.Y
+                {
+                    class ProgramException : Exception
+                    {
+                    }
+                }
+                """,
+                """
+
+                using System;
+
+                namespace X.Y
+                {
+                    class ProgramException : Exception
+                    {
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestUnnecessaryDirectiveWithNamespaceAndDerivedFromQualifiedBaseType()
+        {
+            await VerifyCodeFixAsync(
+                NullableContextOptions.Enable,
+                """
+                [|#nullable disable|]
+
+                namespace X.Y
+                {
+                    class ProgramException : System.Exception
+                    {
+                    }
+                }
+                """,
+                """
+
+                namespace X.Y
+                {
+                    class ProgramException : System.Exception
+                    {
+                    }
+                }
+                """);
+        }
+
+        [Fact]
+        public async Task TestUnnecessaryDirectiveWithQualifiedUsingDirectives()
+        {
+            await VerifyCodeFixAsync(
+                NullableContextOptions.Enable,
+                """
+                [|#nullable disable|]
+
+                using System;
+                using System.Runtime.InteropServices;
+                using CustomException = System.Exception;
+                using static System.String;
+                """,
+                """
+
+                using System;
+                using System.Runtime.InteropServices;
+                using CustomException = System.Exception;
+                using static System.String;
+                """);
+        }
+
         [Theory]
         [InlineData("disable")]
         [InlineData("restore")]


### PR DESCRIPTION
Follow-up to #62004 that allows many additional unnecessary directives to be removed.