### PR TITLE
Add Integration tests for Inheritance margin

### DIFF
--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginCanvas.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginCanvas.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin.MarginGlyph;
+
+namespace Microsoft.VisualStudio.LanguageServices.InheritanceMargin
+{
+    internal class InheritanceMarginCanvas : Canvas
+    {
+        public event EventHandler<(InheritanceMarginGlyph? glyphAdded, InheritanceMarginGlyph? glyphRemoved)>? OnGlyphsChanged;
+
+        protected override void OnVisualChildrenChanged(DependencyObject visualAdded, DependencyObject visualRemoved)
+        {
+            base.OnVisualChildrenChanged(visualAdded, visualRemoved);
+            if (OnGlyphsChanged != null)
+            {
+                OnGlyphsChanged(this, (visualAdded as InheritanceMarginGlyph, visualRemoved as InheritanceMarginGlyph));
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginCanvas.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginCanvas.cs
@@ -20,10 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServices.InheritanceMargin
         protected override void OnVisualChildrenChanged(DependencyObject visualAdded, DependencyObject visualRemoved)
         {
             base.OnVisualChildrenChanged(visualAdded, visualRemoved);
-            if (OnGlyphsChanged != null)
-            {
-                OnGlyphsChanged(this, (visualAdded as InheritanceMarginGlyph, visualRemoved as InheritanceMarginGlyph));
-            }
+            OnGlyphsChanged?.Invoke(this, (visualAdded as InheritanceMarginGlyph, visualRemoved as InheritanceMarginGlyph));
         }
     }
 }

--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginViewMargin.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginViewMargin.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
     internal class InheritanceMarginViewMargin : ForegroundThreadAffinitizedObject, IWpfTextViewMargin
     {
         // 16 (width of the crisp image) + 2 * 1 (width of the border) = 18
-        public const double HeightAndWidthOfMargin = 18;
+        internal const double HeightAndWidthOfMargin = 18;
         private readonly IWpfTextView _textView;
         private readonly ITagAggregator<InheritanceMarginTag> _tagAggregator;
         private readonly IGlobalOptionService _globalOptions;
@@ -176,7 +176,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             }
         }
 
-        internal void RefreshGlyphsOver(ITextViewLine textViewLine)
+        private void RefreshGlyphsOver(ITextViewLine textViewLine)
         {
             if (!_globalOptions.GetOption(FeatureOnOffOptions.InheritanceMarginCombinedWithIndicatorMargin))
             {

--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginViewMargin.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginViewMargin.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.VisualStudio.LanguageServices.InheritanceMargin;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
@@ -25,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
     internal class InheritanceMarginViewMargin : ForegroundThreadAffinitizedObject, IWpfTextViewMargin
     {
         // 16 (width of the crisp image) + 2 * 1 (width of the border) = 18
-        private const double HeightAndWidthOfMargin = 18;
+        public const double HeightAndWidthOfMargin = 18;
         private readonly IWpfTextView _textView;
         private readonly ITagAggregator<InheritanceMarginTag> _tagAggregator;
         private readonly IGlobalOptionService _globalOptions;
@@ -57,7 +58,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             _tagAggregator = tagAggregator;
             _globalOptions = globalOptions;
             _languageName = languageName;
-            _mainCanvas = new Canvas { ClipToBounds = true, Width = HeightAndWidthOfMargin };
+            _mainCanvas = new InheritanceMarginCanvas { ClipToBounds = true, Width = HeightAndWidthOfMargin };
             _grid = new Grid();
             _grid.Children.Add(_mainCanvas);
             _glyphManager = new InheritanceGlyphManager(
@@ -175,7 +176,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             }
         }
 
-        private void RefreshGlyphsOver(ITextViewLine textViewLine)
+        internal void RefreshGlyphsOver(ITextViewLine textViewLine)
         {
             if (!_globalOptions.GetOption(FeatureOnOffOptions.InheritanceMarginCombinedWithIndicatorMargin))
             {

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpInheritanceMarginTests.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpInheritanceMarginTests.cs
@@ -68,6 +68,7 @@ class Implementation : IBar
 
             await TestServices.InheritanceMargin.SetTextAndEnsureGlyphsAppearAsync(
 @"
+using System;
 interface IBar
 {
     event EventHandler e1, e2;
@@ -78,7 +79,7 @@ class Implementation : IBar
     public event EventHandler e1, e2;
 }", expectedGlyphsNumberInMargin: 4, HangMitigatingCancellationToken);
 
-            await TestServices.InheritanceMargin.ClickTheGlyphOnLine(4, HangMitigatingCancellationToken);
+            await TestServices.InheritanceMargin.ClickTheGlyphOnLine(5, HangMitigatingCancellationToken);
 
             // The context menu contains two members, e1 and e2.
             // Move focus to menu item of 'event e1'
@@ -100,7 +101,7 @@ class Implementation : IBar
 
             await TestServices.InheritanceMargin.SetTextAndEnsureGlyphsAppearAsync(
 @"
-using System.Collections
+using System.Collections;
 
 class Implementation : IEnumerable
 {
@@ -117,6 +118,7 @@ class Implementation : IEnumerable
             // Navigate to 'IEnumerable'
             await TestServices.Input.SendAsync(VirtualKey.Enter);
             await TestServices.EditorVerifier.TextContainsAsync(@"public interface IEnumerable$$", assertCaretPosition: true);
+            await TestServices.EditorVerifier.VerifyActiveViewIsInMetadataWorkspaceAsync(HangMitigatingCancellationToken);
         }
 
         [IdeFact]
@@ -154,7 +156,7 @@ class Implementation : IBar
             // Navigate to 'IBar'
             await TestServices.Input.SendAsync(VirtualKey.Enter);
             await TestServices.EditorVerifier.TextContainsAsync(@"Public Interface IBar$$", assertCaretPosition: true);
-
+            await TestServices.EditorVerifier.VerifyActiveViewIsNotInMetadataWorkspaceAsync(HangMitigatingCancellationToken);
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpInheritanceMarginTests.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpInheritanceMarginTests.cs
@@ -51,7 +51,7 @@ class Implementation : IBar
 
             await TestServices.InheritanceMargin.ClickTheGlyphOnLine(2, HangMitigatingCancellationToken);
 
-            // Move focus to menu item of 'class Implementation'
+            // Move focus to menu item of 'IBar', the destination is targeting 'class Implementation'
             await TestServices.Input.SendAsync(VirtualKey.Tab);
             // Navigate to the destination
             await TestServices.Input.SendAsync(VirtualKey.Enter);
@@ -80,6 +80,7 @@ class Implementation : IBar
 
             await TestServices.InheritanceMargin.ClickTheGlyphOnLine(4, HangMitigatingCancellationToken);
 
+            // The context menu contains two members, e1 and e2.
             // Move focus to menu item of 'event e1'
             await TestServices.Input.SendAsync(VirtualKey.Tab);
             // Expand the submenu
@@ -87,6 +88,31 @@ class Implementation : IBar
             // Navigate to the implemention
             await TestServices.Input.SendAsync(VirtualKey.Enter);
             await TestServices.EditorVerifier.TextContainsAsync(@"public event EventHandler e1$$, e2;", assertCaretPosition: true);
+        }
+
+        [IdeFact]
+        public async Task TestNavigateToMetadata()
+        {
+            var project = ProjectName;
+            await TestServices.InheritanceMargin.EnableOptionsAsync(LanguageName, cancellationToken: HangMitigatingCancellationToken);
+            await TestServices.SolutionExplorer.AddFileAsync(project, "Test.cs", cancellationToken: HangMitigatingCancellationToken);
+            await TestServices.SolutionExplorer.OpenFileAsync(project, "Test.cs", HangMitigatingCancellationToken);
+
+            await TestServices.InheritanceMargin.SetTextAndEnsureGlyphsAppearAsync(
+@"
+using System.Collections
+
+class Implementation : IEnumerable
+{
+}", expectedGlyphsNumberInMargin: 1, HangMitigatingCancellationToken);
+
+            await TestServices.InheritanceMargin.ClickTheGlyphOnLine(4, HangMitigatingCancellationToken);
+
+            // Move focus to menu item of 'class Implementation'
+            await TestServices.Input.SendAsync(VirtualKey.Tab);
+            // Navigate to 'IEnumerable'
+            await TestServices.Input.SendAsync(VirtualKey.Enter);
+            await TestServices.EditorVerifier.TextContainsAsync(@"public interface IEnumerable$$", assertCaretPosition: true);
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InheritanceMarginInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InheritanceMarginInProcess.cs
@@ -48,6 +48,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
 
             if (combinedWithIndicatorMargin)
             {
+                // Glyphs in Indicator margin are owned by editor, and we don't know when the glyphs would be added/removed.
                 optionService.SetGlobalOption(new OptionKey(FeatureOnOffOptions.InheritanceMarginCombinedWithIndicatorMargin), false);
             }
         }
@@ -84,7 +85,8 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
         {
             await WaitForApplicationIdleAsync(cancellationToken);
             var glyph = await GetTheGlyphOnLineAsync(lineNumber, cancellationToken);
-            // TODO: Ideally, we should not rely on creating WPF event, and using real mouse to click.
+
+            // Ideally, we should not rely on creating WPF event, and simulate real mouse click to open the context menu.
             glyph.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
         }
 
@@ -93,13 +95,12 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             var activeView = await TestServices.Editor.GetActiveTextViewAsync(cancellationToken);
             var wpfTextViewLine = activeView.TextViewLines[lineNumber - 1];
-            var viewTop = activeView.ViewportTop;
             var midOfTheLine = wpfTextViewLine.TextTop + wpfTextViewLine.Height / 2;
             var margin = await GetTextViewMarginAsync(cancellationToken);
 
             var grid = (Grid)margin.VisualElement;
+            // There will be only one Canvas element.
             Assert.True(grid.Children.Count == 1);
-
             var containingCanvas = (Canvas)((Grid)margin.VisualElement).Children[0];
 
             var glyphsOnLine = new List<InheritanceMarginGlyph>();

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InheritanceMarginInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InheritanceMarginInProcess.cs
@@ -1,0 +1,139 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using Microsoft.CodeAnalysis.Editor.Shared.Options;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.UnitTests;
+using Microsoft.VisualStudio.CorDebugInterop;
+using Microsoft.VisualStudio.Extensibility.Testing;
+using Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin;
+using Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMargin.MarginGlyph;
+using Microsoft.VisualStudio.LanguageServices.InheritanceMargin;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Tagging;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
+{
+    [TestService]
+    internal partial class InheritanceMarginInProcess
+    {
+        private const double HeightAndWidthOfTheGlyph = InheritanceMarginViewMargin.HeightAndWidthOfMargin;
+        private const string MarginName = nameof(InheritanceMarginViewMargin);
+
+        public async Task EnableOptionsAsync(string languageName, CancellationToken cancellationToken)
+        {
+            var optionService = await GetComponentModelServiceAsync<IGlobalOptionService>(cancellationToken).ConfigureAwait(false);
+            var showInheritanceMargin = optionService.GetOption(FeatureOnOffOptions.ShowInheritanceMargin, languageName);
+            var combinedWithIndicatorMargin = optionService.GetOption(FeatureOnOffOptions.InheritanceMarginCombinedWithIndicatorMargin);
+
+            if (showInheritanceMargin != true)
+            {
+                optionService.SetGlobalOption(new OptionKey(FeatureOnOffOptions.ShowInheritanceMargin, languageName), true);
+            }
+
+            if (combinedWithIndicatorMargin)
+            {
+                optionService.SetGlobalOption(new OptionKey(FeatureOnOffOptions.InheritanceMarginCombinedWithIndicatorMargin), false);
+            }
+        }
+
+        public async Task SetTextAndEnsureGlyphsAppearAsync(string text, int expectedGlyphsNumberInMargin, CancellationToken cancellationToken)
+        {
+            var margin = await GetTextViewMarginAsync(cancellationToken);
+            var marginCanvas = (InheritanceMarginCanvas)((Grid)margin.VisualElement).Children[0];
+            var currentGlyphsNumber = marginCanvas.Children.Count;
+            var taskCompletionSource = new TaskCompletionSource<bool>();
+            using var _ = cancellationToken.Register(() => taskCompletionSource.SetCanceled());
+
+            try
+            {
+                marginCanvas.OnGlyphsChanged += OnGlyphChanged;
+
+                await TestServices.Editor.SetTextAsync(text, cancellationToken);
+                await taskCompletionSource.Task;
+            }
+            finally
+            {
+                marginCanvas.OnGlyphsChanged -= OnGlyphChanged;
+            }
+
+            void OnGlyphChanged(object sender, (InheritanceMarginGlyph? glyphAdded, InheritanceMarginGlyph? glyphRemoved) changedGlyphs)
+            {
+                var (glyphAdded, glyphRemoved) = changedGlyphs;
+                if (glyphAdded is not null)
+                {
+                    currentGlyphsNumber++;
+                }
+
+                if (glyphRemoved is not null)
+                {
+                    currentGlyphsNumber--;
+                }
+
+                if (currentGlyphsNumber == expectedGlyphsNumberInMargin)
+                {
+                    taskCompletionSource.SetResult(true);
+                }
+            }
+        }
+
+        public async Task ClickTheGlyphOnLine(int lineNumber, CancellationToken cancellationToken)
+        {
+            await WaitForApplicationIdleAsync(cancellationToken);
+            var glyph = await GetTheGlyphOnLineAsync(lineNumber, cancellationToken);
+            // TODO: Ideally, we should not rely on creating WPF event, and using real mouse to click.
+            glyph.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+        }
+
+        public async Task<InheritanceMarginGlyph> GetTheGlyphOnLineAsync(int lineNumber, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            var activeView = await TestServices.Editor.GetActiveTextViewAsync(cancellationToken);
+            var wpfTextViewLine = activeView.TextViewLines[lineNumber - 1];
+            var viewTop = activeView.ViewportTop;
+            var midOfTheLine = wpfTextViewLine.TextTop + wpfTextViewLine.Height / 2;
+            var margin = await GetTextViewMarginAsync(cancellationToken);
+            var containingCanvas = (Canvas)((Grid)margin.VisualElement).Children[0];
+
+            foreach (var glyph in containingCanvas.Children)
+            {
+                if (glyph is InheritanceMarginGlyph inheritanceMarginGlyph)
+                {
+                    var glyphTop = Canvas.GetTop(inheritanceMarginGlyph);
+                    var glyphBottom = glyphTop + HeightAndWidthOfTheGlyph;
+                    if (midOfTheLine > glyphTop && midOfTheLine < glyphBottom)
+                    {
+                        return inheritanceMarginGlyph;
+                    }
+                }
+            }
+
+            Assert.False(true, $"No {nameof(InheritanceMarginGlyph)} is found at line: {lineNumber}.");
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        private async Task<IWpfTextViewMargin> GetTextViewMarginAsync(CancellationToken cancellationToken)
+        {
+            await WaitForApplicationIdleAsync(cancellationToken);
+            var vsTextManager = await GetRequiredGlobalServiceAsync<SVsTextManager, IVsTextManager>(cancellationToken);
+            var vsTextView = await vsTextManager.GetActiveViewAsync(JoinableTaskFactory, cancellationToken);
+            var testViewHost = await vsTextView.GetTextViewHostAsync(JoinableTaskFactory, cancellationToken);
+            return testViewHost.GetTextViewMargin(MarginName);
+        }
+    }
+}


### PR DESCRIPTION
Tracking issue: https://github.com/dotnet/roslyn/issues/55714
Add 4 tests to cover the important scenarios of Inheritance margin.
1. Navigate from file to file
2. Navigate from file to metadata
3. Navigate from project to project.
4. Multiple members on the same line. 

There is the remaining thing for this test, right now I simulate the mouse click by creating a WPF event, and ideally, I feel it would be better to simulate the click by real moving the mouse.
I talked to Sam about this and the correct way seems to be to have a separate InputSimulator class to do that.
And I feel even WPF event is not perfect, these tests should be good to prevent many regressions.