### PR TITLE
Remove unused value assignment lambda capture case

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedValueAssignmentTests.cs
@@ -8908,8 +8908,10 @@ namespace ConsoleApp
         }
 
         [WorkItem(57650, "https://github.com/dotnet/roslyn/issues/57650")]
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
-        public async Task NotUnusedVarInParenthesizedLambdaTest()
+        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnusedValues)]
+        [InlineData(nameof(PreferDiscard))]
+        [InlineData(nameof(PreferUnusedLocal))]
+        public async Task UseInLambda_WithInvocationOutsideLocalScope(string optionName)
         {
             await TestMissingInRegularAndScriptAsync(
 @"using System;
@@ -8925,7 +8927,7 @@ class C
         }
         act();
     }
-}");
+}", optionName);
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.DataFlowAnalyzer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/FlowAnalysis/SymbolUsageAnalysis/SymbolUsageAnalysis.DataFlowAnalyzer.cs
@@ -157,7 +157,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
                 ProcessOutOfScopeLocals();
                 return _analysisData.CurrentBlockAnalysisData;
 
-                // Local functions
+                // Function added to address OOM when analyzing symbol usage analysis for locals.
+                // This reduces tracking locals as they go out of scope.
                 void ProcessOutOfScopeLocals()
                 {
                     if (branch == null)
@@ -175,10 +176,15 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.SymbolUsageAnalysis
 
                     foreach (var region in branch.LeavingRegions)
                     {
-                        /*foreach (var local in region.Locals)
+                        foreach (var local in region.Locals)
                         {
-                            _analysisData.CurrentBlockAnalysisData.Clear(local);
-                        }*/
+                            // If locals are captured in local/anonymous functions,
+                            // then they are not technically out of scope.
+                            if (!_analysisData.CapturedLocals.Contains(local))
+                            {
+                                _analysisData.CurrentBlockAnalysisData.Clear(local);
+                            }
+                        }
 
                         if (region.Kind == ControlFlowRegionKind.TryAndFinally)
                         {


### PR DESCRIPTION
Fixes: #57650 and #57344 and #64198

There was an assumption being made that once we are outside the defining region for the local, we can no longer access it but that is not the case for lambda captures.
