### PR TITLE
Improve the experience of completion around required members

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
@@ -996,6 +996,28 @@ class D
             await VerifyItemIsAbsentAsync(markup, "this");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task RequiredMembersLabeledAndSelected()
+        {
+            var markup = @"
+class C
+{
+    public required int RequiredField;
+    public required int RequiredProperty { get; set; }
+}
+
+class D
+{
+    static void Main(string[] args)
+    {
+        var t = new C() { $$ };
+    }
+}";
+
+            await VerifyItemExistsAsync(markup, "RequiredField", inlineDescription: FeaturesResources.Required, matchPriority: MatchPriority.Preselect);
+            await VerifyItemExistsAsync(markup, "RequiredProperty", inlineDescription: FeaturesResources.Required);
+        }
+
         [WorkItem(15205, "https://github.com/dotnet/roslyn/issues/15205")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task NestedPropertyInitializers1()

--- a/src/Features/Core/Portable/Completion/Providers/AbstractObjectInitializerCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractObjectInitializerCompletionProvider.cs
@@ -62,17 +62,32 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var alreadyTypedMembers = GetInitializedMembers(semanticModel.SyntaxTree, position, cancellationToken);
             var uninitializedMembers = members.Where(m => !alreadyTypedMembers.Contains(m.Name));
 
-            uninitializedMembers = uninitializedMembers.Where(m => m.IsEditorBrowsable(context.CompletionOptions.HideAdvancedMembers, semanticModel.Compilation));
+            // Sort the members by name so if we preselect one, it'll be stable
+            uninitializedMembers = uninitializedMembers.Where(m => m.IsEditorBrowsable(context.CompletionOptions.HideAdvancedMembers, semanticModel.Compilation))
+                                                       .OrderBy(m => m.Name);
+
+            var firstUnitializedRequiredMember = true;
 
             foreach (var uninitializedMember in uninitializedMembers)
             {
+                var rules = s_rules;
+
+                // We'll hard select the first required member to make it a bit easier to type out an object initializer
+                // with a bunch of members.
+                if (firstUnitializedRequiredMember && uninitializedMember.IsRequired())
+                {
+                    rules = rules.WithSelectionBehavior(CompletionItemSelectionBehavior.HardSelection).WithMatchPriority(MatchPriority.Preselect);
+                    firstUnitializedRequiredMember = false;
+                }
+
                 context.AddItem(SymbolCompletionItem.CreateWithSymbolId(
                     displayText: EscapeIdentifier(uninitializedMember),
                     displayTextSuffix: "",
                     insertionText: null,
                     symbols: ImmutableArray.Create(uninitializedMember),
                     contextPosition: initializerLocation.SourceSpan.Start,
-                    rules: s_rules));
+                    inlineDescription: uninitializedMember.IsRequired() ? FeaturesResources.Required : null,
+                    rules: rules));
             }
         }
 

--- a/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/SymbolCompletionItem.cs
@@ -16,7 +16,7 @@ using Microsoft.CodeAnalysis.Shared.Utilities;
 
 namespace Microsoft.CodeAnalysis.Completion.Providers
 {
-    internal static partial class SymbolCompletionItem
+    internal static class SymbolCompletionItem
     {
         private const string InsertionTextProperty = "InsertionText";
 

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -3147,4 +3147,8 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   <data name="Fixing_0" xml:space="preserve">
     <value>Fixing '{0}'</value>
   </data>
+  <data name="Required" xml:space="preserve">
+    <value>required</value>
+    <comment>Used in the object initializer completion.</comment>
+  </data>
 </root>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -2525,6 +2525,11 @@ Pozitivní kontrolní výrazy zpětného vyhledávání s nulovou délkou se obv
         <target state="new">Replace conditional expression with statements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Required">
+        <source>required</source>
+        <target state="new">required</target>
+        <note>Used in the object initializer completion.</note>
+      </trans-unit>
       <trans-unit id="Resolve_conflict_markers">
         <source>Resolve conflict markers</source>
         <target state="translated">Vyřešit značky konfliktů</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -2525,6 +2525,11 @@ Positive Lookbehindassertionen mit Nullbreite werden normalerweise am Anfang reg
         <target state="new">Replace conditional expression with statements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Required">
+        <source>required</source>
+        <target state="new">required</target>
+        <note>Used in the object initializer completion.</note>
+      </trans-unit>
       <trans-unit id="Resolve_conflict_markers">
         <source>Resolve conflict markers</source>
         <target state="translated">Konfliktmarkierungen auflösen</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -2525,6 +2525,11 @@ Las aserciones de búsqueda retrasada (lookbehind) positivas de ancho cero se us
         <target state="new">Replace conditional expression with statements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Required">
+        <source>required</source>
+        <target state="new">required</target>
+        <note>Used in the object initializer completion.</note>
+      </trans-unit>
       <trans-unit id="Resolve_conflict_markers">
         <source>Resolve conflict markers</source>
         <target state="translated">Resolver los marcadores de conflicto</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -2525,6 +2525,11 @@ Les assertions arrière positives de largeur nulle sont généralement utilisée
         <target state="new">Replace conditional expression with statements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Required">
+        <source>required</source>
+        <target state="new">required</target>
+        <note>Used in the object initializer completion.</note>
+      </trans-unit>
       <trans-unit id="Resolve_conflict_markers">
         <source>Resolve conflict markers</source>
         <target state="translated">Résoudre les marqueurs de conflit</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -2525,6 +2525,11 @@ Le asserzioni lookbehind positive di larghezza zero vengono usate in genere all'
         <target state="new">Replace conditional expression with statements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Required">
+        <source>required</source>
+        <target state="new">required</target>
+        <note>Used in the object initializer completion.</note>
+      </trans-unit>
       <trans-unit id="Resolve_conflict_markers">
         <source>Resolve conflict markers</source>
         <target state="translated">Risolvi gli indicatori di conflitto</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -2525,6 +2525,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="new">Replace conditional expression with statements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Required">
+        <source>required</source>
+        <target state="new">required</target>
+        <note>Used in the object initializer completion.</note>
+      </trans-unit>
       <trans-unit id="Resolve_conflict_markers">
         <source>Resolve conflict markers</source>
         <target state="translated">競合マーカーの解決</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -2525,6 +2525,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="new">Replace conditional expression with statements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Required">
+        <source>required</source>
+        <target state="new">required</target>
+        <note>Used in the object initializer completion.</note>
+      </trans-unit>
       <trans-unit id="Resolve_conflict_markers">
         <source>Resolve conflict markers</source>
         <target state="translated">충돌 표식 확인</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -2525,6 +2525,11 @@ Pozytywne asercje wsteczne o zerowej szerokości są zwykle używane na początk
         <target state="new">Replace conditional expression with statements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Required">
+        <source>required</source>
+        <target state="new">required</target>
+        <note>Used in the object initializer completion.</note>
+      </trans-unit>
       <trans-unit id="Resolve_conflict_markers">
         <source>Resolve conflict markers</source>
         <target state="translated">Rozwiąż znaczniki konfliktów</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -2525,6 +2525,11 @@ As declarações de lookbehind positivas de largura zero normalmente são usadas
         <target state="new">Replace conditional expression with statements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Required">
+        <source>required</source>
+        <target state="new">required</target>
+        <note>Used in the object initializer completion.</note>
+      </trans-unit>
       <trans-unit id="Resolve_conflict_markers">
         <source>Resolve conflict markers</source>
         <target state="translated">Resolver marcadores de conflitos</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -2525,6 +2525,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="new">Replace conditional expression with statements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Required">
+        <source>required</source>
+        <target state="new">required</target>
+        <note>Used in the object initializer completion.</note>
+      </trans-unit>
       <trans-unit id="Resolve_conflict_markers">
         <source>Resolve conflict markers</source>
         <target state="translated">Разрешение меток конфликтов</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -2525,6 +2525,11 @@ Sıfır genişlikli pozitif geri yönlü onaylamalar genellikle normal ifadeleri
         <target state="new">Replace conditional expression with statements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Required">
+        <source>required</source>
+        <target state="new">required</target>
+        <note>Used in the object initializer completion.</note>
+      </trans-unit>
       <trans-unit id="Resolve_conflict_markers">
         <source>Resolve conflict markers</source>
         <target state="translated">Çakışma işaretçilerini çözümle</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -2525,6 +2525,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="new">Replace conditional expression with statements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Required">
+        <source>required</source>
+        <target state="new">required</target>
+        <note>Used in the object initializer completion.</note>
+      </trans-unit>
       <trans-unit id="Resolve_conflict_markers">
         <source>Resolve conflict markers</source>
         <target state="translated">解决冲突标记</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -2525,6 +2525,11 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
         <target state="new">Replace conditional expression with statements</target>
         <note />
       </trans-unit>
+      <trans-unit id="Required">
+        <source>required</source>
+        <target state="new">required</target>
+        <note>Used in the object initializer completion.</note>
+      </trans-unit>
       <trans-unit id="Resolve_conflict_markers">
         <source>Resolve conflict markers</source>
         <target state="translated">解決衝突標記</target>


### PR DESCRIPTION
For completion inside an object initializer, this makes a few tweaks to the experience:

1. Show the word "required" so those that are required are more easily identified.
2. Preselect the first required member, so that you can just immediately hit equals to type them out.

Closes https://github.com/dotnet/roslyn/issues/61534

![image](https://user-images.githubusercontent.com/201340/174888614-53baffc1-3521-41d7-a67b-35bde5ad4503.png)
