### PR TITLE
Avoid intermediary allocation in Incremental Driver

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
 
             var expected = ImmutableArray.Create((10, EntryState.Added, 0), (11, EntryState.Added, 1), (2, EntryState.Cached, 0), (3, EntryState.Cached, 1), (20, EntryState.Modified, 0), (21, EntryState.Modified, 1), (22, EntryState.Modified, 2), (6, EntryState.Removed, 0));
             AssertTableEntries(newTable, expected);
-            Assert.Equal(new[] { 2, 3 }, cachedEntries);
+            Assert.Equal(new[] { 2, 3 }, cachedEntries.ToImmutableArray());
             Assert.Equal(6, Assert.Single(removedEntries));
             Assert.True(didRemoveEntries);
         }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis
 
             internal Builder(NodeStateTable<T> previous, string? name, bool stepTrackingEnabled)
             {
-                _states = ArrayBuilder<TableEntry>.GetInstance();
+                _states = ArrayBuilder<TableEntry>.GetInstance(previous._states.Length);
                 _previous = previous;
                 _name = name;
                 if (stepTrackingEnabled)
@@ -226,15 +226,15 @@ namespace Microsoft.CodeAnalysis
                 return true;
             }
 
-            public bool TryUseCachedEntries(TimeSpan elapsedTime, ImmutableArray<(IncrementalGeneratorRunStep InputStep, int OutputIndex)> stepInputs, out ImmutableArray<T> entries)
+            internal bool TryUseCachedEntries(TimeSpan elapsedTime, ImmutableArray<(IncrementalGeneratorRunStep InputStep, int OutputIndex)> stepInputs, out TableEntry entry)
             {
                 if (!TryUseCachedEntries(elapsedTime, stepInputs))
                 {
-                    entries = default;
+                    entry = default;
                     return false;
                 }
 
-                entries = _states[^1].ToImmutableArray();
+                entry = _states[^1];
                 return true;
             }
 
@@ -316,9 +316,17 @@ namespace Microsoft.CodeAnalysis
                 RecordStepInfoForLastEntry(elapsedTime, stepInputs, overallInputState);
             }
 
-            public void AddEntries(ImmutableArray<T> values, EntryState state, TimeSpan elapsedTime, ImmutableArray<(IncrementalGeneratorRunStep InputStep, int OutputIndex)> stepInputs, EntryState overallInputState)
+            public TableEntry AddEntries(ImmutableArray<T> values, EntryState state, TimeSpan elapsedTime, ImmutableArray<(IncrementalGeneratorRunStep InputStep, int OutputIndex)> stepInputs, EntryState overallInputState)
             {
-                _states.Add(new TableEntry(values, state));
+                var tableEntry = new TableEntry(values, state);
+                _states.Add(tableEntry);
+                RecordStepInfoForLastEntry(elapsedTime, stepInputs, overallInputState);
+                return tableEntry;
+            }
+
+            public void AddEntries(TableEntry entry, TimeSpan elapsedTime, ImmutableArray<(IncrementalGeneratorRunStep InputStep, int OutputIndex)> stepInputs, EntryState overallInputState)
+            {
+                _states.Add(entry);
                 RecordStepInfoForLastEntry(elapsedTime, stepInputs, overallInputState);
             }
 
@@ -393,7 +401,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private readonly struct TableEntry
+        internal readonly struct TableEntry
         {
             private static readonly ImmutableArray<EntryState> s_allAddedEntries = ImmutableArray.Create(EntryState.Added);
             private static readonly ImmutableArray<EntryState> s_allCachedEntries = ImmutableArray.Create(EntryState.Cached);
@@ -456,6 +464,29 @@ namespace Microsoft.CodeAnalysis
                 EntryState.Removed => s_allRemovedEntries,
                 _ => throw ExceptionUtilities.Unreachable
             };
+
+            public Enumerator GetEnumerator()
+                => new(this);
+
+            public struct Enumerator
+            {
+                private readonly TableEntry _entry;
+                private int _index = -1;
+
+                public Enumerator(TableEntry tableEntry)
+                {
+                    _entry = tableEntry;
+                }
+
+                public bool MoveNext()
+                {
+                    _index++;
+                    return _index < _entry.Count;
+                }
+
+                public T Current => _entry.GetItem(_index);
+            }
+
 
 #if DEBUG
             public override string ToString()

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/PredicateSyntaxStrategy.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/PredicateSyntaxStrategy.cs
@@ -82,15 +82,15 @@ namespace Microsoft.CodeAnalysis
                     Debug.Assert(model is object);
 
                     // get the syntax nodes from cache, or a syntax walk using the filter
-                    if (state != EntryState.Cached || !_filterTable.TryUseCachedEntries(TimeSpan.Zero, noInputStepsStepInfo, out ImmutableArray<SyntaxNode> nodes))
+                    if (state != EntryState.Cached || !_filterTable.TryUseCachedEntries(TimeSpan.Zero, noInputStepsStepInfo, out NodeStateTable<SyntaxNode>.TableEntry entry))
                     {
                         var stopwatch = SharedStopwatch.StartNew();
-                        nodes = getFilteredNodes(root.Value, _owner._filterFunc, cancellationToken);
-                        _filterTable.AddEntries(nodes, state, stopwatch.Elapsed, noInputStepsStepInfo, state);
+                        var nodes = getFilteredNodes(root.Value, _owner._filterFunc, cancellationToken);
+                        entry = _filterTable.AddEntries(nodes, state, stopwatch.Elapsed, noInputStepsStepInfo, state);
                     }
 
                     // now, using the obtained syntax nodes, run the transform
-                    foreach (SyntaxNode node in nodes)
+                    foreach (SyntaxNode node in entry)
                     {
                         var stopwatch = SharedStopwatch.StartNew();
                         var value = new GeneratorSyntaxContext(node, model, _owner._syntaxHelper);


### PR DESCRIPTION
This saves 600 MB of allocs in my editing testing. 