### PR TITLE
Don't load parts early from MEF that aren't needed

### DIFF
--- a/src/VisualStudio/Core/Def/Library/AbstractLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Library/AbstractLibraryManager.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -13,22 +14,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library
     internal abstract partial class AbstractLibraryManager : IVsCoTaskMemFreeMyStrings
     {
         internal readonly Guid LibraryGuid;
-        private readonly IServiceProvider _serviceProvider;
         private readonly IntPtr _imageListPtr;
 
-        protected AbstractLibraryManager(Guid libraryGuid, IServiceProvider serviceProvider)
+        protected AbstractLibraryManager(Guid libraryGuid, IComponentModel componentModel, IServiceProvider serviceProvider)
         {
             LibraryGuid = libraryGuid;
-            _serviceProvider = serviceProvider;
+            ComponentModel = componentModel;
+            ServiceProvider = serviceProvider;
 
             var vsShell = serviceProvider.GetService(typeof(SVsShell)) as IVsShell;
             vsShell?.TryGetPropertyValue(__VSSPROPID.VSSPROPID_ObjectMgrTypesImgList, out _imageListPtr);
         }
 
-        public IServiceProvider ServiceProvider
-        {
-            get { return _serviceProvider; }
-        }
+        public IComponentModel ComponentModel { get; }
+        public IServiceProvider ServiceProvider { get; }
 
         public IntPtr ImageListPtr
         {

--- a/src/VisualStudio/Core/Def/Library/AbstractObjectList.cs
+++ b/src/VisualStudio/Core/Def/Library/AbstractObjectList.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -315,7 +316,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library
                 return VSConstants.E_INVALIDARG;
 
             // Fire and forget
-            _ = GoToSourceAsync(index, srcType);
+            var asynchronousOperationListener = LibraryManager.ComponentModel.GetService<IAsynchronousOperationListenerProvider>().GetListener(FeatureAttribute.LibraryManager);
+            var asyncToken = asynchronousOperationListener.BeginAsyncOperation(nameof(IVsSimpleObjectList2) + "." + nameof(IVsSimpleObjectList2.GoToSource));
+
+            GoToSourceAsync(index, srcType).CompletesAsyncOperation(asyncToken);
             return VSConstants.S_OK;
         }
 

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
@@ -492,7 +492,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
                                 // also knows something is happening as the window, with the progress-banner will pop up
                                 // immediately.
                                 var streamingPresenter = ComponentModel.GetService<IStreamingFindUsagesPresenter>();
-                                _ = FindReferencesAsync(streamingPresenter, symbolListItem, project);
+                                var asynchronousOperationListener = ComponentModel.GetService<IAsynchronousOperationListenerProvider>().GetListener(FeatureAttribute.LibraryManager);
+
+                                var asyncToken = asynchronousOperationListener.BeginAsyncOperation(nameof(AbstractObjectBrowserLibraryManager) + "." + nameof(TryExec));
+                                FindReferencesAsync(streamingPresenter, symbolListItem, project).CompletesAsyncOperation(asyncToken);
                                 return true;
                             }
                         }

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
@@ -42,10 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
         private AbstractListItemFactory _listItemFactory;
         private readonly object _classMemberGate = new();
 
-        private readonly IStreamingFindUsagesPresenter _streamingPresenter;
-
-        public readonly IUIThreadOperationExecutor OperationExecutor;
-        public readonly IAsynchronousOperationListener AsynchronousOperationListener;
+        public readonly IComponentModel ComponentModel;
 
         protected AbstractObjectBrowserLibraryManager(
             string languageName,
@@ -57,14 +54,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
         {
             _languageName = languageName;
 
+            ComponentModel = componentModel;
             Workspace = workspace;
             Workspace.WorkspaceChanged += OnWorkspaceChanged;
 
             _libraryService = new Lazy<ILibraryService>(() => Workspace.Services.GetLanguageServices(_languageName).GetService<ILibraryService>());
-            _streamingPresenter = componentModel.DefaultExportProvider.GetExportedValue<IStreamingFindUsagesPresenter>();
-
-            OperationExecutor = componentModel.DefaultExportProvider.GetExportedValue<IUIThreadOperationExecutor>();
-            AsynchronousOperationListener = componentModel.DefaultExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>().GetListener(FeatureAttribute.LibraryManager);
         }
 
         internal abstract AbstractDescriptionBuilder CreateDescriptionBuilder(
@@ -500,7 +494,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
                                 // asynchronously added to the FindReferences window as they are computed.  The user
                                 // also knows something is happening as the window, with the progress-banner will pop up
                                 // immediately.
-                                _ = FindReferencesAsync(_streamingPresenter, symbolListItem, project);
+                                var streamingPresenter = ComponentModel.GetService<IStreamingFindUsagesPresenter>();
+                                _ = FindReferencesAsync(streamingPresenter, symbolListItem, project);
                                 return true;
                             }
                         }

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
@@ -42,19 +42,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
         private AbstractListItemFactory _listItemFactory;
         private readonly object _classMemberGate = new();
 
-        public readonly IComponentModel ComponentModel;
-
         protected AbstractObjectBrowserLibraryManager(
             string languageName,
             Guid libraryGuid,
             IServiceProvider serviceProvider,
             IComponentModel componentModel,
             VisualStudioWorkspace workspace)
-            : base(libraryGuid, serviceProvider)
+            : base(libraryGuid, componentModel, serviceProvider)
         {
             _languageName = languageName;
 
-            ComponentModel = componentModel;
             Workspace = workspace;
             Workspace.WorkspaceChanged += OnWorkspaceChanged;
 

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/ObjectList.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/ObjectList.cs
@@ -747,8 +747,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
         {
             try
             {
-                using var token = _manager.AsynchronousOperationListener.BeginAsyncOperation(nameof(GoToSourceAsync));
-                using var context = _manager.OperationExecutor.BeginExecute(ServicesVSResources.IntelliSense, EditorFeaturesResources.Navigating, allowCancellation: true, showProgress: false);
+
+                var asynchronousOperationListener = _manager.ComponentModel.GetService<IAsynchronousOperationListenerProvider>().GetListener(FeatureAttribute.LibraryManager);
+                var operationExecutor = _manager.ComponentModel.GetService<IUIThreadOperationExecutor>();
+
+                using var token = asynchronousOperationListener.BeginAsyncOperation(nameof(GoToSourceAsync));
+                using var context = operationExecutor.BeginExecute(ServicesVSResources.IntelliSense, EditorFeaturesResources.Navigating, allowCancellation: true, showProgress: false);
 
                 var cancellationToken = context.UserCancellationToken;
                 if (srcType == VSOBJGOTOSRCTYPE.GS_DEFINITION &&

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/ObjectList.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/ObjectList.cs
@@ -745,11 +745,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
         {
             try
             {
-
-                var asynchronousOperationListener = LibraryManager.ComponentModel.GetService<IAsynchronousOperationListenerProvider>().GetListener(FeatureAttribute.LibraryManager);
                 var operationExecutor = LibraryManager.ComponentModel.GetService<IUIThreadOperationExecutor>();
 
-                using var token = asynchronousOperationListener.BeginAsyncOperation(nameof(GoToSourceAsync));
                 using var context = operationExecutor.BeginExecute(ServicesVSResources.IntelliSense, EditorFeaturesResources.Navigating, allowCancellation: true, showProgress: false);
 
                 var cancellationToken = context.UserCancellationToken;

--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/ObjectList.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/ObjectList.cs
@@ -30,7 +30,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
         private readonly ObjectList _parentList;
         private readonly ObjectListItem _parentListItem;
         private readonly uint _flags;
-        private readonly AbstractObjectBrowserLibraryManager _manager;
         private readonly ImmutableArray<ObjectListItem> _items;
 
         public ObjectList(
@@ -55,7 +54,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             _flags = flags;
             _parentList = parentList;
             _parentListItem = parentListItem;
-            _manager = manager;
 
             _items = items;
 
@@ -517,17 +515,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             switch (listKind)
             {
                 case ObjectListKind.Types:
-                    return new ObjectList(ObjectListKind.Types, flags, this, listItem, _manager, this.LibraryManager.GetTypeListItems(listItem, compilation));
+                    return new ObjectList(ObjectListKind.Types, flags, this, listItem, LibraryManager, this.LibraryManager.GetTypeListItems(listItem, compilation));
                 case ObjectListKind.Hierarchy:
-                    return new ObjectList(ObjectListKind.Hierarchy, flags, this, listItem, _manager, this.LibraryManager.GetFolderListItems(listItem, compilation));
+                    return new ObjectList(ObjectListKind.Hierarchy, flags, this, listItem, LibraryManager, this.LibraryManager.GetFolderListItems(listItem, compilation));
                 case ObjectListKind.Namespaces:
-                    return new ObjectList(ObjectListKind.Namespaces, flags, this, listItem, _manager, this.LibraryManager.GetNamespaceListItems(listItem, compilation));
+                    return new ObjectList(ObjectListKind.Namespaces, flags, this, listItem, LibraryManager, this.LibraryManager.GetNamespaceListItems(listItem, compilation));
                 case ObjectListKind.Members:
-                    return new ObjectList(ObjectListKind.Members, flags, this, listItem, _manager, this.LibraryManager.GetMemberListItems(listItem, compilation));
+                    return new ObjectList(ObjectListKind.Members, flags, this, listItem, LibraryManager, this.LibraryManager.GetMemberListItems(listItem, compilation));
                 case ObjectListKind.References:
-                    return new ObjectList(ObjectListKind.References, flags, this, listItem, _manager, this.LibraryManager.GetReferenceListItems(listItem, compilation));
+                    return new ObjectList(ObjectListKind.References, flags, this, listItem, LibraryManager, this.LibraryManager.GetReferenceListItems(listItem, compilation));
                 case ObjectListKind.BaseTypes:
-                    return new ObjectList(ObjectListKind.BaseTypes, flags, this, listItem, _manager, this.LibraryManager.GetBaseTypeListItems(listItem, compilation));
+                    return new ObjectList(ObjectListKind.BaseTypes, flags, this, listItem, LibraryManager, this.LibraryManager.GetBaseTypeListItems(listItem, compilation));
             }
 
             throw new NotImplementedException();
@@ -748,8 +746,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             try
             {
 
-                var asynchronousOperationListener = _manager.ComponentModel.GetService<IAsynchronousOperationListenerProvider>().GetListener(FeatureAttribute.LibraryManager);
-                var operationExecutor = _manager.ComponentModel.GetService<IUIThreadOperationExecutor>();
+                var asynchronousOperationListener = LibraryManager.ComponentModel.GetService<IAsynchronousOperationListenerProvider>().GetListener(FeatureAttribute.LibraryManager);
+                var operationExecutor = LibraryManager.ComponentModel.GetService<IUIThreadOperationExecutor>();
 
                 using var token = asynchronousOperationListener.BeginAsyncOperation(nameof(GoToSourceAsync));
                 using var context = operationExecutor.BeginExecute(ServicesVSResources.IntelliSense, EditorFeaturesResources.Navigating, allowCancellation: true, showProgress: false);
@@ -780,15 +778,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             {
                 case ObjectListKind.Projects:
                 case ObjectListKind.References:
-                    return _manager.PackageVersion;
+                    return LibraryManager.PackageVersion;
                 case ObjectListKind.BaseTypes:
                 case ObjectListKind.Namespaces:
                 case ObjectListKind.Types:
-                    return _manager.ClassVersion;
+                    return LibraryManager.ClassVersion;
                 case ObjectListKind.Members:
-                    return _manager.MembersVersion;
+                    return LibraryManager.MembersVersion;
                 case ObjectListKind.Hierarchy:
-                    return _manager.ClassVersion | _manager.MembersVersion;
+                    return LibraryManager.ClassVersion | LibraryManager.MembersVersion;
 
                 default:
                     Debug.Fail("Unsupported object list kind: " + _kind.ToString());


### PR DESCRIPTION
When our package loads, we register our library objects which is what drives class view and object browser. The constructor for this proactively loads a few services which are then only used if you invoked go to definition or find references through the object browser. It's a tiny cost (25ms) in one trace but each little bit counts when trying to make load times better.