### PR TITLE
testing out caching common binary assets

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -188,6 +188,10 @@ jobs:
   steps:
     - template: eng/pipelines/checkout-windows-task.yml
 
+    - template: eng/pipelines/restore-windows-task.yml
+      parameters:
+        configuration: Debug
+
     - script: eng/test-determinism.cmd -configuration Debug
       displayName: Build - Validate determinism
 
@@ -203,6 +207,10 @@ jobs:
   timeoutInMinutes: 90
   steps:
     - template: eng/pipelines/checkout-windows-task.yml
+
+    - template: eng/pipelines/restore-windows-task.yml
+      parameters:
+        configuration: Release
 
     - script: eng/test-build-correctness.cmd -configuration Release -enableDumps
       displayName: Build - Validate correctness
@@ -246,11 +254,9 @@ jobs:
   steps:
     - template: eng/pipelines/checkout-windows-task.yml
 
-    - task: PowerShell@2
-      displayName: Restore
-      inputs:
-        filePath: eng/build.ps1
-        arguments: -configuration Debug -prepareMachine -ci -restore -binaryLog
+    - template: eng/pipelines/restore-windows-task.yml
+      parameters:
+        configuration: Debug
 
     - powershell: .\eng\test-rebuild.ps1 -ci -configuration Release
       displayName: Run BuildValidator

--- a/eng/pipelines/build-unix-job.yml
+++ b/eng/pipelines/build-unix-job.yml
@@ -36,7 +36,7 @@ jobs:
     - task: CacheBeta@1
       displayName: .dotnet Cache
       inputs:
-        key: 'dotnet |  $(Agent.OS) | ${{ parameters.configuration }} | $(Build.SourcesDirectory)/global.json'
+        key: '"dotnet" |  "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json'
         path: $(Build.SourcesDirectory)/.dotnet
       continueOnError: true
 

--- a/eng/pipelines/build-unix-job.yml
+++ b/eng/pipelines/build-unix-job.yml
@@ -30,28 +30,9 @@ jobs:
   steps:
     - template: checkout-unix-task.yml
 
-    - script: echo "##vso[task.setvariable variable=NUGET_PACKAGES]$(Build.SourcesDirectory)/.packages"
-      displayName: Set NuGet Packages Directory
-
-    - task: CacheBeta@1
-      displayName: .dotnet Cache
-      inputs:
-        key: '"dotnet" |  "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json'
-        path: $(Build.SourcesDirectory)/.dotnet
-      continueOnError: true
-
-    - task: CacheBeta@1
-      displayName: .packages Cache
-      inputs:
-        key: '"nuget" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json | $(Build.SourcesDirectory)/eng/Versions.props | $(Build.SourcesDirectory)/eng/Version.Details.xml'
-        path: $(NUGET_PACKAGES)
-        cacheHitVar: NUGET_CACHE_RESTORED
-      continueOnError: true
-
-    - script: ./eng/build.sh --ci --restore --prepareMachine --binaryLog --configuration ${{ parameters.configuration }}
-      displayName: Restore
-      env:
-        NUGET_PACKAGES: $(NUGET_PACKAGES)
+    - template: restore-unix-task.yml
+      parameters:
+        configuration: ${{ parameters.configuration }}
 
     - script: ./eng/build.sh --ci --build --publish --pack --prepareMachine --binaryLog --skipDocumentation --configuration ${{ parameters.configuration }}
       displayName: Build

--- a/eng/pipelines/build-unix-job.yml
+++ b/eng/pipelines/build-unix-job.yml
@@ -30,8 +30,28 @@ jobs:
   steps:
     - template: checkout-unix-task.yml
 
+    - script: echo "##vso[task.setvariable variable=NUGET_PACKAGES]$(Build.SourcesDirectory)/.packages"
+      displayName: Set Nuet Packages Directory
+
+    - task: CacheBeta@1
+      displayName: .dotnet Cache
+      inputs:
+        key: 'dotnet |  $(Agent.OS) | ${{ parameters.configuration }} | $(Build.SourcesDirectory)/global.json'
+        path: $(Build.SourcesDirectory)/.dotnet
+      continueOnError: true
+
+    - task: CacheBeta@1
+      displayName: .packages Cache
+      inputs:
+        key: 'nuget | $(Agent.OS) | $(Build.SourcesDirectory)/global.json | $(Build.SourcesDirectory)/eng/Versions.props | $(Build.SourcesDirectory)/eng/Version.Details.xml'
+        path: $(NUGET_PACKAGES)
+        cacheHitVar: NUGET_CACHE_RESTORED
+      continueOnError: true
+
     - script: ./eng/build.sh --ci --restore --prepareMachine --binaryLog --configuration ${{ parameters.configuration }}
       displayName: Restore
+      env:
+        NUGET_PACKAGES: $(NUGET_PACKAGES)
 
     - script: ./eng/build.sh --ci --build --publish --pack --prepareMachine --binaryLog --skipDocumentation --configuration ${{ parameters.configuration }}
       displayName: Build

--- a/eng/pipelines/build-unix-job.yml
+++ b/eng/pipelines/build-unix-job.yml
@@ -43,7 +43,7 @@ jobs:
     - task: CacheBeta@1
       displayName: .packages Cache
       inputs:
-        key: 'nuget | $(Agent.OS) | $(Build.SourcesDirectory)/global.json | $(Build.SourcesDirectory)/eng/Versions.props | $(Build.SourcesDirectory)/eng/Version.Details.xml'
+        key: '"nuget" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json | $(Build.SourcesDirectory)/eng/Versions.props | $(Build.SourcesDirectory)/eng/Version.Details.xml'
         path: $(NUGET_PACKAGES)
         cacheHitVar: NUGET_CACHE_RESTORED
       continueOnError: true

--- a/eng/pipelines/build-unix-job.yml
+++ b/eng/pipelines/build-unix-job.yml
@@ -31,7 +31,7 @@ jobs:
     - template: checkout-unix-task.yml
 
     - script: echo "##vso[task.setvariable variable=NUGET_PACKAGES]$(Build.SourcesDirectory)/.packages"
-      displayName: Set Nuet Packages Directory
+      displayName: Set NuGet Packages Directory
 
     - task: CacheBeta@1
       displayName: .dotnet Cache

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -36,7 +36,7 @@ jobs:
     - task: CacheBeta@1
       displayName: .tools Cache
       inputs:
-        key: 'tools | $(Agent.OS) | $(Build.SourcesDirectory)/global.json'
+        key: '"tools" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json'
         path: $(Build.SourcesDirectory)/.tools
       continueOnError: true
 

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -33,8 +33,35 @@ jobs:
   steps:
     - template: checkout-windows-task.yml
 
+    - task: CacheBeta@1
+      displayName: .tools Cache
+      inputs:
+        key: 'tools | $(Agent.OS) | $(Build.SourcesDirectory)/global.json'
+        path: $(Build.SourcesDirectory)/.tools
+      continueOnError: true
+
+    - task: CacheBeta@1
+      displayName: .dotnet Cache
+      inputs:
+        key: 'dotnet | $(Agent.OS) | $(Build.SourcesDirectory)/global.json'
+        path: $(Build.SourcesDirectory)/.dotnet
+      continueOnError: true
+
+    - powershell: Write-Host "##vso[task.setvariable variable=NUGET_PACKAGES]$(Build.SourcesDirectory)/.packages"
+      displayName: Set Nuet Packages Directory
+
+    - task: CacheBeta@1
+      displayName: .packages Cache
+      inputs:
+        key: 'nuget | $(Agent.OS) | $(Build.SourcesDirectory)/global.json | $(Build.SourcesDirectory)/eng/Versions.props | $(Build.SourcesDirectory)/eng/Version.Details.xml'
+        path: $(NUGET_PACKAGES)
+        cacheHitVar: NUGET_CACHE_RESTORED
+      continueOnError: true
+
     - task: PowerShell@2
       displayName: Restore
+      env:
+        NUGET_PACKAGES: $(NUGET_PACKAGES)
       inputs:
         filePath: eng/build.ps1
         arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -restore -binaryLog

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -33,38 +33,9 @@ jobs:
   steps:
     - template: checkout-windows-task.yml
 
-    - task: CacheBeta@1
-      displayName: .tools Cache
-      inputs:
-        key: '"tools" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json'
-        path: $(Build.SourcesDirectory)/.tools
-      continueOnError: true
-
-    - task: CacheBeta@1
-      displayName: .dotnet Cache
-      inputs:
-        key: '"dotnet" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json'
-        path: $(Build.SourcesDirectory)/.dotnet
-      continueOnError: true
-
-    - powershell: Write-Host "##vso[task.setvariable variable=NUGET_PACKAGES]$(Build.SourcesDirectory)/.packages"
-      displayName: Set NuGet Packages Directory
-
-    - task: CacheBeta@1
-      displayName: .packages Cache
-      inputs:
-        key: '"nuget" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json | $(Build.SourcesDirectory)/eng/Versions.props | $(Build.SourcesDirectory)/eng/Version.Details.xml'
-        path: $(NUGET_PACKAGES)
-        cacheHitVar: NUGET_CACHE_RESTORED
-      continueOnError: true
-
-    - task: PowerShell@2
-      displayName: Restore
-      env:
-        NUGET_PACKAGES: $(NUGET_PACKAGES)
-      inputs:
-        filePath: eng/build.ps1
-        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -restore -binaryLog
+    - template: restore-windows-task.yml
+      parameters:
+        configuration: ${{ parameters.configuration }}
 
     - task: PowerShell@2 
       displayName: Build

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -48,7 +48,7 @@ jobs:
       continueOnError: true
 
     - powershell: Write-Host "##vso[task.setvariable variable=NUGET_PACKAGES]$(Build.SourcesDirectory)/.packages"
-      displayName: Set Nuet Packages Directory
+      displayName: Set NuGet Packages Directory
 
     - task: CacheBeta@1
       displayName: .packages Cache

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -43,7 +43,7 @@ jobs:
     - task: CacheBeta@1
       displayName: .dotnet Cache
       inputs:
-        key: 'dotnet | $(Agent.OS) | $(Build.SourcesDirectory)/global.json'
+        key: '"dotnet" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json'
         path: $(Build.SourcesDirectory)/.dotnet
       continueOnError: true
 

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -53,7 +53,7 @@ jobs:
     - task: CacheBeta@1
       displayName: .packages Cache
       inputs:
-        key: 'nuget | $(Agent.OS) | $(Build.SourcesDirectory)/global.json | $(Build.SourcesDirectory)/eng/Versions.props | $(Build.SourcesDirectory)/eng/Version.Details.xml'
+        key: '"nuget" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json | $(Build.SourcesDirectory)/eng/Versions.props | $(Build.SourcesDirectory)/eng/Version.Details.xml'
         path: $(NUGET_PACKAGES)
         cacheHitVar: NUGET_CACHE_RESTORED
       continueOnError: true

--- a/eng/pipelines/restore-unix-task.yml
+++ b/eng/pipelines/restore-unix-task.yml
@@ -1,0 +1,29 @@
+# cache nuget packages to enable faster restore on Windows
+parameters:
+  - name: configuration
+    type: string
+    default: 'Debug'
+
+steps:
+    - task: CacheBeta@1
+      displayName: .dotnet Cache
+      inputs:
+        key: '"dotnet" |  "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json'
+        path: $(Build.SourcesDirectory)/.dotnet
+      continueOnError: true
+
+    - task: CacheBeta@1
+      displayName: .packages Cache
+      inputs:
+        key: '"nuget" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json | $(Build.SourcesDirectory)/eng/Versions.props | $(Build.SourcesDirectory)/eng/Version.Details.xml'
+        path: $(NUGET_PACKAGES)
+        cacheHitVar: NUGET_CACHE_RESTORED
+      continueOnError: true
+
+    - script: echo "##vso[task.setvariable variable=NUGET_PACKAGES]$(Build.SourcesDirectory)/.packages"
+      displayName: Set NuGet Packages Directory
+
+    - script: ./eng/build.sh --ci --restore --prepareMachine --binaryLog --configuration ${{ parameters.configuration }}
+      displayName: Restore
+      env:
+        NUGET_PACKAGES: $(NUGET_PACKAGES)

--- a/eng/pipelines/restore-unix-task.yml
+++ b/eng/pipelines/restore-unix-task.yml
@@ -15,7 +15,7 @@ steps:
     - task: CacheBeta@1
       displayName: .packages Cache
       inputs:
-        key: '"nuget" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json | $(Build.SourcesDirectory)/eng/Versions.props | $(Build.SourcesDirectory)/eng/Version.Details.xml'
+        key: '"nuget" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json | $(Build.SourcesDirectory)/NuGet.config | $(Build.SourcesDirectory)/eng/Versions.props | $(Build.SourcesDirectory)/eng/Version.Details.xml'
         path: $(NUGET_PACKAGES)
         cacheHitVar: NUGET_CACHE_RESTORED
       continueOnError: true

--- a/eng/pipelines/restore-unix-task.yml
+++ b/eng/pipelines/restore-unix-task.yml
@@ -1,4 +1,4 @@
-# cache nuget packages to enable faster restore on Windows
+# cache nuget packages to enable faster restore on Unix-like environments
 parameters:
   - name: configuration
     type: string

--- a/eng/pipelines/restore-windows-task.yml
+++ b/eng/pipelines/restore-windows-task.yml
@@ -25,7 +25,7 @@ steps:
     - task: CacheBeta@1
       displayName: .packages Cache
       inputs:
-        key: '"nuget" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json | $(Build.SourcesDirectory)/eng/Versions.props | $(Build.SourcesDirectory)/eng/Version.Details.xml'
+        key: '"nuget" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json | $(Build.SourcesDirectory)/NuGet.config | $(Build.SourcesDirectory)/eng/Versions.props | $(Build.SourcesDirectory)/eng/Version.Details.xml'
         path: $(NUGET_PACKAGES)
         cacheHitVar: NUGET_CACHE_RESTORED
       continueOnError: true

--- a/eng/pipelines/restore-windows-task.yml
+++ b/eng/pipelines/restore-windows-task.yml
@@ -1,0 +1,39 @@
+# cache nuget packages to enable faster restore on Windows
+parameters:
+  - name: configuration
+    type: string
+    default: 'Debug'
+
+steps:
+    - task: CacheBeta@1
+      displayName: .tools Cache
+      inputs:
+        key: '"tools" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json'
+        path: $(Build.SourcesDirectory)/.tools
+      continueOnError: true
+
+    - task: CacheBeta@1
+      displayName: .dotnet Cache
+      inputs:
+        key: '"dotnet" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json'
+        path: $(Build.SourcesDirectory)/.dotnet
+      continueOnError: true
+
+    - powershell: Write-Host "##vso[task.setvariable variable=NUGET_PACKAGES]$(Build.SourcesDirectory)/.packages"
+      displayName: Set NuGet Packages Directory
+
+    - task: CacheBeta@1
+      displayName: .packages Cache
+      inputs:
+        key: '"nuget" | "$(Agent.OS)" | $(Build.SourcesDirectory)/global.json | $(Build.SourcesDirectory)/eng/Versions.props | $(Build.SourcesDirectory)/eng/Version.Details.xml'
+        path: $(NUGET_PACKAGES)
+        cacheHitVar: NUGET_CACHE_RESTORED
+      continueOnError: true
+
+    - task: PowerShell@2
+      displayName: Restore
+      env:
+        NUGET_PACKAGES: $(NUGET_PACKAGES)
+      inputs:
+        filePath: eng/build.ps1
+        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -restore -binaryLog


### PR DESCRIPTION
So this doesn't improve build times on linux but for windows:

| Without Cache | With Cache |
|--------|-------|
| <img width="185" alt="image" src="https://user-images.githubusercontent.com/9797472/175436294-8a6ed75a-24ed-42e2-853f-6beb1a6f7f16.png"> | <img width="154" alt="image" src="https://user-images.githubusercontent.com/9797472/175436384-e6fc9534-70f5-48c9-8795-f446d70f07ab.png"> |

It should improve restore times because we are downloading one large file and expanding it at once instead of creating 4 GB of tiny files.

Note that I am using the `CacheBeta` task because it is significantly faster. The regular `Cache` task is actually slower then just running restore each time
