### PR TITLE
Issue/50181

### DIFF
--- a/src/Analyzers/CSharp/Tests/UseExpressionBody/UseExpressionBodyForPropertiesAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseExpressionBody/UseExpressionBodyForPropertiesAnalyzerTests.cs
@@ -533,5 +533,29 @@ class C
 }";
             await TestWithUseExpressionBody(code, fixedCode, LanguageVersion.CSharp6);
         }
+
+        [WorkItem(50181, "https://github.com/dotnet/roslyn/issues/50181")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExpressionBody)]
+        public async Task TestUseExpressionBodyPreserveComments()
+        {
+            var code = @"
+public class C
+{
+    {|IDE0025:public long Length                   //N
+    {
+        // N = N1 + N2
+        get { return 1 + 2; }
+    }|}
+}";
+            var fixedCode = @"
+public class C
+{
+    public long Length                   //N
+
+        // N = N1 + N2
+        => 1 + 2;
+}";
+            await TestWithUseExpressionBody(code, fixedCode);
+        }
     }
 }

--- a/src/Analyzers/CSharp/Tests/UseExpressionBody/UseExpressionBodyForPropertiesAnalyzerTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseExpressionBody/UseExpressionBodyForPropertiesAnalyzerTests.cs
@@ -551,8 +551,7 @@ public class C
 public class C
 {
     public long Length                   //N
-
-        // N = N1 + N2
+                                         // N = N1 + N2
         => 1 + 2;
 }";
             await TestWithUseExpressionBody(code, fixedCode);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
@@ -63,13 +63,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             {
                 arrowExpression = SyntaxFactory.ArrowExpressionClause(expression);
 
-                if (block.GetRequiredParent().Kind() == SyntaxKind.GetAccessorDeclaration)
+                var parent = block.GetRequiredParent();
+
+                if (parent.Kind() == SyntaxKind.GetAccessorDeclaration)
                 {
-                    var comments = block.GetRequiredParent().GetLeadingTrivia().Where(t => !t.IsWhitespaceOrEndOfLine());
+                    var comments = parent.GetLeadingTrivia().Where(t => !t.IsWhitespaceOrEndOfLine());
                     if (!comments.IsEmpty())
                     {
                         arrowExpression = arrowExpression.WithLeadingTrivia(
-                            block.GetRequiredParent().GetLeadingTrivia());
+                            parent.GetLeadingTrivia());
                     }
                 }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 {
                     // The close brace of the block may have important trivia on it (like 
                     // comments or directives).  Preserve them on the semicolon when we
-                    // convert to an expression body.
+                    // convert to an expression body
                     semicolonToken = semicolonToken.WithAppendedTrailingTrivia(
                         block.CloseBraceToken.LeadingTrivia.Where(t => !t.IsWhitespaceOrEndOfLine()));
                     return true;
@@ -62,6 +62,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 block.TryConvertToExpressionBody(languageVersion, preference, out var expression, out semicolonToken))
             {
                 arrowExpression = SyntaxFactory.ArrowExpressionClause(expression);
+                arrowExpression = arrowExpression.WithPrependedLeadingTrivia(
+                        block.GetAncestors().FirstOrDefault().GetLeadingTrivia());
+                arrowExpression = arrowExpression.WithPrependedLeadingTrivia(
+                        block.GetAncestors().FirstOrDefault().GetTrailingTrivia());
                 return true;
             }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 {
                     // The close brace of the block may have important trivia on it (like 
                     // comments or directives).  Preserve them on the semicolon when we
-                    // convert to an expression body
+                    // convert to an expression body.
                     semicolonToken = semicolonToken.WithAppendedTrailingTrivia(
                         block.CloseBraceToken.LeadingTrivia.Where(t => !t.IsWhitespaceOrEndOfLine()));
                     return true;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
@@ -62,10 +62,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 block.TryConvertToExpressionBody(languageVersion, preference, out var expression, out semicolonToken))
             {
                 arrowExpression = SyntaxFactory.ArrowExpressionClause(expression);
-                arrowExpression = arrowExpression.WithPrependedLeadingTrivia(
-                        block.GetAncestors().FirstOrDefault().GetLeadingTrivia());
-                arrowExpression = arrowExpression.WithPrependedLeadingTrivia(
-                        block.GetAncestors().FirstOrDefault().GetTrailingTrivia());
+
+                if (block.GetRequiredParent().Kind() == SyntaxKind.GetAccessorDeclaration)
+                {
+                    arrowExpression = arrowExpression.WithLeadingTrivia(
+                        block.GetRequiredParent().GetLeadingTrivia());
+                }
+
                 return true;
             }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
@@ -65,8 +65,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
                 if (block.GetRequiredParent().Kind() == SyntaxKind.GetAccessorDeclaration)
                 {
-                    arrowExpression = arrowExpression.WithLeadingTrivia(
-                        block.GetRequiredParent().GetLeadingTrivia());
+                    var comments = block.GetRequiredParent().GetLeadingTrivia().Where(t => t.IsSingleOrMultiLineComment());
+                    if (!comments.IsEmpty())
+                    {
+                        arrowExpression = arrowExpression.WithLeadingTrivia(
+                            block.GetRequiredParent().GetLeadingTrivia());
+                    }
                 }
 
                 return true;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/BlockSyntaxExtensions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
                 if (block.GetRequiredParent().Kind() == SyntaxKind.GetAccessorDeclaration)
                 {
-                    var comments = block.GetRequiredParent().GetLeadingTrivia().Where(t => t.IsSingleOrMultiLineComment());
+                    var comments = block.GetRequiredParent().GetLeadingTrivia().Where(t => !t.IsWhitespaceOrEndOfLine());
                     if (!comments.IsEmpty())
                     {
                         arrowExpression = arrowExpression.WithLeadingTrivia(


### PR DESCRIPTION
Fixed an error that occurred when using the body expression refactoring option, causing the refactoring to delete the comments.

Fixes https://github.com/dotnet/roslyn/issues/50181