### PR TITLE
Fix top-level activation for Move Static Members

### DIFF
--- a/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
@@ -2295,7 +2295,7 @@ namespace TestNs1
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
-        public async Task TestSelectInKeyWordOfDeclaration1()
+        public async Task TestSelectInKeywordOfDeclaration1()
         {
             var initialMarkup = @"
 namespace TestNs1
@@ -2326,7 +2326,7 @@ namespace TestNs1
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
-        public async Task TestSelectInKeyWordOfMulitFieldDeclaration()
+        public async Task TestSelectInKeywordOfMulitFieldDeclaration()
         {
             var initialMarkup = @"
 namespace TestNs1
@@ -2358,7 +2358,7 @@ namespace TestNs1
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
-        public async Task TestSelectInKeyWordOfDeclaration2()
+        public async Task TestSelectInKeywordOfDeclaration2()
         {
             var initialMarkup = @"
 namespace TestNs1

--- a/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
@@ -2326,6 +2326,38 @@ namespace TestNs1
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
+        public async Task TestSelectInKeyWordOfMulitFieldDeclaration()
+        {
+            var initialMarkup = @"
+namespace TestNs1
+{
+    public class Class1
+    {
+        pub[||]lic static int TestField = 1, foo = 0;
+    }
+}";
+            var selectedDestinationName = "Class1Helpers";
+            var newFileName = "Class1Helpers.cs";
+            var selectedMembers = ImmutableArray.Create("TestField");
+            var expectedResult1 = @"
+namespace TestNs1
+{
+    public class Class1
+    {
+        public static int foo = 0;
+    }
+}";
+            var expectedResult2 = @"namespace TestNs1
+{
+    internal static class Class1Helpers
+    {
+        public static int TestField = 1;
+    }
+}";
+            await TestMovementNewFileAsync(initialMarkup, expectedResult1, expectedResult2, newFileName, selectedMembers, selectedDestinationName).ConfigureAwait(false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
         public async Task TestSelectInKeyWordOfDeclaration2()
         {
             var initialMarkup = @"
@@ -2564,6 +2596,44 @@ namespace TestNs1
     }
 }";
             await TestNoRefactoringAsync(initialMarkup).ConfigureAwait(false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
+        public async Task TestSelectTopLevelDeclaration1_NoAction()
+        {
+            var initialMarkup = @"
+using System;
+
+[||]_ = 42;";
+            var test = new Test("", ImmutableArray<string>.Empty)
+            {
+                TestState =
+                {
+                    OutputKind = OutputKind.ConsoleApplication
+                },
+                TestCode = initialMarkup,
+                FixedCode = initialMarkup,
+            };
+            test.LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9;
+            await test.RunAsync().ConfigureAwait(false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
+        public async Task TestSelectTopLevelDeclaration2_NoAction()
+        {
+            var initialMarkup = @"
+[||]_ = 42;";
+            var test = new Test("", ImmutableArray<string>.Empty)
+            {
+                TestState =
+                {
+                    OutputKind = OutputKind.ConsoleApplication
+                },
+                TestCode = initialMarkup,
+                FixedCode = initialMarkup,
+            };
+            test.LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9;
+            await test.RunAsync().ConfigureAwait(false);
         }
         #endregion
 

--- a/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
@@ -2613,8 +2613,9 @@ using System;
                 },
                 TestCode = initialMarkup,
                 FixedCode = initialMarkup,
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
             };
-            test.LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9;
+
             await test.RunAsync().ConfigureAwait(false);
         }
 
@@ -2631,8 +2632,9 @@ using System;
                 },
                 TestCode = initialMarkup,
                 FixedCode = initialMarkup,
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
             };
-            test.LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9;
+
             await test.RunAsync().ConfigureAwait(false);
         }
         #endregion

--- a/src/Features/Core/Portable/MoveStaticMembers/AbstractMoveStaticMembersRefactoringProvider.cs
+++ b/src/Features/Core/Portable/MoveStaticMembers/AbstractMoveStaticMembersRefactoringProvider.cs
@@ -39,15 +39,14 @@ namespace Microsoft.CodeAnalysis.MoveStaticMembers
             }
 
             var selectedMember = semanticModel.GetDeclaredSymbol(memberDeclaration, cancellationToken);
-            if (selectedMember is null || selectedMember.ContainingType is null ||
-                !selectedMember.IsStatic || !MemberAndDestinationValidator.IsMemberValid(selectedMember))
+            if (selectedMember?.ContainingType is null || !selectedMember.IsStatic || !MemberAndDestinationValidator.IsMemberValid(selectedMember))
             {
                 return;
             }
 
             var action = new MoveStaticMembersWithDialogCodeAction(document, memberDeclaration.Span, service, selectedMember.ContainingType, context.Options, selectedMember: selectedMember);
 
-            context.RegisterRefactoring(action);
+            context.RegisterRefactoring(action, memberDeclaration.Span);
         }
     }
 }

--- a/src/Features/Core/Portable/MoveStaticMembers/AbstractMoveStaticMembersRefactoringProvider.cs
+++ b/src/Features/Core/Portable/MoveStaticMembers/AbstractMoveStaticMembersRefactoringProvider.cs
@@ -38,7 +38,13 @@ namespace Microsoft.CodeAnalysis.MoveStaticMembers
                 return;
             }
 
-            var selectedType = semanticModel.GetEnclosingNamedType(span.Start, cancellationToken);
+            var selectedMember = semanticModel.GetDeclaredSymbol(memberDeclaration, cancellationToken);
+            if (selectedMember is null || selectedMember.ContainingType is null)
+            {
+                return;
+            }
+
+            var selectedType = selectedMember.ContainingType;
             if (selectedType == null)
             {
                 return;
@@ -55,7 +61,7 @@ namespace Microsoft.CodeAnalysis.MoveStaticMembers
 
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
 
-            var action = new MoveStaticMembersWithDialogCodeAction(document, span, service, selectedType, context.Options, selectedMember: selectedMembers[0]);
+            var action = new MoveStaticMembersWithDialogCodeAction(document, span, service, selectedType, context.Options, selectedMember: selectedMember);
 
             context.RegisterRefactoring(action, selectedMembers[0].DeclaringSyntaxReferences[0].Span);
         }

--- a/src/Features/Core/Portable/MoveStaticMembers/AbstractMoveStaticMembersRefactoringProvider.cs
+++ b/src/Features/Core/Portable/MoveStaticMembers/AbstractMoveStaticMembersRefactoringProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.MoveStaticMembers
                 return;
             }
 
-            var action = new MoveStaticMembersWithDialogCodeAction(document, memberDeclaration.Span, service, selectedMember.ContainingType, context.Options, selectedMember: selectedMember);
+            var action = new MoveStaticMembersWithDialogCodeAction(document, service, selectedMember.ContainingType, context.Options, selectedMember: selectedMember);
 
             context.RegisterRefactoring(action, memberDeclaration.Span);
         }

--- a/src/Features/Core/Portable/MoveStaticMembers/MoveStaticMembersWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/MoveStaticMembers/MoveStaticMembersWithDialogCodeAction.cs
@@ -30,12 +30,10 @@ namespace Microsoft.CodeAnalysis.MoveStaticMembers
         private readonly IMoveStaticMembersOptionsService _service;
         private readonly CleanCodeGenerationOptionsProvider _fallbackOptions;
 
-        public TextSpan Span { get; }
         public override string Title => FeaturesResources.Move_static_members_to_another_type;
 
         public MoveStaticMembersWithDialogCodeAction(
             Document document,
-            TextSpan span,
             IMoveStaticMembersOptionsService service,
             INamedTypeSymbol selectedType,
             CleanCodeGenerationOptionsProvider fallbackOptions,
@@ -46,7 +44,6 @@ namespace Microsoft.CodeAnalysis.MoveStaticMembers
             _selectedType = selectedType;
             _fallbackOptions = fallbackOptions;
             _selectedMember = selectedMember;
-            Span = span;
         }
 
         public override object? GetOptions(CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes #59470

Change selection logic for Move Static Members to follow more closely with Extract Class and Pull Members Up, where we get the enclosing type and selected symbol from the selected syntax node instead of the selection span and its members. This fixes the problem where the refactoring was being suggested on top-level statements.

Offers a slight change in the dialog box behavior, in that it will now preselect the member that triggered the activation, instead of the first member of the enclosing class.

Added tests to document non-activation in top-level statement.