### PR TITLE
Support switch expression in CompleteStatementHandler

### DIFF
--- a/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
@@ -156,9 +156,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement
                 delimiters = startingNode.GetBrackets();
             }
 
-            if (delimiters == default && TryGetParentsWithBraces(startingNode, out var parentsWithBraces))
+            if (delimiters == default)
             {
-                delimiters = parentsWithBraces.GetBraces();
+                delimiters = startingNode.GetBraces();
             }
 
             var (openingDelimiter, closingDelimiter) = delimiters;
@@ -470,21 +470,5 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement
                 currentNode.GetParentheses().closeParen.IsMissing ||
                 currentNode.GetBraces().closeBrace.IsMissing;
         }
-
-        private static bool TryGetParentsWithBraces(SyntaxNode currentNode, [NotNullWhen(true)] out SyntaxNode? parentsWithBraces)
-        {
-            // Switch Expression could be followed by semicolon.
-            if (currentNode.GetAncestorsOrThis(IsSyntaxNodeWithBracesCouldBeFollowedBySemicolon).FirstOrDefault() is { } parent)
-            {
-                parentsWithBraces = parent;
-                return true;
-            }
-
-            parentsWithBraces = null;
-            return false;
-        }
-
-        private static bool IsSyntaxNodeWithBracesCouldBeFollowedBySemicolon(SyntaxNode node)
-            => node is SwitchExpressionSyntax;
     }
 }

--- a/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
@@ -5,7 +5,6 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.AutomaticCompletion;
 using Microsoft.CodeAnalysis.CSharp;

--- a/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/CompleteStatement/CompleteStatementCommandHandler.cs
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement
                 SyntaxKind.UncheckedExpression,
                 SyntaxKind.TypeOfExpression,
                 SyntaxKind.TupleExpression,
-                SyntaxKind.SwitchExpression) || currentNode is InitializerExpressionSyntax)
+                SyntaxKind.SwitchExpression))
             {
                 // make sure the closing delimiter exists
                 if (RequiredDelimiterIsMissing(currentNode))
@@ -485,6 +485,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.CompleteStatement
         }
 
         private static bool IsSyntaxNodeWithBracesCouldBeFollowedBySemicolon(SyntaxNode node)
-            => node is SwitchExpressionSyntax or InitializerExpressionSyntax;
+            => node is SwitchExpressionSyntax;
     }
 }

--- a/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
@@ -4299,59 +4299,6 @@ public class Bar
             VerifyNoSpecialSemicolonHandling(code);
         }
 
-        [WpfFact]
-        public void TestInitializer()
-        {
-            var code = @"
-using System.Collections;
-public class Bar
-{
-    public void Test()
-    {
-        var l = new List<int>()
-        {
-            1,
-            2$$
-        }
-    }
-}";
-
-            var expected = @"
-using System.Collections;
-public class Bar
-{
-    public void Test()
-    {
-        var l = new List<int>()
-        {
-            1,
-            2
-        };$$
-    }
-}";
-            VerifyTypingSemicolon(code, expected);
-        }
-
-        [WpfFact]
-        public void TestOutsideInitializer()
-        {
-            var code = @"
-using System.Collections;
-public class Bar
-{
-    public void Test()
-    {
-        var l = new List<int>()
-        $${
-            1,
-            2
-        }
-    }
-}";
-
-            VerifyNoSpecialSemicolonHandling(code);
-        }
-
         protected override TestWorkspace CreateTestWorkspace(string code)
             => TestWorkspace.CreateCSharp(code);
     }

--- a/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
@@ -4257,8 +4257,8 @@ public class Bar
         var a = myString switch
         {
             ""Hello"" => 1,
-            ""World"" => 2,
-            _ => 3$$
+           $$ ""World"" => 2,
+            _ => 3
         }
     }
 }";
@@ -4280,6 +4280,26 @@ public class Bar
         }
 
         [WpfFact]
+        public void TestNotInBracesSwitchExpression()
+        {
+            var code = @"
+public class Bar
+{
+    public void Test(string myString)
+    {
+        var a = myString switch
+        $${
+            ""Hello"" => 1,
+            ""World"" => 2,
+            _ => 3
+        }
+    }
+}";
+
+            VerifyNoSpecialSemicolonHandling(code);
+        }
+
+        [WpfFact]
         public void TestInitializer()
         {
             var code = @"
@@ -4288,7 +4308,11 @@ public class Bar
 {
     public void Test()
     {
-        var l = new List<int>() { 1, 2 $$}
+        var l = new List<int>()
+        {
+            1,
+            2$$
+        }
     }
 }";
 
@@ -4298,10 +4322,34 @@ public class Bar
 {
     public void Test()
     {
-        var l = new List<int>() { 1, 2 };$$
+        var l = new List<int>()
+        {
+            1,
+            2
+        };$$
     }
 }";
             VerifyTypingSemicolon(code, expected);
+        }
+
+        [WpfFact]
+        public void TestOutsideInitializer()
+        {
+            var code = @"
+using System.Collections;
+public class Bar
+{
+    public void Test()
+    {
+        var l = new List<int>()
+        $${
+            1,
+            2
+        }
+    }
+}";
+
+            VerifyNoSpecialSemicolonHandling(code);
         }
 
         protected override TestWorkspace CreateTestWorkspace(string code)

--- a/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
@@ -4247,7 +4247,7 @@ public class ClassC
         }
 
         [WpfFact]
-        public void Test()
+        public void TestSwitchExpression()
         {
             var code = @"
 public class Bar
@@ -4274,6 +4274,31 @@ public class Bar
             ""World"" => 2,
             _ => 3
         };$$
+    }
+}";
+            VerifyTypingSemicolon(code, expected);
+        }
+
+        [WpfFact]
+        public void TestInitializer()
+        {
+            var code = @"
+using System.Collections;
+public class Bar
+{
+    public void Test()
+    {
+        var l = new List<int>() { 1, 2 $$}
+    }
+}";
+
+            var expected = @"
+using System.Collections;
+public class Bar
+{
+    public void Test()
+    {
+        var l = new List<int>() { 1, 2 };$$
     }
 }";
             VerifyTypingSemicolon(code, expected);

--- a/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
@@ -4257,8 +4257,8 @@ public class Bar
         var a = myString switch
         {
             ""Hello"" => 1,
-           $$ ""World"" => 2,
-            _ => 3
+            ""World"" => 2,
+            _ => 3$$
         }
     }
 }";

--- a/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
+++ b/src/EditorFeatures/CSharpTest/CompleteStatement/CSharpCompleteStatementCommandHandlerTests.cs
@@ -4245,6 +4245,40 @@ public class ClassC
                     globalOptions.SetGlobalOption(new OptionKey(FeatureOnOffOptions.AutomaticallyCompleteStatementOnSemicolon), false);
                 });
         }
+
+        [WpfFact]
+        public void Test()
+        {
+            var code = @"
+public class Bar
+{
+    public void Test(string myString)
+    {
+        var a = myString switch
+        {
+            ""Hello"" => 1,
+            ""World"" => 2,
+            _ => 3$$
+        }
+    }
+}";
+
+            var expected = @"
+public class Bar
+{
+    public void Test(string myString)
+    {
+        var a = myString switch
+        {
+            ""Hello"" => 1,
+            ""World"" => 2,
+            _ => 3
+        };$$
+    }
+}";
+            VerifyTypingSemicolon(code, expected);
+        }
+
         protected override TestWorkspace CreateTestWorkspace(string code)
             => TestWorkspace.CreateCSharp(code);
     }


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/57213

After this change, if you enter `;` inside the `{   }` of switch expression, the caret would be moved to the end of the statement.