### PR TITLE
Add members to PythiaCompletionProviderBase to move IntelliCode off internal APIs

### DIFF
--- a/src/Features/Core/Portable/ExternalAccess/Pythia/Api/PythiaCompletionProviderBase.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Pythia/Api/PythiaCompletionProviderBase.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
 {
@@ -55,8 +56,24 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia.Api
         public static CompletionDescription GetDescription(CompletionItem item)
             => CommonCompletionItem.GetDescription(item);
 
+        internal sealed override async Task<CompletionDescription> GetDescriptionWorkerAsync(
+            Document document, CompletionItem item, CompletionOptions options, SymbolDescriptionOptions displayOptions, CancellationToken cancellationToken)
+        {
+            var description = await GetDescriptionAsync(item, document, displayOptions, cancellationToken).ConfigureAwait(false);
+            return UpdateDescription(description);
+        }
+
+        protected virtual CompletionDescription UpdateDescription(CompletionDescription completionDescription)
+            => completionDescription;
+
         public static bool TryGetInsertionText(CompletionItem item, [NotNullWhen(true)] out string? insertionText)
             => SymbolCompletionItem.TryGetInsertionText(item, out insertionText);
+
+        public sealed override bool IsInsertionTrigger(SourceText text, int insertedCharacterPosition, CompletionOptions options)
+            => IsInsertionTriggerWorker(text, insertedCharacterPosition);
+
+        protected virtual bool IsInsertionTriggerWorker(SourceText text, int insertedCharacterPosition)
+            => text[insertedCharacterPosition] == '.';
 
         public override Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, char? commitKey = null, CancellationToken cancellationToken = default)
             => base.GetChangeAsync(document, item, commitKey, cancellationToken);


### PR DESCRIPTION
Intellicode is suppressing RS0035 to access our internal types, which make it very fragile against changes to our internals (e.g. https://github.com/dotnet/roslyn/issues/61980 is caused by https://github.com/dotnet/roslyn/pull/60888). This PR added APIs to the ExternalAccess type so they can remove those suppressions.

