### PR TITLE
Exclude BCL libraries from Roslyn vsix

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -304,4 +304,8 @@
     <UsingToolMicrosoftNetCompilers Condition="'$(BootstrapBuildPath)' == ''">true</UsingToolMicrosoftNetCompilers>
     <UseVSTestRunner>true</UseVSTestRunner>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- We should try to keep this version in sync with the version of app-local runtime in VS. -->
+    <MicrosoftNetCoreAppPackagesVersion>6.0.6</MicrosoftNetCoreAppPackagesVersion>
+  </PropertyGroup>
 </Project>

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.csproj
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.csproj
@@ -21,19 +21,14 @@
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="$(MicrosoftVisualStudioTelemetryVersion)" />
     <PackageReference Include="SQLitePCLRaw.bundle_green" Version="$(SQLitePCLRawbundle_greenVersion)" />
     <!-- We use the content of these two runtime pacakges to exclude BCL library from the dependencies we need to deploy as part of Roslyn vsix. -->
-    <PackageReference Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNETCoreAppRuntimewinx64Version)" ExcludeAssets="all" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="$(MicrosoftWindowsDesktopAppRuntimewinx64Version)" ExcludeAssets="all" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNETCoreAppRuntimewinx64Version)" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="$(MicrosoftWindowsDesktopAppRuntimewinx64Version)" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <Target Name="PublishProjectOutputGroup" DependsOnTargets="Publish" Returns="@(_PublishedFiles)">  
-    <PropertyGroup>
-      <_RuntimeLibraryDir>$(NuGetPackageRoot)Microsoft.NETCore.App.Runtime.win-x64\$(MicrosoftNETCoreAppRuntimewinx64Version)\runtimes\win-x64</_RuntimeLibraryDir>
-      <_RuntimeWindowsLibraryDir>$(NuGetPackageRoot)Microsoft.WindowsDesktop.App.Runtime.win-x64\$(MicrosoftWindowsDesktopAppRuntimewinx64Version)\runtimes\win-x64</_RuntimeWindowsLibraryDir>
-    </PropertyGroup>
-    <Error Text="Can't locate runtime libraries" Condition="!Exists('$(_RuntimeLibraryDir)') or !Exists('$(_RuntimeWindowsLibraryDir)')"/>
+  <Target Name="PublishProjectOutputGroup" DependsOnTargets="Publish" Returns="@(_PublishedFiles)">
     <ItemGroup>
-      <_RuntimeLibraries Include="$(_RuntimeLibraryDir)\**\*.dll" />
-      <_RuntimeLibraries Include="$(_RuntimeWindowsLibraryDir)\**\*.dll" />
+      <_RuntimeLibraries Include="$(PkgMicrosoft_NETCore_App_Runtime_win-x64)\runtimes\win-x64\**\*.dll" />
+      <_RuntimeLibraries Include="$(PkgMicrosoft_WindowsDesktop_App_Runtime_win-x64)\runtimes\win-x64\**\*.dll" />
     </ItemGroup>
     <ItemGroup>
       <_ExcludedFiles Include="$(PublishDir)**\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.*" />

--- a/src/Workspaces/Remote/ServiceHub.CoreComponents/Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.csproj
+++ b/src/Workspaces/Remote/ServiceHub.CoreComponents/Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.csproj
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <MicrosoftNETCoreAppRuntimewinx64Version>$(MicrosoftNetCoreAppPackagesVersion)</MicrosoftNETCoreAppRuntimewinx64Version>
+    <MicrosoftWindowsDesktopAppRuntimewinx64Version>$(MicrosoftNetCoreAppPackagesVersion)</MicrosoftWindowsDesktopAppRuntimewinx64Version>
     <!--
     The purpose of this project is to include all dependecies of Microsoft.CodeAnalysis.Remote.ServiceHub and C# and VB features layer targeting .Net Core.
     -->
@@ -18,31 +20,32 @@
     <!-- These references need to be deployed to the vsix subfolder containing servicehub bits for .Net Core -->
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="$(MicrosoftVisualStudioTelemetryVersion)" />
     <PackageReference Include="SQLitePCLRaw.bundle_green" Version="$(SQLitePCLRawbundle_greenVersion)" />
+    <!-- We use the content of these two runtime pacakges to exclude BCL library from the dependencies we need to deploy as part of Roslyn vsix. -->
+    <PackageReference Include="Microsoft.NETCore.App.Runtime.win-x64" Version="$(MicrosoftNETCoreAppRuntimewinx64Version)" ExcludeAssets="all" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.WindowsDesktop.App.Runtime.win-x64" Version="$(MicrosoftWindowsDesktopAppRuntimewinx64Version)" ExcludeAssets="all" PrivateAssets="all" />
   </ItemGroup>
 
-  <Target Name="PublishProjectOutputGroup" DependsOnTargets="Publish" Returns="@(_PublishedFiles)">
+  <Target Name="PublishProjectOutputGroup" DependsOnTargets="Publish" Returns="@(_PublishedFiles)">  
+    <PropertyGroup>
+      <_RuntimeLibraryDir>$(NuGetPackageRoot)Microsoft.NETCore.App.Runtime.win-x64\$(MicrosoftNETCoreAppRuntimewinx64Version)\runtimes\win-x64</_RuntimeLibraryDir>
+      <_RuntimeWindowsLibraryDir>$(NuGetPackageRoot)Microsoft.WindowsDesktop.App.Runtime.win-x64\$(MicrosoftWindowsDesktopAppRuntimewinx64Version)\runtimes\win-x64</_RuntimeWindowsLibraryDir>
+    </PropertyGroup>
+    <Error Text="Can't locate runtime libraries" Condition="!Exists('$(_RuntimeLibraryDir)') or !Exists('$(_RuntimeWindowsLibraryDir)')"/>
+    <ItemGroup>
+      <_RuntimeLibraries Include="$(_RuntimeLibraryDir)\**\*.dll" />
+      <_RuntimeLibraries Include="$(_RuntimeWindowsLibraryDir)\**\*.dll" />
+    </ItemGroup>
     <ItemGroup>
       <_ExcludedFiles Include="$(PublishDir)**\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.*" />
       <_ExcludedFiles Include="$(PublishDir)**\*.pdb" />
       <!-- the only assembly we need under runtime folder (runtimes\win-x64\native\e_sqlite3.dll) is handled by the vsix project directly -->
       <_ExcludedFiles Include="$(PublishDir)\runtimes\**\*.*" />
-      <!-- For binaries below, we want to use the version provided by the runtime in VS, not the ones from the NuGet packages. 
-      However, we can't safely exclude shared dependencies from ServiceHub host folder: we might be referencing a higher version,
-      or back-compat might not be guaranteed in the version shipped by host. -->
-      <_ExcludedFiles Include="$(PublishDir)\Microsoft.Win32.Registry.dll" />
-      <_ExcludedFiles Include="$(PublishDir)\Microsoft.Win32.SystemEvents.dll" />
-      <_ExcludedFiles Include="$(PublishDir)\System.CodeDom.dll" />
-      <_ExcludedFiles Include="$(PublishDir)\System.Configuration.ConfigurationManager.dll" />
-      <_ExcludedFiles Include="$(PublishDir)\System.Diagnostics.DiagnosticSource.dll" />
-      <_ExcludedFiles Include="$(PublishDir)\System.Diagnostics.PerformanceCounter.dll" />
-      <_ExcludedFiles Include="$(PublishDir)\System.Drawing.Common.dll" />
-      <_ExcludedFiles Include="$(PublishDir)\System.Runtime.CompilerServices.Unsafe.dll" />
-      <_ExcludedFiles Include="$(PublishDir)\System.Security.AccessControl.dll" />
-      <_ExcludedFiles Include="$(PublishDir)\System.Security.Cryptography.ProtectedData.dll" />
-      <_ExcludedFiles Include="$(PublishDir)\System.Security.Permissions.dll" />
-      <_ExcludedFiles Include="$(PublishDir)\System.Security.Principal.Windows.dll" />
-      <_ExcludedFiles Include="$(PublishDir)\System.Threading.Tasks.Dataflow.dll" />
-      <_ExcludedFiles Include="$(PublishDir)\System.Windows.Extensions.dll" />
+      <!-- 
+        For BCL, we want to use the version provided by the runtime in VS, not the ones from the NuGet packages. 
+        However, we can't safely exclude shared dependencies from ServiceHub host folder: we might be referencing
+        a higher version, or back-compat might not be guaranteed in the version shipped by host.
+      -->
+      <_ExcludedFiles Include="@(_RuntimeLibraries->'$(PublishDir)\%(FileName)%(Extension)')" />
     </ItemGroup>
     <ItemGroup>
       <!-- Need to include and then update items (https://github.com/microsoft/msbuild/issues/1053) -->


### PR DESCRIPTION
This change would make sure everything shipped as part of runtime would not be deployed by us again, so we don't need to manually maintain an exclusion list.

@tmat 