### PR TITLE
Use SharedStopwatch to avoid allocations in SyntaxStore

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/SyntaxStore.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SyntaxStore.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis
                                 var currentNode = syntaxInputBuilders[i].node;
                                 try
                                 {
-                                    Stopwatch sw = Stopwatch.StartNew();
+                                    var sw = SharedStopwatch.StartNew();
                                     try
                                     {
                                         _cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
Piggy backing off of the trace at https://github.com/dotnet/roslyn/pull/62132#issue-1284129513

Should reduce allocations by 670MB on that specific trace.

cc @CyrusNajmabadi 