### PR TITLE
Move to a shared stopwatch in the incremental generator

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/SyntaxStore.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SyntaxStore.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Threading;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -89,7 +90,7 @@ namespace Microsoft.CodeAnalysis
                                 var currentNode = syntaxInputBuilders[i].node;
                                 try
                                 {
-                                    Stopwatch sw = Stopwatch.StartNew();
+                                    var sw = SharedStopwatch.StartNew();
                                     try
                                     {
                                         _cancellationToken.ThrowIfCancellationRequested();

--- a/src/Tools/IdeCoreBenchmarks/IncrementalSourceGeneratorBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/IncrementalSourceGeneratorBenchmarks.cs
@@ -173,7 +173,7 @@ namespace IdeCoreBenchmarks
             Thread.Sleep(5000);
 
             var totalIncrementalTime = TimeSpan.Zero;
-            for (var i = 0; i < 1000; i++)
+            for (var i = 0; i < 5000; i++)
             {
                 var changedText = sourceText.WithChanges(new TextChange(new TextSpan(0, 0), $"// added text{i}\r\n"));
                 var changedTree = syntaxTree.WithChangedText(changedText);


### PR DESCRIPTION
Shaves off around 700 MB of unnecessary allocations:

![image](https://user-images.githubusercontent.com/4564579/175662038-6a2357bf-f40f-4c16-8555-f627ab89a709.png)
