### PR TITLE
Separate out connection failures

### DIFF
--- a/src/Compilers/Core/CommandLine/BuildProtocol.cs
+++ b/src/Compilers/Core/CommandLine/BuildProtocol.cs
@@ -290,6 +290,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
             // The server hash did not match the one supplied by the client
             IncorrectHash,
+
+            // Cannot connect to the server
+            CannotConnect,
         }
 
         public abstract ResponseType Type { get; }
@@ -364,6 +367,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
                         return ShutdownBuildResponse.Create(reader);
                     case ResponseType.Rejected:
                         return RejectedBuildResponse.Create(reader);
+
+                    // Intentional fall through
+                    case ResponseType.CannotConnect:
                     default:
                         throw new InvalidOperationException("Received invalid response type from server.");
                 }
@@ -493,6 +499,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
         }
     }
 
+    /// <summary>
+    /// The <see cref="BuildRequest"/> was rejected by the server.
+    /// </summary>
     internal sealed class RejectedBuildResponse : BuildResponse
     {
         public string Reason;
@@ -515,6 +524,16 @@ namespace Microsoft.CodeAnalysis.CommandLine
             Debug.Assert(reason is object);
             return new RejectedBuildResponse(reason);
         }
+    }
+
+    /// <summary>
+    /// Used when the client cannot connect to the server.
+    /// </summary>
+    internal sealed class CannotConnectResponse : BuildResponse
+    {
+        public override ResponseType Type => ResponseType.CannotConnect;
+
+        protected override void AddResponseBody(BinaryWriter writer) { }
     }
 
     // The id numbers below are just random. It's useful to use id numbers

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -669,6 +669,10 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     LogCompilationMessage(logger, requestId, CompilationKind.FatalError, "server reports different hash version than build task");
                     return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
 
+                case BuildResponse.ResponseType.CannotConnect:
+                    LogCompilationMessage(logger, requestId, CompilationKind.ToolFallback, $"cannot connect to the server");
+                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
+
                 case BuildResponse.ResponseType.Rejected:
                     var rejectedResponse = (RejectedBuildResponse)response;
                     LogCompilationMessage(logger, requestId, CompilationKind.ToolFallback, $"server rejected the request '{rejectedResponse.Reason}'");

--- a/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
+++ b/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
-using System.Diagnostics;
 
 #if DEBUG || BOOTSTRAP
 using System;

--- a/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
+++ b/src/Compilers/Core/MSBuildTask/ValidateBootstrap.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
+using System.Diagnostics;
 
 #if DEBUG || BOOTSTRAP
 using System;
@@ -70,18 +71,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 }
             }
 
-            // This represents the maximum number of failed build attempts on the server before we will declare
-            // that the overall build itself failed. 
+            // This represents the maximum number of failed connection attempts on the server before we will declare
+            // that the overall build itself failed. Keeping this at zero is not realistic because even in a fully
+            // functioning server connection failures are expected. The server could be too busy to accept connections
+            // fast enough. Anything above this count though is considered worth investigating by the compiler team.
             //
-            // The goal is to keep this at zero. The errors here are a mix of repository construction errors (having
-            // incompatible NuGet analyzers) and product errors (having flaky behavior in the server). Any time this
-            // number goes above zero it means we are dropping connections during developer inner loop builds and 
-            // hence measurably slowing down our productivity.
-            //
-            // When we find issues in the server or our infra we can temporarily raise this number while it is
-            // being worked out but should file a bug to track getting this to zero.
-            const int maxRejectCount = 0;
-            var rejectCount = 0;
+            const int maxCannotConnectCount = 2;
+            var cannotConnectCount = 0;
             foreach (var tuple in s_failedQueue.ToList())
             {
                 switch (tuple.ResponseType)
@@ -96,10 +92,14 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                         allGood = false;
                         break;
                     case ResponseType.Rejected:
-                        rejectCount++;
-                        if (rejectCount > maxRejectCount)
+                        Log.LogError($"Compiler request rejected");
+                        allGood = false;
+                        break;
+                    case ResponseType.CannotConnect:
+                        cannotConnectCount++;
+                        if (cannotConnectCount > maxCannotConnectCount)
                         {
-                            Log.LogError($"Too many compiler server connection failures detected");
+                            Log.LogError("Too many errors connecting to the server");
                             allGood = false;
                         }
                         break;

--- a/src/Compilers/Server/VBCSCompilerTests/BuildServerConnectionTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildServerConnectionTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 },
                 Logger,
                 cancellationToken: default);
-            Assert.True(response is RejectedBuildResponse);
+            Assert.True(response is CannotConnectResponse);
             Assert.True(ran);
         }
 
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                     },
                     Logger,
                     cancellationToken: default);
-                Assert.True(response is RejectedBuildResponse);
+                Assert.True(response is CannotConnectResponse);
             }
 
             Assert.Equal(5, count);

--- a/src/Compilers/Shared/BuildClient.cs
+++ b/src/Compilers/Shared/BuildClient.cs
@@ -256,6 +256,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
                 case BuildResponse.ResponseType.IncorrectHash:
                 case BuildResponse.ResponseType.Rejected:
                 case BuildResponse.ResponseType.AnalyzerInconsistency:
+                case BuildResponse.ResponseType.CannotConnect:
                     // Build could not be completed on the server.
                     return null;
                 default:

--- a/src/Compilers/Shared/BuildServerConnection.cs
+++ b/src/Compilers/Shared/BuildServerConnection.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             using var pipe = await tryConnectToServer(pipeName, timeoutOverride, logger, tryCreateServerFunc, cancellationToken).ConfigureAwait(false);
             if (pipe is null)
             {
-                return new RejectedBuildResponse("Failed to connect to server");
+                return new CannotConnectResponse();
             }
             else
             {


### PR DESCRIPTION
This changes the compiler to have a specific failure when it cannot
connect to the server. This lets us treat it separately from cases where
the server connected succeeded but the server rejected the request.

The reason for this change is cannot connect failures are not
necessarily an indicator of a code issue. A fully functional build can
hit connection issues for a variety of reasons. For example if the
server is too busy and can't respond to a connection event in time.

Having a separate response means we can handle the failures differently
in bootstrap builds. The bootstrap build will not fail now until it sees
more than three of these. That should reduce the false positive rate we
see in our infra.