### PR TITLE
draft: Allow trailing comma in ComplexElementInitializerExpression

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -12720,7 +12720,6 @@ tryAgain:
                             list.AddSeparator(this.EatToken(SyntaxKind.CommaToken));
                             if (this.CurrentToken.Kind == SyntaxKind.CloseBraceToken)
                             {
-                                closeBraceError = MakeError(this.CurrentToken, ErrorCode.ERR_ExpressionExpected);
                                 break;
                             }
                             list.Add(this.ParseExpressionCore());

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -5221,9 +5221,8 @@ static class Test
 
         [WorkItem(536674, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/536674")]
         [Fact]
-        public void CS1733ERR_ExpressionExpected()
+        public void TestTrailingCommaInComplexElementInitializerExpression()
         {
-            // diff error msg - CS1525
             var test = @"
 using System.Collections.Generic;
 using System.Collections;
@@ -5236,7 +5235,7 @@ static class Test
 }
 ";
 
-            ParseAndValidate(test, Diagnostic(ErrorCode.ERR_ExpressionExpected, "}"));
+            ParseAndValidate(test);
         }
 
         [WorkItem(536674, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/536674")]


### PR DESCRIPTION
Aligns with https://github.com/dotnet/roslyn/blob/f7634f7503665406e717d27bbac581b13a0c21b6/src/Compilers/CSharp/Portable/Syntax/Syntax.xml#L1521

not sure what the spec says. Could someone confirm?