### PR TITLE
Cleanups for our logging helpers

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/AsyncCompletionLogger.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/AsyncCompletionLogger.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 {
     internal static class AsyncCompletionLogger
     {
-        private static readonly LogAggregator<ActionInfo> s_logAggregator = new();
+        private static readonly CountLogAggregator<ActionInfo> s_countLogAggregator = new();
         private static readonly StatisticLogAggregator<ActionInfo> s_statisticLogAggregator = new();
         private static readonly HistogramLogAggregator<ActionInfo> s_histogramLogAggregator = new(25, 500);
 
@@ -45,26 +45,26 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
         internal static void LogImportCompletionGetContext(bool isBlocking, bool delayed)
         {
-            s_logAggregator.IncreaseCount(ActionInfo.SessionWithTypeImportCompletionEnabled);
+            s_countLogAggregator.IncreaseCount(ActionInfo.SessionWithTypeImportCompletionEnabled);
 
             if (isBlocking)
-                s_logAggregator.IncreaseCount(ActionInfo.SessionWithImportCompletionBlocking);
+                s_countLogAggregator.IncreaseCount(ActionInfo.SessionWithImportCompletionBlocking);
 
             if (delayed)
-                s_logAggregator.IncreaseCount(ActionInfo.SessionWithImportCompletionDelayed);
+                s_countLogAggregator.IncreaseCount(ActionInfo.SessionWithImportCompletionDelayed);
         }
 
         internal static void LogSessionWithDelayedImportCompletionIncludedInUpdate() =>
-            s_logAggregator.IncreaseCount(ActionInfo.SessionWithDelayedImportCompletionIncludedInUpdate);
+            s_countLogAggregator.IncreaseCount(ActionInfo.SessionWithDelayedImportCompletionIncludedInUpdate);
 
         internal static void LogAdditionalTicksToCompleteDelayedImportCompletionDataPoint(TimeSpan timeSpan) =>
             s_histogramLogAggregator.IncreaseCount(ActionInfo.AdditionalTicksToCompleteDelayedImportCompletion, timeSpan);
 
         internal static void LogDelayedImportCompletionIncluded() =>
-            s_logAggregator.IncreaseCount(ActionInfo.SessionWithTypeImportCompletionEnabled);
+            s_countLogAggregator.IncreaseCount(ActionInfo.SessionWithTypeImportCompletionEnabled);
 
         internal static void LogExpanderUsage() =>
-            s_logAggregator.IncreaseCount(ActionInfo.ExpanderUsageCount);
+            s_countLogAggregator.IncreaseCount(ActionInfo.ExpanderUsageCount);
 
         internal static void LogGetDefaultsMatchTicksDataPoint(int count) =>
             s_statisticLogAggregator.AddDataPoint(ActionInfo.GetDefaultsMatchTicks, count);
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     m[CreateProperty(info, nameof(StatisticResult.Count))] = statistics.Count;
                 }
 
-                foreach (var kv in s_logAggregator)
+                foreach (var kv in s_countLogAggregator)
                 {
                     var mergeInfo = kv.Key.ToString("f");
                     m[mergeInfo] = kv.Value.GetCount();

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/AsyncCompletionLogger.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/AsyncCompletionLogger.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             s_countLogAggregator.IncreaseCount(ActionInfo.SessionWithDelayedImportCompletionIncludedInUpdate);
 
         internal static void LogAdditionalTicksToCompleteDelayedImportCompletionDataPoint(TimeSpan timeSpan) =>
-            s_histogramLogAggregator.IncreaseCount(ActionInfo.AdditionalTicksToCompleteDelayedImportCompletion, timeSpan);
+            s_histogramLogAggregator.LogTime(ActionInfo.AdditionalTicksToCompleteDelayedImportCompletion, timeSpan);
 
         internal static void LogDelayedImportCompletionIncluded() =>
             s_countLogAggregator.IncreaseCount(ActionInfo.SessionWithTypeImportCompletionEnabled);
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         internal static void LogSourceInitializationTicksDataPoint(TimeSpan elapsed)
         {
             s_statisticLogAggregator.AddDataPoint(ActionInfo.SourceInitializationTicks, elapsed);
-            s_histogramLogAggregator.IncreaseCount(ActionInfo.SourceInitializationTicks, elapsed);
+            s_histogramLogAggregator.LogTime(ActionInfo.SourceInitializationTicks, elapsed);
         }
 
         internal static void LogSourceGetContextTicksDataPoint(TimeSpan elapsed, bool isCanceled)
@@ -82,13 +82,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 : ActionInfo.SourceGetContextCompletedTicks;
 
             s_statisticLogAggregator.AddDataPoint(key, elapsed);
-            s_histogramLogAggregator.IncreaseCount(key, elapsed);
+            s_histogramLogAggregator.LogTime(key, elapsed);
         }
 
         internal static void LogItemManagerSortTicksDataPoint(TimeSpan elapsed)
         {
             s_statisticLogAggregator.AddDataPoint(ActionInfo.ItemManagerSortTicks, elapsed);
-            s_histogramLogAggregator.IncreaseCount(ActionInfo.ItemManagerSortTicks, elapsed);
+            s_histogramLogAggregator.LogTime(ActionInfo.ItemManagerSortTicks, elapsed);
         }
 
         internal static void LogItemManagerUpdateDataPoint(TimeSpan elapsed, bool isCanceled)
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 : ActionInfo.ItemManagerUpdateCompletedTicks;
 
             s_statisticLogAggregator.AddDataPoint(key, elapsed);
-            s_histogramLogAggregator.IncreaseCount(key, elapsed);
+            s_histogramLogAggregator.LogTime(key, elapsed);
         }
 
         internal static void ReportTelemetry()

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/AsyncCompletionLogger.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/AsyncCompletionLogger.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.CodeAnalysis.Internal.Log;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion
@@ -56,8 +57,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         internal static void LogSessionWithDelayedImportCompletionIncludedInUpdate() =>
             s_logAggregator.IncreaseCount((int)ActionInfo.SessionWithDelayedImportCompletionIncludedInUpdate);
 
-        internal static void LogAdditionalTicksToCompleteDelayedImportCompletionDataPoint(int count) =>
-            s_histogramLogAggregator.IncreaseCount((int)ActionInfo.AdditionalTicksToCompleteDelayedImportCompletion, count);
+        internal static void LogAdditionalTicksToCompleteDelayedImportCompletionDataPoint(TimeSpan timeSpan) =>
+            s_histogramLogAggregator.IncreaseCount((int)ActionInfo.AdditionalTicksToCompleteDelayedImportCompletion, timeSpan);
 
         internal static void LogDelayedImportCompletionIncluded() =>
             s_logAggregator.IncreaseCount((int)ActionInfo.SessionWithTypeImportCompletionEnabled);
@@ -68,36 +69,36 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         internal static void LogGetDefaultsMatchTicksDataPoint(int count) =>
             s_statisticLogAggregator.AddDataPoint((int)ActionInfo.GetDefaultsMatchTicks, count);
 
-        internal static void LogSourceInitializationTicksDataPoint(int count)
+        internal static void LogSourceInitializationTicksDataPoint(TimeSpan elapsed)
         {
-            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.SourceInitializationTicks, count);
-            s_histogramLogAggregator.IncreaseCount((int)ActionInfo.SourceInitializationTicks, count);
+            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.SourceInitializationTicks, elapsed);
+            s_histogramLogAggregator.IncreaseCount((int)ActionInfo.SourceInitializationTicks, elapsed);
         }
 
-        internal static void LogSourceGetContextTicksDataPoint(int count, bool isCanceled)
+        internal static void LogSourceGetContextTicksDataPoint(TimeSpan elapsed, bool isCanceled)
         {
             var key = isCanceled
                 ? ActionInfo.SourceGetContextCanceledTicks
                 : ActionInfo.SourceGetContextCompletedTicks;
 
-            s_statisticLogAggregator.AddDataPoint((int)key, count);
-            s_histogramLogAggregator.IncreaseCount((int)key, count);
+            s_statisticLogAggregator.AddDataPoint((int)key, elapsed);
+            s_histogramLogAggregator.IncreaseCount((int)key, elapsed);
         }
 
-        internal static void LogItemManagerSortTicksDataPoint(int count)
+        internal static void LogItemManagerSortTicksDataPoint(TimeSpan elapsed)
         {
-            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.ItemManagerSortTicks, count);
-            s_histogramLogAggregator.IncreaseCount((int)ActionInfo.ItemManagerSortTicks, count);
+            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.ItemManagerSortTicks, elapsed);
+            s_histogramLogAggregator.IncreaseCount((int)ActionInfo.ItemManagerSortTicks, elapsed);
         }
 
-        internal static void LogItemManagerUpdateDataPoint(int count, bool isCanceled)
+        internal static void LogItemManagerUpdateDataPoint(TimeSpan elapsed, bool isCanceled)
         {
             var key = isCanceled
                 ? ActionInfo.ItemManagerUpdateCanceledTicks
                 : ActionInfo.ItemManagerUpdateCompletedTicks;
 
-            s_statisticLogAggregator.AddDataPoint((int)key, count);
-            s_histogramLogAggregator.IncreaseCount((int)key, count);
+            s_statisticLogAggregator.AddDataPoint((int)key, elapsed);
+            s_histogramLogAggregator.IncreaseCount((int)key, elapsed);
         }
 
         internal static void ReportTelemetry()

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             }
             finally
             {
-                AsyncCompletionLogger.LogSourceInitializationTicksDataPoint((int)stopwatch.Elapsed.TotalMilliseconds);
+                AsyncCompletionLogger.LogSourceInitializationTicksDataPoint(stopwatch.Elapsed);
             }
         }
 
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                         // There could be a race around the usage of this stopwatch, I ignored it since we just need a rough idea:
                         // we always log the time even if the stopwatch's not started regardless of whether expand items are included intially
                         // (that number can be obtained via another property.)
-                        AsyncCompletionLogger.LogAdditionalTicksToCompleteDelayedImportCompletionDataPoint((int)stopwatch.ElapsedMilliseconds);
+                        AsyncCompletionLogger.LogAdditionalTicksToCompleteDelayedImportCompletionDataPoint(stopwatch.Elapsed);
 
                         return result;
                     }, cancellationToken);
@@ -342,7 +342,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             }
             finally
             {
-                AsyncCompletionLogger.LogSourceGetContextTicksDataPoint((int)totalStopWatch.Elapsed.TotalMilliseconds, isCanceled: cancellationToken.IsCancellationRequested);
+                AsyncCompletionLogger.LogSourceGetContextTicksDataPoint(totalStopWatch.Elapsed, isCanceled: cancellationToken.IsCancellationRequested);
             }
 
             static VSCompletionContext CombineCompletionContext(VSCompletionContext context1, VSCompletionContext context2)

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
             // Sort by default comparer of Roslyn CompletionItem
             var sortedItems = data.InitialList.OrderBy(CompletionItemData.GetOrAddDummyRoslynItem).ToImmutableArray();
-            AsyncCompletionLogger.LogItemManagerSortTicksDataPoint((int)stopwatch.Elapsed.TotalMilliseconds);
+            AsyncCompletionLogger.LogItemManagerSortTicksDataPoint(stopwatch.Elapsed);
             return Task.FromResult(sortedItems);
         }
 
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             }
             finally
             {
-                AsyncCompletionLogger.LogItemManagerUpdateDataPoint((int)stopwatch.Elapsed.TotalMilliseconds, isCanceled: cancellationToken.IsCancellationRequested);
+                AsyncCompletionLogger.LogItemManagerUpdateDataPoint(stopwatch.Elapsed, isCanceled: cancellationToken.IsCancellationRequested);
             }
         }
     }

--- a/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
+++ b/src/Features/Core/Portable/ChangeSignature/AbstractChangeSignatureService.cs
@@ -427,7 +427,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
             }
 
             telemetryTimer.Stop();
-            ChangeSignatureLogger.LogCommitInformation(telemetryNumberOfDeclarationsToUpdate, telemetryNumberOfReferencesToUpdate, (int)telemetryTimer.ElapsedMilliseconds);
+            ChangeSignatureLogger.LogCommitInformation(telemetryNumberOfDeclarationsToUpdate, telemetryNumberOfReferencesToUpdate, telemetryTimer.Elapsed);
 
             return (currentSolution, confirmationMessage);
         }

--- a/src/Features/Core/Portable/ChangeSignature/ChangeSignatureTelemetryLogger.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ChangeSignatureTelemetryLogger.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
             s_countLogAggregator.IncreaseCountBy(ActionInfo.CommittedSessionNumberOfCallSitesUpdated, numCallSitesUpdated);
 
             s_statisticLogAggregator.AddDataPoint(ActionInfo.CommittedSessionCommitElapsedMS, (int)elapsedTime.TotalMilliseconds);
-            s_histogramLogAggregator.IncreaseCount(ActionInfo.CommittedSessionCommitElapsedMS, elapsedTime);
+            s_histogramLogAggregator.LogTime(ActionInfo.CommittedSessionCommitElapsedMS, elapsedTime);
         }
 
         internal static void LogAddedParameterTypeBinds()

--- a/src/Features/Core/Portable/ChangeSignature/ChangeSignatureTelemetryLogger.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ChangeSignatureTelemetryLogger.cs
@@ -15,9 +15,9 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
         private const string Minimum = nameof(Minimum);
         private const string Mean = nameof(Mean);
 
-        private static readonly LogAggregator s_logAggregator = new();
-        private static readonly StatisticLogAggregator s_statisticLogAggregator = new();
-        private static readonly HistogramLogAggregator s_histogramLogAggregator = new(bucketSize: 1000, maxBucketValue: 30000);
+        private static readonly LogAggregator<ActionInfo> s_logAggregator = new();
+        private static readonly StatisticLogAggregator<ActionInfo> s_statisticLogAggregator = new();
+        private static readonly HistogramLogAggregator<ActionInfo> s_histogramLogAggregator = new(bucketSize: 1000, maxBucketValue: 30000);
 
         internal enum ActionInfo
         {
@@ -63,31 +63,31 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
         }
 
         internal static void LogChangeSignatureDialogLaunched() =>
-            s_logAggregator.IncreaseCount((int)ActionInfo.ChangeSignatureDialogLaunched);
+            s_logAggregator.IncreaseCount(ActionInfo.ChangeSignatureDialogLaunched);
 
         internal static void LogChangeSignatureDialogCommitted() =>
-            s_logAggregator.IncreaseCount((int)ActionInfo.ChangeSignatureDialogCommitted);
+            s_logAggregator.IncreaseCount(ActionInfo.ChangeSignatureDialogCommitted);
 
         internal static void LogAddParameterDialogLaunched() =>
-            s_logAggregator.IncreaseCount((int)ActionInfo.AddParameterDialogLaunched);
+            s_logAggregator.IncreaseCount(ActionInfo.AddParameterDialogLaunched);
 
         internal static void LogAddParameterDialogCommitted() =>
-            s_logAggregator.IncreaseCount((int)ActionInfo.AddParameterDialogCommitted);
+            s_logAggregator.IncreaseCount(ActionInfo.AddParameterDialogCommitted);
 
         internal static void LogTransformationInformation(int numOriginalParameters, int numParametersAdded, int numParametersRemoved, bool anyParametersReordered)
         {
             LogTransformationCombination(numParametersAdded > 0, numParametersRemoved > 0, anyParametersReordered);
 
-            s_logAggregator.IncreaseCountBy((int)ActionInfo.CommittedSession_OriginalParameterCount, numOriginalParameters);
+            s_logAggregator.IncreaseCountBy(ActionInfo.CommittedSession_OriginalParameterCount, numOriginalParameters);
 
             if (numParametersAdded > 0)
             {
-                s_logAggregator.IncreaseCountBy((int)ActionInfo.CommittedSessionWithAdded_NumberAdded, numParametersAdded);
+                s_logAggregator.IncreaseCountBy(ActionInfo.CommittedSessionWithAdded_NumberAdded, numParametersAdded);
             }
 
             if (numParametersRemoved > 0)
             {
-                s_logAggregator.IncreaseCountBy((int)ActionInfo.CommittedSessionWithRemoved_NumberRemoved, numParametersRemoved);
+                s_logAggregator.IncreaseCountBy(ActionInfo.CommittedSessionWithRemoved_NumberRemoved, numParametersRemoved);
             }
         }
 
@@ -96,88 +96,88 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
             // All three transformations
             if (parametersAdded && parametersRemoved && parametersReordered)
             {
-                s_logAggregator.IncreaseCount((int)ActionInfo.CommittedSessionAddedRemovedReordered);
+                s_logAggregator.IncreaseCount(ActionInfo.CommittedSessionAddedRemovedReordered);
                 return;
             }
 
             // Two transformations
             if (parametersAdded && parametersRemoved)
             {
-                s_logAggregator.IncreaseCount((int)ActionInfo.CommittedSessionAddedRemovedOnly);
+                s_logAggregator.IncreaseCount(ActionInfo.CommittedSessionAddedRemovedOnly);
                 return;
             }
 
             if (parametersAdded && parametersReordered)
             {
-                s_logAggregator.IncreaseCount((int)ActionInfo.CommittedSessionAddedReorderedOnly);
+                s_logAggregator.IncreaseCount(ActionInfo.CommittedSessionAddedReorderedOnly);
                 return;
             }
 
             if (parametersRemoved && parametersReordered)
             {
-                s_logAggregator.IncreaseCount((int)ActionInfo.CommittedSessionRemovedReorderedOnly);
+                s_logAggregator.IncreaseCount(ActionInfo.CommittedSessionRemovedReorderedOnly);
                 return;
             }
 
             // One transformation
             if (parametersAdded)
             {
-                s_logAggregator.IncreaseCount((int)ActionInfo.CommittedSessionAddedOnly);
+                s_logAggregator.IncreaseCount(ActionInfo.CommittedSessionAddedOnly);
                 return;
             }
 
             if (parametersRemoved)
             {
-                s_logAggregator.IncreaseCount((int)ActionInfo.CommittedSessionRemovedOnly);
+                s_logAggregator.IncreaseCount(ActionInfo.CommittedSessionRemovedOnly);
                 return;
             }
 
             if (parametersReordered)
             {
-                s_logAggregator.IncreaseCount((int)ActionInfo.CommittedSessionReorderedOnly);
+                s_logAggregator.IncreaseCount(ActionInfo.CommittedSessionReorderedOnly);
                 return;
             }
         }
 
         internal static void LogCommitInformation(int numDeclarationsUpdated, int numCallSitesUpdated, TimeSpan elapsedTime)
         {
-            s_logAggregator.IncreaseCount((int)ActionInfo.ChangeSignatureCommitCompleted);
+            s_logAggregator.IncreaseCount(ActionInfo.ChangeSignatureCommitCompleted);
 
-            s_logAggregator.IncreaseCountBy((int)ActionInfo.CommittedSessionNumberOfDeclarationsUpdated, numDeclarationsUpdated);
-            s_logAggregator.IncreaseCountBy((int)ActionInfo.CommittedSessionNumberOfCallSitesUpdated, numCallSitesUpdated);
+            s_logAggregator.IncreaseCountBy(ActionInfo.CommittedSessionNumberOfDeclarationsUpdated, numDeclarationsUpdated);
+            s_logAggregator.IncreaseCountBy(ActionInfo.CommittedSessionNumberOfCallSitesUpdated, numCallSitesUpdated);
 
-            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.CommittedSessionCommitElapsedMS, (int)elapsedTime.TotalMilliseconds);
-            s_histogramLogAggregator.IncreaseCount((int)ActionInfo.CommittedSessionCommitElapsedMS, elapsedTime);
+            s_statisticLogAggregator.AddDataPoint(ActionInfo.CommittedSessionCommitElapsedMS, (int)elapsedTime.TotalMilliseconds);
+            s_histogramLogAggregator.IncreaseCount(ActionInfo.CommittedSessionCommitElapsedMS, elapsedTime);
         }
 
         internal static void LogAddedParameterTypeBinds()
         {
-            s_logAggregator.IncreaseCount((int)ActionInfo.AddedParameterTypeBinds);
+            s_logAggregator.IncreaseCount(ActionInfo.AddedParameterTypeBinds);
         }
 
         internal static void LogAddedParameterRequired()
         {
-            s_logAggregator.IncreaseCount((int)ActionInfo.AddedParameterRequired);
+            s_logAggregator.IncreaseCount(ActionInfo.AddedParameterRequired);
         }
 
         internal static void LogAddedParameter_ValueExplicit()
         {
-            s_logAggregator.IncreaseCount((int)ActionInfo.AddedParameterValueExplicit);
+            s_logAggregator.IncreaseCount(ActionInfo.AddedParameterValueExplicit);
         }
 
         internal static void LogAddedParameter_ValueExplicitNamed()
         {
-            s_logAggregator.IncreaseCount((int)ActionInfo.AddedParameterValueExplicitNamed);
+            s_logAggregator.IncreaseCount(ActionInfo.AddedParameterValueExplicitNamed);
         }
 
         internal static void LogAddedParameter_ValueTODO()
         {
-            s_logAggregator.IncreaseCount((int)ActionInfo.AddedParameterValueTODO);
+            s_logAggregator.IncreaseCount(ActionInfo.AddedParameterValueTODO);
         }
 
         internal static void LogAddedParameter_ValueOmitted()
         {
-            s_logAggregator.IncreaseCount((int)ActionInfo.AddedParameterValueOmitted);
+            s_logAggregator.IncreaseCount(ActionInfo.AddedParameterValueOmitted);
         }
 
         internal static void ReportTelemetry()
@@ -186,13 +186,13 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
             {
                 foreach (var kv in s_logAggregator)
                 {
-                    var info = ((ActionInfo)kv.Key).ToString("f");
+                    var info = kv.Key.ToString("f");
                     m[info] = kv.Value.GetCount();
                 }
 
                 foreach (var kv in s_statisticLogAggregator)
                 {
-                    var info = ((ActionInfo)kv.Key).ToString("f");
+                    var info = kv.Key.ToString("f");
                     var statistics = kv.Value.GetStatisticResult();
 
                     m[CreateProperty(info, Maximum)] = statistics.Maximum;
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
 
                 foreach (var kv in s_histogramLogAggregator)
                 {
-                    var info = ((ActionInfo)kv.Key).ToString("f");
+                    var info = kv.Key.ToString("f");
                     m[$"{info}.BucketSize"] = kv.Value.BucketSize;
                     m[$"{info}.MaxBucketValue"] = kv.Value.MaxBucketValue;
                     m[$"{info}.Buckets"] = kv.Value.GetBucketsAsString();

--- a/src/Features/Core/Portable/ChangeSignature/ChangeSignatureTelemetryLogger.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ChangeSignatureTelemetryLogger.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
         private const string Minimum = nameof(Minimum);
         private const string Mean = nameof(Mean);
 
-        private static readonly LogAggregator<ActionInfo> s_logAggregator = new();
+        private static readonly CountLogAggregator<ActionInfo> s_countLogAggregator = new();
         private static readonly StatisticLogAggregator<ActionInfo> s_statisticLogAggregator = new();
         private static readonly HistogramLogAggregator<ActionInfo> s_histogramLogAggregator = new(bucketSize: 1000, maxBucketValue: 30000);
 
@@ -63,31 +63,31 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
         }
 
         internal static void LogChangeSignatureDialogLaunched() =>
-            s_logAggregator.IncreaseCount(ActionInfo.ChangeSignatureDialogLaunched);
+            s_countLogAggregator.IncreaseCount(ActionInfo.ChangeSignatureDialogLaunched);
 
         internal static void LogChangeSignatureDialogCommitted() =>
-            s_logAggregator.IncreaseCount(ActionInfo.ChangeSignatureDialogCommitted);
+            s_countLogAggregator.IncreaseCount(ActionInfo.ChangeSignatureDialogCommitted);
 
         internal static void LogAddParameterDialogLaunched() =>
-            s_logAggregator.IncreaseCount(ActionInfo.AddParameterDialogLaunched);
+            s_countLogAggregator.IncreaseCount(ActionInfo.AddParameterDialogLaunched);
 
         internal static void LogAddParameterDialogCommitted() =>
-            s_logAggregator.IncreaseCount(ActionInfo.AddParameterDialogCommitted);
+            s_countLogAggregator.IncreaseCount(ActionInfo.AddParameterDialogCommitted);
 
         internal static void LogTransformationInformation(int numOriginalParameters, int numParametersAdded, int numParametersRemoved, bool anyParametersReordered)
         {
             LogTransformationCombination(numParametersAdded > 0, numParametersRemoved > 0, anyParametersReordered);
 
-            s_logAggregator.IncreaseCountBy(ActionInfo.CommittedSession_OriginalParameterCount, numOriginalParameters);
+            s_countLogAggregator.IncreaseCountBy(ActionInfo.CommittedSession_OriginalParameterCount, numOriginalParameters);
 
             if (numParametersAdded > 0)
             {
-                s_logAggregator.IncreaseCountBy(ActionInfo.CommittedSessionWithAdded_NumberAdded, numParametersAdded);
+                s_countLogAggregator.IncreaseCountBy(ActionInfo.CommittedSessionWithAdded_NumberAdded, numParametersAdded);
             }
 
             if (numParametersRemoved > 0)
             {
-                s_logAggregator.IncreaseCountBy(ActionInfo.CommittedSessionWithRemoved_NumberRemoved, numParametersRemoved);
+                s_countLogAggregator.IncreaseCountBy(ActionInfo.CommittedSessionWithRemoved_NumberRemoved, numParametersRemoved);
             }
         }
 
@@ -96,55 +96,55 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
             // All three transformations
             if (parametersAdded && parametersRemoved && parametersReordered)
             {
-                s_logAggregator.IncreaseCount(ActionInfo.CommittedSessionAddedRemovedReordered);
+                s_countLogAggregator.IncreaseCount(ActionInfo.CommittedSessionAddedRemovedReordered);
                 return;
             }
 
             // Two transformations
             if (parametersAdded && parametersRemoved)
             {
-                s_logAggregator.IncreaseCount(ActionInfo.CommittedSessionAddedRemovedOnly);
+                s_countLogAggregator.IncreaseCount(ActionInfo.CommittedSessionAddedRemovedOnly);
                 return;
             }
 
             if (parametersAdded && parametersReordered)
             {
-                s_logAggregator.IncreaseCount(ActionInfo.CommittedSessionAddedReorderedOnly);
+                s_countLogAggregator.IncreaseCount(ActionInfo.CommittedSessionAddedReorderedOnly);
                 return;
             }
 
             if (parametersRemoved && parametersReordered)
             {
-                s_logAggregator.IncreaseCount(ActionInfo.CommittedSessionRemovedReorderedOnly);
+                s_countLogAggregator.IncreaseCount(ActionInfo.CommittedSessionRemovedReorderedOnly);
                 return;
             }
 
             // One transformation
             if (parametersAdded)
             {
-                s_logAggregator.IncreaseCount(ActionInfo.CommittedSessionAddedOnly);
+                s_countLogAggregator.IncreaseCount(ActionInfo.CommittedSessionAddedOnly);
                 return;
             }
 
             if (parametersRemoved)
             {
-                s_logAggregator.IncreaseCount(ActionInfo.CommittedSessionRemovedOnly);
+                s_countLogAggregator.IncreaseCount(ActionInfo.CommittedSessionRemovedOnly);
                 return;
             }
 
             if (parametersReordered)
             {
-                s_logAggregator.IncreaseCount(ActionInfo.CommittedSessionReorderedOnly);
+                s_countLogAggregator.IncreaseCount(ActionInfo.CommittedSessionReorderedOnly);
                 return;
             }
         }
 
         internal static void LogCommitInformation(int numDeclarationsUpdated, int numCallSitesUpdated, TimeSpan elapsedTime)
         {
-            s_logAggregator.IncreaseCount(ActionInfo.ChangeSignatureCommitCompleted);
+            s_countLogAggregator.IncreaseCount(ActionInfo.ChangeSignatureCommitCompleted);
 
-            s_logAggregator.IncreaseCountBy(ActionInfo.CommittedSessionNumberOfDeclarationsUpdated, numDeclarationsUpdated);
-            s_logAggregator.IncreaseCountBy(ActionInfo.CommittedSessionNumberOfCallSitesUpdated, numCallSitesUpdated);
+            s_countLogAggregator.IncreaseCountBy(ActionInfo.CommittedSessionNumberOfDeclarationsUpdated, numDeclarationsUpdated);
+            s_countLogAggregator.IncreaseCountBy(ActionInfo.CommittedSessionNumberOfCallSitesUpdated, numCallSitesUpdated);
 
             s_statisticLogAggregator.AddDataPoint(ActionInfo.CommittedSessionCommitElapsedMS, (int)elapsedTime.TotalMilliseconds);
             s_histogramLogAggregator.IncreaseCount(ActionInfo.CommittedSessionCommitElapsedMS, elapsedTime);
@@ -152,39 +152,39 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
 
         internal static void LogAddedParameterTypeBinds()
         {
-            s_logAggregator.IncreaseCount(ActionInfo.AddedParameterTypeBinds);
+            s_countLogAggregator.IncreaseCount(ActionInfo.AddedParameterTypeBinds);
         }
 
         internal static void LogAddedParameterRequired()
         {
-            s_logAggregator.IncreaseCount(ActionInfo.AddedParameterRequired);
+            s_countLogAggregator.IncreaseCount(ActionInfo.AddedParameterRequired);
         }
 
         internal static void LogAddedParameter_ValueExplicit()
         {
-            s_logAggregator.IncreaseCount(ActionInfo.AddedParameterValueExplicit);
+            s_countLogAggregator.IncreaseCount(ActionInfo.AddedParameterValueExplicit);
         }
 
         internal static void LogAddedParameter_ValueExplicitNamed()
         {
-            s_logAggregator.IncreaseCount(ActionInfo.AddedParameterValueExplicitNamed);
+            s_countLogAggregator.IncreaseCount(ActionInfo.AddedParameterValueExplicitNamed);
         }
 
         internal static void LogAddedParameter_ValueTODO()
         {
-            s_logAggregator.IncreaseCount(ActionInfo.AddedParameterValueTODO);
+            s_countLogAggregator.IncreaseCount(ActionInfo.AddedParameterValueTODO);
         }
 
         internal static void LogAddedParameter_ValueOmitted()
         {
-            s_logAggregator.IncreaseCount(ActionInfo.AddedParameterValueOmitted);
+            s_countLogAggregator.IncreaseCount(ActionInfo.AddedParameterValueOmitted);
         }
 
         internal static void ReportTelemetry()
         {
             Logger.Log(FunctionId.ChangeSignature_Data, KeyValueLogMessage.Create(m =>
             {
-                foreach (var kv in s_logAggregator)
+                foreach (var kv in s_countLogAggregator)
                 {
                     var info = kv.Key.ToString("f");
                     m[info] = kv.Value.GetCount();

--- a/src/Features/Core/Portable/ChangeSignature/ChangeSignatureTelemetryLogger.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ChangeSignatureTelemetryLogger.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using Microsoft.CodeAnalysis.Internal.Log;
 
 namespace Microsoft.CodeAnalysis.ChangeSignature
@@ -138,15 +139,15 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
             }
         }
 
-        internal static void LogCommitInformation(int numDeclarationsUpdated, int numCallSitesUpdated, int elapsedMS)
+        internal static void LogCommitInformation(int numDeclarationsUpdated, int numCallSitesUpdated, TimeSpan elapsedTime)
         {
             s_logAggregator.IncreaseCount((int)ActionInfo.ChangeSignatureCommitCompleted);
 
             s_logAggregator.IncreaseCountBy((int)ActionInfo.CommittedSessionNumberOfDeclarationsUpdated, numDeclarationsUpdated);
             s_logAggregator.IncreaseCountBy((int)ActionInfo.CommittedSessionNumberOfCallSitesUpdated, numCallSitesUpdated);
 
-            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.CommittedSessionCommitElapsedMS, elapsedMS);
-            s_histogramLogAggregator.IncreaseCount((int)ActionInfo.CommittedSessionCommitElapsedMS, elapsedMS);
+            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.CommittedSessionCommitElapsedMS, (int)elapsedTime.TotalMilliseconds);
+            s_histogramLogAggregator.IncreaseCount((int)ActionInfo.CommittedSessionCommitElapsedMS, elapsedTime);
         }
 
         internal static void LogAddedParameterTypeBinds()

--- a/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
+++ b/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Completion.Log
 
         internal static void LogTypeImportCompletionTicksDataPoint(TimeSpan elapsed)
         {
-            s_histogramLogAggregator.IncreaseCount(ActionInfo.TypeImportCompletionTicks, elapsed);
+            s_histogramLogAggregator.LogTime(ActionInfo.TypeImportCompletionTicks, elapsed);
             s_statisticLogAggregator.AddDataPoint(ActionInfo.TypeImportCompletionTicks, elapsed);
         }
 
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Completion.Log
 
         internal static void LogExtensionMethodCompletionTicksDataPoint(TimeSpan total, TimeSpan getSymbols, TimeSpan createItems, bool isRemote)
         {
-            s_histogramLogAggregator.IncreaseCount(ActionInfo.ExtensionMethodCompletionTicks, total);
+            s_histogramLogAggregator.LogTime(ActionInfo.ExtensionMethodCompletionTicks, total);
             s_statisticLogAggregator.AddDataPoint(ActionInfo.ExtensionMethodCompletionTicks, total);
 
             if (isRemote)

--- a/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
+++ b/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.CodeAnalysis.Internal.Log;
 
 namespace Microsoft.CodeAnalysis.Completion.Log
@@ -33,10 +34,10 @@ namespace Microsoft.CodeAnalysis.Completion.Log
             CommitUsingDotToAddParenthesis
         }
 
-        internal static void LogTypeImportCompletionTicksDataPoint(int count)
+        internal static void LogTypeImportCompletionTicksDataPoint(TimeSpan elapsed)
         {
-            s_histogramLogAggregator.IncreaseCount((int)ActionInfo.TypeImportCompletionTicks, count);
-            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.TypeImportCompletionTicks, count);
+            s_histogramLogAggregator.IncreaseCount((int)ActionInfo.TypeImportCompletionTicks, elapsed);
+            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.TypeImportCompletionTicks, elapsed);
         }
 
         internal static void LogTypeImportCompletionItemCountDataPoint(int count) =>
@@ -51,14 +52,14 @@ namespace Microsoft.CodeAnalysis.Completion.Log
         internal static void LogCommitOfTypeImportCompletionItem() =>
             s_logAggregator.IncreaseCount((int)ActionInfo.CommitsOfTypeImportCompletionItem);
 
-        internal static void LogExtensionMethodCompletionTicksDataPoint(int total, int getSymbols, int createItems, bool isRemote)
+        internal static void LogExtensionMethodCompletionTicksDataPoint(TimeSpan total, TimeSpan getSymbols, TimeSpan createItems, bool isRemote)
         {
             s_histogramLogAggregator.IncreaseCount((int)ActionInfo.ExtensionMethodCompletionTicks, total);
             s_statisticLogAggregator.AddDataPoint((int)ActionInfo.ExtensionMethodCompletionTicks, total);
 
             if (isRemote)
             {
-                s_statisticLogAggregator.AddDataPoint((int)ActionInfo.ExtensionMethodCompletionRemoteTicks, (total - getSymbols - createItems));
+                s_statisticLogAggregator.AddDataPoint((int)ActionInfo.ExtensionMethodCompletionRemoteTicks, total - getSymbols - createItems);
             }
 
             s_statisticLogAggregator.AddDataPoint((int)ActionInfo.ExtensionMethodCompletionGetSymbolsTicks, getSymbols);

--- a/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
+++ b/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Completion.Log
     internal static class CompletionProvidersLogger
     {
         private static readonly StatisticLogAggregator<ActionInfo> s_statisticLogAggregator = new();
-        private static readonly LogAggregator<ActionInfo> s_logAggregator = new();
+        private static readonly CountLogAggregator<ActionInfo> s_countLogAggregator = new();
 
         private static readonly HistogramLogAggregator<ActionInfo> s_histogramLogAggregator = new(bucketSize: 50, maxBucketValue: 1000);
 
@@ -47,10 +47,10 @@ namespace Microsoft.CodeAnalysis.Completion.Log
             s_statisticLogAggregator.AddDataPoint(ActionInfo.TypeImportCompletionReferenceCount, count);
 
         internal static void LogTypeImportCompletionCacheMiss() =>
-            s_logAggregator.IncreaseCount(ActionInfo.TypeImportCompletionCacheMissCount);
+            s_countLogAggregator.IncreaseCount(ActionInfo.TypeImportCompletionCacheMissCount);
 
         internal static void LogCommitOfTypeImportCompletionItem() =>
-            s_logAggregator.IncreaseCount(ActionInfo.CommitsOfTypeImportCompletionItem);
+            s_countLogAggregator.IncreaseCount(ActionInfo.CommitsOfTypeImportCompletionItem);
 
         internal static void LogExtensionMethodCompletionTicksDataPoint(TimeSpan total, TimeSpan getSymbols, TimeSpan createItems, bool isRemote)
         {
@@ -70,16 +70,16 @@ namespace Microsoft.CodeAnalysis.Completion.Log
             s_statisticLogAggregator.AddDataPoint(ActionInfo.ExtensionMethodCompletionMethodsProvided, count);
 
         internal static void LogCommitOfExtensionMethodImportCompletionItem() =>
-            s_logAggregator.IncreaseCount(ActionInfo.CommitsOfExtensionMethodImportCompletionItem);
+            s_countLogAggregator.IncreaseCount(ActionInfo.CommitsOfExtensionMethodImportCompletionItem);
 
         internal static void LogExtensionMethodCompletionPartialResultCount() =>
-            s_logAggregator.IncreaseCount(ActionInfo.ExtensionMethodCompletionPartialResultCount);
+            s_countLogAggregator.IncreaseCount(ActionInfo.ExtensionMethodCompletionPartialResultCount);
 
         internal static void LogCommitUsingSemicolonToAddParenthesis() =>
-            s_logAggregator.IncreaseCount(ActionInfo.CommitUsingSemicolonToAddParenthesis);
+            s_countLogAggregator.IncreaseCount(ActionInfo.CommitUsingSemicolonToAddParenthesis);
 
         internal static void LogCommitUsingDotToAddParenthesis() =>
-            s_logAggregator.IncreaseCount(ActionInfo.CommitUsingDotToAddParenthesis);
+            s_countLogAggregator.IncreaseCount(ActionInfo.CommitUsingDotToAddParenthesis);
 
         internal static void LogCustomizedCommitToAddParenthesis(char? commitChar)
         {
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Completion.Log
                     m[CreateProperty(info, nameof(statistics.Count))] = statistics.Count;
                 }
 
-                foreach (var kv in s_logAggregator)
+                foreach (var kv in s_countLogAggregator)
                 {
                     var info = ((ActionInfo)kv.Key).ToString("f");
                     m[info] = kv.Value.GetCount();

--- a/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
+++ b/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
@@ -9,10 +9,10 @@ namespace Microsoft.CodeAnalysis.Completion.Log
 {
     internal static class CompletionProvidersLogger
     {
-        private static readonly StatisticLogAggregator s_statisticLogAggregator = new();
-        private static readonly LogAggregator s_logAggregator = new();
+        private static readonly StatisticLogAggregator<ActionInfo> s_statisticLogAggregator = new();
+        private static readonly LogAggregator<ActionInfo> s_logAggregator = new();
 
-        private static readonly HistogramLogAggregator s_histogramLogAggregator = new(bucketSize: 50, maxBucketValue: 1000);
+        private static readonly HistogramLogAggregator<ActionInfo> s_histogramLogAggregator = new(bucketSize: 50, maxBucketValue: 1000);
 
         internal enum ActionInfo
         {
@@ -36,50 +36,50 @@ namespace Microsoft.CodeAnalysis.Completion.Log
 
         internal static void LogTypeImportCompletionTicksDataPoint(TimeSpan elapsed)
         {
-            s_histogramLogAggregator.IncreaseCount((int)ActionInfo.TypeImportCompletionTicks, elapsed);
-            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.TypeImportCompletionTicks, elapsed);
+            s_histogramLogAggregator.IncreaseCount(ActionInfo.TypeImportCompletionTicks, elapsed);
+            s_statisticLogAggregator.AddDataPoint(ActionInfo.TypeImportCompletionTicks, elapsed);
         }
 
         internal static void LogTypeImportCompletionItemCountDataPoint(int count) =>
-            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.TypeImportCompletionItemCount, count);
+            s_statisticLogAggregator.AddDataPoint(ActionInfo.TypeImportCompletionItemCount, count);
 
         internal static void LogTypeImportCompletionReferenceCountDataPoint(int count) =>
-            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.TypeImportCompletionReferenceCount, count);
+            s_statisticLogAggregator.AddDataPoint(ActionInfo.TypeImportCompletionReferenceCount, count);
 
         internal static void LogTypeImportCompletionCacheMiss() =>
-            s_logAggregator.IncreaseCount((int)ActionInfo.TypeImportCompletionCacheMissCount);
+            s_logAggregator.IncreaseCount(ActionInfo.TypeImportCompletionCacheMissCount);
 
         internal static void LogCommitOfTypeImportCompletionItem() =>
-            s_logAggregator.IncreaseCount((int)ActionInfo.CommitsOfTypeImportCompletionItem);
+            s_logAggregator.IncreaseCount(ActionInfo.CommitsOfTypeImportCompletionItem);
 
         internal static void LogExtensionMethodCompletionTicksDataPoint(TimeSpan total, TimeSpan getSymbols, TimeSpan createItems, bool isRemote)
         {
-            s_histogramLogAggregator.IncreaseCount((int)ActionInfo.ExtensionMethodCompletionTicks, total);
-            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.ExtensionMethodCompletionTicks, total);
+            s_histogramLogAggregator.IncreaseCount(ActionInfo.ExtensionMethodCompletionTicks, total);
+            s_statisticLogAggregator.AddDataPoint(ActionInfo.ExtensionMethodCompletionTicks, total);
 
             if (isRemote)
             {
-                s_statisticLogAggregator.AddDataPoint((int)ActionInfo.ExtensionMethodCompletionRemoteTicks, total - getSymbols - createItems);
+                s_statisticLogAggregator.AddDataPoint(ActionInfo.ExtensionMethodCompletionRemoteTicks, total - getSymbols - createItems);
             }
 
-            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.ExtensionMethodCompletionGetSymbolsTicks, getSymbols);
-            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.ExtensionMethodCompletionCreateItemsTicks, createItems);
+            s_statisticLogAggregator.AddDataPoint(ActionInfo.ExtensionMethodCompletionGetSymbolsTicks, getSymbols);
+            s_statisticLogAggregator.AddDataPoint(ActionInfo.ExtensionMethodCompletionCreateItemsTicks, createItems);
         }
 
         internal static void LogExtensionMethodCompletionMethodsProvidedDataPoint(int count) =>
-            s_statisticLogAggregator.AddDataPoint((int)ActionInfo.ExtensionMethodCompletionMethodsProvided, count);
+            s_statisticLogAggregator.AddDataPoint(ActionInfo.ExtensionMethodCompletionMethodsProvided, count);
 
         internal static void LogCommitOfExtensionMethodImportCompletionItem() =>
-            s_logAggregator.IncreaseCount((int)ActionInfo.CommitsOfExtensionMethodImportCompletionItem);
+            s_logAggregator.IncreaseCount(ActionInfo.CommitsOfExtensionMethodImportCompletionItem);
 
         internal static void LogExtensionMethodCompletionPartialResultCount() =>
-            s_logAggregator.IncreaseCount((int)ActionInfo.ExtensionMethodCompletionPartialResultCount);
+            s_logAggregator.IncreaseCount(ActionInfo.ExtensionMethodCompletionPartialResultCount);
 
         internal static void LogCommitUsingSemicolonToAddParenthesis() =>
-            s_logAggregator.IncreaseCount((int)ActionInfo.CommitUsingSemicolonToAddParenthesis);
+            s_logAggregator.IncreaseCount(ActionInfo.CommitUsingSemicolonToAddParenthesis);
 
         internal static void LogCommitUsingDotToAddParenthesis() =>
-            s_logAggregator.IncreaseCount((int)ActionInfo.CommitUsingDotToAddParenthesis);
+            s_logAggregator.IncreaseCount(ActionInfo.CommitUsingDotToAddParenthesis);
 
         internal static void LogCustomizedCommitToAddParenthesis(char? commitChar)
         {

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Completion.Providers
 {
@@ -43,7 +44,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 var syntaxFacts = completionContext.Document.GetRequiredLanguageService<ISyntaxFactsService>();
                 if (TryGetReceiverTypeSymbol(syntaxContext, syntaxFacts, cancellationToken, out var receiverTypeSymbol))
                 {
-                    var ticks = Environment.TickCount;
+                    var totalTime = SharedStopwatch.StartNew();
+
                     var inferredTypes = completionContext.CompletionOptions.TargetTypedCompletionFilter
                         ? syntaxContext.InferredTypes
                         : ImmutableArray<ITypeSymbol>.Empty;
@@ -65,9 +67,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     completionContext.AddItems(result.CompletionItems.Select(i => Convert(i, receiverTypeKey)));
 
                     // report telemetry:
-                    var totalTicks = Environment.TickCount - ticks;
                     CompletionProvidersLogger.LogExtensionMethodCompletionTicksDataPoint(
-                        totalTicks, result.GetSymbolsTicks, result.CreateItemsTicks, result.IsRemote);
+                        totalTime.Elapsed, result.GetSymbolsTime, result.CreateItemsTime, result.IsRemote);
 
                     if (result.IsPartialResult)
                         CompletionProvidersLogger.LogExtensionMethodCompletionPartialResultCount();

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionProvider.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         private class TelemetryCounter
         {
-            private readonly int _tick;
+            private readonly SharedStopwatch _elapsedTime;
 
             public int ItemsCount { get; set; }
             public int ReferenceCount { get; set; }
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             public TelemetryCounter()
             {
-                _tick = Environment.TickCount;
+                _elapsedTime = SharedStopwatch.StartNew();
             }
 
             public void Report()
@@ -182,8 +182,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 }
 
                 // cache miss still count towards the cost of completion, so we need to log regardless of it.
-                var delta = Environment.TickCount - _tick;
-                CompletionProvidersLogger.LogTypeImportCompletionTicksDataPoint(delta);
+                CompletionProvidersLogger.LogTypeImportCompletionTicksDataPoint(_elapsedTime.Elapsed);
                 CompletionProvidersLogger.LogTypeImportCompletionItemCountDataPoint(ItemsCount);
                 CompletionProvidersLogger.LogTypeImportCompletionReferenceCountDataPoint(ReferenceCount);
             }

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             bool isRemote,
             CancellationToken cancellationToken)
         {
-            var ticks = Environment.TickCount;
+            var stopwatch = SharedStopwatch.StartNew();
 
             // First find symbols of all applicable extension methods.
             // Workspace's syntax/symbol index is used to avoid iterating every method symbols in the solution.
@@ -98,15 +98,15 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 document, position, receiverTypeSymbol, namespaceInScope, cancellationToken).ConfigureAwait(false);
             var (extentsionMethodSymbols, isPartialResult) = await symbolComputer.GetExtensionMethodSymbolsAsync(forceCacheCreation, hideAdvancedMembers, cancellationToken).ConfigureAwait(false);
 
-            var getSymbolsTicks = Environment.TickCount - ticks;
-            ticks = Environment.TickCount;
+            var getSymbolsTime = stopwatch.Elapsed;
+            stopwatch = SharedStopwatch.StartNew();
 
             var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
             var items = ConvertSymbolsToCompletionItems(compilation, extentsionMethodSymbols, targetTypes, cancellationToken);
 
-            var createItemsTicks = Environment.TickCount - ticks;
+            var createItemsTime = stopwatch.Elapsed;
 
-            return new SerializableUnimportedExtensionMethods(items, isPartialResult, getSymbolsTicks, createItemsTicks, isRemote);
+            return new SerializableUnimportedExtensionMethods(items, isPartialResult, getSymbolsTime, createItemsTime, isRemote);
         }
 
         public static async ValueTask BatchUpdateCacheAsync(ImmutableSegmentedList<Project> projects, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/SerializableUnimportedExtensionMethods.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/SerializableUnimportedExtensionMethods.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.Runtime.Serialization;
 
@@ -17,10 +18,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         public readonly bool IsPartialResult;
 
         [DataMember(Order = 2)]
-        public readonly int GetSymbolsTicks;
+        public readonly TimeSpan GetSymbolsTime;
 
         [DataMember(Order = 3)]
-        public readonly int CreateItemsTicks;
+        public readonly TimeSpan CreateItemsTime;
 
         [DataMember(Order = 4)]
         public readonly bool IsRemote;
@@ -28,14 +29,14 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         public SerializableUnimportedExtensionMethods(
             ImmutableArray<SerializableImportCompletionItem> completionItems,
             bool isPartialResult,
-            int getSymbolsTicks,
-            int createItemsTicks,
+            TimeSpan getSymbolsTime,
+            TimeSpan createItemsTime,
             bool isRemote)
         {
             CompletionItems = completionItems;
             IsPartialResult = isPartialResult;
-            GetSymbolsTicks = getSymbolsTicks;
-            CreateItemsTicks = createItemsTicks;
+            GetSymbolsTime = getSymbolsTime;
+            CreateItemsTime = createItemsTime;
             IsRemote = isRemote;
         }
     }

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -1066,7 +1066,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private static void ReportTelemetry(DebuggingSessionTelemetry.Data data)
         {
             // report telemetry (fire and forget):
-            _ = Task.Run(() => DebuggingSessionTelemetry.Log(data, Logger.Log, LogAggregator<object>.GetNextId));
+            _ = Task.Run(() => DebuggingSessionTelemetry.Log(data, Logger.Log, CountLogAggregator<object>.GetNextId));
         }
 
         internal TestAccessor GetTestAccessor()

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -1066,7 +1066,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private static void ReportTelemetry(DebuggingSessionTelemetry.Data data)
         {
             // report telemetry (fire and forget):
-            _ = Task.Run(() => DebuggingSessionTelemetry.Log(data, Logger.Log, CountLogAggregator<object>.GetNextId));
+            _ = Task.Run(() => DebuggingSessionTelemetry.Log(data, Logger.Log, CorrelationIdFactory.GetNextId));
         }
 
         internal TestAccessor GetTestAccessor()

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -1066,7 +1066,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private static void ReportTelemetry(DebuggingSessionTelemetry.Data data)
         {
             // report telemetry (fire and forget):
-            _ = Task.Run(() => DebuggingSessionTelemetry.Log(data, Logger.Log, LogAggregator.GetNextId));
+            _ = Task.Run(() => DebuggingSessionTelemetry.Log(data, Logger.Log, LogAggregator<object>.GetNextId));
         }
 
         internal TestAccessor GetTestAccessor()

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerLogger.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerLogger.cs
@@ -134,10 +134,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }));
         }
 
-        public static void LogWorkspaceEvent(LogAggregator logAggregator, int kind)
+        public static void LogWorkspaceEvent(LogAggregator<WorkspaceChangeKind> logAggregator, WorkspaceChangeKind kind)
             => logAggregator.IncreaseCount(kind);
 
-        public static void LogWorkCoordinatorShutdown(int correlationId, LogAggregator logAggregator)
+        public static void LogWorkCoordinatorShutdown(int correlationId, LogAggregator<WorkspaceChangeKind> logAggregator)
         {
             Logger.Log(FunctionId.WorkCoordinator_Shutdown, KeyValueLogMessage.Create(m =>
             {
@@ -145,23 +145,23 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 foreach (var kv in logAggregator)
                 {
-                    var change = ((WorkspaceChangeKind)kv.Key).ToString();
+                    var change = kv.Key.ToString();
                     m[change] = kv.Value.GetCount();
                 }
             }));
         }
 
-        public static void LogGlobalOperation(LogAggregator logAggregator)
+        public static void LogGlobalOperation(LogAggregator<object> logAggregator)
             => logAggregator.IncreaseCount(GlobalOperation);
 
-        public static void LogActiveFileEnqueue(LogAggregator logAggregator)
+        public static void LogActiveFileEnqueue(LogAggregator<object> logAggregator)
             => logAggregator.IncreaseCount(ActiveFileEnqueue);
 
-        public static void LogWorkItemEnqueue(LogAggregator logAggregator, ProjectId _)
+        public static void LogWorkItemEnqueue(LogAggregator<object> logAggregator, ProjectId _)
             => logAggregator.IncreaseCount(ProjectEnqueue);
 
         public static void LogWorkItemEnqueue(
-            LogAggregator logAggregator, string language, DocumentId? documentId, InvocationReasons reasons, bool lowPriority, SyntaxPath? activeMember, bool added)
+            LogAggregator<object> logAggregator, string language, DocumentId? documentId, InvocationReasons reasons, bool lowPriority, SyntaxPath? activeMember, bool added)
         {
             logAggregator.IncreaseCount(language);
             logAggregator.IncreaseCount(added ? NewWorkItem : UpdateWorkItem);
@@ -183,16 +183,16 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }
         }
 
-        public static void LogHigherPriority(LogAggregator logAggregator, Guid documentId)
+        public static void LogHigherPriority(LogAggregator<object> logAggregator, Guid documentId)
         {
             logAggregator.IncreaseCount(HigherPriority);
             logAggregator.IncreaseCount(ValueTuple.Create(HigherPriority, documentId));
         }
 
-        public static void LogResetStates(LogAggregator logAggregator)
+        public static void LogResetStates(LogAggregator<object> logAggregator)
             => logAggregator.IncreaseCount(ResetStates);
 
-        public static void LogIncrementalAnalyzerProcessorStatistics(int correlationId, Solution solution, LogAggregator logAggregator, ImmutableArray<IIncrementalAnalyzer> analyzers)
+        public static void LogIncrementalAnalyzerProcessorStatistics(int correlationId, Solution solution, LogAggregator<object> logAggregator, ImmutableArray<IIncrementalAnalyzer> analyzers)
         {
             Logger.Log(FunctionId.IncrementalAnalyzerProcessor_Shutdown, KeyValueLogMessage.Create(m =>
             {
@@ -207,22 +207,21 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     if (key is string stringKey)
                     {
                         m[stringKey] = counter.GetCount();
-                        continue;
                     }
-
-                    if (key is ValueTuple<string, Guid> propertyNameAndId)
+                    else if (key is ValueTuple<string, Guid> propertyNameAndId)
                     {
                         var list = statMap.GetOrAdd(propertyNameAndId.Item1, _ => new List<int>());
                         list.Add(counter.GetCount());
-                        continue;
                     }
-
-                    throw ExceptionUtilities.Unreachable;
+                    else
+                    {
+                        throw ExceptionUtilities.Unreachable;
+                    }
                 }
 
                 foreach (var (propertyName, propertyValues) in statMap)
                 {
-                    var result = LogAggregator.GetStatistics(propertyValues);
+                    var result = LogAggregator<object>.GetStatistics(propertyValues);
 
                     m[CreateProperty(propertyName, Max)] = result.Maximum;
                     m[CreateProperty(propertyName, Min)] = result.Minimum;
@@ -253,19 +252,19 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         private static string CreateProperty(string parent, string child)
             => parent + "." + child;
 
-        public static void LogProcessCloseDocument(LogAggregator logAggregator, Guid documentId)
+        public static void LogProcessCloseDocument(LogAggregator<object> logAggregator, Guid documentId)
         {
             logAggregator.IncreaseCount(CloseDocument);
             logAggregator.IncreaseCount(ValueTuple.Create(CloseDocument, documentId));
         }
 
-        public static void LogProcessOpenDocument(LogAggregator logAggregator, Guid documentId)
+        public static void LogProcessOpenDocument(LogAggregator<object> logAggregator, Guid documentId)
         {
             logAggregator.IncreaseCount(OpenDocument);
             logAggregator.IncreaseCount(ValueTuple.Create(OpenDocument, documentId));
         }
 
-        public static void LogProcessActiveFileDocument(LogAggregator logAggregator, Guid _, bool processed)
+        public static void LogProcessActiveFileDocument(LogAggregator<object> logAggregator, Guid _, bool processed)
         {
             if (processed)
             {
@@ -277,7 +276,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }
         }
 
-        public static void LogProcessDocument(LogAggregator logAggregator, Guid documentId, bool processed)
+        public static void LogProcessDocument(LogAggregator<object> logAggregator, Guid documentId, bool processed)
         {
             if (processed)
             {
@@ -291,10 +290,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             logAggregator.IncreaseCount(ValueTuple.Create(ProcessDocument, documentId));
         }
 
-        public static void LogProcessDocumentNotExist(LogAggregator logAggregator)
+        public static void LogProcessDocumentNotExist(LogAggregator<object> logAggregator)
             => logAggregator.IncreaseCount(DocumentNotExist);
 
-        public static void LogProcessProject(LogAggregator logAggregator, Guid projectId, bool processed)
+        public static void LogProcessProject(LogAggregator<object> logAggregator, Guid projectId, bool processed)
         {
             if (processed)
             {
@@ -308,7 +307,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             logAggregator.IncreaseCount(ValueTuple.Create(ProcessProject, projectId));
         }
 
-        public static void LogProcessProjectNotExist(LogAggregator logAggregator)
+        public static void LogProcessProjectNotExist(LogAggregator<object> logAggregator)
             => logAggregator.IncreaseCount(ProjectNotExist);
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerLogger.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerLogger.cs
@@ -134,10 +134,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }));
         }
 
-        public static void LogWorkspaceEvent(LogAggregator<WorkspaceChangeKind> logAggregator, WorkspaceChangeKind kind)
+        public static void LogWorkspaceEvent(CountLogAggregator<WorkspaceChangeKind> logAggregator, WorkspaceChangeKind kind)
             => logAggregator.IncreaseCount(kind);
 
-        public static void LogWorkCoordinatorShutdown(int correlationId, LogAggregator<WorkspaceChangeKind> logAggregator)
+        public static void LogWorkCoordinatorShutdown(int correlationId, CountLogAggregator<WorkspaceChangeKind> logAggregator)
         {
             Logger.Log(FunctionId.WorkCoordinator_Shutdown, KeyValueLogMessage.Create(m =>
             {
@@ -151,17 +151,17 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }));
         }
 
-        public static void LogGlobalOperation(LogAggregator<object> logAggregator)
+        public static void LogGlobalOperation(CountLogAggregator<object> logAggregator)
             => logAggregator.IncreaseCount(GlobalOperation);
 
-        public static void LogActiveFileEnqueue(LogAggregator<object> logAggregator)
+        public static void LogActiveFileEnqueue(CountLogAggregator<object> logAggregator)
             => logAggregator.IncreaseCount(ActiveFileEnqueue);
 
-        public static void LogWorkItemEnqueue(LogAggregator<object> logAggregator, ProjectId _)
+        public static void LogWorkItemEnqueue(CountLogAggregator<object> logAggregator, ProjectId _)
             => logAggregator.IncreaseCount(ProjectEnqueue);
 
         public static void LogWorkItemEnqueue(
-            LogAggregator<object> logAggregator, string language, DocumentId? documentId, InvocationReasons reasons, bool lowPriority, SyntaxPath? activeMember, bool added)
+            CountLogAggregator<object> logAggregator, string language, DocumentId? documentId, InvocationReasons reasons, bool lowPriority, SyntaxPath? activeMember, bool added)
         {
             logAggregator.IncreaseCount(language);
             logAggregator.IncreaseCount(added ? NewWorkItem : UpdateWorkItem);
@@ -183,16 +183,16 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }
         }
 
-        public static void LogHigherPriority(LogAggregator<object> logAggregator, Guid documentId)
+        public static void LogHigherPriority(CountLogAggregator<object> logAggregator, Guid documentId)
         {
             logAggregator.IncreaseCount(HigherPriority);
             logAggregator.IncreaseCount(ValueTuple.Create(HigherPriority, documentId));
         }
 
-        public static void LogResetStates(LogAggregator<object> logAggregator)
+        public static void LogResetStates(CountLogAggregator<object> logAggregator)
             => logAggregator.IncreaseCount(ResetStates);
 
-        public static void LogIncrementalAnalyzerProcessorStatistics(int correlationId, Solution solution, LogAggregator<object> logAggregator, ImmutableArray<IIncrementalAnalyzer> analyzers)
+        public static void LogIncrementalAnalyzerProcessorStatistics(int correlationId, Solution solution, CountLogAggregator<object> logAggregator, ImmutableArray<IIncrementalAnalyzer> analyzers)
         {
             Logger.Log(FunctionId.IncrementalAnalyzerProcessor_Shutdown, KeyValueLogMessage.Create(m =>
             {
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 foreach (var (propertyName, propertyValues) in statMap)
                 {
-                    var result = LogAggregator<object>.GetStatistics(propertyValues);
+                    var result = CountLogAggregator<object>.GetStatistics(propertyValues);
 
                     m[CreateProperty(propertyName, Max)] = result.Maximum;
                     m[CreateProperty(propertyName, Min)] = result.Minimum;
@@ -252,19 +252,19 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         private static string CreateProperty(string parent, string child)
             => parent + "." + child;
 
-        public static void LogProcessCloseDocument(LogAggregator<object> logAggregator, Guid documentId)
+        public static void LogProcessCloseDocument(CountLogAggregator<object> logAggregator, Guid documentId)
         {
             logAggregator.IncreaseCount(CloseDocument);
             logAggregator.IncreaseCount(ValueTuple.Create(CloseDocument, documentId));
         }
 
-        public static void LogProcessOpenDocument(LogAggregator<object> logAggregator, Guid documentId)
+        public static void LogProcessOpenDocument(CountLogAggregator<object> logAggregator, Guid documentId)
         {
             logAggregator.IncreaseCount(OpenDocument);
             logAggregator.IncreaseCount(ValueTuple.Create(OpenDocument, documentId));
         }
 
-        public static void LogProcessActiveFileDocument(LogAggregator<object> logAggregator, Guid _, bool processed)
+        public static void LogProcessActiveFileDocument(CountLogAggregator<object> logAggregator, Guid _, bool processed)
         {
             if (processed)
             {
@@ -276,7 +276,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             }
         }
 
-        public static void LogProcessDocument(LogAggregator<object> logAggregator, Guid documentId, bool processed)
+        public static void LogProcessDocument(CountLogAggregator<object> logAggregator, Guid documentId, bool processed)
         {
             if (processed)
             {
@@ -290,10 +290,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             logAggregator.IncreaseCount(ValueTuple.Create(ProcessDocument, documentId));
         }
 
-        public static void LogProcessDocumentNotExist(LogAggregator<object> logAggregator)
+        public static void LogProcessDocumentNotExist(CountLogAggregator<object> logAggregator)
             => logAggregator.IncreaseCount(DocumentNotExist);
 
-        public static void LogProcessProject(LogAggregator<object> logAggregator, Guid projectId, bool processed)
+        public static void LogProcessProject(CountLogAggregator<object> logAggregator, Guid projectId, bool processed)
         {
             if (processed)
             {
@@ -307,7 +307,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             logAggregator.IncreaseCount(ValueTuple.Create(ProcessProject, projectId));
         }
 
-        public static void LogProcessProjectNotExist(LogAggregator<object> logAggregator)
+        public static void LogProcessProjectNotExist(CountLogAggregator<object> logAggregator)
             => logAggregator.IncreaseCount(ProjectNotExist);
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerLogger.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerLogger.cs
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 foreach (var (propertyName, propertyValues) in statMap)
                 {
-                    var result = CountLogAggregator<object>.GetStatistics(propertyValues);
+                    var result = StatisticResult.FromList(propertyValues);
 
                     m[CreateProperty(propertyName, Max)] = result.Maximum;
                     m[CreateProperty(propertyName, Min)] = result.Minimum;

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         {
             Contract.ThrowIfNull(workspace.Kind);
 
-            var correlationId = CountLogAggregator<object>.GetNextId();
+            var correlationId = CorrelationIdFactory.GetNextId();
 
             lock (_gate)
             {

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         {
             Contract.ThrowIfNull(workspace.Kind);
 
-            var correlationId = LogAggregator<object>.GetNextId();
+            var correlationId = CountLogAggregator<object>.GetNextId();
 
             lock (_gate)
             {

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         {
             Contract.ThrowIfNull(workspace.Kind);
 
-            var correlationId = LogAggregator.GetNextId();
+            var correlationId = LogAggregator<object>.GetNextId();
 
             lock (_gate)
             {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -42,7 +42,11 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 // NOTE: IDiagnosticAnalyzerService can be null in test environment.
                 private readonly Lazy<IDiagnosticAnalyzerService?> _lazyDiagnosticAnalyzerService;
 
-                private LogAggregator _logAggregator = new();
+                /// <summary>
+                /// The keys in this are either a string or a (string, Guid) tuple. See <see cref="SolutionCrawlerLogger.LogIncrementalAnalyzerProcessorStatistics"/>
+                /// for what is writing this out.
+                /// </summary>
+                private LogAggregator<object> _logAggregator = new();
 
                 public IncrementalAnalyzerProcessor(
                     IAsynchronousOperationListener listener,
@@ -150,7 +154,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     => _registration.Workspace.GetOpenDocumentIds();
 
                 private void ResetLogAggregator()
-                    => _logAggregator = new LogAggregator();
+                    => _logAggregator = new LogAggregator<object>();
 
                 private void ReportPendingWorkItemCount()
                 {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 /// The keys in this are either a string or a (string, Guid) tuple. See <see cref="SolutionCrawlerLogger.LogIncrementalAnalyzerProcessorStatistics"/>
                 /// for what is writing this out.
                 /// </summary>
-                private LogAggregator<object> _logAggregator = new();
+                private CountLogAggregator<object> _logAggregator = new();
 
                 public IncrementalAnalyzerProcessor(
                     IAsynchronousOperationListener listener,
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     => _registration.Workspace.GetOpenDocumentIds();
 
                 private void ResetLogAggregator()
-                    => _logAggregator = new LogAggregator<object>();
+                    => _logAggregator = new CountLogAggregator<object>();
 
                 private void ReportPendingWorkItemCount()
                 {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             private readonly Registration _registration;
             private readonly object _gate = new();
 
-            private readonly LogAggregator<WorkspaceChangeKind> _logAggregator = new();
+            private readonly CountLogAggregator<WorkspaceChangeKind> _logAggregator = new();
             private readonly IAsynchronousOperationListener _listener;
             private readonly IDocumentTrackingService _documentTrackingService;
             private readonly IWorkspaceConfigurationService? _workspaceConfigurationService;

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             private readonly Registration _registration;
             private readonly object _gate = new();
 
-            private readonly LogAggregator _logAggregator = new();
+            private readonly LogAggregator<WorkspaceChangeKind> _logAggregator = new();
             private readonly IAsynchronousOperationListener _listener;
             private readonly IDocumentTrackingService _documentTrackingService;
             private readonly IWorkspaceConfigurationService? _workspaceConfigurationService;
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
             private void ProcessEvent(WorkspaceChangeEventArgs args, string eventName)
             {
-                SolutionCrawlerLogger.LogWorkspaceEvent(_logAggregator, (int)args.Kind);
+                SolutionCrawlerLogger.LogWorkspaceEvent(_logAggregator, args.Kind);
 
                 // TODO: add telemetry that record how much it takes to process an event (max, min, average and etc)
                 switch (args.Kind)

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // subscribe to active context changed event for new workspace
             workspace.DocumentActiveContextChanged += OnDocumentActiveContextChanged;
 
-            return new DiagnosticIncrementalAnalyzer(this, LogAggregator<object>.GetNextId(), workspace, AnalyzerInfoCache);
+            return new DiagnosticIncrementalAnalyzer(this, CountLogAggregator<object>.GetNextId(), workspace, AnalyzerInfoCache);
         }
 
         private void OnDocumentActiveContextChanged(object? sender, DocumentActiveContextChangedEventArgs e)

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // subscribe to active context changed event for new workspace
             workspace.DocumentActiveContextChanged += OnDocumentActiveContextChanged;
 
-            return new DiagnosticIncrementalAnalyzer(this, LogAggregator.GetNextId(), workspace, AnalyzerInfoCache);
+            return new DiagnosticIncrementalAnalyzer(this, LogAggregator<object>.GetNextId(), workspace, AnalyzerInfoCache);
         }
 
         private void OnDocumentActiveContextChanged(object? sender, DocumentActiveContextChangedEventArgs e)

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             // subscribe to active context changed event for new workspace
             workspace.DocumentActiveContextChanged += OnDocumentActiveContextChanged;
 
-            return new DiagnosticIncrementalAnalyzer(this, CountLogAggregator<object>.GetNextId(), workspace, AnalyzerInfoCache);
+            return new DiagnosticIncrementalAnalyzer(this, CorrelationIdFactory.GetNextId(), workspace, AnalyzerInfoCache);
         }
 
         private void OnDocumentActiveContextChanged(object? sender, DocumentActiveContextChangedEventArgs e)

--- a/src/Features/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
@@ -42,9 +42,9 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
     /// </summary>
     private readonly ConcurrentDictionary<string, Counter> _requestCounters;
 
-    private readonly LogAggregator<string> _findDocumentResults;
+    private readonly CountLogAggregator<string> _findDocumentResults;
 
-    private readonly LogAggregator<bool> _usedForkedSolutionCounter;
+    private readonly CountLogAggregator<bool> _usedForkedSolutionCounter;
 
     private int _disposed;
 

--- a/src/Features/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
@@ -87,10 +87,10 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
     {
         // Find the bucket corresponding to the queued duration and update the count of durations in that bucket.
         // This is not broken down per method as time in queue is not specific to an LSP method.
-        _queuedDurationLogAggregator.IncreaseCount(QueuedDurationKey, Convert.ToDecimal(queuedDuration.TotalMilliseconds));
+        _queuedDurationLogAggregator.IncreaseCount(QueuedDurationKey, queuedDuration);
 
         // Store the request time metrics per LSP method.
-        _requestDurationLogAggregator.IncreaseCount(methodName, Convert.ToDecimal(ComputeLogValue(requestDuration.TotalMilliseconds)));
+        _requestDurationLogAggregator.IncreaseCount(methodName, (int)ComputeLogValue(requestDuration.TotalMilliseconds));
         _requestCounters.GetOrAdd(methodName, (_) => new Counter()).IncrementCount(result);
     }
 

--- a/src/Features/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
@@ -87,7 +87,7 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
     {
         // Find the bucket corresponding to the queued duration and update the count of durations in that bucket.
         // This is not broken down per method as time in queue is not specific to an LSP method.
-        _queuedDurationLogAggregator.IncreaseCount(QueuedDurationKey, queuedDuration);
+        _queuedDurationLogAggregator.LogTime(QueuedDurationKey, queuedDuration);
 
         // Store the request time metrics per LSP method.
         _requestDurationLogAggregator.IncreaseCount(methodName, (int)ComputeLogValue(requestDuration.TotalMilliseconds));

--- a/src/Features/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestTelemetryLogger.cs
@@ -24,7 +24,7 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
     /// <summary>
     /// Histogram to aggregate the time in queue metrics.
     /// </summary>
-    private readonly HistogramLogAggregator _queuedDurationLogAggregator;
+    private readonly HistogramLogAggregator<string> _queuedDurationLogAggregator;
 
     /// <summary>
     /// Histogram to aggregate total request duration metrics.
@@ -34,7 +34,7 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
     /// This provides highly detailed buckets when duration is in MS, but less detailed
     /// when the duration is in terms of seconds or minutes.
     /// </summary>
-    private readonly HistogramLogAggregator _requestDurationLogAggregator;
+    private readonly HistogramLogAggregator<string> _requestDurationLogAggregator;
 
     /// <summary>
     /// Store request counters in a concurrent dictionary as non-mutating LSP requests can
@@ -42,9 +42,9 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
     /// </summary>
     private readonly ConcurrentDictionary<string, Counter> _requestCounters;
 
-    private readonly LogAggregator _findDocumentResults;
+    private readonly LogAggregator<string> _findDocumentResults;
 
-    private readonly LogAggregator _usedForkedSolutionCounter;
+    private readonly LogAggregator<bool> _usedForkedSolutionCounter;
 
     private int _disposed;
 
@@ -57,11 +57,11 @@ internal sealed class RequestTelemetryLogger : IDisposable, ILspService
 
         // Buckets queued duration into 10ms buckets with the last bucket starting at 1000ms.
         // Queue times are relatively short and fall under 50ms, so tracking past 1000ms is not useful.
-        _queuedDurationLogAggregator = new HistogramLogAggregator(bucketSize: 10, maxBucketValue: 1000);
+        _queuedDurationLogAggregator = new HistogramLogAggregator<string>(bucketSize: 10, maxBucketValue: 1000);
 
         // Since this is a log based histogram, these are appropriate bucket sizes for the log data.
         // A bucket at 1 corresponds to ~26ms, while the max bucket value corresponds to ~17minutes
-        _requestDurationLogAggregator = new HistogramLogAggregator(bucketSize: 1, maxBucketValue: 40);
+        _requestDurationLogAggregator = new HistogramLogAggregator<string>(bucketSize: 1, maxBucketValue: 40);
     }
 
     public void UpdateFindDocumentTelemetryData(bool success, string? workspaceKind)

--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginLogger.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginLogger.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServices.InheritanceMargin
 
         public static void LogGenerateBackgroundInheritanceInfo(TimeSpan elapsedTime)
             => s_histogramLogAggregator.IncreaseCount(
-                ActionInfo.GetInheritanceMarginMembers, Convert.ToDecimal(elapsedTime.TotalMilliseconds));
+                ActionInfo.GetInheritanceMarginMembers, elapsedTime);
 
         public static void LogInheritanceTargetsMenuOpen()
             => Logger.Log(FunctionId.InheritanceMargin_TargetsMenuOpen, KeyValueLogMessage.Create(LogType.UserAction));

--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginLogger.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginLogger.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.LanguageServices.InheritanceMargin
     internal static class InheritanceMarginLogger
     {
         // 1 sec per bucket, and if it takes more than 1 min, then this log is considered as time-out in the last bucket.
-        private static readonly HistogramLogAggregator s_histogramLogAggregator = new(1000, 60000);
+        private static readonly HistogramLogAggregator<ActionInfo> s_histogramLogAggregator = new(1000, 60000);
 
         private enum ActionInfo
         {

--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginLogger.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginLogger.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.InheritanceMargin
         }
 
         public static void LogGenerateBackgroundInheritanceInfo(TimeSpan elapsedTime)
-            => s_histogramLogAggregator.IncreaseCount(
+            => s_histogramLogAggregator.LogTime(
                 ActionInfo.GetInheritanceMarginMembers, elapsedTime);
 
         public static void LogInheritanceTargetsMenuOpen()

--- a/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/CommonFixAllState.cs
+++ b/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/CommonFixAllState.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CodeFixesAndRefactorings
         where TFixAllProvider : IFixAllProvider
         where TFixAllState : CommonFixAllState<TProvider, TFixAllProvider, TFixAllState>
     {
-        public int CorrelationId { get; } = LogAggregator.GetNextId();
+        public int CorrelationId { get; } = LogAggregator<object>.GetNextId();
         public TFixAllProvider FixAllProvider { get; }
         public string? CodeActionEquivalenceKey { get; }
         public TProvider Provider { get; }

--- a/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/CommonFixAllState.cs
+++ b/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/CommonFixAllState.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CodeFixesAndRefactorings
         where TFixAllProvider : IFixAllProvider
         where TFixAllState : CommonFixAllState<TProvider, TFixAllProvider, TFixAllState>
     {
-        public int CorrelationId { get; } = CountLogAggregator<object>.GetNextId();
+        public int CorrelationId { get; } = CorrelationIdFactory.GetNextId();
         public TFixAllProvider FixAllProvider { get; }
         public string? CodeActionEquivalenceKey { get; }
         public TProvider Provider { get; }

--- a/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/CommonFixAllState.cs
+++ b/src/Workspaces/Core/Portable/CodeFixesAndRefactorings/CommonFixAllState.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CodeFixesAndRefactorings
         where TFixAllProvider : IFixAllProvider
         where TFixAllState : CommonFixAllState<TProvider, TFixAllProvider, TFixAllState>
     {
-        public int CorrelationId { get; } = LogAggregator<object>.GetNextId();
+        public int CorrelationId { get; } = CountLogAggregator<object>.GetNextId();
         public TFixAllProvider FixAllProvider { get; }
         public string? CodeActionEquivalenceKey { get; }
         public TProvider Provider { get; }

--- a/src/Workspaces/Core/Portable/Log/CorrelationIdFactory.cs
+++ b/src/Workspaces/Core/Portable/Log/CorrelationIdFactory.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace Microsoft.CodeAnalysis.Internal.Log
+{
+    internal static class CorrelationIdFactory
+    {
+        private static int s_globalId;
+
+        public static int GetNextId()
+            => Interlocked.Increment(ref s_globalId);
+    }
+}

--- a/src/Workspaces/Core/Portable/Log/HistogramLogAggregator.cs
+++ b/src/Workspaces/Core/Portable/Log/HistogramLogAggregator.cs
@@ -32,10 +32,16 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         protected override HistogramCounter CreateCounter()
             => new(_bucketSize, _maxBucketValue, _bucketCount);
 
-        public void IncreaseCount(object key, decimal value)
+        public void IncreaseCount(object key, int value)
         {
             var counter = GetCounter(key);
             counter.IncreaseCount(value);
+        }
+
+        public void IncreaseCount(object key, TimeSpan timeSpan)
+        {
+            var counter = GetCounter(key);
+            counter.IncreaseCount((int)timeSpan.TotalMilliseconds);
         }
 
         public HistogramCounter? GetValue(object key)
@@ -62,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
                 _buckets = new int[BucketCount];
             }
 
-            public void IncreaseCount(decimal value)
+            public void IncreaseCount(int value)
             {
                 var bucket = GetBucket(value);
                 _buckets[bucket]++;
@@ -86,9 +92,9 @@ namespace Microsoft.CodeAnalysis.Internal.Log
                 return pooledStringBuilder.ToStringAndFree();
             }
 
-            private int GetBucket(decimal value)
+            private int GetBucket(int value)
             {
-                var bucket = (int)Math.Floor(value / BucketSize);
+                var bucket = value / BucketSize;
                 if (bucket >= BucketCount)
                 {
                     bucket = BucketCount - 1;

--- a/src/Workspaces/Core/Portable/Log/HistogramLogAggregator.cs
+++ b/src/Workspaces/Core/Portable/Log/HistogramLogAggregator.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
     /// <summary>
     /// Defines a log aggregator to create a histogram
     /// </summary>
-    internal sealed class HistogramLogAggregator : AbstractLogAggregator<HistogramLogAggregator.HistogramCounter>
+    internal sealed class HistogramLogAggregator<TKey> : AbstractLogAggregator<TKey, HistogramLogAggregator<TKey>.HistogramCounter>
     {
         private readonly int _bucketSize;
         private readonly int _maxBucketValue;
@@ -32,19 +32,19 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         protected override HistogramCounter CreateCounter()
             => new(_bucketSize, _maxBucketValue, _bucketCount);
 
-        public void IncreaseCount(object key, int value)
+        public void IncreaseCount(TKey key, int value)
         {
             var counter = GetCounter(key);
             counter.IncreaseCount(value);
         }
 
-        public void IncreaseCount(object key, TimeSpan timeSpan)
+        public void IncreaseCount(TKey key, TimeSpan timeSpan)
         {
             var counter = GetCounter(key);
             counter.IncreaseCount((int)timeSpan.TotalMilliseconds);
         }
 
-        public HistogramCounter? GetValue(object key)
+        public HistogramCounter? GetValue(TKey key)
         {
             TryGetCounter(key, out var counter);
             return counter;

--- a/src/Workspaces/Core/Portable/Log/HistogramLogAggregator.cs
+++ b/src/Workspaces/Core/Portable/Log/HistogramLogAggregator.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
             counter.IncreaseCount(value);
         }
 
-        public void IncreaseCount(TKey key, TimeSpan timeSpan)
+        public void LogTime(TKey key, TimeSpan timeSpan)
         {
             var counter = GetCounter(key);
             counter.IncreaseCount((int)timeSpan.TotalMilliseconds);

--- a/src/Workspaces/Core/Portable/Log/StatisticLogAggregator.cs
+++ b/src/Workspaces/Core/Portable/Log/StatisticLogAggregator.cs
@@ -8,23 +8,23 @@ using System;
 
 namespace Microsoft.CodeAnalysis.Internal.Log
 {
-    internal sealed class StatisticLogAggregator : AbstractLogAggregator<StatisticLogAggregator.StatisticCounter>
+    internal sealed class StatisticLogAggregator<TKey> : AbstractLogAggregator<TKey, StatisticLogAggregator<TKey>.StatisticCounter>
     {
         protected override StatisticCounter CreateCounter()
             => new();
 
-        public void AddDataPoint(object key, int value)
+        public void AddDataPoint(TKey key, int value)
         {
             var counter = GetCounter(key);
             counter.AddDataPoint(value);
         }
 
-        public void AddDataPoint(object key, TimeSpan timeSpan)
+        public void AddDataPoint(TKey key, TimeSpan timeSpan)
         {
             AddDataPoint(key, (int)timeSpan.TotalMilliseconds);
         }
 
-        public StatisticResult GetStaticticResult(object key)
+        public StatisticResult GetStaticticResult(TKey key)
         {
             if (TryGetCounter(key, out var counter))
             {

--- a/src/Workspaces/Core/Portable/Log/StatisticLogAggregator.cs
+++ b/src/Workspaces/Core/Portable/Log/StatisticLogAggregator.cs
@@ -4,6 +4,8 @@
 
 #nullable disable
 
+using System;
+
 namespace Microsoft.CodeAnalysis.Internal.Log
 {
     internal sealed class StatisticLogAggregator : AbstractLogAggregator<StatisticLogAggregator.StatisticCounter>
@@ -15,6 +17,11 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         {
             var counter = GetCounter(key);
             counter.AddDataPoint(value);
+        }
+
+        public void AddDataPoint(object key, TimeSpan timeSpan)
+        {
+            AddDataPoint(key, (int)timeSpan.TotalMilliseconds);
         }
 
         public StatisticResult GetStaticticResult(object key)

--- a/src/Workspaces/Core/Portable/Log/StatisticResult.cs
+++ b/src/Workspaces/Core/Portable/Log/StatisticResult.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Collections.Generic;
+using System.Linq;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Internal.Log
+{
+    internal struct StatisticResult
+    {
+        public static StatisticResult FromList(List<int> values)
+        {
+            if (values.Count == 0)
+            {
+                return default;
+            }
+
+            var max = int.MinValue;
+            var min = int.MaxValue;
+
+            var total = 0;
+            for (var i = 0; i < values.Count; i++)
+            {
+                var current = values[i];
+                max = max < current ? current : max;
+                min = min > current ? current : min;
+
+                total += current;
+            }
+
+            var mean = total / values.Count;
+            var median = values[values.Count / 2];
+
+            var range = max - min;
+            var mode = values.GroupBy(i => i).OrderByDescending(g => g.Count()).FirstOrDefault().Key;
+
+            return new StatisticResult(max, min, median, mean, range, mode, values.Count);
+        }
+
+        /// <summary>
+        /// maximum value
+        /// </summary>
+        public readonly int Maximum;
+
+        /// <summary>
+        /// minimum value
+        /// </summary>
+        public readonly int Minimum;
+
+        /// <summary>
+        /// middle value of the total data set
+        /// </summary>
+        public readonly int? Median;
+
+        /// <summary>
+        /// average value of the total data set
+        /// </summary>
+        public readonly int Mean;
+
+        /// <summary>
+        /// most frequent value in the total data set
+        /// </summary>
+        public readonly int? Mode;
+
+        /// <summary>
+        /// difference between max and min value
+        /// </summary>
+        public readonly int Range;
+
+        /// <summary>
+        /// number of data points in the total data set
+        /// </summary>
+        public readonly int Count;
+
+        public StatisticResult(int max, int min, int? median, int mean, int range, int? mode, int count)
+        {
+            this.Maximum = max;
+            this.Minimum = min;
+            this.Median = median;
+            this.Mean = mean;
+            this.Range = range;
+            this.Mode = mode;
+            this.Count = count;
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionLogger.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionLogger.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Logging
 {
     internal static class SolutionLogger
     {
-        private static readonly LogAggregator s_logAggregator = new();
+        private static readonly LogAggregator<string> s_logAggregator = new();
 
         public static void UseExistingPartialProjectState()
             => s_logAggregator.IncreaseCount(nameof(UseExistingPartialProjectState));

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionLogger.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionLogger.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Logging
 {
     internal static class SolutionLogger
     {
-        private static readonly LogAggregator<string> s_logAggregator = new();
+        private static readonly CountLogAggregator<string> s_logAggregator = new();
 
         public static void UseExistingPartialProjectState()
             => s_logAggregator.IncreaseCount(nameof(UseExistingPartialProjectState));

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Log/AbstractLogAggregator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Log/AbstractLogAggregator.cs
@@ -17,19 +17,19 @@ namespace Microsoft.CodeAnalysis.Internal.Log
     /// <summary>
     /// helper class to aggregate some numeric value log in client side
     /// </summary>
-    internal abstract class AbstractLogAggregator<T> : IEnumerable<KeyValuePair<object, T>>
+    internal abstract class AbstractLogAggregator<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
     {
         private static int s_globalId;
 
-        private readonly ConcurrentDictionary<object, T> _map = new(concurrencyLevel: 2, capacity: 2);
-        private readonly Func<object, T> _createCounter;
+        private readonly ConcurrentDictionary<TKey, TValue> _map = new(concurrencyLevel: 2, capacity: 2);
+        private readonly Func<TKey, TValue> _createCounter;
 
         protected AbstractLogAggregator()
         {
             _createCounter = _ => CreateCounter();
         }
 
-        protected abstract T CreateCounter();
+        protected abstract TValue CreateCounter();
 
         public static int GetNextId()
             => Interlocked.Increment(ref s_globalId);
@@ -65,17 +65,17 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         public bool IsEmpty => _map.IsEmpty;
 
-        public IEnumerator<KeyValuePair<object, T>> GetEnumerator()
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
             => _map.GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator()
             => this.GetEnumerator();
 
         [PerformanceSensitive("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1279909", AllowCaptures = false)]
-        protected T GetCounter(object key)
+        protected TValue GetCounter(TKey key)
             => _map.GetOrAdd(key, _createCounter);
 
-        protected bool TryGetCounter(object key, out T counter)
+        protected bool TryGetCounter(TKey key, out TValue counter)
         {
             if (_map.TryGetValue(key, out counter))
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Log/AbstractLogAggregator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Log/AbstractLogAggregator.cs
@@ -19,8 +19,6 @@ namespace Microsoft.CodeAnalysis.Internal.Log
     /// </summary>
     internal abstract class AbstractLogAggregator<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
     {
-        private static int s_globalId;
-
         private readonly ConcurrentDictionary<TKey, TValue> _map = new(concurrencyLevel: 2, capacity: 2);
         private readonly Func<TKey, TValue> _createCounter;
 
@@ -30,9 +28,6 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         }
 
         protected abstract TValue CreateCounter();
-
-        public static int GetNextId()
-            => Interlocked.Increment(ref s_globalId);
 
         public static StatisticResult GetStatistics(List<int> values)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Log/AbstractLogAggregator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Log/AbstractLogAggregator.cs
@@ -29,35 +29,6 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         protected abstract TValue CreateCounter();
 
-        public static StatisticResult GetStatistics(List<int> values)
-        {
-            if (values.Count == 0)
-            {
-                return default;
-            }
-
-            var max = int.MinValue;
-            var min = int.MaxValue;
-
-            var total = 0;
-            for (var i = 0; i < values.Count; i++)
-            {
-                var current = values[i];
-                max = max < current ? current : max;
-                min = min > current ? current : min;
-
-                total += current;
-            }
-
-            var mean = total / values.Count;
-            var median = values[values.Count / 2];
-
-            var range = max - min;
-            var mode = values.GroupBy(i => i).OrderByDescending(g => g.Count()).FirstOrDefault().Key;
-
-            return new StatisticResult(max, min, median, mean, range, mode, values.Count);
-        }
-
         public bool IsEmpty => _map.IsEmpty;
 
         public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
@@ -78,55 +49,6 @@ namespace Microsoft.CodeAnalysis.Internal.Log
             }
 
             return false;
-        }
-    }
-
-    internal struct StatisticResult
-    {
-        /// <summary>
-        /// maximum value
-        /// </summary>
-        public readonly int Maximum;
-
-        /// <summary>
-        /// minimum value
-        /// </summary>
-        public readonly int Minimum;
-
-        /// <summary>
-        /// middle value of the total data set
-        /// </summary>
-        public readonly int? Median;
-
-        /// <summary>
-        /// average value of the total data set
-        /// </summary>
-        public readonly int Mean;
-
-        /// <summary>
-        /// most frequent value in the total data set
-        /// </summary>
-        public readonly int? Mode;
-
-        /// <summary>
-        /// difference between max and min value
-        /// </summary>
-        public readonly int Range;
-
-        /// <summary>
-        /// number of data points in the total data set
-        /// </summary>
-        public readonly int Count;
-
-        public StatisticResult(int max, int min, int? median, int mean, int range, int? mode, int count)
-        {
-            this.Maximum = max;
-            this.Minimum = min;
-            this.Median = median;
-            this.Mean = mean;
-            this.Range = range;
-            this.Mode = mode;
-            this.Count = count;
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Log/CountLogAggregator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Log/CountLogAggregator.cs
@@ -8,7 +8,7 @@ using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Internal.Log
 {
-    internal class LogAggregator<TKey> : AbstractLogAggregator<TKey, LogAggregator<TKey>.Counter>
+    internal class CountLogAggregator<TKey> : AbstractLogAggregator<TKey, CountLogAggregator<TKey>.Counter>
     {
         protected override Counter CreateCounter()
             => new();

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Log/LogAggregator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Log/LogAggregator.cs
@@ -8,30 +8,30 @@ using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Internal.Log
 {
-    internal class LogAggregator : AbstractLogAggregator<LogAggregator.Counter>
+    internal class LogAggregator<TKey> : AbstractLogAggregator<TKey, LogAggregator<TKey>.Counter>
     {
         protected override Counter CreateCounter()
             => new();
 
-        public void SetCount(object key, int count)
+        public void SetCount(TKey key, int count)
         {
             var counter = GetCounter(key);
             counter.SetCount(count);
         }
 
-        public void IncreaseCount(object key)
+        public void IncreaseCount(TKey key)
         {
             var counter = GetCounter(key);
             counter.IncreaseCount();
         }
 
-        public void IncreaseCountBy(object key, int value)
+        public void IncreaseCountBy(TKey key, int value)
         {
             var counter = GetCounter(key);
             counter.IncreaseCountBy(value);
         }
 
-        public int GetCount(object key)
+        public int GetCount(TKey key)
         {
             if (TryGetCounter(key, out var counter))
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/WorkspaceExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/WorkspaceExtensions.projitems
@@ -54,7 +54,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)LanguageServices\TypeInferenceService\AbstractTypeInferenceService.AbstractTypeInferrer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LanguageServices\TypeInferenceService\AbstractTypeInferenceService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LanguageServices\TypeInferenceService\ITypeInferenceService.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Log\LogAggregator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Log\CountLogAggregator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Log\AbstractLogAggregator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LanguageServices\SemanticsFactsService\AbstractSemanticFactsService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LanguageServices\SemanticsFactsService\ISemanticFactsService.cs" />


### PR DESCRIPTION
While looking at our existing logging code to figure out what I can reuse, I noticed a few bits that could use some cleanup. Changes:

1. Pass around TimeSpans instead of ints for time; this avoids some confusion around units (especially when called "ticks" since that term is ambiguous between different units)
2. Make the types that are implicitly keyed by something generic, so the type of key is clear.
3. Rename LogAggregator to CountLogAggregator, so that way the naming matches its sibling types in the type hierarchy.
4. Move some helpers out of the abstract generic class that don't need to be there.

Commit at a time may or may not help; on one hand each change is pretty mechanical, but the same pieces of code may get touched by multiple commits so that might increase the total amount of code to read pretty significantly.