### PR TITLE
Make sure spans are valid before trying to get exception regions

### DIFF
--- a/src/EditorFeatures/Test/EditAndContinue/ActiveStatementsMapTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/ActiveStatementsMapTests.cs
@@ -127,6 +127,47 @@ S5();
         }
 
         [Fact]
+        public async Task InvalidActiveStatements()
+        {
+            using var workspace = new TestWorkspace(composition: FeaturesTestCompositions.Features);
+
+            var source = @"
+class C
+{
+    void F()
+    {
+S1();
+    }
+}";
+
+            var solution = workspace.CurrentSolution
+                .AddProject("proj", "proj", LanguageNames.CSharp)
+                .AddDocument("doc", SourceText.From(source, Encoding.UTF8), filePath: "a.cs").Project.Solution;
+
+            var project = solution.Projects.Single();
+            var document = project.Documents.Single();
+            var analyzer = project.LanguageServices.GetRequiredService<IEditAndContinueAnalyzer>();
+
+            var documentPathMap = new Dictionary<string, ImmutableArray<ActiveStatement>>();
+
+            var moduleId = Guid.NewGuid();
+            var token = 0x06000001;
+            ManagedActiveStatementDebugInfo CreateInfo(int startLine, int startColumn, int endLine, int endColumn, string fileName)
+                => new(new(new(moduleId, token++, version: 1), ilOffset: 0), fileName, new SourceSpan(startLine, startColumn, endLine, endColumn), ActiveStatementFlags.MethodUpToDate);
+
+            // Create a bad active span that is outside the document, but passes the `TryGetTextSpan` check in ActiveStatementMap
+            var debugInfos = ImmutableArray.Create(
+                CreateInfo(7, 9, 7, 10, "a.cs")
+            );
+
+            var map = ActiveStatementsMap.Create(debugInfos, remapping: ImmutableDictionary<ManagedMethodId, ImmutableArray<NonRemappableRegion>>.Empty);
+
+            var oldSpans = await map.GetOldActiveStatementsAsync(analyzer, document, CancellationToken.None);
+
+            AssertEx.Empty(oldSpans);
+        }
+
+        [Fact]
         public void ExpandMultiLineSpan()
         {
             using var workspace = new TestWorkspace(composition: FeaturesTestCompositions.Features);

--- a/src/Features/Core/Portable/EditAndContinue/ActiveStatementsMap.cs
+++ b/src/Features/Core/Portable/EditAndContinue/ActiveStatementsMap.cs
@@ -188,6 +188,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 // Also guard against active statements unmapped to multiple locations in the unmapped file
                 // (when multiple #line map to the same span that overlaps with the active statement).
                 if (TryGetTextSpan(oldText.Lines, unmappedLineSpan, out var unmappedSpan) &&
+                    oldRoot.FullSpan.Contains(unmappedSpan.Start) &&
                     mappedStatements.Add(activeStatement))
                 {
                     var exceptionRegions = analyzer.GetExceptionRegions(oldRoot, unmappedSpan, activeStatement.IsNonLeaf, cancellationToken);


### PR DESCRIPTION
Fixes [AB#1563342](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1563342)

I couldn't repro this, but [the check in `TryGetTextSpan`](https://github.com/dotnet/roslyn/blob/main/src/Features/Core/Portable/EditAndContinue/ActiveStatementsMap.cs#L263) only checks line numbers, not line length, so hopefully this isn't a controversial change.