### PR TITLE
Use the prior cached state for the Razor generator in later runs

### DIFF
--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -8,6 +8,7 @@ Microsoft.CodeAnalysis.GeneratorAttributeSyntaxContext.GeneratorAttributeSyntaxC
 Microsoft.CodeAnalysis.GeneratorAttributeSyntaxContext.SemanticModel.get -> Microsoft.CodeAnalysis.SemanticModel!
 Microsoft.CodeAnalysis.GeneratorAttributeSyntaxContext.TargetNode.get -> Microsoft.CodeAnalysis.SyntaxNode!
 Microsoft.CodeAnalysis.GeneratorAttributeSyntaxContext.TargetSymbol.get -> Microsoft.CodeAnalysis.ISymbol!
+Microsoft.CodeAnalysis.GeneratorDriver.ReplaceGenerators(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ISourceGenerator!> generators) -> Microsoft.CodeAnalysis.GeneratorDriver!
 Microsoft.CodeAnalysis.IFieldSymbol.IsRequired.get -> bool
 Microsoft.CodeAnalysis.IFieldSymbol.RefCustomModifiers.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.CustomModifier!>
 Microsoft.CodeAnalysis.IFieldSymbol.RefKind.get -> Microsoft.CodeAnalysis.RefKind

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -74,6 +74,28 @@ namespace Microsoft.CodeAnalysis
             return FromState(newState);
         }
 
+        public GeneratorDriver ReplaceGenerators(ImmutableArray<ISourceGenerator> generators)
+        {
+            var incrementalGenerators = GetIncrementalGenerators(generators, SourceExtension);
+            var states = ArrayBuilder<GeneratorState>.GetInstance(generators.Length);
+
+            foreach (var generator in generators)
+            {
+                var existingIndex = _state.Generators.IndexOf(generator);
+
+                if (existingIndex >= 0)
+                {
+                    states.Add(_state.GeneratorStates[existingIndex]);
+                }
+                else
+                {
+                    states.Add(GeneratorState.Empty);
+                }
+            }
+
+            return FromState(_state.With(generators, incrementalGenerators, states.ToImmutableAndFree()));
+        }
+
         public GeneratorDriver RemoveGenerators(ImmutableArray<ISourceGenerator> generators)
         {
             var newGenerators = _state.Generators;

--- a/src/EditorFeatures/Test/EditAndContinue/CompileTimeSolutionProviderTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/CompileTimeSolutionProviderTests.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
 using Roslyn.Test.Utilities;
+using Roslyn.Test.Utilities.TestGenerators;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
@@ -79,6 +80,79 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 compileTimeSolution, ImmutableArray.Create(documentId, sourceGeneratedDoc.Id), designTimeSolution, CancellationToken.None, sourceGeneratedPathPrefix);
 
             AssertEx.Equal(new[] { documentId, designTimeDocumentId }, actualDesignTimeDocumentIds);
+        }
+
+        [Fact]
+        public async Task GeneratorOutputCachedBetweenAcrossCompileTimeSolutions()
+        {
+            var workspace = new TestWorkspace(composition: FeaturesTestCompositions.Features);
+            var projectId = ProjectId.CreateNewId();
+
+            var generatorInvocations = 0;
+
+            var generator = new PipelineCallbackGenerator(context =>
+            {
+                // We'll replicate a simple example of how the razor generator handles disabling here so the test
+                // functions similar to the real world
+                var isDisabled = context.AnalyzerConfigOptionsProvider.Select(
+                    (o, ct) => o.GlobalOptions.TryGetValue("build_property.SuppressRazorSourceGenerator", out var value) && bool.Parse(value));
+
+                var sources = context.AdditionalTextsProvider.Combine(isDisabled).Select((pair, ct) =>
+                {
+                    var (additionalText, isDisabledFlag) = pair;
+
+                    if (isDisabledFlag)
+                        return null;
+
+                    Interlocked.Increment(ref generatorInvocations);
+                    return "// " + additionalText.GetText(ct)!.ToString();
+                });
+
+                context.RegisterSourceOutput(sources, (context, s) =>
+                {
+                    if (s != null)
+                        context.AddSource("hint", SourceText.From(s));
+                });
+            });
+
+            var analyzerConfigId = DocumentId.CreateNewId(projectId);
+            var additionalDocumentId = DocumentId.CreateNewId(projectId);
+
+            var analyzerConfigText = "is_global = true\r\nbuild_property.SuppressRazorSourceGenerator = true";
+
+            workspace.SetCurrentSolution(s => s.
+                AddProject(ProjectInfo.Create(projectId, VersionStamp.Default, "proj", "proj", LanguageNames.CSharp)).
+                AddAnalyzerReference(projectId, new TestGeneratorReference(generator)).
+                AddAdditionalDocument(additionalDocumentId, "additional", SourceText.From(""), filePath: "additional.razor").
+                AddAnalyzerConfigDocument(analyzerConfigId, "config", SourceText.From(analyzerConfigText), filePath: "Z:\\RazorSourceGenerator.razorencconfig"),
+                WorkspaceChangeKind.SolutionAdded);
+
+            // Fetch a compilation first for the base solution; we're doing this because currently if we try to move the
+            // cached generator state to a snapshot that has no CompilationTracker at all, we won't update the state.
+            _ = await workspace.CurrentSolution.GetRequiredProject(projectId).GetCompilationAsync();
+
+            var provider = workspace.Services.GetRequiredService<ICompileTimeSolutionProvider>();
+            var compileTimeSolution1 = provider.GetCompileTimeSolution(workspace.CurrentSolution);
+
+            _ = await compileTimeSolution1.GetRequiredProject(projectId).GetCompilationAsync();
+
+            Assert.Equal(1, generatorInvocations);
+
+            // Now do something that shouldn't force the generator to rerun; we must change this through the workspace since the
+            // service itself uses versions that won't change otherwise
+            var documentId = DocumentId.CreateNewId(projectId);
+            workspace.SetCurrentSolution(
+                s => s.AddDocument(documentId, "Test.cs", "// source file"),
+                WorkspaceChangeKind.DocumentAdded,
+                projectId,
+                documentId);
+
+            var compileTimeSolution2 = provider.GetCompileTimeSolution(workspace.CurrentSolution);
+            Assert.NotSame(compileTimeSolution1, compileTimeSolution2);
+
+            _ = await compileTimeSolution2.GetRequiredProject(projectId).GetCompilationAsync();
+
+            Assert.Equal(1, generatorInvocations);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1774,6 +1774,25 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
+        /// Returns a new Solution which represents the same state as before, but with the cached generator driver state from the given project updated to match.
+        /// </summary>
+        /// <remarks>
+        /// When generators are ran in a Solution snapshot, they may cache state to speed up future runs. For Razor, we only run their generator on forked
+        /// solutions that are thrown away; this API gives us a way to reuse that cached state in other forked solutions, since otherwise there's no way to reuse
+        /// the cached state.
+        /// </remarks>
+        internal Solution WithCachedSourceGeneratorState(ProjectId projectToUpdate, Project projectWithCachedGeneratorState)
+        {
+            var newState = _state.WithCachedSourceGeneratorState(projectToUpdate, projectWithCachedGeneratorState);
+            if (newState == _state)
+            {
+                return this;
+            }
+
+            return new Solution(newState);
+        }
+
+        /// <summary>
         /// Gets an objects that lists the added, changed and removed projects between
         /// this solution and the specified solution.
         /// </summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1866,6 +1866,28 @@ namespace Microsoft.CodeAnalysis
                 frozenSourceGeneratedDocument: null);
         }
 
+        /// <inheritdoc cref="Solution.WithCachedSourceGeneratorState(ProjectId, Project)"/>
+        public SolutionState WithCachedSourceGeneratorState(ProjectId projectToUpdate, Project projectWithCachedGeneratorState)
+        {
+            CheckContainsProject(projectToUpdate);
+
+            // First see if we have a generator driver that we can get from the other project.
+            if (!projectWithCachedGeneratorState.Solution.State.TryGetCompilationTracker(projectWithCachedGeneratorState.Id, out var tracker) ||
+                tracker.GeneratorDriver is null)
+            {
+                // We don't actually have any state at all, so no change.
+                return this;
+            }
+
+            var projectToUpdateState = GetRequiredProjectState(projectToUpdate);
+
+            return ForkProject(
+                projectToUpdateState,
+                translate: new CompilationAndGeneratorDriverTranslationAction.ReplaceGeneratorDriverAction(
+                    tracker.GeneratorDriver,
+                    newProjectState: projectToUpdateState));
+        }
+
         /// <summary>
         /// Symbols need to be either <see cref="IAssemblySymbol"/> or <see cref="IModuleSymbol"/>.
         /// </summary>


### PR DESCRIPTION
The CompileTimeSolutionProvider forks the main Workspace's Solution snapshot and temporarily enables the Razor generator for that forked version. When a later edit were to happen, we'd end up throwing out that snapshot and re-forking the Solution again, this meant that any cached state from the Razor generator gets thrown out for later runs. This uses the new API just added to try to properly cache the Razor generator output from the prior run.

This will ultimately help with closing https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1554147. That was happening because the Razor generator was running even if it was disabled. That's been fixed, but will regress successive Hot Reload applications because of the issue described; this will help us not regress that as well. (We believe we haven't seen evidence of that regression in a new bug because the SDK change isn't in our performance testing runs yet, even though it's already been merged.)

Closes https://github.com/dotnet/roslyn/issues/62796