### PR TITLE
A couple of fixups for the Utf-8 string literal code fix and analyzer

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseUtf8StringLiteral/UseUtf8StringLiteralDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseUtf8StringLiteral/UseUtf8StringLiteralDiagnosticAnalyzer.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis.CodeStyle;
@@ -152,8 +153,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UseUtf8StringLiteral
             for (var i = 0; i < arrayCreationElements.Length;)
             {
                 // Need to call a method to do the actual rune decoding as it uses stackalloc, and stackalloc
-                // in a loop is a bad idea
-                if (!TryGetNextRune(arrayCreationElements, i, out var rune, out var bytesConsumed))
+                // in a loop is a bad idea. We also exclude any characters that are control or format chars
+                if (!TryGetNextRune(arrayCreationElements, i, out var rune, out var bytesConsumed) ||
+                    Rune.GetUnicodeCategory(rune) is UnicodeCategory.Control or UnicodeCategory.Format)
                     return false;
 
                 i += bytesConsumed;

--- a/src/Analyzers/CSharp/CodeFixes/UseUtf8StringLiteral/UseUtf8StringLiteralCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseUtf8StringLiteral/UseUtf8StringLiteralCodeFixProvider.cs
@@ -48,12 +48,26 @@ namespace Microsoft.CodeAnalysis.CSharp.UseUtf8StringLiteral
         {
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
+            var readOnlySpanType = semanticModel.Compilation.GetBestTypeByMetadataName(typeof(ReadOnlySpan<>).FullName!);
+            // The analyzer wouldn't raise a diagnostic if this were null
+            Contract.ThrowIfNull(readOnlySpanType);
+
             foreach (var diagnostic in diagnostics)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var node = diagnostic.Location.FindNode(getInnermostNodeForTie: true, cancellationToken);
-                var stringValue = GetUtf8StringValueForDiagnostic(semanticModel, diagnostic, cancellationToken);
+                var arrayOp = GetArrayCreationOperation(semanticModel, diagnostic, cancellationToken);
+                Contract.ThrowIfNull(arrayOp.Initializer);
+
+                var stringValue = GetUtf8StringValueFromArrayInitializer(arrayOp.Initializer);
+
+                // If our array is parented by a conversion to ReadOnlySpan<byte> then we don't want to call
+                // ToArray after the string literal, or we'll be regressing perf.
+                var isConvertedToReadOnlySpan = arrayOp.Parent is IConversionOperation conversion &&
+                    conversion.Type is INamedTypeSymbol { IsGenericType: true } namedType &&
+                    namedType.ConstructedFrom == readOnlySpanType &&
+                    namedType.TypeArguments[0].SpecialType == SpecialType.System_Byte;
 
                 // If we're replacing a byte array that is passed to a parameter array, not and an explicit array creation
                 // then node will be the ArgumentListSyntax that the implicit array creation is just a part of, so we have
@@ -68,16 +82,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UseUtf8StringLiteral
 
                 if (node is BaseArgumentListSyntax argumentList)
                 {
-                    editor.ReplaceNode(node, CreateArgumentListWithUtf8String(argumentList, diagnostic.Location, stringValue));
+                    editor.ReplaceNode(node, CreateArgumentListWithUtf8String(argumentList, diagnostic.Location, stringValue, isConvertedToReadOnlySpan));
                 }
                 else
                 {
-                    editor.ReplaceNode(node, CreateUtf8String(node, stringValue));
+                    editor.ReplaceNode(node, CreateUtf8String(node, stringValue, isConvertedToReadOnlySpan));
                 }
             }
         }
 
-        private static string GetUtf8StringValueForDiagnostic(SemanticModel semanticModel, Diagnostic diagnostic, CancellationToken cancellationToken)
+        private static IArrayCreationOperation GetArrayCreationOperation(SemanticModel semanticModel, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
             // For computing the UTF-8 string we need the original location of the array creation
             // operation, which is stored in additional locations.
@@ -90,15 +104,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UseUtf8StringLiteral
             if (!Enum.TryParse(operationLocationString, out UseUtf8StringLiteralDiagnosticAnalyzer.ArrayCreationOperationLocation operationLocation))
                 throw ExceptionUtilities.Unreachable;
 
-            IArrayCreationOperation arrayOp;
-
             // Because we get the location from an IOperation.Syntax, sometimes we have to look a
             // little harder to get back from syntax to the operation that triggered the diagnostic
             if (operationLocation == UseUtf8StringLiteralDiagnosticAnalyzer.ArrayCreationOperationLocation.Ancestors)
             {
                 // For collection initializers where the Add method takes a param array, and the array creation
                 // will be a parent of the operation
-                arrayOp = FindArrayCreationOperationAncestor(operation);
+                return FindArrayCreationOperationAncestor(operation);
             }
             else if (operationLocation == UseUtf8StringLiteralDiagnosticAnalyzer.ArrayCreationOperationLocation.Descendants)
             {
@@ -106,29 +118,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UseUtf8StringLiteral
                 // will be the invocation, or similar, that has the argument, and we need to descend child
                 // nodes to find the one we are interested in. To make sure we're finding the right one,
                 // we can use the diagnostic location for that, since the analyzer raises it on the first element.
-                arrayOp = operation.DescendantsAndSelf()
+                return operation.DescendantsAndSelf()
                     .OfType<IArrayCreationOperation>()
                     .Where(a => a.Initializer?.ElementValues.FirstOrDefault()?.Syntax.SpanStart == diagnostic.Location.SourceSpan.Start)
                     .First();
             }
-            else
-            {
-                arrayOp = (IArrayCreationOperation)operation;
-            }
 
-            Contract.ThrowIfNull(arrayOp.Initializer);
-
-            // Get our list of bytes from the array elements
-            using var _ = PooledStringBuilder.GetInstance(out var builder);
-            builder.Capacity = arrayOp.Initializer.ElementValues.Length;
-            if (!UseUtf8StringLiteralDiagnosticAnalyzer.TryConvertToUtf8String(builder, arrayOp.Initializer.ElementValues))
-            {
-                // We shouldn't get here, because the code fix shouldn't ask for a string value
-                // if the analyzer couldn't convert it
-                throw ExceptionUtilities.Unreachable;
-            }
-
-            return builder.ToString();
+            return (IArrayCreationOperation)operation;
 
             static IArrayCreationOperation FindArrayCreationOperationAncestor(IOperation operation)
             {
@@ -144,7 +140,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UseUtf8StringLiteral
             }
         }
 
-        private static SyntaxNode CreateArgumentListWithUtf8String(BaseArgumentListSyntax argumentList, Location location, string stringValue)
+        private static string GetUtf8StringValueFromArrayInitializer(IArrayInitializerOperation initializer)
+        {
+            // Get our list of bytes from the array elements
+            using var _ = PooledStringBuilder.GetInstance(out var builder);
+            builder.Capacity = initializer.ElementValues.Length;
+            if (!UseUtf8StringLiteralDiagnosticAnalyzer.TryConvertToUtf8String(builder, initializer.ElementValues))
+            {
+                // We shouldn't get here, because the code fix shouldn't ask for a string value
+                // if the analyzer couldn't convert it
+                throw ExceptionUtilities.Unreachable;
+            }
+
+            return builder.ToString();
+        }
+
+        private static SyntaxNode CreateArgumentListWithUtf8String(BaseArgumentListSyntax argumentList, Location location, string stringValue, bool isConvertedToReadOnlySpan)
         {
             // To construct our new argument list we add any existing tokens before the location
             // and then once we hit the location, we add our string literal
@@ -164,7 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseUtf8StringLiteral
                 {
                     // We don't need to worry about leading trivia here, because anything before the current
                     // argument will have been trailing trivia on the previous comma.
-                    var stringLiteral = CreateUtf8String(SyntaxTriviaList.Empty, stringValue, argumentList.Arguments.Last().GetTrailingTrivia());
+                    var stringLiteral = CreateUtf8String(SyntaxTriviaList.Empty, stringValue, argumentList.Arguments.Last().GetTrailingTrivia(), isConvertedToReadOnlySpan);
                     arguments.Add(SyntaxFactory.Argument(stringLiteral));
                     break;
                 }
@@ -175,24 +186,30 @@ namespace Microsoft.CodeAnalysis.CSharp.UseUtf8StringLiteral
             return argumentList.WithArguments(SyntaxFactory.SeparatedList<ArgumentSyntax>(arguments));
         }
 
-        private static InvocationExpressionSyntax CreateUtf8String(SyntaxNode nodeToTakeTriviaFrom, string stringValue)
+        private static ExpressionSyntax CreateUtf8String(SyntaxNode nodeToTakeTriviaFrom, string stringValue, bool isConvertedToReadOnlySpan)
         {
-            return CreateUtf8String(nodeToTakeTriviaFrom.GetLeadingTrivia(), stringValue, nodeToTakeTriviaFrom.GetTrailingTrivia());
+            return CreateUtf8String(nodeToTakeTriviaFrom.GetLeadingTrivia(), stringValue, nodeToTakeTriviaFrom.GetTrailingTrivia(), isConvertedToReadOnlySpan);
         }
 
-        private static InvocationExpressionSyntax CreateUtf8String(SyntaxTriviaList leadingTrivia, string stringValue, SyntaxTriviaList trailingTrivia)
+        private static ExpressionSyntax CreateUtf8String(SyntaxTriviaList leadingTrivia, string stringValue, SyntaxTriviaList trailingTrivia, bool isConvertedToReadOnlySpan)
         {
-            var literal = SyntaxFactory.Token(
+            var stringLiteral = SyntaxFactory.LiteralExpression(SyntaxKind.Utf8StringLiteralExpression,
+                SyntaxFactory.Token(
                     leading: leadingTrivia,
                     kind: SyntaxKind.Utf8StringLiteralToken,
                     text: QuoteCharacter + stringValue + QuoteCharacter + Suffix,
                     valueText: "",
-                    trailing: SyntaxTriviaList.Empty);
+                    trailing: SyntaxTriviaList.Empty));
+
+            if (isConvertedToReadOnlySpan)
+            {
+                return stringLiteral.WithTrailingTrivia(trailingTrivia);
+            }
 
             return SyntaxFactory.InvocationExpression(
                      SyntaxFactory.MemberAccessExpression(
                          SyntaxKind.SimpleMemberAccessExpression,
-                         SyntaxFactory.LiteralExpression(SyntaxKind.Utf8StringLiteralExpression, literal),
+                         stringLiteral,
                          SyntaxFactory.IdentifierName(nameof(ReadOnlySpan<byte>.ToArray))))
                    .WithTrailingTrivia(trailingTrivia);
         }

--- a/src/Analyzers/CSharp/CodeFixes/UseUtf8StringLiteral/UseUtf8StringLiteralCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseUtf8StringLiteral/UseUtf8StringLiteralCodeFixProvider.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseUtf8StringLiteral
                 // ToArray after the string literal, or we'll be regressing perf.
                 var isConvertedToReadOnlySpan = arrayOp.Parent is IConversionOperation conversion &&
                     conversion.Type is INamedTypeSymbol { IsGenericType: true } namedType &&
-                    namedType.ConstructedFrom.Equals(readOnlySpanType) &&
+                    namedType.OriginalDefinition.Equals(readOnlySpanType) &&
                     namedType.TypeArguments[0].SpecialType == SpecialType.System_Byte;
 
                 // If we're replacing a byte array that is passed to a parameter array, not and an explicit array creation

--- a/src/Analyzers/CSharp/Tests/UseUtf8StringLiteral/UseUtf8StringLiteralTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseUtf8StringLiteral/UseUtf8StringLiteralTests.cs
@@ -505,35 +505,6 @@ public class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseUtf8StringLiteral)]
-        public async Task TestEscapeChars()
-        {
-            await new VerifyCS.Test
-            {
-                TestCode =
-@"
-public class C
-{
-    public void M()
-    {
-        var x = [|new|] byte[] { 34, 92, 0, 7, 8, 12, 10, 13, 9, 11 };
-    }
-}",
-                FixedCode =
-@"
-public class C
-{
-    public void M()
-    {
-        var x = ""\""\\\0\a\b\f\n\r\t\v""u8.ToArray();
-    }
-}",
-                CodeActionValidationMode = CodeActionValidationMode.None,
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
-            }.RunAsync();
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseUtf8StringLiteral)]
         public async Task TestEmoji()
         {
             await new VerifyCS.Test
@@ -761,41 +732,8 @@ ref struct S
         }
 
         [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsUseUtf8StringLiteral)]
-        // Various cases copied from https://github.com/dotnet/runtime/blob/main/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http3/QPackDecoderTest.cs
-        [InlineData(new byte[] { 0x37, 0x02, 0x74, 0x72, 0x61, 0x6e, 0x73, 0x6c, 0x61, 0x74, 0x65 }, "7translate")]
-        [InlineData(new byte[] { 0x3f, 0x01 }, "?")]
-        public async Task TestValidUtf8Strings(byte[] bytes, string stringValue)
-        {
-            await new VerifyCS.Test
-            {
-                TestCode =
-$@"
-public class C
-{{
-    private static readonly byte[] _bytes = [|new|] byte[] {{ {string.Join(", ", bytes)} }};
-}}
-",
-                FixedCode =
-$@"
-public class C
-{{
-    private static readonly byte[] _bytes = ""{stringValue}""u8.ToArray();
-}}
-",
-                CodeActionValidationMode = CodeActionValidationMode.None,
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
-                LanguageVersion = LanguageVersion.Preview
-            }.RunAsync();
-
-            // Lets make sure there aren't any false positives here, and make sure the byte array actually
-            // correctly round-trips via UTF-8
-            var newStringValue = Encoding.UTF8.GetString(bytes);
-            Assert.Equal(stringValue, newStringValue);
-            var newBytes = Encoding.UTF8.GetBytes(stringValue);
-            Assert.Equal(bytes, newBytes);
-        }
-
-        [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsUseUtf8StringLiteral)]
+        // Standard C# escape characters
+        [InlineData(new byte[] { 34, 92, 0, 7, 8, 12, 10, 13, 9, 11 })]
         // Various cases copied from https://github.com/dotnet/runtime/blob/main/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http2/HuffmanDecodingTests.cs
         [InlineData(new byte[] { 0xff, 0xcf })]
         [InlineData(new byte[] { 0b100111_00, 0b101_10100, 0b0_101000_0, 0b0111_1111 })]
@@ -803,8 +741,12 @@ public class C
         [InlineData(new byte[] { 0xfe, 0x53 })]
         [InlineData(new byte[] { 0xff, 0xff, 0xf6, 0xff, 0xff, 0xfd, 0x68 })]
         [InlineData(new byte[] { 0xff, 0xff, 0xf9, 0xff, 0xff, 0xfd, 0x86 })]
-        // _headerNameHuffmanBytes from https://github.com/dotnet/runtime/blob/main/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http3/QPackDecoderTest.cs
+        // Various cases copied from https://github.com/dotnet/runtime/blob/main/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http3/QPackDecoderTest.cs
         [InlineData(new byte[] { 0xa8, 0xbe, 0x16, 0x9c, 0xa3, 0x90, 0xb6, 0x7f })]
+        [InlineData(new byte[] { 0x37, 0x02, 0x74, 0x72, 0x61, 0x6e, 0x73, 0x6c, 0x61, 0x74, 0x65 })]
+        [InlineData(new byte[] { 0x3f, 0x01 })]
+        // DaysInMonth365 from https://github.com/dotnet/runtime/blob/b5a8ece073110140e2d9696cdfdc047ec78c2fa1/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+        [InlineData(new byte[] { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 })]
         public async Task TestInvalidUtf8Strings(byte[] bytes)
         {
             await new VerifyCS.Test
@@ -820,12 +762,61 @@ public class C
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
                 LanguageVersion = LanguageVersion.Preview
             }.RunAsync();
+        }
 
-            // Lets make sure there aren't any false negatives here, and see if the byte array would actually
-            // correctly round-trip via UTF-8
-            var stringValue = Encoding.UTF8.GetString(bytes);
-            var newBytes = Encoding.UTF8.GetBytes(stringValue);
-            Assert.NotEqual(bytes, newBytes);
+        [Fact]
+        public async Task TestDoesNotOfferForControlCharacters()
+        {
+            // Copied from https://github.com/dotnet/runtime/blob/6a889d234267a4c96ed21d0e1660dce787d78a38/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Conversion.cs
+            var input = """
+                class C
+                {
+                    internal enum ConvKind
+                    {
+                        Identity = 1,  // Identity conversion
+                        Implicit = 2,  // Implicit conversion
+                        Explicit = 3,  // Explicit conversion
+                        Unknown = 4,  // Unknown so call canConvert
+                        None = 5,  // None
+                    }
+
+                    private const byte ID = (byte)ConvKind.Identity;  // 0x01
+                    private const byte IMP = (byte)ConvKind.Implicit; // 0x02
+                    private const byte EXP = (byte)ConvKind.Explicit; // 0x03
+                    private const byte NO = (byte)ConvKind.None;      // 0x05
+                    private const byte CONV_KIND_MASK = 0x0F;
+                    private const byte UDC = 0x40;
+                    private const byte XUD = EXP | UDC;
+                    private const byte IUD = IMP | UDC;
+
+                    private static readonly byte[][] s_simpleTypeConversions =
+                    {
+                        // to:                   BYTE I2   I4   I8   FLT  DBL  DEC  CHAR BOOL SBYTE U2   U4   U8
+                        /* from */
+                         new byte[] /* BYTE */ { ID,  IMP, IMP, IMP, IMP, IMP, IUD, EXP, NO,  EXP,  IMP, IMP, IMP },
+                         new byte[] /*   I2 */ { EXP, ID,  IMP, IMP, IMP, IMP, IUD, EXP, NO,  EXP,  EXP, EXP, EXP },
+                         new byte[] /*   I4 */ { EXP, EXP, ID,  IMP, IMP, IMP, IUD, EXP, NO,  EXP,  EXP, EXP, EXP },
+                         new byte[] /*   I8 */ { EXP, EXP, EXP, ID,  IMP, IMP, IUD, EXP, NO,  EXP,  EXP, EXP, EXP },
+                         new byte[] /*  FLT */ { EXP, EXP, EXP, EXP, ID,  IMP, XUD, EXP, NO,  EXP,  EXP, EXP, EXP },
+                         new byte[] /*  DBL */ { EXP, EXP, EXP, EXP, EXP, ID,  XUD, EXP, NO,  EXP,  EXP, EXP, EXP },
+                         new byte[] /*  DEC */ { XUD, XUD, XUD, XUD, XUD, XUD, ID,  XUD, NO,  XUD,  XUD, XUD, XUD },
+                         new byte[] /* CHAR */ { EXP, EXP, IMP, IMP, IMP, IMP, IUD, ID,  NO,  EXP,  IMP, IMP, IMP },
+                         new byte[] /* BOOL */ { NO,  NO,  NO,  NO,  NO,  NO,  NO,  NO,  ID,  NO,   NO,  NO,  NO  },
+                         new byte[] /*SBYTE */ { EXP, IMP, IMP, IMP, IMP, IMP, IUD, EXP, NO,  ID,   EXP, EXP, EXP },
+                         new byte[] /*   U2 */ { EXP, EXP, IMP, IMP, IMP, IMP, IUD, EXP, NO,  EXP,  ID,  IMP, IMP },
+                         new byte[] /*   U4 */ { EXP, EXP, EXP, IMP, IMP, IMP, IUD, EXP, NO,  EXP,  EXP, ID,  IMP },
+                         new byte[] /*   U8 */ { EXP, EXP, EXP, EXP, IMP, IMP, IUD, EXP, NO,  EXP,  EXP, EXP, ID  },
+                    };
+                }
+                """;
+
+            await new VerifyCS.Test
+            {
+                TestCode = input,
+                CodeActionValidationMode = CodeActionValidationMode.None,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
+                LanguageVersion = LanguageVersion.Preview
+            }.RunAsync();
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseUtf8StringLiteral)]

--- a/src/Analyzers/CSharp/Tests/UseUtf8StringLiteral/UseUtf8StringLiteralTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseUtf8StringLiteral/UseUtf8StringLiteralTests.cs
@@ -505,6 +505,35 @@ public class C
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseUtf8StringLiteral)]
+        public async Task TestEscapeChars()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode =
+@"
+public class C
+{
+    public void M()
+    {
+        var x = [|new|] byte[] { 34, 92, 10, 13, 9 };
+    }
+}",
+                FixedCode =
+@"
+public class C
+{
+    public void M()
+    {
+        var x = ""\""\\\n\r\t""u8.ToArray();
+    }
+}",
+                CodeActionValidationMode = CodeActionValidationMode.None,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
+                LanguageVersion = LanguageVersion.Preview
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseUtf8StringLiteral)]
         public async Task TestEmoji()
         {
             await new VerifyCS.Test
@@ -733,7 +762,7 @@ ref struct S
 
         [Theory, Trait(Traits.Feature, Traits.Features.CodeActionsUseUtf8StringLiteral)]
         // Standard C# escape characters
-        [InlineData(new byte[] { 34, 92, 0, 7, 8, 12, 10, 13, 9, 11 })]
+        [InlineData(new byte[] { 0, 7, 8, 12, 11 })]
         // Various cases copied from https://github.com/dotnet/runtime/blob/main/src/libraries/Common/tests/Tests/System/Net/aspnetcore/Http2/HuffmanDecodingTests.cs
         [InlineData(new byte[] { 0xff, 0xcf })]
         [InlineData(new byte[] { 0b100111_00, 0b101_10100, 0b0_101000_0, 0b0111_1111 })]

--- a/src/Analyzers/CSharp/Tests/UseUtf8StringLiteral/UseUtf8StringLiteralTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseUtf8StringLiteral/UseUtf8StringLiteralTests.cs
@@ -1457,5 +1457,71 @@ public class C
                 LanguageVersion = LanguageVersion.Preview
             }.RunAsync();
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseUtf8StringLiteral)]
+        public async Task TestTargettingReadOnlySpan1()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode =
+@"
+using System;
+
+public class C
+{
+    public void M()
+    {
+        ReadOnlySpan<byte> x = [|new|] byte[] { 65, 66, 67 };
+    }
+}",
+                FixedCode =
+@"
+using System;
+
+public class C
+{
+    public void M()
+    {
+        ReadOnlySpan<byte> x = ""ABC""u8;
+    }
+}",
+                CodeActionValidationMode = CodeActionValidationMode.None,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
+                LanguageVersion = LanguageVersion.Preview
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseUtf8StringLiteral)]
+        public async Task TestTargettingReadOnlySpan2()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode =
+@"
+using System;
+
+public class C
+{
+    public void M(ReadOnlySpan<byte> x)
+    {
+        M(/* 1 */[|new|] byte[] { 65, 66, 67 }/* 2 */);
+    }
+}",
+                FixedCode =
+@"
+using System;
+
+public class C
+{
+    public void M(ReadOnlySpan<byte> x)
+    {
+        M(/* 1 */""ABC""u8/* 2 */);
+    }
+}",
+                CodeActionValidationMode = CodeActionValidationMode.None,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
+                LanguageVersion = LanguageVersion.Preview
+            }.RunAsync();
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/62207

* Don't offer if the resulting string would have control or format characters 
* Don't call `.ToArray()` if the array is being converted to a `ReadOnlySpan<byte>`