### PR TITLE
see if hard links reduce artifacts size enough to use public images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,7 @@ jobs:
     jobName: Build_Unix_Debug
     testArtifactName: Transport_Artifacts_Unix_Debug
     configuration: Debug
-    queueName: Build.Ubuntu.1804.Amd64.Open
+    vmImageName: ubuntu-latest
 
 - template: eng/pipelines/test-unix-job.yml
   parameters:
@@ -230,7 +230,7 @@ jobs:
 
 - job: Correctness_TodoCheck
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-latest
   timeoutInMinutes: 10
   steps:
     - template: eng/pipelines/checkout-task.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -245,6 +245,8 @@ jobs:
 
     - task: PowerShell@2
       displayName: Restore
+      env:
+        NUGET_CERT_REVOCATION_MODE: offline
       inputs:
         filePath: eng/build.ps1
         arguments: -configuration Debug -prepareMachine -ci -restore -binaryLog

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,14 +35,14 @@ jobs:
     jobName: Build_Windows_Debug
     testArtifactName: Transport_Artifacts_Windows_Debug
     configuration: Debug
-    queueName: Build.Windows.Amd64.VS2022.Pre.Open
+    vmImageName: windows-latest
 
 - template: eng/pipelines/build-windows-job.yml
   parameters:
     jobName: Build_Windows_Release
     testArtifactName: Transport_Artifacts_Windows_Release
     configuration: Release
-    queueName: Build.Windows.Amd64.VS2022.Pre.Open
+    vmImageName: windows-latest
 
 - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
   - template: eng/pipelines/test-windows-job.yml
@@ -183,7 +183,7 @@ jobs:
 - job: Correctness_Determinism
   pool:
     name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+    vmImage: windows-latest
   timeoutInMinutes: 90
   steps:
     - template: eng/pipelines/checkout-task.yml
@@ -199,7 +199,7 @@ jobs:
 - job: Correctness_Build
   pool:
     name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+    vmImage: windows-latest
   timeoutInMinutes: 90
   steps:
     - template: eng/pipelines/checkout-task.yml
@@ -241,7 +241,7 @@ jobs:
 - job: Correctness_Rebuild
   pool:
     name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+    vmImage: windows-latest
   timeoutInMinutes: 90
   steps:
     - template: eng/pipelines/checkout-task.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,6 +182,7 @@ jobs:
 
 - job: Correctness_Determinism
   pool:
+    name: NetCore1ESPool-Public
     vmImage: windows-latest
   timeoutInMinutes: 90
   steps:
@@ -197,6 +198,7 @@ jobs:
 
 - job: Correctness_Build
   pool:
+    name: NetCore1ESPool-Public
     vmImage: windows-latest
   timeoutInMinutes: 90
   steps:
@@ -238,6 +240,7 @@ jobs:
 
 - job: Correctness_Rebuild
   pool:
+    name: NetCore1ESPool-Public
     vmImage: windows-latest
   timeoutInMinutes: 90
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,7 +182,6 @@ jobs:
 
 - job: Correctness_Determinism
   pool:
-    name: NetCore1ESPool-Public
     vmImage: windows-latest
   timeoutInMinutes: 90
   steps:
@@ -198,7 +197,6 @@ jobs:
 
 - job: Correctness_Build
   pool:
-    name: NetCore1ESPool-Public
     vmImage: windows-latest
   timeoutInMinutes: 90
   steps:
@@ -240,7 +238,6 @@ jobs:
 
 - job: Correctness_Rebuild
   pool:
-    name: NetCore1ESPool-Public
     vmImage: windows-latest
   timeoutInMinutes: 90
   steps:

--- a/eng/pipelines/build-unix-job.yml
+++ b/eng/pipelines/build-unix-job.yml
@@ -19,8 +19,8 @@ parameters:
 jobs:
 - job: ${{ parameters.jobName }}
   pool:
-    name: NetCore1ESPool-Public
     ${{ if ne(parameters.queueName, '') }}:
+      name: NetCore1ESPool-Public
       demands: ImageOverride -equals ${{ parameters.queueName }}
 
     ${{ if ne(parameters.vmImageName, '') }}:

--- a/eng/pipelines/build-unix-job.yml
+++ b/eng/pipelines/build-unix-job.yml
@@ -19,8 +19,8 @@ parameters:
 jobs:
 - job: ${{ parameters.jobName }}
   pool:
+    name: NetCore1ESPool-Public
     ${{ if ne(parameters.queueName, '') }}:
-      name: NetCore1ESPool-Public
       demands: ImageOverride -equals ${{ parameters.queueName }}
 
     ${{ if ne(parameters.vmImageName, '') }}:

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -22,8 +22,8 @@ parameters:
 jobs:
 - job: ${{ parameters.jobName }}
   pool:
+    name: NetCore1ESPool-Public
     ${{ if ne(parameters.queueName, '') }}:
-      name: NetCore1ESPool-Public
       demands: ImageOverride -equals ${{ parameters.queueName }}
 
     ${{ if ne(parameters.vmImageName, '') }}:

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -22,8 +22,8 @@ parameters:
 jobs:
 - job: ${{ parameters.jobName }}
   pool:
-    name: NetCore1ESPool-Public
     ${{ if ne(parameters.queueName, '') }}:
+      name: NetCore1ESPool-Public
       demands: ImageOverride -equals ${{ parameters.queueName }}
 
     ${{ if ne(parameters.vmImageName, '') }}:

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -35,6 +35,8 @@ jobs:
 
     - task: PowerShell@2
       displayName: Restore
+      env:
+        NUGET_CERT_REVOCATION_MODE: offline
       inputs:
         filePath: eng/build.ps1
         arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -restore -binaryLog

--- a/eng/pipelines/checkout-task.yml
+++ b/eng/pipelines/checkout-task.yml
@@ -3,8 +3,6 @@ steps:
   - checkout: none
   - script: |
       git init
-      git config --local core.compression 0
-      git config --local core.looseCompression 0
       git config --local checkout.workers 0
       git config --local fetch.parallel 0
       git config --local index.threads 0

--- a/eng/pipelines/checkout-task.yml
+++ b/eng/pipelines/checkout-task.yml
@@ -1,5 +1,15 @@
-# Shallow checkout sources on Windows
+# Shallow checkout sources
 steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 1 # Fetch only one commit
+  - checkout: none
+  - script: |
+      git init
+      git config --local core.compression 0
+      git config --local core.looseCompression 0
+      git config --local checkout.workers 0
+      git config --local fetch.parallel 0
+      git config --local index.threads 0
+      git config --local pack.threads 0
+      git remote add origin "$(Build.Repository.Uri)"
+      git fetch --progress --no-tags --no-auto-maintenance --depth=1 origin "$(Build.SourceVersion)"
+      git checkout --progress "$(Build.SourceVersion)"
+    displayName: Shallow Checkout

--- a/eng/pipelines/test-windows-job.yml
+++ b/eng/pipelines/test-windows-job.yml
@@ -26,7 +26,7 @@ jobs:
     # Note that when helix is enabled, the agent running this job is essentially
     # a thin client that kicks off a helix job and waits for it to complete.
     # Thus we don't use a helix queue to run the job here, and instead use the plentiful AzDO vmImages.
-    vmImage: windows-2019
+    vmImage: windows-latest
   timeoutInMinutes: 120
   steps:
     - checkout: none


### PR DESCRIPTION
with @jaredpar's work to use hard links on ci we are now under the 10GB limit for use of public azure vms. Using these machines instead of dnceng machines will reduce wait times for vm allocation by 20 minutes on average.