### PR TITLE
Theme The "Generate Overrides" Dialog

### DIFF
--- a/src/VisualStudio/Core/Def/PickMembers/PickMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/PickMembers/PickMembersDialog.xaml
@@ -11,6 +11,8 @@
              xmlns:u="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation.Utilities"
              xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
              xmlns:imagecatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
+             xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+             xmlns:platformimaging="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
              mc:Ignorable="d" 
              d:DesignHeight="380" d:DesignWidth="460"
              Height="380" Width="460"
@@ -23,14 +25,15 @@
              HasDialogFrame="True"
              WindowStartupLocation="CenterOwner"
              vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
-             Background="{DynamicResource {x:Static vs:ThemedDialogColors.WindowPanelBrushKey}}">
+             Background="{DynamicResource {x:Static vs:ThemedDialogColors.WindowPanelBrushKey}}"
+             platformimaging:ImageThemingUtilities.ImageBackgroundColor="{StaticResource {x:Static vsshell:VsColors.ToolWindowBackgroundKey}}">
     <Window.Resources>
         <Style TargetType="ListBoxItem">
             <Setter Property="IsTabStop" 
                     Value="False" />
         </Style>
 
-        <Style TargetType="u:AutomationDelegatingListView" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogListViewStyleKey}}" />
+        <Style TargetType="u:AutomationDelegatingListView" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogListViewStyleKey}}" x:Key="AutomationDelegatingListViewStyle" />
         <Thickness x:Key="labelPadding">0, 5, 0, 2</Thickness>
         <Thickness x:Key="okCancelButtonPadding">9,2,9,2</Thickness>
         <Thickness x:Key="selectDeselectButtonPadding">9,2,9,2</Thickness>
@@ -60,7 +63,8 @@
         <GroupBox x:Uid="MemberSelectionGroupBox"
                   Margin="0, 9, 0, 0"
                   Grid.Row="1"
-                  Header="{Binding ElementName=dialog, Path=PickMembersTitle}">
+                  Header="{Binding ElementName=dialog, Path=PickMembersTitle}"
+                  Foreground="{DynamicResource {x:Static vs:ThemedDialogColors.HeaderTextBrushKey}}">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*" />
@@ -78,7 +82,9 @@
                           SelectedIndex="{Binding SelectedIndex, Mode=TwoWay}"
                           PreviewKeyDown="OnListViewPreviewKeyDown"
                           MouseDoubleClick="OnListViewDoubleClick"
-                          ItemsSource="{Binding MemberContainers, Mode=TwoWay}">
+                          ItemsSource="{Binding MemberContainers, Mode=TwoWay}"
+                          Background="{DynamicResource {x:Static vs:ThemedDialogColors.WindowPanelBrushKey}}"
+                          Foreground="{DynamicResource {x:Static vs:ThemedDialogColors.ListBoxTextBrushKey}}">
                     <u:AutomationDelegatingListView.ItemTemplate x:Uid="SelectableMemberListItem">
                         <DataTemplate>
                             <StackPanel Orientation="Horizontal">
@@ -111,8 +117,7 @@
                         <imaging:CrispImage Name="UpArrowImage" 
                                         Height="16" 
                                         Width="16" 
-                                        Moniker="{x:Static imagecatalog:KnownMonikers.MoveUp}"
-                                        Grayscale="{Binding IsEnabled, ElementName=UpButton, Converter={StaticResource NegateBooleanConverter}}"/>
+                                        Moniker="{x:Static imagecatalog:KnownMonikers.MoveUp}" />
                     </Button>
                     <Button Name="DownButton" 
                                  AutomationProperties.Name="{Binding MoveDownAutomationText}"
@@ -124,8 +129,7 @@
                         <imaging:CrispImage Name="DownArrowImage" 
                                         Height="16" 
                                         Width="16" 
-                                        Moniker="{x:Static imagecatalog:KnownMonikers.MoveDown}" 
-                                        Grayscale="{Binding IsEnabled, ElementName=DownButton, Converter={StaticResource NegateBooleanConverter}}"/>
+                                        Moniker="{x:Static imagecatalog:KnownMonikers.MoveDown}" />
 
                     </Button>
 

--- a/src/VisualStudio/Core/Def/PickMembers/PickMembersDialog.xaml
+++ b/src/VisualStudio/Core/Def/PickMembers/PickMembersDialog.xaml
@@ -21,12 +21,16 @@
              ResizeMode="CanResizeWithGrip"
              ShowInTaskbar="False"
              HasDialogFrame="True"
-             WindowStartupLocation="CenterOwner">
+             WindowStartupLocation="CenterOwner"
+             vs:ThemedDialogStyleLoader.UseDefaultThemedDialogStyles="True"
+             Background="{DynamicResource {x:Static vs:ThemedDialogColors.WindowPanelBrushKey}}">
     <Window.Resources>
         <Style TargetType="ListBoxItem">
             <Setter Property="IsTabStop" 
                     Value="False" />
         </Style>
+
+        <Style TargetType="u:AutomationDelegatingListView" BasedOn="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogListViewStyleKey}}" />
         <Thickness x:Key="labelPadding">0, 5, 0, 2</Thickness>
         <Thickness x:Key="okCancelButtonPadding">9,2,9,2</Thickness>
         <Thickness x:Key="selectDeselectButtonPadding">9,2,9,2</Thickness>
@@ -97,7 +101,7 @@
 
                 <StackPanel Grid.Column="1">
 
-                    <vs:DialogButton Name="UpButton" 
+                    <Button Name="UpButton" 
                                  AutomationProperties.Name="{Binding MoveUpAutomationText}"
                                  Margin="0 9 4 0"
                                  IsEnabled="{Binding CanMoveUp, Mode=OneWay}" 
@@ -109,8 +113,8 @@
                                         Width="16" 
                                         Moniker="{x:Static imagecatalog:KnownMonikers.MoveUp}"
                                         Grayscale="{Binding IsEnabled, ElementName=UpButton, Converter={StaticResource NegateBooleanConverter}}"/>
-                    </vs:DialogButton>
-                    <vs:DialogButton Name="DownButton" 
+                    </Button>
+                    <Button Name="DownButton" 
                                  AutomationProperties.Name="{Binding MoveDownAutomationText}"
                                  Margin="0 9 4 0"
                                  IsEnabled="{Binding CanMoveDown, Mode=OneWay}" 
@@ -123,7 +127,7 @@
                                         Moniker="{x:Static imagecatalog:KnownMonikers.MoveDown}" 
                                         Grayscale="{Binding IsEnabled, ElementName=DownButton, Converter={StaticResource NegateBooleanConverter}}"/>
 
-                    </vs:DialogButton>
+                    </Button>
 
                     <Button x:Uid="SelectAllButton"
                             Content="{Binding ElementName=dialog, Path=SelectAll}" 

--- a/src/VisualStudio/Core/Def/PickMembers/PickMembersDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/PickMembers/PickMembersDialog.xaml.cs
@@ -158,9 +158,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.PickMembers
 
             public Button CancelButton => _dialog.CancelButton;
 
-            public DialogButton UpButton => _dialog.UpButton;
+            public Button UpButton => _dialog.UpButton;
 
-            public DialogButton DownButton => _dialog.DownButton;
+            public Button DownButton => _dialog.DownButton;
 
             public AutomationDelegatingListView Members => _dialog.Members;
         }


### PR DESCRIPTION
fixes #61812 

We were in a mix of themed and unthemed. This PR themes the entire dialog for use. 

### Original (Before Fix)

![image](https://user-images.githubusercontent.com/475144/176504773-af7c4d94-d500-4f5e-bff8-aaaaa8b671b0.png)


### Blue Theme 

![image](https://user-images.githubusercontent.com/475144/176504508-dc5aa706-79f0-4ba5-901e-dc2bb323a88d.png)


### Dark Theme

![image](https://user-images.githubusercontent.com/475144/176504622-3bb0f4d1-a97f-4167-b79e-340817d516f9.png)
