### PR TITLE
When we're removing the last project, fire SolutionRemoved

### DIFF
--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         break;
 
                     case WorkspaceChangeKind.SolutionCleared:
-                        EnqueueFullSolutionEvent(args.OldSolution, InvocationReasons.DocumentRemoved, eventName);
+                        EnqueueFullSolutionEvent(args.OldSolution, InvocationReasons.SolutionRemoved, eventName);
                         break;
 
                     case WorkspaceChangeKind.ProjectAdded:

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProject.cs
@@ -1231,7 +1231,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 // references being converted to metadata references (or vice versa) and we might either
                 // miss stopping a file watcher or might end up double-stopping a file watcher.
                 remainingMetadataReferences = w.CurrentSolution.GetRequiredProject(Id).MetadataReferences;
-                w.OnProjectRemoved(Id);
+                _workspace.RemoveProjectFromTrackingMaps_NoLock(Id);
+
+                // If this is our last project, clear the entire solution.
+                if (w.CurrentSolution.ProjectIds.Count == 1)
+                {
+                    _workspace.RemoveSolution_NoLock();
+                }
+                else
+                {
+                    _workspace.OnProjectRemoved(Id);
+                }
             });
 
             Contract.ThrowIfNull(remainingMetadataReferences);

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectFactory.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectFactory.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Api;
@@ -115,6 +116,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     .WithTelemetryId(creationInfo.ProjectGuid);
 
                 // If we don't have any projects and this is our first project being added, then we'll create a new SolutionId
+                // and count this as the solution being added so that event is raised.
                 if (w.CurrentSolution.ProjectIds.Count == 0)
                 {
                     var solutionSessionId = GetSolutionSessionId();

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -1667,7 +1667,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return _projectReferenceInfoMap.GetOrAdd(projectId, _ => new ProjectReferenceInformation());
         }
 
-        protected internal override void OnProjectRemoved(ProjectId projectId)
+        /// <summary>
+        /// Removes the project from the various maps this type maintains; it's still up to the caller to actually remove
+        /// the project in one way or another.
+        /// </summary>
+        internal void RemoveProjectFromTrackingMaps_NoLock(ProjectId projectId)
         {
             string? languageName;
 
@@ -1711,14 +1715,37 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
             }
 
-            base.OnProjectRemoved(projectId);
-
             // Try to update the UI context info.  But cancel that work if we're shutting down.
             _threadingContext.RunWithShutdownBlockAsync(async cancellationToken =>
             {
                 using var asyncToken = _workspaceListener.BeginAsyncOperation(nameof(RefreshProjectExistsUIContextForLanguageAsync));
                 await RefreshProjectExistsUIContextForLanguageAsync(languageName, cancellationToken).ConfigureAwait(false);
             });
+        }
+
+        internal void RemoveSolution_NoLock()
+        {
+            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
+
+            // At this point, we should have had RemoveProjectFromTrackingMaps_NoLock called for everything else, so it's just the solution itself
+            // to clean up
+            Contract.ThrowIfFalse(_projectReferenceInfoMap.Count == 0);
+            Contract.ThrowIfFalse(_projectToHierarchyMap.Count == 0);
+            Contract.ThrowIfFalse(_projectToGuidMap.Count == 0);
+            Contract.ThrowIfFalse(_projectToMaxSupportedLangVersionMap.Count == 0);
+            Contract.ThrowIfFalse(_projectToDependencyNodeTargetIdentifier.Count == 0);
+            Contract.ThrowIfFalse(_projectToRuleSetFilePath.Count == 0);
+            Contract.ThrowIfFalse(_projectSystemNameToProjectsMap.Count == 0);
+
+            // Create a new empty solution and set this; we will reuse the same SolutionId and path since components still may have persistence information they still need
+            // to look up by that location; we also keep the existing analyzer references around since those are host-level analyzers that were loaded asynchronously.
+            SetCurrentSolution(
+                solution => CreateSolution(
+                    SolutionInfo.Create(
+                        SolutionId.CreateNewId(),
+                        VersionStamp.Create(),
+                        analyzerReferences: solution.AnalyzerReferences)),
+                WorkspaceChangeKind.SolutionRemoved);
         }
 
         private sealed class ProjectReferenceInformation

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/WorkspaceChangedEventTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/WorkspaceChangedEventTests.vb
@@ -106,5 +106,21 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Assert.Same(startingSolution, environment.Workspace.CurrentSolution)
             End Using
         End Function
+
+        <WpfFact>
+        <CombinatorialData>
+        Public Async Function AddingAndRemovingOnlyProjectTriggersSolutionAddedAndSolutionRemoved() As Task
+            Using environment = New TestEnvironment()
+                Dim workspaceChangeEvents = New WorkspaceChangeWatcher(environment)
+                Dim project = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
+                    "Project", LanguageNames.CSharp, CancellationToken.None)
+
+                Assert.Equal(WorkspaceChangeKind.SolutionAdded, Assert.Single(Await workspaceChangeEvents.GetNewChangeEventsAsync()).Kind)
+
+                project.RemoveFromWorkspace()
+
+                Assert.Equal(WorkspaceChangeKind.SolutionRemoved, Assert.Single(Await workspaceChangeEvents.GetNewChangeEventsAsync()).Kind)
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpFindReferences.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpFindReferences.cs
@@ -164,9 +164,9 @@ class Program
 
             await TestServices.SolutionExplorer.CloseSolutionAsync(HangMitigatingCancellationToken);
 
-            // because the solution cache directory is stored in the user temp folder, 
-            // closing the solution has no effect on what is returned.
-            Assert.NotNull(persistentStorageConfiguration.TryGetStorageLocation(SolutionKey.ToSolutionKey(visualStudioWorkspace.CurrentSolution)));
+            // Since we no longer have an open solution, we don't have a storage location for it, since that
+            // depends on the open solution.
+            Assert.Null(persistentStorageConfiguration.TryGetStorageLocation(SolutionKey.ToSolutionKey(visualStudioWorkspace.CurrentSolution)));
         }
 
         private async Task WaitForNavigateAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
We have a fair bit of code that assumed it could look for a WorkspaceChangeKind of SolutionRemoved or SolutionCleared to indicate when we've closed the solution and can drop caches and such. Except we never actually fired anything like that. This fires SolutionRemoved on the removal of the last project.

We had a test that asserted that the solution persistence service would continue to return the solution path even once the solution was closed; this fixes that test to assert that it's no longer available.