### PR TITLE
Always clear diagnostics when ending a debug session

### DIFF
--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
@@ -57,11 +57,15 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// Clears all diagnostics reported thru this source.
         /// We do not track the particular reported diagnostics here since we can just clear all of them at once.
         /// </summary>
-        public void ClearDiagnostics()
+        public void ClearDiagnostics(bool isSessionEnding = false)
         {
             // If ClearDiagnostics is called and there weren't any diagnostics previously, then there is no point incrementing
             // our version number and potentially invalidating caches unnecessarily.
-            if (_previouslyHadDiagnostics)
+            // If the debug session is ending, however, we want to always increment otherwise we can get stuck. eg if the user
+            // makes a rude edit during a debug session, but doesn't apply the changes, the rude edit will be raised without
+            // this class knowing about it, and then if the debug session is stopped, we have no knowledge of any diagnostics here
+            // so don't bump our version number, but the document checksum also doesn't change, so we get stuck with the rude edit.
+            if (isSessionEnding || _previouslyHadDiagnostics)
             {
                 _previouslyHadDiagnostics = false;
                 _diagnosticsVersion++;

--- a/src/Features/Core/Portable/EditAndContinue/Remote/RemoteDebuggingSessionProxy.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/RemoteDebuggingSessionProxy.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             diagnosticService.Reanalyze(_workspace, documentIds: documentsToReanalyze);
 
             // clear emit/apply diagnostics reported previously:
-            diagnosticUpdateSource.ClearDiagnostics();
+            diagnosticUpdateSource.ClearDiagnostics(isSessionEnding: false);
         }
 
         public async ValueTask EndDebuggingSessionAsync(Solution compileTimeSolution, EditAndContinueDiagnosticUpdateSource diagnosticUpdateSource, IDiagnosticAnalyzerService diagnosticService, CancellationToken cancellationToken)
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             diagnosticService.Reanalyze(_workspace, documentIds: designTimeDocumentsToReanalyze);
 
             // clear emit/apply diagnostics reported previously:
-            diagnosticUpdateSource.ClearDiagnostics();
+            diagnosticUpdateSource.ClearDiagnostics(isSessionEnding: true);
 
             Dispose();
         }
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
 
             // clear emit/apply diagnostics reported previously:
-            diagnosticUpdateSource.ClearDiagnostics();
+            diagnosticUpdateSource.ClearDiagnostics(isSessionEnding: false);
 
             // clear all reported rude edits:
             diagnosticService.Reanalyze(_workspace, documentIds: rudeEdits.Select(d => d.DocumentId));


### PR DESCRIPTION
Fixes (maybe only part of?) https://github.com/dotnet/roslyn/issues/62197

FYI @tmat @dibarbet 

This fixes the issue for regular C# and Razor files, when pull diagnostics is turned on, but the issue persists in Razor with pull diagnostics turned off. Not sure what that means though :)

Explanation of the scenario and fix is in the comment in the code.