### PR TITLE
Add public APIs for opened and closed event handling for non-source d…

### DIFF
--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -6,6 +6,13 @@ Microsoft.CodeAnalysis.Editing.DeclarationModifiers.IsRequired.get -> bool
 Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WithIsRequired(bool isRequired) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers
 Microsoft.CodeAnalysis.Editing.SyntaxEditor.SyntaxEditor(Microsoft.CodeAnalysis.SyntaxNode root, Microsoft.CodeAnalysis.Host.HostWorkspaceServices services) -> void
 *REMOVED*static Microsoft.CodeAnalysis.Editing.SyntaxGenerator.DefaultRemoveOptions -> Microsoft.CodeAnalysis.SyntaxRemoveOptions
+Microsoft.CodeAnalysis.TextDocumentEventArgs
+Microsoft.CodeAnalysis.TextDocumentEventArgs.Document.get -> Microsoft.CodeAnalysis.TextDocument
+Microsoft.CodeAnalysis.TextDocumentEventArgs.TextDocumentEventArgs(Microsoft.CodeAnalysis.TextDocument document) -> void
+Microsoft.CodeAnalysis.Workspace.RaiseTextDocumentClosedEventAsync(Microsoft.CodeAnalysis.TextDocument document) -> System.Threading.Tasks.Task
+Microsoft.CodeAnalysis.Workspace.RaiseTextDocumentOpenedEventAsync(Microsoft.CodeAnalysis.TextDocument document) -> System.Threading.Tasks.Task
+Microsoft.CodeAnalysis.Workspace.TextDocumentClosed -> System.EventHandler<Microsoft.CodeAnalysis.TextDocumentEventArgs>
+Microsoft.CodeAnalysis.Workspace.TextDocumentOpened -> System.EventHandler<Microsoft.CodeAnalysis.TextDocumentEventArgs>
 static Microsoft.CodeAnalysis.Classification.ClassificationTypeNames.AllTypeNames.get -> System.Collections.Immutable.ImmutableArray<string>
 static Microsoft.CodeAnalysis.CodeFixes.FixAllProvider.Create(System.Func<Microsoft.CodeAnalysis.CodeFixes.FixAllContext, Microsoft.CodeAnalysis.Document, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>, System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Document>> fixAllAsync, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.CodeFixes.FixAllScope> supportedFixAllScopes) -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider
 static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.Required.get -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers

--- a/src/Workspaces/Core/Portable/Workspace/TextDocumentEventArgs.cs
+++ b/src/Workspaces/Core/Portable/Workspace/TextDocumentEventArgs.cs
@@ -7,7 +7,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
-    internal sealed class TextDocumentEventArgs : EventArgs
+    public sealed class TextDocumentEventArgs : EventArgs
     {
         public TextDocument Document { get; }
 

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// An event that is fired when any <see cref="TextDocument"/> is opened in the editor.
         /// </summary>
-        internal event EventHandler<TextDocumentEventArgs> TextDocumentOpened
+        public event EventHandler<TextDocumentEventArgs> TextDocumentOpened
         {
             add
             {
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private protected Task RaiseTextDocumentOpenedEventAsync(TextDocument document)
+        protected Task RaiseTextDocumentOpenedEventAsync(TextDocument document)
             => RaiseTextDocumentOpenedOrClosedEventAsync(document, new TextDocumentEventArgs(document), TextDocumentOpenedEventName);
 
         private Task RaiseTextDocumentOpenedOrClosedEventAsync<TDocument, TDocumentEventArgs>(
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// An event that is fired when any <see cref="TextDocument"/> is closed in the editor.
         /// </summary>
-        internal event EventHandler<TextDocumentEventArgs> TextDocumentClosed
+        public event EventHandler<TextDocumentEventArgs> TextDocumentClosed
         {
             add
             {
@@ -198,7 +198,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private protected Task RaiseTextDocumentClosedEventAsync(TextDocument document)
+        protected Task RaiseTextDocumentClosedEventAsync(TextDocument document)
             => RaiseTextDocumentOpenedOrClosedEventAsync(document, new TextDocumentEventArgs(document), TextDocumentClosedEventName);
 
         /// <summary>


### PR DESCRIPTION
…ocuments

Public APIs were approved in https://github.com/dotnet/roslyn/issues/61523#issuecomment-1164883478.

NOTE: Once the Unit testing team moves to the new public APIs, we can delete the corresponding ExternalAccess layer APIs which were added as a temporary workaround.