### PR TITLE
Set capacity of builder to avoid expensive garbage.

### DIFF
--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -106,16 +106,20 @@ namespace Microsoft.CodeAnalysis
             if (IsCached)
                 return this;
 
-            var compacted = ArrayBuilder<TableEntry>.GetInstance();
+            var nonRemovedCount = _states.Count(static e => !e.IsRemoved);
+
+            var compacted = ArrayBuilder<TableEntry>.GetInstance(nonRemovedCount);
             foreach (var entry in _states)
             {
                 if (!entry.IsRemoved)
-                {
                     compacted.Add(entry.AsCached());
-                }
             }
+
             // When we're preparing a table for caching between runs, we drop the step information as we cannot guarantee the graph structure while also updating
             // the input states
+
+            // Ensure we are completely full so that ToImmutable translates to a MoveToImmutable
+            Debug.Assert(compacted.Count == nonRemovedCount);
             return new NodeStateTable<T>(compacted.ToImmutableAndFree(), ImmutableArray<IncrementalGeneratorRunStep>.Empty, hasTrackedSteps: false);
         }
 


### PR DESCRIPTION
This drops running time of benchmark from 4.7 to 3.5s (25% win).  And it drops total memory consumption from 2.4GB:

![image](https://user-images.githubusercontent.com/4564579/176711988-fbeaf428-8493-403a-a228-8a311cc77633.png)

to 1.8GB (25% win):

![image](https://user-images.githubusercontent.com/4564579/176712112-64d76779-33e4-4b56-a8f1-d612409b79f4.png)
