### PR TITLE
Remove Skip-SymbolCheck suffix in insert.yml

### DIFF
--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -68,7 +68,7 @@ steps:
       Write-Host "##vso[task.setvariable variable=Template.CreateDraftPR]$($true)"
       Write-Host "##vso[task.setvariable variable=Template.AutoComplete]$($false)"
       Write-Host "##vso[task.setvariable variable=Template.TitlePrefix]$('')"
-      Write-Host "##vso[task.setvariable variable=Template.TitleSuffix]$('[Skip-SymbolCheck]')"
+      Write-Host "##vso[task.setvariable variable=Template.TitleSuffix]$('')"
       Write-Host "##vso[task.setvariable variable=Template.InsertToolset]$($true)"
       Write-Host "##vso[task.setvariable variable=Template.ComponentAzdoUri]$('')"
       Write-Host "##vso[task.setvariable variable=Template.ComponentProjectName]$('')"


### PR DESCRIPTION
We missed a spot in #62211 :) This is the oldest supported release branch so I think the right place to make the change.

cc @JoeRobich @dibarbet

edit: Looks like 16.9 is actually supported [till October](https://docs.microsoft.com/en-us/lifecycle/products/visual-studio-2019) but probably not a big deal if that branch continues to provide the suffix.