### PR TITLE
Walk green-nodes in incremental-generator attribute-finding path

### DIFF
--- a/src/Compilers/CSharp/Portable/SourceGeneration/CSharpSyntaxHelper.cs
+++ b/src/Compilers/CSharp/Portable/SourceGeneration/CSharpSyntaxHelper.cs
@@ -21,6 +21,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override bool IsCaseSensitive
             => true;
 
+        public override int AttributeListKind
+            => (int)SyntaxKind.AttributeList;
+
         public override bool IsValidIdentifier(string name)
             => SyntaxFacts.IsValidIdentifier(name);
 

--- a/src/Compilers/Core/Portable/SourceGeneration/ISyntaxHelper.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/ISyntaxHelper.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CodeAnalysis.SourceGeneration
     internal interface ISyntaxHelper
     {
         bool IsCaseSensitive { get; }
+        int AttributeListKind { get; }
 
         bool IsValidIdentifier(string name);
 
@@ -40,6 +41,7 @@ namespace Microsoft.CodeAnalysis.SourceGeneration
     internal abstract class AbstractSyntaxHelper : ISyntaxHelper
     {
         public abstract bool IsCaseSensitive { get; }
+        public abstract int AttributeListKind { get; }
 
         public abstract bool IsValidIdentifier(string name);
 

--- a/src/Compilers/VisualBasic/Portable/SourceGeneration/VisualBasicSyntaxHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/SourceGeneration/VisualBasicSyntaxHelper.vb
@@ -19,6 +19,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Public Overrides ReadOnly Property IsCaseSensitive As Boolean = False
 
+        Public Overrides ReadOnly Property AttributeListKind As Integer = SyntaxKind.AttributeList
+
         Public Overrides Function IsValidIdentifier(name As String) As Boolean
             Return SyntaxFacts.IsValidIdentifier(name)
         End Function


### PR DESCRIPTION
We need to walk the syntax tree both to find the global aliases that may be in a file, and also to look for attributes.

This change has us walk the green tree instead, especially so we can bail out from checking trees that don't have any attributes, without realizing the red-tree.  This save 100MB of ram in incremental testing (About 7.5%).

Before:

![image](https://user-images.githubusercontent.com/4564579/176777888-6987d6a7-c457-4e2d-b43c-da0dc021d936.png)

After:

![image](https://user-images.githubusercontent.com/4564579/176777905-136707fe-d153-4068-ac70-fb5478d995ff.png)
