### PR TITLE
Do not look for load/reference directives when there can't be any

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (Options.Kind == SourceCodeKind.Script)
                 {
                     var compilationUnitRoot = GetCompilationUnitRoot();
-                    return compilationUnitRoot.GetReferenceDirectives().Count > 0 || compilationUnitRoot.GetLoadDirectives().Count > 0;
+                    return compilationUnitRoot.HasReferenceOrLoadDirectives();
                 }
 
                 return false;

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxTree.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert(HasCompilationUnitRoot);
 
-                return Options.Kind == SourceCodeKind.Script && GetCompilationUnitRoot().GetReferenceDirectives().Count > 0;
+                return Options.Kind == SourceCodeKind.Script && GetCompilationUnitRoot().HasReferenceDirectives;
             }
         }
 
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (Options.Kind == SourceCodeKind.Script)
                 {
                     var compilationUnitRoot = GetCompilationUnitRoot();
-                    return compilationUnitRoot.HasReferenceOrLoadDirectives();
+                    return compilationUnitRoot.HasReferenceDirectives || compilationUnitRoot.HasLoadDirectives;
                 }
 
                 return false;

--- a/src/Compilers/CSharp/Portable/Syntax/CompilationUnitSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CompilationUnitSyntax.cs
@@ -41,6 +41,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             return firstToken.GetDirectives<LoadDirectiveTriviaSyntax>(filter: null);
         }
 
+        internal bool HasReferenceOrLoadDirectives()
+        {
+            if (this.ContainsDirectives)
+            {
+                // #r and #load directives are always on the first token of the compilation unit.
+                var firstToken = this.GetFirstToken(includeZeroWidth: true);
+                if (firstToken.ContainsDirectives)
+                {
+                    foreach (var trivia in firstToken.LeadingTrivia)
+                    {
+                        if (trivia.GetStructure() is ReferenceDirectiveTriviaSyntax or LoadDirectiveTriviaSyntax)
+                            return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
         internal Syntax.InternalSyntax.DirectiveStack GetConditionalDirectivesStack()
         {
             IEnumerable<DirectiveTriviaSyntax> directives = this.GetDirectives(filter: IsActiveConditionalDirective);

--- a/src/Compilers/CSharp/Portable/Syntax/CompilationUnitSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CompilationUnitSyntax.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Syntax
 {
@@ -19,9 +20,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         internal IList<ReferenceDirectiveTriviaSyntax> GetReferenceDirectives(Func<ReferenceDirectiveTriviaSyntax, bool>? filter)
         {
+            if (!this.ContainsDirectives)
+                return SpecializedCollections.EmptyList<ReferenceDirectiveTriviaSyntax>();
+
             // #r directives are always on the first token of the compilation unit.
             var firstToken = (SyntaxNodeOrToken)this.GetFirstToken(includeZeroWidth: true);
-            return firstToken.GetDirectives<ReferenceDirectiveTriviaSyntax>(filter);
+            return firstToken.GetDirectives(filter);
         }
 
         /// <summary>
@@ -29,6 +33,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         /// </summary>
         public IList<LoadDirectiveTriviaSyntax> GetLoadDirectives()
         {
+            if (!this.ContainsDirectives)
+                return SpecializedCollections.EmptyList<LoadDirectiveTriviaSyntax>();
+
             // #load directives are always on the first token of the compilation unit.
             var firstToken = (SyntaxNodeOrToken)this.GetFirstToken(includeZeroWidth: true);
             return firstToken.GetDirectives<LoadDirectiveTriviaSyntax>(filter: null);

--- a/src/Compilers/CSharp/Portable/Syntax/CompilationUnitSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CompilationUnitSyntax.cs
@@ -41,18 +41,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             return firstToken.GetDirectives<LoadDirectiveTriviaSyntax>(filter: null);
         }
 
-        internal bool HasReferenceOrLoadDirectives()
+        internal bool HasReferenceDirectives
+            // #r and #load directives are always on the first token of the compilation unit.
+            => HasFirstTokenDirective(static n => n is ReferenceDirectiveTriviaSyntax);
+
+        internal bool HasLoadDirectives
+            // #r and #load directives are always on the first token of the compilation unit.
+            => HasFirstTokenDirective(static n => n is LoadDirectiveTriviaSyntax);
+
+        private bool HasFirstTokenDirective(Func<SyntaxNode, bool> predicate)
         {
             if (this.ContainsDirectives)
             {
-                // #r and #load directives are always on the first token of the compilation unit.
                 var firstToken = this.GetFirstToken(includeZeroWidth: true);
                 if (firstToken.ContainsDirectives)
                 {
                     foreach (var trivia in firstToken.LeadingTrivia)
                     {
-                        if (trivia.GetStructure() is ReferenceDirectiveTriviaSyntax or LoadDirectiveTriviaSyntax)
+                        if (trivia.GetStructure() is { } structure &&
+                            predicate(structure))
+                        {
                             return true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Not a huge win.  But saves 18MB of unnecessary allocations in incremental scenarios:

Before:
![image](https://user-images.githubusercontent.com/4564579/176958389-a1f13469-5e8b-401c-a728-5b96177f2f27.png)

After:
Gone.