### PR TITLE
Run official build post-build steps on VS2022

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -307,7 +307,8 @@ stages:
       dependsOn:
         - OfficialBuild
       pool:
-        vmImage: windows-2019
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals Build.Windows.Amd64.VS2022
 
 - stage: insert
   dependsOn:


### PR DESCRIPTION
Fixes error seen in [official build](https://dev.azure.com/dnceng/internal/_build/results?buildId=1857110&view=logs&j=b11b921d-8982-5bb3-754b-b114d42fd804&t=cdcedd1f-8008-523f-9da1-cc35fbfef9a3&l=45)
```
 error NETSDK1182: Targeting .NET 6.0 in Visual Studio 2019 is not supported.
```
