### PR TITLE
Match type parameter if it's not annotated properly

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithAnnotations.cs
@@ -530,7 +530,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public bool Is(TypeParameterSymbol other)
         {
-            return NullableAnnotation.IsOblivious() && ((object)DefaultType == other) &&
+            return !NullableAnnotation.IsAnnotated() && ((object)DefaultType == other) &&
                    CustomModifiers.IsEmpty;
         }
 


### PR DESCRIPTION
Fixes #58966

Draft for now. Need to figure out if this affects anything in the compiler to add tests.