### PR TITLE
Publish main-vs-deps VS PRs

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -132,7 +132,7 @@
       ],
       "vsBranch": "main",
       "vsMajorVersion": 17,
-      "insertionCreateDraftPR": true,
+      "insertionCreateDraftPR": false,
       "insertionTitlePrefix": "[d17.4p1]"
     }
   }


### PR DESCRIPTION
Now that VS main points to 17.4 P1, we should be able to automatically publish insertion PRs from main-vs-deps.