### PR TITLE
Handle diff3 conflict markers

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -2399,6 +2399,7 @@ LoopExit:
                     // recognize >>>>>>> as we are scanning the trivia after a ======= marker 
                     // (which can never be part of legal code).
                     // case '>':
+                    case '|':
                     case '=':
                     case '<':
                         if (!isTrailing)
@@ -2429,7 +2430,7 @@ LoopExit:
             if (position == 0 || SyntaxFacts.IsNewLine(text[position - 1]))
             {
                 var firstCh = text[position];
-                Debug.Assert(firstCh == '<' || firstCh == '=' || firstCh == '>');
+                Debug.Assert(firstCh is '<' or '|' or '=' or '>');
 
                 if ((position + s_conflictMarkerLength) <= text.Length)
                 {
@@ -2441,7 +2442,7 @@ LoopExit:
                         }
                     }
 
-                    if (firstCh == '=')
+                    if (firstCh is '|' or '=')
                     {
                         return true;
                     }
@@ -2470,21 +2471,21 @@ LoopExit:
             // Now add the newlines as the next trivia.
             LexConflictMarkerEndOfLine(ref triviaList);
 
-            // Now, if it was an ======= marker, then also created a DisabledText trivia for
+            // Now, if it was an ||||||| or ======= marker, then also created a DisabledText trivia for
             // the contents of the file after it, up until the next >>>>>>> marker we see.
-            if (startCh == '=')
+            if (startCh is '|' or '=')
             {
-                LexConflictMarkerDisabledText(ref triviaList);
+                LexConflictMarkerDisabledText(startCh == '=', ref triviaList);
             }
         }
 
-        private SyntaxListBuilder LexConflictMarkerDisabledText(ref SyntaxListBuilder triviaList)
+        private SyntaxListBuilder LexConflictMarkerDisabledText(bool atSecondMiddleMarker, ref SyntaxListBuilder triviaList)
         {
-            // Consume everything from the start of the mid-conflict marker to the start of the next
-            // end-conflict marker.
+            // Consume everything from the end of the current mid-conflict marker to the start of the next
+            // end-conflict marker
             this.Start();
 
-            var hitEndConflictMarker = false;
+            var hitNextMarker = false;
             while (true)
             {
                 var ch = this.TextWindow.PeekChar();
@@ -2493,10 +2494,16 @@ LoopExit:
                     break;
                 }
 
+                if (!atSecondMiddleMarker && ch == '=' && IsConflictMarkerTrivia())
+                {
+                    hitNextMarker = true;
+                    break;
+                }
+
                 // If we hit the end-conflict marker, then lex it out at this point.
                 if (ch == '>' && IsConflictMarkerTrivia())
                 {
-                    hitEndConflictMarker = true;
+                    hitNextMarker = true;
                     break;
                 }
 
@@ -2508,7 +2515,7 @@ LoopExit:
                 this.AddTrivia(SyntaxFactory.DisabledText(TextWindow.GetText(false)), ref triviaList);
             }
 
-            if (hitEndConflictMarker)
+            if (hitNextMarker)
             {
                 LexConflictMarkerTrivia(ref triviaList);
             }

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -3766,14 +3766,11 @@ class C
             var trivia = token.LeadingTrivia[0];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
             Assert.Equal("======= Trailing", trivia.ToFullString());
-            Assert.Equal(16, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
 
             trivia = token.LeadingTrivia[1];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(16, trivia.Span.Start);
-            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
@@ -3788,9 +3785,7 @@ class C
 
             trivia = token.LeadingTrivia[3];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(65, trivia.Span.Start);
             Assert.Equal(">>>>>>> Actually the end", trivia.ToFullString());
-            Assert.Equal(24, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
         }
@@ -3813,14 +3808,11 @@ class C
             var trivia = token.LeadingTrivia[0];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
             Assert.Equal("======= Trailing", trivia.ToFullString());
-            Assert.Equal(16, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
 
             trivia = token.LeadingTrivia[1];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(16, trivia.Span.Start);
-            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
@@ -3830,14 +3822,10 @@ class C
                 more disabled text
 
                 """, trivia.ToFullString());
-            Assert.Equal(18, trivia.Span.Start);
-            Assert.Equal(47, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[3];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(65, trivia.Span.Start);
             Assert.Equal(">>>>>>> Actually the end", trivia.ToFullString());
-            Assert.Equal(24, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
         }
@@ -3867,7 +3855,6 @@ class C
             Assert.True(token.HasLeadingTrivia);
             var trivia = token.LeadingTrivia.Single();
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(22, trivia.Span.Length);
 
             Assert.True(trivia.ContainsDiagnostics);
             var errors = trivia.Errors();
@@ -3883,7 +3870,6 @@ class C
             Assert.Equal(3, token.LeadingTrivia.Count);
             trivia = token.LeadingTrivia[0];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(16, trivia.Span.Length);
 
             Assert.True(trivia.ContainsDiagnostics);
             errors = trivia.Errors();
@@ -3892,13 +3878,9 @@ class C
 
             trivia = token.LeadingTrivia[1];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(16, trivia.Span.Start);
-            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal(18, trivia.Span.Start);
-            Assert.Equal(13, trivia.Span.Length);
 
             token = Lex("""
                 ||||||| Trailing
@@ -3911,7 +3893,6 @@ class C
 
             trivia = token.LeadingTrivia[0];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(16, trivia.Span.Length);
 
             Assert.True(trivia.ContainsDiagnostics);
             errors = trivia.Errors();
@@ -3920,11 +3901,9 @@ class C
 
             trivia = token.LeadingTrivia[1];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal(34, trivia.Span.Length);
 
             token = Lex("""
                 ||||||| Trailing
@@ -3936,7 +3915,6 @@ class C
             Assert.Equal(4, token.LeadingTrivia.Count);
             var trivia1 = token.LeadingTrivia[0];
             Assert.True(trivia1.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(16, trivia1.Span.Length);
 
             Assert.True(trivia1.ContainsDiagnostics);
             errors = trivia1.Errors();
@@ -3945,18 +3923,12 @@ class C
 
             var trivia2 = token.LeadingTrivia[1];
             Assert.True(trivia2.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(16, trivia2.Span.Start);
-            Assert.Equal(2, trivia2.Span.Length);
 
             var trivia3 = token.LeadingTrivia[2];
             Assert.True(trivia3.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal(18, trivia3.Span.Start);
-            Assert.Equal(15, trivia3.Span.Length);
 
             var trivia4 = token.LeadingTrivia[3];
             Assert.True(trivia4.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(33, trivia4.Span.Start);
-            Assert.Equal(24, trivia4.Span.Length);
 
             Assert.True(trivia4.ContainsDiagnostics);
             errors = trivia4.Errors();
@@ -3973,7 +3945,6 @@ class C
             Assert.Equal(3, token.LeadingTrivia.Count);
             trivia1 = token.LeadingTrivia[0];
             Assert.True(trivia1.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(16, trivia1.Span.Length);
 
             Assert.True(trivia1.ContainsDiagnostics);
             errors = trivia1.Errors();
@@ -3982,13 +3953,9 @@ class C
 
             trivia2 = token.LeadingTrivia[1];
             Assert.True(trivia2.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(16, trivia2.Span.Start);
-            Assert.Equal(2, trivia2.Span.Length);
 
             trivia3 = token.LeadingTrivia[2];
             Assert.True(trivia3.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(18, trivia3.Span.Start);
-            Assert.Equal(24, trivia3.Span.Length);
 
             Assert.True(trivia3.ContainsDiagnostics);
             errors = trivia3.Errors();
@@ -4011,32 +3978,24 @@ class C
             var trivia = token.LeadingTrivia[0];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
             Assert.Equal("||||||| Mid", trivia.ToFullString());
-            Assert.Equal(11, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
 
             trivia = token.LeadingTrivia[1];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(11, trivia.Span.Start);
-            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
             Assert.Equal("======= Trailing", trivia.ToFullString());
-            Assert.Equal(16, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
 
             trivia = token.LeadingTrivia[3];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(29, trivia.Span.Start);
-            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[4];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(31, trivia.Span.Start);
             Assert.Equal(">>>>>>> Actually the end", trivia.ToFullString());
-            Assert.Equal(24, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
         }
@@ -4058,14 +4017,11 @@ class C
             var trivia = token.LeadingTrivia[0];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
             Assert.Equal("||||||| Mid", trivia.ToFullString());
-            Assert.Equal(11, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
 
             trivia = token.LeadingTrivia[1];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(11, trivia.Span.Start);
-            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
@@ -4073,20 +4029,15 @@ class C
                 disabled text 1
 
                 """, trivia.ToFullString());
-            Assert.Equal(13, trivia.Span.Start);
-            Assert.Equal(17, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[3];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
             Assert.Equal("======= Trailing", trivia.ToFullString());
-            Assert.Equal(16, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
 
             trivia = token.LeadingTrivia[4];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(46, trivia.Span.Start);
-            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[5];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
@@ -4094,14 +4045,10 @@ class C
                 disabled text 2
 
                 """, trivia.ToFullString());
-            Assert.Equal(48, trivia.Span.Start);
-            Assert.Equal(17, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[6];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(65, trivia.Span.Start);
             Assert.Equal(">>>>>>> Actually the end", trivia.ToFullString());
-            Assert.Equal(24, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
         }
@@ -4126,14 +4073,11 @@ class C
             var trivia = token.LeadingTrivia[0];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
             Assert.Equal("||||||| Mid", trivia.ToFullString());
-            Assert.Equal(11, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
 
             trivia = token.LeadingTrivia[1];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(11, trivia.Span.Start);
-            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
@@ -4141,20 +4085,15 @@ class C
                 disabled text 1
 
                 """, trivia.ToFullString());
-            Assert.Equal(13, trivia.Span.Start);
-            Assert.Equal(17, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[3];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
             Assert.Equal("======= Trailing", trivia.ToFullString());
-            Assert.Equal(16, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
 
             trivia = token.LeadingTrivia[4];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(46, trivia.Span.Start);
-            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[5];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
@@ -4164,14 +4103,10 @@ class C
                 more disabled text
 
                 """, trivia.ToFullString());
-            Assert.Equal(48, trivia.Span.Start);
-            Assert.Equal(47, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[6];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(95, trivia.Span.Start);
             Assert.Equal(">>>>>>> Actually the end", trivia.ToFullString());
-            Assert.Equal(24, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
         }
@@ -4196,14 +4131,11 @@ class C
             var trivia = token.LeadingTrivia[0];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
             Assert.Equal("||||||| Mid", trivia.ToFullString());
-            Assert.Equal(11, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
 
             trivia = token.LeadingTrivia[1];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(11, trivia.Span.Start);
-            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
@@ -4213,20 +4145,15 @@ class C
                 more disabled text
 
                 """, trivia.ToFullString());
-            Assert.Equal(13, trivia.Span.Start);
-            Assert.Equal(47, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[3];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
             Assert.Equal("======= Trailing", trivia.ToFullString());
-            Assert.Equal(16, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
 
             trivia = token.LeadingTrivia[4];
             Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
-            Assert.Equal(76, trivia.Span.Start);
-            Assert.Equal(2, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[5];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
@@ -4234,14 +4161,10 @@ class C
                 disabled text 2
 
                 """, trivia.ToFullString());
-            Assert.Equal(78, trivia.Span.Start);
-            Assert.Equal(17, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[6];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
-            Assert.Equal(95, trivia.Span.Start);
             Assert.Equal(">>>>>>> Actually the end", trivia.ToFullString());
-            Assert.Equal(24, trivia.Span.Length);
             Assert.True(trivia.ContainsDiagnostics);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
         }

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -3719,7 +3719,12 @@ class C
             Assert.Equal(34, trivia.Span.Length);
 
 
-            token = Lex("{\r\n======= Trailing\r\ndisabled text\r\n>>>>>>> Actually the end").Skip(1).First();
+            token = Lex("""
+                {
+                ======= Trailing
+                disabled text
+                >>>>>>> Actually the end
+                """).Skip(1).First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.True(token.HasLeadingTrivia);
             Assert.Equal(4, token.LeadingTrivia.Count);
@@ -3747,7 +3752,13 @@ class C
         public void TestEqualsConflictMarker3()
         {
             // second ======= is part of disabled text
-            var token = Lex("======= Trailing\r\ndisabled text 2\r\n======= \r\nmore disabled text\r\n>>>>>>> Actually the end").First();
+            var token = Lex("""
+                ======= Trailing
+                disabled text 2
+                ======= 
+                more disabled text
+                >>>>>>> Actually the end
+                """).First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.True(token.HasLeadingTrivia);
             Assert.Equal(4, token.LeadingTrivia.Count);
@@ -3766,7 +3777,59 @@ class C
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal("disabled text 2\r\n======= \r\nmore disabled text\r\n", trivia.ToFullString());
+            Assert.Equal("""
+                disabled text 2
+                ======= 
+                more disabled text
+
+                """, trivia.ToFullString());
+            Assert.Equal(18, trivia.Span.Start);
+            Assert.Equal(47, trivia.Span.Length);
+
+            trivia = token.LeadingTrivia[3];
+            Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
+            Assert.Equal(65, trivia.Span.Start);
+            Assert.Equal(">>>>>>> Actually the end", trivia.ToFullString());
+            Assert.Equal(24, trivia.Span.Length);
+            Assert.True(trivia.ContainsDiagnostics);
+            Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
+        }
+
+        [Fact]
+        public void TestEqualsConflictMarker4()
+        {
+            // ||||||| is part of disabled text
+            var token = Lex("""
+                ======= Trailing
+                disabled text 2
+                ||||||| 
+                more disabled text
+                >>>>>>> Actually the end
+                """).First();
+            Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
+            Assert.True(token.HasLeadingTrivia);
+            Assert.Equal(4, token.LeadingTrivia.Count);
+
+            var trivia = token.LeadingTrivia[0];
+            Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);
+            Assert.Equal("======= Trailing", trivia.ToFullString());
+            Assert.Equal(16, trivia.Span.Length);
+            Assert.True(trivia.ContainsDiagnostics);
+            Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, trivia.Errors().Single().Code);
+
+            trivia = token.LeadingTrivia[1];
+            Assert.True(trivia.Kind() == SyntaxKind.EndOfLineTrivia);
+            Assert.Equal(16, trivia.Span.Start);
+            Assert.Equal(2, trivia.Span.Length);
+
+            trivia = token.LeadingTrivia[2];
+            Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
+            Assert.Equal("""
+                disabled text 2
+                ||||||| 
+                more disabled text
+
+                """, trivia.ToFullString());
             Assert.Equal(18, trivia.Span.Start);
             Assert.Equal(47, trivia.Span.Length);
 
@@ -3811,7 +3874,10 @@ class C
             Assert.Equal(1, errors.Length);
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, errors[0].Code);
 
-            token = Lex("||||||| Trailing\r\ndisabled text").First();
+            token = Lex("""
+                ||||||| Trailing
+                disabled text
+                """).First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.True(token.HasLeadingTrivia);
             Assert.Equal(3, token.LeadingTrivia.Count);
@@ -3834,7 +3900,11 @@ class C
             Assert.Equal(18, trivia.Span.Start);
             Assert.Equal(13, trivia.Span.Length);
 
-            token = Lex("||||||| Trailing\r\ndisabled text\r\n>>>> still disabled").First();
+            token = Lex("""
+                ||||||| Trailing
+                disabled text
+                >>>> still disabled
+                """).First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.True(token.HasLeadingTrivia);
             Assert.Equal(3, token.LeadingTrivia.Count);
@@ -3856,7 +3926,11 @@ class C
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
             Assert.Equal(34, trivia.Span.Length);
 
-            token = Lex("||||||| Trailing\r\ndisabled text\r\n>>>>>>> Actually the end").First();
+            token = Lex("""
+                ||||||| Trailing
+                disabled text
+                >>>>>>> Actually the end
+                """).First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.True(token.HasLeadingTrivia);
             Assert.Equal(4, token.LeadingTrivia.Count);
@@ -3890,7 +3964,10 @@ class C
             Assert.Equal((int)ErrorCode.ERR_Merge_conflict_marker_encountered, errors[0].Code);
 
 
-            token = Lex("||||||| Trailing\r\n>>>>>>> Actually the end").First();
+            token = Lex("""
+                ||||||| Trailing
+                >>>>>>> Actually the end
+                """).First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.True(token.HasLeadingTrivia);
             Assert.Equal(3, token.LeadingTrivia.Count);
@@ -3922,7 +3999,11 @@ class C
         [Fact]
         public void TestPipeConflictMarker2()
         {
-            var token = Lex("||||||| Mid\r\n======= Trailing\r\n>>>>>>> Actually the end").First();
+            var token = Lex("""
+                ||||||| Mid
+                ======= Trailing
+                >>>>>>> Actually the end
+                """).First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.True(token.HasLeadingTrivia);
             Assert.Equal(5, token.LeadingTrivia.Count);
@@ -3963,7 +4044,13 @@ class C
         [Fact]
         public void TestPipeConflictMarker3()
         {
-            var token = Lex("||||||| Mid\r\ndisabled text 1\r\n======= Trailing\r\ndisabled text 2\r\n>>>>>>> Actually the end").First();
+            var token = Lex("""
+                ||||||| Mid
+                disabled text 1
+                ======= Trailing
+                disabled text 2
+                >>>>>>> Actually the end
+                """).First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.True(token.HasLeadingTrivia);
             Assert.Equal(7, token.LeadingTrivia.Count);
@@ -3982,7 +4069,10 @@ class C
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal("disabled text 1\r\n", trivia.ToFullString());
+            Assert.Equal("""
+                disabled text 1
+
+                """, trivia.ToFullString());
             Assert.Equal(13, trivia.Span.Start);
             Assert.Equal(17, trivia.Span.Length);
 
@@ -4000,7 +4090,10 @@ class C
 
             trivia = token.LeadingTrivia[5];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal("disabled text 2\r\n", trivia.ToFullString());
+            Assert.Equal("""
+                disabled text 2
+
+                """, trivia.ToFullString());
             Assert.Equal(48, trivia.Span.Start);
             Assert.Equal(17, trivia.Span.Length);
 
@@ -4017,7 +4110,15 @@ class C
         public void TestPipeConflictMarker4()
         {
             // second ======= is pat of disabled text
-            var token = Lex("||||||| Mid\r\ndisabled text 1\r\n======= Trailing\r\ndisabled text 2\r\n======= \r\nmore disabled text\r\n>>>>>>> Actually the end").First();
+            var token = Lex("""
+                ||||||| Mid
+                disabled text 1
+                ======= Trailing
+                disabled text 2
+                ======= 
+                more disabled text
+                >>>>>>> Actually the end
+                """).First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.True(token.HasLeadingTrivia);
             Assert.Equal(7, token.LeadingTrivia.Count);
@@ -4036,7 +4137,10 @@ class C
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal("disabled text 1\r\n", trivia.ToFullString());
+            Assert.Equal("""
+                disabled text 1
+
+                """, trivia.ToFullString());
             Assert.Equal(13, trivia.Span.Start);
             Assert.Equal(17, trivia.Span.Length);
 
@@ -4054,7 +4158,12 @@ class C
 
             trivia = token.LeadingTrivia[5];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal("disabled text 2\r\n======= \r\nmore disabled text\r\n", trivia.ToFullString());
+            Assert.Equal("""
+                disabled text 2
+                ======= 
+                more disabled text
+
+                """, trivia.ToFullString());
             Assert.Equal(48, trivia.Span.Start);
             Assert.Equal(47, trivia.Span.Length);
 
@@ -4071,7 +4180,15 @@ class C
         public void TestPipeConflictMarker5()
         {
             // second ||||||| is pat of disabled text
-            var token = Lex("||||||| Mid\r\ndisabled text 1\r\n||||||| \r\nmore disabled text\r\n======= Trailing\r\ndisabled text 2\r\n>>>>>>> Actually the end").First();
+            var token = Lex("""
+                ||||||| Mid
+                disabled text 1
+                ||||||| 
+                more disabled text
+                ======= Trailing
+                disabled text 2
+                >>>>>>> Actually the end
+                """).First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.True(token.HasLeadingTrivia);
             Assert.Equal(7, token.LeadingTrivia.Count);
@@ -4090,7 +4207,12 @@ class C
 
             trivia = token.LeadingTrivia[2];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal("disabled text 1\r\n||||||| \r\nmore disabled text\r\n", trivia.ToFullString());
+            Assert.Equal("""
+                disabled text 1
+                ||||||| 
+                more disabled text
+
+                """, trivia.ToFullString());
             Assert.Equal(13, trivia.Span.Start);
             Assert.Equal(47, trivia.Span.Length);
 
@@ -4108,7 +4230,10 @@ class C
 
             trivia = token.LeadingTrivia[5];
             Assert.True(trivia.Kind() == SyntaxKind.DisabledTextTrivia);
-            Assert.Equal("disabled text 2\r\n", trivia.ToFullString());
+            Assert.Equal("""
+                disabled text 2
+
+                """, trivia.ToFullString());
             Assert.Equal(78, trivia.Span.Start);
             Assert.Equal(17, trivia.Span.Length);
 

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -3719,12 +3719,7 @@ class C
             Assert.Equal(34, trivia.Span.Length);
 
 
-            token = Lex("""
-                {
-                ======= Trailing
-                disabled text
-                >>>>>>> Actually the end
-                """).Skip(1).First();
+            token = Lex("{\r\n======= Trailing\r\ndisabled text\r\n>>>>>>> Actually the end").Skip(1).First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.True(token.HasLeadingTrivia);
             Assert.Equal(4, token.LeadingTrivia.Count);
@@ -3780,8 +3775,6 @@ class C
                 more disabled text
 
                 """, trivia.ToFullString());
-            Assert.Equal(18, trivia.Span.Start);
-            Assert.Equal(47, trivia.Span.Length);
 
             trivia = token.LeadingTrivia[3];
             Assert.True(trivia.Kind() == SyntaxKind.ConflictMarkerTrivia);

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -3746,7 +3746,7 @@ class C
         [Fact]
         public void TestEqualsConflictMarker3()
         {
-            // second ======= is pat of disabled text
+            // second ======= is part of disabled text
             var token = Lex("======= Trailing\r\ndisabled text 2\r\n======= \r\nmore disabled text\r\n>>>>>>> Actually the end").First();
             Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind());
             Assert.True(token.HasLeadingTrivia);

--- a/src/Compilers/VisualBasic/Test/Syntax/Scanner/ScannerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Scanner/ScannerTests.vb
@@ -389,6 +389,313 @@ Public Class ScannerTests
     End Sub
 
     <Fact>
+    Public Sub TestEqualsConflictMarker3()
+        Dim token = SyntaxFactory.ParseTokens("======= trailing chars" & vbCrLf & "======= more trailing chars").First()
+        Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind())
+        Assert.True(token.HasLeadingTrivia)
+        Assert.Equal(3, token.LeadingTrivia.Count)
+
+        Dim trivia = token.LeadingTrivia(0)
+        Assert.True(trivia.Kind() = SyntaxKind.ConflictMarkerTrivia)
+        Assert.Equal(trivia.Span.Length, 22)
+        Assert.Equal("======= trailing chars", trivia.ToFullString())
+        Assert.True(trivia.ContainsDiagnostics)
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, trivia.Errors().First().Code)
+
+        trivia = token.LeadingTrivia(1)
+        Assert.True(trivia.Kind() = SyntaxKind.EndOfLineTrivia)
+        Assert.Equal(trivia.Span.Start, 22)
+        Assert.Equal(trivia.Span.Length, 2)
+
+        trivia = token.LeadingTrivia(2)
+        Assert.True(trivia.Kind() = SyntaxKind.DisabledTextTrivia)
+        Assert.Equal(trivia.Span.Start, 24)
+        Assert.Equal(trivia.Span.Length, 27)
+        Assert.Equal("======= more trailing chars", trivia.ToFullString())
+    End Sub
+
+    <Fact>
+    Public Sub TestPipeConflictMarker1()
+        ' Has to be the start of a line.
+        Dim token = SyntaxFactory.ParseTokens(" |||||||").First()
+        Assert.Equal(SyntaxKind.BadToken, token.Kind())
+        Assert.True(token.HasLeadingTrivia)
+        Assert.True(token.LeadingTrivia.Single().Kind() = SyntaxKind.WhitespaceTrivia)
+
+        ' Has to have at least seven characters.
+        token = SyntaxFactory.ParseTokens("|||||| ").First()
+        Assert.Equal(SyntaxKind.BadToken, token.Kind())
+
+        ' Start of line, seven characters
+        token = SyntaxFactory.ParseTokens("|||||||").First()
+        Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind())
+        Assert.True(token.HasLeadingTrivia)
+        Assert.True(token.LeadingTrivia.Single().Kind() = SyntaxKind.ConflictMarkerTrivia)
+
+        ' Start of line, seven characters
+        token = SyntaxFactory.ParseTokens("||||||| trailing chars").First()
+        Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind())
+        Assert.True(token.HasLeadingTrivia)
+        Dim trivia = token.LeadingTrivia.Single()
+        Assert.True(trivia.Kind() = SyntaxKind.ConflictMarkerTrivia)
+        Assert.Equal(trivia.Span.Length, 22)
+
+        Assert.True(trivia.ContainsDiagnostics)
+        Dim err = trivia.Errors().First
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, err.Code)
+
+        token = SyntaxFactory.ParseTokens("||||||| Trailing" & vbCrLf & "disabled text").First()
+        Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind())
+        Assert.True(token.HasLeadingTrivia)
+        Assert.Equal(3, token.LeadingTrivia.Count)
+        trivia = token.LeadingTrivia(0)
+        Assert.True(trivia.Kind() = SyntaxKind.ConflictMarkerTrivia)
+        Assert.Equal(trivia.Span.Length, 16)
+
+        Assert.True(trivia.ContainsDiagnostics)
+        err = trivia.Errors().First
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, err.Code)
+
+        trivia = token.LeadingTrivia(1)
+        Assert.True(trivia.Kind() = SyntaxKind.EndOfLineTrivia)
+        Assert.Equal(trivia.Span.Start, 16)
+        Assert.Equal(trivia.Span.Length, 2)
+
+        trivia = token.LeadingTrivia(2)
+        Assert.True(trivia.Kind() = SyntaxKind.DisabledTextTrivia)
+        Assert.Equal(trivia.Span.Start, 18)
+        Assert.Equal(trivia.Span.Length, 13)
+
+        token = SyntaxFactory.ParseTokens("||||||| Trailing" & vbCrLf & "disabled text" & vbCrLf & ">>>> still disabled").First()
+        Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind())
+        Assert.True(token.HasLeadingTrivia)
+        Assert.Equal(3, token.LeadingTrivia.Count)
+
+        trivia = token.LeadingTrivia(0)
+        Assert.True(trivia.Kind() = SyntaxKind.ConflictMarkerTrivia)
+        Assert.Equal(trivia.Span.Length, 16)
+
+        Assert.True(trivia.ContainsDiagnostics)
+        err = trivia.Errors().First
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, err.Code)
+
+        trivia = token.LeadingTrivia(1)
+        Assert.True(trivia.Kind() = SyntaxKind.EndOfLineTrivia)
+        Assert.Equal(trivia.Span.Length, 2)
+
+        trivia = token.LeadingTrivia(2)
+        Assert.True(trivia.Kind() = SyntaxKind.DisabledTextTrivia)
+        Assert.Equal(trivia.Span.Length, 34)
+
+
+        token = SyntaxFactory.ParseTokens("||||||| Trailing" & vbCrLf & "disabled text" & vbCrLf & ">>>>>>> Actually the end").First()
+        Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind())
+        Assert.True(token.HasLeadingTrivia)
+        Assert.Equal(token.LeadingTrivia.Count, 4)
+        Dim trivia1 = token.LeadingTrivia(0)
+        Assert.True(trivia1.Kind() = SyntaxKind.ConflictMarkerTrivia)
+        Assert.Equal(trivia1.Span.Length, 16)
+
+        Assert.True(trivia1.ContainsDiagnostics)
+        err = trivia1.Errors().First
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, err.Code)
+
+        Dim trivia2 = token.LeadingTrivia(1)
+        Assert.True(trivia2.Kind() = SyntaxKind.EndOfLineTrivia)
+        Assert.Equal(trivia2.Span.Start, 16)
+        Assert.Equal(trivia2.Span.Length, 2)
+
+        Dim trivia3 = token.LeadingTrivia(2)
+        Assert.True(trivia3.Kind() = SyntaxKind.DisabledTextTrivia)
+        Assert.Equal(trivia3.Span.Start, 18)
+        Assert.Equal(trivia3.Span.Length, 15)
+
+        Dim trivia4 = token.LeadingTrivia(3)
+        Assert.True(trivia4.Kind() = SyntaxKind.ConflictMarkerTrivia)
+        Assert.Equal(trivia4.Span.Start, 33)
+        Assert.Equal(trivia4.Span.Length, 24)
+
+        Assert.True(trivia4.ContainsDiagnostics)
+        err = trivia4.Errors().First
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, err.Code)
+    End Sub
+
+    <Fact>
+    Public Sub TestPipeConflictMarker2()
+        ' Has to be the start of a line.
+        Dim token = SyntaxFactory.ParseTokens("{" & vbCrLf & " |||||||").Skip(2).First()
+        Assert.Equal(SyntaxKind.BadToken, token.Kind())
+        Assert.True(token.HasLeadingTrivia)
+        Assert.True(token.LeadingTrivia.Single().Kind() = SyntaxKind.WhitespaceTrivia)
+
+        ' Has to have at least seven characters.
+        token = SyntaxFactory.ParseTokens("{" & vbCrLf & "|||||| ").Skip(2).First()
+        Assert.Equal(SyntaxKind.BadToken, token.Kind())
+
+        ' Start of line, seven characters
+        token = SyntaxFactory.ParseTokens("{" & vbCrLf & "|||||||").Skip(2).First()
+        Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind())
+        Assert.True(token.HasLeadingTrivia)
+        Dim trivia = token.LeadingTrivia.Single()
+        Assert.True(trivia.Kind() = SyntaxKind.ConflictMarkerTrivia)
+
+        Assert.True(trivia.ContainsDiagnostics)
+        Dim err = trivia.Errors().First
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, err.Code)
+
+
+        ' Start of line, seven characters
+        token = SyntaxFactory.ParseTokens("{" & vbCrLf & "||||||| trailing chars").Skip(2).First()
+        Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind())
+        Assert.True(token.HasLeadingTrivia)
+        trivia = token.LeadingTrivia.Single()
+        Assert.True(trivia.Kind() = SyntaxKind.ConflictMarkerTrivia)
+        Assert.Equal(trivia.Span.Length, 22)
+
+        Assert.True(trivia.ContainsDiagnostics)
+        err = trivia.Errors().First
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, err.Code)
+
+        token = SyntaxFactory.ParseTokens("{" & vbCrLf & "||||||| Trailing" & vbCrLf & "disabled text").Skip(2).First()
+        Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind())
+        Assert.True(token.HasLeadingTrivia)
+        Assert.Equal(3, token.LeadingTrivia.Count)
+        trivia = token.LeadingTrivia(0)
+        Assert.True(trivia.Kind() = SyntaxKind.ConflictMarkerTrivia)
+        Assert.Equal(trivia.Span.Length, 16)
+
+        Assert.True(trivia.ContainsDiagnostics)
+        err = trivia.Errors().First
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, err.Code)
+
+        trivia = token.LeadingTrivia(1)
+        Assert.True(trivia.Kind() = SyntaxKind.EndOfLineTrivia)
+        Assert.Equal(trivia.Span.Start, 19)
+        Assert.Equal(trivia.Span.Length, 2)
+
+        trivia = token.LeadingTrivia(2)
+        Assert.True(trivia.Kind() = SyntaxKind.DisabledTextTrivia)
+        Assert.Equal(trivia.Span.Start, 21)
+        Assert.Equal(trivia.Span.Length, 13)
+
+        token = SyntaxFactory.ParseTokens("{" & vbCrLf & "||||||| Trailing" & vbCrLf & "disabled text" & vbCrLf & ">>>> still disabled").Skip(2).First()
+        Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind())
+        Assert.True(token.HasLeadingTrivia)
+        Assert.Equal(3, token.LeadingTrivia.Count)
+
+        trivia = token.LeadingTrivia(0)
+        Assert.True(trivia.Kind() = SyntaxKind.ConflictMarkerTrivia)
+        Assert.Equal(trivia.Span.Length, 16)
+
+        Assert.True(trivia.ContainsDiagnostics)
+        err = trivia.Errors().First
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, err.Code)
+
+        trivia = token.LeadingTrivia(1)
+        Assert.True(trivia.Kind() = SyntaxKind.EndOfLineTrivia)
+        Assert.Equal(trivia.Span.Length, 2)
+
+        trivia = token.LeadingTrivia(2)
+        Assert.True(trivia.Kind() = SyntaxKind.DisabledTextTrivia)
+        Assert.Equal(trivia.Span.Length, 34)
+
+
+        token = SyntaxFactory.ParseTokens("{" & vbCrLf & "||||||| Trailing" & vbCrLf & "disabled text" & vbCrLf & ">>>>>>> Actually the end").Skip(2).First()
+        Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind())
+        Assert.True(token.HasLeadingTrivia)
+        Assert.Equal(token.LeadingTrivia.Count, 4)
+        Dim trivia1 = token.LeadingTrivia(0)
+        Assert.True(trivia1.Kind() = SyntaxKind.ConflictMarkerTrivia)
+        Assert.Equal(trivia1.Span.Length, 16)
+
+        Assert.True(trivia1.ContainsDiagnostics)
+        err = trivia1.Errors().First
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, err.Code)
+
+        Dim trivia2 = token.LeadingTrivia(1)
+        Assert.True(trivia2.Kind() = SyntaxKind.EndOfLineTrivia)
+        Assert.Equal(trivia2.Span.Start, 19)
+        Assert.Equal(trivia2.Span.Length, 2)
+
+        Dim trivia3 = token.LeadingTrivia(2)
+        Assert.True(trivia3.Kind() = SyntaxKind.DisabledTextTrivia)
+        Assert.Equal(trivia3.Span.Start, 21)
+        Assert.Equal(trivia3.Span.Length, 15)
+
+        Dim trivia4 = token.LeadingTrivia(3)
+        Assert.True(trivia4.Kind() = SyntaxKind.ConflictMarkerTrivia)
+        Assert.Equal(trivia4.Span.Start, 36)
+        Assert.Equal(trivia4.Span.Length, 24)
+
+        Assert.True(trivia4.ContainsDiagnostics)
+        err = trivia4.Errors().First
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, err.Code)
+    End Sub
+
+    <Fact>
+    Public Sub TestPipeConflictMarker3()
+        Dim token = SyntaxFactory.ParseTokens("||||||| trailing chars" & vbCrLf & "||||||| more trailing chars").First()
+        Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind())
+        Assert.True(token.HasLeadingTrivia)
+        Assert.Equal(3, token.LeadingTrivia.Count)
+
+        Dim trivia = token.LeadingTrivia(0)
+        Assert.True(trivia.Kind() = SyntaxKind.ConflictMarkerTrivia)
+        Assert.Equal(trivia.Span.Length, 22)
+        Assert.Equal("||||||| trailing chars", trivia.ToFullString())
+        Assert.True(trivia.ContainsDiagnostics)
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, trivia.Errors().First().Code)
+
+        trivia = token.LeadingTrivia(1)
+        Assert.True(trivia.Kind() = SyntaxKind.EndOfLineTrivia)
+        Assert.Equal(trivia.Span.Start, 22)
+        Assert.Equal(trivia.Span.Length, 2)
+
+        trivia = token.LeadingTrivia(2)
+        Assert.True(trivia.Kind() = SyntaxKind.DisabledTextTrivia)
+        Assert.Equal(trivia.Span.Start, 24)
+        Assert.Equal(trivia.Span.Length, 27)
+        Assert.Equal("||||||| more trailing chars", trivia.ToFullString())
+    End Sub
+
+    <Fact>
+    Public Sub TestPipeConflictMarker4()
+        Dim token = SyntaxFactory.ParseTokens("||||||| trailing chars" & vbCrLf & "disabled text" & vbCrLf & "======= more trailing chars" & vbCrLf & "more disabled text" & vbCrLf & ">>>>>>> end trailing chars").First()
+        Assert.Equal(SyntaxKind.EndOfFileToken, token.Kind())
+        Assert.True(token.HasLeadingTrivia)
+        Assert.Equal(7, token.LeadingTrivia.Count)
+
+        Dim trivia = token.LeadingTrivia(0)
+        Assert.True(trivia.Kind() = SyntaxKind.ConflictMarkerTrivia)
+        Assert.Equal("||||||| trailing chars", trivia.ToFullString())
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, trivia.Errors().First().Code)
+
+        trivia = token.LeadingTrivia(1)
+        Assert.True(trivia.Kind() = SyntaxKind.EndOfLineTrivia)
+
+        trivia = token.LeadingTrivia(2)
+        Assert.True(trivia.Kind() = SyntaxKind.DisabledTextTrivia)
+        Assert.Equal("disabled text" & vbCrLf, trivia.ToFullString())
+
+        trivia = token.LeadingTrivia(3)
+        Assert.True(trivia.Kind() = SyntaxKind.ConflictMarkerTrivia)
+        Assert.Equal("======= more trailing chars", trivia.ToFullString())
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, trivia.Errors().First().Code)
+
+        trivia = token.LeadingTrivia(4)
+        Assert.True(trivia.Kind() = SyntaxKind.EndOfLineTrivia)
+
+        trivia = token.LeadingTrivia(5)
+        Assert.True(trivia.Kind() = SyntaxKind.DisabledTextTrivia)
+        Assert.Equal("more disabled text" & vbCrLf, trivia.ToFullString())
+
+        trivia = token.LeadingTrivia(6)
+        Assert.True(trivia.Kind() = SyntaxKind.ConflictMarkerTrivia)
+        Assert.Equal(">>>>>>> end trailing chars", trivia.ToFullString())
+        Assert.Equal(ERRID.ERR_Merge_conflict_marker_encountered, trivia.Errors().First().Code)
+    End Sub
+
+    <Fact>
     Public Sub Scanner_EndOfText()
         Dim tk = ScanOnce("")
         Assert.Equal(SyntaxKind.EndOfFileToken, tk.Kind)

--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -4543,6 +4543,47 @@ void M()
 
         [Theory]
         [CombinatorialData]
+        public async Task TestConflictMarkers2(TestHost testHost)
+        {
+            await TestAsync(
+@"class C
+{
+<<<<<<< Start
+    public void Goo();
+||||||| Baseline
+    int removed;
+=======
+    public void Bar();
+>>>>>>> End
+}",
+                testHost,
+                Keyword("class"),
+                Class("C"),
+                Punctuation.OpenCurly,
+                Comment("<<<<<<< Start"),
+                Keyword("public"),
+                Keyword("void"),
+                Method("Goo"),
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Punctuation.Semicolon,
+                Comment("||||||| Baseline"),
+                Keyword("int"),
+                Identifier("removed"),
+                Punctuation.Semicolon,
+                Comment("======="),
+                Keyword("public"),
+                Keyword("void"),
+                Identifier("Bar"),
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Punctuation.Semicolon,
+                Comment(">>>>>>> End"),
+                Punctuation.CloseCurly);
+        }
+
+        [Theory]
+        [CombinatorialData]
         public async Task TestUnmanagedConstraint_InsideMethod(TestHost testHost)
         {
             await TestInMethodAsync(@"

--- a/src/EditorFeatures/CSharpTest/ConflictMarkerResolution/ConflictMarkerResolutionTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConflictMarkerResolution/ConflictMarkerResolutionTests.cs
@@ -73,6 +73,61 @@ namespace N
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestTakeTop_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+{|CS8300:||||||||} Baseline!
+    class Removed { }
+{|CS8300:=======|}
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
         public async Task TestTakeBottom1()
         {
             var source = @"
@@ -89,6 +144,61 @@ namespace N
             Console.WriteLine(""My section"");
         }
     }
+{|CS8300:=======|}
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestTakeBottom1_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+{|CS8300:||||||||} Baseline!
+    class Removed { }
 {|CS8300:=======|}
     class Program2
     {
@@ -187,6 +297,69 @@ namespace N
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestTakeBoth1_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+{|CS8300:||||||||} Baseline!
+    class Removed { }
+{|CS8300:=======|}
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 2,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBothEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
         public async Task TestEmptyTop_TakeTop()
         {
             var source = @"
@@ -224,6 +397,45 @@ namespace N
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestEmptyTop_TakeTop_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+{|CS8300:||||||||} Baseline!
+    class Removed { }
+{|CS8300:=======|}
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
         public async Task TestEmptyTop_TakeBottom()
         {
             var source = @"
@@ -232,6 +444,53 @@ using System;
 namespace N
 {
 {|CS8300:<<<<<<<|} This is mine!
+{|CS8300:=======|}
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestEmptyTop_TakeBottom_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+{|CS8300:||||||||} Baseline!
+    class Removed { }
 {|CS8300:=======|}
     class Program2
     {
@@ -314,6 +573,53 @@ namespace N
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestEmptyBottom_TakeTop_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+{|CS8300:||||||||} Baseline!
+    class Removed { }
+{|CS8300:=======|}
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
         public async Task TestEmptyBottom_TakeBottom()
         {
             var source = @"
@@ -330,6 +636,45 @@ namespace N
             Console.WriteLine(""My section"");
         }
     }
+{|CS8300:=======|}
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestEmptyBottom_TakeBottom_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+{|CS8300:||||||||} Baseline!
+    class Removed { }
 {|CS8300:=======|}
 {|CS8300:>>>>>>>|} This is theirs!
 }";
@@ -575,9 +920,53 @@ public class Class1
             }.RunAsync();
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestTakeTop_TopCommentedOut_WithBaseline()
+        {
+            var source = @"
+public class Class1
+{
+    public void M()
+    {
+        /*
+<<<<<<< dest
+         * a thing
+         */
+{|CS8300:||||||||} Baseline!
+         * previous thing
+         */
+{|CS8300:=======|}
+         * another thing
+         */
+{|CS8300:>>>>>>>|} source
+        // */
+    }
+}";
+            var fixedSource = @"
+public class Class1
+{
+    public void M()
+    {
+        /*
+         * a thing
+         */
+        // */
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
+            }.RunAsync();
+        }
+
         [WorkItem(23847, "https://github.com/dotnet/roslyn/issues/23847")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
-        public async Task TestTakeTop_MiddleAndBottomCommentedOut()
+        public async Task TestTakeTop_SecondMiddleAndBottomCommentedOut()
         {
             var source = @"
 public class Class1
@@ -587,6 +976,47 @@ public class Class1
 {|CS8300:<<<<<<<|} dest
         /*
          * a thing
+=======
+         *
+         * another thing
+>>>>>>> source
+         */
+    }
+}";
+            var fixedSource = @"
+public class Class1
+{
+    public void M()
+    {
+        /*
+         * a thing
+         */
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestTakeTop_FirstMiddleAndSecondMiddleAndBottomCommentedOut()
+        {
+            var source = @"
+public class Class1
+{
+    public void M()
+    {
+{|CS8300:<<<<<<<|} dest
+        /*
+         * a thing
+|||||||| Baseline!
+         * previous thing
 =======
          *
          * another thing
@@ -648,6 +1078,40 @@ a"";
             }.RunAsync();
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestTakeTop_TopInString_WithBaseline()
+        {
+            var source = @"
+class X {
+  void x() {
+    var x = @""
+<<<<<<< working copy
+a"";
+{|CS8300:||||||||} baseline
+previous"";
+{|CS8300:=======|}
+b"";
+{|CS8300:>>>>>>>|} merge rev
+  }
+}";
+            var fixedSource = @"
+class X {
+  void x() {
+    var x = @""
+a"";
+  }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
+            }.RunAsync();
+        }
+
         [WorkItem(23847, "https://github.com/dotnet/roslyn/issues/23847")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
         public async Task TestTakeBottom_TopInString()
@@ -658,6 +1122,40 @@ class X {
     var x = @""
 <<<<<<< working copy
 a"";
+{|CS8300:=======|}
+b"";
+{|CS8300:>>>>>>>|} merge rev
+  }
+}";
+            var fixedSource = @"
+class X {
+  void x() {
+    var x = @""
+b"";
+  }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestTakeBottom_TopInString_WithBaseline()
+        {
+            var source = @"
+class X {
+  void x() {
+    var x = @""
+<<<<<<< working copy
+a"";
+{|CS8300:||||||||} baseline
+previous"";
 {|CS8300:=======|}
 b"";
 {|CS8300:>>>>>>>|} merge rev
@@ -697,6 +1195,22 @@ class X {
             }.RunAsync();
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestMissingWithFirstMiddleMarkerAtTopOfFile()
+        {
+            var source = @"{|CS8300:||||||||} baseline
+{|CS8300:=======|}
+class X {
+}
+{|CS8300:>>>>>>>|} merge rev";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = source,
+            }.RunAsync();
+        }
+
         [WorkItem(23847, "https://github.com/dotnet/roslyn/issues/23847")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
         public async Task TestMissingWithMiddleMarkerAtBottomOfFile()
@@ -705,6 +1219,21 @@ class X {
 class X {
 }
 {|CS8300:=======|}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = source,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestMissingWithFirstMiddleMarkerAtBottomOfFile()
+        {
+            var source = @"{|CS8300:<<<<<<<|} working copy
+class X {
+}
+{|CS8300:||||||||}";
 
             await new VerifyCS.Test
             {
@@ -736,6 +1265,62 @@ namespace N
     class Program3
     {
     }
+{|CS8300:=======|}
+    class Program4
+    {
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+    class Program
+    {
+    }
+
+    class Program3
+    {
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 2,
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestFixAll1_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+    class Program
+    {
+    }
+{|CS8300:||||||||} baseline
+    class Removed { }
+{|CS8300:=======|}
+    class Program2
+    {
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+
+{|CS8300:<<<<<<<|} This is mine!
+    class Program3
+    {
+    }
+{|CS8300:||||||||} baseline
+    class Removed2 { }
 {|CS8300:=======|}
     class Program4
     {
@@ -819,6 +1404,62 @@ namespace N
             }.RunAsync();
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestFixAll2_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+    class Program
+    {
+    }
+{|CS8300:||||||||} baseline
+    class Removed { }
+{|CS8300:=======|}
+    class Program2
+    {
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+
+{|CS8300:<<<<<<<|} This is mine!
+    class Program3
+    {
+    }
+{|CS8300:||||||||} baseline
+    class Removed2 { }
+{|CS8300:=======|}
+    class Program4
+    {
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+    class Program2
+    {
+    }
+
+    class Program4
+    {
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 2,
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey,
+            }.RunAsync();
+        }
+
         [WorkItem(21107, "https://github.com/dotnet/roslyn/issues/21107")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
         public async Task TestFixAll3()
@@ -842,6 +1483,68 @@ namespace N
     class Program3
     {
     }
+{|CS8300:=======|}
+    class Program4
+    {
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+    class Program
+    {
+    }
+    class Program2
+    {
+    }
+
+    class Program3
+    {
+    }
+    class Program4
+    {
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 2,
+                CodeActionIndex = 2,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBothEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestFixAll3_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+    class Program
+    {
+    }
+{|CS8300:||||||||} baseline
+    class Removed { }
+{|CS8300:=======|}
+    class Program2
+    {
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+
+{|CS8300:<<<<<<<|} This is mine!
+    class Program3
+    {
+    }
+{|CS8300:||||||||} baseline
+    class Removed2 { }
 {|CS8300:=======|}
     class Program4
     {

--- a/src/EditorFeatures/CSharpTest/ConflictMarkerResolution/ConflictMarkerResolutionTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConflictMarkerResolution/ConflictMarkerResolutionTests.cs
@@ -73,61 +73,6 @@ namespace N
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
-        public async Task TestTakeTop_WithBaseline()
-        {
-            var source = @"
-using System;
-
-namespace N
-{
-{|CS8300:<<<<<<<|} This is mine!
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            Program p;
-            Console.WriteLine(""My section"");
-        }
-    }
-{|CS8300:||||||||} Baseline!
-    class Removed { }
-{|CS8300:=======|}
-    class Program2
-    {
-        static void Main2(string[] args)
-        {
-            Program2 p;
-            Console.WriteLine(""Their section"");
-        }
-    }
-{|CS8300:>>>>>>>|} This is theirs!
-}";
-            var fixedSource = @"
-using System;
-
-namespace N
-{
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            Program p;
-            Console.WriteLine(""My section"");
-        }
-    }
-}";
-
-            await new VerifyCS.Test
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-                NumberOfIncrementalIterations = 1,
-                CodeActionIndex = 0,
-                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
-            }.RunAsync();
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
         public async Task TestTakeBottom1()
         {
             var source = @"
@@ -144,61 +89,6 @@ namespace N
             Console.WriteLine(""My section"");
         }
     }
-{|CS8300:=======|}
-    class Program2
-    {
-        static void Main2(string[] args)
-        {
-            Program2 p;
-            Console.WriteLine(""Their section"");
-        }
-    }
-{|CS8300:>>>>>>>|} This is theirs!
-}";
-            var fixedSource = @"
-using System;
-
-namespace N
-{
-    class Program2
-    {
-        static void Main2(string[] args)
-        {
-            Program2 p;
-            Console.WriteLine(""Their section"");
-        }
-    }
-}";
-
-            await new VerifyCS.Test
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-                NumberOfIncrementalIterations = 1,
-                CodeActionIndex = 1,
-                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey,
-            }.RunAsync();
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
-        public async Task TestTakeBottom1_WithBaseline()
-        {
-            var source = @"
-using System;
-
-namespace N
-{
-{|CS8300:<<<<<<<|} This is mine!
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            Program p;
-            Console.WriteLine(""My section"");
-        }
-    }
-{|CS8300:||||||||} Baseline!
-    class Removed { }
 {|CS8300:=======|}
     class Program2
     {
@@ -297,69 +187,6 @@ namespace N
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
-        public async Task TestTakeBoth1_WithBaseline()
-        {
-            var source = @"
-using System;
-
-namespace N
-{
-{|CS8300:<<<<<<<|} This is mine!
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            Program p;
-            Console.WriteLine(""My section"");
-        }
-    }
-{|CS8300:||||||||} Baseline!
-    class Removed { }
-{|CS8300:=======|}
-    class Program2
-    {
-        static void Main2(string[] args)
-        {
-            Program2 p;
-            Console.WriteLine(""Their section"");
-        }
-    }
-{|CS8300:>>>>>>>|} This is theirs!
-}";
-            var fixedSource = @"
-using System;
-
-namespace N
-{
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            Program p;
-            Console.WriteLine(""My section"");
-        }
-    }
-    class Program2
-    {
-        static void Main2(string[] args)
-        {
-            Program2 p;
-            Console.WriteLine(""Their section"");
-        }
-    }
-}";
-
-            await new VerifyCS.Test
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-                NumberOfIncrementalIterations = 1,
-                CodeActionIndex = 2,
-                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBothEquivalenceKey,
-            }.RunAsync();
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
         public async Task TestEmptyTop_TakeTop()
         {
             var source = @"
@@ -397,45 +224,6 @@ namespace N
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
-        public async Task TestEmptyTop_TakeTop_WithBaseline()
-        {
-            var source = @"
-using System;
-
-namespace N
-{
-{|CS8300:<<<<<<<|} This is mine!
-{|CS8300:||||||||} Baseline!
-    class Removed { }
-{|CS8300:=======|}
-    class Program2
-    {
-        static void Main2(string[] args)
-        {
-            Program2 p;
-            Console.WriteLine(""Their section"");
-        }
-    }
-{|CS8300:>>>>>>>|} This is theirs!
-}";
-            var fixedSource = @"
-using System;
-
-namespace N
-{
-}";
-
-            await new VerifyCS.Test
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-                NumberOfIncrementalIterations = 1,
-                CodeActionIndex = 0,
-                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
-            }.RunAsync();
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
         public async Task TestEmptyTop_TakeBottom()
         {
             var source = @"
@@ -444,53 +232,6 @@ using System;
 namespace N
 {
 {|CS8300:<<<<<<<|} This is mine!
-{|CS8300:=======|}
-    class Program2
-    {
-        static void Main2(string[] args)
-        {
-            Program2 p;
-            Console.WriteLine(""Their section"");
-        }
-    }
-{|CS8300:>>>>>>>|} This is theirs!
-}";
-            var fixedSource = @"
-using System;
-
-namespace N
-{
-    class Program2
-    {
-        static void Main2(string[] args)
-        {
-            Program2 p;
-            Console.WriteLine(""Their section"");
-        }
-    }
-}";
-
-            await new VerifyCS.Test
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-                NumberOfIncrementalIterations = 1,
-                CodeActionIndex = 1,
-                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey,
-            }.RunAsync();
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
-        public async Task TestEmptyTop_TakeBottom_WithBaseline()
-        {
-            var source = @"
-using System;
-
-namespace N
-{
-{|CS8300:<<<<<<<|} This is mine!
-{|CS8300:||||||||} Baseline!
-    class Removed { }
 {|CS8300:=======|}
     class Program2
     {
@@ -573,53 +314,6 @@ namespace N
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
-        public async Task TestEmptyBottom_TakeTop_WithBaseline()
-        {
-            var source = @"
-using System;
-
-namespace N
-{
-{|CS8300:<<<<<<<|} This is mine!
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            Program p;
-            Console.WriteLine(""My section"");
-        }
-    }
-{|CS8300:||||||||} Baseline!
-    class Removed { }
-{|CS8300:=======|}
-{|CS8300:>>>>>>>|} This is theirs!
-}";
-            var fixedSource = @"
-using System;
-
-namespace N
-{
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            Program p;
-            Console.WriteLine(""My section"");
-        }
-    }
-}";
-
-            await new VerifyCS.Test
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-                NumberOfIncrementalIterations = 1,
-                CodeActionIndex = 0,
-                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
-            }.RunAsync();
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
         public async Task TestEmptyBottom_TakeBottom()
         {
             var source = @"
@@ -636,45 +330,6 @@ namespace N
             Console.WriteLine(""My section"");
         }
     }
-{|CS8300:=======|}
-{|CS8300:>>>>>>>|} This is theirs!
-}";
-            var fixedSource = @"
-using System;
-
-namespace N
-{
-}";
-
-            await new VerifyCS.Test
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-                NumberOfIncrementalIterations = 1,
-                CodeActionIndex = 1,
-                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey,
-            }.RunAsync();
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
-        public async Task TestEmptyBottom_TakeBottom_WithBaseline()
-        {
-            var source = @"
-using System;
-
-namespace N
-{
-{|CS8300:<<<<<<<|} This is mine!
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            Program p;
-            Console.WriteLine(""My section"");
-        }
-    }
-{|CS8300:||||||||} Baseline!
-    class Removed { }
 {|CS8300:=======|}
 {|CS8300:>>>>>>>|} This is theirs!
 }";
@@ -920,50 +575,6 @@ public class Class1
             }.RunAsync();
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
-        public async Task TestTakeTop_TopCommentedOut_WithBaseline()
-        {
-            var source = @"
-public class Class1
-{
-    public void M()
-    {
-        /*
-<<<<<<< dest
-         * a thing
-         */
-{|CS8300:||||||||} Baseline!
-         * previous thing
-         */
-{|CS8300:=======|}
-         * another thing
-         */
-{|CS8300:>>>>>>>|} source
-        // */
-    }
-}";
-            var fixedSource = @"
-public class Class1
-{
-    public void M()
-    {
-        /*
-         * a thing
-         */
-        // */
-    }
-}";
-
-            await new VerifyCS.Test
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-                NumberOfIncrementalIterations = 1,
-                CodeActionIndex = 0,
-                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
-            }.RunAsync();
-        }
-
         [WorkItem(23847, "https://github.com/dotnet/roslyn/issues/23847")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
         public async Task TestTakeTop_SecondMiddleAndBottomCommentedOut()
@@ -976,47 +587,6 @@ public class Class1
 {|CS8300:<<<<<<<|} dest
         /*
          * a thing
-=======
-         *
-         * another thing
->>>>>>> source
-         */
-    }
-}";
-            var fixedSource = @"
-public class Class1
-{
-    public void M()
-    {
-        /*
-         * a thing
-         */
-    }
-}";
-
-            await new VerifyCS.Test
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-                NumberOfIncrementalIterations = 1,
-                CodeActionIndex = 0,
-                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
-            }.RunAsync();
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
-        public async Task TestTakeTop_FirstMiddleAndSecondMiddleAndBottomCommentedOut()
-        {
-            var source = @"
-public class Class1
-{
-    public void M()
-    {
-{|CS8300:<<<<<<<|} dest
-        /*
-         * a thing
-|||||||| Baseline!
-         * previous thing
 =======
          *
          * another thing
@@ -1078,40 +648,6 @@ a"";
             }.RunAsync();
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
-        public async Task TestTakeTop_TopInString_WithBaseline()
-        {
-            var source = @"
-class X {
-  void x() {
-    var x = @""
-<<<<<<< working copy
-a"";
-{|CS8300:||||||||} baseline
-previous"";
-{|CS8300:=======|}
-b"";
-{|CS8300:>>>>>>>|} merge rev
-  }
-}";
-            var fixedSource = @"
-class X {
-  void x() {
-    var x = @""
-a"";
-  }
-}";
-
-            await new VerifyCS.Test
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-                NumberOfIncrementalIterations = 1,
-                CodeActionIndex = 0,
-                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
-            }.RunAsync();
-        }
-
         [WorkItem(23847, "https://github.com/dotnet/roslyn/issues/23847")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
         public async Task TestTakeBottom_TopInString()
@@ -1145,61 +681,11 @@ b"";
             }.RunAsync();
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
-        public async Task TestTakeBottom_TopInString_WithBaseline()
-        {
-            var source = @"
-class X {
-  void x() {
-    var x = @""
-<<<<<<< working copy
-a"";
-{|CS8300:||||||||} baseline
-previous"";
-{|CS8300:=======|}
-b"";
-{|CS8300:>>>>>>>|} merge rev
-  }
-}";
-            var fixedSource = @"
-class X {
-  void x() {
-    var x = @""
-b"";
-  }
-}";
-
-            await new VerifyCS.Test
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-                NumberOfIncrementalIterations = 1,
-                CodeActionIndex = 1,
-                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey,
-            }.RunAsync();
-        }
-
         [WorkItem(23847, "https://github.com/dotnet/roslyn/issues/23847")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
         public async Task TestMissingWithMiddleMarkerAtTopOfFile()
         {
             var source = @"{|CS8300:=======|}
-class X {
-}
-{|CS8300:>>>>>>>|} merge rev";
-
-            await new VerifyCS.Test
-            {
-                TestCode = source,
-                FixedCode = source,
-            }.RunAsync();
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
-        public async Task TestMissingWithFirstMiddleMarkerAtTopOfFile()
-        {
-            var source = @"{|CS8300:||||||||} baseline
-{|CS8300:=======|}
 class X {
 }
 {|CS8300:>>>>>>>|} merge rev";
@@ -1295,62 +781,6 @@ namespace N
             }.RunAsync();
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
-        public async Task TestFixAll1_WithBaseline()
-        {
-            var source = @"
-using System;
-
-namespace N
-{
-{|CS8300:<<<<<<<|} This is mine!
-    class Program
-    {
-    }
-{|CS8300:||||||||} baseline
-    class Removed { }
-{|CS8300:=======|}
-    class Program2
-    {
-    }
-{|CS8300:>>>>>>>|} This is theirs!
-
-{|CS8300:<<<<<<<|} This is mine!
-    class Program3
-    {
-    }
-{|CS8300:||||||||} baseline
-    class Removed2 { }
-{|CS8300:=======|}
-    class Program4
-    {
-    }
-{|CS8300:>>>>>>>|} This is theirs!
-}";
-            var fixedSource = @"
-using System;
-
-namespace N
-{
-    class Program
-    {
-    }
-
-    class Program3
-    {
-    }
-}";
-
-            await new VerifyCS.Test
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-                NumberOfIncrementalIterations = 2,
-                CodeActionIndex = 0,
-                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
-            }.RunAsync();
-        }
-
         [WorkItem(21107, "https://github.com/dotnet/roslyn/issues/21107")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
         public async Task TestFixAll2()
@@ -1374,62 +804,6 @@ namespace N
     class Program3
     {
     }
-{|CS8300:=======|}
-    class Program4
-    {
-    }
-{|CS8300:>>>>>>>|} This is theirs!
-}";
-            var fixedSource = @"
-using System;
-
-namespace N
-{
-    class Program2
-    {
-    }
-
-    class Program4
-    {
-    }
-}";
-
-            await new VerifyCS.Test
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-                NumberOfIncrementalIterations = 2,
-                CodeActionIndex = 1,
-                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey,
-            }.RunAsync();
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
-        public async Task TestFixAll2_WithBaseline()
-        {
-            var source = @"
-using System;
-
-namespace N
-{
-{|CS8300:<<<<<<<|} This is mine!
-    class Program
-    {
-    }
-{|CS8300:||||||||} baseline
-    class Removed { }
-{|CS8300:=======|}
-    class Program2
-    {
-    }
-{|CS8300:>>>>>>>|} This is theirs!
-
-{|CS8300:<<<<<<<|} This is mine!
-    class Program3
-    {
-    }
-{|CS8300:||||||||} baseline
-    class Removed2 { }
 {|CS8300:=======|}
     class Program4
     {
@@ -1516,6 +890,632 @@ namespace N
                 NumberOfIncrementalIterations = 2,
                 CodeActionIndex = 2,
                 CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBothEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestTakeTop_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+{|CS8300:||||||||} Baseline!
+    class Removed { }
+{|CS8300:=======|}
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestTakeBottom1_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+{|CS8300:||||||||} Baseline!
+    class Removed { }
+{|CS8300:=======|}
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestTakeBoth1_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+{|CS8300:||||||||} Baseline!
+    class Removed { }
+{|CS8300:=======|}
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 2,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBothEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestEmptyTop_TakeTop_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+{|CS8300:||||||||} Baseline!
+    class Removed { }
+{|CS8300:=======|}
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestEmptyTop_TakeBottom_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+{|CS8300:||||||||} Baseline!
+    class Removed { }
+{|CS8300:=======|}
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+    class Program2
+    {
+        static void Main2(string[] args)
+        {
+            Program2 p;
+            Console.WriteLine(""Their section"");
+        }
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestEmptyBottom_TakeTop_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+{|CS8300:||||||||} Baseline!
+    class Removed { }
+{|CS8300:=======|}
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestEmptyBottom_TakeBottom_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program p;
+            Console.WriteLine(""My section"");
+        }
+    }
+{|CS8300:||||||||} Baseline!
+    class Removed { }
+{|CS8300:=======|}
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestTakeTop_TopCommentedOut_WithBaseline()
+        {
+            var source = @"
+public class Class1
+{
+    public void M()
+    {
+        /*
+<<<<<<< dest
+         * a thing
+         */
+{|CS8300:||||||||} Baseline!
+         * previous thing
+         */
+{|CS8300:=======|}
+         * another thing
+         */
+{|CS8300:>>>>>>>|} source
+        // */
+    }
+}";
+            var fixedSource = @"
+public class Class1
+{
+    public void M()
+    {
+        /*
+         * a thing
+         */
+        // */
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestTakeTop_FirstMiddleAndSecondMiddleAndBottomCommentedOut()
+        {
+            var source = @"
+public class Class1
+{
+    public void M()
+    {
+{|CS8300:<<<<<<<|} dest
+        /*
+         * a thing
+|||||||| Baseline!
+         * previous thing
+=======
+         *
+         * another thing
+>>>>>>> source
+         */
+    }
+}";
+            var fixedSource = @"
+public class Class1
+{
+    public void M()
+    {
+        /*
+         * a thing
+         */
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestTakeTop_TopInString_WithBaseline()
+        {
+            var source = @"
+class X {
+  void x() {
+    var x = @""
+<<<<<<< working copy
+a"";
+{|CS8300:||||||||} baseline
+previous"";
+{|CS8300:=======|}
+b"";
+{|CS8300:>>>>>>>|} merge rev
+  }
+}";
+            var fixedSource = @"
+class X {
+  void x() {
+    var x = @""
+a"";
+  }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestTakeBottom_TopInString_WithBaseline()
+        {
+            var source = @"
+class X {
+  void x() {
+    var x = @""
+<<<<<<< working copy
+a"";
+{|CS8300:||||||||} baseline
+previous"";
+{|CS8300:=======|}
+b"";
+{|CS8300:>>>>>>>|} merge rev
+  }
+}";
+            var fixedSource = @"
+class X {
+  void x() {
+    var x = @""
+b"";
+  }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 1,
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestMissingWithFirstMiddleMarkerAtTopOfFile()
+        {
+            var source = @"{|CS8300:||||||||} baseline
+{|CS8300:=======|}
+class X {
+}
+{|CS8300:>>>>>>>|} merge rev";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = source,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestFixAll1_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+    class Program
+    {
+    }
+{|CS8300:||||||||} baseline
+    class Removed { }
+{|CS8300:=======|}
+    class Program2
+    {
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+
+{|CS8300:<<<<<<<|} This is mine!
+    class Program3
+    {
+    }
+{|CS8300:||||||||} baseline
+    class Removed2 { }
+{|CS8300:=======|}
+    class Program4
+    {
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+    class Program
+    {
+    }
+
+    class Program3
+    {
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 2,
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey,
+            }.RunAsync();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)]
+        public async Task TestFixAll2_WithBaseline()
+        {
+            var source = @"
+using System;
+
+namespace N
+{
+{|CS8300:<<<<<<<|} This is mine!
+    class Program
+    {
+    }
+{|CS8300:||||||||} baseline
+    class Removed { }
+{|CS8300:=======|}
+    class Program2
+    {
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+
+{|CS8300:<<<<<<<|} This is mine!
+    class Program3
+    {
+    }
+{|CS8300:||||||||} baseline
+    class Removed2 { }
+{|CS8300:=======|}
+    class Program4
+    {
+    }
+{|CS8300:>>>>>>>|} This is theirs!
+}";
+            var fixedSource = @"
+using System;
+
+namespace N
+{
+    class Program2
+    {
+    }
+
+    class Program4
+    {
+    }
+}";
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                NumberOfIncrementalIterations = 2,
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey,
             }.RunAsync();
         }
 

--- a/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
@@ -5182,6 +5182,44 @@ end interface"
         End Function
 
         <Theory, CombinatorialData>
+        Public Async Function TestConflictMarkers2(testHost As TestHost) As Task
+            Dim code =
+"interface I
+<<<<<<< Start
+    sub Goo()
+||||||| Baseline
+    sub Removed()
+=======
+    sub Bar()
+>>>>>>> End
+end interface"
+
+            Await TestAsync(
+                code,
+                testHost,
+                Keyword("interface"),
+                [Interface]("I"),
+                Comment("<<<<<<< Start"),
+                Keyword("sub"),
+                Method("Goo"),
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Comment("||||||| Baseline"),
+                Keyword("sub"),
+                Identifier("Removed"),
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Comment("======="),
+                Keyword("sub"),
+                Identifier("Bar"),
+                Punctuation.OpenParen,
+                Punctuation.CloseParen,
+                Comment(">>>>>>> End"),
+                Keyword("end"),
+                Keyword("interface"))
+        End Function
+
+        <Theory, CombinatorialData>
         Public Async Function TestConstField(testHost As TestHost) As Task
             Dim code = "Const Number = 42"
 

--- a/src/EditorFeatures/VisualBasicTest/ConflictMarkerResolution/ConflictMarkerResolutionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConflictMarkerResolution/ConflictMarkerResolutionTests.vb
@@ -289,5 +289,6 @@ end namespace"
                 .CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBothEquivalenceKey
             }.RunAsync()
         End Function
+        ' TODO2 test in VB too
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/ConflictMarkerResolution/ConflictMarkerResolutionTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConflictMarkerResolution/ConflictMarkerResolutionTests.vb
@@ -289,6 +289,309 @@ end namespace"
                 .CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBothEquivalenceKey
             }.RunAsync()
         End Function
-        ' TODO2 test in VB too
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)>
+        Public Async Function TestTakeTop1_WithBaseline() As Task
+            Dim source =
+"
+imports System
+
+namespace N
+{|BC37284:<<<<<<< This is mine!|}
+    class Program
+        sub Main()
+            dim p as Program
+            Console.WriteLine(""My section"")
+        end sub
+    end class
+{|BC37284:||||||| Baseline|}
+    class Removed
+    end class
+{|BC37284:=======|}
+    class Program2
+        sub Main2()
+            dim p as Program2
+            Console.WriteLine(""Their section"")
+        end sub
+    end class
+{|BC37284:>>>>>>> This is theirs!|}
+end namespace"
+            Dim fixedSource = "
+imports System
+
+namespace N
+    class Program
+        sub Main()
+            dim p as Program
+            Console.WriteLine(""My section"")
+        end sub
+    end class
+end namespace"
+
+            Await New VerifyVB.Test With
+            {
+                .TestCode = source,
+                .FixedCode = fixedSource,
+                .NumberOfIncrementalIterations = 1,
+                .CodeActionIndex = 0,
+                .CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey
+            }.RunAsync()
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)>
+        Public Async Function TestTakeBottom1_WithBaseline() As Task
+            Dim source =
+"
+imports System
+
+namespace N
+{|BC37284:<<<<<<< This is mine!|}
+    class Program
+        sub Main()
+            dim p as Program
+            Console.WriteLine(""My section"")
+        end sub
+    end class
+{|BC37284:||||||| Baseline|}
+    class Removed
+    end class
+{|BC37284:=======|}
+    class Program2
+        sub Main2()
+            dim p as Program2
+            Console.WriteLine(""Their section"")
+        end sub
+    end class
+{|BC37284:>>>>>>> This is theirs!|}
+end namespace"
+            Dim fixedSource = "
+imports System
+
+namespace N
+    class Program2
+        sub Main2()
+            dim p as Program2
+            Console.WriteLine(""Their section"")
+        end sub
+    end class
+end namespace"
+
+            Await New VerifyVB.Test With
+            {
+                .TestCode = source,
+                .FixedCode = fixedSource,
+                .NumberOfIncrementalIterations = 1,
+                .CodeActionIndex = 1,
+                .CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey
+            }.RunAsync()
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)>
+        Public Async Function TestTakeBoth1_WithBaseline() As Task
+            Dim source =
+"
+imports System
+
+namespace N
+{|BC37284:<<<<<<< This is mine!|}
+    class Program
+        sub Main()
+            dim p as Program
+            Console.WriteLine(""My section"")
+        end sub
+    end class
+{|BC37284:||||||| Baseline|}
+    class Removed
+    end class
+{|BC37284:=======|}
+    class Program2
+        sub Main2()
+            dim p as Program2
+            Console.WriteLine(""Their section"")
+        end sub
+    end class
+{|BC37284:>>>>>>> This is theirs!|}
+end namespace"
+            Dim fixedSource = "
+imports System
+
+namespace N
+    class Program
+        sub Main()
+            dim p as Program
+            Console.WriteLine(""My section"")
+        end sub
+    end class
+    class Program2
+        sub Main2()
+            dim p as Program2
+            Console.WriteLine(""Their section"")
+        end sub
+    end class
+end namespace"
+
+            Await New VerifyVB.Test With
+            {
+                .TestCode = source,
+                .FixedCode = fixedSource,
+                .NumberOfIncrementalIterations = 1,
+                .CodeActionIndex = 2,
+                .CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBothEquivalenceKey
+            }.RunAsync()
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)>
+        Public Async Function TestFixAll1_WithBaseline() As Task
+            Dim source =
+"
+imports System
+
+namespace N
+{|BC37284:<<<<<<< This is mine!|}
+    class Program
+    end class
+{|BC37284:||||||| Baseline|}
+    class Removed 
+    end class
+{|BC37284:=======|}
+    class Program2
+    end class
+{|BC37284:>>>>>>> This is theirs!|}
+
+{|BC37284:<<<<<<< This is mine!|}
+    class Program3
+    end class
+{|BC37284:||||||| Baseline|}
+    class Removed2
+    end class
+{|BC37284:=======|}
+    class Program4
+    end class
+{|BC37284:>>>>>>> This is theirs!|}
+end namespace"
+            Dim fixedSource = "
+imports System
+
+namespace N
+    class Program
+    end class
+
+    class Program3
+    end class
+end namespace"
+
+            Await New VerifyVB.Test With
+            {
+                .TestCode = source,
+                .FixedCode = fixedSource,
+                .NumberOfIncrementalIterations = 2,
+                .CodeActionIndex = 0,
+                .CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeTopEquivalenceKey
+            }.RunAsync()
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)>
+        Public Async Function TestFixAll2_WithBaseline() As Task
+            Dim source =
+"
+imports System
+
+namespace N
+{|BC37284:<<<<<<< This is mine!|}
+    class Program
+    end class
+{|BC37284:||||||||}
+    class Removed
+    end class
+{|BC37284:=======|}
+    class Program2
+    end class
+{|BC37284:>>>>>>> This is theirs!|}
+
+{|BC37284:<<<<<<< This is mine!|}
+    class Program3
+    end class
+{|BC37284:||||||||}
+    class Removed2
+    end class
+{|BC37284:=======|}
+    class Program4
+    end class
+{|BC37284:>>>>>>> This is theirs!|}
+end namespace"
+            Dim fixedSource = "
+imports System
+
+namespace N
+    class Program2
+    end class
+
+    class Program4
+    end class
+end namespace"
+
+            Await New VerifyVB.Test With
+            {
+                .TestCode = source,
+                .FixedCode = fixedSource,
+                .NumberOfIncrementalIterations = 2,
+                .CodeActionIndex = 1,
+                .CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBottomEquivalenceKey
+            }.RunAsync()
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsResolveConflictMarker)>
+        Public Async Function TestFixAll3_WithBaseline() As Task
+            Dim source =
+"
+imports System
+
+namespace N
+{|BC37284:<<<<<<< This is mine!|}
+    class Program
+    end class
+{|BC37284:||||||| Baseline|}
+    class Removed
+    end class
+{|BC37284:=======|}
+    class Program2
+    end class
+{|BC37284:>>>>>>> This is theirs!|}
+
+{|BC37284:<<<<<<< This is mine!|}
+    class Program3
+    end class
+{|BC37284:||||||| Baseline|}
+    class Removed2
+    end class
+{|BC37284:=======|}
+    class Program4
+    end class
+{|BC37284:>>>>>>> This is theirs!|}
+end namespace"
+            Dim fixedSource = "
+imports System
+
+namespace N
+    class Program
+    end class
+    class Program2
+    end class
+
+    class Program3
+    end class
+    class Program4
+    end class
+end namespace"
+
+            Await New VerifyVB.Test With
+            {
+                .TestCode = source,
+                .FixedCode = fixedSource,
+                .NumberOfIncrementalIterations = 2,
+                .CodeActionIndex = 2,
+                .CodeActionEquivalenceKey = AbstractResolveConflictMarkerCodeFixProvider.TakeBothEquivalenceKey
+            }.RunAsync()
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/ConflictMarkerResolution/AbstractConflictMarkerCodeFixProvider.cs
+++ b/src/Features/Core/Portable/ConflictMarkerResolution/AbstractConflictMarkerCodeFixProvider.cs
@@ -56,18 +56,19 @@ namespace Microsoft.CodeAnalysis.ConflictMarkerResolution
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             var position = context.Span.Start;
-            if (!ShouldFix(root, text, position, out var startLine, out var middleLine, out var endLine))
+            if (!ShouldFix(root, text, position, out var startLine, out var firstMiddleLine, out var secondMiddleLine, out var endLine))
                 return;
 
-            RegisterCodeFixes(context, startLine, middleLine, endLine);
+            RegisterCodeFixes(context, startLine, firstMiddleLine, secondMiddleLine, endLine);
         }
 
         private bool ShouldFix(
             SyntaxNode root, SourceText text, int position,
-            out TextLine startLine, out TextLine middleLine, out TextLine endLine)
+            out TextLine startLine, out TextLine firstMiddleLine, out TextLine secondMiddleLine, out TextLine endLine)
         {
             startLine = default;
-            middleLine = default;
+            firstMiddleLine = default;
+            secondMiddleLine = default;
             endLine = default;
 
             var lines = text.Lines;
@@ -78,27 +79,40 @@ namespace Microsoft.CodeAnalysis.ConflictMarkerResolution
                 return false;
             }
 
-            if (!TryGetConflictLines(text, position, out startLine, out middleLine, out endLine))
+            if (!TryGetConflictLines(text, position, out startLine, out firstMiddleLine, out secondMiddleLine, out endLine))
                 return false;
 
             var startTrivia = root.FindTrivia(startLine.Start);
-            var middleTrivia = root.FindTrivia(middleLine.Start);
+            var firstMiddleTrivia = root.FindTrivia(firstMiddleLine.Start);
+            var secondMiddleTrivia = root.FindTrivia(secondMiddleLine.Start);
 
-            if (position == middleLine.Start)
+            if (position == firstMiddleLine.Start)
             {
-                // we were on the ======= lines.  We only want to report here if there was no
+                // we were on the ||||||| lines.  We only want to report here if there was no
                 // conflict trivia on the <<<<<<< line (since we would have already reported the
                 // issue there.
                 if (startTrivia.RawKind == _syntaxKinds.ConflictMarkerTrivia)
                     return false;
             }
+            else if (position == secondMiddleLine.Start)
+            {
+                // we were on the ======= lines.  We only want to report here if there was no
+                // conflict trivia on the ||||||| or  <<<<<<< line (since we would have already reported the
+                // issue there.
+                if (startTrivia.RawKind == _syntaxKinds.ConflictMarkerTrivia ||
+                    (firstMiddleLine != secondMiddleLine && firstMiddleTrivia.RawKind == _syntaxKinds.ConflictMarkerTrivia))
+                {
+                    return false;
+                }
+            }
             else if (position == endLine.Start)
             {
                 // we were on the >>>>>>> lines.  We only want to report here if there was no
-                // conflict trivia on the ======= or <<<<<<< line (since we would have already reported the
+                // conflict trivia on the ||||||| or ======= or <<<<<<< line (since we would have already reported the
                 // issue there.
                 if (startTrivia.RawKind == _syntaxKinds.ConflictMarkerTrivia ||
-                    middleTrivia.RawKind == _syntaxKinds.ConflictMarkerTrivia)
+                    (firstMiddleLine != secondMiddleLine && firstMiddleTrivia.RawKind == _syntaxKinds.ConflictMarkerTrivia) ||
+                    secondMiddleTrivia.RawKind == _syntaxKinds.ConflictMarkerTrivia)
                 {
                     return false;
                 }
@@ -109,27 +123,66 @@ namespace Microsoft.CodeAnalysis.ConflictMarkerResolution
 
         private static bool TryGetConflictLines(
             SourceText text, int position,
-            out TextLine startLine, out TextLine middleLine, out TextLine endLine)
+            out TextLine startLine, out TextLine firstMiddleLine, out TextLine secondMiddleLine, out TextLine endLine)
         {
             startLine = default;
-            middleLine = default;
+            firstMiddleLine = default;
+            secondMiddleLine = default;
             endLine = default;
 
             var lines = text.Lines;
+            bool foundBarLine;
+            bool success;
             switch (text[position])
             {
                 case '<':
                     startLine = lines.GetLineFromPosition(position);
-                    return TryFindLineForwards(startLine, '=', out middleLine) &&
-                           TryFindLineForwards(middleLine, '>', out endLine);
+                    foundBarLine = TryFindLineForwards(startLine, '|', out firstMiddleLine);
+
+                    success = TryFindLineForwards(foundBarLine ? firstMiddleLine : startLine, '=', out secondMiddleLine) &&
+                              TryFindLineForwards(secondMiddleLine, '>', out endLine);
+
+                    if (success && !foundBarLine)
+                    {
+                        firstMiddleLine = secondMiddleLine;
+                    }
+
+                    return success;
+                case '|':
+                    firstMiddleLine = lines.GetLineFromPosition(position);
+                    return TryFindLineBackwards(firstMiddleLine, '<', out startLine) &&
+                           TryFindLineForwards(firstMiddleLine, '=', out secondMiddleLine) &&
+                           TryFindLineForwards(secondMiddleLine, '>', out endLine);
                 case '=':
-                    middleLine = lines.GetLineFromPosition(position);
-                    return TryFindLineBackwards(middleLine, '<', out startLine) &&
-                           TryFindLineForwards(middleLine, '>', out endLine);
+                    secondMiddleLine = lines.GetLineFromPosition(position);
+                    foundBarLine = TryFindLineBackwards(secondMiddleLine, '|', out firstMiddleLine);
+
+                    success = TryFindLineBackwards(foundBarLine ? firstMiddleLine : secondMiddleLine, '<', out startLine) &&
+                              TryFindLineForwards(secondMiddleLine, '>', out endLine);
+
+                    if (success && !foundBarLine)
+                    {
+                        firstMiddleLine = secondMiddleLine;
+                    }
+
+                    return success;
                 case '>':
                     endLine = lines.GetLineFromPosition(position);
-                    return TryFindLineBackwards(endLine, '=', out middleLine) &&
-                           TryFindLineBackwards(middleLine, '<', out startLine);
+                    if (!TryFindLineBackwards(endLine, '=', out secondMiddleLine))
+                    {
+                        return false;
+                    }
+
+                    foundBarLine = TryFindLineBackwards(secondMiddleLine, '|', out firstMiddleLine);
+
+                    success = TryFindLineBackwards(secondMiddleLine, '<', out startLine);
+
+                    if (success && !foundBarLine)
+                    {
+                        firstMiddleLine = secondMiddleLine;
+                    }
+
+                    return success;
                 default:
                     throw ExceptionUtilities.UnexpectedValue(text[position]);
             }
@@ -193,7 +246,7 @@ namespace Microsoft.CodeAnalysis.ConflictMarkerResolution
         }
 
         private static void RegisterCodeFixes(
-            CodeFixContext context, TextLine startLine, TextLine middleLine, TextLine endLine)
+            CodeFixContext context, TextLine startLine, TextLine firstMiddleLine, TextLine secondMiddleLine, TextLine endLine)
         {
             var document = context.Document;
 
@@ -208,35 +261,36 @@ namespace Microsoft.CodeAnalysis.ConflictMarkerResolution
                 : string.Format(FeaturesResources.Take_0, bottomText);
 
             var startPos = startLine.Start;
-            var equalsPos = middleLine.Start;
+            var firstMiddlePos = firstMiddleLine.Start;
+            var secondMiddlePos = secondMiddleLine.Start;
             var endPos = endLine.Start;
 
             context.RegisterCodeFix(
                 CodeAction.Create(takeTopText,
-                    c => TakeTopAsync(document, startPos, equalsPos, endPos, c),
+                    c => TakeTopAsync(document, startPos, firstMiddlePos, secondMiddlePos, endPos, c),
                     TakeTopEquivalenceKey),
                 context.Diagnostics);
             context.RegisterCodeFix(
                 CodeAction.Create(takeBottomText,
-                    c => TakeBottomAsync(document, startPos, equalsPos, endPos, c),
+                    c => TakeBottomAsync(document, startPos, firstMiddlePos, secondMiddlePos, endPos, c),
                     TakeBottomEquivalenceKey),
                 context.Diagnostics);
             context.RegisterCodeFix(
                 CodeAction.Create(FeaturesResources.Take_both,
-                    c => TakeBothAsync(document, startPos, equalsPos, endPos, c),
+                    c => TakeBothAsync(document, startPos, firstMiddlePos, secondMiddlePos, endPos, c),
                     TakeBothEquivalenceKey),
                 context.Diagnostics);
         }
 
         private static async Task<Document> AddEditsAsync(
-            Document document, int startPos, int equalsPos, int endPos,
-            Action<SourceText, ArrayBuilder<TextChange>, int, int, int> addEdits,
+            Document document, int startPos, int firstMiddlePos, int secondMiddlePos, int endPos,
+            Action<SourceText, ArrayBuilder<TextChange>, int, int, int, int> addEdits,
             CancellationToken cancellationToken)
         {
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             using var _ = ArrayBuilder<TextChange>.GetInstance(out var edits);
-            addEdits(text, edits, startPos, equalsPos, endPos);
+            addEdits(text, edits, startPos, firstMiddlePos, secondMiddlePos, endPos);
 
             var finalText = text.WithChanges(edits);
             return document.WithText(finalText);
@@ -244,23 +298,23 @@ namespace Microsoft.CodeAnalysis.ConflictMarkerResolution
 
         private static void AddTopEdits(
             SourceText text, ArrayBuilder<TextChange> edits,
-            int startPos, int equalsPos, int endPos)
+            int startPos, int firstMiddlePos, int secondMiddlePos, int endPos)
         {
             // Delete the line containing <<<<<<<
             var startEnd = GetEndIncludingLineBreak(text, startPos);
             edits.Add(new TextChange(TextSpan.FromBounds(startPos, startEnd), ""));
 
-            // Remove the chunk of text (inclusive) from ======= through >>>>>>>
+            // Remove the chunk of text (inclusive) from ||||||| or ======= through >>>>>>>
             var bottomEnd = GetEndIncludingLineBreak(text, endPos);
-            edits.Add(new TextChange(TextSpan.FromBounds(equalsPos, bottomEnd), ""));
+            edits.Add(new TextChange(TextSpan.FromBounds(firstMiddlePos, bottomEnd), ""));
         }
 
         private static void AddBottomEdits(
             SourceText text, ArrayBuilder<TextChange> edits,
-            int startPos, int equalsPos, int endPos)
+            int startPos, int firstMiddlePos, int secondMiddlePos, int endPos)
         {
             // Remove the chunk of text (inclusive) from <<<<<<< through =======
-            var equalsEnd = GetEndIncludingLineBreak(text, equalsPos);
+            var equalsEnd = GetEndIncludingLineBreak(text, secondMiddlePos);
             edits.Add(new TextChange(TextSpan.FromBounds(startPos, equalsEnd), ""));
 
             // Delete the line containing >>>>>>> 
@@ -270,29 +324,38 @@ namespace Microsoft.CodeAnalysis.ConflictMarkerResolution
 
         private static void AddBothEdits(
             SourceText text, ArrayBuilder<TextChange> edits,
-            int startPos, int equalsPos, int endPos)
+            int startPos, int firstMiddlePos, int secondMiddlePos, int endPos)
         {
             // Delete the line containing <<<<<<<
             var startEnd = GetEndIncludingLineBreak(text, startPos);
             edits.Add(new TextChange(TextSpan.FromBounds(startPos, startEnd), ""));
 
-            // Delete the line containing =======
-            var equalsEnd = GetEndIncludingLineBreak(text, equalsPos);
-            edits.Add(new TextChange(TextSpan.FromBounds(equalsPos, equalsEnd), ""));
+            if (firstMiddlePos == secondMiddlePos)
+            {
+                // Delete the line containing =======
+                var equalsEnd = GetEndIncludingLineBreak(text, secondMiddlePos);
+                edits.Add(new TextChange(TextSpan.FromBounds(secondMiddlePos, equalsEnd), ""));
+            }
+            else
+            {
+                // Remove the chunk of text (inclusive) from ||||||| through =======
+                var equalsEnd = GetEndIncludingLineBreak(text, secondMiddlePos);
+                edits.Add(new TextChange(TextSpan.FromBounds(firstMiddlePos, equalsEnd), ""));
+            }
 
             // Delete the line containing >>>>>>>
             var bottomEnd = GetEndIncludingLineBreak(text, endPos);
             edits.Add(new TextChange(TextSpan.FromBounds(endPos, bottomEnd), ""));
         }
 
-        private static Task<Document> TakeTopAsync(Document document, int startPos, int equalsPos, int endPos, CancellationToken cancellationToken)
-            => AddEditsAsync(document, startPos, equalsPos, endPos, AddTopEdits, cancellationToken);
+        private static Task<Document> TakeTopAsync(Document document, int startPos, int firstMiddlePos, int secondMiddlePos, int endPos, CancellationToken cancellationToken)
+            => AddEditsAsync(document, startPos, firstMiddlePos, secondMiddlePos, endPos, AddTopEdits, cancellationToken);
 
-        private static Task<Document> TakeBottomAsync(Document document, int startPos, int equalsPos, int endPos, CancellationToken cancellationToken)
-            => AddEditsAsync(document, startPos, equalsPos, endPos, AddBottomEdits, cancellationToken);
+        private static Task<Document> TakeBottomAsync(Document document, int startPos, int firstMiddlePos, int secondMiddlePos, int endPos, CancellationToken cancellationToken)
+            => AddEditsAsync(document, startPos, firstMiddlePos, secondMiddlePos, endPos, AddBottomEdits, cancellationToken);
 
-        private static Task<Document> TakeBothAsync(Document document, int startPos, int equalsPos, int endPos, CancellationToken cancellationToken)
-            => AddEditsAsync(document, startPos, equalsPos, endPos, AddBothEdits, cancellationToken);
+        private static Task<Document> TakeBothAsync(Document document, int startPos, int firstMiddlePos, int secondMiddlePos, int endPos, CancellationToken cancellationToken)
+            => AddEditsAsync(document, startPos, firstMiddlePos, secondMiddlePos, endPos, AddBothEdits, cancellationToken);
 
         private static int GetEndIncludingLineBreak(SourceText text, int position)
             => text.Lines.GetLineFromPosition(position).SpanIncludingLineBreak.End;
@@ -322,25 +385,26 @@ namespace Microsoft.CodeAnalysis.ConflictMarkerResolution
             foreach (var diagnostic in diagnostics)
             {
                 var position = diagnostic.Location.SourceSpan.Start;
-                if (!ShouldFix(root, text, position, out var startLine, out var middleLine, out var endLine))
+                if (!ShouldFix(root, text, position, out var startLine, out var firstMiddleLine, out var secondMiddleLine, out var endLine))
                     continue;
 
                 var startPos = startLine.Start;
-                var equalsPos = middleLine.Start;
+                var firstMiddlePos = firstMiddleLine.Start;
+                var secondMiddlePos = secondMiddleLine.Start;
                 var endPos = endLine.Start;
 
                 switch (equivalenceKey)
                 {
                     case TakeTopEquivalenceKey:
-                        AddTopEdits(text, edits, startPos, equalsPos, endPos);
+                        AddTopEdits(text, edits, startPos, firstMiddlePos, secondMiddlePos, endPos);
                         continue;
 
                     case TakeBottomEquivalenceKey:
-                        AddBottomEdits(text, edits, startPos, equalsPos, endPos);
+                        AddBottomEdits(text, edits, startPos, firstMiddlePos, secondMiddlePos, endPos);
                         continue;
 
                     case TakeBothEquivalenceKey:
-                        AddBothEdits(text, edits, startPos, equalsPos, endPos);
+                        AddBothEdits(text, edits, startPos, firstMiddlePos, secondMiddlePos, endPos);
                         continue;
 
                     default:


### PR DESCRIPTION
Extends our [support](https://github.com/dotnet/roslyn/pull/15850) for diff markers in source to diff3 format (which adds a '|||||||' conflict marker).
Recent example of diff3: https://github.com/dotnet/roslyn/commit/80bdf2453604d088f294d4fc1963033446ff1f53
`git config --global merge.conflictstyle diff3`
