### PR TITLE
Add array initialization optimization

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -1956,6 +1956,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
             else
             {
+                EmitArrayIndices(expression.Bounds);
                 _builder.EmitArrayCreation(_module.Translate(arrayType), expression.Syntax, _diagnostics);
             }
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -1564,7 +1564,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         private void EmitStaticCallExpression(BoundCall call, UseKind useKind)
         {
             var method = call.Method;
-            var receiver = call.ReceiverOpt ?? null;
+            var receiver = call.ReceiverOpt;
             var arguments = call.Arguments;
 
             EmitStaticCall(method, receiver, arguments, useKind, call.Syntax, call.ArgumentRefKindsOpt);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -2012,7 +2012,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 if (!used && ConstructorNotSideEffecting(constructor))
                 {
                     // ctor has no side-effects, so we will just evaluate the arguments
-
                     foreach (var arg in expression.Arguments)
                     {
                         EmitExpression(arg, used: false);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -1534,35 +1534,40 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             FreeOptTemp(tempOpt);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private void EmitStaticCallExpression(BoundCall call, UseKind useKind)
+        private void EmitStaticCall(MethodSymbol method, BoundExpression receiverOpt, ImmutableArray<BoundExpression> arguments, UseKind useKind, SyntaxNode syntax, ImmutableArray<RefKind> refKindsOpt)
         {
-            var method = call.Method;
-            var receiver = call.ReceiverOpt;
-            var arguments = call.Arguments;
-
             Debug.Assert(method.IsStatic);
 
-            EmitArguments(arguments, method.Parameters, call.ArgumentRefKindsOpt);
+            EmitArguments(arguments, method.Parameters, refKindsOpt);
             int stackBehavior = GetCallStackBehavior(method, arguments);
 
             if (method.IsAbstract || method.IsVirtual)
             {
-                if (receiver is not BoundTypeExpression { Type: { TypeKind: TypeKind.TypeParameter } })
+                if (receiverOpt is not BoundTypeExpression { Type.TypeKind: TypeKind.TypeParameter })
                 {
                     throw ExceptionUtilities.Unreachable;
                 }
 
                 _builder.EmitOpCode(ILOpCode.Constrained);
-                EmitSymbolToken(receiver.Type, receiver.Syntax);
+                EmitSymbolToken(receiverOpt.Type, receiverOpt.Syntax);
             }
 
             _builder.EmitOpCode(ILOpCode.Call, stackBehavior);
 
-            EmitSymbolToken(method, call.Syntax,
-                            method.IsVararg ? (BoundArgListOperator)arguments[arguments.Length - 1] : null);
+            EmitSymbolToken(method, syntax,
+                            method.IsVararg ? (BoundArgListOperator)arguments[^1] : null);
 
-            EmitCallCleanup(call.Syntax, useKind, method);
+            EmitCallCleanup(syntax, useKind, method);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void EmitStaticCallExpression(BoundCall call, UseKind useKind)
+        {
+            var method = call.Method;
+            var receiver = call.ReceiverOpt ?? null;
+            var arguments = call.Arguments;
+
+            EmitStaticCall(method, receiver, arguments, useKind, call.Syntax, call.ArgumentRefKindsOpt);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -1917,16 +1922,37 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             EmitPopIfUnused(used);
         }
 
+        private void EmitUninitializedArrayCreation(BoundArrayCreation expression, SyntaxNode syntax, MethodSymbol allocUninitialized)
+        {
+            var arrLen = ConstantValue.Create(expression.InitializerOpt.Initializers.Length);
+            var pinned = ConstantValue.Create(false);
+
+            var arg1 = new BoundLiteral(syntax, arrLen, _module.Compilation.GetSpecialType(SpecialType.System_Int32));
+            var arg2 = new BoundLiteral(syntax, pinned, _module.Compilation.GetSpecialType(SpecialType.System_Boolean));
+
+            var arguments = ImmutableArray.Create<BoundExpression>(arg1, arg2);
+
+            EmitStaticCall(allocUninitialized, null, arguments, UseKind.UsedAsValue, syntax,
+                                ImmutableArray.Create(RefKind.None, RefKind.None));
+        }
+
         private void EmitArrayCreationExpression(BoundArrayCreation expression, bool used)
         {
             var arrayType = (ArrayTypeSymbol)expression.Type;
-
-            EmitArrayIndices(expression.Bounds);
-
             if (arrayType.IsSZArray)
             {
-                _builder.EmitOpCode(ILOpCode.Newarr);
-                EmitSymbolToken(arrayType.ElementType, expression.Syntax);
+                var allocUninitialized = _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_GC__AllocateUninitializedArray_T);
+                if (expression.InitializerOpt != null && allocUninitialized is MethodSymbol { } alloc)
+                {
+                    var constructed = alloc.Construct(ImmutableArray.Create(arrayType.ElementType));
+                    EmitUninitializedArrayCreation(expression, expression.Syntax, constructed);
+                }
+                else
+                {
+                    EmitArrayIndices(expression.Bounds);
+                    _builder.EmitOpCode(ILOpCode.Newarr);
+                    EmitSymbolToken(arrayType.ElementType, expression.Syntax);
+                }
             }
             else
             {
@@ -1985,6 +2011,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 if (!used && ConstructorNotSideEffecting(constructor))
                 {
                     // ctor has no side-effects, so we will just evaluate the arguments
+
                     foreach (var arg in expression.Arguments)
                     {
                         EmitExpression(arg, used: false);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -17339,7 +17339,7 @@ class Program {
   IL_0039:  ret
 }
 ";
-            CompileAndVerify(source, targetFramework: TargetFramework.NetStandard20, expectedOutput: "1234")
+            CompileAndVerify(source, targetFramework: ExecutionConditionUtil.IsDesktop ? TargetFramework.NetFramework : TargetFramework.NetStandard20, expectedOutput: "1234")
                .VerifyIL("Program.Main(string[])", expect);
         }
 
@@ -17431,7 +17431,7 @@ public class Program {
 
             CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "3 5 7")
                 .VerifyIL("Program.Main(string[])", expectILNet50);
-            CompileAndVerify(source, targetFramework: TargetFramework.NetStandard20, expectedOutput: "3 5 7")
+            CompileAndVerify(source, targetFramework: ExecutionConditionUtil.IsDesktop ? TargetFramework.NetFramework : TargetFramework.NetStandard20, expectedOutput: "3 5 7")
                 .VerifyIL("Program.Main(string[])", expectILNetStandard20);
         }
 
@@ -17744,7 +17744,7 @@ public class Program {
             CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "abcdefghijk")
                 .VerifyIL("Program.Main(string[])", expectILNet50);
 
-            CompileAndVerify(source, targetFramework: TargetFramework.NetStandard20, expectedOutput: "abcdefghijk")
+            CompileAndVerify(source, targetFramework: ExecutionConditionUtil.IsDesktop ? TargetFramework.NetFramework : TargetFramework.NetStandard20, expectedOutput: "abcdefghijk")
                 .VerifyIL("Program.Main(string[])", expectILNetStandard20);
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -17282,7 +17282,10 @@ class Program {
   IL_003a:  ret
 }
 ";
-            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "1234")
+
+            // We need >= Net50 to have access to System.GC.AllocateUninitializedArray, but this means the use of the initialize array helper will cause a PEVerify failure,
+            // so we have to skip verification
+            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "1234", verify: Verification.Skipped)
                .VerifyIL("Program.Main(string[])", expect);
         }
 
@@ -17362,40 +17365,7 @@ public class Program {
     }
 }
 """;
-            var expectILNet50 = @"
-{
-  // Code size       74 (0x4a)
-  .maxstack  6
-  .locals init (int[,] V_0) //m
-  IL_0000:  ldc.i4.3
-  IL_0001:  ldc.i4.3
-  IL_0002:  newobj     ""int[*,*]..ctor""
-  IL_0007:  dup
-  IL_0008:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=36 <PrivateImplementationDetails>.E3D25E7590EDD76206831801F67D1EE231D8B90A2BB4BFE31A152BE21D2F536C""
-  IL_000d:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
-  IL_0012:  stloc.0
-  IL_0013:  ldstr      ""{0} {1} {2}""
-  IL_0018:  ldloc.0
-  IL_0019:  ldc.i4.0
-  IL_001a:  ldc.i4.2
-  IL_001b:  call       ""int[*,*].Get""
-  IL_0020:  box        ""int""
-  IL_0025:  ldloc.0
-  IL_0026:  ldc.i4.1
-  IL_0027:  ldc.i4.1
-  IL_0028:  call       ""int[*,*].Get""
-  IL_002d:  box        ""int""
-  IL_0032:  ldloc.0
-  IL_0033:  ldc.i4.2
-  IL_0034:  ldc.i4.0
-  IL_0035:  call       ""int[*,*].Get""
-  IL_003a:  box        ""int""
-  IL_003f:  call       ""string string.Format(string, object, object, object)""
-  IL_0044:  call       ""void System.Console.WriteLine(string)""
-  IL_0049:  ret
-}
-";
-            var expectILNetStandard20 = @"
+            var expectIL = @"
 {
   // Code size       74 (0x4a)
   .maxstack  6
@@ -17429,10 +17399,14 @@ public class Program {
 }
 ";
 
-            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "3 5 7")
-                .VerifyIL("Program.Main(string[])", expectILNet50);
+
+            // We need >= Net50 to have access to System.GC.AllocateUninitializedArray, but this means the use of the initialize array helper will cause a PEVerify failure,
+            // so we have to skip verification
+            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "3 5 7", verify: Verification.Skipped)
+                .VerifyIL("Program.Main(string[])", expectIL);
+
             CompileAndVerify(source, targetFramework: ExecutionConditionUtil.IsDesktop ? TargetFramework.NetFramework : TargetFramework.NetStandard20, expectedOutput: "3 5 7")
-                .VerifyIL("Program.Main(string[])", expectILNetStandard20);
+                .VerifyIL("Program.Main(string[])", expectIL);
         }
 
         [Fact]
@@ -17553,6 +17527,7 @@ public class Program {
   IL_0088:  ldloc.2
   IL_0089:  ldelem.ref
   IL_008a:  stloc.3
+
   IL_008b:  ldc.i4.0
   IL_008c:  stloc.s    V_4
   IL_008e:  br.s       IL_00c4
@@ -17614,6 +17589,7 @@ public class Program {
                 char[][] V_3,
                 int V_4,
                 char[] V_5,
+            
                 int V_6,
                 char V_7) //c
   IL_0000:  ldc.i4.2
@@ -17741,7 +17717,9 @@ public class Program {
 }
 ";
 
-            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "abcdefghijk")
+            // We need >= Net50 to have access to System.GC.AllocateUninitializedArray, but this means the use of the initialize array helper will cause a PEVerify failure,
+            // so we have to skip verification
+            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "abcdefghijk", verify: Verification.Skipped)
                 .VerifyIL("Program.Main(string[])", expectILNet50);
 
             CompileAndVerify(source, targetFramework: ExecutionConditionUtil.IsDesktop ? TargetFramework.NetFramework : TargetFramework.NetStandard20, expectedOutput: "abcdefghijk")

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -17362,8 +17362,77 @@ public class Program {
     }
 }
 """;
-            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "3 5 7");
-            CompileAndVerify(source, targetFramework: TargetFramework.NetStandard20, expectedOutput: "3 5 7");
+            var expectILNet50 = @"
+{
+  // Code size       74 (0x4a)
+  .maxstack  6
+  .locals init (int[,] V_0) //m
+  IL_0000:  ldc.i4.3
+  IL_0001:  ldc.i4.3
+  IL_0002:  newobj     ""int[*,*]..ctor""
+  IL_0007:  dup
+  IL_0008:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=36 <PrivateImplementationDetails>.E3D25E7590EDD76206831801F67D1EE231D8B90A2BB4BFE31A152BE21D2F536C""
+  IL_000d:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0012:  stloc.0
+  IL_0013:  ldstr      ""{0} {1} {2}""
+  IL_0018:  ldloc.0
+  IL_0019:  ldc.i4.0
+  IL_001a:  ldc.i4.2
+  IL_001b:  call       ""int[*,*].Get""
+  IL_0020:  box        ""int""
+  IL_0025:  ldloc.0
+  IL_0026:  ldc.i4.1
+  IL_0027:  ldc.i4.1
+  IL_0028:  call       ""int[*,*].Get""
+  IL_002d:  box        ""int""
+  IL_0032:  ldloc.0
+  IL_0033:  ldc.i4.2
+  IL_0034:  ldc.i4.0
+  IL_0035:  call       ""int[*,*].Get""
+  IL_003a:  box        ""int""
+  IL_003f:  call       ""string string.Format(string, object, object, object)""
+  IL_0044:  call       ""void System.Console.WriteLine(string)""
+  IL_0049:  ret
+}
+";
+            var expectILNetStandard20 = @"
+{
+  // Code size       74 (0x4a)
+  .maxstack  6
+  .locals init (int[,] V_0) //m
+  IL_0000:  ldc.i4.3
+  IL_0001:  ldc.i4.3
+  IL_0002:  newobj     ""int[*,*]..ctor""
+  IL_0007:  dup
+  IL_0008:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=36 <PrivateImplementationDetails>.E3D25E7590EDD76206831801F67D1EE231D8B90A2BB4BFE31A152BE21D2F536C""
+  IL_000d:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0012:  stloc.0
+  IL_0013:  ldstr      ""{0} {1} {2}""
+  IL_0018:  ldloc.0
+  IL_0019:  ldc.i4.0
+  IL_001a:  ldc.i4.2
+  IL_001b:  call       ""int[*,*].Get""
+  IL_0020:  box        ""int""
+  IL_0025:  ldloc.0
+  IL_0026:  ldc.i4.1
+  IL_0027:  ldc.i4.1
+  IL_0028:  call       ""int[*,*].Get""
+  IL_002d:  box        ""int""
+  IL_0032:  ldloc.0
+  IL_0033:  ldc.i4.2
+  IL_0034:  ldc.i4.0
+  IL_0035:  call       ""int[*,*].Get""
+  IL_003a:  box        ""int""
+  IL_003f:  call       ""string string.Format(string, object, object, object)""
+  IL_0044:  call       ""void System.Console.WriteLine(string)""
+  IL_0049:  ret
+}
+";
+
+            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "3 5 7")
+                .VerifyIL("Program.Main(string[])", expectILNet50);
+            CompileAndVerify(source, targetFramework: TargetFramework.NetStandard20, expectedOutput: "3 5 7")
+                .VerifyIL("Program.Main(string[])", expectILNetStandard20);
         }
 
         [Fact]
@@ -17391,8 +17460,292 @@ public class Program {
     }
 }
 """;
-            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "abcdefghijk");
-            CompileAndVerify(source, targetFramework: TargetFramework.NetStandard20, expectedOutput: "abcdefghijk");
+            var expectILNet50 = @"
+{
+  // Code size      220 (0xdc)
+  .maxstack  10
+  .locals init (string V_0, //s
+                char[][][] V_1,
+                int V_2,
+                char[][] V_3,
+                int V_4,
+                char[] V_5,
+                int V_6,
+                char V_7) //c
+  IL_0000:  ldc.i4.2
+  IL_0001:  ldc.i4.0
+  IL_0002:  call       ""char[][][] System.GC.AllocateUninitializedArray<char[][]>(int, bool)""
+  IL_0007:  dup
+  IL_0008:  ldc.i4.0
+  IL_0009:  ldc.i4.2
+  IL_000a:  ldc.i4.0
+  IL_000b:  call       ""char[][] System.GC.AllocateUninitializedArray<char[]>(int, bool)""
+  IL_0010:  dup
+  IL_0011:  ldc.i4.0
+  IL_0012:  ldc.i4.3
+  IL_0013:  ldc.i4.0
+  IL_0014:  call       ""char[] System.GC.AllocateUninitializedArray<char>(int, bool)""
+  IL_0019:  dup
+  IL_001a:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6 <PrivateImplementationDetails>.13E228567E8249FCE53337F25D7970DE3BD68AB2653424C7B8F9FD05E33CAEDF""
+  IL_001f:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0024:  stelem.ref
+  IL_0025:  dup
+  IL_0026:  ldc.i4.1
+  IL_0027:  ldc.i4.2
+  IL_0028:  ldc.i4.0
+  IL_0029:  call       ""char[] System.GC.AllocateUninitializedArray<char>(int, bool)""
+  IL_002e:  dup
+  IL_002f:  ldc.i4.0
+  IL_0030:  ldc.i4.s   100
+  IL_0032:  stelem.i2
+  IL_0033:  dup
+  IL_0034:  ldc.i4.1
+  IL_0035:  ldc.i4.s   101
+  IL_0037:  stelem.i2
+  IL_0038:  stelem.ref
+  IL_0039:  stelem.ref
+  IL_003a:  dup
+  IL_003b:  ldc.i4.1
+  IL_003c:  ldc.i4.3
+  IL_003d:  ldc.i4.0
+  IL_003e:  call       ""char[][] System.GC.AllocateUninitializedArray<char[]>(int, bool)""
+  IL_0043:  dup
+  IL_0044:  ldc.i4.0
+  IL_0045:  ldc.i4.1
+  IL_0046:  ldc.i4.0
+  IL_0047:  call       ""char[] System.GC.AllocateUninitializedArray<char>(int, bool)""
+  IL_004c:  dup
+  IL_004d:  ldc.i4.0
+  IL_004e:  ldc.i4.s   102
+  IL_0050:  stelem.i2
+  IL_0051:  stelem.ref
+  IL_0052:  dup
+  IL_0053:  ldc.i4.1
+  IL_0054:  ldc.i4.2
+  IL_0055:  ldc.i4.0
+  IL_0056:  call       ""char[] System.GC.AllocateUninitializedArray<char>(int, bool)""
+  IL_005b:  dup
+  IL_005c:  ldc.i4.0
+  IL_005d:  ldc.i4.s   103
+  IL_005f:  stelem.i2
+  IL_0060:  dup
+  IL_0061:  ldc.i4.1
+  IL_0062:  ldc.i4.s   104
+  IL_0064:  stelem.i2
+  IL_0065:  stelem.ref
+  IL_0066:  dup
+  IL_0067:  ldc.i4.2
+  IL_0068:  ldc.i4.3
+  IL_0069:  ldc.i4.0
+  IL_006a:  call       ""char[] System.GC.AllocateUninitializedArray<char>(int, bool)""
+  IL_006f:  dup
+  IL_0070:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6 <PrivateImplementationDetails>.99E43808F0CC9DF6F2A31F9E6DC0EC210FE0B8CCC6C89D0DF97D48B28BAAC039""
+  IL_0075:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_007a:  stelem.ref
+  IL_007b:  stelem.ref
+  IL_007c:  ldstr      """"
+  IL_0081:  stloc.0
+  IL_0082:  stloc.1
+  IL_0083:  ldc.i4.0
+  IL_0084:  stloc.2
+  IL_0085:  br.s       IL_00cf
+  IL_0087:  ldloc.1
+  IL_0088:  ldloc.2
+  IL_0089:  ldelem.ref
+  IL_008a:  stloc.3
+  IL_008b:  ldc.i4.0
+  IL_008c:  stloc.s    V_4
+  IL_008e:  br.s       IL_00c4
+  IL_0090:  ldloc.3
+  IL_0091:  ldloc.s    V_4
+  IL_0093:  ldelem.ref
+  IL_0094:  stloc.s    V_5
+  IL_0096:  ldc.i4.0
+  IL_0097:  stloc.s    V_6
+  IL_0099:  br.s       IL_00b6
+  IL_009b:  ldloc.s    V_5
+  IL_009d:  ldloc.s    V_6
+  IL_009f:  ldelem.u2
+  IL_00a0:  stloc.s    V_7
+  IL_00a2:  ldloc.0
+  IL_00a3:  ldloca.s   V_7
+  IL_00a5:  call       ""string char.ToString()""
+  IL_00aa:  call       ""string string.Concat(string, string)""
+  IL_00af:  stloc.0
+  IL_00b0:  ldloc.s    V_6
+  IL_00b2:  ldc.i4.1
+  IL_00b3:  add
+  IL_00b4:  stloc.s    V_6
+  IL_00b6:  ldloc.s    V_6
+  IL_00b8:  ldloc.s    V_5
+  IL_00ba:  ldlen
+  IL_00bb:  conv.i4
+  IL_00bc:  blt.s      IL_009b
+  IL_00be:  ldloc.s    V_4
+  IL_00c0:  ldc.i4.1
+  IL_00c1:  add
+  IL_00c2:  stloc.s    V_4
+  IL_00c4:  ldloc.s    V_4
+  IL_00c6:  ldloc.3
+  IL_00c7:  ldlen
+  IL_00c8:  conv.i4
+  IL_00c9:  blt.s      IL_0090
+  IL_00cb:  ldloc.2
+  IL_00cc:  ldc.i4.1
+  IL_00cd:  add
+  IL_00ce:  stloc.2
+  IL_00cf:  ldloc.2
+  IL_00d0:  ldloc.1
+  IL_00d1:  ldlen
+  IL_00d2:  conv.i4
+  IL_00d3:  blt.s      IL_0087
+  IL_00d5:  ldloc.0
+  IL_00d6:  call       ""void System.Console.WriteLine(string)""
+  IL_00db:  ret
+}
+";
+            var expectILNetStandard20 = @"
+{
+  // Code size      212 (0xd4)
+  .maxstack  10
+  .locals init (string V_0, //s
+                char[][][] V_1,
+                int V_2,
+                char[][] V_3,
+                int V_4,
+                char[] V_5,
+                int V_6,
+                char V_7) //c
+  IL_0000:  ldc.i4.2
+  IL_0001:  newarr     ""char[][]""
+  IL_0006:  dup
+  IL_0007:  ldc.i4.0
+  IL_0008:  ldc.i4.2
+  IL_0009:  newarr     ""char[]""
+  IL_000e:  dup
+  IL_000f:  ldc.i4.0
+  IL_0010:  ldc.i4.3
+  IL_0011:  newarr     ""char""
+  IL_0016:  dup
+  IL_0017:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6 <PrivateImplementationDetails>.13E228567E8249FCE53337F25D7970DE3BD68AB2653424C7B8F9FD05E33CAEDF""
+  IL_001c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0021:  stelem.ref
+  IL_0022:  dup
+  IL_0023:  ldc.i4.1
+  IL_0024:  ldc.i4.2
+  IL_0025:  newarr     ""char""
+  IL_002a:  dup
+  IL_002b:  ldc.i4.0
+  IL_002c:  ldc.i4.s   100
+  IL_002e:  stelem.i2
+  IL_002f:  dup
+  IL_0030:  ldc.i4.1
+  IL_0031:  ldc.i4.s   101
+  IL_0033:  stelem.i2
+  IL_0034:  stelem.ref
+  IL_0035:  stelem.ref
+  IL_0036:  dup
+  IL_0037:  ldc.i4.1
+  IL_0038:  ldc.i4.3
+  IL_0039:  newarr     ""char[]""
+  IL_003e:  dup
+  IL_003f:  ldc.i4.0
+  IL_0040:  ldc.i4.1
+  IL_0041:  newarr     ""char""
+  IL_0046:  dup
+  IL_0047:  ldc.i4.0
+  IL_0048:  ldc.i4.s   102
+  IL_004a:  stelem.i2
+  IL_004b:  stelem.ref
+  IL_004c:  dup
+  IL_004d:  ldc.i4.1
+  IL_004e:  ldc.i4.2
+  IL_004f:  newarr     ""char""
+  IL_0054:  dup
+  IL_0055:  ldc.i4.0
+  IL_0056:  ldc.i4.s   103
+  IL_0058:  stelem.i2
+  IL_0059:  dup
+  IL_005a:  ldc.i4.1
+  IL_005b:  ldc.i4.s   104
+  IL_005d:  stelem.i2
+  IL_005e:  stelem.ref
+  IL_005f:  dup
+  IL_0060:  ldc.i4.2
+  IL_0061:  ldc.i4.3
+  IL_0062:  newarr     ""char""
+  IL_0067:  dup
+  IL_0068:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6 <PrivateImplementationDetails>.99E43808F0CC9DF6F2A31F9E6DC0EC210FE0B8CCC6C89D0DF97D48B28BAAC039""
+  IL_006d:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0072:  stelem.ref
+  IL_0073:  stelem.ref
+  IL_0074:  ldstr      """"
+  IL_0079:  stloc.0
+  IL_007a:  stloc.1
+  IL_007b:  ldc.i4.0
+  IL_007c:  stloc.2
+  IL_007d:  br.s       IL_00c7
+  IL_007f:  ldloc.1
+  IL_0080:  ldloc.2
+  IL_0081:  ldelem.ref
+  IL_0082:  stloc.3
+  IL_0083:  ldc.i4.0
+  IL_0084:  stloc.s    V_4
+  IL_0086:  br.s       IL_00bc
+  IL_0088:  ldloc.3
+  IL_0089:  ldloc.s    V_4
+  IL_008b:  ldelem.ref
+  IL_008c:  stloc.s    V_5
+  IL_008e:  ldc.i4.0
+  IL_008f:  stloc.s    V_6
+  IL_0091:  br.s       IL_00ae
+  IL_0093:  ldloc.s    V_5
+  IL_0095:  ldloc.s    V_6
+  IL_0097:  ldelem.u2
+  IL_0098:  stloc.s    V_7
+  IL_009a:  ldloc.0
+  IL_009b:  ldloca.s   V_7
+  IL_009d:  call       ""string char.ToString()""
+  IL_00a2:  call       ""string string.Concat(string, string)""
+  IL_00a7:  stloc.0
+  IL_00a8:  ldloc.s    V_6
+  IL_00aa:  ldc.i4.1
+  IL_00ab:  add
+  IL_00ac:  stloc.s    V_6
+  IL_00ae:  ldloc.s    V_6
+  IL_00b0:  ldloc.s    V_5
+  IL_00b2:  ldlen
+  IL_00b3:  conv.i4
+  IL_00b4:  blt.s      IL_0093
+  IL_00b6:  ldloc.s    V_4
+  IL_00b8:  ldc.i4.1
+  IL_00b9:  add
+  IL_00ba:  stloc.s    V_4
+  IL_00bc:  ldloc.s    V_4
+  IL_00be:  ldloc.3
+  IL_00bf:  ldlen
+  IL_00c0:  conv.i4
+  IL_00c1:  blt.s      IL_0088
+  IL_00c3:  ldloc.2
+  IL_00c4:  ldc.i4.1
+  IL_00c5:  add
+  IL_00c6:  stloc.2
+  IL_00c7:  ldloc.2
+  IL_00c8:  ldloc.1
+  IL_00c9:  ldlen
+  IL_00ca:  conv.i4
+  IL_00cb:  blt.s      IL_007f
+  IL_00cd:  ldloc.0
+  IL_00ce:  call       ""void System.Console.WriteLine(string)""
+  IL_00d3:  ret
+}
+";
+
+            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "abcdefghijk")
+                .VerifyIL("Program.Main(string[])", expectILNet50);
+
+            CompileAndVerify(source, targetFramework: TargetFramework.NetStandard20, expectedOutput: "abcdefghijk")
+                .VerifyIL("Program.Main(string[])", expectILNetStandard20);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -17125,7 +17125,7 @@ partial class C
         System.Console.WriteLine(""in called"");
     }
 }
-static class Program
+static class Programverify: Verification.Skipped
 {
     static void Main()
     {
@@ -17226,6 +17226,121 @@ System.Threading.Tasks.Task`1[System.Object]
 Success
 True
 ", verify: Verification.FailsILVerify).VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(61011, "https://github.com/dotnet/roslyn/issues/61011")]
+        public void Issue61011_TFMHasMember()
+        {
+            var source = """
+using System;
+
+class Program {
+    public static void Main(string[] args) {
+        int[] arr = new int[] {1, 2, 3, 4};
+        foreach (var i in arr) {
+            Console.Write($"{i}");
+        }
+    }
+}
+""";
+            var expect = @"
+{
+  // Code size       59 (0x3b)
+  .maxstack  3
+  .locals init (int[] V_0,
+                int V_1,
+                int V_2) //i
+  IL_0000:  ldc.i4.4
+  IL_0001:  ldc.i4.0
+  IL_0002:  call       ""int[] System.GC.AllocateUninitializedArray<int>(int, bool)""
+  IL_0007:  dup
+  IL_0008:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.CF97ADEEDB59E05BFD73A2B4C2A8885708C4F4F70C84C64B27120E72AB733B72""
+  IL_000d:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0012:  stloc.0
+  IL_0013:  ldc.i4.0
+  IL_0014:  stloc.1
+  IL_0015:  br.s       IL_0034
+  IL_0017:  ldloc.0
+  IL_0018:  ldloc.1
+  IL_0019:  ldelem.i4
+  IL_001a:  stloc.2
+  IL_001b:  ldstr      ""{0}""
+  IL_0020:  ldloc.2
+  IL_0021:  box        ""int""
+  IL_0026:  call       ""string string.Format(string, object)""
+  IL_002b:  call       ""void System.Console.Write(string)""
+  IL_0030:  ldloc.1
+  IL_0031:  ldc.i4.1
+  IL_0032:  add
+  IL_0033:  stloc.1
+  IL_0034:  ldloc.1
+  IL_0035:  ldloc.0
+  IL_0036:  ldlen
+  IL_0037:  conv.i4
+  IL_0038:  blt.s      IL_0017
+  IL_003a:  ret
+}
+";
+            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "1234")
+               .VerifyIL("Program.Main(string[])", expect);
+        }
+
+        [Fact]
+        [WorkItem(61011, "https://github.com/dotnet/roslyn/issues/61011")]
+        public void Issue61011_TFMDoesNotHaveMember()
+        {
+            var source = """
+using System;
+
+class Program {
+    public static void Main(string[] args) {
+        int[] arr = new int[] {1, 2, 3, 4};
+        foreach (var i in arr) {
+            Console.Write($"{i}");
+        }
+    }
+}
+""";
+            var expect = @"
+{
+  // Code size       58 (0x3a)
+  .maxstack  3
+  .locals init (int[] V_0,
+                int V_1,
+                int V_2) //i
+  IL_0000:  ldc.i4.4
+  IL_0001:  newarr     ""int""
+  IL_0006:  dup
+  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.CF97ADEEDB59E05BFD73A2B4C2A8885708C4F4F70C84C64B27120E72AB733B72""
+  IL_000c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0011:  stloc.0
+  IL_0012:  ldc.i4.0
+  IL_0013:  stloc.1
+  IL_0014:  br.s       IL_0033
+  IL_0016:  ldloc.0
+  IL_0017:  ldloc.1
+  IL_0018:  ldelem.i4
+  IL_0019:  stloc.2
+  IL_001a:  ldstr      ""{0}""
+  IL_001f:  ldloc.2
+  IL_0020:  box        ""int""
+  IL_0025:  call       ""string string.Format(string, object)""
+  IL_002a:  call       ""void System.Console.Write(string)""
+  IL_002f:  ldloc.1
+  IL_0030:  ldc.i4.1
+  IL_0031:  add
+  IL_0032:  stloc.1
+  IL_0033:  ldloc.1
+  IL_0034:  ldloc.0
+  IL_0035:  ldlen
+  IL_0036:  conv.i4
+  IL_0037:  blt.s      IL_0016
+  IL_0039:  ret
+}
+";
+            CompileAndVerify(source, targetFramework: TargetFramework.NetStandard20, expectedOutput: "1234")
+               .VerifyIL("Program.Main(string[])", expect);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -17125,8 +17125,8 @@ partial class C
         System.Console.WriteLine(""in called"");
     }
 }
-static class Programverify: Verification.Skipped
-{
+
+static class Program {
     static void Main()
     {
         new C().Call();
@@ -17341,6 +17341,58 @@ class Program {
 ";
             CompileAndVerify(source, targetFramework: TargetFramework.NetStandard20, expectedOutput: "1234")
                .VerifyIL("Program.Main(string[])", expect);
+        }
+
+
+        [Fact]
+        [WorkItem(61011, "https://github.com/dotnet/roslyn/issues/61011")]
+        public void Issue61011_2()
+        {
+            var source = """
+using System;
+public class Program {
+    public static void Main(string[] args) {
+        int[,] m = new int[3, 3]
+        {
+            {1, 2, 3},
+            {4, 5, 6},
+            {7, 8, 9}
+        };
+        Console.WriteLine($"{m[0, 2]} {m[1, 1]} {m[2, 0]}");
+    }
+}
+""";
+            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "3 5 7");
+            CompileAndVerify(source, targetFramework: TargetFramework.NetStandard20, expectedOutput: "3 5 7");
+        }
+
+        [Fact]
+        [WorkItem(61011, "https://github.com/dotnet/roslyn/issues/61011")]
+        public void Issue61011_3()
+        {
+            var source = """
+using System;
+public class Program {
+    public static void Main(string[] args) {
+        var jagged = new[] {
+           new[] {new[] {'a', 'b', 'c'}, new[]{'d', 'e'}},
+           new[] {new[] {'f'}, new[]{'g', 'h'}, new[]{'i', 'j', 'k'}},
+        };
+       
+       string s = "";
+       foreach (var arr0 in jagged) {
+           foreach (var arr1 in arr0) {
+               foreach (var c in arr1) {
+                   s += c;
+               }
+           }
+       }
+       Console.WriteLine(s);
+    }
+}
+""";
+            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "abcdefghijk");
+            CompileAndVerify(source, targetFramework: TargetFramework.NetStandard20, expectedOutput: "abcdefghijk");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -17125,7 +17125,6 @@ partial class C
         System.Console.WriteLine(""in called"");
     }
 }
-
 static class Program {
     static void Main()
     {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -17285,7 +17285,7 @@ class Program {
 
             // We need >= Net50 to have access to System.GC.AllocateUninitializedArray, but this means the use of the initialize array helper will cause a PEVerify failure,
             // so we have to skip verification
-            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "1234", verify: Verification.Skipped)
+            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: ExecutionConditionUtil.IsDesktop ? null : "1234", verify: Verification.Skipped)
                .VerifyIL("Program.Main(string[])", expect);
         }
 
@@ -17402,7 +17402,7 @@ public class Program {
 
             // We need >= Net50 to have access to System.GC.AllocateUninitializedArray, but this means the use of the initialize array helper will cause a PEVerify failure,
             // so we have to skip verification
-            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "3 5 7", verify: Verification.Skipped)
+            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: ExecutionConditionUtil.IsDesktop ? null : "3 5 7", verify: Verification.Skipped)
                 .VerifyIL("Program.Main(string[])", expectIL);
 
             CompileAndVerify(source, targetFramework: ExecutionConditionUtil.IsDesktop ? TargetFramework.NetFramework : TargetFramework.NetStandard20, expectedOutput: "3 5 7")
@@ -17719,7 +17719,7 @@ public class Program {
 
             // We need >= Net50 to have access to System.GC.AllocateUninitializedArray, but this means the use of the initialize array helper will cause a PEVerify failure,
             // so we have to skip verification
-            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: "abcdefghijk", verify: Verification.Skipped)
+            CompileAndVerify(source, targetFramework: TargetFramework.Net50, expectedOutput: ExecutionConditionUtil.IsDesktop ? null : "abcdefghijk", verify: Verification.Skipped)
                 .VerifyIL("Program.Main(string[])", expectILNet50);
 
             CompileAndVerify(source, targetFramework: ExecutionConditionUtil.IsDesktop ? TargetFramework.NetFramework : TargetFramework.NetStandard20, expectedOutput: "abcdefghijk")

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -3942,62 +3942,63 @@ Caught");
 
 
             verifier.VerifyIL("<top-level-statements-entry-point>", @"
-{
-  // Code size      122 (0x7a)
+ {
+  // Code size      123 (0x7b)
   .maxstack  4
   .locals init (System.ReadOnlySpan<char> V_0, //s
                 System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_1)
   IL_0000:  ldc.i4.1
-  IL_0001:  newarr     ""char""
-  IL_0006:  dup
-  IL_0007:  ldc.i4.0
-  IL_0008:  ldc.i4.s   105
-  IL_000a:  stelem.i2
-  IL_000b:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.op_Implicit(char[])""
-  IL_0010:  stloc.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  call       ""char[] System.GC.AllocateUninitializedArray<char>(int, bool)""
+  IL_0007:  dup
+  IL_0008:  ldc.i4.0
+  IL_0009:  ldc.i4.s   105
+  IL_000b:  stelem.i2
+  IL_000c:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.op_Implicit(char[])""
+  IL_0011:  stloc.0
   .try
   {
-    IL_0011:  ldstr      ""Starting try""
-    IL_0016:  call       ""void System.Console.WriteLine(string)""
-    IL_001b:  newobj     ""MyException..ctor()""
-    IL_0020:  dup
-    IL_0021:  ldloca.s   V_0
-    IL_0023:  constrained. ""System.ReadOnlySpan<char>""
-    IL_0029:  callvirt   ""string object.ToString()""
-    IL_002e:  callvirt   ""void MyException.Prop.set""
-    IL_0033:  throw
+    IL_0012:  ldstr      ""Starting try""
+    IL_0017:  call       ""void System.Console.WriteLine(string)""
+    IL_001c:  newobj     ""MyException..ctor()""
+    IL_0021:  dup
+    IL_0022:  ldloca.s   V_0
+    IL_0024:  constrained. ""System.ReadOnlySpan<char>""
+    IL_002a:  callvirt   ""string object.ToString()""
+    IL_002f:  callvirt   ""void MyException.Prop.set""
+    IL_0034:  throw
   }
   filter
   {
-    IL_0034:  isinst     ""MyException""
-    IL_0039:  dup
-    IL_003a:  brtrue.s   IL_0040
-    IL_003c:  pop
-    IL_003d:  ldc.i4.0
-    IL_003e:  br.s       IL_006a
-    IL_0040:  callvirt   ""string object.ToString()""
-    IL_0045:  ldloca.s   V_1
-    IL_0047:  ldc.i4.0
-    IL_0048:  ldc.i4.1
-    IL_0049:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
-    IL_004e:  ldloca.s   V_1
-    IL_0050:  ldloc.0
-    IL_0051:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>)""
-    IL_0056:  ldloca.s   V_1
-    IL_0058:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
-    IL_005d:  callvirt   ""string string.Trim()""
-    IL_0062:  call       ""bool string.op_Equality(string, string)""
-    IL_0067:  ldc.i4.0
-    IL_0068:  cgt.un
-    IL_006a:  endfilter
+    IL_0035:  isinst     ""MyException""
+    IL_003a:  dup
+    IL_003b:  brtrue.s   IL_0041
+    IL_003d:  pop
+    IL_003e:  ldc.i4.0
+    IL_003f:  br.s       IL_006b
+    IL_0041:  callvirt   ""string object.ToString()""
+    IL_0046:  ldloca.s   V_1
+    IL_0048:  ldc.i4.0
+    IL_0049:  ldc.i4.1
+    IL_004a:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
+    IL_004f:  ldloca.s   V_1
+    IL_0051:  ldloc.0
+    IL_0052:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>)""
+    IL_0057:  ldloca.s   V_1
+    IL_0059:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
+    IL_005e:  callvirt   ""string string.Trim()""
+    IL_0063:  call       ""bool string.op_Equality(string, string)""
+    IL_0068:  ldc.i4.0
+    IL_0069:  cgt.un
+    IL_006b:  endfilter
   }  // end filter
   {  // handler
-    IL_006c:  pop
-    IL_006d:  ldstr      ""Caught""
-    IL_0072:  call       ""void System.Console.WriteLine(string)""
-    IL_0077:  leave.s    IL_0079
+    IL_006d:  pop
+    IL_006e:  ldstr      ""Caught""
+    IL_0073:  call       ""void System.Console.WriteLine(string)""
+    IL_0078:  leave.s    IL_007a
   }
-  IL_0079:  ret
+  IL_007a:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RawInterpolationTests_Handler.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RawInterpolationTests_Handler.cs
@@ -2369,61 +2369,62 @@ Caught");
 
         verifier.VerifyIL("<top-level-statements-entry-point>", @"
 {
-  // Code size      122 (0x7a)
+  // Code size      123 (0x7b)
   .maxstack  4
   .locals init (System.ReadOnlySpan<char> V_0, //s
                 System.Runtime.CompilerServices.DefaultInterpolatedStringHandler V_1)
   IL_0000:  ldc.i4.1
-  IL_0001:  newarr     ""char""
-  IL_0006:  dup
-  IL_0007:  ldc.i4.0
-  IL_0008:  ldc.i4.s   105
-  IL_000a:  stelem.i2
-  IL_000b:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.op_Implicit(char[])""
-  IL_0010:  stloc.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  call       ""char[] System.GC.AllocateUninitializedArray<char>(int, bool)""
+  IL_0007:  dup
+  IL_0008:  ldc.i4.0
+  IL_0009:  ldc.i4.s   105
+  IL_000b:  stelem.i2
+  IL_000c:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.op_Implicit(char[])""
+  IL_0011:  stloc.0
   .try
   {
-    IL_0011:  ldstr      ""Starting try""
-    IL_0016:  call       ""void System.Console.WriteLine(string)""
-    IL_001b:  newobj     ""MyException..ctor()""
-    IL_0020:  dup
-    IL_0021:  ldloca.s   V_0
-    IL_0023:  constrained. ""System.ReadOnlySpan<char>""
-    IL_0029:  callvirt   ""string object.ToString()""
-    IL_002e:  callvirt   ""void MyException.Prop.set""
-    IL_0033:  throw
+    IL_0012:  ldstr      ""Starting try""
+    IL_0017:  call       ""void System.Console.WriteLine(string)""
+    IL_001c:  newobj     ""MyException..ctor()""
+    IL_0021:  dup
+    IL_0022:  ldloca.s   V_0
+    IL_0024:  constrained. ""System.ReadOnlySpan<char>""
+    IL_002a:  callvirt   ""string object.ToString()""
+    IL_002f:  callvirt   ""void MyException.Prop.set""
+    IL_0034:  throw
   }
   filter
   {
-    IL_0034:  isinst     ""MyException""
-    IL_0039:  dup
-    IL_003a:  brtrue.s   IL_0040
-    IL_003c:  pop
-    IL_003d:  ldc.i4.0
-    IL_003e:  br.s       IL_006a
-    IL_0040:  callvirt   ""string object.ToString()""
-    IL_0045:  ldloca.s   V_1
-    IL_0047:  ldc.i4.0
-    IL_0048:  ldc.i4.1
-    IL_0049:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
-    IL_004e:  ldloca.s   V_1
-    IL_0050:  ldloc.0
-    IL_0051:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>)""
-    IL_0056:  ldloca.s   V_1
-    IL_0058:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
-    IL_005d:  callvirt   ""string string.Trim()""
-    IL_0062:  call       ""bool string.op_Equality(string, string)""
-    IL_0067:  ldc.i4.0
-    IL_0068:  cgt.un
-    IL_006a:  endfilter
+    IL_0035:  isinst     ""MyException""
+    IL_003a:  dup
+    IL_003b:  brtrue.s   IL_0041
+    IL_003d:  pop
+    IL_003e:  ldc.i4.0
+    IL_003f:  br.s       IL_006b
+    IL_0041:  callvirt   ""string object.ToString()""
+    IL_0046:  ldloca.s   V_1
+    IL_0048:  ldc.i4.0
+    IL_0049:  ldc.i4.1
+    IL_004a:  call       ""System.Runtime.CompilerServices.DefaultInterpolatedStringHandler..ctor(int, int)""
+    IL_004f:  ldloca.s   V_1
+    IL_0051:  ldloc.0
+    IL_0052:  call       ""void System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted(System.ReadOnlySpan<char>)""
+    IL_0057:  ldloca.s   V_1
+    IL_0059:  call       ""string System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.ToStringAndClear()""
+    IL_005e:  callvirt   ""string string.Trim()""
+    IL_0063:  call       ""bool string.op_Equality(string, string)""
+    IL_0068:  ldc.i4.0
+    IL_0069:  cgt.un
+    IL_006b:  endfilter
   }  // end filter
   {  // handler
-    IL_006c:  pop
-    IL_006d:  ldstr      ""Caught""
-    IL_0072:  call       ""void System.Console.WriteLine(string)""
-    IL_0077:  leave.s    IL_0079
+    IL_006d:  pop
+    IL_006e:  ldstr      ""Caught""
+    IL_0073:  call       ""void System.Console.WriteLine(string)""
+    IL_0078:  leave.s    IL_007a
   }
-  IL_0079:  ret
+  IL_007a:  ret
 }
 ");
     }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/Utf8StringsLiteralsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/Utf8StringsLiteralsTests.cs
@@ -1860,17 +1860,18 @@ class C
 
             verifier.VerifyIL("C.Test3()", @"
 {
-  // Code size       25 (0x19)
+  // Code size       26 (0x1a)
   .maxstack  3
   IL_0000:  ldc.i4.4
-  IL_0001:  newarr     ""byte""
-  IL_0006:  dup
-  IL_0007:  ldtoken    ""int <PrivateImplementationDetails>.F3D4280708A6C4BEA1BAEB5AD5A4B659E705A90BDD448840276EA20CB151BE57""
-  IL_000c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
-  IL_0011:  ldc.i4.0
-  IL_0012:  ldc.i4.3
-  IL_0013:  newobj     ""System.ReadOnlySpan<byte>..ctor(byte[], int, int)""
-  IL_0018:  ret
+  IL_0001:  ldc.i4.0
+  IL_0002:  call       ""byte[] System.GC.AllocateUninitializedArray<byte>(int, bool)""
+  IL_0007:  dup
+  IL_0008:  ldtoken    ""int <PrivateImplementationDetails>.F3D4280708A6C4BEA1BAEB5AD5A4B659E705A90BDD448840276EA20CB151BE57""
+  IL_000d:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0012:  ldc.i4.0
+  IL_0013:  ldc.i4.3
+  IL_0014:  newobj     ""System.ReadOnlySpan<byte>..ctor(byte[], int, int)""
+  IL_0019:  ret
 }
 ");
         }
@@ -3218,22 +3219,23 @@ class C
 
             verifier.VerifyIL("C.Test3()", @"
 {
-  // Code size       30 (0x1e)
+  // Code size       31 (0x1f)
   .maxstack  3
   .locals init (System.ReadOnlySpan<byte> V_0)
   IL_0000:  nop
   IL_0001:  ldc.i4.3
-  IL_0002:  newarr     ""byte""
-  IL_0007:  dup
-  IL_0008:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=3 <PrivateImplementationDetails>.039058C6F2C0CB492C533B0A4D14EF77CC0F78ABCCCED5287D84A1A2011CFB81""
-  IL_000d:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
-  IL_0012:  " + startOpCode + @"
-  IL_0013:  " + lengthOpCode + @"
-  IL_0014:  newobj     ""System.ReadOnlySpan<byte>..ctor(byte[], int, int)""
-  IL_0019:  stloc.0
-  IL_001a:  br.s       IL_001c
-  IL_001c:  ldloc.0
-  IL_001d:  ret
+  IL_0002:  ldc.i4.0
+  IL_0003:  call       ""byte[] System.GC.AllocateUninitializedArray<byte>(int, bool)""
+  IL_0008:  dup
+  IL_0009:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=3 <PrivateImplementationDetails>.039058C6F2C0CB492C533B0A4D14EF77CC0F78ABCCCED5287D84A1A2011CFB81""
+  IL_000e:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0013:  " + startOpCode + @"
+  IL_0014:  " + lengthOpCode + @"
+  IL_0015:  newobj     ""System.ReadOnlySpan<byte>..ctor(byte[], int, int)""
+  IL_001a:  stloc.0
+  IL_001b:  br.s       IL_001d
+  IL_001d:  ldloc.0
+  IL_001e:  ret
 }
 ");
         }
@@ -3310,22 +3312,23 @@ class C
 
             verifier.VerifyIL("C.Test3()", @"
 {
-  // Code size       30 (0x1e)
+  // Code size       31 (0x1f)
   .maxstack  3
   .locals init (System.ReadOnlySpan<byte> V_0)
   IL_0000:  nop
   IL_0001:  ldc.i4.3
-  IL_0002:  newarr     ""byte""
-  IL_0007:  dup
-  IL_0008:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=3 <PrivateImplementationDetails>.039058C6F2C0CB492C533B0A4D14EF77CC0F78ABCCCED5287D84A1A2011CFB81""
-  IL_000d:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
-  IL_0012:  ldc.i4.1
+  IL_0002:  ldc.i4.0
+  IL_0003:  call       ""byte[] System.GC.AllocateUninitializedArray<byte>(int, bool)""
+  IL_0008:  dup
+  IL_0009:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=3 <PrivateImplementationDetails>.039058C6F2C0CB492C533B0A4D14EF77CC0F78ABCCCED5287D84A1A2011CFB81""
+  IL_000e:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0013:  ldc.i4.1
-  IL_0014:  newobj     ""System.ReadOnlySpan<byte>..ctor(byte[], int, int)""
-  IL_0019:  stloc.0
-  IL_001a:  br.s       IL_001c
-  IL_001c:  ldloc.0
-  IL_001d:  ret
+  IL_0014:  ldc.i4.1
+  IL_0015:  newobj     ""System.ReadOnlySpan<byte>..ctor(byte[], int, int)""
+  IL_001a:  stloc.0
+  IL_001b:  br.s       IL_001d
+  IL_001d:  ldloc.0
+  IL_001e:  ret
 }
 ");
         }
@@ -3359,22 +3362,23 @@ class C
 
             verifier.VerifyIL("C.Test3()", @"
 {
-  // Code size       34 (0x22)
+  // Code size       35 (0x23)
   .maxstack  3
   .locals init (System.ReadOnlySpan<byte> V_0)
   IL_0000:  nop
   IL_0001:  ldc.i4.3
-  IL_0002:  newarr     ""byte""
-  IL_0007:  dup
-  IL_0008:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=3 <PrivateImplementationDetails>.039058C6F2C0CB492C533B0A4D14EF77CC0F78ABCCCED5287D84A1A2011CFB81""
-  IL_000d:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
-  IL_0012:  ldsfld     ""int C.Start""
-  IL_0017:  ldc.i4.2
-  IL_0018:  newobj     ""System.ReadOnlySpan<byte>..ctor(byte[], int, int)""
-  IL_001d:  stloc.0
-  IL_001e:  br.s       IL_0020
-  IL_0020:  ldloc.0
-  IL_0021:  ret
+  IL_0002:  ldc.i4.0
+  IL_0003:  call       ""byte[] System.GC.AllocateUninitializedArray<byte>(int, bool)""
+  IL_0008:  dup
+  IL_0009:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=3 <PrivateImplementationDetails>.039058C6F2C0CB492C533B0A4D14EF77CC0F78ABCCCED5287D84A1A2011CFB81""
+  IL_000e:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0013:  ldsfld     ""int C.Start""
+  IL_0018:  ldc.i4.2
+  IL_0019:  newobj     ""System.ReadOnlySpan<byte>..ctor(byte[], int, int)""
+  IL_001e:  stloc.0
+  IL_001f:  br.s       IL_0021
+  IL_0021:  ldloc.0
+  IL_0022:  ret
 }
 ");
         }
@@ -3408,22 +3412,23 @@ class C
 
             verifier.VerifyIL("C.Test3()", @"
 {
-  // Code size       34 (0x22)
+  // Code size       35 (0x23)
   .maxstack  3
   .locals init (System.ReadOnlySpan<byte> V_0)
   IL_0000:  nop
   IL_0001:  ldc.i4.3
-  IL_0002:  newarr     ""byte""
-  IL_0007:  dup
-  IL_0008:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=3 <PrivateImplementationDetails>.039058C6F2C0CB492C533B0A4D14EF77CC0F78ABCCCED5287D84A1A2011CFB81""
-  IL_000d:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
-  IL_0012:  ldc.i4.0
-  IL_0013:  ldsfld     ""int C.Length""
-  IL_0018:  newobj     ""System.ReadOnlySpan<byte>..ctor(byte[], int, int)""
-  IL_001d:  stloc.0
-  IL_001e:  br.s       IL_0020
-  IL_0020:  ldloc.0
-  IL_0021:  ret
+  IL_0002:  ldc.i4.0
+  IL_0003:  call       ""byte[] System.GC.AllocateUninitializedArray<byte>(int, bool)""
+  IL_0008:  dup
+  IL_0009:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=3 <PrivateImplementationDetails>.039058C6F2C0CB492C533B0A4D14EF77CC0F78ABCCCED5287D84A1A2011CFB81""
+  IL_000e:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0013:  ldc.i4.0
+  IL_0014:  ldsfld     ""int C.Length""
+  IL_0019:  newobj     ""System.ReadOnlySpan<byte>..ctor(byte[], int, int)""
+  IL_001e:  stloc.0
+  IL_001f:  br.s       IL_0021
+  IL_0021:  ldloc.0
+  IL_0022:  ret
 }
 ");
         }
@@ -3458,22 +3463,23 @@ class C
 
             verifier.VerifyIL("C.Test3()", @"
 {
-  // Code size       38 (0x26)
+  // Code size       39 (0x27)
   .maxstack  3
   .locals init (System.ReadOnlySpan<byte> V_0)
   IL_0000:  nop
   IL_0001:  ldc.i4.3
-  IL_0002:  newarr     ""byte""
-  IL_0007:  dup
-  IL_0008:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=3 <PrivateImplementationDetails>.039058C6F2C0CB492C533B0A4D14EF77CC0F78ABCCCED5287D84A1A2011CFB81""
-  IL_000d:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
-  IL_0012:  ldsfld     ""int C.Start""
-  IL_0017:  ldsfld     ""int C.Length""
-  IL_001c:  newobj     ""System.ReadOnlySpan<byte>..ctor(byte[], int, int)""
-  IL_0021:  stloc.0
-  IL_0022:  br.s       IL_0024
-  IL_0024:  ldloc.0
-  IL_0025:  ret
+  IL_0002:  ldc.i4.0
+  IL_0003:  call       ""byte[] System.GC.AllocateUninitializedArray<byte>(int, bool)""
+  IL_0008:  dup
+  IL_0009:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=3 <PrivateImplementationDetails>.039058C6F2C0CB492C533B0A4D14EF77CC0F78ABCCCED5287D84A1A2011CFB81""
+  IL_000e:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0013:  ldsfld     ""int C.Start""
+  IL_0018:  ldsfld     ""int C.Length""
+  IL_001d:  newobj     ""System.ReadOnlySpan<byte>..ctor(byte[], int, int)""
+  IL_0022:  stloc.0
+  IL_0023:  br.s       IL_0025
+  IL_0025:  ldloc.0
+  IL_0026:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -623,7 +623,6 @@ namespace System
                     case WellKnownType.System_Runtime_CompilerServices_ITuple:
                     case WellKnownType.System_Runtime_CompilerServices_NonNullTypesAttribute:
                     case WellKnownType.Microsoft_CodeAnalysis_EmbeddedAttribute:
-                    case WellKnownType.System_GC:
                         // Not always available.
                         continue;
                     case WellKnownType.ExtSentinel:

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -623,6 +623,7 @@ namespace System
                     case WellKnownType.System_Runtime_CompilerServices_ITuple:
                     case WellKnownType.System_Runtime_CompilerServices_NonNullTypesAttribute:
                     case WellKnownType.Microsoft_CodeAnalysis_EmbeddedAttribute:
+                    case WellKnownType.System_GC:
                         // Not always available.
                         continue;
                     case WellKnownType.ExtSentinel:
@@ -990,10 +991,10 @@ namespace System
                     case WellKnownMember.System_Runtime_CompilerServices_IsUnmanagedAttribute__ctor:
                     case WellKnownMember.System_Runtime_CompilerServices_ITuple__get_Item:
                     case WellKnownMember.System_Runtime_CompilerServices_ITuple__get_Length:
+                    case WellKnownMember.System_GC__AllocateUninitializedArray_T:
                         // Not always available.
                         continue;
                 }
-                if (wkm == WellKnownMember.Count) continue; // Not a real value.
 
                 var symbol = comp.GetWellKnownTypeMember(wkm);
                 Assert.True((object)symbol != null, $"Unexpected null for {wkm}");

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/StaticAbstractMembersInInterfacesTests.cs
@@ -10102,68 +10102,22 @@ class Test
                         verifier.VerifyIL("Test.MT3(I1, dynamic)",
 @"
 {
-  // Code size       97 (0x61)
-  .maxstack  8
-  IL_0000:  nop
-  IL_0001:  ldarg.0
-  IL_0002:  call       ""bool I1.op_False(I1)""
-  IL_0007:  brtrue.s   IL_0060
-  IL_0009:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>> Test.<>o__2.<>p__0""
-  IL_000e:  brfalse.s  IL_0012
-  IL_0010:  br.s       IL_0047
-  IL_0012:  ldc.i4.8
-  IL_0013:  ldc.i4.2
-  IL_0014:  ldtoken    ""Test""
-  IL_0019:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_001e:  ldc.i4.2
-  IL_001f:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-  IL_0024:  dup
-  IL_0025:  ldc.i4.0
-  IL_0026:  ldc.i4.1
-  IL_0027:  ldnull
-  IL_0028:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-  IL_002d:  stelem.ref
-  IL_002e:  dup
-  IL_002f:  ldc.i4.1
-  IL_0030:  ldc.i4.0
-  IL_0031:  ldnull
-  IL_0032:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-  IL_0037:  stelem.ref
-  IL_0038:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.BinaryOperation(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Linq.Expressions.ExpressionType, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-  IL_003d:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_0042:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>> Test.<>o__2.<>p__0""
-  IL_0047:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>> Test.<>o__2.<>p__0""
-  IL_004c:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>>.Target""
-  IL_0051:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>> Test.<>o__2.<>p__0""
-  IL_0056:  ldarg.0
-  IL_0057:  ldarg.1
-  IL_0058:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, I1, dynamic)""
-  IL_005d:  pop
-  IL_005e:  br.s       IL_0060
-  IL_0060:  ret
-}
-");
-                    }
-                    else
-                    {
-                        verifier.VerifyIL("Test.MT3(I1, dynamic)",
-@"
-{
   // Code size       98 (0x62)
   .maxstack  8
   IL_0000:  nop
   IL_0001:  ldarg.0
-  IL_0002:  call       ""bool I1.op_True(I1)""
+  IL_0002:  call       ""bool I1.op_False(I1)""
   IL_0007:  brtrue.s   IL_0061
   IL_0009:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>> Test.<>o__2.<>p__0""
   IL_000e:  brfalse.s  IL_0012
   IL_0010:  br.s       IL_0048
   IL_0012:  ldc.i4.8
-  IL_0013:  ldc.i4.s   36
-  IL_0015:  ldtoken    ""Test""
-  IL_001a:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_001f:  ldc.i4.2
-  IL_0020:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+  IL_0013:  ldc.i4.2
+  IL_0014:  ldtoken    ""Test""
+  IL_0019:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_001e:  ldc.i4.2
+  IL_001f:  ldc.i4.0
+  IL_0020:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo[] System.GC.AllocateUninitializedArray<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>(int, bool)""
   IL_0025:  dup
   IL_0026:  ldc.i4.0
   IL_0027:  ldc.i4.1
@@ -10188,6 +10142,54 @@ class Test
   IL_005e:  pop
   IL_005f:  br.s       IL_0061
   IL_0061:  ret
+}
+");
+                    }
+                    else
+                    {
+                        verifier.VerifyIL("Test.MT3(I1, dynamic)",
+@"
+{
+  // Code size       99 (0x63)
+  .maxstack  8
+  IL_0000:  nop
+  IL_0001:  ldarg.0
+  IL_0002:  call       ""bool I1.op_True(I1)""
+  IL_0007:  brtrue.s   IL_0062
+  IL_0009:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>> Test.<>o__2.<>p__0""
+  IL_000e:  brfalse.s  IL_0012
+  IL_0010:  br.s       IL_0049
+  IL_0012:  ldc.i4.8
+  IL_0013:  ldc.i4.s   36
+  IL_0015:  ldtoken    ""Test""
+  IL_001a:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_001f:  ldc.i4.2
+  IL_0020:  ldc.i4.0
+  IL_0021:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo[] System.GC.AllocateUninitializedArray<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>(int, bool)""
+  IL_0026:  dup
+  IL_0027:  ldc.i4.0
+  IL_0028:  ldc.i4.1
+  IL_0029:  ldnull
+  IL_002a:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_002f:  stelem.ref
+  IL_0030:  dup
+  IL_0031:  ldc.i4.1
+  IL_0032:  ldc.i4.0
+  IL_0033:  ldnull
+  IL_0034:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+  IL_0039:  stelem.ref
+  IL_003a:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.BinaryOperation(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Linq.Expressions.ExpressionType, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+  IL_003f:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_0044:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>> Test.<>o__2.<>p__0""
+  IL_0049:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>> Test.<>o__2.<>p__0""
+  IL_004e:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>>.Target""
+  IL_0053:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>> Test.<>o__2.<>p__0""
+  IL_0058:  ldarg.0
+  IL_0059:  ldarg.1
+  IL_005a:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, I1, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, I1, dynamic)""
+  IL_005f:  pop
+  IL_0060:  br.s       IL_0062
+  IL_0062:  ret
 }
 ");
                     }

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -532,6 +532,8 @@ namespace Microsoft.CodeAnalysis
 
         System_MissingMethodException__ctor,
 
+        System_GC__AllocateUninitializedArray_T,
+
         Count
 
         // Remember to update the AllWellKnownTypeMembers tests when making changes here

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3785,7 +3785,6 @@ namespace Microsoft.CodeAnalysis
                 "get_OffsetToStringData",                   // System_Runtime_CompilerServices_RuntimeHelpers__get_OffsetToStringData
                 "GetSubArray",                              // System_Runtime_CompilerServices_RuntimeHelpers__GetSubArray_T
                 "EnsureSufficientExecutionStack",           // System_Runtime_CompilerServices_RuntimeHelpers__EnsureSufficientExecutionStack
-
                 "Capture",                                  // System_Runtime_ExceptionServices_ExceptionDispatchInfo__Capture
                 "Throw",                                    // System_Runtime_ExceptionServices_ExceptionDispatchInfo__Throw
                 ".ctor",                                    // System_Security_UnverifiableCodeAttribute__ctor
@@ -3824,7 +3823,6 @@ namespace Microsoft.CodeAnalysis
                 "ToLong",                                   // Microsoft_VisualBasic_CompilerServices_Conversions__ToLongString
                 "ToULong",                                  // Microsoft_VisualBasic_CompilerServices_Conversions__ToULongString
                 "ToSingle",                                 // Microsoft_VisualBasic_CompilerServices_Conversions__ToSingleString
-
                 "ToDouble",                                 // Microsoft_VisualBasic_CompilerServices_Conversions__ToDoubleString
                 "ToDecimal",                                // Microsoft_VisualBasic_CompilerServices_Conversions__ToDecimalString
                 "ToDate",                                   // Microsoft_VisualBasic_CompilerServices_Conversions__ToDateString
@@ -3844,7 +3842,6 @@ namespace Microsoft.CodeAnalysis
                 "ToString",                                 // Microsoft_VisualBasic_CompilerServices_Conversions__ToStringObject
                 "ToBoolean",                                // Microsoft_VisualBasic_CompilerServices_Conversions__ToBooleanObject
                 "ToSByte",                                  // Microsoft_VisualBasic_CompilerServices_Conversions__ToSByteObject
-
                 "ToByte",                                   // Microsoft_VisualBasic_CompilerServices_Conversions__ToByteObject
                 "ToShort",                                  // Microsoft_VisualBasic_CompilerServices_Conversions__ToShortObject
                 "ToUShort",                                 // Microsoft_VisualBasic_CompilerServices_Conversions__ToUShortObject

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -1068,6 +1068,7 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Security_Permissions_SecurityAction,
 
+
                 // System_Security_Permissions_SecurityPermissionAttribute__SkipVerification
                 (byte)MemberFlags.Property,                                                                                 // Flags
                 (byte)WellKnownType.System_Security_Permissions_SecurityPermissionAttribute,                                // DeclaringTypeId
@@ -1276,6 +1277,7 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.Microsoft_CSharp_RuntimeBinder_CSharpBinderFlags,
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Type,
+
                     (byte)SignatureTypeCode.GenericTypeInstance,
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Collections_Generic_IEnumerable_T,
                     1,
@@ -1292,6 +1294,7 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Type,
                     (byte)SignatureTypeCode.GenericTypeInstance,
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Collections_Generic_IEnumerable_T,
+
                     1,
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.Microsoft_CSharp_RuntimeBinder_CSharpArgumentInfo,
 
@@ -1316,6 +1319,7 @@ namespace Microsoft.CodeAnalysis
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
                 (byte)WellKnownType.Microsoft_VisualBasic_CompilerServices_Conversions,                                     // DeclaringTypeId
                 0,                                                                                                          // Arity
+
                     1,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean, // Return Type
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
@@ -1357,6 +1361,7 @@ namespace Microsoft.CodeAnalysis
                 (byte)WellKnownType.Microsoft_VisualBasic_CompilerServices_Conversions,                                     // DeclaringTypeId
                 0,                                                                                                          // Arity
                     1,                                                                                                      // Method Signature
+
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32, // Return Type
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
 
@@ -3647,7 +3652,15 @@ namespace Microsoft.CodeAnalysis
                  0,                                                                                                                          // Arity
                     0,                                                                                                                       // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
-
+                    
+                // System_GC__AllocateUninitializedArray_T
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)WellKnownType.ExtSentinel,  (byte)(WellKnownType.System_GC - WellKnownType.ExtSentinel),                                         // DeclaringTypeId
+                1,                                                                                                          // Arity
+                    2,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.GenericMethodParameter, 0, // Return type
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean,
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -3777,6 +3790,7 @@ namespace Microsoft.CodeAnalysis
                 "get_OffsetToStringData",                   // System_Runtime_CompilerServices_RuntimeHelpers__get_OffsetToStringData
                 "GetSubArray",                              // System_Runtime_CompilerServices_RuntimeHelpers__GetSubArray_T
                 "EnsureSufficientExecutionStack",           // System_Runtime_CompilerServices_RuntimeHelpers__EnsureSufficientExecutionStack
+
                 "Capture",                                  // System_Runtime_ExceptionServices_ExceptionDispatchInfo__Capture
                 "Throw",                                    // System_Runtime_ExceptionServices_ExceptionDispatchInfo__Throw
                 ".ctor",                                    // System_Security_UnverifiableCodeAttribute__ctor
@@ -3815,6 +3829,7 @@ namespace Microsoft.CodeAnalysis
                 "ToLong",                                   // Microsoft_VisualBasic_CompilerServices_Conversions__ToLongString
                 "ToULong",                                  // Microsoft_VisualBasic_CompilerServices_Conversions__ToULongString
                 "ToSingle",                                 // Microsoft_VisualBasic_CompilerServices_Conversions__ToSingleString
+
                 "ToDouble",                                 // Microsoft_VisualBasic_CompilerServices_Conversions__ToDoubleString
                 "ToDecimal",                                // Microsoft_VisualBasic_CompilerServices_Conversions__ToDecimalString
                 "ToDate",                                   // Microsoft_VisualBasic_CompilerServices_Conversions__ToDateString
@@ -3834,6 +3849,7 @@ namespace Microsoft.CodeAnalysis
                 "ToString",                                 // Microsoft_VisualBasic_CompilerServices_Conversions__ToStringObject
                 "ToBoolean",                                // Microsoft_VisualBasic_CompilerServices_Conversions__ToBooleanObject
                 "ToSByte",                                  // Microsoft_VisualBasic_CompilerServices_Conversions__ToSByteObject
+
                 "ToByte",                                   // Microsoft_VisualBasic_CompilerServices_Conversions__ToByteObject
                 "ToShort",                                  // Microsoft_VisualBasic_CompilerServices_Conversions__ToShortObject
                 "ToUShort",                                 // Microsoft_VisualBasic_CompilerServices_Conversions__ToUShortObject
@@ -4104,6 +4120,7 @@ namespace Microsoft.CodeAnalysis
                 "AsSpan",                                   // System_MemoryExtensions__AsSpan_String
                 ".ctor",                                    // System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute_ctor
                 ".ctor",                                    // System_MissingMethodException__ctor
+                "AllocateUninitializedArray",               // System_GC__AllocateUninitializedArray_T 
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -1068,7 +1068,6 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Security_Permissions_SecurityAction,
 
-
                 // System_Security_Permissions_SecurityPermissionAttribute__SkipVerification
                 (byte)MemberFlags.Property,                                                                                 // Flags
                 (byte)WellKnownType.System_Security_Permissions_SecurityPermissionAttribute,                                // DeclaringTypeId
@@ -1277,7 +1276,6 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.Microsoft_CSharp_RuntimeBinder_CSharpBinderFlags,
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Type,
-
                     (byte)SignatureTypeCode.GenericTypeInstance,
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Collections_Generic_IEnumerable_T,
                     1,
@@ -1294,7 +1292,6 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Type,
                     (byte)SignatureTypeCode.GenericTypeInstance,
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Collections_Generic_IEnumerable_T,
-
                     1,
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.Microsoft_CSharp_RuntimeBinder_CSharpArgumentInfo,
 
@@ -1319,7 +1316,6 @@ namespace Microsoft.CodeAnalysis
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
                 (byte)WellKnownType.Microsoft_VisualBasic_CompilerServices_Conversions,                                     // DeclaringTypeId
                 0,                                                                                                          // Arity
-
                     1,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean, // Return Type
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
@@ -1361,7 +1357,6 @@ namespace Microsoft.CodeAnalysis
                 (byte)WellKnownType.Microsoft_VisualBasic_CompilerServices_Conversions,                                     // DeclaringTypeId
                 0,                                                                                                          // Arity
                     1,                                                                                                      // Method Signature
-
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32, // Return Type
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
 

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -326,6 +326,8 @@ namespace Microsoft.CodeAnalysis
 
         System_MissingMethodException,
 
+        System_GC,
+
         NextAvailable,
         // Remember to update the AllWellKnownTypes tests when making changes here
     }
@@ -641,6 +643,7 @@ namespace Microsoft.CodeAnalysis
             "System.MemoryExtensions",
             "System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute",
             "System.MissingMethodException",
+            "System.GC",
         };
 
         private static readonly Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -739,7 +739,8 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_ITuple__get_Item,
                          WellKnownMember.System_Runtime_CompilerServices_ITuple__get_Length,
                          WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject
+                         WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject,
+                         WellKnownMember.System_GC__AllocateUninitializedArray_T
                         ' Not always available.
                         Continue For
                 End Select
@@ -891,7 +892,8 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_ITuple__get_Item,
                          WellKnownMember.System_Runtime_CompilerServices_ITuple__get_Length,
                          WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject
+                         WellKnownMember.System_Runtime_CompilerServices_SwitchExpressionException__ctorObject,
+                         WellKnownMember.System_GC__AllocateUninitializedArray_T
                         ' Not always available.
                         Continue For
                 End Select


### PR DESCRIPTION
Addresses #61011. In the case where a 1-dimensional array is created with an initializer, emit a call to `System.GC.AllocateUninitializedArray` instead of a `newarr` instruction to avoid performing an unnecessary zero-initialization.

