### PR TITLE
Increase timeout for unix single machine job

### DIFF
--- a/eng/pipelines/test-unix-job-single-machine.yml
+++ b/eng/pipelines/test-unix-job-single-machine.yml
@@ -35,7 +35,7 @@ jobs:
 
     ${{ if ne(parameters.vmImageName, '') }}:
       vmImage: ${{ parameters.vmImageName }}
-  timeoutInMinutes: 40
+  timeoutInMinutes: 50
   variables:
     DOTNET_ROLL_FORWARD: LatestMajor
     DOTNET_ROLL_FORWARD_TO_PRERELEASE: 1


### PR DESCRIPTION
This job is starting to take longer and exceeds the 40 minute limit often enough to be problematic. It only runs on rolling builds so not always easy to notice.