### PR TITLE
Allow OmniSharp options to surface through LegacyGlobalOptions

### DIFF
--- a/src/Tools/ExternalAccess/OmniSharp/Options/IOmniSharpLineFormattingOptionsProvider.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/Options/IOmniSharpLineFormattingOptionsProvider.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Options
+{
+    internal interface IOmniSharpLineFormattingOptionsProvider
+    {
+        OmniSharpLineFormattingOptions GetLineFormattingOptions();
+    }
+}

--- a/src/Tools/ExternalAccess/OmniSharp/Options/OmniSharpLineFormattingOptions.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/Options/OmniSharpLineFormattingOptions.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Options
+{
+    internal sealed record class OmniSharpLineFormattingOptions
+    {
+        public bool UseTabs { get; init; } = false;
+        public int TabSize { get; init; } = 4;
+        public int IndentationSize { get; init; } = 4;
+        public string NewLine { get; init; } = Environment.NewLine;
+    }
+}

--- a/src/Tools/ExternalAccess/OmniSharp/Options/OmnisharpLegacyGlobalOptionsWorkspaceService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/Options/OmnisharpLegacyGlobalOptionsWorkspaceService.cs
@@ -2,17 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Composition;
-using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.CodeGeneration;
-using Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers;
-using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.InlineHints;
-using Microsoft.CodeAnalysis.Options;
 using System.Threading.Tasks;
 using System.Threading;
+using System;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.CodeCleanup;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Options
 {
@@ -26,9 +25,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Options
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public OmnisharpLegacyGlobalOptionsWorkspaceService()
+        public OmnisharpLegacyGlobalOptionsWorkspaceService(IOmniSharpLineFormattingOptionsProvider lineFormattingOptionsProvider)
         {
-            _provider = new OmniSharpCleanCodeGenerationOptionsProvider();
+            _provider = new OmniSharpCleanCodeGenerationOptionsProvider(lineFormattingOptionsProvider);
         }
 
         public bool RazorUseTabs
@@ -76,9 +75,30 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Options
 
         internal sealed class OmniSharpCleanCodeGenerationOptionsProvider : AbstractCleanCodeGenerationOptionsProvider
         {
+            private readonly IOmniSharpLineFormattingOptionsProvider _lineFormattingOptionsProvider;
+
+            public OmniSharpCleanCodeGenerationOptionsProvider(IOmniSharpLineFormattingOptionsProvider lineFormattingOptionsProvider)
+            {
+                _lineFormattingOptionsProvider = lineFormattingOptionsProvider;
+            }
+
             public override ValueTask<CleanCodeGenerationOptions> GetCleanCodeGenerationOptionsAsync(HostLanguageServices languageServices, CancellationToken cancellationToken)
             {
-                return new ValueTask<CleanCodeGenerationOptions>(CleanCodeGenerationOptions.GetDefault(languageServices));
+                var lineFormattingOptions = _lineFormattingOptionsProvider.GetLineFormattingOptions();
+                var codeGenerationOptions = CleanCodeGenerationOptions.GetDefault(languageServices) with
+                {
+                    CleanupOptions = CodeCleanupOptions.GetDefault(languageServices) with
+                    {
+                        FormattingOptions = SyntaxFormattingOptions.GetDefault(languageServices).With(new LineFormattingOptions
+                        {
+                            IndentationSize = lineFormattingOptions.IndentationSize,
+                            TabSize = lineFormattingOptions.TabSize,
+                            UseTabs = lineFormattingOptions.UseTabs,
+                            NewLine = lineFormattingOptions.NewLine,
+                        })
+                    }
+                };
+                return new ValueTask<CleanCodeGenerationOptions>(codeGenerationOptions);
             }
         }
     }


### PR DESCRIPTION
In a recent Roslyn insertion attempt (https://github.com/OmniSharp/omnisharp-roslyn/pull/2416) newline related test failures were experienced using the default LegacyGlobalOptionsWorkspaceService implemented for O#. This PR allows for O# to inject in the OmniSharp LineFormattingOptions into the GlobalOptions service.