### PR TITLE
Bump the integration test timeouts a bit

### DIFF
--- a/azure-pipelines-integration-corehost.yml
+++ b/azure-pipelines-integration-corehost.yml
@@ -38,7 +38,7 @@ jobs:
   pool:
     name: NetCore1ESPool-Public
     demands: ImageOverride -equals $(queueName)
-  timeoutInMinutes: 135
+  timeoutInMinutes: 150
   variables:
     - name: XUNIT_LOGS
       value: $(Build.SourcesDirectory)\artifacts\log\Debug
@@ -54,7 +54,7 @@ jobs:
     pool:
       name: NetCore1ESPool-Public
       demands: ImageOverride -equals $(queueName)
-    timeoutInMinutes: 135
+    timeoutInMinutes: 150
     variables:
       - name: XUNIT_LOGS
         value: $(Build.SourcesDirectory)\artifacts\log\Debug

--- a/azure-pipelines-integration-lsp.yml
+++ b/azure-pipelines-integration-lsp.yml
@@ -27,7 +27,7 @@ jobs:
   pool:
     name: NetCore1ESPool-Public
     demands: ImageOverride -equals $(queueName)
-  timeoutInMinutes: 135
+  timeoutInMinutes: 150
 
   steps:
     - template: eng/pipelines/test-integration-job.yml

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -35,7 +35,7 @@ jobs:
     pool:
       name: $(poolName)
       demands: ImageOverride -equals $(queueName)
-    timeoutInMinutes: 135
+    timeoutInMinutes: 150
     variables:
       - name: XUNIT_LOGS
         value: $(Build.SourcesDirectory)\artifacts\log\Debug
@@ -50,7 +50,7 @@ jobs:
   pool:
     name: $(poolName)
     demands: ImageOverride -equals $(queueName)
-  timeoutInMinutes: 135
+  timeoutInMinutes: 150
   variables:
     - name: XUNIT_LOGS
       value: $(Build.SourcesDirectory)\artifacts\log\Debug
@@ -65,7 +65,7 @@ jobs:
   pool:
     name: $(poolName)
     demands: ImageOverride -equals $(queueName)
-  timeoutInMinutes: 135
+  timeoutInMinutes: 150
   variables:
     - name: XUNIT_LOGS
       value: $(Build.SourcesDirectory)\artifacts\log\Release
@@ -81,7 +81,7 @@ jobs:
     pool:
       name: $(poolName)
       demands: ImageOverride -equals $(queueName)
-    timeoutInMinutes: 135
+    timeoutInMinutes: 150
     variables:
       - name: XUNIT_LOGS
         value: $(Build.SourcesDirectory)\artifacts\log\Release


### PR DESCRIPTION
The actual "run tests" portion of our integration tests specify a timeout of 110 minutes; however, it can take 20 minutes of restore and build before we actually get to that portion of the job. I'm investigating a test hang where it seems like the 110 minute timeout is hit but just moments later Azure starts to kill the entire job.