### PR TITLE
Removed error-throwing and added null check instead

### DIFF
--- a/src/Features/Core/Portable/ExtractClass/AbstractExtractClassRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ExtractClass/AbstractExtractClassRefactoringProvider.cs
@@ -67,17 +67,17 @@ namespace Microsoft.CodeAnalysis.ExtractClass
             var (document, span, cancellationToken) = context;
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var memberNodeSymbolPairs = selectedMemberNodes
-                .SelectAsArray(m => (node: m, symbol: semanticModel.GetRequiredDeclaredSymbol(m, cancellationToken)))
+                .SelectAsArray(m => (node: m, symbol: semanticModel.GetDeclaredSymbol(m, cancellationToken)))
                 // Use same logic as pull members up for determining if a selected member
                 // is valid to be moved into a base
-                .WhereAsArray(pair => MemberAndDestinationValidator.IsMemberValid(pair.symbol));
+                .WhereAsArray(pair => pair.symbol != null && MemberAndDestinationValidator.IsMemberValid(pair.symbol));
 
             if (memberNodeSymbolPairs.IsEmpty)
             {
                 return null;
             }
 
-            var selectedMembers = memberNodeSymbolPairs.SelectAsArray(pair => pair.symbol);
+            var selectedMembers = memberNodeSymbolPairs.SelectAsArray(pair => pair.symbol!);
 
             var containingType = selectedMembers.First().ContainingType;
             Contract.ThrowIfNull(containingType);

--- a/src/Features/Core/Portable/MoveStaticMembers/AbstractMoveStaticMembersRefactoringProvider.cs
+++ b/src/Features/Core/Portable/MoveStaticMembers/AbstractMoveStaticMembersRefactoringProvider.cs
@@ -36,23 +36,19 @@ namespace Microsoft.CodeAnalysis.MoveStaticMembers
             }
 
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            if (semanticModel == null)
-            {
-                return;
-            }
 
             var memberNodeSymbolPairs = selectedMemberNodes
-                .SelectAsArray(m => (node: m, symbol: semanticModel.GetRequiredDeclaredSymbol(m, cancellationToken)))
+                .SelectAsArray(m => (node: m, symbol: semanticModel.GetDeclaredSymbol(m, cancellationToken)))
                 // Use same logic as pull members up for determining if a selected member
                 // is valid to be moved into a base
-                .WhereAsArray(pair => MemberAndDestinationValidator.IsMemberValid(pair.symbol) && pair.symbol.IsStatic);
+                .WhereAsArray(pair => pair.symbol != null && MemberAndDestinationValidator.IsMemberValid(pair.symbol) && pair.symbol.IsStatic);
 
             if (memberNodeSymbolPairs.IsEmpty)
             {
                 return;
             }
 
-            var selectedMembers = memberNodeSymbolPairs.SelectAsArray(pair => pair.symbol);
+            var selectedMembers = memberNodeSymbolPairs.SelectAsArray(pair => pair.symbol!);
 
             var containingType = selectedMembers.First().ContainingType;
             Contract.ThrowIfNull(containingType);

--- a/src/Features/Core/Portable/PullMemberUp/AbstractPullMemberUpRefactoringProvider.cs
+++ b/src/Features/Core/Portable/PullMemberUp/AbstractPullMemberUpRefactoringProvider.cs
@@ -48,15 +48,15 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.PullMemberUp
 
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var memberNodeSymbolPairs = selectedMemberNodes
-                .SelectAsArray(m => (node: m, symbol: semanticModel.GetRequiredDeclaredSymbol(m, cancellationToken)))
-                .WhereAsArray(pair => MemberAndDestinationValidator.IsMemberValid(pair.symbol));
+                .SelectAsArray(m => (node: m, symbol: semanticModel.GetDeclaredSymbol(m, cancellationToken)))
+                .WhereAsArray(pair => pair.symbol != null && MemberAndDestinationValidator.IsMemberValid(pair.symbol));
 
             if (memberNodeSymbolPairs.IsEmpty)
             {
                 return;
             }
 
-            var selectedMembers = memberNodeSymbolPairs.SelectAsArray(pair => pair.symbol);
+            var selectedMembers = memberNodeSymbolPairs.SelectAsArray(pair => pair.symbol!);
 
             var containingType = selectedMembers.First().ContainingType;
             Contract.ThrowIfNull(containingType);


### PR DESCRIPTION
I was just working in the main build and I got this:
 
<img width="689" alt="image" src="https://user-images.githubusercontent.com/43689321/177823349-e7603663-ef37-425f-b691-8fe287f88fdf.png">

Since it is only the 3 features I just checked in, I think my change from #62102 threw an error when the document was getting changed (and so semantic info was unavailable). This change filters out symbols for which we can't get semantic info for and quits the refactoring if all the symbols are unavailable, such as in the case where we currently throw an error.