### PR TITLE
Use secondary buffer in contained language file paths

### DIFF
--- a/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/VSTypeScriptContainedLanguageWrapper.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/VSTypeScriptContainedLanguageWrapper.cs
@@ -16,12 +16,32 @@ namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Ap
     {
         private readonly ContainedLanguage _underlyingObject;
 
+        [Obsolete("Remove once TypeScript has stopped using this.", error: true)]
         public VSTypeScriptContainedLanguageWrapper(
             IVsTextBufferCoordinator bufferCoordinator,
             IComponentModel componentModel,
             VSTypeScriptVisualStudioProjectWrapper project,
             IVsHierarchy hierarchy,
             uint itemid,
+            Guid languageServiceGuid) : this(bufferCoordinator, componentModel, project, languageServiceGuid)
+        {
+        }
+
+        [Obsolete("Remove once TypeScript has stopped using this.", error: true)]
+        public VSTypeScriptContainedLanguageWrapper(
+            IVsTextBufferCoordinator bufferCoordinator,
+            IComponentModel componentModel,
+            Workspace workspace,
+            IVsHierarchy hierarchy,
+            uint itemid,
+            Guid languageServiceGuid) : this(bufferCoordinator, componentModel, workspace, languageServiceGuid)
+        {
+        }
+
+        public VSTypeScriptContainedLanguageWrapper(
+            IVsTextBufferCoordinator bufferCoordinator,
+            IComponentModel componentModel,
+            VSTypeScriptVisualStudioProjectWrapper project,
             Guid languageServiceGuid)
         {
             _underlyingObject = new ContainedLanguage(
@@ -38,8 +58,6 @@ namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Ap
             IVsTextBufferCoordinator bufferCoordinator,
             IComponentModel componentModel,
             Workspace workspace,
-            IVsHierarchy hierarchy,
-            uint itemid,
             Guid languageServiceGuid)
         {
             var projectId = ProjectId.CreateNewId();

--- a/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/VSTypeScriptContainedLanguageWrapper.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/VSTypeScriptContainedLanguageWrapper.cs
@@ -30,8 +30,6 @@ namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Ap
                 componentModel.GetService<VisualStudioWorkspace>(),
                 project.Project.Id,
                 project.Project,
-                hierarchy,
-                itemid,
                 languageServiceGuid,
                 vbHelperFormattingRule: null);
         }
@@ -52,12 +50,10 @@ namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Ap
                 workspace,
                 projectId,
                 null,
-                hierarchy,
-                itemid,
                 languageServiceGuid,
                 vbHelperFormattingRule: null);
 
-            var filePath = _underlyingObject.GetFilePathFromBufferOrHierarchy(hierarchy, itemid);
+            var filePath = _underlyingObject.GetFilePathFromBuffers();
             workspace.OnProjectAdded(ProjectInfo.Create(projectId, VersionStamp.Default, filePath, string.Empty, InternalLanguageNames.TypeScript));
         }
 

--- a/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/VSTypeScriptContainedLanguageWrapper.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/VSTypeScriptContainedLanguageWrapper.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable CS0618 // Type or member is obsolete
-
 using System;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.ComponentModelHost;
@@ -18,29 +16,6 @@ namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Ap
     {
         private readonly ContainedLanguage _underlyingObject;
 
-        [Obsolete("Remove once TypeScript has stopped using this.", error: true)]
-        public VSTypeScriptContainedLanguageWrapper(
-            IVsTextBufferCoordinator bufferCoordinator,
-            IComponentModel componentModel,
-            AbstractProject project,
-            IVsHierarchy hierarchy,
-            uint itemid,
-            Guid languageServiceGuid)
-        {
-            var workspace = componentModel.GetService<VisualStudioWorkspace>();
-            var filePath = ContainedLanguage.GetFilePathFromHierarchyAndItemId(hierarchy, itemid);
-
-            _underlyingObject = new ContainedLanguage(
-                bufferCoordinator,
-                componentModel,
-                workspace,
-                project.Id,
-                project.VisualStudioProject,
-                filePath,
-                languageServiceGuid,
-                vbHelperFormattingRule: null);
-        }
-
         public VSTypeScriptContainedLanguageWrapper(
             IVsTextBufferCoordinator bufferCoordinator,
             IComponentModel componentModel,
@@ -49,16 +24,14 @@ namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Ap
             uint itemid,
             Guid languageServiceGuid)
         {
-            var workspace = componentModel.GetService<VisualStudioWorkspace>();
-            var filePath = ContainedLanguage.GetFilePathFromHierarchyAndItemId(hierarchy, itemid);
-
             _underlyingObject = new ContainedLanguage(
                 bufferCoordinator,
                 componentModel,
-                workspace,
+                componentModel.GetService<VisualStudioWorkspace>(),
                 project.Project.Id,
                 project.Project,
-                filePath,
+                hierarchy,
+                itemid,
                 languageServiceGuid,
                 vbHelperFormattingRule: null);
         }
@@ -71,9 +44,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Ap
             uint itemid,
             Guid languageServiceGuid)
         {
-            var filePath = ContainedLanguage.GetFilePathFromHierarchyAndItemId(hierarchy, itemid);
-            var projectId = ProjectId.CreateNewId($"Project for {filePath}");
-            workspace.OnProjectAdded(ProjectInfo.Create(projectId, VersionStamp.Default, filePath, string.Empty, InternalLanguageNames.TypeScript));
+            var projectId = ProjectId.CreateNewId();
 
             _underlyingObject = new ContainedLanguage(
                 bufferCoordinator,
@@ -81,14 +52,17 @@ namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Ap
                 workspace,
                 projectId,
                 null,
-                filePath,
+                hierarchy,
+                itemid,
                 languageServiceGuid,
                 vbHelperFormattingRule: null);
+
+            var filePath = _underlyingObject.GetFilePathFromBufferOrHierarchy(hierarchy, itemid);
+            workspace.OnProjectAdded(ProjectInfo.Create(projectId, VersionStamp.Default, filePath, string.Empty, InternalLanguageNames.TypeScript));
         }
 
         public bool IsDefault => _underlyingObject == null;
 
-        public void DisconnectHost()
-            => _underlyingObject.SetHost(null);
+        public void DisconnectHost() => _underlyingObject.SetHost(null);
     }
 }

--- a/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/VSTypeScriptContainedLanguageWrapper.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/VSTypeScriptContainedLanguageWrapper.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Ap
     {
         private readonly ContainedLanguage _underlyingObject;
 
-        [Obsolete("Remove once TypeScript has stopped using this.", error: true)]
+        [Obsolete("Use the constructor that omits the IVsHierarchy and uint parameters instead.", error: true)]
         public VSTypeScriptContainedLanguageWrapper(
             IVsTextBufferCoordinator bufferCoordinator,
             IComponentModel componentModel,
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Ap
         {
         }
 
-        [Obsolete("Remove once TypeScript has stopped using this.", error: true)]
+        [Obsolete("Use the constructor that omits the IVsHierarchy and uint parameters instead.", error: true)]
         public VSTypeScriptContainedLanguageWrapper(
             IVsTextBufferCoordinator bufferCoordinator,
             IComponentModel componentModel,

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.cs
@@ -281,15 +281,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             IVsTextBufferCoordinator bufferCoordinator, VisualStudioProject project,
             IVsHierarchy hierarchy, uint itemid)
         {
-            var filePath = ContainedLanguage.GetFilePathFromHierarchyAndItemId(hierarchy, itemid);
-
             return new ContainedLanguage(
                 bufferCoordinator,
                 this.Package.ComponentModel,
                 this.Workspace,
                 project.Id,
                 project,
-                filePath,
+                hierarchy,
+                itemid,
                 this.LanguageServiceId);
         }
     }

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.cs
@@ -287,8 +287,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 this.Workspace,
                 project.Id,
                 project,
-                hierarchy,
-                itemid,
                 this.LanguageServiceId);
         }
     }

--- a/src/VisualStudio/Core/Def/Venus/ContainedLanguage.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedLanguage.cs
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
             if (document == null)
             {
-                FatalError.ReportAndPropagate(new InvalidOperationException("Failed to get file path for a contained document"));
+                FatalError.ReportAndPropagate(new InvalidOperationException("Failed to get an ITextDocument for a contained document"));
             }
 
             return document?.FilePath ?? string.Empty;

--- a/src/VisualStudio/Core/Def/Venus/ContainedLanguage.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedLanguage.cs
@@ -96,9 +96,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             var bufferTagAggregatorFactory = ComponentModel.GetService<IBufferTagAggregatorFactoryService>();
             _bufferTagAggregator = bufferTagAggregatorFactory.CreateTagAggregator<ITag>(SubjectBuffer);
 
-            // TODO: Can contained documents be linked or shared?
-            this.DataBuffer.Changed += OnDataBufferChanged;
-
             var filePath = GetFilePathFromBuffers();
             DocumentId documentId;
 
@@ -131,6 +128,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 Project,
                 ComponentModel,
                 vbHelperFormattingRule);
+
+            // TODO: Can contained documents be linked or shared?
+            this.DataBuffer.Changed += OnDataBufferChanged;
         }
 
         public IGlobalOptionService GlobalOptions => _diagnosticAnalyzerService.GlobalOptions;

--- a/src/VisualStudio/Core/Def/Venus/ContainedLanguage.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedLanguage.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         /// </summary>
         public ITextBuffer DataBuffer { get; }
 
-        // Set when a TextViewFIlter is set.  We hold onto this to keep our TagSource objects alive even if Venus
+        // Set when a TextViewFilter is set.  We hold onto this to keep our TagSource objects alive even if Venus
         // disconnects the subject buffer from the view temporarily (which they do frequently).  Otherwise, we have to
         // re-compute all of the tag data when they re-connect it, and this causes issues like classification
         // flickering.

--- a/src/VisualStudio/LiveShare/Impl/Client/Razor/CSharpLspContainedLanguageProvider.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/Razor/CSharpLspContainedLanguageProvider.cs
@@ -47,7 +47,6 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client.Razor
                 _razorProjectFactory.Workspace,
                 projectId,
                 project: null,
-                filePath,
                 Guids.CSharpLanguageServiceId);
         }
     }

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicLanguageService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicLanguageService.vb
@@ -82,8 +82,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
                 bufferCoordinator,
                 Me.Package.ComponentModel,
                 project,
-                hierarchy,
-                itemid,
                 Me.LanguageServiceId)
         End Function
     End Class

--- a/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
@@ -36,8 +36,6 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Venus
                 componentModel.GetService(Of VisualStudioWorkspace)(),
                 project.Id,
                 project,
-                hierarchy,
-                itemid,
                 languageServiceGuid,
                 VisualBasicHelperFormattingRule.Instance)
         End Sub

--- a/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
@@ -23,11 +23,24 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Venus
         Inherits ContainedLanguage
         Implements IVsContainedLanguageStaticEventBinding
 
+        <Obsolete("Use the constructor that omits the IVsHierarchy and UInteger parameters instead.", True)>
         Public Sub New(bufferCoordinator As IVsTextBufferCoordinator,
                 componentModel As IComponentModel,
                 project As VisualStudioProject,
                 hierarchy As IVsHierarchy,
                 itemid As UInteger,
+                languageServiceGuid As Guid)
+
+            Me.New(
+                bufferCoordinator,
+                componentModel,
+                project,
+                languageServiceGuid)
+        End Sub
+
+        Public Sub New(bufferCoordinator As IVsTextBufferCoordinator,
+                componentModel As IComponentModel,
+                project As VisualStudioProject,
                 languageServiceGuid As Guid)
 
             MyBase.New(

--- a/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
@@ -36,7 +36,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Venus
                 componentModel.GetService(Of VisualStudioWorkspace)(),
                 project.Id,
                 project,
-                ContainedLanguage.GetFilePathFromHierarchyAndItemId(hierarchy, itemid),
+                hierarchy,
+                itemid,
                 languageServiceGuid,
                 VisualBasicHelperFormattingRule.Instance)
         End Sub


### PR DESCRIPTION
In order for the fix in https://devdiv.visualstudio.com/DevDiv/_git/WebTools/pullrequest/409059 to work, we need to make sure that contained languages use the file path given to the projection buffer, since it's no longer the same as the one from the original document.