### PR TITLE
Add tests showing the limitations of file-local type shadowing

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
@@ -1455,8 +1455,8 @@ public class FileModifierTests : CSharpTestBase
             {
                 public static partial void Print()
                 {
-                    global::C.M();
-                    C.M();
+                    global::C.M(); // binds to 'class C'/'file class C' from global namespace
+                    C.M(); // binds to class 'UserCode.C'
                 }
             }
 
@@ -1501,8 +1501,8 @@ public class FileModifierTests : CSharpTestBase
                 {
                     public static void Print()
                     {
-                        global::C.M();
-                        C.M();
+                        global::C.M(); // binds to 'class C'/'file class C' from global namespace
+                        C.M(); // binds to class 'UserNamespace.C'
                     }
                 }
             }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FileModifierTests.cs
@@ -745,11 +745,12 @@ public class FileModifierTests : CSharpTestBase
                 static void Main()
                 {
                     C.M();
+                    global::C.M();
                 }
             }
             """;
 
-        var verifier = CompileAndVerify(new[] { source1 + main, source2 }, expectedOutput: "1");
+        var verifier = CompileAndVerify(new[] { source1 + main, source2 }, expectedOutput: "11");
         var comp = (CSharpCompilation)verifier.Compilation;
         var cs = comp.GetMembers("C");
         var tree = comp.SyntaxTrees[0];
@@ -757,7 +758,7 @@ public class FileModifierTests : CSharpTestBase
         Assert.Equal(firstMetadataName, expectedSymbol.MetadataName);
         verify();
 
-        verifier = CompileAndVerify(new[] { source1, source2 + main }, expectedOutput: "2");
+        verifier = CompileAndVerify(new[] { source1, source2 + main }, expectedOutput: "22");
         comp = (CSharpCompilation)verifier.Compilation;
         cs = comp.GetMembers("C");
         tree = comp.SyntaxTrees[1];


### PR DESCRIPTION
Runtime has started to adopt file-local types in dotnet/runtime#71765. We had some questions come up about how the file type is supposed to be bound when other types with the same name are in scope. Adding a few tests to clarify the behavior, and to show in these specific cases that the behavior may be the same whether the 'file' modifier is used or not.