### PR TITLE
Don't report diagnostics if code-style option is disabled

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/ConvertNamespace/ConvertToBlockScopedNamespaceDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertNamespace/ConvertToBlockScopedNamespaceDiagnosticAnalyzer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
                 diagnosticLocation,
                 severity,
                 ImmutableArray.Create(declaration.GetLocation()),
-                ImmutableDictionary<string, string?>.Empty);
+                ImmutableDictionary<string, string?>.Empty).Diagnostic;
         }
     }
 }

--- a/src/Analyzers/CSharp/Analyzers/ConvertNamespace/ConvertToFileScopedNamespaceDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertNamespace/ConvertToFileScopedNamespaceDiagnosticAnalyzer.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
                 diagnosticLocation,
                 severity,
                 ImmutableArray.Create(declaration.GetLocation()),
-                ImmutableDictionary<string, string?>.Empty);
+                ImmutableDictionary<string, string?>.Empty).Diagnostic;
         }
     }
 }

--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBody/UseExpressionBodyDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBody/UseExpressionBodyDiagnosticAnalyzer.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                 var properties = ImmutableDictionary<string, string?>.Empty.Add(nameof(UseExpressionBody), "");
                 return DiagnosticHelper.Create(
                     CreateDescriptorWithId(helper.DiagnosticId, helper.EnforceOnBuild, helper.UseExpressionBodyTitle, helper.UseExpressionBodyTitle),
-                    location, severity, additionalLocations: additionalLocations, properties: properties);
+                    location, severity, additionalLocations: additionalLocations, properties: properties).Diagnostic;
             }
 
             if (helper.CanOfferUseBlockBody(preference, declaration, forAnalyzer: true, out var fixesError, out var expressionBody))
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
                 var additionalLocations = ImmutableArray.Create(declaration.GetLocation());
                 return DiagnosticHelper.Create(
                     CreateDescriptorWithId(helper.DiagnosticId, helper.EnforceOnBuild, helper.UseBlockBodyTitle, helper.UseBlockBodyTitle),
-                    location, severity, additionalLocations: additionalLocations, properties: properties);
+                    location, severity, additionalLocations: additionalLocations, properties: properties).Diagnostic;
             }
 
             return null;

--- a/src/Analyzers/CSharp/Analyzers/UseImplicitOrExplicitType/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseImplicitOrExplicitType/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             context.ReportDiagnostic(CreateDiagnostic(descriptor, declarationStatement, declaredType.StripRefIfNeeded().Span, typeStyle.Severity));
         }
 
-        private static Diagnostic CreateDiagnostic(DiagnosticDescriptor descriptor, SyntaxNode declaration, TextSpan diagnosticSpan, ReportDiagnostic severity)
+        private static DiagnosticHelper.DiagnosticWrapper CreateDiagnostic(DiagnosticDescriptor descriptor, SyntaxNode declaration, TextSpan diagnosticSpan, ReportDiagnostic severity)
             => DiagnosticHelper.Create(descriptor, declaration.SyntaxTree.GetLocation(diagnosticSpan), severity, additionalLocations: null, properties: null);
     }
 }

--- a/src/Analyzers/CSharp/Analyzers/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.cs
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
             return !invocation.Syntax.IsLeftSideOfAnyAssignExpression() || indexer == null || !IsWriteableIndexer(invocation, indexer);
         }
 
-        private Diagnostic CreateDiagnostic(Result result, ReportDiagnostic severity)
+        private DiagnosticHelper.DiagnosticWrapper CreateDiagnostic(Result result, ReportDiagnostic severity)
         {
             // Keep track of the invocation node
             var invocation = result.Invocation;

--- a/src/Analyzers/Core/Analyzers/Helpers/DiagnosticHelper.cs
+++ b/src/Analyzers/Core/Analyzers/Helpers/DiagnosticHelper.cs
@@ -10,13 +10,102 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Json;
 using System.Text;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal static class DiagnosticHelper
     {
+        public readonly struct DiagnosticWrapper
+        {
+            /// <summary>
+            /// Code-style options can have a ReportDiagnostic.Suppress severity. Such diagnostics shouldn't
+            /// be reported, so to do that we want to create a "null" diagnostic.
+            /// Because context.ReportDiagnostic doesn't take null, and it's tedious to do null check in every analyzer,
+            /// we create extension methods that check for null. But the parameter type has to be different for the
+            /// compiler to resolve it during overload resolution. So we use DiagnosticWrapper as the parameter type.
+            /// </summary>
+            /// <param name="diagnostic"></param>
+            public DiagnosticWrapper(Diagnostic? diagnostic)
+            {
+                Diagnostic = diagnostic;
+            }
+
+            public Diagnostic? Diagnostic { get; }
+        }
+
+        public static void ReportDiagnostic(this AdditionalFileAnalysisContext context, DiagnosticWrapper diagnostic)
+        {
+            if (diagnostic.Diagnostic is not null)
+            {
+                context.ReportDiagnostic(diagnostic.Diagnostic);
+            }
+        }
+
+        public static void ReportDiagnostic(this CodeBlockAnalysisContext context, DiagnosticWrapper diagnostic)
+        {
+            if (diagnostic.Diagnostic is not null)
+            {
+                context.ReportDiagnostic(diagnostic.Diagnostic);
+            }
+        }
+
+        public static void ReportDiagnostic(this CompilationAnalysisContext context, DiagnosticWrapper diagnostic)
+        {
+            if (diagnostic.Diagnostic is not null)
+            {
+                context.ReportDiagnostic(diagnostic.Diagnostic);
+            }
+        }
+
+        public static void ReportDiagnostic(this OperationAnalysisContext context, DiagnosticWrapper diagnostic)
+        {
+            if (diagnostic.Diagnostic is not null)
+            {
+                context.ReportDiagnostic(diagnostic.Diagnostic);
+            }
+        }
+
+        public static void ReportDiagnostic(this OperationBlockAnalysisContext context, DiagnosticWrapper diagnostic)
+        {
+            if (diagnostic.Diagnostic is not null)
+            {
+                context.ReportDiagnostic(diagnostic.Diagnostic);
+            }
+        }
+
+        public static void ReportDiagnostic(this SemanticModelAnalysisContext context, DiagnosticWrapper diagnostic)
+        {
+            if (diagnostic.Diagnostic is not null)
+            {
+                context.ReportDiagnostic(diagnostic.Diagnostic);
+            }
+        }
+
+        public static void ReportDiagnostic(this SymbolAnalysisContext context, DiagnosticWrapper diagnostic)
+        {
+            if (diagnostic.Diagnostic is not null)
+            {
+                context.ReportDiagnostic(diagnostic.Diagnostic);
+            }
+        }
+
+        public static void ReportDiagnostic(this SyntaxNodeAnalysisContext context, DiagnosticWrapper diagnostic)
+        {
+            if (diagnostic.Diagnostic is not null)
+            {
+                context.ReportDiagnostic(diagnostic.Diagnostic);
+            }
+        }
+
+        public static void ReportDiagnostic(this SyntaxTreeAnalysisContext context, DiagnosticWrapper diagnostic)
+        {
+            if (diagnostic.Diagnostic is not null)
+            {
+                context.ReportDiagnostic(diagnostic.Diagnostic);
+            }
+        }
+
         /// <summary>
         /// Creates a <see cref="Diagnostic"/> instance.
         /// </summary>
@@ -35,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </param>
         /// <param name="messageArgs">Arguments to the message of the diagnostic.</param>
         /// <returns>The <see cref="Diagnostic"/> instance.</returns>
-        public static Diagnostic Create(
+        public static DiagnosticWrapper Create(
             DiagnosticDescriptor descriptor,
             Location location,
             ReportDiagnostic effectiveSeverity,
@@ -48,17 +137,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 throw new ArgumentNullException(nameof(descriptor));
             }
 
-            LocalizableString message;
-            if (messageArgs == null || messageArgs.Length == 0)
+            if (effectiveSeverity == CodeAnalysis.ReportDiagnostic.Suppress)
             {
-                message = descriptor.MessageFormat;
-            }
-            else
-            {
-                message = new LocalizableStringWithArguments(descriptor.MessageFormat, messageArgs);
+                return new(null);
             }
 
-            return CreateWithMessage(descriptor, location, effectiveSeverity, additionalLocations, properties, message);
+            return new(Diagnostic.Create(descriptor, location, effectiveSeverity.ToDiagnosticSeverity() ?? descriptor.DefaultSeverity, additionalLocations, properties, messageArgs));
         }
 
         /// <summary>
@@ -80,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </param>
         /// <param name="messageArgs">Arguments to the message of the diagnostic.</param>
         /// <returns>The <see cref="Diagnostic"/> instance.</returns>
-        public static Diagnostic CreateWithLocationTags(
+        public static DiagnosticWrapper CreateWithLocationTags(
             DiagnosticDescriptor descriptor,
             Location location,
             ReportDiagnostic effectiveSeverity,
@@ -128,7 +212,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </param>
         /// <param name="messageArgs">Arguments to the message of the diagnostic.</param>
         /// <returns>The <see cref="Diagnostic"/> instance.</returns>
-        public static Diagnostic CreateWithLocationTags(
+        public static DiagnosticWrapper CreateWithLocationTags(
             DiagnosticDescriptor descriptor,
             Location location,
             ReportDiagnostic effectiveSeverity,
@@ -174,7 +258,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </param>
         /// <param name="messageArgs">Arguments to the message of the diagnostic.</param>
         /// <returns>The <see cref="Diagnostic"/> instance.</returns>
-        private static Diagnostic CreateWithLocationTags(
+        private static DiagnosticWrapper CreateWithLocationTags(
             DiagnosticDescriptor descriptor,
             Location location,
             ReportDiagnostic effectiveSeverity,
@@ -206,55 +290,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        /// <summary>
-        /// Creates a <see cref="Diagnostic"/> instance.
-        /// </summary>
-        /// <param name="descriptor">A <see cref="DiagnosticDescriptor"/> describing the diagnostic.</param>
-        /// <param name="location">An optional primary location of the diagnostic. If null, <see cref="Location"/> will return <see cref="Location.None"/>.</param>
-        /// <param name="effectiveSeverity">Effective severity of the diagnostic.</param>
-        /// <param name="additionalLocations">
-        /// An optional set of additional locations related to the diagnostic.
-        /// Typically, these are locations of other items referenced in the message.
-        /// If null, <see cref="Diagnostic.AdditionalLocations"/> will return an empty list.
-        /// </param>
-        /// <param name="properties">
-        /// An optional set of name-value pairs by means of which the analyzer that creates the diagnostic
-        /// can convey more detailed information to the fixer. If null, <see cref="Diagnostic.Properties"/> will return
-        /// <see cref="ImmutableDictionary{TKey, TValue}.Empty"/>.
-        /// </param>
-        /// <param name="message">Localizable message for the diagnostic.</param>
-        /// <returns>The <see cref="Diagnostic"/> instance.</returns>
-        public static Diagnostic CreateWithMessage(
-            DiagnosticDescriptor descriptor,
-            Location location,
-            ReportDiagnostic effectiveSeverity,
-            IEnumerable<Location>? additionalLocations,
-            ImmutableDictionary<string, string?>? properties,
-            LocalizableString message)
-        {
-            if (descriptor == null)
-            {
-                throw new ArgumentNullException(nameof(descriptor));
-            }
-
-            return Diagnostic.Create(
-                descriptor.Id,
-                descriptor.Category,
-                message,
-                effectiveSeverity.ToDiagnosticSeverity() ?? descriptor.DefaultSeverity,
-                descriptor.DefaultSeverity,
-                descriptor.IsEnabledByDefault,
-                warningLevel: effectiveSeverity.WithDefaultSeverity(descriptor.DefaultSeverity) == ReportDiagnostic.Error ? 0 : 1,
-                effectiveSeverity == ReportDiagnostic.Suppress,
-                descriptor.Title,
-                descriptor.Description,
-                descriptor.HelpLinkUri,
-                location,
-                additionalLocations,
-                descriptor.CustomTags,
-                properties);
-        }
-
         public static string? GetHelpLinkForDiagnosticId(string id)
         {
             // TODO: Add documentation for Regex and Json analyzer
@@ -267,91 +302,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             Debug.Assert(id.StartsWith("IDE", StringComparison.Ordinal));
             return $"https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/{id.ToLowerInvariant()}";
-        }
-
-        public sealed class LocalizableStringWithArguments : LocalizableString, IObjectWritable
-        {
-            private readonly LocalizableString _messageFormat;
-            private readonly string[] _formatArguments;
-
-            static LocalizableStringWithArguments()
-                => ObjectBinder.RegisterTypeReader(typeof(LocalizableStringWithArguments), reader => new LocalizableStringWithArguments(reader));
-
-            public LocalizableStringWithArguments(LocalizableString messageFormat, params object[] formatArguments)
-            {
-                if (messageFormat == null)
-                {
-                    throw new ArgumentNullException(nameof(messageFormat));
-                }
-
-                if (formatArguments == null)
-                {
-                    throw new ArgumentNullException(nameof(formatArguments));
-                }
-
-                _messageFormat = messageFormat;
-                _formatArguments = new string[formatArguments.Length];
-                for (var i = 0; i < formatArguments.Length; i++)
-                {
-                    _formatArguments[i] = $"{formatArguments[i]}";
-                }
-            }
-
-            private LocalizableStringWithArguments(ObjectReader reader)
-            {
-                _messageFormat = (LocalizableString)reader.ReadValue();
-
-                var length = reader.ReadInt32();
-                if (length == 0)
-                {
-                    _formatArguments = Array.Empty<string>();
-                }
-                else
-                {
-                    using var argumentsBuilderDisposer = ArrayBuilder<string>.GetInstance(length, out var argumentsBuilder);
-                    for (var i = 0; i < length; i++)
-                    {
-                        argumentsBuilder.Add(reader.ReadString());
-                    }
-
-                    _formatArguments = argumentsBuilder.ToArray();
-                }
-            }
-
-            bool IObjectWritable.ShouldReuseInSerialization => false;
-
-            void IObjectWritable.WriteTo(ObjectWriter writer)
-            {
-                writer.WriteValue(_messageFormat);
-                var length = _formatArguments.Length;
-                writer.WriteInt32(length);
-                for (var i = 0; i < length; i++)
-                {
-                    writer.WriteString(_formatArguments[i]);
-                }
-            }
-
-            protected override string GetText(IFormatProvider? formatProvider)
-            {
-                var messageFormat = _messageFormat.ToString(formatProvider);
-                return messageFormat != null ?
-                    (_formatArguments.Length > 0 ? string.Format(formatProvider, messageFormat, _formatArguments) : messageFormat) :
-                    string.Empty;
-            }
-
-            protected override bool AreEqual(object? other)
-            {
-                return other is LocalizableStringWithArguments otherResourceString &&
-                    _messageFormat.Equals(otherResourceString._messageFormat) &&
-                    _formatArguments.SequenceEqual(otherResourceString._formatArguments, (a, b) => a == b);
-            }
-
-            protected override int GetHash()
-            {
-                return Hash.Combine(
-                    _messageFormat.GetHashCode(),
-                    Hash.CombineValues(_formatArguments));
-            }
         }
     }
 }

--- a/src/Analyzers/Core/Analyzers/NamingStyle/NamingStyleDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/Core/Analyzers/NamingStyle/NamingStyleDiagnosticAnalyzerBase.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             builder["OptionName"] = nameof(NamingStyleOptions.NamingPreferences);
             builder["OptionLanguage"] = compilation.Language;
 
-            return DiagnosticHelper.Create(Descriptor, symbol.Locations.First(), applicableRule.EnforcementLevel, additionalLocations: null, builder.ToImmutable(), failureReason);
+            return DiagnosticHelper.Create(Descriptor, symbol.Locations.First(), applicableRule.EnforcementLevel, additionalLocations: null, builder.ToImmutable(), failureReason).Diagnostic;
         }
 
         public override DiagnosticAnalyzerCategory GetAnalyzerCategory()

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
@@ -87,6 +87,30 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
             description: new LocalizableResourceString(nameof(AnalyzersResources.Avoid_unused_parameters_in_your_code_If_the_parameter_cannot_be_removed_then_change_its_name_so_it_starts_with_an_underscore_and_is_optionally_followed_by_an_integer_such_as__comma__1_comma__2_etc_These_are_treated_as_special_discard_symbol_names), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
             isUnnecessary: true);
 
+        private static readonly DiagnosticDescriptor s_unusedParameterRuleForPublicApiHasReference = CreateDescriptorWithId(
+            IDEDiagnosticIds.UnusedParameterDiagnosticId,
+            EnforceOnBuildValues.UnusedParameter,
+            new LocalizableResourceString(nameof(AnalyzersResources.Remove_unused_parameter), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+            new LocalizableResourceString(nameof(AnalyzersResources.Parameter_0_can_be_removed_if_it_is_not_part_of_a_shipped_public_API_its_initial_value_is_never_used), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+            description: new LocalizableResourceString(nameof(AnalyzersResources.Avoid_unused_parameters_in_your_code_If_the_parameter_cannot_be_removed_then_change_its_name_so_it_starts_with_an_underscore_and_is_optionally_followed_by_an_integer_such_as__comma__1_comma__2_etc_These_are_treated_as_special_discard_symbol_names), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+            isUnnecessary: true);
+
+        private static readonly DiagnosticDescriptor s_unusedParameterRuleForPublicApiNoReference = CreateDescriptorWithId(
+            IDEDiagnosticIds.UnusedParameterDiagnosticId,
+            EnforceOnBuildValues.UnusedParameter,
+            new LocalizableResourceString(nameof(AnalyzersResources.Remove_unused_parameter), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+            new LocalizableResourceString(nameof(AnalyzersResources.Remove_unused_parameter_0_if_it_is_not_part_of_a_shipped_public_API), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+            description: new LocalizableResourceString(nameof(AnalyzersResources.Avoid_unused_parameters_in_your_code_If_the_parameter_cannot_be_removed_then_change_its_name_so_it_starts_with_an_underscore_and_is_optionally_followed_by_an_integer_such_as__comma__1_comma__2_etc_These_are_treated_as_special_discard_symbol_names), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+            isUnnecessary: true);
+
+        private static readonly DiagnosticDescriptor s_unusedParameterRuleForNonPublicApiHasReference = CreateDescriptorWithId(
+            IDEDiagnosticIds.UnusedParameterDiagnosticId,
+            EnforceOnBuildValues.UnusedParameter,
+            new LocalizableResourceString(nameof(AnalyzersResources.Remove_unused_parameter), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+            new LocalizableResourceString(nameof(AnalyzersResources.Parameter_0_can_be_removed_its_initial_value_is_never_used), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+            description: new LocalizableResourceString(nameof(AnalyzersResources.Avoid_unused_parameters_in_your_code_If_the_parameter_cannot_be_removed_then_change_its_name_so_it_starts_with_an_underscore_and_is_optionally_followed_by_an_integer_such_as__comma__1_comma__2_etc_These_are_treated_as_special_discard_symbol_names), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+            isUnnecessary: true);
+
         private static readonly PropertiesMap s_propertiesMap = CreatePropertiesMap();
 
         protected AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer(
@@ -97,7 +121,10 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
                         .Add(s_expressionValueIsUnusedRule, unusedValueExpressionStatementOption)
                         .Add(s_valueAssignedIsUnusedRule, unusedValueAssignmentOption),
                    ImmutableDictionary<DiagnosticDescriptor, IPerLanguageOption>.Empty
-                        .Add(s_unusedParameterRule, CodeStyleOptions2.UnusedParameters),
+                        .Add(s_unusedParameterRule, CodeStyleOptions2.UnusedParameters)
+                        .Add(s_unusedParameterRuleForPublicApiHasReference, CodeStyleOptions2.UnusedParameters)
+                        .Add(s_unusedParameterRuleForPublicApiNoReference, CodeStyleOptions2.UnusedParameters)
+                        .Add(s_unusedParameterRuleForNonPublicApiHasReference, CodeStyleOptions2.UnusedParameters),
                    language)
         {
         }

--- a/src/Features/CSharp/Portable/UseExpressionBodyForLambda/UseExpressionBodyForLambdaCodeStyleProvider_Analysis.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBodyForLambda/UseExpressionBodyForLambdaCodeStyleProvider_Analysis.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBodyForLambda
                 var properties = ImmutableDictionary<string, string>.Empty;
                 return DiagnosticHelper.Create(
                     CreateDescriptorWithId(UseExpressionBodyTitle, UseExpressionBodyTitle),
-                    location, option.Notification.Severity, additionalLocations, properties);
+                    location, option.Notification.Severity, additionalLocations, properties).Diagnostic;
             }
 
             if (CanOfferUseBlockBody(semanticModel, option.Value, declaration, cancellationToken))
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBodyForLambda
                 var additionalLocations = ImmutableArray.Create(declaration.GetLocation());
                 return DiagnosticHelper.Create(
                     CreateDescriptorWithId(UseBlockBodyTitle, UseBlockBodyTitle),
-                    location, option.Notification.Severity, additionalLocations, properties);
+                    location, option.Notification.Severity, additionalLocations, properties).Diagnostic;
             }
 
             return null;

--- a/src/Features/Core/Portable/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/SimplifyTypeNames/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -145,10 +145,10 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
             }
 
             diagnostic = CreateDiagnostic(model, options, issueSpan, diagnosticId, inDeclaration);
-            return true;
+            return diagnostic is not null;
         }
 
-        internal static Diagnostic CreateDiagnostic(SemanticModel model, TSimplifierOptions options, TextSpan issueSpan, string diagnosticId, bool inDeclaration)
+        private static Diagnostic? CreateDiagnostic(SemanticModel model, TSimplifierOptions options, TextSpan issueSpan, string diagnosticId, bool inDeclaration)
         {
             DiagnosticDescriptor descriptor;
             ReportDiagnostic severity;
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.SimplifyTypeNames
             }
 #endif
 
-            return diagnostic;
+            return diagnostic.Diagnostic;
         }
 
         public DiagnosticAnalyzerCategory GetAnalyzerCategory()


### PR DESCRIPTION
Replces https://github.com/dotnet/roslyn/pull/62150

Previously, we report diagnostics with `IsSuppressed` if the code-style option is disabled. The use of `IsSuppressed` in this case is suspicious, this property is related to source (attribute/pragma) suppressions. If code-style option is disabled, no diagnostic should be reported.

@mavasani for review