### PR TITLE
Export embedded language detector through EA layer for asp.net

### DIFF
--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreCSharpRouteSyntaxDetector.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreCSharpRouteSyntaxDetector.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.EmbeddedLanguages.LanguageServices;
+using Microsoft.CodeAnalysis.EmbeddedLanguages;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
+{
+    internal sealed class AspNetCoreCSharpRouteSyntaxDetector
+    {
+        public static readonly AspNetCoreCSharpRouteSyntaxDetector Instance = new();
+
+        private readonly EmbeddedLanguageDetector _detector = new(
+            CSharpEmbeddedLanguagesProvider.Info,
+            ImmutableArray.Create("Route"));
+
+        private AspNetCoreCSharpRouteSyntaxDetector()
+        {
+        }
+
+        public bool IsEmbeddedLanguageToken(
+            SyntaxToken token,
+            SemanticModel semanticModel,
+            CancellationToken cancellationToken,
+            [NotNullWhen(true)] out string? identifier,
+            out IEnumerable<string>? options)
+        {
+            return _detector.IsEmbeddedLanguageToken(token, semanticModel, cancellationToken, out identifier, out options);
+        }
+    }
+}

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualChar.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualChar.cs
@@ -11,11 +11,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
 {
     internal readonly struct AspNetCoreVirtualChar : IEquatable<AspNetCoreVirtualChar>
     {
-        private readonly VirtualChar _virtualChar;
+        internal readonly VirtualChar VirtualChar;
 
         internal AspNetCoreVirtualChar(VirtualChar virtualChar)
         {
-            _virtualChar = virtualChar;
+            VirtualChar = virtualChar;
         }
 
         /// <summary>
@@ -25,28 +25,28 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
         {
             // Rune is an internal shim with netstandard2.0 and accessing it throws an internal access exception.
             // Expose integer value. Can be converted back to Rune by caller.
-            get => _virtualChar.Rune.Value;
+            get => VirtualChar.Rune.Value;
         }
 
         /// <inheritdoc cref="VirtualChar.SurrogateChar"/>
-        public char SurrogateChar => _virtualChar.SurrogateChar;
+        public char SurrogateChar => VirtualChar.SurrogateChar;
 
         /// <inheritdoc cref="VirtualChar.Span"/>
-        public TextSpan Span => _virtualChar.Span;
+        public TextSpan Span => VirtualChar.Span;
 
         /// <inheritdoc cref="VirtualChar.Value"/>
-        public int Value => _virtualChar.Value;
+        public int Value => VirtualChar.Value;
 
         /// <inheritdoc cref="VirtualChar.ToString"/>
-        public override string ToString() => _virtualChar.ToString();
+        public override string ToString() => VirtualChar.ToString();
 
         /// <inheritdoc cref="VirtualChar.Equals(object)"/>
         public override bool Equals(object? obj) => obj is AspNetCoreVirtualChar vc && Equals(vc);
 
         /// <inheritdoc cref="VirtualChar.Equals(VirtualChar)"/>
-        public bool Equals(AspNetCoreVirtualChar other) => _virtualChar.Equals(other._virtualChar);
+        public bool Equals(AspNetCoreVirtualChar other) => VirtualChar.Equals(other.VirtualChar);
 
         /// <inheritdoc cref="VirtualChar.GetHashCode"/>
-        public override int GetHashCode() => _virtualChar.GetHashCode();
+        public override int GetHashCode() => VirtualChar.GetHashCode();
     }
 }

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
@@ -24,6 +24,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
         /// <inheritdoc cref="VirtualCharSequence.Empty"/>
         public static readonly AspNetCoreVirtualCharSequence Empty = new(VirtualCharSequence.Empty);
 
+        /// <inheritdoc cref="VirtualCharSequence.IsDefault"/>
+        public int IsDefault => _virtualCharSequence.IsDefault;
+
         /// <inheritdoc cref="VirtualCharSequence.Length"/>
         public int Length => _virtualCharSequence.Length;
 
@@ -44,15 +47,19 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
             AspNetCoreVirtualCharSequence chars1, AspNetCoreVirtualCharSequence chars2) =>
             new(VirtualCharSequence.FromBounds(chars1._virtualCharSequence, chars2._virtualCharSequence));
 
+        /// <inheritdoc cref="VirtualCharSequence.IndexOf"/>
         public int IndexOf(AspNetCoreVirtualChar @char)
             => _virtualCharSequence.IndexOf(@char.VirtualChar);
 
+        /// <inheritdoc cref="VirtualCharSequence.Contains"/>
         public bool Contains(AspNetCoreVirtualChar @char)
             => _virtualCharSequence.Contains(@char.VirtualChar);
 
+        /// <inheritdoc cref="VirtualCharSequence.GetEnumerator"/>
         public Enumerator GetEnumerator()
             => new Enumerator(_virtualCharSequence.GetEnumerator());
 
+        /// <inheritdoc cref="VirtualCharSequence.Enumerator"/>
         public struct Enumerator : IEnumerator<AspNetCoreVirtualChar>
         {
             private VirtualCharSequence.Enumerator _enumerator;

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
@@ -3,7 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
@@ -40,5 +43,39 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
         public static AspNetCoreVirtualCharSequence FromBounds(
             AspNetCoreVirtualCharSequence chars1, AspNetCoreVirtualCharSequence chars2) =>
             new(VirtualCharSequence.FromBounds(chars1._virtualCharSequence, chars2._virtualCharSequence));
+
+        public int IndexOf(AspNetCoreVirtualChar @char)
+            => _virtualCharSequence.IndexOf(@char.VirtualChar);
+
+        public bool Contains(AspNetCoreVirtualChar @char)
+            => _virtualCharSequence.Contains(@char.VirtualChar);
+
+        public Enumerator GetEnumerator()
+            => new Enumerator(_virtualCharSequence.GetEnumerator());
+
+        public struct Enumerator : IEnumerator<AspNetCoreVirtualChar>
+        {
+            private VirtualCharSequence.Enumerator _enumerator;
+
+            public Enumerator(VirtualCharSequence.Enumerator enumerator)
+            {
+                _enumerator = enumerator;
+            }
+
+            public bool MoveNext()
+                => _enumerator.MoveNext();
+
+            public AspNetCoreVirtualChar Current
+                => new(_enumerator.Current);
+
+            public void Reset()
+                => _enumerator.Reset();
+
+            object IEnumerator.Current
+                => this.Current;
+
+            public void Dispose()
+                => _enumerator.Dispose();
+        }
     }
 }

--- a/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
+++ b/src/Tools/ExternalAccess/AspNetCore/EmbeddedLanguages/AspNetCoreVirtualCharSequence.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.EmbeddedLanguages
         public static readonly AspNetCoreVirtualCharSequence Empty = new(VirtualCharSequence.Empty);
 
         /// <inheritdoc cref="VirtualCharSequence.IsDefault"/>
-        public int IsDefault => _virtualCharSequence.IsDefault;
+        public bool IsDefault => _virtualCharSequence.IsDefault;
 
         /// <inheritdoc cref="VirtualCharSequence.Length"/>
         public int Length => _virtualCharSequence.Length;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequence.Enumerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequence.Enumerator.cs
@@ -24,11 +24,11 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars
             public bool MoveNext() => ++_position < _virtualCharSequence.Length;
             public VirtualChar Current => _virtualCharSequence[_position];
 
-            void IEnumerator.Reset()
+            public void Reset()
                 => _position = -1;
 
             object? IEnumerator.Current => this.Current;
-            void IDisposable.Dispose() { }
+            public void Dispose() { }
         }
     }
 }


### PR DESCRIPTION
ASP currently has a copy of this (which isn't great, esp. as we fix/enhance our impl) that they use for determining if they're in a Route-syntax string for completion and diagnostic analyzers.  This will allow them to avoid a bunch of code duplication and maintenance costs.