### PR TITLE
Node Selection Incomplete member and Global Statement fix

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.ExtractClass;
 using Microsoft.CodeAnalysis.PullMemberUp;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Testing;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
@@ -2227,6 +2228,65 @@ internal class MyBase<T1, T3>
                     }
                 },
                 DialogSelection = MakeSelection("Field1", "Method")
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestIncompleteFieldSelection_NoAction()
+        {
+            var input = @"
+class C
+{
+    pub[||] int Foo = 0;
+}
+";
+            var test = new Test
+            {
+                TestCode = input,
+                FixedCode = input
+            };
+            // no need for dialog selection because we shouldn't activate at all
+            test.ExpectedDiagnostics.Add( DiagnosticResult.CompilerError("CS1519").WithSpan(4, 9, 4, 12).WithArguments("int"));
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestIncompleteMethodSelection_NoAction()
+        {
+            var input = @"
+class C
+{
+    pub[||] int Foo()
+    {
+        return 5;
+    }
+}
+";
+            var test = new Test
+            {
+                TestCode = input,
+                FixedCode = input
+            };
+            // no need for dialog selection because we shouldn't activate at all
+            test.ExpectedDiagnostics.Add(DiagnosticResult.CompilerError("CS1519").WithSpan(4, 9, 4, 12).WithArguments("int"));
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestTopLevelStatementSelection_NoAction()
+        {
+            var input = @"
+[||]_ = 42;
+";
+            await new Test
+            {
+                TestCode = input,
+                FixedCode = input,
+                LanguageVersion = LanguageVersion.CSharp10,
+                TestState =
+                {
+                    OutputKind = OutputKind.ConsoleApplication
+                }
             }.RunAsync();
         }
 

--- a/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/MoveStaticMembers/CSharpMoveStaticMembersTests.cs
@@ -4,10 +4,14 @@
 
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using System.Windows.Documents;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.MoveStaticMembers;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities.MoveStaticMembers;
+using Microsoft.CodeAnalysis.Testing;
+using Newtonsoft.Json.Linq;
+using TestResources.MetadataTests;
 using Xunit;
 using VerifyCS = Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.CSharpCodeRefactoringVerifier<
     Microsoft.CodeAnalysis.CSharp.CodeRefactorings.MoveStaticMembers.CSharpMoveStaticMembersRefactoringProvider>;
@@ -3156,6 +3160,89 @@ namespace TestNs1
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
+        public async Task TestSelectMalformedMethod_NoAction()
+        {
+            var initialMarkup = @"
+namespace TestNs1
+{
+    public class Class1
+    {
+        public st[||] int TestMethod()
+        {
+            return 0;
+        }
+    }
+}";
+            var test = new Test("", ImmutableArray<string>.Empty, "")
+            {
+                TestCode = initialMarkup,
+                FixedCode = initialMarkup,
+            };
+            test.ExpectedDiagnostics.Add(DiagnosticResult.CompilerError("CS1519").WithSpan(6, 19, 6, 22).WithArguments("int"));
+            await test.RunAsync().ConfigureAwait(false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
+        public async Task TestSelectMalformedField_NoAction1()
+        {
+            var initialMarkup = @"
+namespace TestNs1
+{
+    public class Class1
+    {
+        public st[||] int TestField = 0;
+    }
+}";
+            var test = new Test("", ImmutableArray<string>.Empty, "")
+            {
+                TestCode = initialMarkup,
+                FixedCode = initialMarkup,
+            };
+            test.ExpectedDiagnostics.Add(DiagnosticResult.CompilerError("CS1519").WithSpan(6, 19, 6, 22).WithArguments("int"));
+            await test.RunAsync().ConfigureAwait(false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
+        public async Task TestSelectMalformedField_NoAction2()
+        {
+            var initialMarkup = @"
+namespace TestNs1
+{
+    public class Class1
+    {
+        public st[| int Test|]Field = 0;
+    }
+}";
+            var test = new Test("", ImmutableArray<string>.Empty, "")
+            {
+                TestCode = initialMarkup,
+                FixedCode = initialMarkup,
+            };
+            test.ExpectedDiagnostics.Add(DiagnosticResult.CompilerError("CS1519").WithSpan(6, 19, 6, 22).WithArguments("int"));
+            await test.RunAsync().ConfigureAwait(false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
+        public async Task TestSelectMalformedField_NoAction3()
+        {
+            var initialMarkup = @"
+namespace TestNs1
+{
+    public class Class1
+    {
+        [|public st int TestField = 0;|]
+    }
+}";
+            var test = new Test("", ImmutableArray<string>.Empty, "")
+            {
+                TestCode = initialMarkup,
+                FixedCode = initialMarkup,
+            };
+            test.ExpectedDiagnostics.Add(DiagnosticResult.CompilerError("CS1519").WithSpan(6, 19, 6, 22).WithArguments("int"));
+            await test.RunAsync().ConfigureAwait(false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
         public async Task TestSelectPropertyBody_NoAction()
         {
             var initialMarkup = @"
@@ -3230,6 +3317,72 @@ namespace TestNs1
     }
 }";
             await TestNoRefactoringAsync(initialMarkup).ConfigureAwait(false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
+        public async Task TestSelectTopLevelStatement_NoAction1()
+        {
+            var initialMarkup = @"
+using System;
+
+[||]Console.WriteLine(5);
+";
+
+            await new Test("", ImmutableArray<string>.Empty, "")
+            {
+                TestCode = initialMarkup,
+                FixedCode = initialMarkup,
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp10,
+                TestState =
+                {
+                    OutputKind = OutputKind.ConsoleApplication
+                },
+            }.RunAsync().ConfigureAwait(false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
+        public async Task TestSelectTopLevelStatement_NoAction2()
+        {
+            var initialMarkup = @"
+using System;
+
+[|Console.WriteLine(5);|]
+";
+
+            await new Test("", ImmutableArray<string>.Empty, "")
+            {
+                TestCode = initialMarkup,
+                FixedCode = initialMarkup,
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp10,
+                TestState =
+                {
+                    OutputKind = OutputKind.ConsoleApplication
+                },
+            }.RunAsync().ConfigureAwait(false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)]
+        public async Task TestSelectTopLevelLocalFunction_NoAction()
+        {
+            var initialMarkup = @"
+DoSomething();
+
+static int Do[||]Something()
+{
+    return 5;
+}
+";
+
+            await new Test("", ImmutableArray<string>.Empty, "")
+            {
+                TestCode = initialMarkup,
+                FixedCode = initialMarkup,
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp10,
+                TestState =
+                {
+                    OutputKind = OutputKind.ConsoleApplication
+                },
+            }.RunAsync().ConfigureAwait(false);
         }
         #endregion
 

--- a/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
+++ b/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
@@ -5897,7 +5897,7 @@ namespace PushUpTest
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
         public async Task TestRefactoringSelectionFieldKeyword1_NoAction()
         {
             var text = @"
@@ -5912,7 +5912,7 @@ public class Bar : BaseClass
             await TestQuickActionNotProvidedAsync(text);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
         public async Task TestRefactoringSelectionFieldKeyword2()
         {
             var text = @"
@@ -5936,7 +5936,7 @@ public class Bar : BaseClass
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
         public async Task TestRefactoringSelectionFieldAfterSemicolon()
         {
             var text = @"
@@ -5960,7 +5960,7 @@ public class Bar : BaseClass
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
         public async Task TestRefactoringSelectionFieldEntireDeclaration()
         {
             var text = @"
@@ -5984,7 +5984,7 @@ public class Bar : BaseClass
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
         public async Task TestRefactoringSelectionMultipleFieldsInDeclaration1()
         {
             var text = @"
@@ -6009,7 +6009,7 @@ public class Bar : BaseClass
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
         public async Task TestRefactoringSelectionMultipleFieldsInDeclaration2()
         {
             var text = @"
@@ -6034,7 +6034,7 @@ public class Bar : BaseClass
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
         public async Task TestRefactoringSelectionMultipleFieldsInDeclaration3()
         {
             var text = @"
@@ -6059,7 +6059,7 @@ public class Bar : BaseClass
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
         public async Task TestRefactoringSelectionMultipleMembers1()
         {
             var text = @"
@@ -6095,7 +6095,7 @@ public class Bar : BaseClass
         }
 
         // Some of these have weird whitespace spacing that might suggest a bug
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
         public async Task TestRefactoringSelectionMultipleMembers2()
         {
             var text = @"
@@ -6134,7 +6134,7 @@ public class Bar : BaseClass
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
         public async Task TestRefactoringSelectionMultipleMembers3()
         {
             var text = @"
@@ -6171,7 +6171,7 @@ public class Bar : BaseClass
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
-        [Fact]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
         public async Task TestRefactoringSelectionMultipleMembers4()
         {
             var text = @"
@@ -6208,6 +6208,40 @@ public class Bar : BaseClass
     }
 }";
             await TestWithPullMemberDialogAsync(text, expected);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
+        public async Task TestRefactoringSelectionIncompleteField_NoAction()
+        {
+            var text = @"
+public class BaseClass
+{
+}
+
+public class Bar : BaseClass
+{
+    publ[||] int Goo = 10;
+}";
+            // we expect a diagnostic/error, but also we shouldn't provide the refactoring
+            await TestQuickActionNotProvidedAsync(text);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPullMemberUp)]
+        public async Task TestRefactoringSelectionIncompleteMethod_NoAction()
+        {
+            var text = @"
+public class BaseClass
+{
+}
+
+public class Bar : BaseClass
+{
+    publ[||] int DoSomething() {
+        return 5;
+    }
+}";
+            // we expect a diagnostic/error, but also we shouldn't provide the refactoring
+            await TestQuickActionNotProvidedAsync(text);
         }
         #endregion
     }

--- a/src/EditorFeatures/VisualBasicTest/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
@@ -5,6 +5,7 @@
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.MoveStaticMembers
 Imports Microsoft.CodeAnalysis.Test.Utilities.MoveStaticMembers
+Imports Microsoft.CodeAnalysis.Testing
 Imports VerifyVB = Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.VisualBasicCodeRefactoringVerifier(Of
     Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.MoveStaticMembers.VisualBasicMoveStaticMembersRefactoringProvider)
 
@@ -2828,6 +2829,42 @@ Namespace TestNs
 End Namespace"
 
             Await TestNoRefactoringAsync(initialMarkup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>
+        Public Async Function TestSelectInIncompleteField_NoAction1() As Task
+            Dim initialMarkup = "
+Namespace TestNs
+    Public Class Class1
+        Public[||]
+    End Class
+End Namespace"
+
+            Dim test = New Test("", ImmutableArray(Of String).Empty, "") With
+            {
+                .TestCode = initialMarkup,
+                .FixedCode = initialMarkup
+            }
+            test.ExpectedDiagnostics.Add(DiagnosticResult.CompilerError("BC30203").WithSpan(4, 15, 4, 15))
+            Await test.RunAsync().ConfigureAwait(False)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>
+        Public Async Function TestSelectInIncompleteField_NoAction2() As Task
+            Dim initialMarkup = "
+Namespace TestNs
+    Public Class Class1
+        Public Sha[||] TestField As Integer = 0
+    End Class
+End Namespace"
+
+            Dim test = New Test("", ImmutableArray(Of String).Empty, "") With
+            {
+                .TestCode = initialMarkup,
+                .FixedCode = initialMarkup
+            }
+            test.ExpectedDiagnostics.Add(DiagnosticResult.CompilerError("BC30205").WithSpan(4, 20, 4, 29))
+            Await test.RunAsync().ConfigureAwait(False)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>

--- a/src/Features/CSharp/Portable/CodeRefactorings/NodeSelectionHelpers.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/NodeSelectionHelpers.cs
@@ -42,6 +42,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings
                     {
                         FieldDeclarationSyntax fieldDeclaration => fieldDeclaration.Declaration.Variables.AsImmutable<SyntaxNode>(),
                         EventFieldDeclarationSyntax eventFieldDeclaration => eventFieldDeclaration.Declaration.Variables.AsImmutable<SyntaxNode>(),
+                        IncompleteMemberSyntax _ => ImmutableArray<SyntaxNode>.Empty,
+                        GlobalStatementSyntax _ => ImmutableArray<SyntaxNode>.Empty,
                         _ => ImmutableArray.Create<SyntaxNode>(memberDeclaration),
                     };
                 }
@@ -53,7 +55,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings
                 // pick up on keywords before the declaration, such as "public static int".
                 // We could potentially use it for every case if that behavior changes
                 var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-                return await CSharpSelectedMembers.Instance.GetSelectedMembersAsync(tree, span, allowPartialSelection: true, cancellationToken).ConfigureAwait(false);
+                var members = await CSharpSelectedMembers.Instance.GetSelectedMembersAsync(tree, span, allowPartialSelection: true, cancellationToken).ConfigureAwait(false);
+                return members.Any(m => m is GlobalStatementSyntax or IncompleteMemberSyntax)
+                    ? ImmutableArray<SyntaxNode>.Empty
+                    : members;
             }
         }
     }


### PR DESCRIPTION
Continuation/related to #62467

Fixes issue described there where Move Static Members, Extract Class, and Pull Members Up refactorings would fail due to not being able to get the symbol on certain members, namely `IncompleteMemberSyntax` and `GlobalStatementSyntax`. Adds a filter in the `NodeSelectionHelpers.cs` for both the empty and nonempty span case, where either of those types being found will return an empty array instead of the actual member(s), causing the refactoring to not provide anything. VB does'nt have this problem, as they don't use the same `MemberDeclarationSyntax` and so neither of these incorrect types would show up.

Adds tests for all these refactoring tools.