### PR TITLE
Fix null reference in DiagnosticIncrementalAnalyzer.CompilationManager

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.CompilationManager.cs
@@ -27,12 +27,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             var ideOptions = AnalyzerService.GlobalOptions.GetIdeAnalyzerOptions(project);
 
-            if (_projectCompilationsWithAnalyzers.TryGetValue(project, out var compilationWithAnalyzers) &&
-                ((WorkspaceAnalyzerOptions)compilationWithAnalyzers!.AnalysisOptions.Options!).IdeOptions == ideOptions)
+            if (_projectCompilationsWithAnalyzers.TryGetValue(project, out var compilationWithAnalyzers))
             {
-                // we have cached one, return that.
-                AssertAnalyzers(compilationWithAnalyzers, stateSets);
-                return compilationWithAnalyzers;
+                // We may have cached a null entry if we determiend that there are no actual analyzers to run.
+                if (compilationWithAnalyzers is null)
+                {
+                    return null;
+                }
+                else if (((WorkspaceAnalyzerOptions)compilationWithAnalyzers.AnalysisOptions.Options!).IdeOptions == ideOptions)
+                {
+                    // we have cached one, return that.
+                    AssertAnalyzers(compilationWithAnalyzers, stateSets);
+                    return compilationWithAnalyzers;
+                }
             }
 
             // Create driver that holds onto compilation and associated analyzers


### PR DESCRIPTION
We cache the CompilationWithAnalyzers for a project, but the value can be null if we concluded there are no analyzers and thus we don't need one in the first place. A refactoring introduced a bug where we assumed it was always non-null.

Fixes https://github.com/dotnet/roslyn/issues/62381