### PR TITLE
Support reading binary logs in the LSIF generator

### DIFF
--- a/src/Features/Lsif/Generator/CompilerInvocation.cs
+++ b/src/Features/Lsif/Generator/CompilerInvocation.cs
@@ -35,7 +35,11 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
         {
             var invocationInfo = JsonConvert.DeserializeObject<CompilerInvocationInfo>(jsonContents);
             Assumes.Present(invocationInfo);
+            return await CreateFromInvocationInfoAsync(invocationInfo);
+        }
 
+        public static async Task<CompilerInvocation> CreateFromInvocationInfoAsync(CompilerInvocationInfo invocationInfo)
+        {
             // We will use a Workspace to simplify the creation of the compilation, but will be careful not to return the Workspace instance from this class.
             // We will still provide the language services which are used by the generator itself, but we don't tie it to a Workspace object so we can
             // run this as an in-proc source generator if one day desired.
@@ -180,7 +184,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
         /// <summary>
         /// A simple data class that represents the schema for JSON serialization.
         /// </summary>
-        private sealed class CompilerInvocationInfo
+        public sealed class CompilerInvocationInfo
         {
 #nullable disable // this class is used for deserialization by Newtonsoft.Json, so we don't really need warnings about this class itself
 

--- a/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
+++ b/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
@@ -47,6 +47,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorVersion)" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="$(MSBuildStructuredLoggerVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.CommandLine.Experimental" Version="$(SystemCommandLineExperimentalVersion)" />
   </ItemGroup>

--- a/src/Features/Lsif/Generator/Program.cs
+++ b/src/Features/Lsif/Generator/Program.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
@@ -14,6 +15,7 @@ using System.Threading.Tasks;
 using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing;
 using Microsoft.CodeAnalysis.MSBuild;
+using CompilerInvocationsReader = Microsoft.Build.Logging.StructuredLogger.CompilerInvocationsReader;
 
 namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
 {
@@ -26,17 +28,18 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
                 new Option("--solution", "input solution file") { Argument = new Argument<FileInfo>().ExistingOnly() },
                 new Option("--project", "input project file") { Argument = new Argument<FileInfo>().ExistingOnly() },
                 new Option("--compiler-invocation", "path to a .json file that contains the information for a csc/vbc invocation") { Argument = new Argument<FileInfo>().ExistingOnly() },
+                new Option("--binlog", "path to a MSBuild binlog that csc/vbc invocations will be extracted from") { Argument = new Argument<FileInfo>().ExistingOnly() },
                 new Option("--output", "file to write the LSIF output to, instead of the console") { Argument = new Argument<string?>(defaultValue: () => null).LegalFilePathsOnly() },
                 new Option("--output-format", "format of LSIF output") { Argument = new Argument<LsifFormat>(defaultValue: () => LsifFormat.Line) },
                 new Option("--log", "file to write a log to") { Argument = new Argument<string?>(defaultValue: () => null).LegalFilePathsOnly() }
             };
 
-            generateCommand.Handler = CommandHandler.Create((Func<FileInfo?, FileInfo?, FileInfo?, string?, LsifFormat, string?, Task>)GenerateAsync);
+            generateCommand.Handler = CommandHandler.Create((Func<FileInfo?, FileInfo?, FileInfo?, FileInfo?, string?, LsifFormat, string?, Task>)GenerateAsync);
 
             return generateCommand.InvokeAsync(args);
         }
 
-        private static async Task GenerateAsync(FileInfo? solution, FileInfo? project, FileInfo? compilerInvocation, string? output, LsifFormat outputFormat, string? log)
+        private static async Task GenerateAsync(FileInfo? solution, FileInfo? project, FileInfo? compilerInvocation, FileInfo? binLog, string? output, LsifFormat outputFormat, string? log)
         {
             // If we have an output file, we'll write to that, else we'll use Console.Out
             using var outputFile = output != null ? new StreamWriter(output) : null;
@@ -53,21 +56,29 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
             try
             {
                 // Exactly one of "solution", or "project" or "compilerInvocation" should be specified
-                if (solution != null && project == null && compilerInvocation == null)
+                var fileInputs = new[] { solution, project, compilerInvocation, binLog };
+                var nonNullFileInputs = fileInputs.Count(p => p is not null);
+
+                if (nonNullFileInputs != 1)
+                {
+                    throw new Exception("Exactly one of either a solution path, project path or a compiler invocation path should be supplied.");
+                }
+
+                if (solution != null)
                 {
                     await GenerateFromSolutionAsync(solution, lsifWriter, logFile);
                 }
-                else if (solution == null && project != null && compilerInvocation == null)
+                else if (project != null)
                 {
                     await GenerateFromProjectAsync(project, lsifWriter, logFile);
                 }
-                else if (solution == null && project == null && compilerInvocation != null)
+                else if (compilerInvocation != null)
                 {
                     await GenerateFromCompilerInvocationAsync(compilerInvocation, lsifWriter, logFile);
                 }
                 else
                 {
-                    throw new Exception("Exactly one of either a solution path, project path or a compiler invocation path should be supplied.");
+                    await GenerateFromBinaryLogAsync(binLog!, lsifWriter, logFile);
                 }
             }
             catch (Exception e)
@@ -179,6 +190,33 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
 
             await lsifGenerator.GenerateForCompilationAsync(compilerInvocation.Compilation, compilerInvocation.ProjectFilePath, compilerInvocation.LanguageServices, compilerInvocation.Options);
             await logFile.WriteLineAsync($"Generation for {compilerInvocation.ProjectFilePath} completed in {generationStopwatch.Elapsed.ToDisplayString()}.");
+        }
+
+        private static async Task GenerateFromBinaryLogAsync(FileInfo binLog, ILsifJsonWriter lsifWriter, TextWriter logFile)
+        {
+            await logFile.WriteLineAsync($"Reading binlog {binLog.FullName}...");
+            var msbuildInvocations = CompilerInvocationsReader.ReadInvocations(binLog.FullName).ToImmutableArray();
+
+            await logFile.WriteLineAsync($"Load of the binlog complete; {msbuildInvocations.Length} invocations were found.");
+
+            var lsifGenerator = Generator.CreateAndWriteCapabilitiesVertex(lsifWriter);
+
+            foreach (var msbuildInvocation in msbuildInvocations)
+            {
+                // Convert from the MSBuild "CompilerInvocation" type to our type that we use for our JSON-input mode already.
+                var invocationInfo = new CompilerInvocation.CompilerInvocationInfo
+                {
+                    Arguments = msbuildInvocation.CommandLineArguments,
+                    ProjectFilePath = msbuildInvocation.ProjectFilePath,
+                    Tool = msbuildInvocation.Language == Microsoft.Build.Logging.StructuredLogger.CompilerInvocation.CSharp ? "csc" : "vbc"
+                };
+
+                var compilerInvocation = await CompilerInvocation.CreateFromInvocationInfoAsync(invocationInfo);
+
+                var generationStopwatch = Stopwatch.StartNew();
+                await lsifGenerator.GenerateForCompilationAsync(compilerInvocation.Compilation, compilerInvocation.ProjectFilePath, compilerInvocation.LanguageServices, compilerInvocation.Options);
+                await logFile.WriteLineAsync($"Generation for {compilerInvocation.ProjectFilePath} completed in {generationStopwatch.Elapsed.ToDisplayString()}.");
+            }
         }
     }
 }


### PR DESCRIPTION
This consumes a binlog and extracts out the compiler invocations during that build. From there, we then reconstruct the compilations and then produce LSIF indexes for them.

- [ ] Add a unit test (or decide creating one is too funky)