### PR TITLE
Fast path detecting what sort of using construct we have.

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -8241,15 +8241,26 @@ done:;
 
             if (IsDeclarationModifier(tk)) // treat `const int x = 2;` as a local variable declaration
             {
-                if (tk != SyntaxKind.StaticKeyword) // For `static` we still need to make sure we have a typed identifier after it, because `using static type;` is a valid using directive.
-                {
-                    return true;
-                }
+                // For `using static` is only legal as a using-directive not a using-local-declaration.
+                return tk != SyntaxKind.StaticKeyword;
             }
             else if (SyntaxFacts.IsPredefinedType(tk))
             {
                 return true;
             }
+
+            if (tk == SyntaxKind.IdentifierToken &&
+                PeekToken(2).Kind == SyntaxKind.EqualsToken)
+            {
+                // `using X =`
+                // this is always a using directive.
+                return false;
+            }
+
+            // using-directives are going to be much more common at the top level of a file/namespace than
+            // using-statements.  So do quick syntactic checks before the expensive speculative parse below.
+            if (isDefinitelyUsingDirective())
+                return false;
 
             var resetPoint = this.GetResetPoint();
             try
@@ -8269,6 +8280,29 @@ done:;
             {
                 this.Reset(ref resetPoint);
                 this.Release(ref resetPoint);
+            }
+
+            bool isDefinitelyUsingDirective()
+            {
+                // look for the incredibly common `using X.Y.Z;` syntax
+
+                var index = 1;
+                while (this.PeekToken(index).Kind == SyntaxKind.IdentifierToken)
+                {
+                    var nextKind = this.PeekToken(index + 1).Kind;
+                    if (nextKind == SyntaxKind.SemicolonToken)
+                        return true;
+
+                    if (nextKind == SyntaxKind.DotToken)
+                    {
+                        index += 2;
+                        continue;
+                    }
+
+                    break;
+                }
+
+                return false;
             }
         }
 


### PR DESCRIPTION
Motivated by traces showing we're spending 8% of parsing time just checking what sort of `using` we have.  In practice a top-level using is going to be a using-directive (e.g. `using System.Collections.Generic;`) not a using-statement `using var x = ...`, so look for that fast form first, without the expensive parsing/reset path that will almost always succeed at parsing a type (e.g. `System.Collections.Generic` is a legal type name) but will then fail out immediately after that.