### PR TITLE
Use ASP.NET indentation setting in C# scripts in ASPX page

### DIFF
--- a/src/VisualStudio/Core/Def/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedDocument.cs
@@ -871,10 +871,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
         private int GetBaseIndentation(SyntaxNode root, SourceText text, TextSpan span)
         {
-            // Is this right?  We should probably get this from the IVsContainedLanguageHost instead.
             var editorOptions = _editorOptionsService.Factory.GetOptions(DataBuffer);
-
-            var additionalIndentation = GetAdditionalIndentation(root, text, span);
+            var additionalIndentation = GetAdditionalIndentation(root, text, span, hostIndentationSize: editorOptions.GetIndentSize());
 
             // Skip over the first line, since it's in "Venus space" anyway.
             var startingLine = text.Lines.GetLineFromPosition(span.Start);
@@ -936,11 +934,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             return (start <= end) ? TextSpan.FromBounds(start, end + 1) : default;
         }
 
-        private int GetAdditionalIndentation(SyntaxNode root, SourceText text, TextSpan span)
+        private int GetAdditionalIndentation(SyntaxNode root, SourceText text, TextSpan span, int hostIndentationSize)
         {
             if (_hostType == HostType.HTML)
             {
-                return _workspace.Options.GetOption(FormattingOptions.IndentationSize, _project.Language);
+                return hostIndentationSize;
             }
 
             if (_hostType == HostType.Razor)
@@ -997,7 +995,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                         }
                     }
 
-                    return _workspace.Options.GetOption(FormattingOptions.IndentationSize, _project.Language);
+                    return hostIndentationSize;
                 }
             }
 


### PR DESCRIPTION
Previously we have used the C# settings, but that's not consistent with other code that uses ASP.NET settings for indentation.

Fixes one of the issues observed in https://github.com/dotnet/roslyn/issues/62204.