### PR TITLE
Apply changes directly to text buffer - take 2

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/CSharpFormatterTestsBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/CSharpFormatterTestsBase.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Indentation;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Formatting;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
@@ -99,18 +100,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
             var formatter = new CSharpSmartTokenFormatter(options, rules, (CompilationUnitSyntax)documentSyntax.Root, documentSyntax.Text);
             var changes = formatter.FormatToken(token, CancellationToken.None);
 
-            ApplyChanges(buffer, changes);
-        }
-
-        private static void ApplyChanges(ITextBuffer buffer, IList<TextChange> changes)
-        {
-            using var edit = buffer.CreateEdit();
-            foreach (var change in changes)
-            {
-                edit.Replace(change.Span.ToSpan(), change.NewText);
-            }
-
-            edit.Apply();
+            buffer.ApplyChanges(changes);
         }
 
         protected static async Task<int> GetSmartTokenFormatterIndentationAsync(

--- a/src/EditorFeatures/Core/CommentSelection/AbstractCommentSelectionBase.cs
+++ b/src/EditorFeatures/Core/CommentSelection/AbstractCommentSelectionBase.cs
@@ -125,49 +125,39 @@ namespace Microsoft.CodeAnalysis.CommentSelection
         /// </summary>
         private void ApplyEdits(Document document, ITextView textView, ITextBuffer subjectBuffer, string title, CommentSelectionResult edits, CancellationToken cancellationToken)
         {
-            var workspace = document.Project.Solution.Workspace;
-
-            // Create tracking spans to track the text changes.
-            var currentSnapshot = subjectBuffer.CurrentSnapshot;
-            var trackingSpans = edits.TrackingSpans
-                .SelectAsArray(textSpan => (originalSpan: textSpan, trackingSpan: CreateTrackingSpan(edits.ResultOperation, currentSnapshot, textSpan.TrackingTextSpan)));
+            var originalSnapshot = subjectBuffer.CurrentSnapshot;
 
             // Apply the text changes.
-            SourceText newText;
             using (var transaction = new CaretPreservingEditTransaction(title, textView, _undoHistoryRegistry, _editorOperationsFactoryService))
             {
-                var oldSolution = workspace.CurrentSolution;
-
-                var oldDocument = oldSolution.GetRequiredDocument(document.Id);
-                var oldText = oldDocument.GetTextSynchronously(cancellationToken);
-                newText = oldText.WithChanges(edits.TextChanges.Distinct());
-
-                var newSolution = oldSolution.WithDocumentText(document.Id, newText, PreservationMode.PreserveIdentity);
-                workspace.TryApplyChanges(newSolution);
-
+                subjectBuffer.ApplyChanges(edits.TextChanges);
                 transaction.Complete();
             }
 
-            // Convert the tracking spans into snapshot spans for formatting and selection.
-            var trackingSnapshotSpans = trackingSpans.Select(s => CreateSnapshotSpan(subjectBuffer.CurrentSnapshot, s.trackingSpan, s.originalSpan));
-
-            if (trackingSnapshotSpans.Any())
+            if (edits.TrackingSpans.Any())
             {
+                // Create tracking spans to track the text changes.
+                var trackingSpans = edits.TrackingSpans
+                    .SelectAsArray(textSpan => (originalSpan: textSpan, trackingSpan: CreateTrackingSpan(edits.ResultOperation, originalSnapshot, textSpan.TrackingTextSpan)));
+
+                // Convert the tracking spans into snapshot spans for formatting and selection.
+                var trackingSnapshotSpans = trackingSpans.Select(s => CreateSnapshotSpan(subjectBuffer.CurrentSnapshot, s.trackingSpan, s.originalSpan));
+
                 if (edits.ResultOperation == Operation.Uncomment && document.SupportsSyntaxTree)
                 {
                     // Format the document only during uncomment operations.  Use second transaction so it can be undone.
                     using var transaction = new CaretPreservingEditTransaction(title, textView, _undoHistoryRegistry, _editorOperationsFactoryService);
 
+                    var newText = subjectBuffer.CurrentSnapshot.AsText();
+                    var oldSyntaxTree = document.GetSyntaxTreeSynchronously(cancellationToken);
+                    var newRoot = oldSyntaxTree.WithChangedText(newText).GetRoot(cancellationToken);
+
                     var formattingOptions = subjectBuffer.GetSyntaxFormattingOptions(_editorOptionsService, document.Project.LanguageServices, explicitFormat: false);
+                    var formattingSpans = trackingSnapshotSpans.Select(change => CommonFormattingHelpers.GetFormattingSpan(newRoot, change.Span.ToTextSpan()));
+                    var formattedChanges = Formatter.GetFormattedTextChanges(newRoot, formattingSpans, document.Project.Solution.Workspace.Services, formattingOptions, rules: null, cancellationToken);
 
-                    var updatedDocument = workspace.CurrentSolution.GetRequiredDocument(document.Id);
-                    var root = updatedDocument.GetRequiredSyntaxRootSynchronously(cancellationToken);
+                    subjectBuffer.ApplyChanges(formattedChanges);
 
-                    var formattingSpans = trackingSnapshotSpans.Select(change => CommonFormattingHelpers.GetFormattingSpan(root, change.Span.ToTextSpan()));
-                    var formattedRoot = Formatter.Format(root, formattingSpans, workspace.Services, formattingOptions, rules: null, cancellationToken);
-                    var formattedDocument = document.WithSyntaxRoot(formattedRoot);
-
-                    workspace.ApplyDocumentChanges(formattedDocument, cancellationToken);
                     transaction.Complete();
                 }
 

--- a/src/EditorFeatures/Core/Editor/IContainedDocument.cs
+++ b/src/EditorFeatures/Core/Editor/IContainedDocument.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.CodeAnalysis.Editor;
+
+internal interface IContainedDocument
+{
+    public ITextSnapshot ApplyChanges(IEnumerable<TextChange> changes);
+}

--- a/src/EditorFeatures/Core/Formatting/FormatCommandHandler.Paste.cs
+++ b/src/EditorFeatures/Core/Formatting/FormatCommandHandler.Paste.cs
@@ -55,7 +55,9 @@ namespace Microsoft.CodeAnalysis.Formatting
                 return;
             }
 
-            var document = args.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+            var subjectBuffer = args.SubjectBuffer;
+
+            var document = subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document == null)
             {
                 return;
@@ -86,16 +88,16 @@ namespace Microsoft.CodeAnalysis.Formatting
             }
 
             var trackingSpan = caretPosition.Value.Snapshot.CreateTrackingSpan(caretPosition.Value.Position, 0, SpanTrackingMode.EdgeInclusive);
-            var span = trackingSpan.GetSpan(args.SubjectBuffer.CurrentSnapshot).Span.ToTextSpan();
+            var span = trackingSpan.GetSpan(subjectBuffer.CurrentSnapshot).Span.ToTextSpan();
 
             // Note: C# always completes synchronously, TypeScript is async
-            var changes = formattingService.GetFormattingChangesOnPasteAsync(document, args.SubjectBuffer, span, cancellationToken).WaitAndGetResult(cancellationToken);
+            var changes = formattingService.GetFormattingChangesOnPasteAsync(document, subjectBuffer, span, cancellationToken).WaitAndGetResult(cancellationToken);
             if (changes.IsEmpty)
             {
                 return;
             }
 
-            solution.Workspace.ApplyTextChanges(document.Id, changes, cancellationToken);
+            subjectBuffer.ApplyChanges(changes);
         }
     }
 }

--- a/src/EditorFeatures/Core/Formatting/FormatCommandHandler.cs
+++ b/src/EditorFeatures/Core/Formatting/FormatCommandHandler.cs
@@ -75,28 +75,21 @@ namespace Microsoft.CodeAnalysis.Formatting
                     return;
                 }
 
-                var workspace = document.Project.Solution.Workspace;
-                ApplyChanges(workspace, document.Id, changes, selectionOpt, cancellationToken);
-                transaction.Complete();
-            }
-        }
-
-        private static void ApplyChanges(Workspace workspace, DocumentId documentId, IList<TextChange> changes, TextSpan? selectionOpt, CancellationToken cancellationToken)
-        {
-            if (selectionOpt.HasValue)
-            {
-                var ruleFactory = workspace.Services.GetRequiredService<IHostDependentFormattingRuleFactoryService>();
-
-                changes = ruleFactory.FilterFormattedChanges(documentId, selectionOpt.Value, changes).ToList();
-                if (changes.Count == 0)
+                if (selectionOpt.HasValue)
                 {
-                    return;
+                    var ruleFactory = document.Project.Solution.Workspace.Services.GetRequiredService<IHostDependentFormattingRuleFactoryService>();
+                    changes = ruleFactory.FilterFormattedChanges(document.Id, selectionOpt.Value, changes).ToImmutableArray();
                 }
-            }
 
-            using (Logger.LogBlock(FunctionId.Formatting_ApplyResultToBuffer, cancellationToken))
-            {
-                workspace.ApplyTextChanges(documentId, changes, cancellationToken);
+                if (!changes.IsEmpty)
+                {
+                    using (Logger.LogBlock(FunctionId.Formatting_ApplyResultToBuffer, cancellationToken))
+                    {
+                        textBuffer.ApplyChanges(changes);
+                    }
+                }
+
+                transaction.Complete();
             }
         }
 
@@ -191,7 +184,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             using (var transaction = CreateEditTransaction(textView, EditorFeaturesResources.Automatic_Formatting))
             {
                 transaction.MergePolicy = AutomaticCodeChangeMergePolicy.Instance;
-                document.Project.Solution.Workspace.ApplyTextChanges(document.Id, textChanges, cancellationToken);
+                subjectBuffer.ApplyChanges(textChanges);
                 transaction.Complete();
             }
 
@@ -202,7 +195,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 return;
             }
 
-            var snapshotAfterFormatting = args.SubjectBuffer.CurrentSnapshot;
+            var snapshotAfterFormatting = subjectBuffer.CurrentSnapshot;
 
             var oldCaretPosition = caretPosition.Value.TranslateTo(snapshotAfterFormatting, PointTrackingMode.Negative);
             var newCaretPosition = newCaretPositionMarker.Value.TranslateTo(snapshotAfterFormatting, PointTrackingMode.Negative);

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -249,58 +249,59 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return new AsyncCompletionData.CommitResult(isHandled: true, AsyncCompletionData.CommitBehavior.None);
             }
 
+            ITextSnapshot updatedCurrentSnapshot;
             using (var edit = subjectBuffer.CreateEdit(EditOptions.DefaultMinimalChange, reiteratedVersionNumber: null, editTag: null))
             {
                 edit.Replace(mappedSpan.Span, change.TextChange.NewText);
 
                 // edit.Apply() may trigger changes made by extensions.
                 // updatedCurrentSnapshot will contain changes made by Roslyn but not by other extensions.
-                var updatedCurrentSnapshot = edit.Apply();
+                updatedCurrentSnapshot = edit.Apply();
+            }
 
-                if (change.NewPosition.HasValue)
+            if (change.NewPosition.HasValue)
+            {
+                // Roslyn knows how to position the caret in the snapshot we just created.
+                // If there were more edits made by extensions, TryMoveCaretToAndEnsureVisible maps the snapshot point to the most recent one.
+                view.TryMoveCaretToAndEnsureVisible(new SnapshotPoint(updatedCurrentSnapshot, change.NewPosition.Value));
+            }
+            else
+            {
+                // Or, If we're doing a minimal change, then the edit that we make to the 
+                // buffer may not make the total text change that places the caret where we 
+                // would expect it to go based on the requested change. In this case, 
+                // determine where the item should go and set the care manually.
+
+                // Note: we only want to move the caret if the caret would have been moved 
+                // by the edit.  i.e. if the caret was actually in the mapped span that 
+                // we're replacing.
+                var caretPositionInBuffer = view.GetCaretPoint(subjectBuffer);
+                if (caretPositionInBuffer.HasValue && mappedSpan.IntersectsWith(caretPositionInBuffer.Value))
                 {
-                    // Roslyn knows how to position the caret in the snapshot we just created.
-                    // If there were more edits made by extensions, TryMoveCaretToAndEnsureVisible maps the snapshot point to the most recent one.
-                    view.TryMoveCaretToAndEnsureVisible(new SnapshotPoint(updatedCurrentSnapshot, change.NewPosition.Value));
+                    view.TryMoveCaretToAndEnsureVisible(new SnapshotPoint(subjectBuffer.CurrentSnapshot, mappedSpan.Start.Position + textChange.NewText?.Length ?? 0));
                 }
                 else
                 {
-                    // Or, If we're doing a minimal change, then the edit that we make to the 
-                    // buffer may not make the total text change that places the caret where we 
-                    // would expect it to go based on the requested change. In this case, 
-                    // determine where the item should go and set the care manually.
-
-                    // Note: we only want to move the caret if the caret would have been moved 
-                    // by the edit.  i.e. if the caret was actually in the mapped span that 
-                    // we're replacing.
-                    var caretPositionInBuffer = view.GetCaretPoint(subjectBuffer);
-                    if (caretPositionInBuffer.HasValue && mappedSpan.IntersectsWith(caretPositionInBuffer.Value))
-                    {
-                        view.TryMoveCaretToAndEnsureVisible(new SnapshotPoint(subjectBuffer.CurrentSnapshot, mappedSpan.Start.Position + textChange.NewText?.Length ?? 0));
-                    }
-                    else
-                    {
-                        view.Caret.EnsureVisible();
-                    }
+                    view.Caret.EnsureVisible();
                 }
+            }
 
-                includesCommitCharacter = change.IncludesCommitCharacter;
+            includesCommitCharacter = change.IncludesCommitCharacter;
 
-                if (roslynItem.Rules.FormatOnCommit)
+            if (roslynItem.Rules.FormatOnCommit)
+            {
+                // The edit updates the snapshot however other extensions may make changes there.
+                // Therefore, it is required to use subjectBuffer.CurrentSnapshot for further calculations rather than the updated current snapshot defined above.
+                var currentDocument = subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+                var formattingService = currentDocument?.GetRequiredLanguageService<IFormattingInteractionService>();
+
+                if (currentDocument != null && formattingService != null)
                 {
-                    // The edit updates the snapshot however other extensions may make changes there.
-                    // Therefore, it is required to use subjectBuffer.CurrentSnapshot for further calculations rather than the updated current snapshot defined above.
-                    var currentDocument = subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
-                    var formattingService = currentDocument?.GetRequiredLanguageService<IFormattingInteractionService>();
+                    var spanToFormat = triggerSnapshotSpan.TranslateTo(subjectBuffer.CurrentSnapshot, SpanTrackingMode.EdgeInclusive);
 
-                    if (currentDocument != null && formattingService != null)
-                    {
-                        var spanToFormat = triggerSnapshotSpan.TranslateTo(subjectBuffer.CurrentSnapshot, SpanTrackingMode.EdgeInclusive);
-
-                        // Note: C# always completes synchronously, TypeScript is async
-                        var changes = formattingService.GetFormattingChangesAsync(currentDocument, subjectBuffer, spanToFormat.Span.ToTextSpan(), cancellationToken).WaitAndGetResult(cancellationToken);
-                        currentDocument.Project.Solution.Workspace.ApplyTextChanges(currentDocument.Id, changes, cancellationToken);
-                    }
+                    // Note: C# always completes synchronously, TypeScript is async
+                    var changes = formattingService.GetFormattingChangesAsync(currentDocument, subjectBuffer, spanToFormat.Span.ToTextSpan(), cancellationToken).WaitAndGetResult(cancellationToken);
+                    subjectBuffer.ApplyChanges(changes);
                 }
             }
 

--- a/src/EditorFeatures/Core/Options/TextBufferOptionProviders.cs
+++ b/src/EditorFeatures/Core/Options/TextBufferOptionProviders.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.Formatting;
@@ -65,6 +66,14 @@ internal static class TextBufferOptionProviders
             // TODO: Call editorOptions.GetIndentStyle() instead (see https://github.com/dotnet/roslyn/issues/62204):
             IndentStyle = optionsProvider.GlobalOptions.GetOption(IndentationOptionsStorage.SmartIndent, languageServices.Language)
         };
+    }
+
+    public static AddImportPlacementOptions GetAddImportPlacementOptions(this ITextBuffer textBuffer, EditorOptionsService optionsProvider, HostLanguageServices languageServices, bool allowInHiddenRegions)
+    {
+        var editorOptions = optionsProvider.Factory.GetOptions(textBuffer);
+        var configOptions = new EditorAnalyzerConfigOptions(editorOptions);
+        var fallbackOptions = optionsProvider.GlobalOptions.GetAddImportPlacementOptions(languageServices);
+        return configOptions.GetAddImportPlacementOptions(allowInHiddenRegions, fallbackOptions, languageServices);
     }
 
     public static IndentingStyle ToEditorIndentStyle(this FormattingOptions2.IndentStyle value)

--- a/src/EditorFeatures/Core/Shared/Extensions/ITextBufferExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/ITextBufferExtensions.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
@@ -58,6 +60,29 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
             }
 
             return service != null;
+        }
+
+        public static ITextSnapshot ApplyChange(this ITextBuffer buffer, TextChange change)
+        {
+            using var edit = buffer.CreateEdit(EditOptions.DefaultMinimalChange, reiteratedVersionNumber: null, editTag: null);
+            edit.Replace(change.Span.ToSpan(), change.NewText);
+            return edit.Apply();
+        }
+
+        public static ITextSnapshot ApplyChanges(this ITextBuffer buffer, IEnumerable<TextChange> changes)
+        {
+            using var edit = buffer.CreateEdit(EditOptions.DefaultMinimalChange, reiteratedVersionNumber: null, editTag: null);
+            return ApplyChanges(edit, changes);
+        }
+
+        public static ITextSnapshot ApplyChanges(this ITextEdit edit, IEnumerable<TextChange> changes)
+        {
+            foreach (var change in changes)
+            {
+                edit.Replace(change.Span.ToSpan(), change.NewText);
+            }
+
+            return edit.Apply();
         }
     }
 }

--- a/src/EditorFeatures/Core/Shared/Extensions/ITextSnapshotExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/ITextSnapshotExtensions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
 
             using (Logger.LogBlock(FunctionId.Formatting_ApplyResultToBuffer, cancellationToken))
             {
-                document.Project.Solution.Workspace.ApplyTextChanges(document.Id, changes, cancellationToken);
+                textBuffer.ApplyChanges(changes);
             }
         }
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -23,7 +23,6 @@ Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
 Imports Microsoft.VisualStudio.Text.Operations
 Imports Microsoft.VisualStudio.Text.Projection
-Imports Roslyn.Utilities
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
     <[UseExportProvider]>

--- a/src/EditorFeatures/VisualBasic/EndConstructGeneration/SpitLinesResult.vb
+++ b/src/EditorFeatures/VisualBasic/EndConstructGeneration/SpitLinesResult.vb
@@ -49,8 +49,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
             ' in the buffer
             Dim joinedLines = If(_startOnCurrentLine, "", bufferNewLine) + String.Join(bufferNewLine, _lines)
 
-            document.Project.Solution.Workspace.ApplyTextChanges(
-                document.Id, SpecializedCollections.SingletonEnumerable(New TextChange(New TextSpan(caretPosition, 0), joinedLines)), CancellationToken.None)
+            subjectBuffer.ApplyChange(New TextChange(New TextSpan(caretPosition, 0), joinedLines))
 
             SetIndentForFirstBlankLine(textView, subjectBuffer, smartIndentationService, currentLine)
         End Sub

--- a/src/EditorFeatures/VisualBasic/EndConstructGeneration/VisualBasicEndConstructGenerationService.vb
+++ b/src/EditorFeatures/VisualBasic/EndConstructGeneration/VisualBasicEndConstructGenerationService.vb
@@ -323,22 +323,20 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
 
         Private Shared Function InsertEndTextAndUpdateCaretPosition(
             view As ITextView,
+            subjectBuffer As ITextBuffer,
             insertPosition As Integer,
             caretPosition As Integer,
-            endText As String,
-            cancellationToken As CancellationToken
+            endText As String
         ) As Boolean
 
-            Dim document = view.TextSnapshot.GetOpenDocumentInCurrentContextWithChanges()
+            Dim document = subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges()
             If document Is Nothing Then
                 Return False
             End If
 
-            document.Project.Solution.Workspace.ApplyTextChanges(
-                document.Id, SpecializedCollections.SingletonEnumerable(
-                    New TextChange(New TextSpan(insertPosition, 0), endText)), cancellationToken)
+            subjectBuffer.ApplyChange(New TextChange(New TextSpan(insertPosition, 0), endText))
 
-            Dim caretPosAfterEdit = New SnapshotPoint(view.TextSnapshot, caretPosition)
+            Dim caretPosAfterEdit = New SnapshotPoint(subjectBuffer.CurrentSnapshot, caretPosition)
 
             view.TryMoveCaretToAndEnsureVisible(caretPosAfterEdit)
 
@@ -369,7 +367,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
                 End If
 
                 Dim endText = "]]>"
-                Return InsertEndTextAndUpdateCaretPosition(textView, state.CaretPosition, state.TokenToLeft.Span.End, endText, cancellationToken)
+                Return InsertEndTextAndUpdateCaretPosition(textView, subjectBuffer, state.CaretPosition, state.TokenToLeft.Span.End, endText)
             End Using
         End Function
 
@@ -397,7 +395,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
                 End If
 
                 Dim endText = "-->"
-                Return InsertEndTextAndUpdateCaretPosition(textView, state.CaretPosition, state.TokenToLeft.Span.End, endText, cancellationToken)
+                Return InsertEndTextAndUpdateCaretPosition(textView, subjectBuffer, state.CaretPosition, state.TokenToLeft.Span.End, endText)
             End Using
         End Function
 
@@ -425,7 +423,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
                 End If
 
                 Dim endTagText = "</" & xmlStartElement.Name.ToString & ">"
-                Return InsertEndTextAndUpdateCaretPosition(textView, state.CaretPosition, state.TokenToLeft.Span.End, endTagText, cancellationToken)
+                Return InsertEndTextAndUpdateCaretPosition(textView, subjectBuffer, state.CaretPosition, state.TokenToLeft.Span.End, endTagText)
             End Using
         End Function
 
@@ -449,7 +447,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
                 End If
 
                 Dim endText = "  %>" ' NOTE: two spaces are inserted. The caret will be moved between them
-                Return InsertEndTextAndUpdateCaretPosition(textView, state.CaretPosition, state.TokenToLeft.Span.End + 1, endText, cancellationToken)
+                Return InsertEndTextAndUpdateCaretPosition(textView, subjectBuffer, state.CaretPosition, state.TokenToLeft.Span.End + 1, endText)
             End Using
         End Function
 
@@ -478,7 +476,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.EndConstructGeneration
                 End If
 
                 Dim endText = "?>"
-                Return InsertEndTextAndUpdateCaretPosition(textView, state.CaretPosition, state.TokenToLeft.Span.End, endText, cancellationToken)
+                Return InsertEndTextAndUpdateCaretPosition(textView, subjectBuffer, state.CaretPosition, state.TokenToLeft.Span.End, endText)
             End Using
         End Function
 

--- a/src/VisualStudio/Core/Def/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Snippets/AbstractSnippetExpansionClient.cs
@@ -288,17 +288,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
                 {
                     _indentCaretOnCommit = true;
 
-                    var document = this.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
-                    if (document != null)
-                    {
-                        var formattingOptions = document.GetLineFormattingOptionsAsync(EditorOptionsService.GlobalOptions, CancellationToken.None).AsTask().WaitAndGetResult(CancellationToken.None);
-                        _indentDepth = lineText.GetColumnFromLineOffset(lineText.Length, formattingOptions.TabSize);
-                    }
-                    else
-                    {
-                        // If we don't have a document, then just guess the typical default TabSize value.
-                        _indentDepth = lineText.GetColumnFromLineOffset(lineText.Length, tabSize: 4);
-                    }
+                    var formattingOptions = SubjectBuffer.GetLineFormattingOptions(EditorOptionsService, explicitFormat: false);
+                    _indentDepth = lineText.GetColumnFromLineOffset(lineText.Length, formattingOptions.TabSize);
 
                     SubjectBuffer.Delete(new Span(line.Start.Position, line.Length));
                     _ = SubjectBuffer.CurrentSnapshot.GetSpan(new Span(line.Start.Position, 0));
@@ -1067,14 +1058,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
                 return;
             }
 
-            var documentWithImports = this.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
+            var documentWithImports = SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (documentWithImports == null)
             {
                 return;
             }
 
-            var addImportOptions = documentWithImports.GetAddImportPlacementOptionsAsync(EditorOptionsService.GlobalOptions, cancellationToken).AsTask().WaitAndGetResult(cancellationToken);
-            var formattingOptions = documentWithImports.GetSyntaxFormattingOptionsAsync(EditorOptionsService.GlobalOptions, cancellationToken).AsTask().WaitAndGetResult(cancellationToken);
+            var languageServices = documentWithImports.Project.LanguageServices;
+            var addImportOptions = SubjectBuffer.GetAddImportPlacementOptions(EditorOptionsService, languageServices, documentWithImports.AllowImportsInHiddenRegions());
+            var formattingOptions = SubjectBuffer.GetSyntaxFormattingOptions(EditorOptionsService, languageServices, explicitFormat: false);
 
             documentWithImports = AddImports(documentWithImports, addImportOptions, formattingOptions, position, snippetNode, cancellationToken);
             AddReferences(documentWithImports.Project, snippetNode);

--- a/src/VisualStudio/Core/Def/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedDocument.cs
@@ -38,7 +38,7 @@ using IVsTextBufferCoordinator = Microsoft.VisualStudio.TextManager.Interop.IVsT
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 {
 #pragma warning disable CS0618 // Type or member is obsolete
-    internal sealed partial class ContainedDocument : ForegroundThreadAffinitizedObject, IVisualStudioHostDocument
+    internal sealed partial class ContainedDocument : ForegroundThreadAffinitizedObject, IVisualStudioHostDocument, IContainedDocument
 #pragma warning restore CS0618 // Type or member is obsolete
     {
         private const string ReturnReplacementString = @"{|r|}";
@@ -214,11 +214,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
         public void UpdateText(SourceText newText)
         {
-            var subjectBuffer = (IProjectionBuffer)this.SubjectBuffer;
-            var originalSnapshot = subjectBuffer.CurrentSnapshot;
-            var originalText = originalSnapshot.AsText();
+            var originalText = SubjectBuffer.CurrentSnapshot.AsText();
+            ApplyChanges(originalText, newText.GetTextChanges(originalText));
+        }
 
-            var changes = newText.GetTextChanges(originalText);
+        public ITextSnapshot ApplyChanges(IEnumerable<TextChange> changes)
+            => ApplyChanges(SubjectBuffer.CurrentSnapshot.AsText(), changes);
+
+        private ITextSnapshot ApplyChanges(SourceText originalText, IEnumerable<TextChange> changes)
+        {
+            var subjectBuffer = (IProjectionBuffer)SubjectBuffer;
 
             IEnumerable<int> affectedVisibleSpanIndices = null;
             var editorVisibleSpansInOriginal = SharedPools.Default<List<TextSpan>>().AllocateAndClear();
@@ -229,14 +234,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
                 editorVisibleSpansInOriginal.AddRange(GetEditorVisibleSpans());
                 var newChanges = FilterTextChanges(originalText, editorVisibleSpansInOriginal, changes).ToList();
-                if (newChanges.Count == 0)
+                if (newChanges.Count > 0)
                 {
-                    // no change to apply
-                    return;
+                    ApplyChanges(subjectBuffer, newChanges, editorVisibleSpansInOriginal, out affectedVisibleSpanIndices);
+                    AdjustIndentation(subjectBuffer, affectedVisibleSpanIndices);
                 }
 
-                ApplyChanges(subjectBuffer, newChanges, editorVisibleSpansInOriginal, out affectedVisibleSpanIndices);
-                AdjustIndentation(subjectBuffer, affectedVisibleSpanIndices);
+                return subjectBuffer.CurrentSnapshot;
             }
             finally
             {
@@ -245,10 +249,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             }
         }
 
-        private IEnumerable<TextChange> FilterTextChanges(SourceText originalText, List<TextSpan> editorVisibleSpansInOriginal, IReadOnlyList<TextChange> changes)
+        private IEnumerable<TextChange> FilterTextChanges(SourceText originalText, List<TextSpan> editorVisibleSpansInOriginal, IEnumerable<TextChange> changes)
         {
             // no visible spans or changes
-            if (editorVisibleSpansInOriginal.Count == 0 || changes.Count == 0)
+            if (editorVisibleSpansInOriginal.Count == 0 || !changes.Any())
             {
                 // return empty one
                 yield break;

--- a/src/VisualStudio/Core/Def/Venus/ContainedLanguage.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedLanguage.cs
@@ -6,6 +6,7 @@ using System;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
@@ -118,7 +119,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 Workspace.OnDocumentOpened(documentId, SubjectBuffer.AsTextContainer());
             }
 
-            this.ContainedDocument = new ContainedDocument(
+            ContainedDocument = new ContainedDocument(
                 ComponentModel.GetService<IThreadingContext>(),
                 documentId,
                 subjectBuffer: SubjectBuffer,
@@ -128,6 +129,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 Project,
                 ComponentModel,
                 vbHelperFormattingRule);
+
+            // link subject buffer back to the ContainedDocument, so that we can find it given just the buffer:
+            SubjectBuffer.Properties.AddProperty(typeof(IContainedDocument), ContainedDocument);
 
             // TODO: Can contained documents be linked or shared?
             this.DataBuffer.Changed += OnDataBufferChanged;

--- a/src/VisualStudio/Core/Test/Snippets/CSharpSnippetExpansionClientTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/CSharpSnippetExpansionClientTests.vb
@@ -310,22 +310,24 @@ using G=   H.I;
 
             Using workspace = TestWorkspace.Create(workspaceXml, openDocuments:=False)
                 Dim document = workspace.Documents.Single()
+                Dim textBuffer = document.GetTextBuffer()
+                Dim editorOptionsService = workspace.GetService(Of EditorOptionsService)()
+                Dim editorOptions = editorOptionsService.Factory.GetOptions(textBuffer)
 
-                workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(workspace.Options _
-                    .WithChangedOption(FormattingOptions.UseTabs, document.Project.Language, True) _
-                    .WithChangedOption(FormattingOptions.TabSize, document.Project.Language, tabSize) _
-                    .WithChangedOption(FormattingOptions.IndentationSize, document.Project.Language, tabSize)))
+                editorOptions.SetOptionValue(DefaultOptions.ConvertTabsToSpacesOptionId, False)
+                editorOptions.SetOptionValue(DefaultOptions.TabSizeOptionId, tabSize)
+                editorOptions.SetOptionValue(DefaultOptions.IndentSizeOptionId, tabSize)
 
                 Dim snippetExpansionClient = New SnippetExpansionClient(
                     workspace.ExportProvider.GetExportedValue(Of IThreadingContext),
                     Guids.CSharpLanguageServiceId,
                     document.GetTextView(),
-                    document.GetTextBuffer(),
+                    textBuffer,
                     signatureHelpControllerProvider:=Nothing,
                     editorCommandHandlerServiceFactory:=Nothing,
                     editorAdaptersFactoryService:=Nothing,
                     workspace.ExportProvider.GetExports(Of ArgumentProvider, OrderableLanguageMetadata)().ToImmutableArray(),
-                    workspace.GetService(Of EditorOptionsService)())
+                    editorOptionsService)
 
                 SnippetExpansionClientTestsHelper.TestFormattingAndCaretPosition(snippetExpansionClient, document, expectedResult, tabSize * 3)
             End Using


### PR DESCRIPTION
Hook up Venus custom buffer change pre- and post-processing.

Previously this was triggered via `Workspace.TryApplyChanges`.

Validation: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/410945