### PR TITLE
use dnceng images for Correctness_Determinism

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,7 +182,8 @@ jobs:
 
 - job: Correctness_Determinism
   pool:
-    vmImage: windows-latest
+    name: NetCore1ESPool-Public
+    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
   timeoutInMinutes: 90
   steps:
     - template: eng/pipelines/checkout-windows-task.yml


### PR DESCRIPTION
Correctness_Determinism produces more than 10 GB of output and is therefor ineligible to run on public azdo machines