### PR TITLE
Allow symbol keys to resolve against error symbols.

### DIFF
--- a/src/EditorFeatures/CSharpTest/SymbolKey/SymbolKeyErrorTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/SymbolKey/SymbolKeyErrorTypeTests.cs
@@ -1,0 +1,408 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.UnitTests;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.Win32.SafeHandles;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SymbolId
+{
+    public class SymbolKeyErrorTypeTests : SymbolKeyTestBase
+    {
+        [Fact]
+        public void GenericType_NotMissingWithMissingTypeArgument()
+        {
+            var source = """
+                namespace N
+                {
+                    public class C
+                    {
+                        public void M(D<string> x)
+                        {
+                        }
+                    }
+
+                    public class D<T>
+                    {
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.M"));
+        }
+
+        [Fact]
+        public void GenericType_MissingWithNonMissingTypeArgument()
+        {
+            var source = """
+                using System.Collections.Generic;
+
+                namespace N
+                {
+                    public class C
+                    {
+                        public void M(List<D> x)
+                        {
+                        }
+                    }
+
+                    public class D
+                    {
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.M"));
+        }
+
+        [Fact]
+        public void GenericType_MissingWithMissingTypeArgument()
+        {
+            var source = """
+                using System.Collections.Generic;
+
+                namespace N
+                {
+                    public class C
+                    {
+                        public void M(List<string> x)
+                        {
+                        }
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.M"));
+        }
+
+        [Fact]
+        public void Tuple_MissingTypes()
+        {
+            var source = """
+                namespace N
+                {
+                    public class C
+                    {
+                        public void M((string, int) x)
+                        {
+                        }
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.M"));
+        }
+
+        [Fact]
+        public void Tuple_NonMissingTypes()
+        {
+            var source = """
+                namespace N
+                {
+                    public class C
+                    {
+                        public void M((C, D) x)
+                        {
+                        }
+                    }
+
+                    public class D
+                    {
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.M"));
+        }
+
+        [Fact]
+        public void Array_MissingElementType()
+        {
+            var source = """
+                namespace N
+                {
+                    public class C
+                    {
+                        public void M(string[] x)
+                        {
+                        }
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.M"));
+        }
+
+        [Fact]
+        public void Array_NonMissingElementType()
+        {
+            var source = """
+                namespace N
+                {
+                    public class C
+                    {
+                        public void M(D[] x)
+                        {
+                        }
+                    }
+
+                    public class D
+                    {
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.M"));
+        }
+
+        [Fact]
+        public void Pointer_MissingType()
+        {
+            var source = """
+                namespace N
+                {
+                    public class C
+                    {
+                        public unsafe void M(int *x)
+                        {
+                        }
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.M"));
+        }
+
+        [Fact]
+        public void Pointer_NonMissingType()
+        {
+            var source = """
+                namespace N
+                {
+                    public class C
+                    {
+                        public unsafe void M(S *x)
+                        {
+                        }
+                    }
+
+                    public struct S
+                    {
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.M"));
+        }
+
+        [Fact]
+        public void NestedType_MissingInGenericContainer()
+        {
+            var source = """
+                using System.Collections.Generic;
+
+                namespace N
+                {
+                    public class C
+                    {
+                        public void M(List<int>.Enumerator x)
+                        {
+                        }
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.M"));
+        }
+
+        [Fact]
+        public void NestedType_MissingInNonGenericContainer()
+        {
+            var source = """
+                using System.Diagnostics;
+
+                namespace N
+                {
+                    public class C
+                    {
+                        public void M(DebuggableAttribute.DebuggingModes x)
+                        {
+                        }
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.M"));
+        }
+
+        [Fact]
+        public void Method_MissingReturnType()
+        {
+            var source = """
+                namespace N
+                {
+                    public class C
+                    {
+                        public string Create()
+                        {
+                            return new string('c', 1);
+                        }
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.Create"));
+        }
+
+        [Fact]
+        public void Method_MissingParameterType()
+        {
+            var source = """
+                namespace N
+                {
+                    public class C
+                    {
+                        public C Create(string x)
+                        {
+                            return new C();
+                        }
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.Create"));
+        }
+
+        [Fact]
+        public void Constructor_MissingParameterType()
+        {
+            var source = """
+                public class C
+                {
+                    public C(string x)
+                    {
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("C..ctor"));
+        }
+
+        [Fact]
+        public void Indexer_MissingParameterType()
+        {
+            var source = """
+                namespace N
+                {
+                    public class C
+                    {
+                        public C this[string x]
+                        {
+                            get { return null; }
+                            set { }
+                        }
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.this[]"));
+        }
+
+        [Fact]
+        public void Indexer_MissingReturnType()
+        {
+            var source = """
+                namespace N
+                {
+                    public class C
+                    {
+                        public string this[C x]
+                        {
+                            get { return null; }
+                            set { }
+                        }
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.this[]"));
+        }
+
+        [Fact]
+        public void Property_MissingReturnType()
+        {
+            var source = """
+                namespace N
+                {
+                    public class C
+                    {
+                        public string P
+                        {
+                            get { return null; }
+                            set { }
+                        }
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.P"));
+        }
+
+        [Fact]
+        public void EventField_MissingReturnType()
+        {
+            var source = """
+                namespace N
+                {
+                    public class C
+                    {
+                        public event System.EventHandler E;
+                    }
+                }
+                """;
+
+            VerifyResolution(source, c => c.GetMember("N.C.E"));
+        }
+
+        private static void VerifyResolution(string source, Func<Compilation, ISymbol> symbolToResolve)
+        {
+            var sourceCompilation = (Compilation)CreateCompilation(source, options: new(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+            var symbol = symbolToResolve(sourceCompilation);
+
+            Assert.NotNull(symbol);
+
+            var symbolKey = SymbolKey.CreateString(symbol);
+
+            // Create a compilation that references our library, but doesn't reference types needed by the library.
+            // This emulates the experience in Go To Definition when navigating to metadata from the .NET runtime when
+            // implementations are split over multiple assemblies with various type forwards in play.
+            // For example:
+            //   System.Uri exists in System.Private.Uri.dll, but System.String exists in System.Private.CoreLib.dll
+            //   and we want to allow a symbol for System.Uri.Create(System.String) to resolve correctly even when the
+            //   System.Private.CoreLib reference is missing.
+            var emptyCompilation = CSharpCompilation.Create("empty", options: new(OutputKind.DynamicallyLinkedLibrary, concurrentBuild: false))
+                .AddReferences(sourceCompilation.EmitToImageReference());
+
+            var resolution = SymbolKey.ResolveString(symbolKey, emptyCompilation, ignoreAssemblyKey: true, out var failureReason, CancellationToken.None);
+
+            Assert.Null(failureReason);
+            Assert.NotNull(resolution.Symbol);
+
+            // Since we expect some types to be error types, we just use display string to make sure we found the right
+            // symbol.
+            Assert.Equal(symbol.ToDisplayString(), resolution.Symbol!.ToDisplayString());
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/SymbolKey/SymbolKeyMetadataVsSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/SymbolKey/SymbolKeyMetadataVsSourceTests.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -179,6 +180,40 @@ public class App
         #endregion
 
         #region "Metadata vs. Metadata"
+
+        [Fact]
+        public void M2MMissingReferences()
+        {
+            var src1 = @"
+public class Uri
+{
+    public Uri(string path)
+    {
+    }
+}
+";
+
+            var sourceCompilation = (Compilation)CreateCompilation(src1);
+
+            // Create a compilation that references our library, but doesn't reference types needed by the library.
+            // This emulates the experience in Go To Definition when navigating to metadata from the .NET runtime when
+            // implementations are split over multiple assemblies with various type forwards in play.
+            // For example:
+            //   System.Uri exists in System.Private.Uri.dll, but System.String exists in System.Private.CoreLib.dll
+            //   and we want to allow a symbol for System.Uri.Create(System.String) to resolve correctly even when the
+            //   System.Private.CoreLib reference is missing.
+            var emptyCompilation = CSharpCompilation.Create("empty", options: new(OutputKind.ConsoleApplication, concurrentBuild: false))
+                .AddReferences(sourceCompilation.EmitToImageReference());
+
+            var uri = sourceCompilation.SourceModule.GlobalNamespace.GetTypeMembers("Uri").Single();
+            var constructor = uri.GetMembers(".ctor").Single() as IMethodSymbol;
+
+            var symbolKey = SymbolKey.CreateString(constructor);
+            var resolution = SymbolKey.ResolveString(symbolKey.ToString(), emptyCompilation, ignoreAssemblyKey: true, out var failureReason, CancellationToken.None);
+
+            Assert.Null(failureReason);
+            Assert.NotNull(resolution.Symbol);
+        }
 
         [Fact]
         public void M2MMultiTargetingMsCorLib01()

--- a/src/EditorFeatures/CSharpTest/SymbolKey/SymbolKeyMetadataVsSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/SymbolKey/SymbolKeyMetadataVsSourceTests.cs
@@ -182,40 +182,6 @@ public class App
         #region "Metadata vs. Metadata"
 
         [Fact]
-        public void M2MMissingReferences()
-        {
-            var src1 = @"
-public class Uri
-{
-    public Uri(string path)
-    {
-    }
-}
-";
-
-            var sourceCompilation = (Compilation)CreateCompilation(src1);
-
-            // Create a compilation that references our library, but doesn't reference types needed by the library.
-            // This emulates the experience in Go To Definition when navigating to metadata from the .NET runtime when
-            // implementations are split over multiple assemblies with various type forwards in play.
-            // For example:
-            //   System.Uri exists in System.Private.Uri.dll, but System.String exists in System.Private.CoreLib.dll
-            //   and we want to allow a symbol for System.Uri.Create(System.String) to resolve correctly even when the
-            //   System.Private.CoreLib reference is missing.
-            var emptyCompilation = CSharpCompilation.Create("empty", options: new(OutputKind.ConsoleApplication, concurrentBuild: false))
-                .AddReferences(sourceCompilation.EmitToImageReference());
-
-            var uri = sourceCompilation.SourceModule.GlobalNamespace.GetTypeMembers("Uri").Single();
-            var constructor = uri.GetMembers(".ctor").Single() as IMethodSymbol;
-
-            var symbolKey = SymbolKey.CreateString(constructor);
-            var resolution = SymbolKey.ResolveString(symbolKey.ToString(), emptyCompilation, ignoreAssemblyKey: true, out var failureReason, CancellationToken.None);
-
-            Assert.Null(failureReason);
-            Assert.NotNull(resolution.Symbol);
-        }
-
-        [Fact]
         public void M2MMultiTargetingMsCorLib01()
         {
             var src1 = @"using System;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -422,6 +422,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Simplification\SimplifierOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Simplification\SpecialTypeAnnotation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Simplification\SymbolAnnotation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SymbolKey\SymbolKey.AbstractSymbolKey.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SymbolKey\SymbolKey.AliasSymbolKey.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SymbolKey\SymbolKey.AnonymousFunctionOrDelegateSymbolKey.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SymbolKey\SymbolKey.AnonymousTypeSymbolKey.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.AbstractSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.AbstractSymbolKey.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis
+{
+    internal partial struct SymbolKey
+    {
+        private abstract class AbstractSymbolKey<TSymbol>
+            where TSymbol : class, ISymbol
+        {
+            public abstract void Create(TSymbol symbol, SymbolKeyWriter writer);
+
+            public SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
+                => Resolve(reader, reader.CurrentContextualSymbol as TSymbol, out failureReason);
+
+            protected abstract SymbolKeyResolution Resolve(SymbolKeyReader reader, TSymbol? contextualSymbol, out string? failureReason);
+        }
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.AliasSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.AliasSymbolKey.cs
@@ -10,19 +10,22 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial struct SymbolKey
     {
-        private static class AliasSymbolKey
+        private sealed class AliasSymbolKey : AbstractSymbolKey<IAliasSymbol>
         {
-            public static void Create(IAliasSymbol symbol, SymbolKeyWriter visitor)
+            public static readonly AliasSymbolKey Instance = new();
+
+            public sealed override void Create(IAliasSymbol symbol, SymbolKeyWriter visitor)
             {
                 visitor.WriteString(symbol.Name);
                 visitor.WriteSymbolKey(symbol.Target);
                 visitor.WriteString(symbol.DeclaringSyntaxReferences.FirstOrDefault()?.SyntaxTree.FilePath ?? "");
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
+            protected sealed override SymbolKeyResolution Resolve(
+                SymbolKeyReader reader, IAliasSymbol? contextualSymbol, out string? failureReason)
             {
                 var name = reader.ReadRequiredString();
-                var targetResolution = reader.ReadSymbolKey((reader.CurrentContextualSymbol as IAliasSymbol)?.Target, out var targetFailureReason);
+                var targetResolution = reader.ReadSymbolKey(contextualSymbol?.Target, out var targetFailureReason);
                 var filePath = reader.ReadRequiredString();
 
                 if (targetFailureReason != null)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.AliasSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.AliasSymbolKey.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
             {
                 var name = reader.ReadRequiredString();
-                var targetResolution = reader.ReadSymbolKey(out var targetFailureReason);
+                var targetResolution = reader.ReadSymbolKey((reader.CurrentContextualSymbol as IAliasSymbol)?.Target, out var targetFailureReason);
                 var filePath = reader.ReadRequiredString();
 
                 if (targetFailureReason != null)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.AnonymousFunctionOrDelegateSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.AnonymousFunctionOrDelegateSymbolKey.cs
@@ -60,9 +60,9 @@ namespace Microsoft.CodeAnalysis
                 // If this was a key for an anonymous delegate type, then go find the
                 // associated delegate for this lambda and return that instead of the 
                 // lambda function symbol itself.
-                if (isAnonymousDelegateType && symbol != null)
+                if (isAnonymousDelegateType && symbol is IMethodSymbol methodSymbol)
                 {
-                    var anonymousDelegate = ((IMethodSymbol)symbol).AssociatedAnonymousDelegate;
+                    var anonymousDelegate = methodSymbol.AssociatedAnonymousDelegate;
                     symbol = anonymousDelegate;
                 }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ArrayTypeSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ArrayTypeSymbolKey.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis
 
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
             {
-                var elementTypeResolution = reader.ReadSymbolKey(out var elementTypeFailureReason);
+                var elementTypeResolution = reader.ReadSymbolKey((reader.CurrentContextualSymbol as IArrayTypeSymbol)?.ElementType, out var elementTypeFailureReason);
                 var rank = reader.ReadInteger();
 
                 if (elementTypeFailureReason != null)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ArrayTypeSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ArrayTypeSymbolKey.cs
@@ -6,17 +6,20 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial struct SymbolKey
     {
-        private static class ArrayTypeSymbolKey
+        private sealed class ArrayTypeSymbolKey : AbstractSymbolKey<IArrayTypeSymbol>
         {
-            public static void Create(IArrayTypeSymbol symbol, SymbolKeyWriter visitor)
+            public static readonly ArrayTypeSymbolKey Instance = new();
+
+            public sealed override void Create(IArrayTypeSymbol symbol, SymbolKeyWriter visitor)
             {
                 visitor.WriteSymbolKey(symbol.ElementType);
                 visitor.WriteInteger(symbol.Rank);
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
+            protected sealed override SymbolKeyResolution Resolve(
+                SymbolKeyReader reader, IArrayTypeSymbol? contextualSymbol, out string? failureReason)
             {
-                var elementTypeResolution = reader.ReadSymbolKey((reader.CurrentContextualSymbol as IArrayTypeSymbol)?.ElementType, out var elementTypeFailureReason);
+                var elementTypeResolution = reader.ReadSymbolKey(contextualSymbol?.ElementType, out var elementTypeFailureReason);
                 var rank = reader.ReadInteger();
 
                 if (elementTypeFailureReason != null)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.AssemblySymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.AssemblySymbolKey.cs
@@ -8,16 +8,19 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial struct SymbolKey
     {
-        private static class AssemblySymbolKey
+        private sealed class AssemblySymbolKey : AbstractSymbolKey<IAssemblySymbol>
         {
-            public static void Create(IAssemblySymbol symbol, SymbolKeyWriter visitor)
+            public static readonly AssemblySymbolKey Instance = new();
+
+            public sealed override void Create(IAssemblySymbol symbol, SymbolKeyWriter visitor)
             {
                 // If the format of this ever changed, then it's necessary to fixup the
                 // SymbolKeyComparer.RemoveAssemblyKeys function.
                 visitor.WriteString(symbol.Identity.Name);
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
+            protected sealed override SymbolKeyResolution Resolve(
+                SymbolKeyReader reader, IAssemblySymbol? contextualSymbol, out string? failureReason)
             {
                 var assemblyName = reader.ReadString();
                 var compilation = reader.Compilation;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.DynamicTypeSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.DynamicTypeSymbolKey.cs
@@ -6,15 +6,18 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial struct SymbolKey
     {
-        private static class DynamicTypeSymbolKey
+        private sealed class DynamicTypeSymbolKey : AbstractSymbolKey<IDynamicTypeSymbol>
         {
-            public static void Create(SymbolKeyWriter _)
+            public static readonly DynamicTypeSymbolKey Instance = new();
+
+            public sealed override void Create(IDynamicTypeSymbol symbol, SymbolKeyWriter writer)
             {
                 // No need to encode anything here.  There is only ever one dynamic-symbol
                 // per compilation.
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
+            protected sealed override SymbolKeyResolution Resolve(
+                SymbolKeyReader reader, IDynamicTypeSymbol? contextualSymbol, out string? failureReason)
             {
                 if (reader.Compilation.Language == LanguageNames.VisualBasic)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ErrorTypeSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ErrorTypeSymbolKey.cs
@@ -82,15 +82,12 @@ namespace Microsoft.CodeAnalysis
 
                 if (typeArgumentsFailureReason != null)
                 {
+                    Contract.ThrowIfFalse(typeArguments.IsDefault);
                     failureReason = $"({nameof(ErrorTypeSymbolKey)} {nameof(typeArguments)} failed -> {typeArgumentsFailureReason})";
                     return default;
                 }
 
-                if (typeArguments.IsDefault)
-                {
-                    failureReason = $"({nameof(ErrorTypeSymbolKey)} {nameof(typeArguments)} failed)";
-                    return default;
-                }
+                Contract.ThrowIfTrue(typeArguments.IsDefault);
 
                 using var result = PooledArrayBuilder<INamedTypeSymbol>.GetInstance();
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.EventSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.EventSymbolKey.cs
@@ -6,18 +6,21 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial struct SymbolKey
     {
-        private static class EventSymbolKey
+        private sealed class EventSymbolKey : AbstractSymbolKey<IEventSymbol>
         {
-            public static void Create(IEventSymbol symbol, SymbolKeyWriter visitor)
+            public static readonly EventSymbolKey Instance = new();
+
+            public sealed override void Create(IEventSymbol symbol, SymbolKeyWriter visitor)
             {
                 visitor.WriteString(symbol.MetadataName);
                 visitor.WriteSymbolKey(symbol.ContainingType);
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
+            protected sealed override SymbolKeyResolution Resolve(
+                SymbolKeyReader reader, IEventSymbol? contextualSymbol, out string? failureReason)
             {
                 var metadataName = reader.ReadString();
-                var containingTypeResolution = reader.ReadSymbolKey(reader.CurrentContextualSymbol?.ContainingType, out var containingTypeFailureReason);
+                var containingTypeResolution = reader.ReadSymbolKey(contextualSymbol?.ContainingType, out var containingTypeFailureReason);
 
                 if (containingTypeFailureReason != null)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.EventSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.EventSymbolKey.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
             {
                 var metadataName = reader.ReadString();
-                var containingTypeResolution = reader.ReadSymbolKey(out var containingTypeFailureReason);
+                var containingTypeResolution = reader.ReadSymbolKey(reader.CurrentContextualSymbol?.ContainingType, out var containingTypeFailureReason);
 
                 if (containingTypeFailureReason != null)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.FieldSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.FieldSymbolKey.cs
@@ -6,18 +6,21 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial struct SymbolKey
     {
-        private static class FieldSymbolKey
+        private sealed class FieldSymbolKey : AbstractSymbolKey<IFieldSymbol>
         {
-            public static void Create(IFieldSymbol symbol, SymbolKeyWriter visitor)
+            public static readonly FieldSymbolKey Instance = new();
+
+            public sealed override void Create(IFieldSymbol symbol, SymbolKeyWriter visitor)
             {
                 visitor.WriteString(symbol.MetadataName);
                 visitor.WriteSymbolKey(symbol.ContainingType);
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
+            protected sealed override SymbolKeyResolution Resolve(
+                SymbolKeyReader reader, IFieldSymbol? contextualSymbol, out string? failureReason)
             {
                 var metadataName = reader.ReadString();
-                var containingTypeResolution = reader.ReadSymbolKey(reader.CurrentContextualSymbol?.ContainingType, out var containingTypeFailureReason);
+                var containingTypeResolution = reader.ReadSymbolKey(contextualSymbol?.ContainingType, out var containingTypeFailureReason);
 
                 if (containingTypeFailureReason != null)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.FieldSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.FieldSymbolKey.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
             {
                 var metadataName = reader.ReadString();
-                var containingTypeResolution = reader.ReadSymbolKey(out var containingTypeFailureReason);
+                var containingTypeResolution = reader.ReadSymbolKey(reader.CurrentContextualSymbol?.ContainingType, out var containingTypeFailureReason);
 
                 if (containingTypeFailureReason != null)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.FunctionPointerTypeSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.FunctionPointerTypeSymbolKey.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -66,15 +67,12 @@ namespace Microsoft.CodeAnalysis
 
                 if (parameterTypesFailureReason != null)
                 {
+                    Contract.ThrowIfFalse(parameterTypes.IsDefault);
                     failureReason = $"({nameof(FunctionPointerTypeSymbolKey)} {nameof(parameterTypes)} failed -> {parameterTypesFailureReason})";
                     return default;
                 }
 
-                if (parameterTypes.IsDefault)
-                {
-                    failureReason = $"({nameof(FunctionPointerTypeSymbolKey)} no parameter types)";
-                    return default;
-                }
+                Contract.ThrowIfTrue(parameterTypes.IsDefault);
 
                 if (returnType.GetAnySymbol() is not ITypeSymbol returnTypeSymbol)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.MethodSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.MethodSymbolKey.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -20,14 +21,17 @@ namespace Microsoft.CodeAnalysis
 
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
             {
-                var reducedFromResolution = reader.ReadSymbolKey(out var reducedFromFailureReason);
+                var contextualMethod = reader.CurrentContextualSymbol as IMethodSymbol;
+
+                var reducedFromResolution = reader.ReadSymbolKey(contextualMethod?.ReducedFrom, out var reducedFromFailureReason);
+                var receiverTypeResolution = reader.ReadSymbolKey(contextualMethod?.ReceiverType, out var receiverTypeFailureReason);
+
                 if (reducedFromFailureReason != null)
                 {
                     failureReason = $"({nameof(ReducedExtensionMethodSymbolKey)} {nameof(reducedFromResolution)} failed -> {reducedFromFailureReason})";
                     return default;
                 }
 
-                var receiverTypeResolution = reader.ReadSymbolKey(out var receiverTypeFailureReason);
                 if (receiverTypeFailureReason != null)
                 {
                     failureReason = $"({nameof(ReducedExtensionMethodSymbolKey)} {nameof(receiverTypeResolution)} failed -> {receiverTypeFailureReason})";
@@ -38,9 +42,7 @@ namespace Microsoft.CodeAnalysis
                 foreach (var reducedFrom in reducedFromResolution.OfType<IMethodSymbol>())
                 {
                     foreach (var receiverType in receiverTypeResolution.OfType<ITypeSymbol>())
-                    {
                         result.AddIfNotNull(reducedFrom.ReduceExtensionMethod(receiverType));
-                    }
                 }
 
                 return CreateResolution(result, $"({nameof(ReducedExtensionMethodSymbolKey)} failed)", out failureReason);
@@ -60,14 +62,21 @@ namespace Microsoft.CodeAnalysis
 
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
             {
-                var constructedFrom = reader.ReadSymbolKey(out var constructedFromFailureReason);
+                var contextualMethod = reader.CurrentContextualSymbol as IMethodSymbol;
+
+                var constructedFrom = reader.ReadSymbolKey(contextualMethod?.ConstructedFrom, out var constructedFromFailureReason);
+
+                using var typeArguments = reader.ReadSymbolKeyArray<IMethodSymbol, ITypeSymbol>(
+                    contextualMethod,
+                    getContextualType: static (contextualMethod, i) => SafeGet(contextualMethod.TypeArguments, i),
+                    out var typeArgumentsFailureReason);
+
                 if (constructedFromFailureReason != null)
                 {
                     failureReason = $"({nameof(ConstructedMethodSymbolKey)} {nameof(constructedFrom)} failed -> {constructedFromFailureReason})";
                     return default;
                 }
 
-                using var typeArguments = reader.ReadSymbolKeyArray<ITypeSymbol>(out var typeArgumentsFailureReason);
                 if (typeArgumentsFailureReason != null)
                 {
                     failureReason = $"({nameof(ConstructedMethodSymbolKey)} {nameof(typeArguments)} failed -> {typeArgumentsFailureReason})";
@@ -128,8 +137,6 @@ namespace Microsoft.CodeAnalysis
                 // happens with cases like Goo<T>(T t);
                 visitor.PushMethod(symbol);
 
-                visitor.WriteParameterTypesArray(symbol.OriginalDefinition.Parameters);
-
                 if (symbol.MethodKind == MethodKind.Conversion)
                 {
                     visitor.WriteSymbolKey(symbol.ReturnType);
@@ -138,6 +145,8 @@ namespace Microsoft.CodeAnalysis
                 {
                     visitor.WriteSymbolKey(null);
                 }
+
+                visitor.WriteParameterTypesArray(symbol.OriginalDefinition.Parameters);
 
                 // Done writing the signature of this method.  Remove it from the set of methods
                 // we're writing signatures for.
@@ -148,7 +157,7 @@ namespace Microsoft.CodeAnalysis
             {
                 var metadataName = reader.ReadRequiredString();
 
-                var containingType = reader.ReadSymbolKey(out var containingTypeFailureReason);
+                var containingType = reader.ReadSymbolKey(reader.CurrentContextualSymbol?.ContainingSymbol, out var containingTypeFailureReason);
                 var arity = reader.ReadInteger();
                 var isPartialMethodImplementationPart = reader.ReadBoolean();
                 using var parameterRefKinds = reader.ReadRefKindArray();
@@ -161,44 +170,56 @@ namespace Microsoft.CodeAnalysis
                 // Because of this, we keep track of where we are in the reader.  Before resolving
                 // every parameter list, we'll mark which method we're on and we'll rewind to this
                 // point.
-                var beforeParametersPosition = reader.Position;
+                var beforeReturnTypeAndParameters = reader.Position;
 
                 using var methods = GetMembersOfNamedType<IMethodSymbol>(containingType, metadataName: null);
-                using var result = PooledArrayBuilder<IMethodSymbol>.GetInstance();
-
+                IMethodSymbol? method = null;
                 foreach (var candidate in methods)
                 {
-                    var method = Resolve(reader, metadataName, arity, isPartialMethodImplementationPart,
-                        parameterRefKinds, beforeParametersPosition, candidate);
-
-                    // Note: after finding the first method that matches we stop.  That's necessary
-                    // as we cache results while searching.  We don't want to override these positive
-                    // matches with a negative ones if we were to continue searching.
-                    if (method != null)
+                    if (candidate.Arity != arity ||
+                        candidate.MetadataName != metadataName ||
+                        !ParameterRefKindsMatch(candidate.Parameters, parameterRefKinds))
                     {
-                        result.AddIfNotNull(method);
-                        break;
+                        continue;
                     }
+
+                    // Method looks like a potential match.  It has the right arity, name and refkinds match.  We now
+                    // need to do the more complicated work of checking the parameters (and possibly the return type).
+                    // This is more complicated because those symbols might refer to method type parameters.  In order
+                    // for resolution to work on those type parameters, we have to keep track in the reader that we're
+                    // resolving this method. 
+                    using (reader.PushMethod(candidate))
+                    {
+                        method = Resolve(reader, isPartialMethodImplementationPart, candidate);
+                    }
+
+                    // Note: after finding the first method that matches we stop.  That's necessary as we cache results
+                    // while searching.  We don't want to override these positive matches with a negative ones if we
+                    // were to continue searching.
+                    if (method != null)
+                        break;
+
+                    // reset ourselves so we can check the return-type/parameters against the next candidate.
+                    reader.Position = beforeReturnTypeAndParameters;
                 }
 
-                if (reader.Position == beforeParametersPosition)
+                if (reader.Position == beforeReturnTypeAndParameters)
                 {
-                    // We didn't find any candidates.  We still need to stream through this
-                    // method signature so the reader is in a proper position.
+                    // We didn't find a match.  Read through the stream one final time so we're at the correct location
+                    // after this MethodSymbolKey.
 
-                    // Push an null-method to our stack so that any method-type-parameters
-                    // can at least be read (if not resolved) properly.
-                    reader.PushMethod(method: null);
+                    // Push an null-method to our stack so that any method-type-parameters can at least be read (if not
+                    // resolved) properly.
+                    using var _1 = reader.PushMethod(method: null);
 
-                    // read out the values.  We don't actually need to use them, but we have
-                    // to effectively read past them in the string.
+                    // Read the return type.
+                    _ = reader.ReadSymbolKey(contextualSymbol: null, out _);
 
-                    using (reader.ReadSymbolKeyArray<ITypeSymbol>(out _))
-                    {
-                        _ = reader.ReadSymbolKey(out _);
-                    }
-
-                    reader.PopMethod(method: null);
+                    // then the parameter types.
+                    _ = reader.ReadSymbolKeyArray<IMethodSymbol, ITypeSymbol>(
+                        contextualSymbol: null,
+                        getContextualType: static (_, _) => null,
+                        failureReason: out _);
                 }
 
                 if (containingTypeFailureReason != null)
@@ -207,63 +228,39 @@ namespace Microsoft.CodeAnalysis
                     return default;
                 }
 
-                return CreateResolution(result, $"({nameof(MethodSymbolKey)} '{metadataName}' not found)", out failureReason);
-            }
-
-            private static IMethodSymbol? Resolve(
-                SymbolKeyReader reader, string metadataName, int arity, bool isPartialMethodImplementationPart,
-                PooledArrayBuilder<RefKind> parameterRefKinds, int beforeParametersPosition,
-                IMethodSymbol method)
-            {
-                if (method.Arity == arity &&
-                    method.MetadataName == metadataName &&
-                    ParameterRefKindsMatch(method.Parameters, parameterRefKinds))
+                if (method == null)
                 {
-                    // Method looks like a potential match.  It has the right arity, name and 
-                    // refkinds match.  We now need to do the more complicated work of checking
-                    // the parameters (and possibly the return type).  This is more complicated 
-                    // because those symbols might refer to method type parameters.  In order
-                    // for resolution to work on those type parameters, we have to keep track
-                    // in the reader that we're resolving this method. 
-
-                    // Restore our position to right before the list of parameters.  Also, push
-                    // this method into our method-resolution-stack so that we can properly resolve
-                    // method type parameter ordinals.
-                    reader.Position = beforeParametersPosition;
-                    reader.PushMethod(method);
-
-                    var result = Resolve(reader, isPartialMethodImplementationPart, method);
-
-                    reader.PopMethod(method);
-
-                    if (result != null)
-                    {
-                        return result;
-                    }
+                    failureReason = $"({nameof(MethodSymbolKey)} '{metadataName}' not found)";
+                    return default;
                 }
 
-                return null;
+                failureReason = null;
+                return new SymbolKeyResolution(method);
             }
 
             private static IMethodSymbol? Resolve(
                 SymbolKeyReader reader, bool isPartialMethodImplementationPart, IMethodSymbol method)
             {
-                using var originalParameterTypes = reader.ReadSymbolKeyArray<ITypeSymbol>(out _);
-                var returnType = (ITypeSymbol?)reader.ReadSymbolKey(out _).GetAnySymbol();
-
-                if (reader.ParameterTypesMatch(method.OriginalDefinition.Parameters, originalParameterTypes))
+                var returnType = (ITypeSymbol?)reader.ReadSymbolKey(contextualSymbol: method.ReturnType, out _).GetAnySymbol();
+                if (returnType != null &&
+                    !reader.Comparer.Equals(returnType, method.ReturnType))
                 {
-                    if (returnType == null ||
-                        reader.Comparer.Equals(returnType, method.ReturnType))
-                    {
-                        if (isPartialMethodImplementationPart)
-                        {
-                            method = method.PartialImplementationPart ?? method;
-                        }
+                    // ok to early exit here, the topmost caller will reset the position in the stream accordingly.
+                    return null;
+                }
 
-                        Debug.Assert(method != null);
-                        return method;
+                if (reader.ParameterTypesMatch(
+                        method,
+                        getContextualType: static (method, i) => SafeGet(method.Parameters, i)?.Type,
+                        method.OriginalDefinition.Parameters))
+                {
+                    if (isPartialMethodImplementationPart)
+                    {
+                        method = method.PartialImplementationPart ?? method;
                     }
+
+                    Debug.Assert(method != null);
+                    return method;
                 }
 
                 return null;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ModuleSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ModuleSymbolKey.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis
 
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
             {
-                var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
+                var containingSymbolResolution = reader.ReadSymbolKey(reader.CurrentContextualSymbol?.ContainingSymbol, out var containingSymbolFailureReason);
 
                 if (containingSymbolFailureReason != null)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ModuleSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ModuleSymbolKey.cs
@@ -6,14 +6,17 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial struct SymbolKey
     {
-        private static class ModuleSymbolKey
+        private sealed class ModuleSymbolKey : AbstractSymbolKey<IModuleSymbol>
         {
-            public static void Create(IModuleSymbol symbol, SymbolKeyWriter visitor)
+            public static readonly ModuleSymbolKey Instance = new();
+
+            public sealed override void Create(IModuleSymbol symbol, SymbolKeyWriter visitor)
                 => visitor.WriteSymbolKey(symbol.ContainingSymbol);
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
+            protected sealed override SymbolKeyResolution Resolve(
+                SymbolKeyReader reader, IModuleSymbol? contextualSymbol, out string? failureReason)
             {
-                var containingSymbolResolution = reader.ReadSymbolKey(reader.CurrentContextualSymbol?.ContainingSymbol, out var containingSymbolFailureReason);
+                var containingSymbolResolution = reader.ReadSymbolKey(contextualSymbol?.ContainingSymbol, out var containingSymbolFailureReason);
 
                 if (containingSymbolFailureReason != null)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.NamedTypeSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.NamedTypeSymbolKey.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Immutable;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -48,48 +49,104 @@ namespace Microsoft.CodeAnalysis
 
                 if (typeArgumentsFailureReason != null)
                 {
+                    Contract.ThrowIfFalse(typeArguments.IsDefault);
+
                     failureReason = $"({nameof(NamedTypeSymbolKey)} {nameof(typeArguments)} failed -> {typeArgumentsFailureReason})";
                     return default;
                 }
 
-                if (typeArguments.IsDefault)
+                Contract.ThrowIfTrue(typeArguments.IsDefault);
+
+                var typeArgumentsArray = typeArguments.Count == 0
+                    ? Array.Empty<ITypeSymbol>()
+                    : typeArguments.Builder.ToArray();
+
+                var normalResolution = ResolveNormalNamedType(
+                    containingSymbolResolution, containingSymbolFailureReason,
+                    name, arity, filePath, isUnboundGenericType, typeArgumentsArray,
+                    out failureReason);
+
+                if (normalResolution.SymbolCount > 0)
+                    return normalResolution;
+
+                return ResolveContextualErrorType(
+                    reader,
+                    containingSymbolResolution,
+                    name, arity, isUnboundGenericType, typeArgumentsArray,
+                    ref failureReason);
+            }
+
+            private static SymbolKeyResolution ResolveContextualErrorType(
+                SymbolKeyReader reader,
+                SymbolKeyResolution containingSymbolResolution,
+                string name,
+                int arity,
+                bool isUnboundGenericType,
+                ITypeSymbol[] typeArgumentsArray,
+                ref string? failureReason)
+            {
+                // we weren't able to bind the container of this named type to something legitimate.  In normal cases,
+                // that would be the end of resolution.  However, if we are binding in a scenario where we have a
+                // contextual type that is an error type, we can see if our symbol key is a viable match for that error
+                // type.  
+                //
+                // For example, consider if our symbol key references System.String, but we're resolving against a
+                // compilation that is missing a reference to System.String, but has a method `Goo(string s)` which
+                // references it.  This `string s` in `Goo` will be an error type symbol for `System.String` and we *do*
+                // want to allow this to match.
+                //
+                // This is fundamentally inverted from normal resolution.  Normal resolution walks top down from the
+                // root of the compilation to find the match.  However, error symbols cannot be found in that fashion.
+                // Instead, we have to structurally match this error symbol against our own symbol key to see if it is
+                // valid.
+                if (reader.CurrentContextualSymbol is not IErrorTypeSymbol errorType)
+                    return default;
+
+                // Check name/arity. If not hte same, this symbol key isn't referring to the same contextual type
+                // that we're currently looking at.
+                if (errorType.Name != name || errorType.Arity != arity)
+                    return default;
+
+                // If we didn't successfully resolve the containing namespace, then use the contextual type's containing
+                // namespace.  Note: we only do this for namespaces and not containing types.  For containing types we
+                // use recursion to resolve that container properly.  If that failed, then we don't want to continue.
+                if (containingSymbolResolution.SymbolCount == 0 && errorType.ContainingSymbol is INamespaceSymbol containingNamespace)
+                    containingSymbolResolution = new SymbolKeyResolution(containingNamespace);
+
+                using var result = PooledArrayBuilder<INamedTypeSymbol>.GetInstance();
+                foreach (var container in containingSymbolResolution.OfType<INamespaceOrTypeSymbol>())
                 {
-                    failureReason = $"({nameof(NamedTypeSymbolKey)} {nameof(typeArguments)} failed)";
+                    result.AddIfNotNull(Construct(
+                        reader.Compilation.CreateErrorTypeSymbol(container, name, arity),
+                        isUnboundGenericType,
+                        typeArgumentsArray));
+                }
+
+                return CreateResolution(result, $"({nameof(NamedTypeSymbolKey)} failed contextual error resolution)", out failureReason);
+            }
+
+            private static SymbolKeyResolution ResolveNormalNamedType(
+                SymbolKeyResolution containingSymbolResolution,
+                string? containingSymbolFailureReason,
+                string name,
+                int arity,
+                string? filePath,
+                bool isUnboundGenericType,
+                ITypeSymbol[] typeArgumentsArray,
+                out string? failureReason)
+            {
+                if (containingSymbolFailureReason != null)
+                {
+                    failureReason = $"({nameof(NamedTypeSymbolKey)} {nameof(containingSymbolFailureReason)} failed -> {containingSymbolFailureReason})";
                     return default;
                 }
 
-                if (containingSymbolFailureReason != null)
-                {
-                    // we weren't able to bind the container of this named type to something legitimate.  In normal
-                    // cases, that would be the end of resolution.  However, if we are binding in a scenario where we
-                    // have a contextual type that is an error type, we can see if our symbol key is a viable match for
-                    // that error type.  
-                    //
-                    // For example, consider if our symbol key references System.String, but we're resolving against a
-                    // compilation that is missing a reference to System.String, but has a method `Goo(string s)` which
-                    // references it.  This `string s` in `Goo` will be an error type symbol for `System.String` and we
-                    // *do* want to allow this to match.
-                    //
-                    // This is fundamentally inverted from normal resolution.  Normal resolution walks top down from teh
-                    // root of the compilation to find the match.  However, error symbols cannot be found in that
-                    // fashion.  Instead, we have to structurally match this error symbol against our own symbol key to
-                    // see if it is valid.
-                    if (contextualType is not IErrorTypeSymbol)
-                    {
-                        failureReason = $"({nameof(NamedTypeSymbolKey)} {nameof(containingSymbolFailureReason)} failed -> {containingSymbolFailureReason})";
-                        return default;
-                    }
-                }
-
-                var typeArgumentArray = typeArguments.Count == 0
-                    ? Array.Empty<ITypeSymbol>()
-                    : typeArguments.Builder.ToArray();
                 using var result = PooledArrayBuilder<INamedTypeSymbol>.GetInstance();
                 foreach (var nsOrType in containingSymbolResolution.OfType<INamespaceOrTypeSymbol>())
                 {
                     Resolve(
                         result, nsOrType, name, arity, filePath,
-                        isUnboundGenericType, typeArgumentArray);
+                        isUnboundGenericType, typeArgumentsArray);
                 }
 
                 return CreateResolution(result, $"({nameof(NamedTypeSymbolKey)} failed)", out failureReason);
@@ -122,11 +179,15 @@ namespace Microsoft.CodeAnalysis
                         continue;
                     }
 
-                    var currentType = typeArguments.Length > 0 ? type.Construct(typeArguments) : type;
-                    currentType = isUnboundGenericType ? currentType.ConstructUnboundGenericType() : currentType;
-
-                    result.AddIfNotNull(currentType);
+                    result.AddIfNotNull(Construct(type, isUnboundGenericType, typeArguments));
                 }
+            }
+
+            private static INamedTypeSymbol Construct(INamedTypeSymbol type, bool isUnboundGenericType, ITypeSymbol[] typeArguments)
+            {
+                var currentType = typeArguments.Length > 0 ? type.Construct(typeArguments) : type;
+                currentType = isUnboundGenericType ? currentType.ConstructUnboundGenericType() : currentType;
+                return currentType;
             }
         }
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ParameterSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ParameterSymbolKey.cs
@@ -8,15 +8,18 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial struct SymbolKey
     {
-        private static class ParameterSymbolKey
+        private sealed class ParameterSymbolKey : AbstractSymbolKey<IParameterSymbol>
         {
-            public static void Create(IParameterSymbol symbol, SymbolKeyWriter visitor)
+            public static readonly ParameterSymbolKey Instance = new();
+
+            public sealed override void Create(IParameterSymbol symbol, SymbolKeyWriter visitor)
             {
                 visitor.WriteString(symbol.MetadataName);
                 visitor.WriteSymbolKey(symbol.ContainingSymbol);
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
+            protected sealed override SymbolKeyResolution Resolve(
+                SymbolKeyReader reader, IParameterSymbol? contextualSymbol, out string? failureReason)
             {
                 var metadataName = reader.ReadRequiredString();
 
@@ -24,7 +27,7 @@ namespace Microsoft.CodeAnalysis
                 // types to guide how the outer parts of the member may resolve.  We can use contextual typing for the
                 // *signature* portion of the member though.
                 var containingSymbolResolution = reader.ReadSymbolKey(
-                    reader.CurrentContextualSymbol?.ContainingSymbol, out var containingSymbolFailureReason);
+                    contextualSymbol?.ContainingSymbol, out var containingSymbolFailureReason);
 
                 if (containingSymbolFailureReason != null)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ParameterSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ParameterSymbolKey.cs
@@ -19,7 +19,12 @@ namespace Microsoft.CodeAnalysis
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
             {
                 var metadataName = reader.ReadRequiredString();
-                var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
+
+                // Parameters are owned by members, and members are never resolved in a way where we have contextual
+                // types to guide how the outer parts of the member may resolve.  We can use contextual typing for the
+                // *signature* portion of the member though.
+                var containingSymbolResolution = reader.ReadSymbolKey(
+                    reader.CurrentContextualSymbol?.ContainingSymbol, out var containingSymbolFailureReason);
 
                 if (containingSymbolFailureReason != null)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.PointerTypeSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.PointerTypeSymbolKey.cs
@@ -6,14 +6,17 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial struct SymbolKey
     {
-        private static class PointerTypeSymbolKey
+        private sealed class PointerTypeSymbolKey : AbstractSymbolKey<IPointerTypeSymbol>
         {
-            public static void Create(IPointerTypeSymbol symbol, SymbolKeyWriter visitor)
+            public static readonly PointerTypeSymbolKey Instance = new();
+
+            public sealed override void Create(IPointerTypeSymbol symbol, SymbolKeyWriter visitor)
                 => visitor.WriteSymbolKey(symbol.PointedAtType);
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
+            protected sealed override SymbolKeyResolution Resolve(
+                SymbolKeyReader reader, IPointerTypeSymbol? contextualSymbol, out string? failureReason)
             {
-                var pointedAtTypeResolution = reader.ReadSymbolKey((reader.CurrentContextualSymbol as IPointerTypeSymbol)?.PointedAtType, out var pointedAtTypeFailureReason);
+                var pointedAtTypeResolution = reader.ReadSymbolKey(contextualSymbol?.PointedAtType, out var pointedAtTypeFailureReason);
 
                 if (pointedAtTypeFailureReason != null)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.PointerTypeSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.PointerTypeSymbolKey.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis
 
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
             {
-                var pointedAtTypeResolution = reader.ReadSymbolKey(out var pointedAtTypeFailureReason);
+                var pointedAtTypeResolution = reader.ReadSymbolKey((reader.CurrentContextualSymbol as IPointerTypeSymbol)?.PointedAtType, out var pointedAtTypeFailureReason);
 
                 if (pointedAtTypeFailureReason != null)
                 {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.PropertySymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.PropertySymbolKey.cs
@@ -20,10 +20,52 @@ namespace Microsoft.CodeAnalysis
             public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
             {
                 var metadataName = reader.ReadString();
-                var containingTypeResolution = reader.ReadSymbolKey(out var containingTypeFailureReason);
+
+                var containingTypeResolution = reader.ReadSymbolKey(reader.CurrentContextualSymbol?.ContainingSymbol, out var containingTypeFailureReason);
+
                 var isIndexer = reader.ReadBoolean();
                 using var refKinds = reader.ReadRefKindArray();
-                using var parameterTypes = reader.ReadSymbolKeyArray<ITypeSymbol>(out var parameterTypesFailureReason);
+
+                using var properties = GetMembersOfNamedType<IPropertySymbol>(containingTypeResolution, metadataName: null);
+                using var result = PooledArrayBuilder<IPropertySymbol>.GetInstance();
+
+                // For each property that we look at, we'll have to resolve the parameter list and return type in the
+                // context of that method.  This makes sure we can attempt to resolve the parameter list types against
+                // error types in the property we're currently looking at.
+                //
+                // Because of this, we keep track of where we are in the reader.  Before resolving every parameter list,
+                // we'll mark which method we're on and we'll rewind to this point.
+                var beforeParametersPosition = reader.Position;
+
+                IPropertySymbol? property = null;
+                foreach (var candidate in properties)
+                {
+                    if (candidate.Parameters.Length != refKinds.Count ||
+                        candidate.MetadataName != metadataName ||
+                        candidate.IsIndexer != isIndexer ||
+                        !ParameterRefKindsMatch(candidate.OriginalDefinition.Parameters, refKinds))
+                    {
+                        continue;
+                    }
+
+                    property = Resolve(reader, candidate);
+                    if (property != null)
+                        break;
+
+                    // reset ourselves so we can check the return-type/parameters against the next candidate.
+                    reader.Position = beforeParametersPosition;
+                }
+
+                if (reader.Position == beforeParametersPosition)
+                {
+                    // We didn't find a match.  Read through the stream one final time so we're at the correct location
+                    // after this PropertySymbolKey.
+
+                    _ = reader.ReadSymbolKeyArray<IPropertySymbol, ITypeSymbol>(
+                        contextualSymbol: null,
+                        getContextualType: static (_, _) => null,
+                        failureReason: out _);
+                }
 
                 if (containingTypeFailureReason != null)
                 {
@@ -31,33 +73,29 @@ namespace Microsoft.CodeAnalysis
                     return default;
                 }
 
-                if (parameterTypesFailureReason != null)
+                if (property == null)
                 {
-                    failureReason = $"({nameof(PropertySymbolKey)} {nameof(parameterTypes)} failed -> {parameterTypesFailureReason})";
+                    failureReason = $"({nameof(PropertySymbolKey)} '{metadataName}' not found)";
                     return default;
                 }
 
-                if (parameterTypes.IsDefault)
+                failureReason = null;
+                return new SymbolKeyResolution(property);
+            }
+
+            private static IPropertySymbol? Resolve(
+                SymbolKeyReader reader,
+                IPropertySymbol property)
+            {
+                if (reader.ParameterTypesMatch(
+                        property,
+                        getContextualType: static (property, i) => SafeGet(property.OriginalDefinition.Parameters, i)?.Type,
+                        property.OriginalDefinition.Parameters))
                 {
-                    failureReason = $"({nameof(PropertySymbolKey)} no parameter types)";
-                    return default;
+                    return property;
                 }
 
-                using var properties = GetMembersOfNamedType<IPropertySymbol>(containingTypeResolution, metadataName: null);
-                using var result = PooledArrayBuilder<IPropertySymbol>.GetInstance();
-                foreach (var property in properties)
-                {
-                    if (property.Parameters.Length == refKinds.Count &&
-                        property.MetadataName == metadataName &&
-                        property.IsIndexer == isIndexer &&
-                        ParameterRefKindsMatch(property.OriginalDefinition.Parameters, refKinds) &&
-                        reader.ParameterTypesMatch(property.OriginalDefinition.Parameters, parameterTypes))
-                    {
-                        result.AddIfNotNull(property);
-                    }
-                }
-
-                return CreateResolution(result, $"({nameof(PropertySymbolKey)} '{metadataName}' not found)", out failureReason);
+                return null;
             }
         }
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.SymbolKeyReader.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.SymbolKeyReader.cs
@@ -579,15 +579,19 @@ namespace Microsoft.CodeAnalysis
             }
 
             /// <summary>
-            /// Reads an array of symbols out from the key.  Note: the number of symbols returned 
-            /// will either be the same as the original amount written, or <c>default</c> will be 
-            /// returned. It will never be less or more.  <c>default</c> will be returned if any 
-            /// elements could not be resolved to the requested <typeparamref name="TSymbol"/> type 
-            /// in the provided <see cref="SymbolKeyReader.Compilation"/>.
-            /// 
-            /// Callers should <see cref="IDisposable.Dispose"/> the instance returned.  No check is
-            /// necessary if <c>default</c> was returned before calling <see cref="IDisposable.Dispose"/>
+            /// Reads an array of symbols out from the key.  Note: the number of symbols returned will either be the
+            /// same as the original amount written, or <c>default</c> will be returned. It will never be less or more.
+            /// <c>default</c> will be returned if any elements could not be resolved to the requested <typeparamref
+            /// name="TSymbol"/> type in the provided <see cref="SymbolKeyReader.Compilation"/>.
+            /// <para>
+            /// Callers should <see cref="IDisposable.Dispose"/> the instance returned.  No check is necessary if
+            /// <c>default</c> was returned before calling <see cref="IDisposable.Dispose"/>
+            /// </para>
             /// </summary>
+            /// <remarks>
+            /// If <c>default</c> is returned then <paramref name="failureReason"/> will be non-null.  Similarly, if
+            /// <paramref name="failureReason"/> is non-null, then only <c>default</c> will be returned.
+            /// </remarks>
             public PooledArrayBuilder<TSymbol> ReadSymbolKeyArray<TContextualSymbol, TSymbol>(
                 TContextualSymbol? contextualSymbol,
                 Func<TContextualSymbol, int, ITypeSymbol?> getContextualType,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.SymbolKeyWriter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.SymbolKeyWriter.cs
@@ -319,31 +319,31 @@ namespace Microsoft.CodeAnalysis
             public override void VisitAlias(IAliasSymbol aliasSymbol)
             {
                 WriteType(SymbolKeyType.Alias);
-                AliasSymbolKey.Create(aliasSymbol, this);
+                AliasSymbolKey.Instance.Create(aliasSymbol, this);
             }
 
             public override void VisitArrayType(IArrayTypeSymbol arrayTypeSymbol)
             {
                 WriteType(SymbolKeyType.ArrayType);
-                ArrayTypeSymbolKey.Create(arrayTypeSymbol, this);
+                ArrayTypeSymbolKey.Instance.Create(arrayTypeSymbol, this);
             }
 
             public override void VisitAssembly(IAssemblySymbol assemblySymbol)
             {
                 WriteType(SymbolKeyType.Assembly);
-                AssemblySymbolKey.Create(assemblySymbol, this);
+                AssemblySymbolKey.Instance.Create(assemblySymbol, this);
             }
 
             public override void VisitDynamicType(IDynamicTypeSymbol dynamicTypeSymbol)
             {
                 WriteType(SymbolKeyType.DynamicType);
-                DynamicTypeSymbolKey.Create(this);
+                DynamicTypeSymbolKey.Instance.Create(dynamicTypeSymbol, this);
             }
 
             public override void VisitField(IFieldSymbol fieldSymbol)
             {
                 WriteType(SymbolKeyType.Field);
-                FieldSymbolKey.Create(fieldSymbol, this);
+                FieldSymbolKey.Instance.Create(fieldSymbol, this);
             }
 
             public override void VisitLabel(ILabelSymbol labelSymbol)
@@ -360,7 +360,7 @@ namespace Microsoft.CodeAnalysis
                 if (!methodSymbol.Equals(methodSymbol.ConstructedFrom))
                 {
                     WriteType(SymbolKeyType.ConstructedMethod);
-                    ConstructedMethodSymbolKey.Create(methodSymbol, this);
+                    ConstructedMethodSymbolKey.Instance.Create(methodSymbol, this);
                 }
                 else
                 {
@@ -368,7 +368,7 @@ namespace Microsoft.CodeAnalysis
                     {
                         case MethodKind.ReducedExtension:
                             WriteType(SymbolKeyType.ReducedExtensionMethod);
-                            ReducedExtensionMethodSymbolKey.Create(methodSymbol, this);
+                            ReducedExtensionMethodSymbolKey.Instance.Create(methodSymbol, this);
                             break;
 
                         case MethodKind.AnonymousFunction:
@@ -381,7 +381,7 @@ namespace Microsoft.CodeAnalysis
 
                         default:
                             WriteType(SymbolKeyType.Method);
-                            MethodSymbolKey.Create(methodSymbol, this);
+                            MethodSymbolKey.Instance.Create(methodSymbol, this);
                             break;
                     }
                 }
@@ -390,7 +390,7 @@ namespace Microsoft.CodeAnalysis
             public override void VisitModule(IModuleSymbol moduleSymbol)
             {
                 WriteType(SymbolKeyType.Module);
-                ModuleSymbolKey.Create(moduleSymbol, this);
+                ModuleSymbolKey.Instance.Create(moduleSymbol, this);
             }
 
             public override void VisitNamedType(INamedTypeSymbol namedTypeSymbol)
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis
                 if (namedTypeSymbol.TypeKind == TypeKind.Error)
                 {
                     WriteType(SymbolKeyType.ErrorType);
-                    ErrorTypeSymbolKey.Create(namedTypeSymbol, this);
+                    ErrorTypeSymbolKey.Instance.Create(namedTypeSymbol, this);
                 }
                 else if (namedTypeSymbol.IsTupleType && namedTypeSymbol.TupleUnderlyingType is INamedTypeSymbol underlyingType && underlyingType != namedTypeSymbol)
                 {
@@ -406,7 +406,7 @@ namespace Microsoft.CodeAnalysis
                     // We only need to store this extra information if there is some
                     // (ie. the current type differs from the underlying type, which has no element names)
                     WriteType(SymbolKeyType.TupleType);
-                    TupleTypeSymbolKey.Create(namedTypeSymbol, this);
+                    TupleTypeSymbolKey.Instance.Create(namedTypeSymbol, this);
                 }
                 else if (namedTypeSymbol.IsAnonymousType)
                 {
@@ -418,50 +418,50 @@ namespace Microsoft.CodeAnalysis
                     else
                     {
                         WriteType(SymbolKeyType.AnonymousType);
-                        AnonymousTypeSymbolKey.Create(namedTypeSymbol, this);
+                        AnonymousTypeSymbolKey.Instance.Create(namedTypeSymbol, this);
                     }
                 }
                 else
                 {
                     WriteType(SymbolKeyType.NamedType);
-                    NamedTypeSymbolKey.Create(namedTypeSymbol, this);
+                    NamedTypeSymbolKey.Instance.Create(namedTypeSymbol, this);
                 }
             }
 
             public override void VisitNamespace(INamespaceSymbol namespaceSymbol)
             {
                 WriteType(SymbolKeyType.Namespace);
-                NamespaceSymbolKey.Create(namespaceSymbol, this);
+                NamespaceSymbolKey.Instance.Create(namespaceSymbol, this);
             }
 
             public override void VisitParameter(IParameterSymbol parameterSymbol)
             {
                 WriteType(SymbolKeyType.Parameter);
-                ParameterSymbolKey.Create(parameterSymbol, this);
+                ParameterSymbolKey.Instance.Create(parameterSymbol, this);
             }
 
             public override void VisitPointerType(IPointerTypeSymbol pointerTypeSymbol)
             {
                 WriteType(SymbolKeyType.PointerType);
-                PointerTypeSymbolKey.Create(pointerTypeSymbol, this);
+                PointerTypeSymbolKey.Instance.Create(pointerTypeSymbol, this);
             }
 
             public override void VisitFunctionPointerType(IFunctionPointerTypeSymbol symbol)
             {
                 WriteType(SymbolKeyType.FunctionPointer);
-                FunctionPointerTypeSymbolKey.Create(symbol, this);
+                FunctionPointerTypeSymbolKey.Instance.Create(symbol, this);
             }
 
             public override void VisitProperty(IPropertySymbol propertySymbol)
             {
                 WriteType(SymbolKeyType.Property);
-                PropertySymbolKey.Create(propertySymbol, this);
+                PropertySymbolKey.Instance.Create(propertySymbol, this);
             }
 
             public override void VisitEvent(IEventSymbol eventSymbol)
             {
                 WriteType(SymbolKeyType.Event);
-                EventSymbolKey.Create(eventSymbol, this);
+                EventSymbolKey.Instance.Create(eventSymbol, this);
             }
 
             public override void VisitTypeParameter(ITypeParameterSymbol typeParameterSymbol)
@@ -477,7 +477,7 @@ namespace Microsoft.CodeAnalysis
                 else
                 {
                     WriteType(SymbolKeyType.TypeParameter);
-                    TypeParameterSymbolKey.Create(typeParameterSymbol, this);
+                    TypeParameterSymbolKey.Instance.Create(typeParameterSymbol, this);
                 }
             }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.TupleTypeSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.TupleTypeSymbolKey.cs
@@ -13,9 +13,11 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial struct SymbolKey
     {
-        private static class TupleTypeSymbolKey
+        private sealed class TupleTypeSymbolKey : AbstractSymbolKey<INamedTypeSymbol>
         {
-            public static void Create(INamedTypeSymbol symbol, SymbolKeyWriter visitor)
+            public static readonly TupleTypeSymbolKey Instance = new();
+
+            public sealed override void Create(INamedTypeSymbol symbol, SymbolKeyWriter visitor)
             {
                 Debug.Assert(symbol.IsTupleType);
 
@@ -49,19 +51,24 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
+            protected sealed override SymbolKeyResolution Resolve(
+                SymbolKeyReader reader, INamedTypeSymbol? contextualSymbol, out string? failureReason)
             {
+                contextualSymbol = contextualSymbol is { IsTupleType: true } ? contextualSymbol : null;
                 var isError = reader.ReadBoolean();
 
-                return isError ? ResolveErrorTuple(reader, out failureReason) : ResolveNormalTuple(reader, out failureReason);
+                return isError
+                    ? ResolveErrorTuple(reader, contextualSymbol, out failureReason)
+                    : ResolveNormalTuple(reader, contextualSymbol, out failureReason);
             }
 
-            private static SymbolKeyResolution ResolveNormalTuple(SymbolKeyReader reader, out string? failureReason)
+            private static SymbolKeyResolution ResolveNormalTuple(
+                SymbolKeyReader reader, INamedTypeSymbol? contextualSymbol, out string? failureReason)
             {
                 using var elementNames = reader.ReadStringArray();
                 var elementLocations = ReadElementLocations(reader, out var elementLocationsFailureReason);
                 var underlyingTypeResolution = reader.ReadSymbolKey(
-                    (reader.CurrentContextualSymbol as INamedTypeSymbol)?.TupleUnderlyingType,
+                    contextualSymbol?.TupleUnderlyingType,
                     out var underlyingTypeFailureReason);
 
                 if (underlyingTypeFailureReason != null)
@@ -83,12 +90,9 @@ namespace Microsoft.CodeAnalysis
                 return CreateResolution(result, $"({nameof(TupleTypeSymbolKey)} failed)", out failureReason);
             }
 
-            private static SymbolKeyResolution ResolveErrorTuple(SymbolKeyReader reader, out string? failureReason)
+            private static SymbolKeyResolution ResolveErrorTuple(
+                SymbolKeyReader reader, INamedTypeSymbol? contextualType, out string? failureReason)
             {
-                var contextualType = reader.CurrentContextualSymbol is INamedTypeSymbol { IsTupleType: true } tupleType
-                    ? tupleType
-                    : null;
-
                 using var elementNames = reader.ReadStringArray();
                 var elementLocations = ReadElementLocations(reader, out var elementLocationsFailureReason);
                 using var elementTypes = reader.ReadSymbolKeyArray<INamedTypeSymbol, ITypeSymbol>(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.TypeParameterSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.TypeParameterSymbolKey.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis
                 else
                 {
                     var metadataName = reader.ReadString();
-                    var containingSymbolResolution = reader.ReadSymbolKey(out var containingSymbolFailureReason);
+                    var containingSymbolResolution = reader.ReadSymbolKey(reader.CurrentContextualSymbol?.ContainingSymbol, out var containingSymbolFailureReason);
 
                     if (containingSymbolFailureReason != null)
                     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.TypeParameterSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.TypeParameterSymbolKey.cs
@@ -8,9 +8,11 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial struct SymbolKey
     {
-        private static class TypeParameterSymbolKey
+        private sealed class TypeParameterSymbolKey : AbstractSymbolKey<ITypeParameterSymbol>
         {
-            public static void Create(ITypeParameterSymbol symbol, SymbolKeyWriter visitor)
+            public static readonly TypeParameterSymbolKey Instance = new();
+
+            public sealed override void Create(ITypeParameterSymbol symbol, SymbolKeyWriter visitor)
             {
                 if (symbol.TypeParameterKind == TypeParameterKind.Cref)
                 {
@@ -25,7 +27,8 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            public static SymbolKeyResolution Resolve(SymbolKeyReader reader, out string? failureReason)
+            protected sealed override SymbolKeyResolution Resolve(
+                SymbolKeyReader reader, ITypeParameterSymbol? contextualSymbol, out string? failureReason)
             {
                 var isCref = reader.ReadBoolean();
 
@@ -46,7 +49,7 @@ namespace Microsoft.CodeAnalysis
                 else
                 {
                     var metadataName = reader.ReadString();
-                    var containingSymbolResolution = reader.ReadSymbolKey(reader.CurrentContextualSymbol?.ContainingSymbol, out var containingSymbolFailureReason);
+                    var containingSymbolResolution = reader.ReadSymbolKey(contextualSymbol?.ContainingSymbol, out var containingSymbolFailureReason);
 
                     if (containingSymbolFailureReason != null)
                     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis
         /// out a SymbolKey from a previous version of Roslyn and then attempt to use it in a 
         /// newer version where the encoding has changed.
         /// </summary>
-        internal const int FormatVersion = 3;
+        internal const int FormatVersion = 4;
 
         [DataMember(Order = 0)]
         private readonly string _symbolKeyData;
@@ -188,7 +188,8 @@ namespace Microsoft.CodeAnalysis
                 return default;
             }
 
-            var result = reader.ReadSymbolKey(out failureReason);
+            // Initial entrypoint.  No contextual symbol to pass along.
+            var result = reader.ReadSymbolKey(contextualSymbol: null, out failureReason);
             Debug.Assert(reader.Position == symbolKey.Length);
             return result;
         }
@@ -249,6 +250,9 @@ namespace Microsoft.CodeAnalysis
                     CandidateReason.Ambiguous);
             }
         }
+
+        private static T? SafeGet<T>(ImmutableArray<T> values, int index) where T : class
+            => index < values.Length ? values[index] : null;
 
         private static bool Equals(Compilation compilation, string? name1, string? name2)
             => Equals(compilation.IsCaseSensitive, name1, name2);


### PR DESCRIPTION
This is need we have in scenarios where we are resolving a symbol key against a compilation missing all references.  In this case the compiler will generate ErrorTypeSymbols to represent thsoe symbols.  We can accurately check our symbol keys against those to see if those still represent the same symbol.

I recommend reviewing one commit at a time.

THe first commit updates the existing symbol key infrastructure to allow passing along a contextual symbol that we might be able to resolve the key against.  The second commit handles actually using this when we have a key that doesn't resolve but we can see that the compiler has an error symbol in that context.  THe third commit moves to stronger typing.