### PR TITLE
Use OmniSharp LineFormatting fallback options in more places.

### DIFF
--- a/src/Tools/ExternalAccess/OmniSharp/DocumentationComments/OmniSharpDocumentationCommentOptionsWrapper.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/DocumentationComments/OmniSharpDocumentationCommentOptionsWrapper.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.DocumentationComments;
+using Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Options;
 using Microsoft.CodeAnalysis.Formatting;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.DocumentationComments
@@ -19,12 +20,16 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.DocumentationComments
 
         public OmniSharpDocumentationCommentOptionsWrapper(
             bool autoXmlDocCommentGeneration,
-            int tabSize,
-            bool useTabs,
-            string newLine)
+            OmniSharpLineFormattingOptions lineFormattingOptions)
             : this(new DocumentationCommentOptions()
             {
-                LineFormatting = new LineFormattingOptions() { UseTabs = useTabs, TabSize = tabSize, IndentationSize = tabSize, NewLine = newLine },
+                LineFormatting = new LineFormattingOptions()
+                {
+                    UseTabs = lineFormattingOptions.UseTabs,
+                    TabSize = lineFormattingOptions.TabSize,
+                    IndentationSize = lineFormattingOptions.IndentationSize,
+                    NewLine = lineFormattingOptions.NewLine,
+                },
                 AutoXmlDocCommentGeneration = autoXmlDocCommentGeneration
             })
         {

--- a/src/Tools/ExternalAccess/OmniSharp/Formatting/OmniSharpOrganizeImportsOptionsWrapper.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/Formatting/OmniSharpOrganizeImportsOptionsWrapper.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Formatting
         {
         }
 
-        public static async ValueTask<OmniSharpOrganizeImportsOptionsWrapper> FromDocumentAsync(Document document, CancellationToken cancellationToken)
-            => new(await document.GetOrganizeImportsOptionsAsync(fallbackOptions: null, cancellationToken).ConfigureAwait(false));
+        public static async ValueTask<OmniSharpOrganizeImportsOptionsWrapper> FromDocumentAsync(Document document, OmniSharpOrganizeImportsOptionsWrapper fallbackOptions, CancellationToken cancellationToken)
+            => new(await document.GetOrganizeImportsOptionsAsync(fallbackOptions.UnderlyingObject, cancellationToken).ConfigureAwait(false));
     }
 }

--- a/src/Tools/ExternalAccess/OmniSharp/Formatting/OmniSharpSyntaxFormattingOptionsWrapper.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/Formatting/OmniSharpSyntaxFormattingOptionsWrapper.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeCleanup;
+using Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Options;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
 
@@ -20,9 +21,21 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Formatting
             CleanupOptions = cleanupOptions;
         }
 
-        public static async ValueTask<OmniSharpSyntaxFormattingOptionsWrapper> FromDocumentAsync(Document document, CancellationToken cancellationToken)
+        public static async ValueTask<OmniSharpSyntaxFormattingOptionsWrapper> FromDocumentAsync(Document document, OmniSharpLineFormattingOptions fallbackLineFormattingOptions, CancellationToken cancellationToken)
         {
-            var cleanupOptions = await document.GetCodeCleanupOptionsAsync(CodeActionOptions.DefaultProvider, cancellationToken).ConfigureAwait(false);
+            var defaultOptions = CodeCleanupOptions.GetDefault(document.Project.LanguageServices);
+            var fallbackOptions = defaultOptions with
+            {
+                FormattingOptions = defaultOptions.FormattingOptions.With(new LineFormattingOptions
+                {
+                    IndentationSize = fallbackLineFormattingOptions.IndentationSize,
+                    TabSize = fallbackLineFormattingOptions.TabSize,
+                    UseTabs = fallbackLineFormattingOptions.UseTabs,
+                    NewLine = fallbackLineFormattingOptions.NewLine,
+                })
+            };
+
+            var cleanupOptions = await document.GetCodeCleanupOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
             return new OmniSharpSyntaxFormattingOptionsWrapper(cleanupOptions);
         }
     }


### PR DESCRIPTION
OmniSharp sets these "global" formatting options on the Solution.OptionSet. However, when fallback options are not specified, we expect to find the values from AnalyzerConfigOptions. These changes specifically pass in the "global" values of these options as a fallback.