### PR TITLE
Pass LineFormatting options into OmniSharpCodeAction options

### DIFF
--- a/src/Tools/ExternalAccess/OmniSharp/CodeActions/OmniSharpCodeActionOptions.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/CodeActions/OmniSharpCodeActionOptions.cs
@@ -3,7 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.ImplementType;
+using Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Options;
+using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.ImplementType;
 using Microsoft.CodeAnalysis.SymbolSearch;
@@ -11,16 +14,30 @@ using Microsoft.CodeAnalysis.SymbolSearch;
 namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CodeActions
 {
     internal readonly record struct OmniSharpCodeActionOptions(
-        OmniSharpImplementTypeOptions ImplementTypeOptions)
+        OmniSharpImplementTypeOptions ImplementTypeOptions,
+        OmniSharpLineFormattingOptions LineFormattingOptions)
     {
         internal CodeActionOptions GetCodeActionOptions(HostLanguageServices languageServices)
-            => CodeActionOptions.GetDefault(languageServices) with
+        {
+            var defaultOptions = CodeActionOptions.GetDefault(languageServices);
+            return defaultOptions with
             {
+                CleanupOptions = defaultOptions.CleanupOptions with
+                {
+                    FormattingOptions = defaultOptions.CleanupOptions.FormattingOptions.With(new LineFormattingOptions
+                    {
+                        IndentationSize = LineFormattingOptions.IndentationSize,
+                        TabSize = LineFormattingOptions.TabSize,
+                        UseTabs = LineFormattingOptions.UseTabs,
+                        NewLine = LineFormattingOptions.NewLine,
+                    })
+                },
                 ImplementTypeOptions = new()
                 {
                     InsertionBehavior = (ImplementTypeInsertionBehavior)ImplementTypeOptions.InsertionBehavior,
                     PropertyGenerationBehavior = (ImplementTypePropertyGenerationBehavior)ImplementTypeOptions.PropertyGenerationBehavior
                 }
             };
+        }
     }
 }


### PR DESCRIPTION
Another location where LineFormatting options were needed. Continuation of https://github.com/dotnet/roslyn/pull/62690