### PR TITLE
Simplify `AbstractBuiltInCodeStyleDiagnosticAnalyzer` constructors

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/AddBraces/CSharpAddBracesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/AddBraces/CSharpAddBracesDiagnosticAnalyzer.cs
@@ -24,7 +24,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
             : base(IDEDiagnosticIds.AddBracesDiagnosticId,
                    EnforceOnBuildValues.AddBraces,
                    CSharpCodeStyleOptions.PreferBraces,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Add_braces), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Add_braces_to_0_statement), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/ConvertNamespace/ConvertToBlockScopedNamespaceDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertNamespace/ConvertToBlockScopedNamespaceDiagnosticAnalyzer.cs
@@ -23,7 +23,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
             : base(IDEDiagnosticIds.UseBlockScopedNamespaceDiagnosticId,
                    EnforceOnBuildValues.UseBlockScopedNamespace,
                    CSharpCodeStyleOptions.NamespaceDeclarations,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Convert_to_block_scoped_namespace), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {
         }

--- a/src/Analyzers/CSharp/Analyzers/ConvertNamespace/ConvertToFileScopedNamespaceDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertNamespace/ConvertToFileScopedNamespaceDiagnosticAnalyzer.cs
@@ -23,7 +23,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertNamespace
             : base(IDEDiagnosticIds.UseFileScopedNamespaceDiagnosticId,
                    EnforceOnBuildValues.UseFileScopedNamespace,
                    CSharpCodeStyleOptions.NamespaceDeclarations,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Convert_to_file_scoped_namespace), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {
         }

--- a/src/Analyzers/CSharp/Analyzers/ConvertProgram/ConvertToProgramMainDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertProgram/ConvertToProgramMainDiagnosticAnalyzer.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.CSharp.TopLevelStatements
                   IDEDiagnosticIds.UseProgramMainId,
                   EnforceOnBuildValues.UseProgramMain,
                   CSharpCodeStyleOptions.PreferTopLevelStatements,
-                  LanguageNames.CSharp,
                   new LocalizableResourceString(nameof(CSharpAnalyzersResources.Convert_to_Program_Main_style_program), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {
         }

--- a/src/Analyzers/CSharp/Analyzers/ConvertProgram/ConvertToTopLevelStatementsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertProgram/ConvertToTopLevelStatementsDiagnosticAnalyzer.cs
@@ -23,7 +23,6 @@ namespace Microsoft.CodeAnalysis.CSharp.TopLevelStatements
                   IDEDiagnosticIds.UseTopLevelStatementsId,
                   EnforceOnBuildValues.UseTopLevelStatements,
                   CSharpCodeStyleOptions.PreferTopLevelStatements,
-                  LanguageNames.CSharp,
                   new LocalizableResourceString(nameof(CSharpAnalyzersResources.Convert_to_top_level_statements), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {
         }

--- a/src/Analyzers/CSharp/Analyzers/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionDiagnosticAnalyzer.cs
@@ -24,7 +24,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
             : base(IDEDiagnosticIds.ConvertSwitchStatementToExpressionDiagnosticId,
                 EnforceOnBuildValues.ConvertSwitchStatementToExpression,
                 CSharpCodeStyleOptions.PreferSwitchExpression,
-                LanguageNames.CSharp,
                 new LocalizableResourceString(nameof(CSharpAnalyzersResources.Convert_switch_statement_to_expression), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
                 new LocalizableResourceString(nameof(CSharpAnalyzersResources.Use_switch_expression), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/ConvertTypeofToNameof/CSharpConvertTypeOfToNameOfDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/ConvertTypeofToNameof/CSharpConvertTypeOfToNameOfDiagnosticAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertTypeOfToNameOf
     {
         private static readonly string s_title = CSharpAnalyzersResources.typeof_can_be_converted__to_nameof;
 
-        public CSharpConvertTypeOfToNameOfDiagnosticAnalyzer() : base(s_title, LanguageNames.CSharp)
+        public CSharpConvertTypeOfToNameOfDiagnosticAnalyzer() : base(s_title)
         {
         }
 

--- a/src/Analyzers/CSharp/Analyzers/FileHeaders/CSharpFileHeaderDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/FileHeaders/CSharpFileHeaderDiagnosticAnalyzer.cs
@@ -10,11 +10,6 @@ namespace Microsoft.CodeAnalysis.CSharp.FileHeaders
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal class CSharpFileHeaderDiagnosticAnalyzer : AbstractFileHeaderDiagnosticAnalyzer
     {
-        public CSharpFileHeaderDiagnosticAnalyzer()
-            : base(LanguageNames.CSharp)
-        {
-        }
-
         protected override AbstractFileHeaderHelper FileHeaderHelper => CSharpFileHeaderHelper.Instance;
     }
 }

--- a/src/Analyzers/CSharp/Analyzers/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
             : base(IDEDiagnosticIds.InlineDeclarationDiagnosticId,
                    EnforceOnBuildValues.InlineDeclaration,
                    CSharpCodeStyleOptions.PreferInlinedVariableDeclaration,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Inline_variable_declaration), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Variable_declaration_can_be_inlined), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessAnalyzer.cs
@@ -28,7 +28,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
             : base(IDEDiagnosticIds.InvokeDelegateWithConditionalAccessId,
                    EnforceOnBuildValues.InvokeDelegateWithConditionalAccess,
                    CSharpCodeStyleOptions.PreferConditionalDelegateCall,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Delegate_invocation_can_be_simplified), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {
         }

--- a/src/Analyzers/CSharp/Analyzers/MakeLocalFunctionStatic/MakeLocalFunctionStaticDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeLocalFunctionStatic/MakeLocalFunctionStaticDiagnosticAnalyzer.cs
@@ -18,7 +18,6 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeLocalFunctionStatic
             : base(IDEDiagnosticIds.MakeLocalFunctionStaticDiagnosticId,
                    EnforceOnBuildValues.MakeLocalFunctionStatic,
                    CSharpCodeStyleOptions.PreferStaticLocalFunction,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Make_local_function_static), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Local_function_can_be_made_static), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/MisplacedUsingDirectives/MisplacedUsingDirectivesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MisplacedUsingDirectives/MisplacedUsingDirectivesDiagnosticAnalyzer.cs
@@ -38,10 +38,9 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
             s_localizableTitle, s_localizableInsideMessage);
 
         public MisplacedUsingDirectivesDiagnosticAnalyzer()
-           : base(ImmutableDictionary<DiagnosticDescriptor, ILanguageSpecificOption>.Empty
+           : base(ImmutableDictionary<DiagnosticDescriptor, IOption2>.Empty
                     .Add(s_outsideDiagnosticDescriptor, CSharpCodeStyleOptions.PreferredUsingDirectivePlacement)
-                    .Add(s_insideDiagnosticDescriptor, CSharpCodeStyleOptions.PreferredUsingDirectivePlacement),
-                 LanguageNames.CSharp)
+                    .Add(s_insideDiagnosticDescriptor, CSharpCodeStyleOptions.PreferredUsingDirectivePlacement))
         {
         }
 

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ConsecutiveBracePlacement/ConsecutiveBracePlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ConsecutiveBracePlacement/ConsecutiveBracePlacementDiagnosticAnalyzer.cs
@@ -20,7 +20,6 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConsecutiveBracePlacement
             : base(IDEDiagnosticIds.ConsecutiveBracePlacementDiagnosticId,
                    EnforceOnBuildValues.ConsecutiveBracePlacement,
                    CSharpCodeStyleOptions.AllowBlankLinesBetweenConsecutiveBraces,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(
                        nameof(CSharpAnalyzersResources.Consecutive_braces_must_not_have_a_blank_between_them), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/NewLines/ConstructorInitializerPlacement/ConstructorInitializerPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/ConstructorInitializerPlacement/ConstructorInitializerPlacementDiagnosticAnalyzer.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.ConstructorInitializerPlacement
             : base(IDEDiagnosticIds.ConstructorInitializerPlacementDiagnosticId,
                    EnforceOnBuildValues.ConsecutiveBracePlacement,
                    CSharpCodeStyleOptions.AllowBlankLineAfterColonInConstructorInitializer,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(
                        nameof(CSharpAnalyzersResources.Blank_line_not_allowed_after_constructor_initializer_colon), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/NewLines/EmbeddedStatementPlacement/EmbeddedStatementPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/NewLines/EmbeddedStatementPlacement/EmbeddedStatementPlacementDiagnosticAnalyzer.cs
@@ -20,7 +20,6 @@ namespace Microsoft.CodeAnalysis.CSharp.NewLines.EmbeddedStatementPlacement
             : base(IDEDiagnosticIds.EmbeddedStatementPlacementDiagnosticId,
                    EnforceOnBuildValues.EmbeddedStatementPlacement,
                    CSharpCodeStyleOptions.AllowEmbeddedStatementsOnSameLine,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(
                        nameof(CSharpAnalyzersResources.Embedded_statements_must_be_on_their_own_line), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/OrderModifiers/CSharpOrderModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/OrderModifiers/CSharpOrderModifiersDiagnosticAnalyzer.cs
@@ -19,8 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.OrderModifiers
         public CSharpOrderModifiersDiagnosticAnalyzer()
             : base(CSharpSyntaxFacts.Instance,
                    CSharpCodeStyleOptions.PreferredModifierOrder,
-                   CSharpOrderModifiersHelper.Instance,
-                   LanguageNames.CSharp)
+                   CSharpOrderModifiersHelper.Instance)
         {
         }
 

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryLambdaExpression/CSharpRemoveUnnecessaryLambdaExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryLambdaExpression/CSharpRemoveUnnecessaryLambdaExpressionDiagnosticAnalyzer.cs
@@ -34,7 +34,6 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryLambdaExpression
                    EnforceOnBuildValues.RemoveUnnecessaryLambdaExpression,
                    CSharpCodeStyleOptions.PreferMethodGroupConversion,
                    fadingOption: null,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Remove_unnecessary_lambda_expression), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Lambda_expression_can_be_removed), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/RemoveUnusedParametersAndValues/CSharpRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnusedParametersAndValues/CSharpRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
@@ -17,8 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnusedParametersAndValues
     {
         public CSharpRemoveUnusedParametersAndValuesDiagnosticAnalyzer()
             : base(unusedValueExpressionStatementOption: CSharpCodeStyleOptions.UnusedValueExpressionStatement,
-                   unusedValueAssignmentOption: CSharpCodeStyleOptions.UnusedValueAssignment,
-                   LanguageNames.CSharp)
+                   unusedValueAssignmentOption: CSharpCodeStyleOptions.UnusedValueAssignment)
         {
         }
 

--- a/src/Analyzers/CSharp/Analyzers/SimplifyPropertyPattern/CSharpSimplifyPropertyPatternDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/SimplifyPropertyPattern/CSharpSimplifyPropertyPatternDiagnosticAnalyzer.cs
@@ -27,7 +27,6 @@ namespace Microsoft.CodeAnalysis.CSharp.SimplifyPropertyPattern
             : base(IDEDiagnosticIds.SimplifyPropertyPatternDiagnosticId,
                    EnforceOnBuildValues.SimplifyPropertyPattern,
                    CSharpCodeStyleOptions.PreferExtendedPropertyPattern,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Property_pattern_can_be_simplified), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Simplify_property_pattern), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/UseDeconstruction/CSharpUseDeconstructionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseDeconstruction/CSharpUseDeconstructionDiagnosticAnalyzer.cs
@@ -25,7 +25,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDeconstruction
             : base(IDEDiagnosticIds.UseDeconstructionDiagnosticId,
                    EnforceOnBuildValues.UseDeconstruction,
                    CSharpCodeStyleOptions.PreferDeconstructedVariableDeclaration,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Deconstruct_variable_declaration), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Variable_declaration_can_be_deconstructed), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/UseDefaultLiteral/CSharpUseDefaultLiteralDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseDefaultLiteral/CSharpUseDefaultLiteralDiagnosticAnalyzer.cs
@@ -20,7 +20,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDefaultLiteral
                    EnforceOnBuildValues.UseDefaultLiteral,
                    CSharpCodeStyleOptions.PreferSimpleDefaultExpression,
                    fadingOption: null,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Simplify_default_expression), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.default_expression_can_be_simplified), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/UseExpressionBody/UseExpressionBodyDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseExpressionBody/UseExpressionBodyDiagnosticAnalyzer.cs
@@ -27,14 +27,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
         private static readonly ImmutableArray<UseExpressionBodyHelper> _helpers = UseExpressionBodyHelper.Helpers;
 
         public UseExpressionBodyDiagnosticAnalyzer()
-            : base(GetSupportedDescriptorsWithOptions(), LanguageNames.CSharp)
+            : base(GetSupportedDescriptorsWithOptions())
         {
             _syntaxKinds = _helpers.SelectMany(h => h.SyntaxKinds).ToImmutableArray();
         }
 
-        private static ImmutableDictionary<DiagnosticDescriptor, ILanguageSpecificOption> GetSupportedDescriptorsWithOptions()
+        private static ImmutableDictionary<DiagnosticDescriptor, IOption2> GetSupportedDescriptorsWithOptions()
         {
-            var builder = ImmutableDictionary.CreateBuilder<DiagnosticDescriptor, ILanguageSpecificOption>();
+            var builder = ImmutableDictionary.CreateBuilder<DiagnosticDescriptor, IOption2>();
             foreach (var helper in _helpers)
             {
                 var descriptor = CreateDescriptorWithId(helper.DiagnosticId, helper.EnforceOnBuild, helper.UseExpressionBodyTitle, helper.UseExpressionBodyTitle);

--- a/src/Analyzers/CSharp/Analyzers/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseImplicitObjectCreation/CSharpUseImplicitObjectCreationDiagnosticAnalyzer.cs
@@ -23,7 +23,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseImplicitObjectCreation
             : base(IDEDiagnosticIds.UseImplicitObjectCreationDiagnosticId,
                    EnforceOnBuildValues.UseImplicitObjectCreation,
                    CSharpCodeStyleOptions.ImplicitObjectCreationWhenTypeIsApparent,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Use_new), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.new_expression_can_be_simplified), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/UseImplicitOrExplicitType/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseImplicitOrExplicitType/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -29,8 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             string diagnosticId, EnforceOnBuild enforceOnBuild, LocalizableString title, LocalizableString message)
             : base(diagnosticId,
                    enforceOnBuild,
-                   ImmutableHashSet.Create<ILanguageSpecificOption>(CSharpCodeStyleOptions.VarForBuiltInTypes, CSharpCodeStyleOptions.VarWhenTypeIsApparent, CSharpCodeStyleOptions.VarElsewhere),
-                   LanguageNames.CSharp,
+                   ImmutableHashSet.Create<IOption2>(CSharpCodeStyleOptions.VarForBuiltInTypes, CSharpCodeStyleOptions.VarWhenTypeIsApparent, CSharpCodeStyleOptions.VarElsewhere),
                    title, message)
         {
         }

--- a/src/Analyzers/CSharp/Analyzers/UseIndexOrRangeOperator/CSharpUseIndexOperatorDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseIndexOrRangeOperator/CSharpUseIndexOperatorDiagnosticAnalyzer.cs
@@ -46,7 +46,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
             : base(IDEDiagnosticIds.UseIndexOperatorDiagnosticId,
                    EnforceOnBuildValues.UseIndexOperator,
                    CSharpCodeStyleOptions.PreferIndexOperator,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Use_index_operator), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Indexing_can_be_simplified), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseIndexOrRangeOperator/CSharpUseRangeOperatorDiagnosticAnalyzer.cs
@@ -45,7 +45,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIndexOrRangeOperator
             : base(IDEDiagnosticIds.UseRangeOperatorDiagnosticId,
                    EnforceOnBuildValues.UseRangeOperator,
                    CSharpCodeStyleOptions.PreferRangeOperator,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Use_range_operator), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources._0_can_be_simplified), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/UseIsNullCheck/CSharpUseIsNullCheckForCastAndEqualityOperatorDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseIsNullCheck/CSharpUseIsNullCheckForCastAndEqualityOperatorDiagnosticAnalyzer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIsNullCheck
             : base(IDEDiagnosticIds.UseIsNullCheckDiagnosticId,
                    EnforceOnBuildValues.UseIsNullCheck,
                    CodeStyleOptions2.PreferIsNullCheckOverReferenceEqualityMethod,
-                   CSharpAnalyzersResources.Use_is_null_check,
+                   new LocalizableResourceString(nameof(CSharpAnalyzersResources.Use_is_null_check), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
                    new LocalizableResourceString(nameof(AnalyzersResources.Null_check_can_be_simplified), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)))
         {
         }

--- a/src/Analyzers/CSharp/Analyzers/UseIsNullCheck/CSharpUseNullCheckOverTypeCheckDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseIsNullCheck/CSharpUseNullCheckOverTypeCheckDiagnosticAnalyzer.cs
@@ -19,7 +19,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseIsNullCheck
             : base(IDEDiagnosticIds.UseNullCheckOverTypeCheckDiagnosticId,
                    EnforceOnBuildValues.UseNullCheckOverTypeCheck,
                    CSharpCodeStyleOptions.PreferNullCheckOverTypeCheck,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Prefer_null_check_over_type_check), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Null_check_can_be_clarified), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/UseLocalFunction/CSharpUseLocalFunctionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseLocalFunction/CSharpUseLocalFunctionDiagnosticAnalyzer.cs
@@ -45,7 +45,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseLocalFunction
             : base(IDEDiagnosticIds.UseLocalFunctionDiagnosticId,
                    EnforceOnBuildValues.UseLocalFunction,
                    CSharpCodeStyleOptions.PreferLocalOverAnonymousFunction,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(
                        nameof(CSharpAnalyzersResources.Use_local_function), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternCombinators/CSharpUsePatternCombinatorsDiagnosticAnalyzer.cs
@@ -35,7 +35,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternCombinators
             : base(IDEDiagnosticIds.UsePatternCombinatorsDiagnosticId,
                 EnforceOnBuildValues.UsePatternCombinators,
                 CSharpCodeStyleOptions.PreferPatternMatching,
-                LanguageNames.CSharp,
                 s_safePatternTitle,
                 s_safePatternTitle)
         {

--- a/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
@@ -33,7 +33,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             : base(IDEDiagnosticIds.InlineAsTypeCheckId,
                    EnforceOnBuildValues.InlineAsType,
                    CSharpCodeStyleOptions.PreferPatternMatchingOverAsWithNullCheck,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(
                         nameof(CSharpAnalyzersResources.Use_pattern_matching), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpIsAndCastCheckDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpIsAndCastCheckDiagnosticAnalyzer.cs
@@ -37,7 +37,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             : base(IDEDiagnosticIds.InlineIsTypeCheckId,
                    EnforceOnBuildValues.InlineIsType,
                    CSharpCodeStyleOptions.PreferPatternMatchingOverIsWithCastCheck,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(
                        nameof(CSharpAnalyzersResources.Use_pattern_matching), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpUseNotPatternDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpUseNotPatternDiagnosticAnalyzer.cs
@@ -30,7 +30,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             : base(IDEDiagnosticIds.UseNotPatternDiagnosticId,
                    EnforceOnBuildValues.UseNotPattern,
                    CSharpCodeStyleOptions.PreferNotPattern,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(
                         nameof(CSharpAnalyzersResources.Use_pattern_matching), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/UseSimpleUsingStatement/UseSimpleUsingStatementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseSimpleUsingStatement/UseSimpleUsingStatementDiagnosticAnalyzer.cs
@@ -53,7 +53,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseSimpleUsingStatement
             : base(IDEDiagnosticIds.UseSimpleUsingStatementDiagnosticId,
                    EnforceOnBuildValues.UseSimpleUsingStatement,
                    CSharpCodeStyleOptions.PreferSimpleUsingStatement,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.Use_simple_using_statement), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)),
                    new LocalizableResourceString(nameof(CSharpAnalyzersResources.using_statement_can_be_simplified), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/UseThrowExpression/CSharpUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseThrowExpression/CSharpUseThrowExpressionDiagnosticAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseThrowExpression
     internal class CSharpUseThrowExpressionDiagnosticAnalyzer : AbstractUseThrowExpressionDiagnosticAnalyzer
     {
         public CSharpUseThrowExpressionDiagnosticAnalyzer()
-            : base(CSharpCodeStyleOptions.PreferThrowExpression, LanguageNames.CSharp)
+            : base(CSharpCodeStyleOptions.PreferThrowExpression)
         {
         }
 

--- a/src/Analyzers/CSharp/Analyzers/UseTupleSwap/CSharpUseTupleSwapDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseTupleSwap/CSharpUseTupleSwapDiagnosticAnalyzer.cs
@@ -35,7 +35,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseTupleSwap
             : base(IDEDiagnosticIds.UseTupleSwapDiagnosticId,
                    EnforceOnBuildValues.UseTupleSwap,
                    CSharpCodeStyleOptions.PreferTupleSwap,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(
                        nameof(CSharpAnalyzersResources.Use_tuple_to_swap_values), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Analyzers/CSharp/Analyzers/UseUtf8StringLiteral/UseUtf8StringLiteralDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseUtf8StringLiteral/UseUtf8StringLiteralDiagnosticAnalyzer.cs
@@ -36,7 +36,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseUtf8StringLiteral
             : base(IDEDiagnosticIds.UseUtf8StringLiteralDiagnosticId,
                 EnforceOnBuildValues.UseUtf8StringLiteral,
                 CSharpCodeStyleOptions.PreferUtf8StringLiterals,
-                LanguageNames.CSharp,
                 new LocalizableResourceString(nameof(CSharpAnalyzersResources.Use_Utf8_string_literal), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {
         }

--- a/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer.cs
@@ -21,12 +21,12 @@ namespace Microsoft.CodeAnalysis.CodeStyle
     {
         /// <summary>
         /// Constructor for a code style analyzer with a single diagnostic descriptor and
-        /// unique <see cref="IPerLanguageOption"/> code style option.
+        /// unique code style option.
         /// </summary>
         /// <param name="diagnosticId">Diagnostic ID reported by this analyzer</param>
         /// <param name="enforceOnBuild">Build enforcement recommendation for this analyzer</param>
         /// <param name="option">
-        /// Per-language option that can be used to configure the given <paramref name="diagnosticId"/>.
+        /// code style option that can be used to configure the given <paramref name="diagnosticId"/>.
         /// <see langword="null"/>, if there is no such unique option.
         /// </param>
         /// <param name="title">Title for the diagnostic descriptor</param>
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         protected AbstractBuiltInCodeStyleDiagnosticAnalyzer(
             string diagnosticId,
             EnforceOnBuild enforceOnBuild,
-            IPerLanguageOption? option,
+            IOption2? option,
             LocalizableString title,
             LocalizableString? messageFormat = null,
             bool isUnnecessary = false,
@@ -51,39 +51,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
 
         /// <summary>
         /// Constructor for a code style analyzer with a single diagnostic descriptor and
-        /// unique <see cref="ILanguageSpecificOption"/> code style option for the given language.
-        /// </summary>
-        /// <param name="diagnosticId">Diagnostic ID reported by this analyzer</param>
-        /// <param name="enforceOnBuild">Build enforcement recommendation for this analyzer</param>
-        /// <param name="option">
-        /// Language specific option that can be used to configure the given <paramref name="diagnosticId"/>.
-        /// <see langword="null"/>, if there is no such unique option.
-        /// </param>
-        /// <param name="language">Language for the given language-specific <paramref name="option"/>.</param>
-        /// <param name="title">Title for the diagnostic descriptor</param>
-        /// <param name="messageFormat">
-        /// Message for the diagnostic descriptor.
-        /// <see langword="null"/> if the message is identical to the title.
-        /// </param>
-        /// <param name="isUnnecessary"><see langword="true"/> if the diagnostic is reported on unnecessary code; otherwise, <see langword="false"/>.</param>
-        /// <param name="configurable">Flag indicating if the reported diagnostics are configurable by the end users</param>
-        protected AbstractBuiltInCodeStyleDiagnosticAnalyzer(
-            string diagnosticId,
-            EnforceOnBuild enforceOnBuild,
-            ILanguageSpecificOption? option,
-            string language,
-            LocalizableString title,
-            LocalizableString? messageFormat = null,
-            bool isUnnecessary = false,
-            bool configurable = true)
-            : this(diagnosticId, enforceOnBuild, title, messageFormat, isUnnecessary, configurable)
-        {
-            AddDiagnosticIdToOptionMapping(diagnosticId, option, language);
-        }
-
-        /// <summary>
-        /// Constructor for a code style analyzer with a single diagnostic descriptor and
-        /// two or more <see cref="IPerLanguageOption"/> code style options.
+        /// two or more code style options.
         /// </summary>
         /// <param name="diagnosticId">Diagnostic ID reported by this analyzer</param>
         /// <param name="enforceOnBuild">Build enforcement recommendation for this analyzer</param>
@@ -100,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         protected AbstractBuiltInCodeStyleDiagnosticAnalyzer(
             string diagnosticId,
             EnforceOnBuild enforceOnBuild,
-            ImmutableHashSet<IPerLanguageOption> options,
+            ImmutableHashSet<IOption2> options,
             LocalizableString title,
             LocalizableString? messageFormat = null,
             bool isUnnecessary = false,
@@ -113,77 +81,17 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         }
 
         /// <summary>
-        /// Constructor for a code style analyzer with a single diagnostic descriptor and
-        /// two or more <see cref="ILanguageSpecificOption"/> code style options for the given language.
+        /// Constructor for a code style analyzer with a multiple diagnostic descriptors with code style options that can be used to configure each descriptor.
         /// </summary>
-        /// <param name="diagnosticId">Diagnostic ID reported by this analyzer</param>
-        /// <param name="enforceOnBuild">Build enforcement recommendation for this analyzer</param>
-        /// <param name="options">
-        /// Set of two or more language-specific options that can be used to configure the diagnostic severity of the given diagnosticId.
-        /// </param>
-        /// <param name="language">Language for the given language-specific <paramref name="options"/>.</param>
-        /// <param name="title">Title for the diagnostic descriptor</param>
-        /// <param name="messageFormat">
-        /// Message for the diagnostic descriptor.
-        /// Null if the message is identical to the title.
-        /// </param>
-        /// <param name="isUnnecessary"><see langword="true"/> if the diagnostic is reported on unnecessary code; otherwise, <see langword="false"/>.</param>
-        /// <param name="configurable">Flag indicating if the reported diagnostics are configurable by the end users</param>
         protected AbstractBuiltInCodeStyleDiagnosticAnalyzer(
-            string diagnosticId,
-            EnforceOnBuild enforceOnBuild,
-            ImmutableHashSet<ILanguageSpecificOption> options,
-            string language,
-            LocalizableString title,
-            LocalizableString? messageFormat = null,
-            bool isUnnecessary = false,
-            bool configurable = true)
-            : this(diagnosticId, enforceOnBuild, title, messageFormat, isUnnecessary, configurable)
-        {
-            RoslynDebug.Assert(options != null);
-            Debug.Assert(options.Count > 1);
-            AddDiagnosticIdToOptionMapping(diagnosticId, options, language);
-        }
-
-        /// <summary>
-        /// Constructor for a code style analyzer with a multiple diagnostic descriptors with per-language options that can be used to configure each descriptor.
-        /// </summary>
-        protected AbstractBuiltInCodeStyleDiagnosticAnalyzer(ImmutableDictionary<DiagnosticDescriptor, IPerLanguageOption> supportedDiagnosticsWithOptions)
+            ImmutableDictionary<DiagnosticDescriptor, IOption2> supportedDiagnosticsWithOptions)
             : this(supportedDiagnosticsWithOptions.Keys.ToImmutableArray())
         {
             foreach (var (descriptor, option) in supportedDiagnosticsWithOptions)
                 AddDiagnosticIdToOptionMapping(descriptor.Id, option);
         }
 
-        /// <summary>
-        /// Constructor for a code style analyzer with a multiple diagnostic descriptors with language-specific options that can be used to configure each descriptor.
-        /// </summary>
-        protected AbstractBuiltInCodeStyleDiagnosticAnalyzer(
-            ImmutableDictionary<DiagnosticDescriptor, ILanguageSpecificOption> supportedDiagnosticsWithOptions,
-            string language)
-            : this(supportedDiagnosticsWithOptions.Keys.ToImmutableArray())
-        {
-            foreach (var (descriptor, option) in supportedDiagnosticsWithOptions)
-                AddDiagnosticIdToOptionMapping(descriptor.Id, option, language);
-        }
-
-        /// <summary>
-        /// Constructor for a code style analyzer with a multiple diagnostic descriptors with a mix of language-specific and per-language options that can be used to configure each descriptor.
-        /// </summary>
-        protected AbstractBuiltInCodeStyleDiagnosticAnalyzer(
-            ImmutableDictionary<DiagnosticDescriptor, ILanguageSpecificOption> supportedDiagnosticsWithLangaugeSpecificOptions,
-            ImmutableDictionary<DiagnosticDescriptor, IPerLanguageOption> supportedDiagnosticsWithPerLanguageOptions,
-            string language)
-            : this(supportedDiagnosticsWithLangaugeSpecificOptions.Keys.Concat(supportedDiagnosticsWithPerLanguageOptions.Keys).ToImmutableArray())
-        {
-            foreach (var (descriptor, option) in supportedDiagnosticsWithLangaugeSpecificOptions)
-                AddDiagnosticIdToOptionMapping(descriptor.Id, option, language);
-
-            foreach (var (descriptor, option) in supportedDiagnosticsWithPerLanguageOptions)
-                AddDiagnosticIdToOptionMapping(descriptor.Id, option);
-        }
-
-        private static void AddDiagnosticIdToOptionMapping(string diagnosticId, IPerLanguageOption? option)
+        private static void AddDiagnosticIdToOptionMapping(string diagnosticId, IOption2? option)
         {
             if (option != null)
             {
@@ -191,19 +99,8 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             }
         }
 
-        private static void AddDiagnosticIdToOptionMapping(string diagnosticId, ILanguageSpecificOption? option, string language)
-        {
-            if (option != null)
-            {
-                AddDiagnosticIdToOptionMapping(diagnosticId, ImmutableHashSet.Create(option), language);
-            }
-        }
-
-        private static void AddDiagnosticIdToOptionMapping(string diagnosticId, ImmutableHashSet<IPerLanguageOption> options)
+        private static void AddDiagnosticIdToOptionMapping(string diagnosticId, ImmutableHashSet<IOption2> options)
             => IDEDiagnosticIdToOptionMappingHelper.AddOptionMapping(diagnosticId, options);
-
-        private static void AddDiagnosticIdToOptionMapping(string diagnosticId, ImmutableHashSet<ILanguageSpecificOption> options, string language)
-            => IDEDiagnosticIdToOptionMappingHelper.AddOptionMapping(diagnosticId, options, language);
 
         public abstract DiagnosticAnalyzerCategory GetAnalyzerCategory();
 

--- a/src/Analyzers/Core/Analyzers/AbstractBuiltInUnnecessaryCodeStyleDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/AbstractBuiltInUnnecessaryCodeStyleDiagnosticAnalyzer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
     {
         /// <summary>
         /// Constructor for an unnecessary code style analyzer with a single diagnostic descriptor and
-        /// unique <see cref="IPerLanguageOption"/> code style option.
+        /// unique code style option.
         /// </summary>
         /// <param name="diagnosticId">Diagnostic ID reported by this analyzer</param>
         /// <param name="enforceOnBuild">Build enforcement recommendation for this analyzer</param>
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         protected AbstractBuiltInUnnecessaryCodeStyleDiagnosticAnalyzer(
             string diagnosticId,
             EnforceOnBuild enforceOnBuild,
-            IPerLanguageOption? option,
+            IOption2? option,
             PerLanguageOption2<bool>? fadingOption,
             LocalizableString title,
             LocalizableString? messageFormat = null,
@@ -52,42 +52,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
 
         /// <summary>
         /// Constructor for an unnecessary code style analyzer with a single diagnostic descriptor and
-        /// unique <see cref="ILanguageSpecificOption"/> code style option for the given language.
-        /// </summary>
-        /// <param name="diagnosticId">Diagnostic ID reported by this analyzer</param>
-        /// <param name="enforceOnBuild">Build enforcement recommendation for this analyzer</param>
-        /// <param name="option">
-        /// Language specific option that can be used to configure the given <paramref name="diagnosticId"/>.
-        /// <see langword="null"/>, if there is no such unique option.
-        /// </param>
-        /// <param name="fadingOption">
-        /// Per-language fading option that can be used to configure if the diagnostic should be faded in the IDE or not.
-        /// <see langword="null"/>, if there is no such unique fading option.
-        /// </param>
-        /// <param name="language">Language for the given language-specific <paramref name="option"/>.</param>
-        /// <param name="title">Title for the diagnostic descriptor</param>
-        /// <param name="messageFormat">
-        /// Message for the diagnostic descriptor.
-        /// <see langword="null"/> if the message is identical to the title.
-        /// </param>
-        /// <param name="configurable">Flag indicating if the reported diagnostics are configurable by the end users</param>
-        protected AbstractBuiltInUnnecessaryCodeStyleDiagnosticAnalyzer(
-            string diagnosticId,
-            EnforceOnBuild enforceOnBuild,
-            ILanguageSpecificOption? option,
-            PerLanguageOption2<bool>? fadingOption,
-            string language,
-            LocalizableString title,
-            LocalizableString? messageFormat = null,
-            bool configurable = true)
-            : base(diagnosticId, enforceOnBuild, option, language, title, messageFormat, isUnnecessary: true, configurable)
-        {
-            AddDiagnosticIdToFadingOptionMapping(diagnosticId, fadingOption);
-        }
-
-        /// <summary>
-        /// Constructor for an unnecessary code style analyzer with a single diagnostic descriptor and
-        /// two or more <see cref="IPerLanguageOption"/> code style options.
+        /// two or more code style options.
         /// </summary>
         /// <param name="diagnosticId">Diagnostic ID reported by this analyzer</param>
         /// <param name="enforceOnBuild">Build enforcement recommendation for this analyzer</param>
@@ -107,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         protected AbstractBuiltInUnnecessaryCodeStyleDiagnosticAnalyzer(
             string diagnosticId,
             EnforceOnBuild enforceOnBuild,
-            ImmutableHashSet<IPerLanguageOption> options,
+            ImmutableHashSet<IOption2> options,
             PerLanguageOption2<bool>? fadingOption,
             LocalizableString title,
             LocalizableString? messageFormat = null,

--- a/src/Analyzers/Core/Analyzers/AbstractParenthesesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/AbstractParenthesesDiagnosticAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnnecessaryParentheses
             string descriptorId, EnforceOnBuild enforceOnBuild, LocalizableString title, LocalizableString message, bool isUnnecessary = false)
             : base(descriptorId,
                    enforceOnBuild,
-                   options: ImmutableHashSet.Create<IPerLanguageOption>(CodeStyleOptions2.ArithmeticBinaryParentheses, CodeStyleOptions2.RelationalBinaryParentheses, CodeStyleOptions2.OtherBinaryParentheses, CodeStyleOptions2.OtherParentheses),
+                   options: ImmutableHashSet.Create<IOption2>(CodeStyleOptions2.ArithmeticBinaryParentheses, CodeStyleOptions2.RelationalBinaryParentheses, CodeStyleOptions2.OtherBinaryParentheses, CodeStyleOptions2.OtherParentheses),
                    title,
                    message,
                    isUnnecessary: isUnnecessary)

--- a/src/Analyzers/Core/Analyzers/ConvertTypeofToNameof/AbstractConvertTypeOfToNameOfDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/ConvertTypeofToNameof/AbstractConvertTypeOfToNameOfDiagnosticAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.ConvertTypeOfToNameOf
 {
     internal abstract class AbstractConvertTypeOfToNameOfDiagnosticAnalyzer : AbstractBuiltInCodeStyleDiagnosticAnalyzer
     {
-        protected AbstractConvertTypeOfToNameOfDiagnosticAnalyzer(LocalizableString title, string language)
+        protected AbstractConvertTypeOfToNameOfDiagnosticAnalyzer(LocalizableString title)
             : base(diagnosticId: IDEDiagnosticIds.ConvertTypeOfToNameOfDiagnosticId,
                   EnforceOnBuildValues.ConvertTypeOfToNameOf,
                   option: null,

--- a/src/Analyzers/Core/Analyzers/ConvertTypeofToNameof/AbstractConvertTypeOfToNameOfDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/ConvertTypeofToNameof/AbstractConvertTypeOfToNameOfDiagnosticAnalyzer.cs
@@ -18,7 +18,6 @@ namespace Microsoft.CodeAnalysis.ConvertTypeOfToNameOf
             : base(diagnosticId: IDEDiagnosticIds.ConvertTypeOfToNameOfDiagnosticId,
                   EnforceOnBuildValues.ConvertTypeOfToNameOf,
                   option: null,
-                  language: language,
                   title: title)
         {
         }

--- a/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis.FileHeaders
                 IDEDiagnosticIds.FileHeaderMismatch,
                 EnforceOnBuildValues.FileHeaderMismatch,
                 CodeStyleOptions2.FileHeaderTemplate,
-                language,
                 new LocalizableResourceString(nameof(AnalyzersResources.The_file_header_is_missing_or_not_located_at_the_top_of_the_file), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
                 new LocalizableResourceString(nameof(AnalyzersResources.A_source_file_is_missing_a_required_header), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)))
         {

--- a/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/FileHeaders/AbstractFileHeaderDiagnosticAnalyzer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.FileHeaders
 {
     internal abstract class AbstractFileHeaderDiagnosticAnalyzer : AbstractBuiltInCodeStyleDiagnosticAnalyzer
     {
-        protected AbstractFileHeaderDiagnosticAnalyzer(string language)
+        protected AbstractFileHeaderDiagnosticAnalyzer()
             : base(
                 IDEDiagnosticIds.FileHeaderMismatch,
                 EnforceOnBuildValues.FileHeaderMismatch,

--- a/src/Analyzers/Core/Analyzers/IDEDiagnosticIdToOptionMappingHelper.cs
+++ b/src/Analyzers/Core/Analyzers/IDEDiagnosticIdToOptionMappingHelper.cs
@@ -20,48 +20,27 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     internal static class IDEDiagnosticIdToOptionMappingHelper
     {
         private static readonly ConcurrentDictionary<string, ImmutableHashSet<IOption2>> s_diagnosticIdToOptionMap = new();
-        private static readonly ConcurrentDictionary<string, ConcurrentDictionary<string, ImmutableHashSet<IOption2>>> s_diagnosticIdToLanguageSpecificOptionsMap = new();
         private static readonly ConcurrentDictionary<string, PerLanguageOption2<bool>> s_diagnosticIdToFadingOptionMap = new();
 
-        public static bool TryGetMappedOptions(string diagnosticId, string language, [NotNullWhen(true)] out ImmutableHashSet<IOption2>? options)
-            => s_diagnosticIdToOptionMap.TryGetValue(diagnosticId, out options) ||
-               (s_diagnosticIdToLanguageSpecificOptionsMap.TryGetValue(language, out var map) &&
-                map.TryGetValue(diagnosticId, out options));
+        public static bool TryGetMappedOptions(string diagnosticId, [NotNullWhen(true)] out ImmutableHashSet<IOption2>? options)
+            => s_diagnosticIdToOptionMap.TryGetValue(diagnosticId, out options);
 
         public static bool TryGetMappedFadingOption(string diagnosticId, [NotNullWhen(true)] out PerLanguageOption2<bool>? fadingOption)
             => s_diagnosticIdToFadingOptionMap.TryGetValue(diagnosticId, out fadingOption);
 
         public static bool IsKnownIDEDiagnosticId(string diagnosticId)
-            => s_diagnosticIdToOptionMap.ContainsKey(diagnosticId) ||
-               s_diagnosticIdToLanguageSpecificOptionsMap.Values.Any(map => map.ContainsKey(diagnosticId));
+            => s_diagnosticIdToOptionMap.ContainsKey(diagnosticId);
 
-        public static void AddOptionMapping(string diagnosticId, ImmutableHashSet<IPerLanguageOption> perLanguageOptions)
+        public static void AddOptionMapping(string diagnosticId, ImmutableHashSet<IOption2> options)
         {
             diagnosticId = diagnosticId ?? throw new ArgumentNullException(nameof(diagnosticId));
-            perLanguageOptions = perLanguageOptions ?? throw new ArgumentNullException(nameof(perLanguageOptions));
+            options = options ?? throw new ArgumentNullException(nameof(options));
 
-            var options = perLanguageOptions.Cast<IOption2>().ToImmutableHashSet();
-            AddOptionMapping(s_diagnosticIdToOptionMap, diagnosticId, options);
-        }
-
-        public static void AddOptionMapping(string diagnosticId, ImmutableHashSet<ILanguageSpecificOption> languageSpecificOptions, string language)
-        {
-            diagnosticId = diagnosticId ?? throw new ArgumentNullException(nameof(diagnosticId));
-            languageSpecificOptions = languageSpecificOptions ?? throw new ArgumentNullException(nameof(languageSpecificOptions));
-            language = language ?? throw new ArgumentNullException(nameof(language));
-
-            var map = s_diagnosticIdToLanguageSpecificOptionsMap.GetOrAdd(language, _ => new ConcurrentDictionary<string, ImmutableHashSet<IOption2>>());
-            var options = languageSpecificOptions.Cast<IOption2>().ToImmutableHashSet();
-            AddOptionMapping(map, diagnosticId, options);
-        }
-
-        private static void AddOptionMapping(ConcurrentDictionary<string, ImmutableHashSet<IOption2>> map, string diagnosticId, ImmutableHashSet<IOption2> options)
-        {
             // Verify that the option is either being added for the first time, or the existing option is already the same.
             // Latter can happen in tests as we re-instantiate the analyzer for every test, which attempts to add the mapping every time.
-            Debug.Assert(!map.TryGetValue(diagnosticId, out var existingOptions) || options.SetEquals(existingOptions));
+            Debug.Assert(!s_diagnosticIdToOptionMap.TryGetValue(diagnosticId, out var existingOptions) || options.SetEquals(existingOptions));
 
-            map.TryAdd(diagnosticId, options);
+            s_diagnosticIdToOptionMap.TryAdd(diagnosticId, options);
         }
 
         public static void AddFadingOptionMapping(string diagnosticId, PerLanguageOption2<bool> fadingOption)

--- a/src/Analyzers/Core/Analyzers/NewLines/ConsecutiveStatementPlacement/AbstractConsecutiveStatementPlacementDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/NewLines/ConsecutiveStatementPlacement/AbstractConsecutiveStatementPlacementDiagnosticAnalyzer.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.NewLines.ConsecutiveStatementPlacement
             : base(IDEDiagnosticIds.ConsecutiveStatementPlacementDiagnosticId,
                    EnforceOnBuildValues.ConsecutiveStatementPlacement,
                    CodeStyleOptions2.AllowStatementImmediatelyAfterBlock,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(
                        nameof(AnalyzersResources.Blank_line_required_between_block_and_subsequent_statement), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)))
         {

--- a/src/Analyzers/Core/Analyzers/NewLines/MultipleBlankLines/AbstractMultipleBlankLinesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/NewLines/MultipleBlankLines/AbstractMultipleBlankLinesDiagnosticAnalyzer.cs
@@ -20,7 +20,6 @@ namespace Microsoft.CodeAnalysis.NewLines.MultipleBlankLines
             : base(IDEDiagnosticIds.MultipleBlankLinesDiagnosticId,
                    EnforceOnBuildValues.MultipleBlankLines,
                    CodeStyleOptions2.AllowMultipleBlankLines,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(
                        nameof(AnalyzersResources.Avoid_multiple_blank_lines), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)))
         {

--- a/src/Analyzers/Core/Analyzers/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
@@ -19,8 +19,7 @@ namespace Microsoft.CodeAnalysis.OrderModifiers
         protected AbstractOrderModifiersDiagnosticAnalyzer(
             ISyntaxFacts syntaxFacts,
             Option2<CodeStyleOption2<string>> option,
-            AbstractOrderModifiersHelpers helpers,
-            string language)
+            AbstractOrderModifiersHelpers helpers)
             : base(IDEDiagnosticIds.OrderModifiersDiagnosticId,
                    EnforceOnBuildValues.OrderModifiers,
                    option,

--- a/src/Analyzers/Core/Analyzers/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/OrderModifiers/AbstractOrderModifiersDiagnosticAnalyzer.cs
@@ -24,7 +24,6 @@ namespace Microsoft.CodeAnalysis.OrderModifiers
             : base(IDEDiagnosticIds.OrderModifiersDiagnosticId,
                    EnforceOnBuildValues.OrderModifiers,
                    option,
-                   language,
                    new LocalizableResourceString(nameof(AnalyzersResources.Order_modifiers), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
                    new LocalizableResourceString(nameof(AnalyzersResources.Modifiers_are_not_ordered), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)))
         {

--- a/src/Analyzers/Core/Analyzers/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
         protected AbstractQualifyMemberAccessDiagnosticAnalyzer()
             : base(IDEDiagnosticIds.AddThisOrMeQualificationDiagnosticId,
                    EnforceOnBuildValues.AddQualification,
-                   options: ImmutableHashSet.Create<IPerLanguageOption>(CodeStyleOptions2.QualifyFieldAccess, CodeStyleOptions2.QualifyPropertyAccess, CodeStyleOptions2.QualifyMethodAccess, CodeStyleOptions2.QualifyEventAccess),
+                   options: ImmutableHashSet.Create<IOption2>(CodeStyleOptions2.QualifyFieldAccess, CodeStyleOptions2.QualifyPropertyAccess, CodeStyleOptions2.QualifyMethodAccess, CodeStyleOptions2.QualifyEventAccess),
                    new LocalizableResourceString(nameof(AnalyzersResources.Member_access_should_be_qualified), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
                    new LocalizableResourceString(nameof(AnalyzersResources.Add_this_or_Me_qualification), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)))
         {

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
@@ -91,8 +91,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
 
         protected AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer(
             Option2<CodeStyleOption2<UnusedValuePreference>> unusedValueExpressionStatementOption,
-            Option2<CodeStyleOption2<UnusedValuePreference>> unusedValueAssignmentOption,
-            string language)
+            Option2<CodeStyleOption2<UnusedValuePreference>> unusedValueAssignmentOption)
             : base(ImmutableDictionary<DiagnosticDescriptor, IOption2>.Empty
                         .Add(s_expressionValueIsUnusedRule, unusedValueExpressionStatementOption)
                         .Add(s_valueAssignedIsUnusedRule, unusedValueAssignmentOption)

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.cs
@@ -93,12 +93,10 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedParametersAndValues
             Option2<CodeStyleOption2<UnusedValuePreference>> unusedValueExpressionStatementOption,
             Option2<CodeStyleOption2<UnusedValuePreference>> unusedValueAssignmentOption,
             string language)
-            : base(ImmutableDictionary<DiagnosticDescriptor, ILanguageSpecificOption>.Empty
+            : base(ImmutableDictionary<DiagnosticDescriptor, IOption2>.Empty
                         .Add(s_expressionValueIsUnusedRule, unusedValueExpressionStatementOption)
-                        .Add(s_valueAssignedIsUnusedRule, unusedValueAssignmentOption),
-                   ImmutableDictionary<DiagnosticDescriptor, IPerLanguageOption>.Empty
-                        .Add(s_unusedParameterRule, CodeStyleOptions2.UnusedParameters),
-                   language)
+                        .Add(s_valueAssignedIsUnusedRule, unusedValueAssignmentOption)
+                        .Add(s_unusedParameterRule, CodeStyleOptions2.UnusedParameters))
         {
         }
 

--- a/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
             isUnnecessary: true);
 
         protected AbstractUseCollectionInitializerDiagnosticAnalyzer()
-            : base(ImmutableDictionary<DiagnosticDescriptor, IPerLanguageOption>.Empty
+            : base(ImmutableDictionary<DiagnosticDescriptor, IOption2>.Empty
                     .Add(s_descriptor, CodeStyleOptions2.PreferCollectionInitializer)
                     .Add(s_unnecessaryCodeDescriptor, CodeStyleOptions2.PreferCollectionInitializer))
         {

--- a/src/Analyzers/Core/Analyzers/UseInferredMemberName/AbstractUseInferredMemberNameDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseInferredMemberName/AbstractUseInferredMemberNameDiagnosticAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.UseInferredMemberName
         public AbstractUseInferredMemberNameDiagnosticAnalyzer()
             : base(IDEDiagnosticIds.UseInferredMemberNameDiagnosticId,
                    EnforceOnBuildValues.UseInferredMemberName,
-                   options: ImmutableHashSet.Create<IPerLanguageOption>(CodeStyleOptions2.PreferInferredAnonymousTypeMemberNames, CodeStyleOptions2.PreferInferredTupleNames),
+                   options: ImmutableHashSet.Create<IOption2>(CodeStyleOptions2.PreferInferredAnonymousTypeMemberNames, CodeStyleOptions2.PreferInferredTupleNames),
                    fadingOption: null,
                    new LocalizableResourceString(nameof(AnalyzersResources.Use_inferred_member_name), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
                    new LocalizableResourceString(nameof(AnalyzersResources.Member_name_can_be_simplified), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)))

--- a/src/Analyzers/Core/Analyzers/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
         protected abstract bool FadeOutOperatorToken { get; }
 
         protected AbstractUseObjectInitializerDiagnosticAnalyzer()
-            : base(ImmutableDictionary<DiagnosticDescriptor, IPerLanguageOption>.Empty
+            : base(ImmutableDictionary<DiagnosticDescriptor, IOption2>.Empty
                     .Add(s_descriptor, CodeStyleOptions2.PreferObjectInitializer)
                     .Add(s_unnecessaryCodeDescriptor, CodeStyleOptions2.PreferObjectInitializer))
         {

--- a/src/Analyzers/Core/Analyzers/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
@@ -40,7 +40,6 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
             : base(IDEDiagnosticIds.UseThrowExpressionDiagnosticId,
                    EnforceOnBuildValues.UseThrowExpression,
                    preferThrowExpressionOption,
-                   language,
                    new LocalizableResourceString(nameof(AnalyzersResources.Use_throw_expression), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
                    new LocalizableResourceString(nameof(AnalyzersResources.Null_check_can_be_simplified), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)))
         {

--- a/src/Analyzers/Core/Analyzers/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
     internal abstract class AbstractUseThrowExpressionDiagnosticAnalyzer :
         AbstractBuiltInCodeStyleDiagnosticAnalyzer
     {
-        protected AbstractUseThrowExpressionDiagnosticAnalyzer(Option2<CodeStyleOption2<bool>> preferThrowExpressionOption, string language)
+        protected AbstractUseThrowExpressionDiagnosticAnalyzer(Option2<CodeStyleOption2<bool>> preferThrowExpressionOption)
             : base(IDEDiagnosticIds.UseThrowExpressionDiagnosticId,
                    EnforceOnBuildValues.UseThrowExpression,
                    preferThrowExpressionOption,

--- a/src/Analyzers/VisualBasic/Analyzers/ConvertTypeofToNameof/VisualBasicConvertTypeOfToNameOfDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/ConvertTypeofToNameof/VisualBasicConvertTypeOfToNameOfDiagnosticAnalyzer.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ConvertTypeOfToNameOf
         Private Shared ReadOnly s_title As String = VisualBasicAnalyzersResources.GetType_can_be_converted_to_NameOf
 
         Public Sub New()
-            MyBase.New(s_title, LanguageNames.VisualBasic)
+            MyBase.New(s_title)
         End Sub
 
         Protected Overrides Function IsValidTypeofAction(context As OperationAnalysisContext) As Boolean

--- a/src/Analyzers/VisualBasic/Analyzers/FileHeaders/VisualBasicFileHeaderDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/FileHeaders/VisualBasicFileHeaderDiagnosticAnalyzer.vb
@@ -10,10 +10,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FileHeaders
     Friend Class VisualBasicFileHeaderDiagnosticAnalyzer
         Inherits AbstractFileHeaderDiagnosticAnalyzer
 
-        Public Sub New()
-            MyBase.New(LanguageNames.VisualBasic)
-        End Sub
-
         Protected Overrides ReadOnly Property FileHeaderHelper As AbstractFileHeaderHelper
             Get
                 Return VisualBasicFileHeaderHelper.Instance

--- a/src/Analyzers/VisualBasic/Analyzers/OrderModifiers/VisualBasicOrderModifiersDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/OrderModifiers/VisualBasicOrderModifiersDiagnosticAnalyzer.vb
@@ -17,8 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.OrderModifiers
         Public Sub New()
             MyBase.New(VisualBasicSyntaxFacts.Instance,
                        VisualBasicCodeStyleOptions.PreferredModifierOrder,
-                       VisualBasicOrderModifiersHelper.Instance,
-                       LanguageNames.VisualBasic)
+                       VisualBasicOrderModifiersHelper.Instance)
         End Sub
 
         Protected Overrides Function GetPreferredOrderStyle(context As SyntaxTreeAnalysisContext) As CodeStyleOption2(Of String)

--- a/src/Analyzers/VisualBasic/Analyzers/RemoveUnusedParametersAndValues/VisualBasicRemoveUnusedParametersAndValuesDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/RemoveUnusedParametersAndValues/VisualBasicRemoveUnusedParametersAndValuesDiagnosticAnalyzer.vb
@@ -17,8 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.RemoveUnusedParametersAndValues
 
         Public Sub New()
             MyBase.New(unusedValueExpressionStatementOption:=VisualBasicCodeStyleOptions.UnusedValueExpressionStatement,
-                       unusedValueAssignmentOption:=VisualBasicCodeStyleOptions.UnusedValueAssignment,
-                       LanguageNames.VisualBasic)
+                       unusedValueAssignmentOption:=VisualBasicCodeStyleOptions.UnusedValueAssignment)
         End Sub
 
         Protected Overrides Function GetUnusedValueExpressionStatementOption(provider As AnalyzerOptionsProvider) As CodeStyleOption2(Of UnusedValuePreference)

--- a/src/Analyzers/VisualBasic/Analyzers/SimplifyObjectCreation/VisualBasicSimplifyObjectCreationDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/SimplifyObjectCreation/VisualBasicSimplifyObjectCreationDiagnosticAnalyzer.vb
@@ -17,7 +17,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.SimplifyObjectCreation
                 diagnosticId:=IDEDiagnosticIds.SimplifyObjectCreationDiagnosticId,
                 enforceOnBuild:=EnforceOnBuildValues.SimplifyObjectCreation,
                 [option]:=VisualBasicCodeStyleOptions.PreferSimplifiedObjectCreation,
-                language:=LanguageNames.VisualBasic,
                 title:=New LocalizableResourceString(NameOf(VisualBasicAnalyzersResources.Object_creation_can_be_simplified), VisualBasicAnalyzersResources.ResourceManager, GetType(VisualBasicAnalyzersResources)))
         End Sub
 

--- a/src/Analyzers/VisualBasic/Analyzers/UseIsNotExpression/VisualBasicUseIsNotDiagnosticAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseIsNotExpression/VisualBasicUseIsNotDiagnosticAnalyzer.vb
@@ -27,7 +27,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseIsNotExpression
             MyBase.New(IDEDiagnosticIds.UseIsNotExpressionDiagnosticId,
                    EnforceOnBuildValues.UseIsNotExpression,
                    VisualBasicCodeStyleOptions.PreferIsNotExpression,
-                   LanguageNames.VisualBasic,
                    New LocalizableResourceString(
                         NameOf(VisualBasicAnalyzersResources.Use_IsNot_expression), VisualBasicAnalyzersResources.ResourceManager, GetType(VisualBasicAnalyzersResources)))
         End Sub

--- a/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.ConfigureSeverityL
                             continue;
                         }
 
-                        if (!IDEDiagnosticIdToOptionMappingHelper.TryGetMappedOptions(diagnosticId, languageName, out var options))
+                        if (!IDEDiagnosticIdToOptionMappingHelper.TryGetMappedOptions(diagnosticId, out var options))
                         {
                             options = ImmutableHashSet<IOption2>.Empty;
                         }

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckWithoutNameDiagnosticAnalyzer.cs
@@ -44,7 +44,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             : base(IDEDiagnosticIds.InlineIsTypeWithoutNameCheckDiagnosticsId,
                    EnforceOnBuildValues.InlineIsTypeWithoutName,
                    CSharpCodeStyleOptions.PreferPatternMatchingOverIsWithCastCheck,
-                   LanguageNames.CSharp,
                    new LocalizableResourceString(
                        nameof(CSharpAnalyzersResources.Use_pattern_matching), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
         {

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigurationUpdater.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigurationUpdater.cs
@@ -394,7 +394,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration
             Diagnostic diagnostic,
             Project project)
         {
-            if (IDEDiagnosticIdToOptionMappingHelper.TryGetMappedOptions(diagnostic.Id, project.Language, out var options))
+            if (IDEDiagnosticIdToOptionMappingHelper.TryGetMappedOptions(diagnostic.Id, out var options))
             {
                 var optionSet = project.Solution.Workspace.Options;
                 using var _ = ArrayBuilder<(OptionKey, ICodeStyleOption, IEditorConfigStorageLocation2, bool)>.GetInstance(out var builder);

--- a/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureCodeStyle/ConfigureCodeStyleOptionCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/Configuration/ConfigureCodeStyle/ConfigureCodeStyleOptionCodeFixProvider.cs
@@ -48,8 +48,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Configuration.ConfigureCodeStyle
                 return false;
             }
 
-            var language = diagnostic.Location.SourceTree.Options.Language;
-            return IDEDiagnosticIdToOptionMappingHelper.TryGetMappedOptions(diagnostic.Id, language, out var options) &&
+            return IDEDiagnosticIdToOptionMappingHelper.TryGetMappedOptions(diagnostic.Id, out var options) &&
                !options.IsEmpty &&
                options.All(o => o.StorageLocations.Any(static l => l is IEditorConfigStorageLocation2));
         }

--- a/src/Features/Core/Portable/CodeStyle/AbstractCodeStyleProvider.Analysis.cs
+++ b/src/Features/Core/Portable/CodeStyle/AbstractCodeStyleProvider.Analysis.cs
@@ -30,7 +30,6 @@ namespace Microsoft.CodeAnalysis.CodeStyle
                 : base(codeStyleProvider._descriptorId,
                        codeStyleProvider._enforceOnBuild,
                        codeStyleProvider._option,
-                       codeStyleProvider._language,
                        codeStyleProvider._title,
                        codeStyleProvider._message,
                        isUnnecessary,

--- a/src/Features/Core/Portable/PreferFrameworkType/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/PreferFrameworkType/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.PreferFrameworkType
         protected PreferFrameworkTypeDiagnosticAnalyzerBase()
             : base(IDEDiagnosticIds.PreferBuiltInOrFrameworkTypeDiagnosticId,
                    EnforceOnBuildValues.PreferBuiltInOrFrameworkType,
-                   options: ImmutableHashSet.Create<IPerLanguageOption>(CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInDeclaration, CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInMemberAccess),
+                   options: ImmutableHashSet.Create<IOption2>(CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInDeclaration, CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInMemberAccess),
                    new LocalizableResourceString(nameof(FeaturesResources.Use_framework_type), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
                    new LocalizableResourceString(nameof(FeaturesResources.Use_framework_type), FeaturesResources.ResourceManager, typeof(FeaturesResources)))
         {

--- a/src/Features/Core/Portable/SimplifyThisOrMe/AbstractSimplifyThisOrMeDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/SimplifyThisOrMe/AbstractSimplifyThisOrMeDiagnosticAnalyzer.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.SimplifyThisOrMe
         protected AbstractSimplifyThisOrMeDiagnosticAnalyzer()
             : base(IDEDiagnosticIds.RemoveThisOrMeQualificationDiagnosticId,
                    EnforceOnBuildValues.RemoveQualification,
-                   ImmutableHashSet.Create<IPerLanguageOption>(CodeStyleOptions2.QualifyFieldAccess, CodeStyleOptions2.QualifyPropertyAccess, CodeStyleOptions2.QualifyMethodAccess, CodeStyleOptions2.QualifyEventAccess),
+                   ImmutableHashSet.Create<IOption2>(CodeStyleOptions2.QualifyFieldAccess, CodeStyleOptions2.QualifyPropertyAccess, CodeStyleOptions2.QualifyMethodAccess, CodeStyleOptions2.QualifyEventAccess),
                    fadingOption: null,
                    new LocalizableResourceString(nameof(FeaturesResources.Remove_qualification), FeaturesResources.ResourceManager, typeof(FeaturesResources)),
                    new LocalizableResourceString(nameof(WorkspacesResources.Name_can_be_simplified), WorkspacesResources.ResourceManager, typeof(WorkspacesResources)))


### PR DESCRIPTION
Third point of https://github.com/dotnet/roslyn/issues/62666

Changes in `IDEDiagnosticIdToOptionMappingHelper` are the starting point. Basically we had a common dictionary, and language-specific dictionaries. But at the end, we always searched all dictionaries.

I kept a single dictionary, and hence eliminated the need of a `language` parameter, which simplified the constructors.