### PR TITLE
Allow diagnostic tagging to use either push or pull diagnostics

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsTaggerProvider.cs
@@ -54,6 +54,12 @@ namespace Microsoft.CodeAnalysis.Editor.InlineDiagnostics
             _classificationTypeRegistryService = classificationTypeRegistryService;
         }
 
+        protected internal override bool SupportsDignosticMode(DiagnosticMode mode)
+        {
+            // We support inline diagnostics in both push and pull (since lsp doesn't support inline diagnostics yet).
+            return true;
+        }
+
         // Need to override this from AbstractDiagnosticsTaggerProvider because the location option needs to be added
         // to the TaggerEventSource, otherwise it does not get updated until there is a change in the editor.
         protected override ITaggerEventSource CreateEventSource(ITextView? textView, ITextBuffer subjectBuffer)

--- a/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Diagnostics/AbstractDiagnosticsTaggerProvider.cs
@@ -24,6 +24,7 @@ using Microsoft.CodeAnalysis.Workspaces;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
@@ -51,8 +52,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// diagnostics, we don't know how to map the span of the diagnostic to the current snapshot
         /// we're tagging.
         /// </summary>
-        private static readonly ConditionalWeakTable<object, ITextSnapshot> _diagnosticIdToTextSnapshot =
-            new();
+        private static readonly ConditionalWeakTable<object, ITextSnapshot> _diagnosticIdToTextSnapshot = new();
 
         protected AbstractDiagnosticsTaggerProvider(
             IThreadingContext threadingContext,
@@ -65,6 +65,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             _diagnosticService = diagnosticService;
             _diagnosticService.DiagnosticsUpdated += OnDiagnosticsUpdated;
         }
+
+        protected internal abstract bool IsEnabled { get; }
+        protected internal abstract bool SupportsDignosticMode(DiagnosticMode mode);
+        protected internal abstract bool IncludeDiagnostic(DiagnosticData data);
+        protected internal abstract ITagSpan<TTag>? CreateTagSpan(Workspace workspace, bool isLiveUpdate, SnapshotSpan span, DiagnosticData data);
 
         private void OnDiagnosticsUpdated(object? sender, DiagnosticsUpdatedArgs e)
         {
@@ -125,10 +130,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 TaggerEventSources.OnTextChanged(subjectBuffer));
         }
 
-        protected internal abstract bool IsEnabled { get; }
-        protected internal abstract bool IncludeDiagnostic(DiagnosticData data);
-        protected internal abstract ITagSpan<TTag>? CreateTagSpan(Workspace workspace, bool isLiveUpdate, SnapshotSpan span, DiagnosticData data);
-
         /// <summary>
         /// Get the <see cref="DiagnosticDataLocation"/> that should have the tag applied to it.
         /// In most cases, this is the <see cref="DiagnosticData.DataLocation"/> but overrides can change it (e.g. unnecessary classifications).
@@ -148,15 +149,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             TaggerContext<TTag> context, DocumentSnapshotSpan spanToTag, CancellationToken cancellationToken)
         {
             if (!this.IsEnabled)
-            {
                 return;
-            }
+
+            var diagnosticMode = GlobalOptions.GetDiagnosticMode(InternalDiagnosticsOptions.NormalDiagnosticMode);
+            if (!SupportsDignosticMode(diagnosticMode))
+                return;
 
             var document = spanToTag.Document;
             if (document == null)
-            {
                 return;
-            }
 
             var editorSnapshot = spanToTag.SnapshotSpan.Snapshot;
 
@@ -169,10 +170,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             var suppressedDiagnosticsSpans = (NormalizedSnapshotSpanCollection?)null;
             buffer?.Properties.TryGetProperty(PredefinedPreviewTaggerKeys.SuppressDiagnosticsSpansKey, out suppressedDiagnosticsSpans);
 
-            var diagnosticMode = GlobalOptions.GetDiagnosticMode(InternalDiagnosticsOptions.NormalDiagnosticMode);
-
-            var buckets = _diagnosticService.GetPushDiagnosticBuckets(
-                workspace, document.Project.Id, document.Id, diagnosticMode, cancellationToken);
+            var buckets = diagnosticMode switch
+            {
+                DiagnosticMode.Pull => _diagnosticService.GetPullDiagnosticBuckets(workspace, document.Project.Id, document.Id, diagnosticMode, cancellationToken),
+                DiagnosticMode.Push => _diagnosticService.GetPushDiagnosticBuckets(workspace, document.Project.Id, document.Id, diagnosticMode, cancellationToken),
+                _ => throw ExceptionUtilities.UnexpectedValue(diagnosticMode),
+            };
 
             foreach (var bucket in buckets)
             {
@@ -257,7 +260,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 // https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=428328&_a=edit&triage=false
                 // explicitly report NFW to find out what is causing us for out of range.
-                // stop crashing on such occations
+                // stop crashing on such occasions
                 return;
             }
 

--- a/src/EditorFeatures/Core/Diagnostics/DiagnosticsClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Diagnostics/DiagnosticsClassificationTaggerProvider.cs
@@ -61,6 +61,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         protected internal override bool IsEnabled
             => !_editorOptionsService.Factory.GlobalOptions.GetOptionValue(DefaultTextViewHostOptions.IsInContrastModeId);
 
+        protected internal override bool SupportsDignosticMode(DiagnosticMode mode)
+        {
+            // We only support push diagnostics.  When pull diagnostics are on, diagnostic fading is handled by the lsp client.
+            return mode == DiagnosticMode.Push;
+        }
+
         protected internal override bool IncludeDiagnostic(DiagnosticData data)
         {
             if (!data.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary))

--- a/src/EditorFeatures/Core/Diagnostics/DiagnosticsSquiggleTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Diagnostics/DiagnosticsSquiggleTaggerProvider.cs
@@ -44,6 +44,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
         }
 
+        protected internal override bool SupportsDignosticMode(DiagnosticMode mode)
+        {
+            // We only support push diagnostics.  When pull diagnostics are on, squiggles are handled by the lsp client.
+            return mode == DiagnosticMode.Push;
+        }
+
         protected internal override bool IncludeDiagnostic(DiagnosticData diagnostic)
         {
             var isUnnecessary = diagnostic.Severity == DiagnosticSeverity.Hidden && diagnostic.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary);

--- a/src/EditorFeatures/Core/Diagnostics/DiagnosticsSuggestionTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Diagnostics/DiagnosticsSuggestionTaggerProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     [ContentType(ContentTypeNames.RoslynContentType)]
     [ContentType(ContentTypeNames.XamlContentType)]
     [TagType(typeof(IErrorTag))]
-    internal partial class DiagnosticsSuggestionTaggerProvider :
+    internal sealed partial class DiagnosticsSuggestionTaggerProvider :
         AbstractDiagnosticsAdornmentTaggerProvider<IErrorTag>
     {
         private static readonly IEnumerable<Option2<bool>> s_tagSourceOptions =
@@ -46,6 +46,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         protected internal override bool IncludeDiagnostic(DiagnosticData diagnostic)
             => diagnostic.Severity == DiagnosticSeverity.Info;
+
+        protected internal override bool SupportsDignosticMode(DiagnosticMode mode)
+        {
+            // We only support push diagnostics.  When pull diagnostics are on, ellipses suggestions are handled by the
+            // lsp client.
+            return mode == DiagnosticMode.Push;
+        }
 
         protected override IErrorTag CreateTag(Workspace workspace, DiagnosticData diagnostic)
             => new ErrorTag(


### PR DESCRIPTION
Currently diagnostic tagging only uses push diagnostics.  However, we would like to switch to pull diagnostics fully.  This allows tagging to utilize pull diagnostics if that is on.

Note: when pull diagnostics is on the LSP client takes over several tagging roles (like squiggles).  So if that's on, we disable our own taggers there since they're nto needed.