### PR TITLE
Fix GetNext/PreviousDirective's handling of duplicate trivia

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/DirectiveTriviaSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/DirectiveTriviaSyntax.cs
@@ -72,20 +72,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             {
                 foreach (var tr in token.LeadingTrivia)
                 {
-                    if (next)
+                    if (tr.IsDirective)
                     {
-                        if (tr.IsDirective)
+                        var d = (DirectiveTriviaSyntax)tr.GetStructure()!;
+                        if (next)
                         {
-                            var d = (DirectiveTriviaSyntax)tr.GetStructure()!;
                             if (predicate == null || predicate(d))
                             {
                                 return d;
                             }
                         }
-                    }
-                    else if (tr.UnderlyingNode == this.Green)
-                    {
-                        next = true;
+                        else if (tr.UnderlyingNode == this.Green && tr.SpanStart == this.SpanStart && (object)d == this)
+                        {
+                            next = true;
+                        }
                     }
                 }
 
@@ -103,20 +103,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             {
                 foreach (var tr in token.LeadingTrivia.Reverse())
                 {
-                    if (next)
+                    if (tr.IsDirective)
                     {
-                        if (tr.IsDirective)
+                        var d = (DirectiveTriviaSyntax)tr.GetStructure()!;
+                        if (next)
                         {
-                            var d = (DirectiveTriviaSyntax)tr.GetStructure()!;
                             if (predicate == null || predicate(d))
                             {
                                 return d;
                             }
                         }
-                    }
-                    else if (tr.UnderlyingNode == this.Green)
-                    {
-                        next = true;
+                        else if (tr.UnderlyingNode == this.Green && tr.SpanStart == this.SpanStart && (object)d == this)
+                        {
+                            next = true;
+                        }
                     }
                 }
 

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeTests.cs
@@ -7,12 +7,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 using InternalSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
@@ -1303,6 +1303,34 @@ class C {
             Assert.Equal(SyntaxKind.DefineDirectiveTrivia, d4.Kind());
             var d5 = d4.GetPreviousDirective();
             Assert.Null(d5);
+        }
+
+        [Fact]
+        public void TestGetNextAndPreviousDirectiveWithDuplicateTrivia()
+        {
+            var tree = SyntaxFactory.ParseSyntaxTree(
+@"#region R
+class C {
+}
+");
+            var c = tree.GetCompilationUnitRoot().Members[0];
+
+            // Duplicate the leading trivia on the class
+            c = c.WithLeadingTrivia(c.GetLeadingTrivia().Concat(c.GetLeadingTrivia()));
+
+            var leadingTriviaWithDuplicate = c.GetLeadingTrivia();
+            Assert.Equal(2, leadingTriviaWithDuplicate.Count);
+
+            var firstDirective = Assert.IsType<RegionDirectiveTriviaSyntax>(leadingTriviaWithDuplicate[0].GetStructure());
+            var secondDirective = Assert.IsType<RegionDirectiveTriviaSyntax>(leadingTriviaWithDuplicate[1].GetStructure());
+
+            // Test GetNextDirective works correctly
+            Assert.Same(secondDirective, firstDirective.GetNextDirective());
+            Assert.Null(secondDirective.GetNextDirective());
+
+            // Test GetPreviousDirective works correctly
+            Assert.Null(firstDirective.GetPreviousDirective());
+            Assert.Same(secondDirective.GetPreviousDirective(), firstDirective);
         }
 
         [Fact]


### PR DESCRIPTION
GetNext/PreviousDirective work by walking the list of trivia and when they see the SyntaxTrivia that represents 'this', they set a flag and then continue to traverse and return the next directive found. There was a bug though in handling of duplicate trivia: if somebody were to create a node that has the same trivia twice, that may share the underlying green node. The boolean flag of "return next directive" was set if the green node matched, but no checking was done of the span or index to verify it was the correct instance of the green node. This meant that somebody calling GetNextDirective on the second directive would get the second directive back again, since internally the loop would see the first directive, go "oh, that's me!" and return the second one.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1568850, or at least the fact it causes crashes. An IDE bug is causing us to accidentally introduce duplicate trivia, but in the process it's causing compiler functions that depend on GetNext/PreviousDirective to end up in a stack overflow, because they assume progress will be made by these functions.