### PR TITLE
Allow lightbulbs to make text changes, even if an intermediary workspace change occurred.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ApplyChangesOperationTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ApplyChangesOperationTests.cs
@@ -5,21 +5,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.UnitTests.Preview;
-using Microsoft.CodeAnalysis.Editor.UnitTests;
-using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.CodeRefactorings;
-using Microsoft.CodeAnalysis.CodeActions;
 using System.Threading;
-using Roslyn.Test.Utilities;
-using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions

--- a/src/EditorFeatures/CSharpTest/CodeActions/ApplyChangesOperationTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ApplyChangesOperationTests.cs
@@ -1,0 +1,272 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Preview;
+using Microsoft.CodeAnalysis.Editor.UnitTests;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CodeActions;
+using System.Threading;
+using Roslyn.Test.Utilities;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions
+{
+    public class ApplyChangesOperationTests : AbstractCSharpCodeActionTest
+    {
+        protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace, TestParameters parameters)
+            => new MyCodeRefactoringProvider((Func<Solution, Solution>)parameters.fixProviderData);
+
+        private class MyCodeRefactoringProvider : CodeRefactoringProvider
+        {
+            private readonly Func<Solution, Solution> _changeSolution;
+
+            public MyCodeRefactoringProvider(Func<Solution, Solution> changeSolution)
+            {
+                _changeSolution = changeSolution;
+            }
+
+            public sealed override Task ComputeRefactoringsAsync(CodeRefactoringContext context)
+            {
+                var codeAction = new TestCodeAction(_changeSolution(context.Document.Project.Solution));
+                context.RegisterRefactoring(codeAction);
+                return Task.CompletedTask;
+            }
+
+            private sealed class TestCodeAction : CodeAction
+            {
+                private readonly Solution _changedSolution;
+
+                public TestCodeAction(Solution changedSolution)
+                {
+                    _changedSolution = changedSolution;
+                }
+
+                public override string Title => "Title";
+
+                protected override Task<Solution?> GetChangedSolutionAsync(CancellationToken cancellationToken)
+                    => Task.FromResult<Solution?>(_changedSolution);
+            }
+        }
+
+        [WpfFact, WorkItem(1419139, "https://devdiv.visualstudio.com/DevDiv/_queries/edit/1419139")]
+        public async Task TestMakeTextChangeWithInterveningEditToDifferentFile()
+        {
+            // This should succeed as the code action is trying to edit a file that is not touched by the actual
+            // workspace edit that already went in.
+            await TestSuccessfulApplicationAsync(
+@"<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""Program1.cs"">
+class Program1
+{
+}
+        </Document>
+        <Document FilePath=""Program2.cs"">
+class Program2
+{
+}
+        </Document>
+    </Project>
+</Workspace>",
+                codeActionTransform: solution =>
+                {
+                    var document1 = solution.Projects.Single().Documents.Single(d => d.FilePath!.Contains("Program1"));
+                    return solution.WithDocumentText(document1.Id, SourceText.From("NewProgram1Content"));
+                },
+                intermediaryTransform: solution =>
+                {
+                    var document2 = solution.Projects.Single().Documents.Single(d => d.FilePath!.Contains("Program2"));
+                    return solution.WithDocumentText(document2.Id, SourceText.From("NewProgram2Content"));
+                });
+        }
+
+        [WpfFact, WorkItem(1419139, "https://devdiv.visualstudio.com/DevDiv/_queries/edit/1419139")]
+        public async Task TestMakeTextChangeWithInterveningRemovalToDifferentFile()
+        {
+            // This should succeed as the code action is trying to edit a file that is not touched by the actual
+            // workspace edit that already went in.
+            await TestSuccessfulApplicationAsync(
+@"<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""Program1.cs"">
+class Program1
+{
+}
+        </Document>
+        <Document FilePath=""Program2.cs"">
+class Program2
+{
+}
+        </Document>
+    </Project>
+</Workspace>",
+                codeActionTransform: solution =>
+                {
+                    var document1 = solution.Projects.Single().Documents.Single(d => d.FilePath!.Contains("Program1"));
+                    return solution.WithDocumentText(document1.Id, SourceText.From("NewProgram1Content"));
+                },
+                intermediaryTransform: solution =>
+                {
+                    var document2 = solution.Projects.Single().Documents.Single(d => d.FilePath!.Contains("Program2"));
+                    return solution.RemoveDocument(document2.Id);
+                });
+        }
+
+        [WpfFact, WorkItem(1419139, "https://devdiv.visualstudio.com/DevDiv/_queries/edit/1419139")]
+        public async Task TestMakeTextChangeWithInterveningEditToSameFile()
+        {
+            // This should fail as the code action is trying to edit a file that is was already edited by the actual
+            // workspace edit that already went in.
+            await TestFailureApplicationAsync(
+@"<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""Program1.cs"">
+class Program1
+{
+}
+        </Document>
+        <Document FilePath=""Program2.cs"">
+class Program2
+{
+}
+        </Document>
+    </Project>
+</Workspace>",
+                codeActionTransform: solution =>
+                {
+                    var document1 = solution.Projects.Single().Documents.Single(d => d.FilePath!.Contains("Program1"));
+                    return solution.WithDocumentText(document1.Id, SourceText.From("NewProgram1Content1"));
+                },
+                intermediaryTransform: solution =>
+                {
+                    var document1 = solution.Projects.Single().Documents.Single(d => d.FilePath!.Contains("Program1"));
+                    return solution.WithDocumentText(document1.Id, SourceText.From("NewProgram1Content2"));
+                });
+        }
+
+        [WpfFact, WorkItem(1419139, "https://devdiv.visualstudio.com/DevDiv/_queries/edit/1419139")]
+        public async Task TestMakeTextChangeWithInterveningRemovalOfThatFile()
+        {
+            // This should fail as the code action is trying to edit a file that is subsequently removed.
+            await TestFailureApplicationAsync(
+@"<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""Program1.cs"">
+class Program1
+{
+}
+        </Document>
+        <Document FilePath=""Program2.cs"">
+class Program2
+{
+}
+        </Document>
+    </Project>
+</Workspace>",
+                codeActionTransform: solution =>
+                {
+                    var document1 = solution.Projects.Single().Documents.Single(d => d.FilePath!.Contains("Program1"));
+                    return solution.WithDocumentText(document1.Id, SourceText.From("NewProgram1Content1"));
+                },
+                intermediaryTransform: solution =>
+                {
+                    var document1 = solution.Projects.Single().Documents.Single(d => d.FilePath!.Contains("Program1"));
+                    return solution.RemoveDocument(document1.Id);
+                });
+        }
+
+        [WpfFact, WorkItem(1419139, "https://devdiv.visualstudio.com/DevDiv/_queries/edit/1419139")]
+        public async Task TestMakeProjectChangeWithInterveningTextEdit()
+        {
+            // This should fail as we don't want to make non-text changes that may have undesirable results to the solution
+            // given the intervening edits.
+            await TestFailureApplicationAsync(
+@"<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document FilePath=""Program1.cs"">
+class Program1
+{
+}
+        </Document>
+        <Document FilePath=""Program2.cs"">
+class Program2
+{
+}
+        </Document>
+    </Project>
+</Workspace>",
+                codeActionTransform: solution =>
+                {
+                    var document1 = solution.Projects.Single().Documents.Single(d => d.FilePath!.Contains("Program1"));
+                    return solution.RemoveDocument(document1.Id);
+                },
+                intermediaryTransform: solution =>
+                {
+                    var document2 = solution.Projects.Single().Documents.Single(d => d.FilePath!.Contains("Program2"));
+                    return solution.WithDocumentText(document2.Id, SourceText.From("NewProgram1Content2"));
+                });
+        }
+
+        private async Task TestSuccessfulApplicationAsync(
+            string workspaceXml,
+            Func<Solution, Solution> codeActionTransform,
+            Func<Solution, Solution> intermediaryTransform)
+        {
+            await TestApplicationAsync(workspaceXml, codeActionTransform, intermediaryTransform, success: true);
+        }
+
+        private async Task TestFailureApplicationAsync(
+            string workspaceXml,
+            Func<Solution, Solution> codeActionTransform,
+            Func<Solution, Solution> intermediaryTransform)
+        {
+            await TestApplicationAsync(workspaceXml, codeActionTransform, intermediaryTransform, success: false);
+        }
+
+        private async Task TestApplicationAsync(
+            string workspaceXml,
+            Func<Solution, Solution> codeActionTransform,
+            Func<Solution, Solution> intermediaryTransform,
+            bool success)
+        {
+            var parameters = new TestParameters(fixProviderData: codeActionTransform);
+            using var workspace = CreateWorkspaceFromOptions(workspaceXml, parameters);
+
+            var originalSolution = workspace.CurrentSolution;
+
+            var document = GetDocument(workspace);
+            var provider = CreateCodeRefactoringProvider(workspace, parameters);
+
+            var refactorings = new List<CodeAction>();
+            var context = new CodeRefactoringContext(document, new TextSpan(), refactorings.Add, CancellationToken.None);
+
+            // Compute refactorings based on the original solution.
+            await provider.ComputeRefactoringsAsync(context);
+            var action = refactorings.Single();
+            var operations = await action.GetOperationsAsync(CancellationToken.None);
+            var operation = operations.Single();
+
+            // Now make an intermediary edit to the workspace that is applied back in.
+            var changedSolution = intermediaryTransform(originalSolution);
+            Assert.True(workspace.TryApplyChanges(changedSolution));
+
+            // Now try to apply the refactoring, even though an intervening edit happened.
+            var result = await operation.TryApplyAsync(workspace, originalSolution, new ProgressTracker(), CancellationToken.None);
+
+            Assert.Equal(success, result);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/CodeActions/Preview/PreviewExceptionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/Preview/PreviewExceptionTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
             var suggestedAction = new CodeRefactoringSuggestedAction(
                 workspace.ExportProvider.GetExportedValue<IThreadingContext>(),
                 workspace.ExportProvider.GetExportedValue<SuggestedActionsSourceProvider>(),
-                workspace, textBuffer, provider, codeActions.First(), fixAllFlavors: null);
+                workspace, workspace.CurrentSolution, textBuffer, provider, codeActions.First(), fixAllFlavors: null);
             await suggestedAction.GetPreviewAsync(CancellationToken.None);
             Assert.True(extensionManager.IsDisabled(provider));
             Assert.False(extensionManager.IsIgnored(provider));
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
             var suggestedAction = new CodeRefactoringSuggestedAction(
                 workspace.ExportProvider.GetExportedValue<IThreadingContext>(),
                 workspace.ExportProvider.GetExportedValue<SuggestedActionsSourceProvider>(),
-                workspace, textBuffer, provider, codeActions.First(), fixAllFlavors: null);
+                workspace, workspace.CurrentSolution, textBuffer, provider, codeActions.First(), fixAllFlavors: null);
             _ = suggestedAction.DisplayText;
             Assert.True(extensionManager.IsDisabled(provider));
             Assert.False(extensionManager.IsIgnored(provider));
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings
             var suggestedAction = new CodeRefactoringSuggestedAction(
                 workspace.ExportProvider.GetExportedValue<IThreadingContext>(),
                 workspace.ExportProvider.GetExportedValue<SuggestedActionsSourceProvider>(),
-                workspace, textBuffer, provider, codeActions.First(), fixAllFlavors: null);
+                workspace, workspace.CurrentSolution, textBuffer, provider, codeActions.First(), fixAllFlavors: null);
             _ = await suggestedAction.GetActionSetsAsync(CancellationToken.None);
             Assert.True(extensionManager.IsDisabled(provider));
             Assert.False(extensionManager.IsIgnored(provider));

--- a/src/EditorFeatures/Core.Wpf/Suggestions/PreviewChanges/PreviewChangesSuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/PreviewChanges/PreviewChangesSuggestedAction.cs
@@ -23,10 +23,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 IThreadingContext threadingContext,
                 SuggestedActionsSourceProvider sourceProvider,
                 Workspace workspace,
+                Solution originalSolution,
                 ITextBuffer subjectBuffer,
                 object provider,
                 PreviewChangesCodeAction codeAction)
-                : base(threadingContext, sourceProvider, workspace, subjectBuffer, provider, codeAction)
+                : base(threadingContext, sourceProvider, workspace, originalSolution, subjectBuffer, provider, codeAction)
             {
             }
 
@@ -47,8 +48,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 return new PreviewChangesSuggestedAction(
                     suggestedAction.ThreadingContext,
-                    suggestedAction.SourceProvider, suggestedAction.Workspace,
-                    suggestedAction.SubjectBuffer, suggestedAction.Provider,
+                    suggestedAction.SourceProvider,
+                    suggestedAction.Workspace,
+                    suggestedAction.OriginalSolution,
+                    suggestedAction.SubjectBuffer,
+                    suggestedAction.Provider,
                     new PreviewChangesCodeAction(
                         suggestedAction.Workspace, suggestedAction.CodeAction, changeSummary));
             }

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionWithNestedActions.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionWithNestedActions.cs
@@ -27,10 +27,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
         public SuggestedActionWithNestedActions(
             IThreadingContext threadingContext,
-            SuggestedActionsSourceProvider sourceProvider, Workspace workspace,
-            ITextBuffer subjectBuffer, object provider,
-            CodeAction codeAction, ImmutableArray<SuggestedActionSet> nestedActionSets)
-            : base(threadingContext, sourceProvider, workspace, subjectBuffer, provider, codeAction)
+            SuggestedActionsSourceProvider sourceProvider,
+            Workspace workspace,
+            Solution originalSolution,
+            ITextBuffer subjectBuffer,
+            object provider,
+            CodeAction codeAction,
+            ImmutableArray<SuggestedActionSet> nestedActionSets)
+            : base(threadingContext, sourceProvider, workspace, originalSolution, subjectBuffer, provider, codeAction)
         {
             Debug.Assert(!nestedActionSets.IsDefaultOrEmpty);
             NestedActionSets = nestedActionSets;
@@ -38,10 +42,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
         public SuggestedActionWithNestedActions(
             IThreadingContext threadingContext,
-            SuggestedActionsSourceProvider sourceProvider, Workspace workspace,
-            ITextBuffer subjectBuffer, object provider,
-            CodeAction codeAction, SuggestedActionSet nestedActionSet)
-            : this(threadingContext, sourceProvider, workspace, subjectBuffer, provider, codeAction, ImmutableArray.Create(nestedActionSet))
+            SuggestedActionsSourceProvider sourceProvider,
+            Workspace workspace,
+            Solution originalSolution,
+            ITextBuffer subjectBuffer,
+            object provider,
+            CodeAction codeAction,
+            SuggestedActionSet nestedActionSet)
+            : this(threadingContext, sourceProvider, workspace, originalSolution, subjectBuffer, provider, codeAction, ImmutableArray.Create(nestedActionSet))
         {
         }
 

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionWithNestedFlavors.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionWithNestedFlavors.cs
@@ -38,11 +38,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
         public SuggestedActionWithNestedFlavors(
             IThreadingContext threadingContext,
             SuggestedActionsSourceProvider sourceProvider,
-            Workspace workspace, ITextBuffer subjectBuffer,
-            object provider, CodeAction codeAction,
+            Workspace workspace,
+            Solution originalSolution,
+            ITextBuffer subjectBuffer,
+            object provider,
+            CodeAction codeAction,
             SuggestedActionSet additionalFlavors)
-            : base(threadingContext, sourceProvider, workspace, subjectBuffer,
-                   provider, codeAction)
+            : base(threadingContext,
+                   sourceProvider,
+                   workspace,
+                   originalSolution,
+                   subjectBuffer,
+                   provider,
+                   codeAction)
         {
             _additionalFlavors = additionalFlavors;
         }

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/AbstractFixAllSuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/AbstractFixAllSuggestedAction.cs
@@ -28,12 +28,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             IThreadingContext threadingContext,
             SuggestedActionsSourceProvider sourceProvider,
             Workspace workspace,
+            Solution originalSolution,
             ITextBuffer subjectBuffer,
             IFixAllState fixAllState,
             CodeAction originalCodeAction,
             AbstractFixAllCodeAction fixAllCodeAction)
-            : base(threadingContext, sourceProvider, workspace, subjectBuffer,
-                   fixAllState.FixAllProvider, fixAllCodeAction)
+            : base(threadingContext,
+                   sourceProvider,
+                   workspace,
+                   originalSolution,
+                   subjectBuffer,
+                   fixAllState.FixAllProvider,
+                   fixAllCodeAction)
         {
             OriginalCodeAction = originalCodeAction;
             FixAllState = fixAllState;

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/CodeFixSuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/CodeFixSuggestedAction.cs
@@ -26,13 +26,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             IThreadingContext threadingContext,
             SuggestedActionsSourceProvider sourceProvider,
             Workspace workspace,
+            Solution originalSolution,
             ITextBuffer subjectBuffer,
             CodeFix fix,
             object provider,
             CodeAction action,
             SuggestedActionSet fixAllFlavors)
-            : base(threadingContext, sourceProvider, workspace, subjectBuffer,
-                   provider, action, fixAllFlavors)
+            : base(threadingContext,
+                   sourceProvider,
+                   workspace,
+                   originalSolution,
+                   subjectBuffer,
+                   provider,
+                   action,
+                   fixAllFlavors)
         {
             CodeFix = fix;
         }

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/CodeRefactoringSuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/CodeRefactoringSuggestedAction.cs
@@ -24,11 +24,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             IThreadingContext threadingContext,
             SuggestedActionsSourceProvider sourceProvider,
             Workspace workspace,
+            Solution originalSolution,
             ITextBuffer subjectBuffer,
             CodeRefactoringProvider provider,
             CodeAction codeAction,
             SuggestedActionSet fixAllFlavors)
-            : base(threadingContext, sourceProvider, workspace, subjectBuffer, provider, codeAction, fixAllFlavors)
+            : base(threadingContext, sourceProvider, workspace, originalSolution, subjectBuffer, provider, codeAction, fixAllFlavors)
         {
             CodeRefactoringProvider = provider;
         }

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/FixAllCodeFixSuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/FixAllCodeFixSuggestedAction.cs
@@ -25,12 +25,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             IThreadingContext threadingContext,
             SuggestedActionsSourceProvider sourceProvider,
             Workspace workspace,
+            Solution originalSolution,
             ITextBuffer subjectBuffer,
             IFixAllState fixAllState,
             Diagnostic diagnostic,
             CodeAction originalCodeAction)
-            : base(threadingContext, sourceProvider, workspace, subjectBuffer, fixAllState,
-                   originalCodeAction, new FixAllCodeAction(fixAllState))
+            : base(threadingContext,
+                   sourceProvider,
+                   workspace,
+                   originalSolution,
+                   subjectBuffer,
+                   fixAllState,
+                   originalCodeAction,
+                   new FixAllCodeAction(fixAllState))
         {
             Diagnostic = diagnostic;
         }

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/FixAllCodeRefactoringSuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/FixAllCodeRefactoringSuggestedAction.cs
@@ -21,11 +21,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             IThreadingContext threadingContext,
             SuggestedActionsSourceProvider sourceProvider,
             Workspace workspace,
+            Solution originalSolution,
             ITextBuffer subjectBuffer,
             IFixAllState fixAllState,
             CodeAction originalCodeAction)
-            : base(threadingContext, sourceProvider, workspace, subjectBuffer, fixAllState,
-                   originalCodeAction, new FixAllCodeRefactoringCodeAction(fixAllState))
+            : base(threadingContext,
+                   sourceProvider,
+                   workspace,
+                   originalSolution,
+                   subjectBuffer,
+                   fixAllState,
+                   originalCodeAction,
+                   new FixAllCodeRefactoringCodeAction(fixAllState))
         {
         }
     }

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/SuggestedAction.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActions/SuggestedAction.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
         protected readonly SuggestedActionsSourceProvider SourceProvider;
 
         protected readonly Workspace Workspace;
+        protected readonly Solution OriginalSolution;
         protected readonly ITextBuffer SubjectBuffer;
 
         protected readonly object Provider;
@@ -46,6 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             IThreadingContext threadingContext,
             SuggestedActionsSourceProvider sourceProvider,
             Workspace workspace,
+            Solution originalSolution,
             ITextBuffer subjectBuffer,
             object provider,
             CodeAction codeAction)
@@ -56,6 +58,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
             SourceProvider = sourceProvider;
             Workspace = workspace;
+            OriginalSolution = originalSolution;
             SubjectBuffer = subjectBuffer;
             Provider = provider;
             CodeAction = codeAction;
@@ -164,9 +167,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     var document = this.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
 
                     await EditHandler.ApplyAsync(
-                        Workspace, document,
-                        operations.ToImmutableArray(), CodeAction.Title,
-                        progressTracker, cancellationToken).ConfigureAwait(false);
+                        Workspace,
+                        OriginalSolution,
+                        document,
+                        operations.ToImmutableArray(),
+                        CodeAction.Title,
+                        progressTracker,
+                        cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.State.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.State.cs
@@ -24,8 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 public readonly ITextBuffer SubjectBuffer;
                 public readonly WorkspaceRegistration Registration;
 
-                // mutable state
-                public Workspace? Workspace { get; set; }
+                public Workspace? Workspace => Registration.Workspace;
 
                 public State(SuggestedActionsSource source, SuggestedActionsSourceProvider owner, ITextView textView, ITextBuffer textBuffer)
                 {
@@ -39,12 +38,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 void IDisposable.Dispose()
                 {
-                    if (Workspace != null)
-                        Workspace.WorkspaceChanged -= _source.OnWorkspaceChanged;
-
-                    if (Registration != null)
-                        Registration.WorkspaceChanged -= _source.OnWorkspaceChanged;
-
                     if (TextView != null)
                         TextView.Closed -= _source.OnTextViewClosed;
                 }

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.State.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.State.cs
@@ -26,7 +26,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 // mutable state
                 public Workspace? Workspace { get; set; }
-                public int LastSolutionVersionReported;
 
                 public State(SuggestedActionsSource source, SuggestedActionsSourceProvider owner, ITextView textView, ITextBuffer textBuffer)
                 {
@@ -36,17 +35,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     TextView = textView;
                     SubjectBuffer = textBuffer;
                     Registration = Workspace.GetWorkspaceRegistration(textBuffer.AsTextContainer());
-                    LastSolutionVersionReported = InvalidSolutionVersion;
                 }
 
                 void IDisposable.Dispose()
                 {
                     if (Workspace != null)
-                    {
-                        Workspace.Services.GetRequiredService<IWorkspaceStatusService>().StatusChanged -= _source.OnWorkspaceStatusChanged;
-                        Workspace.DocumentActiveContextChanged -= _source.OnActiveContextChanged;
                         Workspace.WorkspaceChanged -= _source.OnWorkspaceChanged;
-                    }
 
                     if (Registration != null)
                         Registration.WorkspaceChanged -= _source.OnWorkspaceChanged;

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -59,10 +59,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 _state = new ReferenceCountedDisposable<State>(new State(this, owner, textView, textBuffer));
 
                 _state.Target.TextView.Closed += OnTextViewClosed;
-
-                RegisterEventsToWorkspace(_state, _state.Target.Registration.Workspace);
-
-                _state.Target.Registration.WorkspaceChanged += OnWorkspaceChanged;
             }
 
             public void Dispose()
@@ -515,27 +511,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
             private void OnTextViewClosed(object sender, EventArgs e)
                 => Dispose();
-
-            private void OnWorkspaceChanged(object sender, EventArgs e)
-            {
-                using var state = _state.TryAddReference();
-                if (state is null)
-                    return;
-
-                // REVIEW: why one need to get new workspace from registration? why not just pass in the new workspace?
-                // add new event registration
-                RegisterEventsToWorkspace(state, state.Target.Registration.Workspace);
-            }
-
-            private void RegisterEventsToWorkspace(ReferenceCountedDisposable<State> state, Workspace? workspace)
-            {
-                state.Target.Workspace = workspace;
-
-                if (state.Target.Workspace == null)
-                    return;
-
-                state.Target.Workspace.WorkspaceChanged += OnWorkspaceChanged;
-            }
 
             public async Task<ISuggestedActionCategorySet?> GetSuggestedActionCategoriesAsync(ISuggestedActionCategorySet requestedActionCategories, SnapshotSpan range, CancellationToken cancellationToken)
             {

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -215,6 +215,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 if (unifiedSuggestedActionSet == null)
                     return null;
 
+                var originalSolution = unifiedSuggestedActionSet.OriginalSolution;
+
                 return new SuggestedActionSet(
                     unifiedSuggestedActionSet.CategoryName,
                     unifiedSuggestedActionSet.Actions.SelectAsArray(set => ConvertToSuggestedAction(set)),
@@ -227,21 +229,21 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     => unifiedSuggestedAction switch
                     {
                         UnifiedCodeFixSuggestedAction codeFixAction => new CodeFixSuggestedAction(
-                            ThreadingContext, owner, codeFixAction.Workspace, subjectBuffer,
+                            ThreadingContext, owner, codeFixAction.Workspace, originalSolution, subjectBuffer,
                             codeFixAction.CodeFix, codeFixAction.Provider, codeFixAction.OriginalCodeAction,
                             ConvertToSuggestedActionSet(codeFixAction.FixAllFlavors, owner, subjectBuffer)),
                         UnifiedCodeRefactoringSuggestedAction codeRefactoringAction => new CodeRefactoringSuggestedAction(
-                            ThreadingContext, owner, codeRefactoringAction.Workspace, subjectBuffer,
+                            ThreadingContext, owner, codeRefactoringAction.Workspace, originalSolution, subjectBuffer,
                             codeRefactoringAction.CodeRefactoringProvider, codeRefactoringAction.OriginalCodeAction,
                             ConvertToSuggestedActionSet(codeRefactoringAction.FixAllFlavors, owner, subjectBuffer)),
                         UnifiedFixAllCodeFixSuggestedAction fixAllAction => new FixAllCodeFixSuggestedAction(
-                            ThreadingContext, owner, fixAllAction.Workspace, subjectBuffer,
+                            ThreadingContext, owner, fixAllAction.Workspace, originalSolution, subjectBuffer,
                             fixAllAction.FixAllState, fixAllAction.Diagnostic, fixAllAction.OriginalCodeAction),
                         UnifiedFixAllCodeRefactoringSuggestedAction fixAllCodeRefactoringAction => new FixAllCodeRefactoringSuggestedAction(
-                            ThreadingContext, owner, fixAllCodeRefactoringAction.Workspace, subjectBuffer,
+                            ThreadingContext, owner, fixAllCodeRefactoringAction.Workspace, originalSolution, subjectBuffer,
                             fixAllCodeRefactoringAction.FixAllState, fixAllCodeRefactoringAction.OriginalCodeAction),
                         UnifiedSuggestedActionWithNestedActions nestedAction => new SuggestedActionWithNestedActions(
-                            ThreadingContext, owner, nestedAction.Workspace, subjectBuffer,
+                            ThreadingContext, owner, nestedAction.Workspace, originalSolution, subjectBuffer,
                             nestedAction.Provider ?? this, nestedAction.OriginalCodeAction,
                             nestedAction.NestedActionSets.SelectAsArray((s, arg) => ConvertToSuggestedActionSet(s, arg.owner, arg.subjectBuffer), (owner, subjectBuffer))),
                         _ => throw ExceptionUtilities.Unreachable

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSourceProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSourceProvider.cs
@@ -45,8 +45,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
         private static readonly Guid s_visualBasicSourceGuid = new Guid("4de30e93-3e0c-40c2-a4ba-1124da4539f6");
         private static readonly Guid s_xamlSourceGuid = new Guid("a0572245-2eab-4c39-9f61-06a6d8c5ddda");
 
-        private const int InvalidSolutionVersion = -1;
-
         private readonly IThreadingContext _threadingContext;
         private readonly ICodeRefactoringService _codeRefactoringService;
         private readonly ICodeFixService _codeFixService;

--- a/src/EditorFeatures/Core/CodeActions/CodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/CodeActions/CodeActionEditHandlerService.cs
@@ -100,9 +100,12 @@ namespace Microsoft.CodeAnalysis.CodeActions
         }
 
         public async Task<bool> ApplyAsync(
-            Workspace workspace, Document? fromDocument,
+            Workspace workspace,
+            Solution originalSolution,
+            Document? fromDocument,
             ImmutableArray<CodeActionOperation> operations,
-            string title, IProgressTracker progressTracker,
+            string title,
+            IProgressTracker progressTracker,
             CancellationToken cancellationToken)
         {
             // Much of the work we're going to do will be on the UI thread, so switch there preemptively.
@@ -148,7 +151,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
                         _threadingContext.ThrowIfNotOnUIThread();
 
                         applied = await operations.Single().TryApplyAsync(
-                            workspace, progressTracker, cancellationToken).ConfigureAwait(true);
+                            workspace, originalSolution, progressTracker, cancellationToken).ConfigureAwait(true);
                     }
                     catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, cancellationToken))
                     {
@@ -174,7 +177,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
                 {
                     // Come back to the UI thread after processing the operations so we can commit the transaction
                     applied = await ProcessOperationsAsync(
-                        workspace, operations, progressTracker, cancellationToken).ConfigureAwait(true);
+                        workspace, originalSolution, operations, progressTracker, cancellationToken).ConfigureAwait(true);
                 }
                 catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, cancellationToken))
                 {
@@ -265,8 +268,11 @@ namespace Microsoft.CodeAnalysis.CodeActions
         /// <returns><see langword="true"/> if all expected <paramref name="operations"/> are applied successfully;
         /// otherwise, <see langword="false"/>.</returns>
         private async Task<bool> ProcessOperationsAsync(
-            Workspace workspace, ImmutableArray<CodeActionOperation> operations,
-            IProgressTracker progressTracker, CancellationToken cancellationToken)
+            Workspace workspace,
+            Solution originalSolution,
+            ImmutableArray<CodeActionOperation> operations,
+            IProgressTracker progressTracker,
+            CancellationToken cancellationToken)
         {
             await this._threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
@@ -284,7 +290,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
                 }
 
                 _threadingContext.ThrowIfNotOnUIThread();
-                applied &= await operation.TryApplyAsync(workspace, progressTracker, cancellationToken).ConfigureAwait(true);
+                applied &= await operation.TryApplyAsync(workspace, originalSolution, progressTracker, cancellationToken).ConfigureAwait(true);
             }
 
             return applied;

--- a/src/EditorFeatures/Core/CodeActions/ICodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/CodeActions/ICodeActionEditHandlerService.cs
@@ -18,9 +18,12 @@ namespace Microsoft.CodeAnalysis.CodeActions
             Workspace workspace, ImmutableArray<CodeActionOperation> operations, CancellationToken cancellationToken);
 
         Task<bool> ApplyAsync(
-            Workspace workspace, Document? fromDocument,
+            Workspace workspace,
+            Solution originalSolution,
+            Document? fromDocument,
             ImmutableArray<CodeActionOperation> operations,
-            string title, IProgressTracker progressTracker,
+            string title,
+            IProgressTracker progressTracker,
             CancellationToken cancellationToken);
     }
 }

--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCodeAction.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCodeAction.cs
@@ -118,7 +118,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                     _threadingContext = threadingContext;
                 }
 
-                internal override async Task<bool> TryApplyAsync(Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
+                internal override async Task<bool> TryApplyAsync(
+                    Workspace workspace, Solution originalSolution, IProgressTracker progressTracker, CancellationToken cancellationToken)
                 {
                     var error = await _committer.TryCommitAsync(cancellationToken).ConfigureAwait(false);
                     if (error == null)

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -766,16 +766,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             Tuple<Solution, Solution> result = null;
             foreach (var operation in operations)
             {
-                if (operation is ApplyChangesOperation && result == null)
+                if (operation is ApplyChangesOperation applyChangesOperation && result == null)
                 {
-                    var oldSolution = workspace.CurrentSolution;
-                    var newSolution = ((ApplyChangesOperation)operation).ChangedSolution;
-                    result = Tuple.Create(oldSolution, newSolution);
+                    result = Tuple.Create(workspace.CurrentSolution, applyChangesOperation.ChangedSolution);
                 }
                 else if (operation.ApplyDuringTests)
                 {
                     var oldSolution = workspace.CurrentSolution;
-                    await operation.TryApplyAsync(workspace, new ProgressTracker(), CancellationToken.None);
+                    await operation.TryApplyAsync(workspace, oldSolution, new ProgressTracker(), CancellationToken.None);
                     var newSolution = workspace.CurrentSolution;
                     result = Tuple.Create(oldSolution, newSolution);
                 }

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionTest.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             await VerifyPreviewContents(workspace, expectedPreviewContents, operations);
 
             var applyChangesOperation = operations.OfType<ApplyChangesOperation>().First();
-            await applyChangesOperation.TryApplyAsync(workspace, new ProgressTracker(), CancellationToken.None);
+            await applyChangesOperation.TryApplyAsync(workspace, workspace.CurrentSolution, new ProgressTracker(), CancellationToken.None);
 
             foreach (var document in workspace.Documents)
             {

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
                 var operations = (await codeAction.GetOperationsAsync(CancellationToken.None)).ToArray();
                 Assert.Equal(1, operations.Length);
 
-                await operations[0].TryApplyAsync(this.Workspace, new ProgressTracker(), CancellationToken.None);
+                await operations[0].TryApplyAsync(this.Workspace, this.Workspace.CurrentSolution, new ProgressTracker(), CancellationToken.None);
             }
         }
 

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -1303,6 +1303,7 @@ class C
 
                 Await editHandler.ApplyAsync(
                     workspace,
+                    workspace.CurrentSolution,
                     workspace.CurrentSolution.GetDocument(workspace.Documents.Single().Id),
                     Await actions.First().NestedCodeActions.First().GetOperationsAsync(CancellationToken.None),
                     "unused",

--- a/src/Features/Core/Portable/AddImport/CodeActions/AssemblyReferenceCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/AssemblyReferenceCodeAction.cs
@@ -79,13 +79,14 @@ namespace Microsoft.CodeAnalysis.AddImport
                     operation.Apply(workspace, cancellationToken);
                 }
 
-                internal override Task<bool> TryApplyAsync(Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
+                internal override Task<bool> TryApplyAsync(
+                    Workspace workspace, Solution originalSolution, IProgressTracker progressTracker, CancellationToken cancellationToken)
                 {
                     var operation = GetApplyChangesOperation(workspace);
                     if (operation is null)
                         return SpecializedTasks.False;
 
-                    return operation.TryApplyAsync(workspace, progressTracker, cancellationToken);
+                    return operation.TryApplyAsync(workspace, originalSolution, progressTracker, cancellationToken);
                 }
 
                 private ApplyChangesOperation? GetApplyChangesOperation(Workspace workspace)

--- a/src/Features/Core/Portable/AddImport/CodeActions/InstallPackageAndAddImportCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/InstallPackageAndAddImportCodeAction.cs
@@ -113,7 +113,8 @@ namespace Microsoft.CodeAnalysis.AddImport
             internal override bool ApplyDuringTests => _installPackageOperation.ApplyDuringTests;
             public override string Title => _installPackageOperation.Title;
 
-            internal override async Task<bool> TryApplyAsync(Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
+            internal override async Task<bool> TryApplyAsync(
+                Workspace workspace, Solution originalSolution, IProgressTracker progressTracker, CancellationToken cancellationToken)
             {
                 var newSolution = workspace.CurrentSolution.WithDocumentText(
                     _changedDocumentId, _newText);
@@ -121,7 +122,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 // First make the changes to add the import to the document.
                 if (workspace.TryApplyChanges(newSolution, progressTracker))
                 {
-                    if (await _installPackageOperation.TryApplyAsync(workspace, progressTracker, cancellationToken).ConfigureAwait(true))
+                    if (await _installPackageOperation.TryApplyAsync(workspace, originalSolution, progressTracker, cancellationToken).ConfigureAwait(true))
                     {
                         return true;
                     }

--- a/src/Features/Core/Portable/AddImport/CodeActions/ProjectSymbolReferenceCodeAction.cs
+++ b/src/Features/Core/Portable/AddImport/CodeActions/ProjectSymbolReferenceCodeAction.cs
@@ -71,12 +71,13 @@ namespace Microsoft.CodeAnalysis.AddImport
                     _applyOperation.Apply(workspace, cancellationToken);
                 }
 
-                internal override Task<bool> TryApplyAsync(Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
+                internal override Task<bool> TryApplyAsync(
+                    Workspace workspace, Solution originalSolution, IProgressTracker progressTracker, CancellationToken cancellationToken)
                 {
                     if (!CanApply(workspace))
                         return SpecializedTasks.False;
 
-                    return _applyOperation.TryApplyAsync(workspace, progressTracker, cancellationToken);
+                    return _applyOperation.TryApplyAsync(workspace, originalSolution, progressTracker, cancellationToken);
                 }
 
                 private bool CanApply(Workspace workspace)

--- a/src/Features/Core/Portable/AddPackage/InstallPackageDirectlyCodeActionOperation.cs
+++ b/src/Features/Core/Portable/AddPackage/InstallPackageDirectlyCodeActionOperation.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.AddPackage
         internal override bool ApplyDuringTests => true;
 
         internal override Task<bool> TryApplyAsync(
-            Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
+            Workspace workspace, Solution originalSolution, IProgressTracker progressTracker, CancellationToken cancellationToken)
         {
             return _installerService.TryInstallPackageAsync(
                 workspace, _document.Id, _source, _packageName,

--- a/src/Features/Core/Portable/ChangeSignature/ChangeSignatureCodeActionOperation.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ChangeSignatureCodeActionOperation.cs
@@ -31,19 +31,16 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
 
         internal override bool ApplyDuringTests => true;
 
-        public sealed override void Apply(Workspace workspace, CancellationToken cancellationToken)
-            => ApplyWorker(workspace, new ProgressTracker());
-
         /// <summary>
         /// Show the confirmation message, if available, before attempting to apply the changes.
         /// </summary>
         internal sealed override Task<bool> TryApplyAsync(
-            Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
+            Workspace workspace, Solution originalSolution, IProgressTracker progressTracker, CancellationToken cancellationToken)
         {
-            return ApplyWorker(workspace, progressTracker) ? SpecializedTasks.True : SpecializedTasks.False;
+            return ApplyWorker(workspace, originalSolution, progressTracker, cancellationToken) ? SpecializedTasks.True : SpecializedTasks.False;
         }
 
-        private bool ApplyWorker(Workspace workspace, IProgressTracker progressTracker)
+        private bool ApplyWorker(Workspace workspace, Solution originalSolution, IProgressTracker progressTracker, CancellationToken cancellationToken)
         {
             if (ConfirmationMessage != null)
             {
@@ -54,7 +51,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
                 }
             }
 
-            return workspace.TryApplyChanges(ChangedSolution, progressTracker);
+            return ApplyChangesOperation.ApplyOrMergeChanges(workspace, originalSolution, ChangedSolution, progressTracker, cancellationToken);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionSet.cs
+++ b/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionSet.cs
@@ -13,6 +13,8 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
     /// </summary>
     internal class UnifiedSuggestedActionSet
     {
+        public Solution OriginalSolution { get; }
+
         public string? CategoryName { get; }
 
         public ImmutableArray<IUnifiedSuggestedAction> Actions { get; }
@@ -24,12 +26,14 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
         public TextSpan? ApplicableToSpan { get; }
 
         public UnifiedSuggestedActionSet(
+            Solution originalSolution,
             string? categoryName,
             ImmutableArray<IUnifiedSuggestedAction> actions,
             object? title,
             UnifiedSuggestedActionSetPriority priority,
             TextSpan? applicableToSpan)
         {
+            OriginalSolution = originalSolution;
             CategoryName = categoryName;
             Actions = actions;
             Title = title;

--- a/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
+++ b/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
@@ -42,6 +42,8 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             Func<string, IDisposable?> addOperationScope,
             CancellationToken cancellationToken)
         {
+            var originalSolution = document.Project.Solution;
+
             // Intentionally switch to a threadpool thread to compute fixes.  We do not want to accidentally
             // run any of this on the UI thread and potentially allow any code to take a dependency on that.
             var fixes = await Task.Run(() => codeFixService.GetFixesAsync(
@@ -54,7 +56,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
                 cancellationToken), cancellationToken).ConfigureAwait(false);
 
             var filteredFixes = fixes.WhereAsArray(c => c.Fixes.Length > 0);
-            var organizedFixes = await OrganizeFixesAsync(workspace, filteredFixes, cancellationToken).ConfigureAwait(false);
+            var organizedFixes = await OrganizeFixesAsync(workspace, originalSolution, filteredFixes, cancellationToken).ConfigureAwait(false);
 
             return organizedFixes;
         }
@@ -64,6 +66,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
         /// </summary>
         private static async Task<ImmutableArray<UnifiedSuggestedActionSet>> OrganizeFixesAsync(
             Workspace workspace,
+            Solution originalSolution,
             ImmutableArray<CodeFixCollection> fixCollections,
             CancellationToken cancellationToken)
         {
@@ -71,10 +74,10 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             using var _ = ArrayBuilder<CodeFixGroupKey>.GetInstance(out var order);
 
             // First group fixes by diagnostic and priority.
-            await GroupFixesAsync(workspace, fixCollections, map, order, cancellationToken).ConfigureAwait(false);
+            await GroupFixesAsync(workspace, originalSolution, fixCollections, map, order, cancellationToken).ConfigureAwait(false);
 
             // Then prioritize between the groups.
-            var prioritizedFixes = PrioritizeFixGroups(map.ToImmutable(), order.ToImmutable(), workspace);
+            var prioritizedFixes = PrioritizeFixGroups(originalSolution, map.ToImmutable(), order.ToImmutable(), workspace);
             return prioritizedFixes;
         }
 
@@ -83,17 +86,19 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
         /// </summary>
         private static async Task GroupFixesAsync(
             Workspace workspace,
+            Solution originalSolution,
             ImmutableArray<CodeFixCollection> fixCollections,
             IDictionary<CodeFixGroupKey, IList<IUnifiedSuggestedAction>> map,
             ArrayBuilder<CodeFixGroupKey> order,
             CancellationToken cancellationToken)
         {
             foreach (var fixCollection in fixCollections)
-                await ProcessFixCollectionAsync(workspace, map, order, fixCollection, cancellationToken).ConfigureAwait(false);
+                await ProcessFixCollectionAsync(workspace, originalSolution, map, order, fixCollection, cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task ProcessFixCollectionAsync(
             Workspace workspace,
+            Solution originalSolution,
             IDictionary<CodeFixGroupKey, IList<IUnifiedSuggestedAction>> map,
             ArrayBuilder<CodeFixGroupKey> order,
             CodeFixCollection fixCollection,
@@ -105,11 +110,11 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             var nonSupressionCodeFixes = fixes.WhereAsArray(f => !IsTopLevelSuppressionAction(f.Action));
             var supressionCodeFixes = fixes.WhereAsArray(f => IsTopLevelSuppressionAction(f.Action));
 
-            await AddCodeActionsAsync(workspace, map, order, fixCollection, GetFixAllSuggestedActionSetAsync, nonSupressionCodeFixes).ConfigureAwait(false);
+            await AddCodeActionsAsync(workspace, originalSolution, map, order, fixCollection, GetFixAllSuggestedActionSetAsync, nonSupressionCodeFixes).ConfigureAwait(false);
 
             // Add suppression fixes to the end of a given SuggestedActionSet so that they
             // always show up last in a group.
-            await AddCodeActionsAsync(workspace, map, order, fixCollection, GetFixAllSuggestedActionSetAsync, supressionCodeFixes).ConfigureAwait(false);
+            await AddCodeActionsAsync(workspace, originalSolution, map, order, fixCollection, GetFixAllSuggestedActionSetAsync, supressionCodeFixes).ConfigureAwait(false);
 
             return;
 
@@ -118,36 +123,40 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
                 => GetUnifiedFixAllSuggestedActionSetAsync(
                     codeAction, fixCount, fixCollection.FixAllState,
                     fixCollection.SupportedScopes, fixCollection.FirstDiagnostic,
-                    workspace, cancellationToken);
+                    workspace, originalSolution, cancellationToken);
         }
 
         private static async Task AddCodeActionsAsync(
-            Workspace workspace, IDictionary<CodeFixGroupKey, IList<IUnifiedSuggestedAction>> map,
-            ArrayBuilder<CodeFixGroupKey> order, CodeFixCollection fixCollection,
+            Workspace workspace,
+            Solution originalSolution,
+            IDictionary<CodeFixGroupKey, IList<IUnifiedSuggestedAction>> map,
+            ArrayBuilder<CodeFixGroupKey> order,
+            CodeFixCollection fixCollection,
             Func<CodeAction, Task<UnifiedSuggestedActionSet?>> getFixAllSuggestedActionSetAsync,
             ImmutableArray<CodeFix> codeFixes)
         {
             foreach (var fix in codeFixes)
             {
-                var unifiedSuggestedAction = await GetUnifiedSuggestedActionAsync(fix.Action, fix).ConfigureAwait(false);
+                var unifiedSuggestedAction = await GetUnifiedSuggestedActionAsync(originalSolution, fix.Action, fix).ConfigureAwait(false);
                 AddFix(fix, unifiedSuggestedAction, map, order);
             }
 
             return;
 
             // Local functions
-            async Task<IUnifiedSuggestedAction> GetUnifiedSuggestedActionAsync(CodeAction action, CodeFix fix)
+            async Task<IUnifiedSuggestedAction> GetUnifiedSuggestedActionAsync(Solution originalSolution, CodeAction action, CodeFix fix)
             {
                 if (action.NestedCodeActions.Length > 0)
                 {
                     using var _ = ArrayBuilder<IUnifiedSuggestedAction>.GetInstance(action.NestedCodeActions.Length, out var unifiedNestedActions);
                     foreach (var nestedAction in action.NestedCodeActions)
                     {
-                        var unifiedNestedAction = await GetUnifiedSuggestedActionAsync(nestedAction, fix).ConfigureAwait(false);
+                        var unifiedNestedAction = await GetUnifiedSuggestedActionAsync(originalSolution, nestedAction, fix).ConfigureAwait(false);
                         unifiedNestedActions.Add(unifiedNestedAction);
                     }
 
                     var set = new UnifiedSuggestedActionSet(
+                        originalSolution,
                         categoryName: null,
                         actions: unifiedNestedActions.ToImmutable(),
                         title: null,
@@ -204,6 +213,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             ImmutableArray<FixAllScope> supportedScopes,
             Diagnostic firstDiagnostic,
             Workspace workspace,
+            Solution originalSolution,
             CancellationToken cancellationToken)
         {
             if (fixAllState == null)
@@ -244,6 +254,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             }
 
             return new UnifiedSuggestedActionSet(
+                originalSolution,
                 categoryName: null,
                 actions: fixAllSuggestedActions.ToImmutable(),
                 title: CodeFixesResources.Fix_all_occurrences_in,
@@ -264,6 +275,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
         /// always show up last after all other fixes (and refactorings) for the selected line of code.
         /// </remarks>
         private static ImmutableArray<UnifiedSuggestedActionSet> PrioritizeFixGroups(
+            Solution originalSolution,
             ImmutableDictionary<CodeFixGroupKey, IList<IUnifiedSuggestedAction>> map,
             ImmutableArray<CodeFixGroupKey> order,
             Workspace workspace)
@@ -277,11 +289,11 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
                 var actions = map[groupKey];
 
                 var nonSuppressionActions = actions.Where(a => !IsTopLevelSuppressionAction(a.OriginalCodeAction)).ToImmutableArray();
-                AddUnifiedSuggestedActionsSet(nonSuppressionActions, groupKey, nonSuppressionSets);
+                AddUnifiedSuggestedActionsSet(originalSolution, nonSuppressionActions, groupKey, nonSuppressionSets);
 
                 var suppressionActions = actions.Where(a => IsTopLevelSuppressionAction(a.OriginalCodeAction) &&
                     !IsBulkConfigurationAction(a.OriginalCodeAction)).ToImmutableArray();
-                AddUnifiedSuggestedActionsSet(suppressionActions, groupKey, suppressionSets);
+                AddUnifiedSuggestedActionsSet(originalSolution, suppressionActions, groupKey, suppressionSets);
 
                 bulkConfigurationActions.AddRange(actions.Where(a => IsBulkConfigurationAction(a.OriginalCodeAction)));
             }
@@ -292,6 +304,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             if (bulkConfigurationActions.Count > 0)
             {
                 var bulkConfigurationSet = new UnifiedSuggestedActionSet(
+                    originalSolution,
                     UnifiedPredefinedSuggestedActionCategoryNames.CodeFix,
                     bulkConfigurationActions.ToImmutable(),
                     title: null,
@@ -314,6 +327,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
                 // to get the span and category for the new top level suggested action.
                 var (span, category) = CombineSpansAndCategory(suppressionSets);
                 var wrappingSet = new UnifiedSuggestedActionSet(
+                    originalSolution,
                     category,
                     actions: ImmutableArray.Create<IUnifiedSuggestedAction>(wrappingSuggestedAction),
                     title: CodeFixesResources.Suppress_or_Configure_issues,
@@ -368,6 +382,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
         }
 
         private static void AddUnifiedSuggestedActionsSet(
+            Solution originalSolution,
             ImmutableArray<IUnifiedSuggestedAction> actions,
             CodeFixGroupKey groupKey,
             ArrayBuilder<UnifiedSuggestedActionSet> sets)
@@ -380,7 +395,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
                 Debug.Assert(groupKey.Item1.HasTextSpan);
                 var category = GetFixCategory(groupKey.Item1.Severity);
                 sets.Add(new UnifiedSuggestedActionSet(
-                    category, group.ToImmutableArray(), title: null, priority, applicableToSpan: groupKey.Item1.GetTextSpan()));
+                    originalSolution, category, group.ToImmutableArray(), title: null, priority, applicableToSpan: groupKey.Item1.GetTextSpan()));
             }
         }
 
@@ -491,6 +506,8 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             CodeRefactoring refactoring,
             CancellationToken cancellationToken)
         {
+            var originalSolution = document.Project.Solution;
+
             using var _ = ArrayBuilder<IUnifiedSuggestedAction>.GetInstance(out var refactoringSuggestedActions);
 
             foreach (var (action, applicableToSpan) in refactoring.CodeActions)
@@ -509,6 +526,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             //     and therefore the complexity of determining the closest one isn't worth the benefit
             //     of slightly more correct orderings in certain edge cases.
             return new UnifiedSuggestedActionSet(
+                originalSolution,
                 UnifiedPredefinedSuggestedActionCategoryNames.Refactoring,
                 actions: actions,
                 title: null,
@@ -528,6 +546,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
                     }
 
                     var set = new UnifiedSuggestedActionSet(
+                        originalSolution,
                         categoryName: null,
                         actions: nestedActions.ToImmutable(),
                         title: null,
@@ -577,6 +596,8 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
                 return null;
             }
 
+            var originalSolution = document.Project.Solution;
+
             using var fixAllSuggestedActionsDisposer = ArrayBuilder<IUnifiedSuggestedAction>.GetInstance(out var fixAllSuggestedActions);
             foreach (var scope in fixAllProviderInfo.SupportedScopes)
             {
@@ -601,6 +622,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             }
 
             return new UnifiedSuggestedActionSet(
+                originalSolution,
                 categoryName: null,
                 actions: fixAllSuggestedActions.ToImmutable(),
                 title: CodeFixesResources.Fix_all_occurrences_in,
@@ -698,7 +720,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
 
         private static UnifiedSuggestedActionSet WithPriority(
             UnifiedSuggestedActionSet set, UnifiedSuggestedActionSetPriority priority)
-            => new(set.CategoryName, set.Actions, set.Title, priority, set.ApplicableToSpan);
+            => new(set.OriginalSolution, set.CategoryName, set.Actions, set.Title, priority, set.ApplicableToSpan);
 
         private static ImmutableArray<UnifiedSuggestedActionSet> InlineActionSetsIfDesirable(
             ImmutableArray<UnifiedSuggestedActionSet> actionSets,
@@ -731,6 +753,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
             }
 
             return new UnifiedSuggestedActionSet(
+                actionSet.OriginalSolution,
                 actionSet.CategoryName,
                 newActions.ToImmutable(),
                 actionSet.Title,
@@ -770,7 +793,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
 
             return actions.Count == 0
                 ? null
-                : new UnifiedSuggestedActionSet(set.CategoryName, actions.ToImmutable(), set.Title, set.Priority, set.ApplicableToSpan);
+                : new UnifiedSuggestedActionSet(set.OriginalSolution, set.CategoryName, actions.ToImmutable(), set.Title, set.Priority, set.ApplicableToSpan);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/TableDataSource/Suppression/VisualStudioDiagnosticListTableCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/TableDataSource/Suppression/VisualStudioDiagnosticListTableCommandHandler.cs
@@ -206,6 +206,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 using var scope = context.AddScope(allowCancellation: true, ServicesVSResources.Updating_severity);
                 await _editHandlerService.ApplyAsync(
                     _workspace,
+                    project.Solution,
                     fromDocument: null,
                     operations: operations,
                     title: ServicesVSResources.Updating_severity,

--- a/src/VisualStudio/Core/Def/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
+++ b/src/VisualStudio/Core/Def/TableDataSource/Suppression/VisualStudioSuppressionFixService.cs
@@ -254,6 +254,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
             try
             {
                 using var token = _listener.BeginAsyncOperation(nameof(ApplySuppressionFix));
+
+                var originalSolution = _workspace.CurrentSolution;
                 var title = GetFixTitle(isAddSuppression);
                 var waitDialogMessage = GetWaitDialogMessage(isAddSuppression);
 
@@ -389,6 +391,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Suppression
                     using var scope = context.AddScope(allowCancellation: true, description: waitDialogMessage);
                     await _editHandlerService.ApplyAsync(
                         _workspace,
+                        originalSolution,
                         fromDocument: null,
                         operations: operations,
                         title: title,

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzersCommandHandler.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/AnalyzersCommandHandler.cs
@@ -431,6 +431,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                 allowCancellation: true,
                 showProgress: true);
 
+            var originalSolution = workspace.CurrentSolution;
             var selectedAction = MapSelectedItemToReportDiagnostic(selectedItem);
             if (!selectedAction.HasValue)
                 return;
@@ -465,6 +466,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
                             var operations = ImmutableArray.Create<CodeActionOperation>(new ApplyChangesOperation(newSolution));
                             await editHandlerService.ApplyAsync(
                                 _workspace,
+                                originalSolution,
                                 fromDocument: null,
                                 operations: operations,
                                 title: ServicesVSResources.Updating_severity,

--- a/src/Workspaces/Core/Portable/CodeActions/Operations/ApplyChangesOperation.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/Operations/ApplyChangesOperation.cs
@@ -3,9 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeActions
@@ -39,11 +43,105 @@ namespace Microsoft.CodeAnalysis.CodeActions
             => workspace.TryApplyChanges(ChangedSolution, new ProgressTracker());
 
         internal sealed override Task<bool> TryApplyAsync(
-            Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
+            Workspace workspace, Solution originalSolution, IProgressTracker progressTracker, CancellationToken cancellationToken)
         {
-            return workspace.TryApplyChanges(ChangedSolution, progressTracker)
-                ? SpecializedTasks.True
-                : SpecializedTasks.False;
+            var currentSolution = workspace.CurrentSolution;
+
+            // if there was no intermediary edit, just apply the change fully.
+            if (ChangedSolution.WorkspaceVersion == currentSolution.WorkspaceVersion)
+                return Task.FromResult(workspace.TryApplyChanges(ChangedSolution, progressTracker));
+
+            // Otherwise, we need to see what changes were actually made and see if we can apply them.  The general rules are:
+            //
+            // 1. we only support text changes when doing merges.  Any other changes to projects/documents are not
+            //    supported because it's very unclear what impact they may have wrt other workspace updates that have
+            //    already happened.
+            //
+            // 2. For text changes, we only support it if the current text of the document we're changing itself has not
+            //    changed. This means we can merge in edits if there were changes to unrelated files, but not if there
+            //    are changes to the current file.  We could consider relaxing this in the future, esp. if we make use
+            //    of some sort of text-merging-library to handle this.  However, the user would then have to handle diff
+            //    markers being inserted into their code that they then have to handle.
+
+            var solutionChanges = this.ChangedSolution.GetChanges(originalSolution);
+
+            if (solutionChanges.GetAddedProjects().Count() > 0 ||
+                solutionChanges.GetAddedAnalyzerReferences().Count() > 0 ||
+                solutionChanges.GetRemovedProjects().Count() > 0 ||
+                solutionChanges.GetRemovedAnalyzerReferences().Count() > 0)
+            {
+                return SpecializedTasks.False;
+            }
+
+            // Take the actual current solution the workspace is pointing to and fork it with just the text changes the
+            // code action wanted to make.  Then apply that fork back into the workspace.
+            var forkedSolution = currentSolution;
+
+            foreach (var changedProject in solutionChanges.GetProjectChanges())
+            {
+                // We only support text changes.  If we see any other changes to this project, bail out immediately.
+                if (changedProject.GetAddedAdditionalDocuments().Count() > 0 ||
+                    changedProject.GetAddedAnalyzerConfigDocuments().Count() > 0 ||
+                    changedProject.GetAddedAnalyzerReferences().Count() > 0 ||
+                    changedProject.GetAddedDocuments().Count() > 0 ||
+                    changedProject.GetAddedMetadataReferences().Count() > 0 ||
+                    changedProject.GetAddedProjectReferences().Count() > 0 ||
+                    changedProject.GetRemovedAdditionalDocuments().Count() > 0 ||
+                    changedProject.GetRemovedAnalyzerConfigDocuments().Count() > 0 ||
+                    changedProject.GetRemovedAnalyzerReferences().Count() > 0 ||
+                    changedProject.GetRemovedDocuments().Count() > 0 ||
+                    changedProject.GetRemovedMetadataReferences().Count() > 0 ||
+                    changedProject.GetRemovedProjectReferences().Count() > 0)
+                {
+                    return SpecializedTasks.False;
+                }
+
+                if (!ProcessDocuments(changedProject, changedProject.GetChangedDocuments(), static (s, i) => s.GetRequiredDocument(i), static (s, i, t) => s.WithDocumentText(i, t)) ||
+                    !ProcessDocuments(changedProject, changedProject.GetChangedAdditionalDocuments(), static (s, i) => s.GetRequiredAdditionalDocument(i), static (s, i, t) => s.WithAdditionalDocumentText(i, t)) ||
+                    !ProcessDocuments(changedProject, changedProject.GetChangedAnalyzerConfigDocuments(), static (s, i) => s.GetRequiredAnalyzerConfigDocument(i), static (s, i, t) => s.WithAnalyzerConfigDocumentText(i, t)))
+                {
+                    return SpecializedTasks.False;
+                }
+            }
+
+            return Task.FromResult(workspace.TryApplyChanges(forkedSolution, progressTracker));
+
+            bool ProcessDocuments(
+                ProjectChanges changedProject,
+                IEnumerable<DocumentId> changedDocuments,
+                Func<Solution, DocumentId, TextDocument> getDocument,
+                Func<Solution, DocumentId, SourceText, Solution> withDocumentText)
+            {
+                var sawChangedDocument = false;
+
+                foreach (var documentId in changedDocuments)
+                {
+                    sawChangedDocument = true;
+
+                    var originalDocument = getDocument(changedProject.OldProject.Solution, documentId);
+                    var changedDocument = getDocument(changedProject.NewProject.Solution, documentId);
+
+                    // it has to be a text change the operation wants to make.  If the operation is making some other
+                    // sort of change, we can't merge this operation in.
+                    if (!changedDocument.HasTextChanged(originalDocument, ignoreUnchangeableDocument: false))
+                        return false;
+
+                    // If the document has gone away, we definitely cannot apply a text change to it.
+                    var currentDocument = getDocument(currentSolution, documentId);
+                    if (currentDocument is null)
+                        return false;
+
+                    // If the file contents changed in the current workspace, then we can't apply this change to it.
+                    // Note: we could potentially try to do a 3-way merge in the future, including handling conflicts
+                    // with that.  For now though, we'll leave that out of scope.
+                    if (originalDocument.HasTextChanged(currentDocument, ignoreUnchangeableDocument: false))
+                        return false;
+
+                    forkedSolution = withDocumentText(forkedSolution, documentId, changedDocument.GetTextSynchronously(cancellationToken));
+                }
+
+                return sawChangedDocument;
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/CodeActions/Operations/ApplyChangesOperation.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/Operations/ApplyChangesOperation.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
                     }
 
                     // If the document has gone away, we definitely cannot apply a text change to it.
-                    var currentDocument = currentSolution.GetDocument(documentId);
+                    var currentDocument = currentSolution.GetTextDocument(documentId);
                     if (currentDocument is null)
                     {
                         Logger.Log(FunctionId.ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_DocumentRemoved, logLevel: LogLevel.Information);

--- a/src/Workspaces/Core/Portable/CodeActions/Operations/CodeActionOperation.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/Operations/CodeActionOperation.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
         /// Called by the host environment to apply the effect of the operation.
         /// This method is guaranteed to be called on the UI thread.
         /// </summary>
-        internal virtual Task<bool> TryApplyAsync(Workspace workspace, IProgressTracker progressTracker, CancellationToken cancellationToken)
+        internal virtual Task<bool> TryApplyAsync(Workspace workspace, Solution originalSolution, IProgressTracker progressTracker, CancellationToken cancellationToken)
         {
             // It is a requirement that this method be called on the UI thread.  So it's safe for us to call
             // into .Apply without any threading operations here.

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ProjectExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ProjectExtensions.cs
@@ -35,15 +35,13 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             => project.Solution.GetDocumentIdsWithFilePath(filePath).FirstOrDefault(id => id.ProjectId == project.Id);
 
         public static Document GetRequiredDocument(this Project project, DocumentId documentId)
-        {
-            var document = project.GetDocument(documentId);
-            if (document == null)
-            {
-                throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
-            }
+            => project.GetDocument(documentId) ?? throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
 
-            return document;
-        }
+        public static TextDocument GetRequiredAdditionalDocument(this Project project, DocumentId documentId)
+            => project.GetAdditionalDocument(documentId) ?? throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
+
+        public static TextDocument GetRequiredAnalyzerConfigDocument(this Project project, DocumentId documentId)
+            => project.GetAnalyzerConfigDocument(documentId) ?? throw new InvalidOperationException(WorkspaceExtensionsResources.The_solution_does_not_contain_the_specified_document);
 
         public static TextDocument GetRequiredTextDocument(this Project project, DocumentId documentId)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1941,9 +1941,9 @@ namespace Microsoft.CodeAnalysis
             this.OnAnalyzerConfigDocumentTextLoaderChanged(id, TextLoader.From(TextAndVersion.Create(text, VersionStamp.Create())));
         }
 
-        #endregion
+#endregion
 
-        #region Checks and Asserts
+#region Checks and Asserts
         /// <summary>
         /// Throws an exception is the solution is not empty.
         /// </summary>
@@ -2197,6 +2197,6 @@ namespace Microsoft.CodeAnalysis
         protected virtual string GetAnalyzerConfigDocumentName(DocumentId documentId)
             => GetDocumentName(documentId);
 
-        #endregion
+#endregion
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1941,9 +1941,9 @@ namespace Microsoft.CodeAnalysis
             this.OnAnalyzerConfigDocumentTextLoaderChanged(id, TextLoader.From(TextAndVersion.Create(text, VersionStamp.Create())));
         }
 
-#endregion
+        #endregion
 
-#region Checks and Asserts
+        #region Checks and Asserts
         /// <summary>
         /// Throws an exception is the solution is not empty.
         /// </summary>
@@ -2197,6 +2197,6 @@ namespace Microsoft.CodeAnalysis
         protected virtual string GetAnalyzerConfigDocumentName(DocumentId documentId)
             => GetDocumentName(documentId);
 
-#endregion
+        #endregion
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -548,5 +548,19 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         Refactoring_FixAllOccurrencesPreviewChanges = 563,
 
         LSP_UsedForkedSolution = 571,
+
+        ApplyChangesOperation_WorkspaceVersionMatch_ApplicationSucceeded = 580,
+        ApplyChangesOperation_WorkspaceVersionMatch_ApplicationFailed = 581,
+        ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationSucceeded = 582,
+        ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_IncompatibleSolutionChange = 583,
+        ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_IncompatibleProjectChange = 584,
+        ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_NoChangedDocument = 585,
+        ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_NoTextChange = 586,
+        ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_DocumentRemoved = 587,
+        ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_TextChangeConflict = 588,
+
+        // please leave the range up through 600 free in case we need to add more items to learn more about ApplyChangesOperation results.
+
+        Next = 600
     }
 }


### PR DESCRIPTION
Fixes [AB#1419139](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1419139).

The general issue we have is that our workspace "TryApplyChanges" logic instantly bails out if it sees that an intervening change to it happened *after* the solution snapshot which was used to compute the lightbulb action.  This is problematic in the case where some background event occurred (perhaps a file was touched outside of VS by a process we don't control), and we end up just failing out of hte operation silently.

THis is particularly problematic as nearly all lightbulbs just make simple text edits, and would have no problem still applying their changes to the workspace even if changes outside of that occurred.

This PR explores a new approach to lightbulb application.  First, if the workspace hasn't had an intermediary edit, we do the application as normal.  However, if there was some workspace change in between, we then fallback to a mode that tries to make the text edits the lightbulb wants *only* if we feel it is safe enough.  To be considered safe, we have the following criteria:

1. the edit the lightbulb wants to make can *only* include text edits (and not things like project edits).  It feels a little too unsafe to potentially make a project edit that might blow away some other high level change like that made outside of the lightbulb.   This is also important for the case where a user does some git operation in the back ground and projects are getting asynchronously reloaded.  We don't want conflicts with that where the lightbulb interferes with the project system.
2. The text edits must only be made to documents that don't have other text edits made to them.  This prevents us from having to deal with incompatible edits, and causing some set of edits to be lost, or introducing some set of conflict text changes the user then has to resolve.

Effectively, we say: if the lightbulb made only text changes, and those text changes are to files that are otherwise unchanged, it's still safe to make those text changes to the workspace in its current state.

Todo: 

- [ ] Tests.