### PR TITLE
Allow for Parsing Lambda Default Parameters

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -13383,13 +13383,8 @@ tryAgain:
             var identifier = this.ParseIdentifierToken();
             ParseParameterNullCheck(ref identifier, out var equalsToken);
 
-
-            // Handle the case where we have a default (optional) lambda parameter by eating '=', followed by 
-            // an EqualsValueClause which is simply an expression.
-            // The EqualsValueClause is then added as an attribute of the
-            // parsed parameter
+            // Parse default value if any
             equalsToken ??= TryEatToken(SyntaxKind.EqualsToken);
-
             var equalsValueClause = equalsToken == null
                 ? null
                 : _syntaxFactory.EqualsValueClause(equalsToken, this.ParseExpressionCore());

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -6820,13 +6820,13 @@ class Program
     }
 }";
             var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics( 
-                    // (4,20): error CS8917: The delegate type could not be inferred.
-                    //         var lam1 = (x = 7) => x;
-                    Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "(x = 7) => x").WithLocation(4, 20),
-                    // (4,23): error CS1065: Default values are not valid in this context.
-                    //         var lam1 = (x = 7) => x;
-                    Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(4, 23));
+            comp.VerifyDiagnostics(
+                // (5,20): error CS8917: The delegate type could not be inferred.
+                //         var lam1 = (x = 7) => x;
+                Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "(x = 7) => x").WithLocation(5, 20),
+                // (5,23): error CS1065: Default values are not valid in this context.
+                //         var lam1 = (x = 7) => x;
+                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(5, 23));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -6782,5 +6782,27 @@ class Program
             Assert.Equal(RefKind.In, lambdas[1].Parameters[0].RefKind);
             Assert.Equal(RefKind.Out, lambdas[2].Parameters[0].RefKind);
         }
+
+
+        [Fact]
+        public void LambdaWithImplicitDefaultParam()
+        {
+            var source =
+@"class Program {
+    public static void Main(string[] args)
+    {
+        var lam1 = (x = 7) => x;
+        lam1();
+    }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics( 
+                    // (4,20): error CS8917: The delegate type could not be inferred.
+                    //         var lam1 = (x = 7) => x;
+                    Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "(x = 7) => x").WithLocation(4, 20),
+                    // (4,23): error CS1065: Default values are not valid in this context.
+                    //         var lam1 = (x = 7) => x;
+                    Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(4, 23));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -6783,12 +6783,36 @@ class Program
             Assert.Equal(RefKind.Out, lambdas[2].Parameters[0].RefKind);
         }
 
+        [Fact]
+        public void LambdaWithExplicitDefaultParam()
+        {
+            var source =
+@"class Program 
+{
+    public static void Main(string[] args)
+    {
+        var lam1 = (int x = 7) => x;
+        lam1();
+    }
+}
+";
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (5,27): error CS1065: Default values are not valid in this context.
+                //         var lam1 = (int x = 7) => x;
+                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(5, 27),
+                // (6,9): error CS7036: There is no argument given that corresponds to the required formal parameter 'arg' of 'Func<int, int>'
+                //         lam1();
+                Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "lam1").WithArguments("arg", "System.Func<int, int>").WithLocation(6, 9));
+        }
 
         [Fact]
         public void LambdaWithImplicitDefaultParam()
         {
             var source =
-@"class Program {
+@"class Program 
+{
     public static void Main(string[] args)
     {
         var lam1 = (x = 7) => x;

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
@@ -5,7 +5,6 @@
 #nullable disable
 
 using System;
-using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -3592,9 +3591,7 @@ class C {
         [Fact]
         public void TestDefaultValueTypedNestedLambda()
         {
-            var source = @"(Func<Func<Func<Func<int, int>, Func<int, int>>, Func<Func<int, int>, Func<int, int>>>, Func<Func<Func<int, int>, Func<int, int>>, Func<Func<int, int>, Func<int, int>>>> a = 
-                                    (Func<Func<Func<int, int>, Func<int, int>>, Func<Func<int, int>, Func<int, int>>> b = 
-                                                    (Func<Func<int, int>, Func<int, int>> c = (Func<int, int> d = (int e = 1) => e) => d) => c) => b) => a";
+            var source = @"(Func<int, int> a = (int b = 5) => b) => a";
             UsingExpression(source);
 
             N(SyntaxKind.ParenthesizedLambdaExpression);
@@ -3610,210 +3607,14 @@ class C {
                             N(SyntaxKind.TypeArgumentList);
                             {
                                 N(SyntaxKind.LessThanToken);
-                                N(SyntaxKind.GenericName);
+                                N(SyntaxKind.PredefinedType);
                                 {
-                                    N(SyntaxKind.IdentifierToken, "Func");
-                                    N(SyntaxKind.TypeArgumentList);
-                                    {
-                                        N(SyntaxKind.LessThanToken);
-                                        N(SyntaxKind.GenericName);
-                                        {
-                                            N(SyntaxKind.IdentifierToken, "Func");
-                                            N(SyntaxKind.TypeArgumentList);
-                                            {
-                                                N(SyntaxKind.LessThanToken);
-                                                N(SyntaxKind.GenericName);
-                                                {
-                                                    N(SyntaxKind.IdentifierToken, "Func");
-                                                    N(SyntaxKind.TypeArgumentList);
-                                                    {
-                                                        N(SyntaxKind.LessThanToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.CommaToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.GreaterThanToken);
-                                                    }
-                                                }
-                                                N(SyntaxKind.CommaToken);
-                                                N(SyntaxKind.GenericName);
-                                                {
-                                                    N(SyntaxKind.IdentifierToken, "Func");
-                                                    N(SyntaxKind.TypeArgumentList);
-                                                    {
-                                                        N(SyntaxKind.LessThanToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.CommaToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.GreaterThanToken);
-                                                    }
-                                                }
-                                                N(SyntaxKind.GreaterThanToken);
-                                            }
-                                        }
-                                        N(SyntaxKind.CommaToken);
-                                        N(SyntaxKind.GenericName);
-                                        {
-                                            N(SyntaxKind.IdentifierToken, "Func");
-                                            N(SyntaxKind.TypeArgumentList);
-                                            {
-                                                N(SyntaxKind.LessThanToken);
-                                                N(SyntaxKind.GenericName);
-                                                {
-                                                    N(SyntaxKind.IdentifierToken, "Func");
-                                                    N(SyntaxKind.TypeArgumentList);
-                                                    {
-                                                        N(SyntaxKind.LessThanToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.CommaToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.GreaterThanToken);
-                                                    }
-                                                }
-                                                N(SyntaxKind.CommaToken);
-                                                N(SyntaxKind.GenericName);
-                                                {
-                                                    N(SyntaxKind.IdentifierToken, "Func");
-                                                    N(SyntaxKind.TypeArgumentList);
-                                                    {
-                                                        N(SyntaxKind.LessThanToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.CommaToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.GreaterThanToken);
-                                                    }
-                                                }
-                                                N(SyntaxKind.GreaterThanToken);
-                                            }
-                                        }
-                                        N(SyntaxKind.GreaterThanToken);
-                                    }
+                                    N(SyntaxKind.IntKeyword);
                                 }
                                 N(SyntaxKind.CommaToken);
-                                N(SyntaxKind.GenericName);
+                                N(SyntaxKind.PredefinedType);
                                 {
-                                    N(SyntaxKind.IdentifierToken, "Func");
-                                    N(SyntaxKind.TypeArgumentList);
-                                    {
-                                        N(SyntaxKind.LessThanToken);
-                                        N(SyntaxKind.GenericName);
-                                        {
-                                            N(SyntaxKind.IdentifierToken, "Func");
-                                            N(SyntaxKind.TypeArgumentList);
-                                            {
-                                                N(SyntaxKind.LessThanToken);
-                                                N(SyntaxKind.GenericName);
-                                                {
-                                                    N(SyntaxKind.IdentifierToken, "Func");
-                                                    N(SyntaxKind.TypeArgumentList);
-                                                    {
-                                                        N(SyntaxKind.LessThanToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.CommaToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.GreaterThanToken);
-                                                    }
-                                                }
-                                                N(SyntaxKind.CommaToken);
-                                                N(SyntaxKind.GenericName);
-                                                {
-                                                    N(SyntaxKind.IdentifierToken, "Func");
-                                                    N(SyntaxKind.TypeArgumentList);
-                                                    {
-                                                        N(SyntaxKind.LessThanToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.CommaToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.GreaterThanToken);
-                                                    }
-                                                }
-                                                N(SyntaxKind.GreaterThanToken);
-                                            }
-                                        }
-                                        N(SyntaxKind.CommaToken);
-                                        N(SyntaxKind.GenericName);
-                                        {
-                                            N(SyntaxKind.IdentifierToken, "Func");
-                                            N(SyntaxKind.TypeArgumentList);
-                                            {
-                                                N(SyntaxKind.LessThanToken);
-                                                N(SyntaxKind.GenericName);
-                                                {
-                                                    N(SyntaxKind.IdentifierToken, "Func");
-                                                    N(SyntaxKind.TypeArgumentList);
-                                                    {
-                                                        N(SyntaxKind.LessThanToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.CommaToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.GreaterThanToken);
-                                                    }
-                                                }
-                                                N(SyntaxKind.CommaToken);
-                                                N(SyntaxKind.GenericName);
-                                                {
-                                                    N(SyntaxKind.IdentifierToken, "Func");
-                                                    N(SyntaxKind.TypeArgumentList);
-                                                    {
-                                                        N(SyntaxKind.LessThanToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.CommaToken);
-                                                        N(SyntaxKind.PredefinedType);
-                                                        {
-                                                            N(SyntaxKind.IntKeyword);
-                                                        }
-                                                        N(SyntaxKind.GreaterThanToken);
-                                                    }
-                                                }
-                                                N(SyntaxKind.GreaterThanToken);
-                                            }
-                                        }
-                                        N(SyntaxKind.GreaterThanToken);
-                                    }
+                                    N(SyntaxKind.IntKeyword);
                                 }
                                 N(SyntaxKind.GreaterThanToken);
                             }
@@ -3829,248 +3630,17 @@ class C {
                                     N(SyntaxKind.OpenParenToken);
                                     N(SyntaxKind.Parameter);
                                     {
-                                        N(SyntaxKind.GenericName);
+                                        N(SyntaxKind.PredefinedType);
                                         {
-                                            N(SyntaxKind.IdentifierToken, "Func");
-                                            N(SyntaxKind.TypeArgumentList);
-                                            {
-                                                N(SyntaxKind.LessThanToken);
-                                                N(SyntaxKind.GenericName);
-                                                {
-                                                    N(SyntaxKind.IdentifierToken, "Func");
-                                                    N(SyntaxKind.TypeArgumentList);
-                                                    {
-                                                        N(SyntaxKind.LessThanToken);
-                                                        N(SyntaxKind.GenericName);
-                                                        {
-                                                            N(SyntaxKind.IdentifierToken, "Func");
-                                                            N(SyntaxKind.TypeArgumentList);
-                                                            {
-                                                                N(SyntaxKind.LessThanToken);
-                                                                N(SyntaxKind.PredefinedType);
-                                                                {
-                                                                    N(SyntaxKind.IntKeyword);
-                                                                }
-                                                                N(SyntaxKind.CommaToken);
-                                                                N(SyntaxKind.PredefinedType);
-                                                                {
-                                                                    N(SyntaxKind.IntKeyword);
-                                                                }
-                                                                N(SyntaxKind.GreaterThanToken);
-                                                            }
-                                                        }
-                                                        N(SyntaxKind.CommaToken);
-                                                        N(SyntaxKind.GenericName);
-                                                        {
-                                                            N(SyntaxKind.IdentifierToken, "Func");
-                                                            N(SyntaxKind.TypeArgumentList);
-                                                            {
-                                                                N(SyntaxKind.LessThanToken);
-                                                                N(SyntaxKind.PredefinedType);
-                                                                {
-                                                                    N(SyntaxKind.IntKeyword);
-                                                                }
-                                                                N(SyntaxKind.CommaToken);
-
-                                                                N(SyntaxKind.PredefinedType);
-                                                                {
-                                                                    N(SyntaxKind.IntKeyword);
-                                                                }
-                                                                N(SyntaxKind.GreaterThanToken);
-                                                            }
-                                                        }
-                                                        N(SyntaxKind.GreaterThanToken);
-                                                    }
-                                                }
-                                                N(SyntaxKind.CommaToken);
-                                                N(SyntaxKind.GenericName);
-                                                {
-                                                    N(SyntaxKind.IdentifierToken, "Func");
-                                                    N(SyntaxKind.TypeArgumentList);
-                                                    {
-                                                        N(SyntaxKind.LessThanToken);
-                                                        N(SyntaxKind.GenericName);
-                                                        {
-                                                            N(SyntaxKind.IdentifierToken, "Func");
-                                                            N(SyntaxKind.TypeArgumentList);
-                                                            {
-                                                                N(SyntaxKind.LessThanToken);
-                                                                N(SyntaxKind.PredefinedType);
-                                                                {
-                                                                    N(SyntaxKind.IntKeyword);
-                                                                }
-                                                                N(SyntaxKind.CommaToken);
-                                                                N(SyntaxKind.PredefinedType);
-                                                                {
-                                                                    N(SyntaxKind.IntKeyword);
-                                                                }
-                                                                N(SyntaxKind.GreaterThanToken);
-                                                            }
-                                                        }
-                                                        N(SyntaxKind.CommaToken);
-                                                        N(SyntaxKind.GenericName);
-                                                        {
-                                                            N(SyntaxKind.IdentifierToken, "Func");
-                                                            N(SyntaxKind.TypeArgumentList);
-                                                            {
-                                                                N(SyntaxKind.LessThanToken);
-                                                                N(SyntaxKind.PredefinedType);
-                                                                {
-                                                                    N(SyntaxKind.IntKeyword);
-                                                                }
-                                                                N(SyntaxKind.CommaToken);
-                                                                N(SyntaxKind.PredefinedType);
-                                                                {
-                                                                    N(SyntaxKind.IntKeyword);
-                                                                }
-                                                                N(SyntaxKind.GreaterThanToken);
-                                                            }
-                                                        }
-                                                        N(SyntaxKind.GreaterThanToken);
-                                                    }
-                                                }
-                                                N(SyntaxKind.GreaterThanToken);
-                                            }
+                                            N(SyntaxKind.IntKeyword);
                                         }
                                         N(SyntaxKind.IdentifierToken, "b");
                                         N(SyntaxKind.EqualsValueClause);
                                         {
                                             N(SyntaxKind.EqualsToken);
-                                            N(SyntaxKind.ParenthesizedLambdaExpression);
+                                            N(SyntaxKind.NumericLiteralExpression);
                                             {
-                                                N(SyntaxKind.ParameterList);
-                                                {
-                                                    N(SyntaxKind.OpenParenToken);
-                                                    N(SyntaxKind.Parameter);
-
-                                                    {
-                                                        N(SyntaxKind.GenericName);
-                                                        {
-                                                            N(SyntaxKind.IdentifierToken, "Func");
-                                                            N(SyntaxKind.TypeArgumentList);
-                                                            {
-                                                                N(SyntaxKind.LessThanToken);
-                                                                N(SyntaxKind.GenericName);
-                                                                {
-                                                                    N(SyntaxKind.IdentifierToken, "Func");
-                                                                    N(SyntaxKind.TypeArgumentList);
-                                                                    {
-                                                                        N(SyntaxKind.LessThanToken);
-                                                                        N(SyntaxKind.PredefinedType);
-                                                                        {
-                                                                            N(SyntaxKind.IntKeyword);
-                                                                        }
-                                                                        N(SyntaxKind.CommaToken);
-                                                                        N(SyntaxKind.PredefinedType);
-                                                                        {
-                                                                            N(SyntaxKind.IntKeyword);
-                                                                        }
-                                                                        N(SyntaxKind.GreaterThanToken);
-                                                                    }
-                                                                }
-                                                                N(SyntaxKind.CommaToken);
-                                                                N(SyntaxKind.GenericName);
-                                                                {
-                                                                    N(SyntaxKind.IdentifierToken, "Func");
-                                                                    N(SyntaxKind.TypeArgumentList);
-                                                                    {
-                                                                        N(SyntaxKind.LessThanToken);
-                                                                        N(SyntaxKind.PredefinedType);
-                                                                        {
-                                                                            N(SyntaxKind.IntKeyword);
-                                                                        }
-                                                                        N(SyntaxKind.CommaToken);
-                                                                        N(SyntaxKind.PredefinedType);
-                                                                        {
-                                                                            N(SyntaxKind.IntKeyword);
-                                                                        }
-                                                                        N(SyntaxKind.GreaterThanToken);
-                                                                    }
-                                                                }
-                                                                N(SyntaxKind.GreaterThanToken);
-                                                            }
-                                                        }
-                                                        N(SyntaxKind.IdentifierToken, "c");
-                                                        N(SyntaxKind.EqualsValueClause);
-                                                        {
-                                                            N(SyntaxKind.EqualsToken);
-                                                            N(SyntaxKind.ParenthesizedLambdaExpression);
-                                                            {
-                                                                N(SyntaxKind.ParameterList);
-                                                                {
-                                                                    N(SyntaxKind.OpenParenToken);
-                                                                    N(SyntaxKind.Parameter);
-                                                                    {
-                                                                        N(SyntaxKind.GenericName);
-                                                                        {
-                                                                            N(SyntaxKind.IdentifierToken, "Func");
-                                                                            N(SyntaxKind.TypeArgumentList);
-                                                                            {
-                                                                                N(SyntaxKind.LessThanToken);
-                                                                                N(SyntaxKind.PredefinedType);
-                                                                                {
-                                                                                    N(SyntaxKind.IntKeyword);
-                                                                                }
-                                                                                N(SyntaxKind.CommaToken);
-                                                                                N(SyntaxKind.PredefinedType);
-                                                                                {
-                                                                                    N(SyntaxKind.IntKeyword);
-                                                                                }
-                                                                                N(SyntaxKind.GreaterThanToken);
-                                                                            }
-                                                                        }
-                                                                        N(SyntaxKind.IdentifierToken, "d");
-                                                                        N(SyntaxKind.EqualsValueClause);
-                                                                        {
-                                                                            N(SyntaxKind.EqualsToken);
-                                                                            N(SyntaxKind.ParenthesizedLambdaExpression);
-                                                                            {
-                                                                                N(SyntaxKind.ParameterList);
-                                                                                {
-                                                                                    N(SyntaxKind.OpenParenToken);
-                                                                                    N(SyntaxKind.Parameter);
-                                                                                    {
-                                                                                        N(SyntaxKind.PredefinedType);
-                                                                                        {
-                                                                                            N(SyntaxKind.IntKeyword);
-                                                                                        }
-                                                                                        N(SyntaxKind.IdentifierToken, "e");
-                                                                                        N(SyntaxKind.EqualsValueClause);
-                                                                                        {
-                                                                                            N(SyntaxKind.EqualsToken);
-                                                                                            N(SyntaxKind.NumericLiteralExpression);
-                                                                                            {
-                                                                                                N(SyntaxKind.NumericLiteralToken, "1");
-                                                                                            }
-                                                                                        }
-                                                                                    }
-                                                                                    N(SyntaxKind.CloseParenToken);
-                                                                                }
-                                                                                N(SyntaxKind.EqualsGreaterThanToken);
-                                                                                N(SyntaxKind.IdentifierName);
-                                                                                {
-                                                                                    N(SyntaxKind.IdentifierToken, "e");
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                    N(SyntaxKind.CloseParenToken);
-                                                                }
-                                                                N(SyntaxKind.EqualsGreaterThanToken);
-                                                                N(SyntaxKind.IdentifierName);
-                                                                {
-                                                                    N(SyntaxKind.IdentifierToken, "d");
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                    N(SyntaxKind.CloseParenToken);
-                                                }
-                                                N(SyntaxKind.EqualsGreaterThanToken);
-                                                N(SyntaxKind.IdentifierName);
-                                                {
-                                                    N(SyntaxKind.IdentifierToken, "c");
-                                                }
+                                                N(SyntaxKind.NumericLiteralToken, "5");
                                             }
                                         }
                                     }
@@ -4171,7 +3741,6 @@ class C {
             }
             EOF();
         }
-
 
         [Fact]
         public void TestNullCheckedDefaultValueSimpleLambda()

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -2651,7 +2652,7 @@ class C {
         }
 
         [Fact]
-        public void TestDefaultValueMissingRestOfLambda()
+        public void TestDefaultValueMissingRestOfLambda1()
         {
             string source = "(int x =";
             UsingExpression(source,
@@ -2676,6 +2677,286 @@ class C {
             }
             EOF();
         }
+
+
+        [Fact]
+        public void TestDefaultValueMissingRestOfLambda2()
+        {
+            string source = "(int x = 5";
+            UsingExpression(source,
+                // (1,1): error CS1073: Unexpected token 'x'
+                // (int x =
+                Diagnostic(ErrorCode.ERR_UnexpectedToken, "(int ").WithArguments("x").WithLocation(1, 1),
+                // (1,2): error CS1525: Invalid expression term 'int'
+                // (int x =
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(1, 2),
+                // (1,6): error CS1026: ) expected
+                // (int x =
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "x").WithLocation(1, 6));
+
+            N(SyntaxKind.ParenthesizedExpression);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.PredefinedType);
+                {
+                    N(SyntaxKind.IntKeyword);
+                }
+                M(SyntaxKind.CloseParenToken);
+            }
+            EOF();
+        }
+
+
+        [Fact]
+        public void TestDefaultValueMissingRestOfLambda3()
+        {
+            string source = "(int x = 3,";
+            UsingExpression(source,
+                // (1,1): error CS1073: Unexpected token 'x'
+                // (int x =
+                Diagnostic(ErrorCode.ERR_UnexpectedToken, "(int ").WithArguments("x").WithLocation(1, 1),
+                // (1,2): error CS1525: Invalid expression term 'int'
+                // (int x =
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(1, 2),
+                // (1,6): error CS1026: ) expected
+                // (int x =
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "x").WithLocation(1, 6));
+
+            N(SyntaxKind.ParenthesizedExpression);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.PredefinedType);
+                {
+                    N(SyntaxKind.IntKeyword);
+                }
+                M(SyntaxKind.CloseParenToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void TestDefaultValueNoIdentifier()
+        {
+            string source = "(int = 3) => 4";
+            UsingExpression(source,
+                // (1,6): error CS1001: Identifier expected
+                // (int = 3) => 4
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "=").WithLocation(1, 6));
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        M(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.NumericLiteralExpression);
+                            {
+                                N(SyntaxKind.NumericLiteralToken, "3");
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "4");
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void TestDefaultValueDoubleEquals()
+        {
+            string source = "(int x = 3 = 3) => x";
+            UsingExpression(source);
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "x");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.SimpleAssignmentExpression);
+                            {
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "3");
+                                }
+                                N(SyntaxKind.EqualsToken);
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "3");
+                                }
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void TestDefaultValueEqualsEquals()
+        {
+            string source = "(int x == 4) => x";
+            UsingExpression(source,
+                // (1,1): error CS1073: Unexpected token 'x'
+                // (int x == 4) => x
+                Diagnostic(ErrorCode.ERR_UnexpectedToken, "(int ").WithArguments("x").WithLocation(1, 1),
+                // (1,2): error CS1525: Invalid expression term 'int'
+                // (int x == 4) => x
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(1, 2),
+                // (1,6): error CS1026: ) expected
+                // (int x == 4) => x
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "x").WithLocation(1, 6));
+
+            N(SyntaxKind.ParenthesizedExpression);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.PredefinedType);
+                {
+                    N(SyntaxKind.IntKeyword);
+                }
+                M(SyntaxKind.CloseParenToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void TestDefaultValueDelegateSyntax()
+        {
+            string source = "delegate(int x = 10) { return x; }";
+            UsingExpression(source);
+
+            N(SyntaxKind.AnonymousMethodExpression);
+            {
+                N(SyntaxKind.DelegateKeyword);
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "x");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.NumericLiteralExpression);
+                            {
+                                N(SyntaxKind.NumericLiteralToken, "10");
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.Block);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.ReturnStatement);
+                    {
+                        N(SyntaxKind.ReturnKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "x");
+                        }
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            EOF();
+        }
+
+
+        [Fact]
+        public void TestDefaultValueWithAttributeOnParam()
+        {
+            string source = "([MyAttribute(3, arg1=true)] int x = -1) => x";
+            UsingExpression(source);
+            EOF();
+        }
+
+        [Fact]
+        public void TestDefaultValueWithOtherModifiers()
+        {
+            string source = "(ref int a, out int b, int c = 0) => { b = a + c; }";
+            UsingExpression(source);
+            EOF();
+        }
+
+
+        [Fact]
+        public void TestDefaultValueWithComplexExpression1()
+        {
+            string source = "(int arg = y switch { < 0 => -1, 0 => 0, > 0 => 1}) => arg";
+            UsingExpression(source);
+            EOF();
+        }
+
+        [Fact]
+        public void TestDefaultValueWithLambdaAsValue()
+        {
+            string source = "(int arg, Func<int, int> lam = (x) => 2 * x) => lam(arg)";
+            UsingExpression(source);
+            EOF();
+        }
+
+        [Fact]
+        public void TestDefaultValueWithSwitchLambdaAsValue()
+        {
+
+            string source = @"(int arg,
+                            Func<int, Color> colorFunc = (Color c = Color.Red) => c switch 
+                                                                           { 1 => Color.Green, 2 => Color.Red, 3 => Color.Blue }) =>
+            { return colorFunc(arg); }";
+            UsingExpression(source);
+            EOF();
+        }
+
+        [Fact]
+        public void TestDefaultValueNestedParens()
+        {
+            string source = "(a = (b = (c = (d = 3) => d) => c) => b) => a";
+            UsingExpression(source);
+            EOF();
+        }
+
+        [Fact]
+        public void TestDefaultValueWithComplexExpression2()
+        {
+            string source = "(int arg = a ? b ? w : x : c ? y : z)  => arg";
+            UsingExpression(source);
+            EOF();
+        }
+
 
         [Fact]
         public void TestNullCheckedDefaultValueSimpleLambda()

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
@@ -2176,10 +2176,7 @@ class C {
         [Fact]
         public void TestDefaultValueParenthesizedLambda1()
         {
-            UsingDeclaration("Func<string, string> func0 = (x = null) => x;", options: TestOptions.RegularPreview,
-                // (1,33): error CS1065: Default values are not valid in this context.
-                // Func<string, string> func0 = (x = null) => x;
-                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(1, 33));
+            UsingDeclaration("Func<string, string> func0 = (x = null) => x;");
             N(SyntaxKind.FieldDeclaration);
             {
                 N(SyntaxKind.VariableDeclaration);
@@ -2216,6 +2213,14 @@ class C {
                                     N(SyntaxKind.Parameter);
                                     {
                                         N(SyntaxKind.IdentifierToken, "x");
+                                        N(SyntaxKind.EqualsValueClause);
+                                        {
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.NullLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NullKeyword);
+                                            }
+                                        }
                                     }
                                     N(SyntaxKind.CloseParenToken);
                                 }
@@ -2236,10 +2241,8 @@ class C {
         [Fact]
         public void TestDefaultValueParenthesizedLambda2()
         {
-            UsingDeclaration("Func<string, string> func0 = (y, x = null) => x;", options: TestOptions.RegularPreview,
-                    // (1,36): error CS1065: Default values are not valid in this context.
-                    // Func<string, string> func0 = (y, x = null) => x;
-                    Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(1, 36));
+            UsingDeclaration("Func<string, string> func0 = (y, x = null) => x;");
+
             N(SyntaxKind.FieldDeclaration);
             {
                 N(SyntaxKind.VariableDeclaration);
@@ -2281,6 +2284,14 @@ class C {
                                     N(SyntaxKind.Parameter);
                                     {
                                         N(SyntaxKind.IdentifierToken, "x");
+                                        N(SyntaxKind.EqualsValueClause);
+                                        {
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.NullLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NullKeyword);
+                                            }
+                                        }
                                     }
                                     N(SyntaxKind.CloseParenToken);
                                 }
@@ -2301,10 +2312,8 @@ class C {
         [Fact]
         public void TestDefaultValueParenthesizedLambdaWithType1()
         {
-            UsingDeclaration("Func<string, string> func0 = (string x = null) => x;", options: TestOptions.RegularPreview,
-                    // (1,40): error CS1065: Default values are not valid in this context.
-                    // Func<string, string> func0 = (string x = null) => x;
-                    Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(1, 40));
+            UsingDeclaration("Func<string, string> func0 = (string x = null) => x;");
+
             N(SyntaxKind.FieldDeclaration);
             {
                 N(SyntaxKind.VariableDeclaration);
@@ -2345,6 +2354,14 @@ class C {
                                             N(SyntaxKind.StringKeyword);
                                         }
                                         N(SyntaxKind.IdentifierToken, "x");
+                                        N(SyntaxKind.EqualsValueClause);
+                                        {
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.NullLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NullKeyword);
+                                            }
+                                        }
                                     }
                                     N(SyntaxKind.CloseParenToken);
                                 }
@@ -2365,10 +2382,8 @@ class C {
         [Fact]
         public void TestDefaultValueParenthesizedLambdaWithType2()
         {
-            UsingDeclaration("Func<string, string> func0 = (string y, string x = null) => x;", options: TestOptions.RegularPreview,
-                    // (1,50): error CS1065: Default values are not valid in this context.
-                    // Func<string, string> func0 = (string y, string x = null) => x;
-                    Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(1, 50));
+            UsingDeclaration("Func<string, string> func0 = (string y, string x = null) => x;");
+
             N(SyntaxKind.FieldDeclaration);
             {
                 N(SyntaxKind.VariableDeclaration);
@@ -2418,6 +2433,15 @@ class C {
                                             N(SyntaxKind.StringKeyword);
                                         }
                                         N(SyntaxKind.IdentifierToken, "x");
+                                        N(SyntaxKind.EqualsValueClause);
+                                        {
+
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.NullLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NullKeyword);
+                                            }
+                                        }
                                     }
                                     N(SyntaxKind.CloseParenToken);
                                 }
@@ -2431,6 +2455,224 @@ class C {
                     }
                 }
                 N(SyntaxKind.SemicolonToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void TestDefaultValueParameterNonConstantExpression()
+        {
+            string source = "(double d = x + y) => d * 2";
+            UsingExpression(source);
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.DoubleKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "d");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.AddExpression);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "x");
+                                }
+                                N(SyntaxKind.PlusToken);
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "y");
+                                }
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.MultiplyExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "d");
+                    }
+                    N(SyntaxKind.AsteriskToken);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "2");
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void TestDefaultMissingValueClause1()
+        {
+            string source = "(string a, double b = ) => double.Parse(a) + b";
+            UsingExpression(source,
+                // (1,23): error CS1525: Invalid expression term ')'
+                // (string a, double b = ) => double.Parse(a) + b
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(1, 23));
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.StringKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.DoubleKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "b");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.AddExpression);
+                {
+                    N(SyntaxKind.InvocationExpression);
+                    {
+                        N(SyntaxKind.SimpleMemberAccessExpression);
+                        {
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.DoubleKeyword);
+                            }
+                            N(SyntaxKind.DotToken);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "Parse");
+                            }
+                        }
+                        N(SyntaxKind.ArgumentList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.Argument);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "a");
+                                }
+                            }
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                    }
+                    N(SyntaxKind.PlusToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "b");
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void TestDefaultMissingValueClause2()
+        {
+            string source = "(int x = , int y) => x + y";
+            UsingExpression(source,
+                    // (1,10): error CS1525: Invalid expression term ','
+                    // (int x = , int y) => x + y
+                    Diagnostic(ErrorCode.ERR_InvalidExprTerm, ",").WithArguments(",").WithLocation(1, 10));
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "x");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "y");
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.AddExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "x");
+                    }
+                    N(SyntaxKind.PlusToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "y");
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void TestDefaultValueMissingRestOfLambda()
+        {
+            string source = "(int x =";
+            UsingExpression(source,
+                // (1,1): error CS1073: Unexpected token 'x'
+                // (int x =
+                Diagnostic(ErrorCode.ERR_UnexpectedToken, "(int ").WithArguments("x").WithLocation(1, 1),
+                // (1,2): error CS1525: Invalid expression term 'int'
+                // (int x =
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "int").WithArguments("int").WithLocation(1, 2),
+                // (1,6): error CS1026: ) expected
+                // (int x =
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "x").WithLocation(1, 6));
+
+            N(SyntaxKind.ParenthesizedExpression);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.PredefinedType);
+                {
+                    N(SyntaxKind.IntKeyword);
+                }
+                M(SyntaxKind.CloseParenToken);
             }
             EOF();
         }
@@ -2504,10 +2746,8 @@ class C {
             UsingDeclaration("Func<string, string> func0 = (x!! = null) => x;", options: TestOptions.RegularPreview,
                 // (1,32): error CS8989: The 'parameter null-checking' feature is not supported.
                 // Func<string, string> func0 = (x!! = null) => x;
-                Diagnostic(ErrorCode.ERR_ParameterNullCheckingNotSupported, "!").WithLocation(1, 32),
-                // (1,35): error CS1065: Default values are not valid in this context.
-                // Func<string, string> func0 = (x!! = null) => x;
-                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(1, 35));
+                Diagnostic(ErrorCode.ERR_ParameterNullCheckingNotSupported, "!").WithLocation(1, 32));
+
             N(SyntaxKind.FieldDeclaration);
             {
                 N(SyntaxKind.VariableDeclaration);
@@ -2544,6 +2784,14 @@ class C {
                                     N(SyntaxKind.Parameter);
                                     {
                                         N(SyntaxKind.IdentifierToken, "x");
+                                        N(SyntaxKind.EqualsValueClause);
+                                        {
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.NullLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NullKeyword);
+                                            }
+                                        }
                                     }
                                     N(SyntaxKind.CloseParenToken);
                                 }
@@ -2567,10 +2815,8 @@ class C {
             UsingDeclaration("Func<string, string> func0 = (y, x!! = null) => x;", options: TestOptions.RegularPreview,
                 // (1,35): error CS8989: The 'parameter null-checking' feature is not supported.
                 // Func<string, string> func0 = (y, x!! = null) => x;
-                Diagnostic(ErrorCode.ERR_ParameterNullCheckingNotSupported, "!").WithLocation(1, 35),
-                // (1,38): error CS1065: Default values are not valid in this context.
-                // Func<string, string> func0 = (y, x!! = null) => x;
-                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(1, 38));
+                Diagnostic(ErrorCode.ERR_ParameterNullCheckingNotSupported, "!").WithLocation(1, 35));
+
             N(SyntaxKind.FieldDeclaration);
             {
                 N(SyntaxKind.VariableDeclaration);
@@ -2612,6 +2858,14 @@ class C {
                                     N(SyntaxKind.Parameter);
                                     {
                                         N(SyntaxKind.IdentifierToken, "x");
+                                        N(SyntaxKind.EqualsValueClause);
+                                        {
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.NullLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NullKeyword);
+                                            }
+                                        }
                                     }
                                     N(SyntaxKind.CloseParenToken);
                                 }
@@ -2635,10 +2889,8 @@ class C {
             UsingDeclaration("Func<string, string> func0 = (string x!! = null) => x;", options: TestOptions.RegularPreview,
                 // (1,39): error CS8989: The 'parameter null-checking' feature is not supported.
                 // Func<string, string> func0 = (string x!! = null) => x;
-                Diagnostic(ErrorCode.ERR_ParameterNullCheckingNotSupported, "!").WithLocation(1, 39),
-                // (1,42): error CS1065: Default values are not valid in this context.
-                // Func<string, string> func0 = (string x!! = null) => x;
-                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(1, 42));
+                Diagnostic(ErrorCode.ERR_ParameterNullCheckingNotSupported, "!").WithLocation(1, 39));
+
             N(SyntaxKind.FieldDeclaration);
             {
                 N(SyntaxKind.VariableDeclaration);
@@ -2679,6 +2931,14 @@ class C {
                                             N(SyntaxKind.StringKeyword);
                                         }
                                         N(SyntaxKind.IdentifierToken, "x");
+                                        N(SyntaxKind.EqualsValueClause);
+                                        {
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.NullLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NullKeyword);
+                                            }
+                                        }
                                     }
                                     N(SyntaxKind.CloseParenToken);
                                 }
@@ -2702,10 +2962,8 @@ class C {
             UsingDeclaration("Func<string, string> func0 = (string y, string x!! = null) => x;", options: TestOptions.RegularPreview,
                 // (1,49): error CS8989: The 'parameter null-checking' feature is not supported.
                 // Func<string, string> func0 = (string y, string x!! = null) => x;
-                Diagnostic(ErrorCode.ERR_ParameterNullCheckingNotSupported, "!").WithLocation(1, 49),
-                // (1,52): error CS1065: Default values are not valid in this context.
-                // Func<string, string> func0 = (string y, string x!! = null) => x;
-                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(1, 52));
+                Diagnostic(ErrorCode.ERR_ParameterNullCheckingNotSupported, "!").WithLocation(1, 49));
+
             N(SyntaxKind.FieldDeclaration);
             {
                 N(SyntaxKind.VariableDeclaration);
@@ -2755,6 +3013,14 @@ class C {
                                             N(SyntaxKind.StringKeyword);
                                         }
                                         N(SyntaxKind.IdentifierToken, "x");
+                                        N(SyntaxKind.EqualsValueClause);
+                                        {
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.NullLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NullKeyword);
+                                            }
+                                        }
                                     }
                                     N(SyntaxKind.CloseParenToken);
                                 }
@@ -3675,480 +3941,6 @@ class C {
             EOF();
         }
 
-        [Fact]
-        public void LambdaDefaultParameter_01()
-        {
-            string source = "(int x = 3) => x";
-            UsingExpression(source);
-
-
-            N(SyntaxKind.ParenthesizedLambdaExpression);
-            {
-                N(SyntaxKind.ParameterList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Parameter);
-                    {
-                        N(SyntaxKind.PredefinedType);
-                        {
-                            N(SyntaxKind.IntKeyword);
-                        }
-                        N(SyntaxKind.IdentifierToken, "x");
-                        N(SyntaxKind.EqualsValueClause);
-                        {
-                            N(SyntaxKind.EqualsToken);
-                            N(SyntaxKind.NumericLiteralExpression);
-                            {
-                                N(SyntaxKind.NumericLiteralToken, "3");
-                            }
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-                N(SyntaxKind.EqualsGreaterThanToken);
-                N(SyntaxKind.IdentifierName);
-                {
-                    N(SyntaxKind.IdentifierToken, "x");
-                }
-            }
-            EOF();
-        }
-
-        [Fact]
-        public void LambdaDefaultParameter_02()
-        {
-            string source = "(double d = x + y) => d * 2";
-            UsingExpression(source);
-            N(SyntaxKind.ParenthesizedLambdaExpression);
-            {
-                N(SyntaxKind.ParameterList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Parameter);
-                    {
-                        N(SyntaxKind.PredefinedType);
-                        {
-                            N(SyntaxKind.DoubleKeyword);
-                        }
-                        N(SyntaxKind.IdentifierToken, "d");
-                        N(SyntaxKind.EqualsValueClause);
-                        {
-                            N(SyntaxKind.EqualsToken);
-                            N(SyntaxKind.AddExpression);
-                            {
-                                N(SyntaxKind.IdentifierName);
-                                {
-                                    N(SyntaxKind.IdentifierToken, "x");
-                                }
-                                N(SyntaxKind.PlusToken);
-                                N(SyntaxKind.IdentifierName);
-                                {
-                                    N(SyntaxKind.IdentifierToken, "y");
-                                }
-                            }
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-                N(SyntaxKind.EqualsGreaterThanToken);
-                N(SyntaxKind.MultiplyExpression);
-                {
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "d");
-                    }
-                    N(SyntaxKind.AsteriskToken);
-                    N(SyntaxKind.NumericLiteralExpression);
-                    {
-                        N(SyntaxKind.NumericLiteralToken, "2");
-                    }
-                }
-            }
-            EOF();
-        }
-
-        [Fact]
-        public void LambdaDefaultParameter_03()
-        {
-            // Implicitly typed lambda parameter with default will parse,
-            // but it will result in a binding-time error
-            string source = "(x = 4) => x + x";
-            UsingExpression(source);
-
-
-            N(SyntaxKind.ParenthesizedLambdaExpression);
-            {
-                N(SyntaxKind.ParameterList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Parameter);
-                    {
-                        N(SyntaxKind.IdentifierToken, "x");
-                        N(SyntaxKind.EqualsValueClause);
-                        {
-                            N(SyntaxKind.EqualsToken);
-                            N(SyntaxKind.NumericLiteralExpression);
-                            {
-                                N(SyntaxKind.NumericLiteralToken, "4");
-                            }
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-                N(SyntaxKind.EqualsGreaterThanToken);
-                N(SyntaxKind.AddExpression);
-                {
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "x");
-                    }
-                    N(SyntaxKind.PlusToken);
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "x");
-                    }
-                }
-            }
-            EOF();
-        }
-
-
-        [Fact]
-        public void LambdaDefaultParameter_04()
-        {
-            string source = """(string s = "abcdef") => s.Contains(s)""";
-            UsingExpression(source);
-
-            N(SyntaxKind.ParenthesizedLambdaExpression);
-            {
-                N(SyntaxKind.ParameterList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Parameter);
-                    {
-                        N(SyntaxKind.PredefinedType);
-                        {
-                            N(SyntaxKind.StringKeyword);
-                        }
-                        N(SyntaxKind.IdentifierToken, "s");
-                        N(SyntaxKind.EqualsValueClause);
-                        {
-                            N(SyntaxKind.EqualsToken);
-                            N(SyntaxKind.StringLiteralExpression);
-                            {
-                                N(SyntaxKind.StringLiteralToken, "\"abcdef\"");
-                            }
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-                N(SyntaxKind.EqualsGreaterThanToken);
-                N(SyntaxKind.InvocationExpression);
-                {
-                    N(SyntaxKind.SimpleMemberAccessExpression);
-                    {
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "s");
-                        }
-                        N(SyntaxKind.DotToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "Contains");
-                        }
-                    }
-                    N(SyntaxKind.ArgumentList);
-                    {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.Argument);
-                        {
-                            N(SyntaxKind.IdentifierName);
-                            {
-                                N(SyntaxKind.IdentifierToken, "s");
-                            }
-                        }
-                        N(SyntaxKind.CloseParenToken);
-                    }
-                }
-            }
-            EOF();
-        }
-
-
-        [Fact]
-        public void LambdaDefaultParameter_05()
-        {
-            // Again, this should parse, but it would be a binding time error
-            string source = "(int x = 4, int y) => x + x";
-            UsingExpression(source);
-
-            N(SyntaxKind.ParenthesizedLambdaExpression);
-            {
-                N(SyntaxKind.ParameterList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Parameter);
-                    {
-                        N(SyntaxKind.PredefinedType);
-                        {
-                            N(SyntaxKind.IntKeyword);
-                        }
-                        N(SyntaxKind.IdentifierToken, "x");
-                        N(SyntaxKind.EqualsValueClause);
-                        {
-                            N(SyntaxKind.EqualsToken);
-                            N(SyntaxKind.NumericLiteralExpression);
-                            {
-                                N(SyntaxKind.NumericLiteralToken, "4");
-                            }
-                        }
-                    }
-                    N(SyntaxKind.CommaToken);
-                    N(SyntaxKind.Parameter);
-                    {
-                        N(SyntaxKind.PredefinedType);
-                        {
-                            N(SyntaxKind.IntKeyword);
-                        }
-                        N(SyntaxKind.IdentifierToken, "y");
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-                N(SyntaxKind.EqualsGreaterThanToken);
-                N(SyntaxKind.AddExpression);
-                {
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "x");
-                    }
-                    N(SyntaxKind.PlusToken);
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "x");
-                    }
-                }
-            }
-            EOF();
-        }
-
-
-        [Fact]
-        public void LambdaDefaultParameter_06()
-        {
-            string source = "(string a, double b = ) => double.Parse(a) + b";
-            UsingExpression(source,
-                // (1,23): error CS1525: Invalid expression term ')'
-                // (string a, double b = ) => double.Parse(a) + b
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(1, 23));
-
-            N(SyntaxKind.ParenthesizedLambdaExpression);
-            {
-                N(SyntaxKind.ParameterList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Parameter);
-                    {
-                        N(SyntaxKind.PredefinedType);
-                        {
-                            N(SyntaxKind.StringKeyword);
-                        }
-                        N(SyntaxKind.IdentifierToken, "a");
-                    }
-                    N(SyntaxKind.CommaToken);
-                    N(SyntaxKind.Parameter);
-                    {
-                        N(SyntaxKind.PredefinedType);
-                        {
-                            N(SyntaxKind.DoubleKeyword);
-                        }
-                        N(SyntaxKind.IdentifierToken, "b");
-                        N(SyntaxKind.EqualsValueClause);
-                        {
-                            N(SyntaxKind.EqualsToken);
-                            M(SyntaxKind.IdentifierName);
-                            {
-                                M(SyntaxKind.IdentifierToken);
-                            }
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-                N(SyntaxKind.EqualsGreaterThanToken);
-                N(SyntaxKind.AddExpression);
-                {
-                    N(SyntaxKind.InvocationExpression);
-                    {
-                        N(SyntaxKind.SimpleMemberAccessExpression);
-                        {
-                            N(SyntaxKind.PredefinedType);
-                            {
-                                N(SyntaxKind.DoubleKeyword);
-                            }
-                            N(SyntaxKind.DotToken);
-                            N(SyntaxKind.IdentifierName);
-                            {
-                                N(SyntaxKind.IdentifierToken, "Parse");
-                            }
-                        }
-                        N(SyntaxKind.ArgumentList);
-                        {
-                            N(SyntaxKind.OpenParenToken);
-                            N(SyntaxKind.Argument);
-                            {
-                                N(SyntaxKind.IdentifierName);
-                                {
-                                    N(SyntaxKind.IdentifierToken, "a");
-                                }
-                            }
-                            N(SyntaxKind.CloseParenToken);
-                        }
-                    }
-                    N(SyntaxKind.PlusToken);
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "b");
-                    }
-                }
-            }
-            EOF();
-        }
-
-        [Fact]
-        public void LambdaDefaultParameter_07()
-        {
-            string source = "(int x = , int y) => x + y";
-            UsingExpression(source,
-                    // (1,10): error CS1525: Invalid expression term ','
-                    // (int x = , int y) => x + y
-                    Diagnostic(ErrorCode.ERR_InvalidExprTerm, ",").WithArguments(",").WithLocation(1, 10));
-            N(SyntaxKind.ParenthesizedLambdaExpression);
-            {
-                N(SyntaxKind.ParameterList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Parameter);
-                    {
-                        N(SyntaxKind.PredefinedType);
-                        {
-                            N(SyntaxKind.IntKeyword);
-                        }
-                        N(SyntaxKind.IdentifierToken, "x");
-                        N(SyntaxKind.EqualsValueClause);
-                        {
-                            N(SyntaxKind.EqualsToken);
-                            M(SyntaxKind.IdentifierName);
-                            {
-                                M(SyntaxKind.IdentifierToken);
-                            }
-                        }
-                    }
-                    N(SyntaxKind.CommaToken);
-                    N(SyntaxKind.Parameter);
-                    {
-                        N(SyntaxKind.PredefinedType);
-                        {
-                            N(SyntaxKind.IntKeyword);
-                        }
-                        N(SyntaxKind.IdentifierToken, "y");
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-                N(SyntaxKind.EqualsGreaterThanToken);
-                N(SyntaxKind.AddExpression);
-                {
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "x");
-                    }
-                    N(SyntaxKind.PlusToken);
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "y");
-                    }
-                }
-            }
-            EOF();
-        }
-
-        [Fact]
-        public void LambdaDefaultParameter_08()
-        {
-            string source = """(string s!!= "abc") => s""";
-            UsingExpression(source, TestOptions.RegularPreview,
-                    // (1,10): error CS8989: The 'parameter null-checking' feature is not supported.
-                    // (string s!!= "abc") => s
-                    Diagnostic(ErrorCode.ERR_ParameterNullCheckingNotSupported, "!").WithLocation(1, 10));
-            N(SyntaxKind.ParenthesizedLambdaExpression);
-            {
-                N(SyntaxKind.ParameterList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Parameter);
-                    {
-                        N(SyntaxKind.PredefinedType);
-                        {
-                            N(SyntaxKind.StringKeyword);
-                        }
-                        N(SyntaxKind.IdentifierToken, "s");
-                        N(SyntaxKind.EqualsValueClause);
-                        {
-                            N(SyntaxKind.EqualsToken);
-                            N(SyntaxKind.StringLiteralExpression);
-                            {
-                                N(SyntaxKind.StringLiteralToken, "\"abc\"");
-                            }
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-                N(SyntaxKind.EqualsGreaterThanToken);
-                N(SyntaxKind.IdentifierName);
-                {
-                    N(SyntaxKind.IdentifierToken, "s");
-                }
-            }
-            EOF();
-        }
-
-        [Fact]
-        public void LambdaDefaultParameter_09()
-        {
-            string source = """(string s !! ="abc") => s""";
-            UsingExpression(source, TestOptions.RegularPreview,
-                    // (1,10): error CS8989: The 'parameter null-checking' feature is not supported.
-                    // (string s!! = "abc") => s
-                    Diagnostic(ErrorCode.ERR_ParameterNullCheckingNotSupported, "!").WithLocation(1, 11));
-            N(SyntaxKind.ParenthesizedLambdaExpression);
-            {
-                N(SyntaxKind.ParameterList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Parameter);
-                    {
-                        N(SyntaxKind.PredefinedType);
-                        {
-                            N(SyntaxKind.StringKeyword);
-                        }
-                        N(SyntaxKind.IdentifierToken, "s");
-                        N(SyntaxKind.EqualsValueClause);
-                        {
-                            N(SyntaxKind.EqualsToken);
-                            N(SyntaxKind.StringLiteralExpression);
-                            {
-                                N(SyntaxKind.StringLiteralToken, "\"abc\"");
-                            }
-                        }
-                    }
-                    N(SyntaxKind.CloseParenToken);
-                }
-                N(SyntaxKind.EqualsGreaterThanToken);
-                N(SyntaxKind.IdentifierName);
-                {
-                    N(SyntaxKind.IdentifierToken, "s");
-                }
-            }
-            EOF();
-        }
     }
 
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
@@ -2901,6 +2901,80 @@ class C {
         {
             string source = "([MyAttribute(3, arg1=true)] int x = -1) => x";
             UsingExpression(source);
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.AttributeList);
+                        {
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.Attribute);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "MyAttribute");
+                                }
+                                N(SyntaxKind.AttributeArgumentList);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    N(SyntaxKind.AttributeArgument);
+                                    {
+                                        N(SyntaxKind.NumericLiteralExpression);
+                                        {
+                                            N(SyntaxKind.NumericLiteralToken, "3");
+                                        }
+                                    }
+                                    N(SyntaxKind.CommaToken);
+                                    N(SyntaxKind.AttributeArgument);
+                                    {
+                                        N(SyntaxKind.NameEquals);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "arg1");
+                                            }
+                                            N(SyntaxKind.EqualsToken);
+                                        }
+                                        N(SyntaxKind.TrueLiteralExpression);
+                                        {
+                                            N(SyntaxKind.TrueKeyword);
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseParenToken);
+                                }
+                            }
+                            N(SyntaxKind.CloseBracketToken);
+                        }
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "x");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.UnaryMinusExpression);
+                            {
+                                N(SyntaxKind.MinusToken);
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "1");
+                                }
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+            }
             EOF();
         }
 
@@ -2909,6 +2983,80 @@ class C {
         {
             string source = "(ref int a, out int b, int c = 0) => { b = a + c; }";
             UsingExpression(source);
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.OutKeyword);
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "b");
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "c");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.NumericLiteralExpression);
+                            {
+                                N(SyntaxKind.NumericLiteralToken, "0");
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.Block);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.ExpressionStatement);
+                    {
+                        N(SyntaxKind.SimpleAssignmentExpression);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "b");
+                            }
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.AddExpression);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "a");
+                                }
+                                N(SyntaxKind.PlusToken);
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "c");
+                                }
+                            }
+                        }
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
             EOF();
         }
 
@@ -2918,6 +3066,95 @@ class C {
         {
             string source = "(int arg = y switch { < 0 => -1, 0 => 0, > 0 => 1}) => arg";
             UsingExpression(source);
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "arg");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.SwitchExpression);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "y");
+                                }
+                                N(SyntaxKind.SwitchKeyword);
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.SwitchExpressionArm);
+                                {
+                                    N(SyntaxKind.RelationalPattern);
+                                    {
+                                        N(SyntaxKind.LessThanToken);
+                                        N(SyntaxKind.NumericLiteralExpression);
+                                        {
+                                            N(SyntaxKind.NumericLiteralToken, "0");
+                                        }
+                                    }
+                                    N(SyntaxKind.EqualsGreaterThanToken);
+                                    N(SyntaxKind.UnaryMinusExpression);
+                                    {
+                                        N(SyntaxKind.MinusToken);
+                                        N(SyntaxKind.NumericLiteralExpression);
+                                        {
+                                            N(SyntaxKind.NumericLiteralToken, "1");
+                                        }
+                                    }
+                                }
+                                N(SyntaxKind.CommaToken);
+                                N(SyntaxKind.SwitchExpressionArm);
+                                {
+                                    N(SyntaxKind.ConstantPattern);
+                                    {
+                                        N(SyntaxKind.NumericLiteralExpression);
+                                        {
+                                            N(SyntaxKind.NumericLiteralToken, "0");
+                                        }
+                                    }
+                                    N(SyntaxKind.EqualsGreaterThanToken);
+                                    N(SyntaxKind.NumericLiteralExpression);
+                                    {
+                                        N(SyntaxKind.NumericLiteralToken, "0");
+                                    }
+                                }
+                                N(SyntaxKind.CommaToken);
+                                N(SyntaxKind.SwitchExpressionArm);
+                                {
+                                    N(SyntaxKind.RelationalPattern);
+                                    {
+                                        N(SyntaxKind.GreaterThanToken);
+                                        N(SyntaxKind.NumericLiteralExpression);
+                                        {
+                                            N(SyntaxKind.NumericLiteralToken, "0");
+                                        }
+                                    }
+                                    N(SyntaxKind.EqualsGreaterThanToken);
+                                    N(SyntaxKind.NumericLiteralExpression);
+                                    {
+                                        N(SyntaxKind.NumericLiteralToken, "1");
+                                    }
+                                }
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "arg");
+                }
+            }
             EOF();
         }
 
@@ -2926,6 +3163,95 @@ class C {
         {
             string source = "(int arg, Func<int, int> lam = (x) => 2 * x) => lam(arg)";
             UsingExpression(source);
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "arg");
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.GenericName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "Func");
+                            N(SyntaxKind.TypeArgumentList);
+                            {
+                                N(SyntaxKind.LessThanToken);
+                                N(SyntaxKind.PredefinedType);
+                                {
+                                    N(SyntaxKind.IntKeyword);
+                                }
+                                N(SyntaxKind.CommaToken);
+                                N(SyntaxKind.PredefinedType);
+                                {
+                                    N(SyntaxKind.IntKeyword);
+                                }
+                                N(SyntaxKind.GreaterThanToken);
+                            }
+                        }
+                        N(SyntaxKind.IdentifierToken, "lam");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.ParenthesizedLambdaExpression);
+                            {
+                                N(SyntaxKind.ParameterList);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    N(SyntaxKind.Parameter);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "x");
+                                    }
+                                    N(SyntaxKind.CloseParenToken);
+                                }
+                                N(SyntaxKind.EqualsGreaterThanToken);
+                                N(SyntaxKind.MultiplyExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralExpression);
+                                    {
+                                        N(SyntaxKind.NumericLiteralToken, "2");
+                                    }
+                                    N(SyntaxKind.AsteriskToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "x");
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.InvocationExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "lam");
+                    }
+                    N(SyntaxKind.ArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Argument);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "arg");
+                            }
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+            }
             EOF();
         }
 
@@ -2938,14 +3264,834 @@ class C {
                                                                            { 1 => Color.Green, 2 => Color.Red, 3 => Color.Blue }) =>
             { return colorFunc(arg); }";
             UsingExpression(source);
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "arg");
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.GenericName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "Func");
+                            N(SyntaxKind.TypeArgumentList);
+                            {
+                                N(SyntaxKind.LessThanToken);
+                                N(SyntaxKind.PredefinedType);
+                                {
+                                    N(SyntaxKind.IntKeyword);
+                                }
+                                N(SyntaxKind.CommaToken);
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Color");
+                                }
+                                N(SyntaxKind.GreaterThanToken);
+                            }
+                        }
+                        N(SyntaxKind.IdentifierToken, "colorFunc");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.ParenthesizedLambdaExpression);
+                            {
+                                N(SyntaxKind.ParameterList);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    N(SyntaxKind.Parameter);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Color");
+                                        }
+                                        N(SyntaxKind.IdentifierToken, "c");
+                                        N(SyntaxKind.EqualsValueClause);
+                                        {
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.SimpleMemberAccessExpression);
+                                            {
+                                                N(SyntaxKind.IdentifierName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "Color");
+                                                }
+                                                N(SyntaxKind.DotToken);
+                                                N(SyntaxKind.IdentifierName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "Red");
+                                                }
+                                            }
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseParenToken);
+                                }
+                                N(SyntaxKind.EqualsGreaterThanToken);
+                                N(SyntaxKind.SwitchExpression);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "c");
+                                    }
+                                    N(SyntaxKind.SwitchKeyword);
+                                    N(SyntaxKind.OpenBraceToken);
+                                    N(SyntaxKind.SwitchExpressionArm);
+                                    {
+                                        N(SyntaxKind.ConstantPattern);
+                                        {
+                                            N(SyntaxKind.NumericLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NumericLiteralToken, "1");
+                                            }
+                                        }
+                                        N(SyntaxKind.EqualsGreaterThanToken);
+                                        N(SyntaxKind.SimpleMemberAccessExpression);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Color");
+                                            }
+                                            N(SyntaxKind.DotToken);
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Green");
+                                            }
+                                        }
+                                    }
+                                    N(SyntaxKind.CommaToken);
+                                    N(SyntaxKind.SwitchExpressionArm);
+                                    {
+                                        N(SyntaxKind.ConstantPattern);
+                                        {
+                                            N(SyntaxKind.NumericLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NumericLiteralToken, "2");
+                                            }
+                                        }
+                                        N(SyntaxKind.EqualsGreaterThanToken);
+                                        N(SyntaxKind.SimpleMemberAccessExpression);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Color");
+                                            }
+                                            N(SyntaxKind.DotToken);
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Red");
+                                            }
+                                        }
+                                    }
+                                    N(SyntaxKind.CommaToken);
+                                    N(SyntaxKind.SwitchExpressionArm);
+                                    {
+                                        N(SyntaxKind.ConstantPattern);
+                                        {
+                                            N(SyntaxKind.NumericLiteralExpression);
+                                            {
+                                                N(SyntaxKind.NumericLiteralToken, "3");
+                                            }
+                                        }
+                                        N(SyntaxKind.EqualsGreaterThanToken);
+                                        N(SyntaxKind.SimpleMemberAccessExpression);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Color");
+                                            }
+                                            N(SyntaxKind.DotToken);
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "Blue");
+                                            }
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseBraceToken);
+                                }
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.Block);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.ReturnStatement);
+                    {
+                        N(SyntaxKind.ReturnKeyword);
+                        N(SyntaxKind.InvocationExpression);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "colorFunc");
+                            }
+                            N(SyntaxKind.ArgumentList);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.Argument);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "arg");
+                                    }
+                                }
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                        }
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
             EOF();
         }
 
         [Fact]
-        public void TestDefaultValueNestedParens()
+        public void TestDefaultValueNestedLambdas()
         {
             string source = "(a = (b = (c = (d = 3) => d) => c) => b) => a";
             UsingExpression(source);
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.IdentifierToken, "a");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.ParenthesizedLambdaExpression);
+                            {
+                                N(SyntaxKind.ParameterList);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    N(SyntaxKind.Parameter);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "b");
+                                        N(SyntaxKind.EqualsValueClause);
+                                        {
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.ParenthesizedLambdaExpression);
+                                            {
+                                                N(SyntaxKind.ParameterList);
+                                                {
+                                                    N(SyntaxKind.OpenParenToken);
+                                                    N(SyntaxKind.Parameter);
+                                                    {
+                                                        N(SyntaxKind.IdentifierToken, "c");
+                                                        N(SyntaxKind.EqualsValueClause);
+                                                        {
+                                                            N(SyntaxKind.EqualsToken);
+                                                            N(SyntaxKind.ParenthesizedLambdaExpression);
+                                                            {
+                                                                N(SyntaxKind.ParameterList);
+                                                                {
+                                                                    N(SyntaxKind.OpenParenToken);
+                                                                    N(SyntaxKind.Parameter);
+                                                                    {
+                                                                        N(SyntaxKind.IdentifierToken, "d");
+                                                                        N(SyntaxKind.EqualsValueClause);
+                                                                        {
+                                                                            N(SyntaxKind.EqualsToken);
+                                                                            N(SyntaxKind.NumericLiteralExpression);
+                                                                            {
+                                                                                N(SyntaxKind.NumericLiteralToken, "3");
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                    N(SyntaxKind.CloseParenToken);
+                                                                }
+                                                                N(SyntaxKind.EqualsGreaterThanToken);
+                                                                N(SyntaxKind.IdentifierName);
+                                                                {
+                                                                    N(SyntaxKind.IdentifierToken, "d");
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                    N(SyntaxKind.CloseParenToken);
+                                                }
+                                                N(SyntaxKind.EqualsGreaterThanToken);
+                                                N(SyntaxKind.IdentifierName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "c");
+                                                }
+                                            }
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseParenToken);
+                                }
+                                N(SyntaxKind.EqualsGreaterThanToken);
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "b");
+                                }
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "a");
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void TestDefaultValueNestedLambdaIncomplete()
+        {
+            var source = "(Func<int, int> l1 = (int a = 1) =>";
+            UsingExpression(source,
+                // (1,1): error CS1073: Unexpected token 'l1'
+                // (Func<int, int> l1 = (int a = 1) =>
+                Diagnostic(ErrorCode.ERR_UnexpectedToken, "(Func<int, int> ").WithArguments("l1").WithLocation(1, 1),
+                // (1,17): error CS1026: ) expected
+                // (Func<int, int> l1 = (int a = 1) =>
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "l1").WithLocation(1, 17));
+
+            N(SyntaxKind.ParenthesizedExpression);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.GenericName);
+                {
+                    N(SyntaxKind.IdentifierToken, "Func");
+                    N(SyntaxKind.TypeArgumentList);
+                    {
+                        N(SyntaxKind.LessThanToken);
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.CommaToken);
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.GreaterThanToken);
+                    }
+                }
+                M(SyntaxKind.CloseParenToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void TestDefaultValueTypedNestedLambda()
+        {
+            var source = @"(Func<Func<Func<Func<int, int>, Func<int, int>>, Func<Func<int, int>, Func<int, int>>>, Func<Func<Func<int, int>, Func<int, int>>, Func<Func<int, int>, Func<int, int>>>> a = 
+                                    (Func<Func<Func<int, int>, Func<int, int>>, Func<Func<int, int>, Func<int, int>>> b = 
+                                                    (Func<Func<int, int>, Func<int, int>> c = (Func<int, int> d = (int e = 1) => e) => d) => c) => b) => a";
+            UsingExpression(source);
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.GenericName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "Func");
+                            N(SyntaxKind.TypeArgumentList);
+                            {
+                                N(SyntaxKind.LessThanToken);
+                                N(SyntaxKind.GenericName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Func");
+                                    N(SyntaxKind.TypeArgumentList);
+                                    {
+                                        N(SyntaxKind.LessThanToken);
+                                        N(SyntaxKind.GenericName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Func");
+                                            N(SyntaxKind.TypeArgumentList);
+                                            {
+                                                N(SyntaxKind.LessThanToken);
+                                                N(SyntaxKind.GenericName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "Func");
+                                                    N(SyntaxKind.TypeArgumentList);
+                                                    {
+                                                        N(SyntaxKind.LessThanToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.CommaToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.GreaterThanToken);
+                                                    }
+                                                }
+                                                N(SyntaxKind.CommaToken);
+                                                N(SyntaxKind.GenericName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "Func");
+                                                    N(SyntaxKind.TypeArgumentList);
+                                                    {
+                                                        N(SyntaxKind.LessThanToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.CommaToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.GreaterThanToken);
+                                                    }
+                                                }
+                                                N(SyntaxKind.GreaterThanToken);
+                                            }
+                                        }
+                                        N(SyntaxKind.CommaToken);
+                                        N(SyntaxKind.GenericName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Func");
+                                            N(SyntaxKind.TypeArgumentList);
+                                            {
+                                                N(SyntaxKind.LessThanToken);
+                                                N(SyntaxKind.GenericName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "Func");
+                                                    N(SyntaxKind.TypeArgumentList);
+                                                    {
+                                                        N(SyntaxKind.LessThanToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.CommaToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.GreaterThanToken);
+                                                    }
+                                                }
+                                                N(SyntaxKind.CommaToken);
+                                                N(SyntaxKind.GenericName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "Func");
+                                                    N(SyntaxKind.TypeArgumentList);
+                                                    {
+                                                        N(SyntaxKind.LessThanToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.CommaToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.GreaterThanToken);
+                                                    }
+                                                }
+                                                N(SyntaxKind.GreaterThanToken);
+                                            }
+                                        }
+                                        N(SyntaxKind.GreaterThanToken);
+                                    }
+                                }
+                                N(SyntaxKind.CommaToken);
+                                N(SyntaxKind.GenericName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Func");
+                                    N(SyntaxKind.TypeArgumentList);
+                                    {
+                                        N(SyntaxKind.LessThanToken);
+                                        N(SyntaxKind.GenericName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Func");
+                                            N(SyntaxKind.TypeArgumentList);
+                                            {
+                                                N(SyntaxKind.LessThanToken);
+                                                N(SyntaxKind.GenericName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "Func");
+                                                    N(SyntaxKind.TypeArgumentList);
+                                                    {
+                                                        N(SyntaxKind.LessThanToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.CommaToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.GreaterThanToken);
+                                                    }
+                                                }
+                                                N(SyntaxKind.CommaToken);
+                                                N(SyntaxKind.GenericName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "Func");
+                                                    N(SyntaxKind.TypeArgumentList);
+                                                    {
+                                                        N(SyntaxKind.LessThanToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.CommaToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.GreaterThanToken);
+                                                    }
+                                                }
+                                                N(SyntaxKind.GreaterThanToken);
+                                            }
+                                        }
+                                        N(SyntaxKind.CommaToken);
+                                        N(SyntaxKind.GenericName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Func");
+                                            N(SyntaxKind.TypeArgumentList);
+                                            {
+                                                N(SyntaxKind.LessThanToken);
+                                                N(SyntaxKind.GenericName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "Func");
+                                                    N(SyntaxKind.TypeArgumentList);
+                                                    {
+                                                        N(SyntaxKind.LessThanToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.CommaToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.GreaterThanToken);
+                                                    }
+                                                }
+                                                N(SyntaxKind.CommaToken);
+                                                N(SyntaxKind.GenericName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "Func");
+                                                    N(SyntaxKind.TypeArgumentList);
+                                                    {
+                                                        N(SyntaxKind.LessThanToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.CommaToken);
+                                                        N(SyntaxKind.PredefinedType);
+                                                        {
+                                                            N(SyntaxKind.IntKeyword);
+                                                        }
+                                                        N(SyntaxKind.GreaterThanToken);
+                                                    }
+                                                }
+                                                N(SyntaxKind.GreaterThanToken);
+                                            }
+                                        }
+                                        N(SyntaxKind.GreaterThanToken);
+                                    }
+                                }
+                                N(SyntaxKind.GreaterThanToken);
+                            }
+                        }
+                        N(SyntaxKind.IdentifierToken, "a");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.ParenthesizedLambdaExpression);
+                            {
+                                N(SyntaxKind.ParameterList);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    N(SyntaxKind.Parameter);
+                                    {
+                                        N(SyntaxKind.GenericName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Func");
+                                            N(SyntaxKind.TypeArgumentList);
+                                            {
+                                                N(SyntaxKind.LessThanToken);
+                                                N(SyntaxKind.GenericName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "Func");
+                                                    N(SyntaxKind.TypeArgumentList);
+                                                    {
+                                                        N(SyntaxKind.LessThanToken);
+                                                        N(SyntaxKind.GenericName);
+                                                        {
+                                                            N(SyntaxKind.IdentifierToken, "Func");
+                                                            N(SyntaxKind.TypeArgumentList);
+                                                            {
+                                                                N(SyntaxKind.LessThanToken);
+                                                                N(SyntaxKind.PredefinedType);
+                                                                {
+                                                                    N(SyntaxKind.IntKeyword);
+                                                                }
+                                                                N(SyntaxKind.CommaToken);
+                                                                N(SyntaxKind.PredefinedType);
+                                                                {
+                                                                    N(SyntaxKind.IntKeyword);
+                                                                }
+                                                                N(SyntaxKind.GreaterThanToken);
+                                                            }
+                                                        }
+                                                        N(SyntaxKind.CommaToken);
+                                                        N(SyntaxKind.GenericName);
+                                                        {
+                                                            N(SyntaxKind.IdentifierToken, "Func");
+                                                            N(SyntaxKind.TypeArgumentList);
+                                                            {
+                                                                N(SyntaxKind.LessThanToken);
+                                                                N(SyntaxKind.PredefinedType);
+                                                                {
+                                                                    N(SyntaxKind.IntKeyword);
+                                                                }
+                                                                N(SyntaxKind.CommaToken);
+
+                                                                N(SyntaxKind.PredefinedType);
+                                                                {
+                                                                    N(SyntaxKind.IntKeyword);
+                                                                }
+                                                                N(SyntaxKind.GreaterThanToken);
+                                                            }
+                                                        }
+                                                        N(SyntaxKind.GreaterThanToken);
+                                                    }
+                                                }
+                                                N(SyntaxKind.CommaToken);
+                                                N(SyntaxKind.GenericName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "Func");
+                                                    N(SyntaxKind.TypeArgumentList);
+                                                    {
+                                                        N(SyntaxKind.LessThanToken);
+                                                        N(SyntaxKind.GenericName);
+                                                        {
+                                                            N(SyntaxKind.IdentifierToken, "Func");
+                                                            N(SyntaxKind.TypeArgumentList);
+                                                            {
+                                                                N(SyntaxKind.LessThanToken);
+                                                                N(SyntaxKind.PredefinedType);
+                                                                {
+                                                                    N(SyntaxKind.IntKeyword);
+                                                                }
+                                                                N(SyntaxKind.CommaToken);
+                                                                N(SyntaxKind.PredefinedType);
+                                                                {
+                                                                    N(SyntaxKind.IntKeyword);
+                                                                }
+                                                                N(SyntaxKind.GreaterThanToken);
+                                                            }
+                                                        }
+                                                        N(SyntaxKind.CommaToken);
+                                                        N(SyntaxKind.GenericName);
+                                                        {
+                                                            N(SyntaxKind.IdentifierToken, "Func");
+                                                            N(SyntaxKind.TypeArgumentList);
+                                                            {
+                                                                N(SyntaxKind.LessThanToken);
+                                                                N(SyntaxKind.PredefinedType);
+                                                                {
+                                                                    N(SyntaxKind.IntKeyword);
+                                                                }
+                                                                N(SyntaxKind.CommaToken);
+                                                                N(SyntaxKind.PredefinedType);
+                                                                {
+                                                                    N(SyntaxKind.IntKeyword);
+                                                                }
+                                                                N(SyntaxKind.GreaterThanToken);
+                                                            }
+                                                        }
+                                                        N(SyntaxKind.GreaterThanToken);
+                                                    }
+                                                }
+                                                N(SyntaxKind.GreaterThanToken);
+                                            }
+                                        }
+                                        N(SyntaxKind.IdentifierToken, "b");
+                                        N(SyntaxKind.EqualsValueClause);
+                                        {
+                                            N(SyntaxKind.EqualsToken);
+                                            N(SyntaxKind.ParenthesizedLambdaExpression);
+                                            {
+                                                N(SyntaxKind.ParameterList);
+                                                {
+                                                    N(SyntaxKind.OpenParenToken);
+                                                    N(SyntaxKind.Parameter);
+
+                                                    {
+                                                        N(SyntaxKind.GenericName);
+                                                        {
+                                                            N(SyntaxKind.IdentifierToken, "Func");
+                                                            N(SyntaxKind.TypeArgumentList);
+                                                            {
+                                                                N(SyntaxKind.LessThanToken);
+                                                                N(SyntaxKind.GenericName);
+                                                                {
+                                                                    N(SyntaxKind.IdentifierToken, "Func");
+                                                                    N(SyntaxKind.TypeArgumentList);
+                                                                    {
+                                                                        N(SyntaxKind.LessThanToken);
+                                                                        N(SyntaxKind.PredefinedType);
+                                                                        {
+                                                                            N(SyntaxKind.IntKeyword);
+                                                                        }
+                                                                        N(SyntaxKind.CommaToken);
+                                                                        N(SyntaxKind.PredefinedType);
+                                                                        {
+                                                                            N(SyntaxKind.IntKeyword);
+                                                                        }
+                                                                        N(SyntaxKind.GreaterThanToken);
+                                                                    }
+                                                                }
+                                                                N(SyntaxKind.CommaToken);
+                                                                N(SyntaxKind.GenericName);
+                                                                {
+                                                                    N(SyntaxKind.IdentifierToken, "Func");
+                                                                    N(SyntaxKind.TypeArgumentList);
+                                                                    {
+                                                                        N(SyntaxKind.LessThanToken);
+                                                                        N(SyntaxKind.PredefinedType);
+                                                                        {
+                                                                            N(SyntaxKind.IntKeyword);
+                                                                        }
+                                                                        N(SyntaxKind.CommaToken);
+                                                                        N(SyntaxKind.PredefinedType);
+                                                                        {
+                                                                            N(SyntaxKind.IntKeyword);
+                                                                        }
+                                                                        N(SyntaxKind.GreaterThanToken);
+                                                                    }
+                                                                }
+                                                                N(SyntaxKind.GreaterThanToken);
+                                                            }
+                                                        }
+                                                        N(SyntaxKind.IdentifierToken, "c");
+                                                        N(SyntaxKind.EqualsValueClause);
+                                                        {
+                                                            N(SyntaxKind.EqualsToken);
+                                                            N(SyntaxKind.ParenthesizedLambdaExpression);
+                                                            {
+                                                                N(SyntaxKind.ParameterList);
+                                                                {
+                                                                    N(SyntaxKind.OpenParenToken);
+                                                                    N(SyntaxKind.Parameter);
+                                                                    {
+                                                                        N(SyntaxKind.GenericName);
+                                                                        {
+                                                                            N(SyntaxKind.IdentifierToken, "Func");
+                                                                            N(SyntaxKind.TypeArgumentList);
+                                                                            {
+                                                                                N(SyntaxKind.LessThanToken);
+                                                                                N(SyntaxKind.PredefinedType);
+                                                                                {
+                                                                                    N(SyntaxKind.IntKeyword);
+                                                                                }
+                                                                                N(SyntaxKind.CommaToken);
+                                                                                N(SyntaxKind.PredefinedType);
+                                                                                {
+                                                                                    N(SyntaxKind.IntKeyword);
+                                                                                }
+                                                                                N(SyntaxKind.GreaterThanToken);
+                                                                            }
+                                                                        }
+                                                                        N(SyntaxKind.IdentifierToken, "d");
+                                                                        N(SyntaxKind.EqualsValueClause);
+                                                                        {
+                                                                            N(SyntaxKind.EqualsToken);
+                                                                            N(SyntaxKind.ParenthesizedLambdaExpression);
+                                                                            {
+                                                                                N(SyntaxKind.ParameterList);
+                                                                                {
+                                                                                    N(SyntaxKind.OpenParenToken);
+                                                                                    N(SyntaxKind.Parameter);
+                                                                                    {
+                                                                                        N(SyntaxKind.PredefinedType);
+                                                                                        {
+                                                                                            N(SyntaxKind.IntKeyword);
+                                                                                        }
+                                                                                        N(SyntaxKind.IdentifierToken, "e");
+                                                                                        N(SyntaxKind.EqualsValueClause);
+                                                                                        {
+                                                                                            N(SyntaxKind.EqualsToken);
+                                                                                            N(SyntaxKind.NumericLiteralExpression);
+                                                                                            {
+                                                                                                N(SyntaxKind.NumericLiteralToken, "1");
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                    N(SyntaxKind.CloseParenToken);
+                                                                                }
+                                                                                N(SyntaxKind.EqualsGreaterThanToken);
+                                                                                N(SyntaxKind.IdentifierName);
+                                                                                {
+                                                                                    N(SyntaxKind.IdentifierToken, "e");
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                    N(SyntaxKind.CloseParenToken);
+                                                                }
+                                                                N(SyntaxKind.EqualsGreaterThanToken);
+                                                                N(SyntaxKind.IdentifierName);
+                                                                {
+                                                                    N(SyntaxKind.IdentifierToken, "d");
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                    N(SyntaxKind.CloseParenToken);
+                                                }
+                                                N(SyntaxKind.EqualsGreaterThanToken);
+                                                N(SyntaxKind.IdentifierName);
+                                                {
+                                                    N(SyntaxKind.IdentifierToken, "c");
+                                                }
+                                            }
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseParenToken);
+                                }
+                                N(SyntaxKind.EqualsGreaterThanToken);
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "b");
+                                }
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "a");
+                }
+            }
             EOF();
         }
 
@@ -2954,6 +4100,75 @@ class C {
         {
             string source = "(int arg = a ? b ? w : x : c ? y : z)  => arg";
             UsingExpression(source);
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "arg");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.ConditionalExpression);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "a");
+                                }
+                                N(SyntaxKind.QuestionToken);
+                                N(SyntaxKind.ConditionalExpression);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "b");
+                                    }
+                                    N(SyntaxKind.QuestionToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "w");
+                                    }
+                                    N(SyntaxKind.ColonToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "x");
+                                    }
+                                }
+                                N(SyntaxKind.ColonToken);
+                                N(SyntaxKind.ConditionalExpression);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "c");
+                                    }
+                                    N(SyntaxKind.QuestionToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "y");
+                                    }
+                                    N(SyntaxKind.ColonToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "z");
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "arg");
+                }
+            }
             EOF();
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LambdaParameterParsingTests.cs
@@ -3674,5 +3674,481 @@ class C {
             }
             EOF();
         }
+
+        [Fact]
+        public void LambdaDefaultParameter_01()
+        {
+            string source = "(int x = 3) => x";
+            UsingExpression(source);
+
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "x");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.NumericLiteralExpression);
+                            {
+                                N(SyntaxKind.NumericLiteralToken, "3");
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void LambdaDefaultParameter_02()
+        {
+            string source = "(double d = x + y) => d * 2";
+            UsingExpression(source);
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.DoubleKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "d");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.AddExpression);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "x");
+                                }
+                                N(SyntaxKind.PlusToken);
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "y");
+                                }
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.MultiplyExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "d");
+                    }
+                    N(SyntaxKind.AsteriskToken);
+                    N(SyntaxKind.NumericLiteralExpression);
+                    {
+                        N(SyntaxKind.NumericLiteralToken, "2");
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void LambdaDefaultParameter_03()
+        {
+            // Implicitly typed lambda parameter with default will parse,
+            // but it will result in a binding-time error
+            string source = "(x = 4) => x + x";
+            UsingExpression(source);
+
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.IdentifierToken, "x");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.NumericLiteralExpression);
+                            {
+                                N(SyntaxKind.NumericLiteralToken, "4");
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.AddExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "x");
+                    }
+                    N(SyntaxKind.PlusToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "x");
+                    }
+                }
+            }
+            EOF();
+        }
+
+
+        [Fact]
+        public void LambdaDefaultParameter_04()
+        {
+            string source = """(string s = "abcdef") => s.Contains(s)""";
+            UsingExpression(source);
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.StringKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "s");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.StringLiteralExpression);
+                            {
+                                N(SyntaxKind.StringLiteralToken, "\"abcdef\"");
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.InvocationExpression);
+                {
+                    N(SyntaxKind.SimpleMemberAccessExpression);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "s");
+                        }
+                        N(SyntaxKind.DotToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "Contains");
+                        }
+                    }
+                    N(SyntaxKind.ArgumentList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Argument);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "s");
+                            }
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+            }
+            EOF();
+        }
+
+
+        [Fact]
+        public void LambdaDefaultParameter_05()
+        {
+            // Again, this should parse, but it would be a binding time error
+            string source = "(int x = 4, int y) => x + x";
+            UsingExpression(source);
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "x");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.NumericLiteralExpression);
+                            {
+                                N(SyntaxKind.NumericLiteralToken, "4");
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "y");
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.AddExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "x");
+                    }
+                    N(SyntaxKind.PlusToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "x");
+                    }
+                }
+            }
+            EOF();
+        }
+
+
+        [Fact]
+        public void LambdaDefaultParameter_06()
+        {
+            string source = "(string a, double b = ) => double.Parse(a) + b";
+            UsingExpression(source,
+                // (1,23): error CS1525: Invalid expression term ')'
+                // (string a, double b = ) => double.Parse(a) + b
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(1, 23));
+
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.StringKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "a");
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.DoubleKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "b");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.AddExpression);
+                {
+                    N(SyntaxKind.InvocationExpression);
+                    {
+                        N(SyntaxKind.SimpleMemberAccessExpression);
+                        {
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.DoubleKeyword);
+                            }
+                            N(SyntaxKind.DotToken);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "Parse");
+                            }
+                        }
+                        N(SyntaxKind.ArgumentList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.Argument);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "a");
+                                }
+                            }
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                    }
+                    N(SyntaxKind.PlusToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "b");
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void LambdaDefaultParameter_07()
+        {
+            string source = "(int x = , int y) => x + y";
+            UsingExpression(source,
+                    // (1,10): error CS1525: Invalid expression term ','
+                    // (int x = , int y) => x + y
+                    Diagnostic(ErrorCode.ERR_InvalidExprTerm, ",").WithArguments(",").WithLocation(1, 10));
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "x");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "y");
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.AddExpression);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "x");
+                    }
+                    N(SyntaxKind.PlusToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "y");
+                    }
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void LambdaDefaultParameter_08()
+        {
+            string source = """(string s!!= "abc") => s""";
+            UsingExpression(source, TestOptions.RegularPreview,
+                    // (1,10): error CS8989: The 'parameter null-checking' feature is not supported.
+                    // (string s!!= "abc") => s
+                    Diagnostic(ErrorCode.ERR_ParameterNullCheckingNotSupported, "!").WithLocation(1, 10));
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.StringKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "s");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.StringLiteralExpression);
+                            {
+                                N(SyntaxKind.StringLiteralToken, "\"abc\"");
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "s");
+                }
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void LambdaDefaultParameter_09()
+        {
+            string source = """(string s !! ="abc") => s""";
+            UsingExpression(source, TestOptions.RegularPreview,
+                    // (1,10): error CS8989: The 'parameter null-checking' feature is not supported.
+                    // (string s!! = "abc") => s
+                    Diagnostic(ErrorCode.ERR_ParameterNullCheckingNotSupported, "!").WithLocation(1, 11));
+            N(SyntaxKind.ParenthesizedLambdaExpression);
+            {
+                N(SyntaxKind.ParameterList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.Parameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.StringKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "s");
+                        N(SyntaxKind.EqualsValueClause);
+                        {
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.StringLiteralExpression);
+                            {
+                                N(SyntaxKind.StringLiteralToken, "\"abc\"");
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "s");
+                }
+            }
+            EOF();
+        }
     }
+
 }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4490,7 +4490,7 @@ class C
             await AssertFormatAsync(expected, code);
         }
 
-        [Fact(Skip = "PROTOTYPE(default-params): =1 is no longer missing")]
+        [Fact]
         [WorkItem(542538, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542538")]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task MissingTokens()
@@ -4511,7 +4511,7 @@ class innerClass
 {
     public innerClass()
     {
-        myDelegate x = (int y=1) => { return; };
+        myDelegate x = (int y = 1) => { return; };
     }
 }";
 

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4490,7 +4490,7 @@ class C
             await AssertFormatAsync(expected, code);
         }
 
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(default-params): =1 is no longer missing")]
         [WorkItem(542538, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542538")]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task MissingTokens()


### PR DESCRIPTION
Updates the parser so that it will no longer throw an error if a default parameter is present in a lambda parameter list. Instead, the default value is parsed and attached to the syntax tree as an `EqualsValueClause`. The parsing behavior here should be nearly identical to parsing default parameters in a method, except that it is in the context of a lambda. 

Note that currently, the binder will throw an error in the presence of lambda default parameter values, so for now the error has effectively moved from the parser to the binder. 
