### PR TITLE
No need to roundtrip symbol when doing OOP rename call.

### DIFF
--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
@@ -51,12 +51,13 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                 var client = await RemoteHostClient.TryGetClientAsync(solution.Workspace, cancellationToken).ConfigureAwait(false);
                 if (client != null)
                 {
+                    var serializableSymbol = SerializableSymbolAndProjectId.Dehydrate(renameLocationSet.Solution, renameLocationSet.Symbol, cancellationToken);
                     var serializableLocationSet = renameLocationSet.Dehydrate(solution, cancellationToken);
                     var nonConflictSymbolIds = nonConflictSymbols?.SelectAsArray(s => SerializableSymbolAndProjectId.Dehydrate(solution, s, cancellationToken)) ?? default;
 
                     var result = await client.TryInvokeAsync<IRemoteRenamerService, SerializableConflictResolution?>(
                         solution,
-                        (service, solutionInfo, callbackId, cancellationToken) => service.ResolveConflictsAsync(solutionInfo, callbackId, serializableLocationSet, replacementText, nonConflictSymbolIds, cancellationToken),
+                        (service, solutionInfo, callbackId, cancellationToken) => service.ResolveConflictsAsync(solutionInfo, callbackId, serializableSymbol, serializableLocationSet, replacementText, nonConflictSymbolIds, cancellationToken),
                         callbackTarget: new RemoteOptionsProvider<CodeCleanupOptions>(solution.Workspace.Services, renameLocationSet.FallbackOptions),
                         cancellationToken).ConfigureAwait(false);
 

--- a/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
@@ -75,68 +75,6 @@ namespace Microsoft.CodeAnalysis.Rename
             => ((RemoteOptionsProvider<CodeCleanupOptions>)GetCallback(callbackId)).GetOptionsAsync(language, cancellationToken);
     }
 
-#if false
-
-    [DataContract]
-    internal class SerializableSearchResult
-    {
-        // We use arrays so we can represent default immutable arrays.
-
-        [DataMember(Order = 0)]
-        public SerializableRenameLocation[]? Locations;
-
-        [DataMember(Order = 1)]
-        public SerializableReferenceLocation[]? ImplicitLocations;
-
-        [DataMember(Order = 2)]
-        public SerializableSymbolAndProjectId[]? ReferencedSymbols;
-
-        [return: NotNullIfNotNull("result")]
-        public static SerializableSearchResult? Dehydrate(Solution solution, RenameLocations.SearchResult? result, CancellationToken cancellationToken)
-            => result == null ? null : new SerializableSearchResult
-            {
-                Locations = result.Locations.Select(SerializableRenameLocation.Dehydrate).ToArray(),
-                ImplicitLocations = result.ImplicitLocations.IsDefault ? null : result.ImplicitLocations.Select(loc => SerializableReferenceLocation.Dehydrate(loc, cancellationToken)).ToArray(),
-                ReferencedSymbols = result.ReferencedSymbols.IsDefault ? null : result.ReferencedSymbols.Select(s => SerializableSymbolAndProjectId.Dehydrate(solution, s, cancellationToken)).ToArray(),
-            };
-
-        public async Task<RenameLocations.SearchResult> RehydrateAsync(Solution solution, CancellationToken cancellationToken)
-        {
-            ImmutableArray<ReferenceLocation> implicitLocations = default;
-            ImmutableArray<ISymbol> referencedSymbols = default;
-
-            Contract.ThrowIfNull(Locations);
-
-            using var _1 = ArrayBuilder<RenameLocation>.GetInstance(Locations.Length, out var locBuilder);
-            foreach (var loc in Locations)
-                locBuilder.Add(await loc.RehydrateAsync(solution, cancellationToken).ConfigureAwait(false));
-
-            var locations = locBuilder.ToImmutableHashSet();
-
-            if (ImplicitLocations != null)
-            {
-                using var _2 = ArrayBuilder<ReferenceLocation>.GetInstance(ImplicitLocations.Length, out var builder);
-                foreach (var loc in ImplicitLocations)
-                    builder.Add(await loc.RehydrateAsync(solution, cancellationToken).ConfigureAwait(false));
-
-                implicitLocations = builder.ToImmutable();
-            }
-
-            if (ReferencedSymbols != null)
-            {
-                using var _3 = ArrayBuilder<ISymbol>.GetInstance(ReferencedSymbols.Length, out var builder);
-                foreach (var symbol in ReferencedSymbols)
-                    builder.AddIfNotNull(await symbol.TryRehydrateAsync(solution, cancellationToken).ConfigureAwait(false));
-
-                referencedSymbols = builder.ToImmutable();
-            }
-
-            return new RenameLocations.SearchResult(locations, implicitLocations, referencedSymbols);
-        }
-    }
-
-#endif
-
     [DataContract]
     internal readonly struct SerializableRenameLocation
     {
@@ -255,40 +193,6 @@ namespace Microsoft.CodeAnalysis.Rename
                 implicitLocations,
                 referencedSymbols);
         }
-
-        //public async Task<RenameLocations.SearchResult> RehydrateAsync(Solution solution, CancellationToken cancellationToken)
-        //{
-        //    ImmutableArray<ReferenceLocation> implicitLocations = default;
-        //    ImmutableArray<ISymbol> referencedSymbols = default;
-
-        //    Contract.ThrowIfNull(Locations);
-
-        //    using var _1 = ArrayBuilder<RenameLocation>.GetInstance(Locations.Length, out var locBuilder);
-        //    foreach (var loc in Locations)
-        //        locBuilder.Add(await loc.RehydrateAsync(solution, cancellationToken).ConfigureAwait(false));
-
-        //    var locations = locBuilder.ToImmutableHashSet();
-
-        //    if (ImplicitLocations != null)
-        //    {
-        //        using var _2 = ArrayBuilder<ReferenceLocation>.GetInstance(ImplicitLocations.Length, out var builder);
-        //        foreach (var loc in ImplicitLocations)
-        //            builder.Add(await loc.RehydrateAsync(solution, cancellationToken).ConfigureAwait(false));
-
-        //        implicitLocations = builder.ToImmutable();
-        //    }
-
-        //    if (ReferencedSymbols != null)
-        //    {
-        //        using var _3 = ArrayBuilder<ISymbol>.GetInstance(ReferencedSymbols.Length, out var builder);
-        //        foreach (var symbol in ReferencedSymbols)
-        //            builder.AddIfNotNull(await symbol.TryRehydrateAsync(solution, cancellationToken).ConfigureAwait(false));
-
-        //        referencedSymbols = builder.ToImmutable();
-        //    }
-
-        //    return new RenameLocations.SearchResult(locations, implicitLocations, referencedSymbols);
-        //}
     }
 
     [DataContract]

--- a/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Rename
                         if (result.HasValue && result.Value != null)
                         {
                             var rehydrated = await TryRehydrateAsync(
-                                solution, fallbackOptions, result.Value, cancellationToken).ConfigureAwait(false);
+                                solution, symbol, fallbackOptions, result.Value, cancellationToken).ConfigureAwait(false);
 
                             if (rehydrated != null)
                                 return rehydrated;

--- a/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
@@ -31,24 +31,26 @@ namespace Microsoft.CodeAnalysis.Rename
         public readonly SymbolRenameOptions Options;
         public readonly CodeCleanupOptionsProvider FallbackOptions;
 
-        private readonly SearchResult _result;
-
-        public ISet<RenameLocation> Locations => _result.Locations;
-        public ImmutableArray<ISymbol> ReferencedSymbols => _result.ReferencedSymbols;
-        public ImmutableArray<ReferenceLocation> ImplicitLocations => _result.ImplicitLocations;
+        public readonly ImmutableHashSet<RenameLocation> Locations;
+        public readonly ImmutableArray<ReferenceLocation> ImplicitLocations;
+        public readonly ImmutableArray<ISymbol> ReferencedSymbols;
 
         private RenameLocations(
             ISymbol symbol,
             Solution solution,
             SymbolRenameOptions options,
             CodeCleanupOptionsProvider fallbackOptions,
-            SearchResult result)
+            ImmutableHashSet<RenameLocation> locations,
+            ImmutableArray<ReferenceLocation> implicitLocations,
+            ImmutableArray<ISymbol> referencedSymbols)
         {
             Solution = solution;
             Symbol = symbol;
             Options = options;
             FallbackOptions = fallbackOptions;
-            _result = result;
+            Locations = locations;
+            ReferencedSymbols = referencedSymbols;
+            ImplicitLocations = implicitLocations;
         }
 
         internal static RenameLocations Create(
@@ -61,8 +63,7 @@ namespace Microsoft.CodeAnalysis.Rename
             CodeCleanupOptionsProvider fallbackOptions)
         {
             return new RenameLocations(
-                symbol, solution, options, fallbackOptions,
-                new SearchResult(locations, implicitLocations, referencedSymbols));
+                symbol, solution, options, fallbackOptions, locations, implicitLocations, referencedSymbols);
         }
 
         /// <summary>
@@ -157,10 +158,9 @@ namespace Microsoft.CodeAnalysis.Rename
 
                 return new RenameLocations(
                     symbol, solution, options, cleanupOptions,
-                    new SearchResult(
-                        mergedLocations.ToImmutable(),
-                        mergedImplicitLocations.ToImmutable(),
-                        mergedReferencedSymbols.ToImmutable()));
+                    mergedLocations.ToImmutable(),
+                    mergedImplicitLocations.ToImmutable(),
+                    mergedReferencedSymbols.ToImmutable());
             }
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/Renamer/RemoteRenamerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Renamer/RemoteRenamerService.cs
@@ -85,6 +85,7 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 var result = await RenameLocations.FindLocationsAsync(
                     symbol, solution, options, fallbackOptions, cancellationToken).ConfigureAwait(false);
+
                 return result.Dehydrate(solution, cancellationToken);
             }, cancellationToken);
         }


### PR DESCRIPTION
Found while doing a larger refactoring.  Extracted out for simplicity.