### PR TITLE
correctness build optimizations

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -203,6 +203,7 @@ jobs:
     buildArguments: -msbuildEngine dotnet -runAnalyzers -warnAsError /p:RoslynEnforceCodeStyle=true /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
 - job: Correctness_Build_Artifacts
+  dependsOn: Determine_Changes
   pool:
     name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
@@ -230,9 +231,11 @@ jobs:
       inputs:
         filePath: eng/generate-compiler-code.ps1
         arguments: -test -configuration Release
-        
+      condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true'))
+      
     - script: $(Build.SourcesDirectory)\.dotnet\dotnet.exe tool run dotnet-format whitespace  $(Build.SourcesDirectory)\src --folder --include-generated --include $(Build.SourcesDirectory)\src\Compilers\CSharp\Portable\Generated\ $(Build.SourcesDirectory)\src\Compilers\VisualBasic\Portable\Generated\ $(Build.SourcesDirectory)\src\ExpressionEvaluator\VisualBasic\Source\ResultProvider\Generated\ --verify-no-changes
       displayName: Validate Generated Syntax Files
+      condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true'))
       
     - template: eng/pipelines/publish-logs.yml
       parameters:
@@ -241,7 +244,7 @@ jobs:
     
 - job: Correctness_Determinism
   dependsOn: Determine_Changes
-  condition: eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true')
+  condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true'))
   pool:
     name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
@@ -259,7 +262,7 @@ jobs:
 
 - job: Correctness_Bootstrap_Build
   dependsOn: Determine_Changes
-  condition: eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true')
+  condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true'))
   pool:
     name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
@@ -301,7 +304,7 @@ jobs:
 
 - job: Correctness_Rebuild
   dependsOn: Determine_Changes
-  condition: eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true')
+  condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true'))
   pool:
     name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -329,13 +329,10 @@ jobs:
 - job: Correctness_Analyzers
   pool:
     name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
   timeoutInMinutes: 35
   steps:
-    - template: eng/pipelines/checkout-windows-task.yml
+    - template: eng/pipelines/checkout-unix-task.yml
       
-    - task: PowerShell@2 
+    - script: ./eng/build.sh --solution Roslyn.sln --restore --build --configuration Debug --prepareMachine --ci --binaryLog --runanalyzers --warnaserror /p:RoslynEnforceCodeStyle=true
       displayName: Build with analyzers
-      inputs:
-        filePath: eng/build.ps1
-        arguments: -msbuildEngine dotnet -restore -build -configuration Debug -prepareMachine -ci -binaryLog -runAnalyzers:$true -warnAsError:$true -properties "/p:RoslynEnforceCodeStyle=true"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,6 +184,16 @@ jobs:
 
 # Build Correctness Jobs
 
+- template: eng/pipelines/evaluate-changed-files.yml
+  parameters:
+    jobName: Determine_Changes
+    vmImageName: ubuntu-latest
+    paths:
+      - subset: compilers
+        include:
+        - src/Compilers/*
+        - src/Dependencies/*
+
 - template: eng/pipelines/build-windows-job.yml
   parameters:
     jobName: Correctness_Code_Analysis
@@ -229,55 +239,55 @@ jobs:
         jobName: Correctness_Build_Artifacts
         configuration: Release
     
-- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-  - job: Correctness_Determinism
-    pool:
-      name: NetCore1ESPool-Public
-      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
-    timeoutInMinutes: 90
-    steps:
-      - template: eng/pipelines/checkout-windows-task.yml
+- job: Correctness_Determinism
+  dependsOn: Determine_Changes
+  condition: eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true')
+  pool:
+    name: NetCore1ESPool-Public
+    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+  timeoutInMinutes: 90
+  steps:
+    - template: eng/pipelines/checkout-windows-task.yml
+    
+    - script: eng/test-determinism.cmd -configuration Debug
+      displayName: Build - Validate determinism
 
-      - script: eng/test-determinism.cmd -configuration Debug
-        displayName: Build - Validate determinism
+    - template: eng/pipelines/publish-logs.yml
+      parameters:
+        jobName: Correctness_Determinism
+        configuration: Debug
 
-      - template: eng/pipelines/publish-logs.yml
-        parameters:
-          jobName: Correctness_Determinism
-          configuration: Debug
+- job: Correctness_Bootstrap_Build
+  dependsOn: Determine_Changes
+  condition: eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true')
+  pool:
+    name: NetCore1ESPool-Public
+    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+  timeoutInMinutes: 90
+  steps:
+    - template: eng/pipelines/checkout-windows-task.yml
 
-- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-  - job: Correctness_Bootstrap_Build
-    pool:
-      name: NetCore1ESPool-Public
-      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
-    timeoutInMinutes: 90
-    steps:
-      - template: eng/pipelines/checkout-windows-task.yml
+    - script: eng/test-build-correctness.cmd -configuration Release -enableDumps
+      displayName: Build - Validate correctness
 
-      - script: eng/test-build-correctness.cmd -configuration Release -enableDumps
-        displayName: Build - Validate correctness
+    - template: eng/pipelines/publish-logs.yml
+      parameters:
+        jobName: Correctness_Bootstrap_Build
+        configuration: Release
 
-      - template: eng/pipelines/publish-logs.yml
-        parameters:
-          jobName: Correctness_Bootstrap_Build
-          configuration: Release
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Artifact Packages
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\Release\PreRelease'
+        ArtifactName: 'Bootstrap Packages - PreRelease'
+        publishLocation: Container
 
-      - task: PublishBuildArtifacts@1
-        displayName: Publish Artifact Packages
-        inputs:
-          PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\Release\PreRelease'
-          ArtifactName: 'Bootstrap Packages - PreRelease'
-          publishLocation: Container
-        condition: succeeded()
-
-      - task: PublishBuildArtifacts@1
-        displayName: Publish VSIX Packages
-        inputs:
-          PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\Release\Installer'
-          ArtifactName: 'Bootstrap VSIX - PreRelease'
-          publishLocation: Container
-        condition: succeeded()
+    - task: PublishBuildArtifacts@1
+      displayName: Publish VSIX Packages
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\Release\Installer'
+        ArtifactName: 'Bootstrap VSIX - PreRelease'
+        publishLocation: Container
 
 - job: Correctness_TodoCheck
   pool:
@@ -289,32 +299,32 @@ jobs:
     - pwsh: eng/todo-check.ps1
       displayName: Validate TODO/PROTOTYPE comments are not present
 
-- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-  - job: Correctness_Rebuild
-    pool:
-      name: NetCore1ESPool-Public
-      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
-    timeoutInMinutes: 90
-    steps:
-      - template: eng/pipelines/checkout-windows-task.yml
+- job: Correctness_Rebuild
+  dependsOn: Determine_Changes
+  condition: eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true')
+  pool:
+    name: NetCore1ESPool-Public
+    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+  timeoutInMinutes: 90
+  steps:
+    - template: eng/pipelines/checkout-windows-task.yml
 
-      - task: PowerShell@2
-        displayName: Restore
-        inputs:
-          filePath: eng/build.ps1
-          arguments: -configuration Debug -prepareMachine -ci -restore -binaryLog
+    - task: PowerShell@2
+      displayName: Restore
+      inputs:
+        filePath: eng/build.ps1
+        arguments: -configuration Debug -prepareMachine -ci -restore -binaryLog
 
-      - powershell: .\eng\test-rebuild.ps1 -ci -configuration Release
-        displayName: Run BuildValidator
+    - powershell: .\eng\test-rebuild.ps1 -ci -configuration Release
+      displayName: Run BuildValidator
 
-      - task: PublishBuildArtifacts@1
-        displayName: Publish BuildValidator debug outputs
-        inputs:
-          PathtoPublish: '$(Build.SourcesDirectory)/artifacts/BuildValidator'
-          ArtifactName: 'BuildValidator_DebugOut'
-          publishLocation: Container
-        continueOnError: true
-        condition: failed()
+    - task: PublishBuildArtifacts@1
+      displayName: Publish BuildValidator debug outputs
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/BuildValidator'
+        ArtifactName: 'BuildValidator_DebugOut'
+        publishLocation: Container
+      continueOnError: true
 
     - template: eng/pipelines/publish-logs.yml
       parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -200,6 +200,8 @@ jobs:
     name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
   timeoutInMinutes: 90
+  variables:
+    compilerChange: $[dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange']]
   steps:
     - template: eng/pipelines/checkout-windows-task.yml
 
@@ -223,11 +225,11 @@ jobs:
       inputs:
         filePath: eng/generate-compiler-code.ps1
         arguments: -test -configuration Release
-      condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true'))
+      condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['compilerChange'], 'true'))
       
     - script: $(Build.SourcesDirectory)\.dotnet\dotnet.exe tool run dotnet-format whitespace  $(Build.SourcesDirectory)\src --folder --include-generated --include $(Build.SourcesDirectory)\src\Compilers\CSharp\Portable\Generated\ $(Build.SourcesDirectory)\src\Compilers\VisualBasic\Portable\Generated\ $(Build.SourcesDirectory)\src\ExpressionEvaluator\VisualBasic\Source\ResultProvider\Generated\ --verify-no-changes
       displayName: Validate Generated Syntax Files
-      condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true'))
+      condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['compilerChange'], 'true'))
       
     - template: eng/pipelines/publish-logs.yml
       parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,53 +184,55 @@ jobs:
 
 # Build Correctness Jobs
 
-- job: Correctness_Determinism
-  pool:
-    name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
-  timeoutInMinutes: 90
-  steps:
-    - template: eng/pipelines/checkout-windows-task.yml
+- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - job: Correctness_Determinism
+    pool:
+      name: NetCore1ESPool-Public
+      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+    timeoutInMinutes: 90
+    steps:
+      - template: eng/pipelines/checkout-windows-task.yml
 
-    - script: eng/test-determinism.cmd -configuration Debug
-      displayName: Build - Validate determinism
+      - script: eng/test-determinism.cmd -configuration Debug
+        displayName: Build - Validate determinism
 
-    - template: eng/pipelines/publish-logs.yml
-      parameters:
-        jobName: Correctness_Determinism
-        configuration: Debug
+      - template: eng/pipelines/publish-logs.yml
+        parameters:
+          jobName: Correctness_Determinism
+          configuration: Debug
 
-- job: Correctness_Build
-  pool:
-    name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
-  timeoutInMinutes: 90
-  steps:
-    - template: eng/pipelines/checkout-windows-task.yml
+- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - job: Correctness_Build
+    pool:
+      name: NetCore1ESPool-Public
+      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+    timeoutInMinutes: 90
+    steps:
+      - template: eng/pipelines/checkout-windows-task.yml
 
-    - script: eng/test-build-correctness.cmd -configuration Release -enableDumps
-      displayName: Build - Validate correctness
+      - script: eng/test-build-correctness.cmd -configuration Release -enableDumps
+        displayName: Build - Validate correctness
 
-    - template: eng/pipelines/publish-logs.yml
-      parameters:
-        jobName: Correctness_Build
-        configuration: Release
+      - template: eng/pipelines/publish-logs.yml
+        parameters:
+          jobName: Correctness_Build
+          configuration: Release
 
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Artifact Packages
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\Release\PreRelease'
-        ArtifactName: 'Packages - PreRelease'
-        publishLocation: Container
-      condition: succeeded()
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Artifact Packages
+        inputs:
+          PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\Release\PreRelease'
+          ArtifactName: 'Packages - PreRelease'
+          publishLocation: Container
+        condition: succeeded()
 
-    - task: PublishBuildArtifacts@1
-      displayName: Publish VSIX Packages
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\Release\Installer'
-        ArtifactName: 'VSIX - PreRelease'
-        publishLocation: Container
-      condition: succeeded()
+      - task: PublishBuildArtifacts@1
+        displayName: Publish VSIX Packages
+        inputs:
+          PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\Release\Installer'
+          ArtifactName: 'VSIX - PreRelease'
+          publishLocation: Container
+        condition: succeeded()
 
 - job: Correctness_TodoCheck
   pool:
@@ -242,47 +244,34 @@ jobs:
     - pwsh: eng/todo-check.ps1
       displayName: Validate TODO/PROTOTYPE comments are not present
 
-- job: Correctness_Rebuild
-  pool:
-    name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
-  timeoutInMinutes: 90
-  steps:
-    - template: eng/pipelines/checkout-windows-task.yml
+- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - job: Correctness_Rebuild
+    pool:
+      name: NetCore1ESPool-Public
+      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+    timeoutInMinutes: 90
+    steps:
+      - template: eng/pipelines/checkout-windows-task.yml
 
-    - task: PowerShell@2
-      displayName: Restore
-      inputs:
-        filePath: eng/build.ps1
-        arguments: -configuration Debug -prepareMachine -ci -restore -binaryLog
+      - task: PowerShell@2
+        displayName: Restore
+        inputs:
+          filePath: eng/build.ps1
+          arguments: -configuration Debug -prepareMachine -ci -restore -binaryLog
 
-    - powershell: .\eng\test-rebuild.ps1 -ci -configuration Release
-      displayName: Run BuildValidator
+      - powershell: .\eng\test-rebuild.ps1 -ci -configuration Release
+        displayName: Run BuildValidator
 
-    - task: PublishBuildArtifacts@1
-      displayName: Publish BuildValidator debug outputs
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/BuildValidator'
-        ArtifactName: 'BuildValidator_DebugOut'
-        publishLocation: Container
-      continueOnError: true
-      condition: failed()
+      - task: PublishBuildArtifacts@1
+        displayName: Publish BuildValidator debug outputs
+        inputs:
+          PathtoPublish: '$(Build.SourcesDirectory)/artifacts/BuildValidator'
+          ArtifactName: 'BuildValidator_DebugOut'
+          publishLocation: Container
+        continueOnError: true
+        condition: failed()
 
     - template: eng/pipelines/publish-logs.yml
       parameters:
         jobName: Correctness_Rebuild
         configuration: Release
-
-- job: Correctness_Analyzers
-  pool:
-    name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
-  timeoutInMinutes: 35
-  steps:
-    - template: eng/pipelines/checkout-windows-task.yml
-
-    - task: PowerShell@2 
-      displayName: Build with analyzers
-      inputs:
-        filePath: eng/build.ps1
-        arguments: -restore -build -configuration Debug -prepareMachine -ci -binaryLog -runAnalyzers:$true -warnAsError:$true -properties "/p:RoslynEnforceCodeStyle=true"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -202,7 +202,7 @@ jobs:
           configuration: Debug
 
 - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-  - job: Correctness_Build
+  - job: Correctness_Bootstrap_Build
     pool:
       name: NetCore1ESPool-Public
       demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
@@ -215,14 +215,14 @@ jobs:
 
       - template: eng/pipelines/publish-logs.yml
         parameters:
-          jobName: Correctness_Build
+          jobName: Correctness_Bootstrap_Build
           configuration: Release
 
       - task: PublishBuildArtifacts@1
         displayName: Publish Artifact Packages
         inputs:
           PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\Release\PreRelease'
-          ArtifactName: 'Packages - PreRelease'
+          ArtifactName: 'Bootstrap Packages - PreRelease'
           publishLocation: Container
         condition: succeeded()
 
@@ -230,7 +230,7 @@ jobs:
         displayName: Publish VSIX Packages
         inputs:
           PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\Release\Installer'
-          ArtifactName: 'VSIX - PreRelease'
+          ArtifactName: 'Bootstrap VSIX - PreRelease'
           publishLocation: Container
         condition: succeeded()
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,6 +184,51 @@ jobs:
 
 # Build Correctness Jobs
 
+- template: eng/pipelines/build-windows-job.yml
+  parameters:
+    jobName: Correctness_Code_Analysis
+    configuration: Debug
+    queueName: Build.Windows.Amd64.VS2022.Pre.Open
+    restoreArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+    buildArguments: -msbuildEngine dotnet -runAnalyzers -warnAsError /p:RoslynEnforceCodeStyle=true /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+
+- job: Correctness_Build_Artifacts
+  pool:
+    name: NetCore1ESPool-Public
+    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+  timeoutInMinutes: 90
+  steps:
+    - template: eng/pipelines/checkout-windows-task.yml
+
+    - task: PowerShell@2
+      displayName: Restore
+      inputs:
+        filePath: eng/build.ps1
+        arguments: -configuration Release -prepareMachine -ci -restore -binaryLog
+
+    - task: PowerShell@2
+      displayName: Build
+      inputs:
+        filePath: eng/build.ps1
+        arguments: -configuration Release -prepareMachine -ci -build -pack -publish -sign -binaryLog
+
+    - script: $(Build.SourcesDirectory)\artifacts\bin\BuildBoss\Release\net472\BuildBoss.exe  -r "$(Build.SourcesDirectory)/" -c Release -p Roslyn.sln
+      displayName: Validate Build Artifacts
+
+    - task: PowerShell@2
+      displayName: Generate Syntax Files
+      inputs:
+        filePath: eng/generate-compiler-code.ps1
+        arguments: -test -configuration Release
+        
+    - script: $(Build.SourcesDirectory)\.dotnet\dotnet.exe tool run dotnet-format whitespace  $(Build.SourcesDirectory)\src --folder --include-generated --include $(Build.SourcesDirectory)\src\Compilers\CSharp\Portable\Generated\ $(Build.SourcesDirectory)\src\Compilers\VisualBasic\Portable\Generated\ $(Build.SourcesDirectory)\src\ExpressionEvaluator\VisualBasic\Source\ResultProvider\Generated\ --verify-no-changes
+      displayName: Validate Generated Syntax Files
+      
+    - template: eng/pipelines/publish-logs.yml
+      parameters:
+        jobName: Correctness_Build_Artifacts
+        configuration: Release
+    
 - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
   - job: Correctness_Determinism
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -194,14 +194,6 @@ jobs:
         - src/Compilers/*
         - src/Dependencies/*
 
-- template: eng/pipelines/build-windows-job.yml
-  parameters:
-    jobName: Correctness_Code_Analysis
-    configuration: Debug
-    queueName: Build.Windows.Amd64.VS2022.Pre.Open
-    restoreArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
-    buildArguments: -msbuildEngine dotnet -runAnalyzers -warnAsError /p:RoslynEnforceCodeStyle=true /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
-
 - job: Correctness_Build_Artifacts
   dependsOn: Determine_Changes
   pool:
@@ -333,3 +325,17 @@ jobs:
       parameters:
         jobName: Correctness_Rebuild
         configuration: Release
+
+- job: Correctness_Analyzers
+  pool:
+    name: NetCore1ESPool-Public
+    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+  timeoutInMinutes: 35
+  steps:
+    - template: eng/pipelines/checkout-windows-task.yml
+      
+    - task: PowerShell@2 
+      displayName: Build with analyzers
+      inputs:
+        filePath: eng/build.ps1
+        arguments: -msbuildEngine dotnet -restore -build -configuration Debug -prepareMachine -ci -binaryLog -runAnalyzers:$true -warnAsError:$true -properties "/p:RoslynEnforceCodeStyle=true"

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -36,6 +36,7 @@ usage()
   echo "  --prepareMachine           Prepare machine for CI run, clean up processes after build"
   echo "  --warnAsError              Treat all warnings as errors"
   echo "  --sourceBuild              Simulate building for source-build"
+  echo "  --solution                 Soluton to build (Default is Compilers.sln)"
   echo ""
   echo "Command line arguments starting with '/p:' are passed through to MSBuild."
 }
@@ -74,6 +75,7 @@ prepare_machine=false
 warn_as_error=false
 properties=""
 source_build=false
+solution_to_build="Compilers.sln"
 
 args=""
 
@@ -160,6 +162,11 @@ while [[ $# > 0 ]]; do
       # have an alias.
       source_build=true
       ;;
+    --solution)
+      solution_to_build=$2
+      args="$args $1"
+      shift
+      ;;
     /p:*)
       properties="$properties $1"
       ;;
@@ -203,7 +210,7 @@ function MakeBootstrapBuild {
 }
 
 function BuildSolution {
-  local solution="Compilers.sln"
+  local solution=$solution_to_build
   echo "$solution:"
 
   InitializeToolset

--- a/eng/evaluate-changed-paths.sh
+++ b/eng/evaluate-changed-paths.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+
+# Disable globbing in this bash script since we iterate over path patterns
+set -f
+
+# Stop script if unbound variable found (use ${var:-} if intentional)
+set -u
+
+# Stop script if command returns non-zero exit code.
+# Prevents hidden errors caused by missing error code propagation.
+set -e
+
+usage()
+{
+  echo "Script that evaluates changed paths and emits an azure devops variable if the changes contained in the current HEAD against the difftarget meet the includepahts/excludepaths filters:"
+  echo "  --difftarget <value>       SHA or branch to diff against. (i.e: HEAD^1, origin/main, 0f4hd36, etc.)"
+  echo "  --excludepaths <value>     Escaped list of paths to exclude from diff separated by '+'. (i.e: 'src/libraries/*+'src/installer/*')"
+  echo "  --includepaths <value>     Escaped list of paths to include on diff separated by '+'. (i.e: 'src/libraries/System.Private.CoreLib/*')"
+  echo "  --subset                   Subset name for which we're evaluating in order to include it in logs"
+  echo "  --azurevariable            Name of azure devops variable to create if change meets filter criteria"
+  echo ""
+
+  echo "Arguments can also be passed in with a single hyphen."
+}
+
+source="${BASH_SOURCE[0]}"
+
+# resolve $source until the file is no longer a symlink
+while [[ -h "$source" ]]; do
+  scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+  source="$(readlink "$source")"
+  # if $source was a relative symlink, we need to resolve it relative to the path where the
+  # symlink file was located
+  [[ $source != /* ]] && source="$scriptroot/$source"
+done
+
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+eng_root=`cd -P "$scriptroot" && pwd`
+
+exclude_paths=()
+include_paths=()
+subset_name=''
+azure_variable=''
+diff_target=''
+
+while [[ $# > 0 ]]; do
+  opt="$(echo "${1/#--/-}" | tr "[:upper:]" "[:lower:]")"
+  case "$opt" in
+    -help|-h)
+      usage
+      exit 0
+      ;;
+    -difftarget)
+      diff_target=$2
+      shift
+      ;;
+    -excludepaths)
+      IFS='+' read -r -a tmp <<< $2
+      exclude_paths+=(${tmp[@]})
+      shift
+      ;;
+    -includepaths)
+      IFS='+' read -r -a tmp <<< $2
+      include_paths+=(${tmp[@]})
+      shift
+      ;;
+    -subset)
+      subset_name=$2
+      shift
+      ;;
+    -azurevariable)
+      azure_variable=$2
+      shift
+      ;;
+  esac
+
+  shift
+done
+
+ci=true # Needed in order to use pipeline-logging-functions.sh
+. "$eng_root/common/pipeline-logging-functions.sh"
+
+# -- expected args --
+# $@: git diff arguments
+customGitDiff() {
+  (
+    set -x
+    git diff -M -C -b --ignore-cr-at-eol --ignore-space-at-eol "$@"
+  )
+}
+
+# runs git diff with supplied filter.
+# -- exit codes --
+# 0: No match was found
+# 1: At least 1 match was found
+#
+# -- expected args --
+# $@: filter string
+probePathsWithExitCode() {
+  local _filter=$@
+  echo ""
+  customGitDiff --exit-code --quiet $diff_target -- $_filter
+}
+
+# -- expected args --
+# $@: filter string
+printMatchedPaths() {
+  local _subset=$subset_name
+  local _filter=$@
+  echo ""
+  echo "----- Matching files for $_subset -----"
+  customGitDiff --name-only $diff_target -- $_filter
+}
+
+probePaths() {
+  local _subset=$subset_name
+  local _azure_devops_var_name=$azure_variable
+  local exclude_path_string=""
+  local include_path_string=""
+  local found_applying_changes=false
+
+  if [[ ${#exclude_paths[@]} -gt 0 ]]; then
+    echo ""
+    echo "******* Probing $_subset exclude paths *******";
+    for _path in "${exclude_paths[@]}"; do
+      echo "$_path"
+      if [[ -z "$exclude_path_string" ]]; then
+        exclude_path_string=":!$_path"
+      else
+        exclude_path_string="$exclude_path_string :!$_path"
+      fi
+    done
+
+    if ! probePathsWithExitCode $exclude_path_string; then
+      found_applying_changes=true
+      printMatchedPaths $exclude_path_string
+    fi
+  fi
+
+  if [[ $found_applying_changes != true && ${#include_paths[@]} -gt 0 ]]; then
+    echo ""
+    echo "******* Probing $_subset include paths *******";
+    for _path in "${include_paths[@]}"; do
+      echo "$_path"
+      if [[ -z "$include_path_string" ]]; then
+        include_path_string=":$_path"
+      else
+        include_path_string="$include_path_string :$_path"
+      fi
+    done
+
+    if ! probePathsWithExitCode $include_path_string; then
+      found_applying_changes=true
+      printMatchedPaths $include_path_string
+    fi
+  fi
+
+  if [[ $found_applying_changes == true ]]; then
+    echo ""
+    echo "Setting pipeline variable $_azure_devops_var_name=true"
+    Write-PipelineSetVariable -name $_azure_devops_var_name -value true -is_multi_job_variable true
+  else
+    echo ""
+    echo "No changed files for $_subset"
+  fi
+}
+
+probePaths

--- a/eng/pipelines/evaluate-changed-files-group.yml
+++ b/eng/pipelines/evaluate-changed-files-group.yml
@@ -1,0 +1,19 @@
+# This step template evaluates git changes using git based on a include/exclude path filter.
+# For more information on how the path evaluation works look at evaluate-changed-paths.sh docs
+# at the beginning of that file.
+
+parameters:
+  # Name for the subset that we're evaluating changes for.
+  # It is required to name the step correctly and so the variable created can be consumable.
+  subsetName: ''
+  # Array containing the arguments that are to be passed down to evaluate-changed-paths.sh
+  # Note that --azurevariable is always set to containschange, no need to pass it down.
+  arguments: []
+
+steps:
+  - ${{ if ne(parameters.arguments[0], '') }}:
+    - script: eng/evaluate-changed-paths.sh
+              --azurevariable containsChange
+              ${{ join(' ', parameters.arguments) }}
+      displayName: Evaluate paths for ${{ parameters.subsetName }}
+      name: ${{ format('SetPathVars_{0}', parameters.subsetName) }} # need a name to access output variable

--- a/eng/pipelines/evaluate-changed-files.yml
+++ b/eng/pipelines/evaluate-changed-files.yml
@@ -1,0 +1,53 @@
+# Template to evaluate common paths in different pipelines.
+parameters:
+- name: jobName
+  type: string
+  default: ''
+- name: queueName
+  type: string
+  default: ''
+- name: vmImageName
+  type: string
+  default: ''
+- name: paths
+  type: object
+  default: []
+
+jobs:
+- job: ${{ parameters.jobName }}
+  pool:
+    ${{ if ne(parameters.queueName, '') }}:
+      name: NetCore1ESPool-Public
+      demands: ImageOverride -equals ${{ parameters.queueName }}
+
+    ${{ if ne(parameters.vmImageName, '') }}:
+      vmImage: ${{ parameters.vmImageName }}
+  timeoutInMinutes: 10
+
+  steps:
+  - checkout: none
+
+  - script: |
+      set -x
+      git init
+      git config --local checkout.workers 0
+      git config --local fetch.parallel 0
+      git remote add origin "$(Build.Repository.Uri)"
+      git fetch --no-tags --no-auto-maintenance --depth=2 origin "$(Build.SourceVersion)"
+      git checkout "$(Build.SourceVersion)"
+    displayName: Shallow Checkout
+  
+  - ${{ if ne(parameters.paths[0], '') }}:
+    - ${{ each path in parameters.paths }}:
+      - template: evaluate-changed-files-group.yml
+        parameters:
+          subsetName: ${{ path.subset }} 
+          arguments:
+          # The commit that we're building is always a merge commit that is merging into the target branch.
+          # So the first parent of the commit is on the target branch and the second parent is on the source branch.
+          - --difftarget HEAD^1
+          - --subset ${{ path.subset }}
+          - ${{ if ne(path.include[0], '') }}:
+            - --includepaths '${{ join('+', path.include) }}'
+          - ${{ if ne(path.exclude[0], '') }}:
+            - --excludepaths '${{ join('+', path.exclude) }}'

--- a/src/VisualStudio/IntegrationTest/TestUtilities/Microsoft.VisualStudio.IntegrationTest.Utilities.csproj
+++ b/src/VisualStudio/IntegrationTest/TestUtilities/Microsoft.VisualStudio.IntegrationTest.Utilities.csproj
@@ -15,7 +15,7 @@
     </PackageDescription>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="App.config" />
     <None Include="Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>


### PR DESCRIPTION
depends on https://github.com/dotnet/roslyn/pull/628

this PR does three things:

1. only run `Correctness_Determinism`, `Correctness_Build`, and `Correctness_Rebuild` on check-in rather than PRs
2. rename `Correctness_Build` to `Correctness_Bootstrap_Build`
3. Create 2 new jobs (`Correctness_Code_Analysis` and `Correctness_Build_Artifacts`) that validate everything the `Correctness_Bootstrap_Build` job does but without using the boot strap compiler.

## Motivation

The bootstrap compiler is _very_ slow and running it on all of Roslyn takes well over an hour. There are bugs that doing this will catch but I am proposing in this PR that we do not block merging on them. With this change we can still validate that we are not breaking bootstrapping, determinism, re-build, or hitting asserts in the analyzer driver. We will just get that notification on checkin.
