### PR TITLE
ci build cleanup

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,8 +36,8 @@ jobs:
     testArtifactName: Transport_Artifacts_Windows_Debug
     configuration: Debug
     queueName: Build.Windows.Amd64.VS2022.Pre.Open
-    restoreArguments: /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
-    buildArguments: /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+    restoreArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+    buildArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
 - template: eng/pipelines/build-windows-job.yml
   parameters:
@@ -45,8 +45,8 @@ jobs:
     testArtifactName: Transport_Artifacts_Windows_Release
     configuration: Release
     queueName: Build.Windows.Amd64.VS2022.Pre.Open
-    restoreArguments: /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
-    buildArguments: /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+    restoreArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+    buildArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
 - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
   - template: eng/pipelines/test-windows-job.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,7 @@ jobs:
     testArtifactName: Transport_Artifacts_Windows_Debug
     configuration: Debug
     queueName: Build.Windows.Amd64.VS2022.Pre.Open
+    buildArguments: /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
 - template: eng/pipelines/build-windows-job.yml
   parameters:
@@ -43,6 +44,7 @@ jobs:
     testArtifactName: Transport_Artifacts_Windows_Release
     configuration: Release
     queueName: Build.Windows.Amd64.VS2022.Pre.Open
+    buildArguments: /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
 - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
   - template: eng/pipelines/test-windows-job.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,7 @@ jobs:
     testArtifactName: Transport_Artifacts_Windows_Debug
     configuration: Debug
     queueName: Build.Windows.Amd64.VS2022.Pre.Open
+    restoreArguments: /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
     buildArguments: /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
 - template: eng/pipelines/build-windows-job.yml
@@ -44,6 +45,7 @@ jobs:
     testArtifactName: Transport_Artifacts_Windows_Release
     configuration: Release
     queueName: Build.Windows.Amd64.VS2022.Pre.Open
+    restoreArguments: /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
     buildArguments: /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
 - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -43,7 +43,7 @@ jobs:
       displayName: Build
       inputs:
         filePath: eng/build.ps1
-        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -build -binaryLog -skipDocumentation /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false ${{ parameters.buildArguments }}
+        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -build -binaryLog -skipDocumentation ${{ parameters.buildArguments }}
 
     - task: PowerShell@2
       displayName: Prepare Unit Tests

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -32,6 +32,8 @@ jobs:
     ${{ if ne(parameters.vmImageName, '') }}:
       vmImage: ${{ parameters.vmImageName }}
   timeoutInMinutes: 40
+  variables:
+    artifactName: ${{ parameters.testArtifactName }}
 
   steps:
     - template: checkout-windows-task.yml
@@ -53,12 +55,14 @@ jobs:
       inputs:
         filePath: eng/prepare-tests.ps1
         arguments: -configuration ${{ parameters.configuration }}
+      condition: and(ne(variables['artifactName'], ''), succeeded())
 
     - task: PublishPipelineArtifact@1
       displayName: Publish Test Payload
       inputs:
         targetPath: '$(Build.SourcesDirectory)\artifacts\testPayload'
         artifactName: ${{ parameters.testArtifactName }}
+      condition: and(ne(variables['artifactName'], ''), succeeded())
 
     - template: publish-logs.yml
       parameters:

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -15,6 +15,9 @@ parameters:
 - name: vmImageName
   type: string
   default: ''
+- name: restoreArguments
+  type: string
+  default: ''
 - name: buildArguments
   type: string
   default: ''
@@ -37,7 +40,7 @@ jobs:
       displayName: Restore
       inputs:
         filePath: eng/build.ps1
-        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -restore -binaryLog /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -restore -binaryLog ${{ parameters.restoreArguments }}
 
     - task: PowerShell@2
       displayName: Build


### PR DESCRIPTION
This is some cleanup [for ](https://github.com/dotnet/roslyn/pull/62336)

It does the following:

- use `buildArguments` parameter instead of manually specifying these arguments in the template
- add `restoreArguments` instead of manually specifying these arguments in the template
- only publish test artifacts if we are given an artifact name
- build with the .NET core version of MSBuild instead of the .NET Framework version.