### PR TITLE
Share state in OOP calls for concurrent calls with the same checksum

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 // same solutionChecksum would then not find the item either there, or in the
                 // _solutionChecksumToLazySolution map.
 
-                var refCountedLazySolution = await GetLazySolutionAsync(
+                var refCountedLazySolution = await GetAndCacheLazySolutionAsync(
                     solutionChecksum,
                     _ => Task.FromResult(solutionTemp),
                     cancellationToken).ConfigureAwait(false);
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Remote
             // We use a reference-counted solution that implements IAsyncDisposable. The computation of 'newSolution'
             // uses eager cancellation, but the asynchronous disposable applies lazy cancellation to the final task that
             // causes cancellation to propagate to the backing lazy operation.
-            var refCountedLazySolution = await GetLazySolutionAsync(
+            var refCountedLazySolution = await GetAndCacheLazySolutionAsync(
                 solutionChecksum,
                 cancellationToken => ComputeSolutionAsync(assetProvider, solutionChecksum, currentSolution, cancellationToken),
                 cancellationToken).ConfigureAwait(false);
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        private async ValueTask<ReferenceCountedDisposable<LazySolution>> GetLazySolutionAsync(
+        private async ValueTask<ReferenceCountedDisposable<LazySolution>> GetAndCacheLazySolutionAsync(
             Checksum solutionChecksum,
             Func<CancellationToken, Task<Solution>> getSolutionAsync,
             CancellationToken cancellationToken)


### PR DESCRIPTION
Found while debugging some oop communication.  My expectation was that a ref-counted solution would be re-used as a call was coming in with the same checksum.  This did not happen though because the first call came in and was going through a fast-path that was not ensuring the item was in the cache the second calls was looking through. 

THis happened because there was an intermediary edit which changed the solution checksum.  In other words, the following happened:

1. Request 1 came in with checksum C1.  It fast pathed to processing solution S1 that was in the fast-path cache.
2. Request 2 came in with checksum C2.  It knocked S1 out of hte fast-path cache.
3. Request 3 came in with checksum C1 (same as request 1).  The fast-path cache did not contain S1, nor did the slow-path cache.  So it had to recompute it.

The fix here is that even when Request1 comes through and sees the item in the fast-path cach, it still makes sure the item is in the slow-path cache as long as it is processing so that concurrent requests using C1 will still find it.