### PR TITLE
Ensure OOP solution fast-path cache properly refcounts items during processing

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/BranchId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/BranchId.cs
@@ -24,5 +24,8 @@ namespace Microsoft.CodeAnalysis
 
         internal static BranchId GetNextId()
             => new(Interlocked.Increment(ref s_nextId));
+
+        public override string ToString()
+            => $"BranchId({_id})";
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -171,9 +171,10 @@ namespace Microsoft.CodeAnalysis.Remote
 
                 // Adding references in the cases where we see we have a direct reference to the solution (the two
                 // if-blocks below) cannot fail.  We only have a matching item in .refCountedSolution if it had a
-                // reference already added to it when it was placed in this cache.  And the only thing that releases
-                // that extra item is code that runs while holding the same gate that we are holding.  So it's not
-                // possible for us to race with anything on this, and so we must succeed.
+                // positive refcount already added to it when it was placed in this cache.  And the only thing that
+                // releases that refcount item is code that runs while holding the same gate that we are holding, and
+                // then clears out the item.  So it's not possible for us to race with anything on this, and so we must
+                // succeed.
 
                 if (_lastRequestedPrimaryBranchSolution.checksum == solutionChecksum)
                     return _lastRequestedPrimaryBranchSolution.refCountedSolution.TryAddReference() ?? throw ExceptionUtilities.Unreachable;

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 // First check our direct caches of the last accessed and last primary solution.
 
-                // Adding references in the cases where we see we have a direct reference to the solution (the two
+                // Adding refcounts in the cases where we see we have a direct reference to the solution (the two
                 // if-blocks below) cannot fail.  We only have a matching item in .refCountedSolution if it had a
                 // positive refcount already added to it when it was placed in this cache.  And the only thing that
                 // releases that refcount item is code that runs while holding the same gate that we are holding, and

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 solutionChecksum,
                 workspaceVersion,
                 fromPrimaryBranch: true,
-                _ => new ValueTask<bool>(true),
+                static _ => ValueTaskFactory.FromResult(false),
                 cancellationToken).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Found while debugging some oop communication. My expectation was that a ref-counted solution would be re-used as a call was coming in with the same checksum. This did not happen though because the first call came in and was going through a fast-path that was not ensuring the item was in the cache the second calls was looking through.

THis happened because there was an intermediary edit which changed the solution checksum. In other words, the following happened:

1. Request 1 came in with checksum C1. It fast pathed to processing solution S1 that was in the fast-path cache.
2. Request 2 came in with checksum C2. It knocked S1 out of hte fast-path cache.
3. Request 3 came in with checksum C1 (same as request 1). The fast-path cache did not contain S1, nor did the slow-path cache. So it had to recompute it.

The fix here is that when we put items in the fast-path cache we properly ref-count them.  That way when request1 is using solution s1, it must still be in the slow-path cache (since its refcount is > 0) so request3 will see it htere.