### PR TITLE
FindMethodSymbolInType - handle the case when a type definition is resolved to a type in a different module.

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/NoPiaLocalHideAndTypeSubstitutionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Metadata/PE/NoPiaLocalHideAndTypeSubstitutionTests.cs
@@ -349,7 +349,9 @@ static class TypeSubstitution
             NamedTypeSymbol classRefLocalType = localConsumerRefsAsm.First(arg => arg.Name == "ExternalAsm1").GlobalNamespace.GetTypeMembers("SubFuncProp").Single();
             MethodSymbol methodSymbol = classRefLocalType.GetMembers("Foo").OfType<MethodSymbol>().Single();
 
-            Assert.Equal(0, methodSymbol.ExplicitInterfaceImplementations.Length);
+            MethodSymbol explicitImpl = methodSymbol.ExplicitInterfaceImplementations.Single();
+            Assert.Equal("void ISubFuncProp.Foo(System.Int32[missing] p)", explicitImpl.ToTestDisplayString());
+            Assert.Same(canonicalType, explicitImpl.ContainingType);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #62863.