### PR TITLE
Update method invocation escape analysis to match spec changes

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -147,6 +147,42 @@ Possible workarounds are:
     }
     ```
 
+## Instance method on ref struct may capture unscoped ref parameters
+
+***Introduced in .NET SDK 7.0.100, Visual Studio 2022 version 17.4.***
+
+With language version C# 11 or later, or with .NET 7.0 or later, a `ref struct` instance method invocation is assumed to capture unscoped `ref` or `in` parameters.
+
+```csharp
+R<int> Use(R<int> r)
+{
+    int i = 42;
+    r.MayCaptureArg(ref i); // error CS8350: may expose variables referenced by parameter 't' outside of their declaration scope
+    return r;
+}
+
+ref struct R<T>
+{
+    public void MayCaptureArg(ref T t) { }
+}
+```
+
+A possible workaround, if the `ref` or `in` parameter is not captured in the `ref struct` instance method, is to declare the parameter as `scoped ref` or `scoped in`.
+
+```csharp
+R<int> Use(R<int> r)
+{
+    int i = 42;
+    r.CannotCaptureArg(ref i); // ok
+    return r;
+}
+
+ref struct R<T>
+{
+    public void CannotCaptureArg(scoped ref T t) { }
+}
+```
+
 ## Method ref struct return escape analysis depends on ref escape of ref arguments
 
 ***Introduced in .NET SDK 7.0.100, Visual Studio 2022 version 17.3.***
@@ -185,6 +221,27 @@ static R Create()
 {
     int i = 0;
     return CannotCaptureArg(ref i); // ok
+}
+```
+
+## `ref` to `ref struct argument considered unscoped in `__arglist`
+
+***Introduced in .NET SDK 7.0.100, Visual Studio 2022 version 17.4.***
+
+With language version C# 11 or later, or with .NET 7.0 or later, a `ref` to a `ref struct` type is considered an unscoped reference when passed as an argument to `__arglist`.
+
+```csharp
+ref struct R { }
+
+class Program
+{
+    static void MayCaptureRef(__arglist) { }
+
+    static void Main()
+    {
+        var r = new R();
+        MayCaptureRef(__arglist(ref r)); // error: may expose variables outside of their declaration scope
+    }
 }
 ```
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1904,7 +1904,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             method.ContainingType.IsRefLikeType :
                             method.ReturnType.IsRefLikeType;
                     case PropertySymbol property:
-                        return property.Type.IsRefLikeType; // PROTOTYPE: This only makes sense if the getter is called, not the setter.
+                        return property.Type.IsRefLikeType;
                     default:
                         return false;
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1558,7 +1558,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argsToParamsOpt,
                 isRefEscape,
                 assumeRefStructReturnType: false,
-                ignoreArglistRefKinds: true, // PROTOTYPE: for compatibility with C#10 behavior; investivate if correct or necessary
+                ignoreArglistRefKinds: true, // https://github.com/dotnet/roslyn/issues/63325: for compatibility with C#10 implementation.
                 argsAndParamsAll);
             foreach (var argAndParam in argsAndParamsAll)
             {
@@ -1698,7 +1698,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 argsToParamsOpt,
                 isRefEscape,
                 assumeRefStructReturnType: false,
-                ignoreArglistRefKinds: true, // PROTOTYPE: for compatibility with C#10 behavior; investivate if correct or necessary
+                ignoreArglistRefKinds: true, // https://github.com/dotnet/roslyn/issues/63325: for compatibility with C#10 implementation.
                 argsAndParamsAll);
             foreach (var argAndParam in argsAndParamsAll)
             {
@@ -1732,7 +1732,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<BoundExpression> argsOpt,
             ImmutableArray<RefKind> argRefKindsOpt,
             ImmutableArray<int> argsToParamsOpt,
-            bool ignoreArglistRefKinds, // PROTOTYPE: for compatibility with C#10 behavior; investivate if correct or necessary
+            bool ignoreArglistRefKinds,
             ArrayBuilder<(ParameterSymbol? Parameter, BoundExpression Argument, RefKind RefKind)> argsAndParams)
         {
             if (receiver is { })

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1998,7 +1998,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             try
             {
-                foreach (var (parameter, argument, refKind) in argsAndParams)
+                foreach (var (_, argument, refKind) in argsAndParams)
                 {
                     if (refKind.IsWritableReference() && argument.Type?.IsRefLikeType == true)
                     {
@@ -2112,7 +2112,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // 2. All `ref` or `out` arguments of `ref struct` types must be assignable by a value with that *safe-to-escape*.
             //    This applies even when the `ref` argument matches a `scoped ref` parameter.
             bool result = true;
-            foreach (var (parameter, argument, refKind) in argsAndParams)
+            foreach (var (_, argument, refKind) in argsAndParams)
             {
                 if (!refKind.IsWritableReference() || argument.Type?.IsRefLikeType != true)
                 {

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1435,49 +1435,86 @@ namespace Microsoft.CodeAnalysis.CSharp
 
 #nullable enable
 
-        /// <summary>
-        /// Returns true if the argument contributes _ref-safe-to-escape_;
-        /// returns false if the argument contributes _safe-to-escape_; and
-        /// returns null if the argument contributes neither.
-        /// </summary>
-        private bool? UseRefEscapeOfInvocationArgument(Symbol symbol, RefKind effectiveRefKind, bool isRefEscape, DeclarationScope scope)
+        private static void GetInvocationArgumentsForEscape(
+            Symbol symbol,
+            BoundExpression? receiver,
+            ImmutableArray<ParameterSymbol> parameters,
+            ImmutableArray<BoundExpression> argsOpt,
+            ImmutableArray<RefKind> argRefKindsOpt,
+            ImmutableArray<int> argsToParamsOpt,
+            bool ignoreArglistRefKinds, // PROTOTYPE: for compatibility with C#10 behavior; investivate if correct or necessary
+            ArrayBuilder<(ParameterSymbol? Parameter, BoundExpression Argument, RefKind RefKind)> argsAndParams)
         {
-            if (!UseUpdatedEscapeRules)
+            if (receiver is { })
             {
-                return effectiveRefKind != RefKind.None && isRefEscape;
+                argsAndParams.Add(getReceiver(symbol, receiver));
             }
 
-            bool useRefEscape = effectiveRefKind switch
+            if (!argsOpt.IsDefault)
             {
-                RefKind.None or RefKind.Out => false,
-                RefKind.Ref or RefKind.In => isRefEscape || hasRefStructType(symbol),
-                _ => throw ExceptionUtilities.UnexpectedValue(effectiveRefKind),
-            };
-
-            if (useRefEscape ?
-                scope != DeclarationScope.Unscoped :
-                scope == DeclarationScope.ValueScoped)
-            {
-                // SPEC: For a given argument `a` that is passed to parameter `p`:
-                // SPEC: 1. If `p` is `scoped ref` then `a` does not contribute *ref-safe-to-escape* when considering arguments.
-                // SPEC: 2. If `p` is `scoped` then `a` does not contribute *safe-to-escape* when considering arguments.
-                return null;
-            }
-
-            return useRefEscape;
-
-            static bool hasRefStructType(Symbol symbol)
-            {
-                switch (symbol)
+                for (int argIndex = 0; argIndex < argsOpt.Length; argIndex++)
                 {
-                    case MethodSymbol method:
-                        return method.MethodKind == MethodKind.Constructor ?
-                            method.ContainingType.IsRefLikeType :
-                            method.ReturnType.IsRefLikeType;
-                    case PropertySymbol property:
-                        return property.Type.IsRefLikeType;
-                    default:
-                        return false;
+                    var argument = argsOpt[argIndex];
+                    if (argument.Kind == BoundKind.ArgListOperator)
+                    {
+                        Debug.Assert(argIndex == argsOpt.Length - 1);
+                        // unwrap varargs and process as more arguments
+                        var argList = (BoundArgListOperator)argument;
+                        getArgList(
+                            argList.Arguments,
+                            ignoreArglistRefKinds ? default : argList.ArgumentRefKindsOpt,
+                            argsAndParams);
+                        break;
+                    }
+
+                    var parameter = argIndex < parameters.Length ?
+                        parameters[argsToParamsOpt.IsDefault ? argIndex : argsToParamsOpt[argIndex]] :
+                        null;
+
+                    var refKind = parameter?.RefKind ?? RefKind.None;
+                    if (!argRefKindsOpt.IsDefault)
+                    {
+                        refKind = argRefKindsOpt[argIndex];
+                        if (refKind == RefKind.None &&
+                            parameter?.RefKind == RefKind.In)
+                        {
+                            refKind = RefKind.In;
+                        }
+                    }
+
+                    argsAndParams.Add((parameter, argument, refKind));
+                }
+            }
+
+            static (ParameterSymbol? Parameter, BoundExpression Argument, RefKind RefKind) getReceiver(Symbol symbol, BoundExpression receiver)
+            {
+                if (symbol is FunctionPointerMethodSymbol)
+                {
+                    return (null, receiver, RefKind.None);
+                }
+                var containingType = symbol.ContainingType;
+                var refKind = containingType.IsStructType() ?
+                    (IsReceiverRefReadOnly(symbol) ? RefKind.RefReadOnly : RefKind.Ref) :
+                    RefKind.None;
+                var method = symbol switch
+                {
+                    MethodSymbol m => m,
+                    PropertySymbol p => p.GetMethod ?? p.SetMethod,
+                    _ => throw ExceptionUtilities.UnexpectedValue(symbol)
+                };
+                return (method?.ThisParameter, receiver, refKind);
+            }
+
+            static void getArgList(
+                ImmutableArray<BoundExpression> argsOpt,
+                ImmutableArray<RefKind> argRefKindsOpt,
+                ArrayBuilder<(ParameterSymbol? Parameter, BoundExpression Argument, RefKind RefKind)> argsAndParams)
+            {
+                for (int argIndex = 0; argIndex < argsOpt.Length; argIndex++)
+                {
+                    var argument = argsOpt[argIndex];
+                    var refKind = argRefKindsOpt.IsDefault ? RefKind.None : argRefKindsOpt[argIndex];
+                    argsAndParams.Add((null, argument, refKind));
                 }
             }
         }
@@ -1490,7 +1527,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// NOTE: we need scopeOfTheContainingExpression as some expressions such as optional <c>in</c> parameters or <c>ref dynamic</c> behave as 
         ///       local variables declared at the scope of the invocation.
         /// </summary>
-        internal uint GetInvocationEscapeScope(
+        private uint GetInvocationEscapeScope(
             Symbol symbol,
             BoundExpression? receiver,
             ImmutableArray<ParameterSymbol> parameters,
@@ -1504,6 +1541,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 #if DEBUG
             Debug.Assert(AllParametersConsideredInEscapeAnalysisHaveArguments(argsOpt, parameters, argsToParamsOpt));
 #endif
+
+            if (UseUpdatedEscapeRules)
+            {
+                return GetInvocationEscapeWithUpdatedRules(symbol, receiver, parameters, argsOpt, argRefKindsOpt, argsToParamsOpt, scopeOfTheContainingExpression, isRefEscape);
+            }
 
             // SPEC: (also applies to the CheckInvocationEscape counterpart)
             //
@@ -1526,30 +1568,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             //by default it is safe to escape
             uint escapeScope = Binder.ExternalScope;
 
-            if (!argsOpt.IsDefault)
+            var argsAndParams = ArrayBuilder<(ParameterSymbol? Parameter, BoundExpression Argument, RefKind RefKind)>.GetInstance();
+            GetInvocationArgumentsForEscape(
+                symbol,
+                receiver: null, // receiver handled explicitly below
+                parameters,
+                argsOpt,
+                argRefKindsOpt,
+                argsToParamsOpt,
+                // ref kinds of varargs are not interesting here. 
+                // __refvalue is not ref-returnable, so ref varargs can't come back from a call
+                ignoreArglistRefKinds: true,
+                argsAndParams);
+
+            try
             {
-moreArguments:
-                for (var argIndex = 0; argIndex < argsOpt.Length; argIndex++)
+                foreach (var (parameter, argument, effectiveRefKind) in argsAndParams)
                 {
-                    var argument = argsOpt[argIndex];
-                    if (argument.Kind == BoundKind.ArgListOperator)
-                    {
-                        Debug.Assert(argIndex == argsOpt.Length - 1, "vararg must be the last");
-                        var argList = (BoundArgListOperator)argument;
-
-                        // unwrap varargs and process as more arguments
-                        argsOpt = argList.Arguments;
-                        // ref kinds of varargs are not interesting here. 
-                        // __refvalue is not ref-returnable, so ref varargs can't come back from a call
-                        argRefKindsOpt = default;
-                        parameters = ImmutableArray<ParameterSymbol>.Empty;
-                        argsToParamsOpt = default;
-
-                        goto moreArguments;
-                    }
-
-                    RefKind effectiveRefKind = GetEffectiveRefKind(argIndex, argRefKindsOpt, parameters, argsToParamsOpt, out DeclarationScope scope);
-
                     // ref escape scope is the narrowest of 
                     // - ref escape of all byref arguments
                     // - val escape of all byval arguments  (ref-like values can be unwrapped into refs, so treat val escape of values as possible ref escape of the result)
@@ -1557,13 +1592,7 @@ moreArguments:
                     // val escape scope is the narrowest of 
                     // - val escape of all byval arguments  (refs cannot be wrapped into values, so their ref escape is irrelevant, only use val escapes)
 
-                    bool? useRefEscape = UseRefEscapeOfInvocationArgument(symbol, effectiveRefKind, isRefEscape, scope);
-                    if (useRefEscape == null)
-                    {
-                        continue;
-                    }
-
-                    var argEscape = useRefEscape.GetValueOrDefault() ?
+                    var argEscape = effectiveRefKind != RefKind.None && isRefEscape ?
                                         GetRefEscape(argument, scopeOfTheContainingExpression) :
                                         GetValEscape(argument, scopeOfTheContainingExpression);
 
@@ -1576,12 +1605,60 @@ moreArguments:
                     }
                 }
             }
+            finally
+            {
+                argsAndParams.Free();
+            }
 
             // check receiver if ref-like
             if (receiver?.Type?.IsRefLikeType == true)
             {
                 escapeScope = Math.Max(escapeScope, GetValEscape(receiver, scopeOfTheContainingExpression));
             }
+
+            return escapeScope;
+        }
+
+        private uint GetInvocationEscapeWithUpdatedRules(
+            Symbol symbol,
+            BoundExpression? receiver,
+            ImmutableArray<ParameterSymbol> parameters,
+            ImmutableArray<BoundExpression> argsOpt,
+            ImmutableArray<RefKind> argRefKindsOpt,
+            ImmutableArray<int> argsToParamsOpt,
+            uint scopeOfTheContainingExpression,
+            bool isRefEscape)
+        {
+            //by default it is safe to escape
+            uint escapeScope = Binder.ExternalScope;
+
+            var argsAndParamsAll = ArrayBuilder<(ParameterSymbol? Parameter, BoundExpression Argument, bool IsRefEscape)>.GetInstance();
+            GetInvocationArgumentsForEscapeWithUpdatedRules(
+                symbol,
+                receiver,
+                parameters,
+                argsOpt,
+                argRefKindsOpt,
+                argsToParamsOpt,
+                isRefEscape,
+                assumeRefStructReturnType: false,
+                ignoreArglistRefKinds: true, // PROTOTYPE: for compatibility with C#10 behavior; investivate if correct or necessary
+                argsAndParamsAll);
+            foreach (var argAndParam in argsAndParamsAll)
+            {
+                var argument = argAndParam.Argument;
+                uint argEscape = argAndParam.IsRefEscape ?
+                    GetRefEscape(argument, scopeOfTheContainingExpression) :
+                    GetValEscape(argument, scopeOfTheContainingExpression);
+
+                escapeScope = Math.Max(escapeScope, argEscape);
+                if (escapeScope >= scopeOfTheContainingExpression)
+                {
+                    // can't get any worse
+                    break;
+                }
+            }
+            argsAndParamsAll.Free();
 
             return escapeScope;
         }
@@ -1613,6 +1690,11 @@ moreArguments:
             Debug.Assert(AllParametersConsideredInEscapeAnalysisHaveArguments(argsOpt, parameters, argsToParamsOpt));
 #endif
 
+            if (UseUpdatedEscapeRules)
+            {
+                return CheckInvocationEscapeWithUpdatedRules(syntax, symbol, receiver, parameters, argsOpt, argRefKindsOpt, argsToParamsOpt, checkingReceiver, escapeFrom, escapeTo, diagnostics, isRefEscape);
+            }
+
             // SPEC: 
             //            In a method invocation, the following constraints apply:
             //•	If there is a ref or out argument to a ref struct type (including the receiver), with safe-to-escape E1, then
@@ -1625,30 +1707,23 @@ moreArguments:
                 receiver = null;
             }
 
-            if (!argsOpt.IsDefault)
+            var argsAndParams = ArrayBuilder<(ParameterSymbol? Parameter, BoundExpression Argument, RefKind RefKind)>.GetInstance();
+            GetInvocationArgumentsForEscape(
+                symbol,
+                receiver: null, // receiver handled explicitly below
+                parameters,
+                argsOpt,
+                argRefKindsOpt,
+                argsToParamsOpt,
+                // ref kinds of varargs are not interesting here. 
+                // __refvalue is not ref-returnable, so ref varargs can't come back from a call
+                ignoreArglistRefKinds: true,
+                argsAndParams);
+
+            try
             {
-moreArguments:
-                for (var argIndex = 0; argIndex < argsOpt.Length; argIndex++)
+                foreach (var (parameter, argument, effectiveRefKind) in argsAndParams)
                 {
-                    var argument = argsOpt[argIndex];
-                    if (argument.Kind == BoundKind.ArgListOperator)
-                    {
-                        Debug.Assert(argIndex == argsOpt.Length - 1, "vararg must be the last");
-                        var argList = (BoundArgListOperator)argument;
-
-                        // unwrap varargs and process as more arguments
-                        argsOpt = argList.Arguments;
-                        // ref kinds of varargs are not interesting here. 
-                        // __refvalue is not ref-returnable, so ref varargs can't come back from a call
-                        argRefKindsOpt = default;
-                        parameters = ImmutableArray<ParameterSymbol>.Empty;
-                        argsToParamsOpt = default;
-
-                        goto moreArguments;
-                    }
-
-                    RefKind effectiveRefKind = GetEffectiveRefKind(argIndex, argRefKindsOpt, parameters, argsToParamsOpt, out DeclarationScope scope);
-
                     // ref escape scope is the narrowest of 
                     // - ref escape of all byref arguments
                     // - val escape of all byval arguments  (ref-like values can be unwrapped into refs, so treat val escape of values as possible ref escape of the result)
@@ -1656,40 +1731,20 @@ moreArguments:
                     // val escape scope is the narrowest of 
                     // - val escape of all byval arguments  (refs cannot be wrapped into values, so their ref escape is irrelevant, only use val escapes)
 
-                    bool? useRefEscape = UseRefEscapeOfInvocationArgument(symbol, effectiveRefKind, isRefEscape, scope);
-                    if (useRefEscape == null)
-                    {
-                        continue;
-                    }
-
-                    var valid = useRefEscape.GetValueOrDefault() ?
+                    var valid = effectiveRefKind != RefKind.None && isRefEscape ?
                                         CheckRefEscape(argument.Syntax, argument, escapeFrom, escapeTo, false, diagnostics) :
                                         CheckValEscape(argument.Syntax, argument, escapeFrom, escapeTo, false, diagnostics);
 
                     if (!valid)
                     {
-                        ErrorCode errorCode = GetStandardCallEscapeError(checkingReceiver);
-
-                        string parameterName;
-                        if (parameters.Length > 0)
-                        {
-                            var paramIndex = argsToParamsOpt.IsDefault ? argIndex : argsToParamsOpt[argIndex];
-                            parameterName = parameters[paramIndex].Name;
-
-                            if (string.IsNullOrEmpty(parameterName))
-                            {
-                                parameterName = paramIndex.ToString();
-                            }
-                        }
-                        else
-                        {
-                            parameterName = "__arglist";
-                        }
-
-                        Error(diagnostics, errorCode, syntax, symbol, parameterName);
+                        ReportInvocationEscapeError(syntax, symbol, parameter, checkingReceiver, diagnostics);
                         return false;
                     }
                 }
+            }
+            finally
+            {
+                argsAndParams.Free();
             }
 
             // check receiver if ref-like
@@ -1699,6 +1754,187 @@ moreArguments:
             }
 
             return true;
+        }
+
+        private bool CheckInvocationEscapeWithUpdatedRules(
+            SyntaxNode syntax,
+            Symbol symbol,
+            BoundExpression? receiver,
+            ImmutableArray<ParameterSymbol> parameters,
+            ImmutableArray<BoundExpression> argsOpt,
+            ImmutableArray<RefKind> argRefKindsOpt,
+            ImmutableArray<int> argsToParamsOpt,
+            bool checkingReceiver,
+            uint escapeFrom,
+            uint escapeTo,
+            BindingDiagnosticBag diagnostics,
+            bool isRefEscape)
+        {
+            bool result = true;
+
+            var argsAndParamsAll = ArrayBuilder<(ParameterSymbol? Parameter, BoundExpression Argument, bool IsRefEscape)>.GetInstance();
+            GetInvocationArgumentsForEscapeWithUpdatedRules(
+                symbol,
+                receiver,
+                parameters,
+                argsOpt,
+                argRefKindsOpt,
+                argsToParamsOpt,
+                isRefEscape,
+                assumeRefStructReturnType: false,
+                ignoreArglistRefKinds: true, // PROTOTYPE: for compatibility with C#10 behavior; investivate if correct or necessary
+                argsAndParamsAll);
+            foreach (var argAndParam in argsAndParamsAll)
+            {
+                var argument = argAndParam.Argument;
+                bool valid = argAndParam.IsRefEscape ?
+                    CheckRefEscape(argument.Syntax, argument, escapeFrom, escapeTo, false, diagnostics) :
+                    CheckValEscape(argument.Syntax, argument, escapeFrom, escapeTo, false, diagnostics);
+
+                if (!valid)
+                {
+                    // For consistency with C#10 implementation, we don't report an additional error
+                    // for the receiver. (In both implementations, the call to Check*Escape() above
+                    // will have reported a specific escape error for the receiver though.)
+                    if ((object)argument != receiver)
+                    {
+                        ReportInvocationEscapeError(syntax, symbol, argAndParam.Parameter, checkingReceiver, diagnostics);
+                    }
+                    result = false;
+                    break;
+                }
+            }
+            argsAndParamsAll.Free();
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the set of arguments to be considered for escape analysis of a method
+        /// invocation. Each argument is returned with the correponding parameter and
+        /// whether analysis should consider value or ref escape. Not all method arguments
+        /// are included, and some arguments may be included twice - once for value, once for ref.
+        /// </summary>
+        private void GetInvocationArgumentsForEscapeWithUpdatedRules(
+            Symbol symbol,
+            BoundExpression? receiver,
+            ImmutableArray<ParameterSymbol> parameters,
+            ImmutableArray<BoundExpression> argsOpt,
+            ImmutableArray<RefKind> argRefKindsOpt,
+            ImmutableArray<int> argsToParamsOpt,
+            bool isRefEscape,
+            bool assumeRefStructReturnType,
+            bool ignoreArglistRefKinds,
+            ArrayBuilder<(ParameterSymbol? Parameter, BoundExpression Argument, bool IsRefEscape)> result)
+        {
+            if (!symbol.RequiresInstanceReceiver())
+            {
+                // ignore receiver when symbol is static
+                receiver = null;
+            }
+
+            var argsAndParams = ArrayBuilder<(ParameterSymbol? Parameter, BoundExpression Argument, RefKind RefKind)>.GetInstance();
+            GetInvocationArgumentsForEscape(
+                symbol,
+                receiver,
+                parameters,
+                argsOpt,
+                argRefKindsOpt,
+                argsToParamsOpt,
+                ignoreArglistRefKinds,
+                argsAndParams);
+
+            // https://github.com/dotnet/csharplang/blob/main/proposals/low-level-struct-improvements.md#rules-method-invocation
+            //
+            // A value resulting from a method invocation `e1.M(e2, ...)` is *safe-to-escape* from the smallest of the following scopes:
+            // 1. The *calling method*
+            // 2. The *safe-to-escape* contributed by all argument expressions
+            // 3. ...
+            //
+            // A value resulting from a method invocation `ref e1.M(e2, ...)` is *ref-safe-to-escape* the smallest of the following scopes:
+            // 1. The *safe-to-escape* of the rvalue of `e1.M(e2, ...)`
+            // 2. ...
+            foreach (var (parameter, argument, _) in argsAndParams)
+            {
+                // For a given argument `a` that is passed to parameter `p`:
+                // 1. ...
+                // 2. If `p` is `scoped` then `a` does not contribute *safe-to-escape* when considering arguments. 
+                if (parameter?.EffectiveScope == DeclarationScope.ValueScoped)
+                {
+                    continue;
+                }
+                result.Add((parameter, argument, IsRefEscape: false));
+            }
+
+            // A value resulting from a method invocation `e1.M(e2, ...)` is *safe-to-escape* from the smallest of the following scopes:
+            // 1. ...
+            // 2. ...
+            // 3. When the return is a `ref struct` then *ref-safe-to-escape* contributed by all `ref` arguments
+            //
+            // A value resulting from a method invocation `ref e1.M(e2, ...)` is *ref-safe-to-escape* the smallest of the following scopes:
+            // 1. ...
+            // 2. The *ref-safe-to-escape* contributed by all `ref` arguments
+            if (isRefEscape || assumeRefStructReturnType || hasRefStructType(symbol))
+            {
+                foreach (var (parameter, argument, effectiveRefKind) in argsAndParams)
+                {
+                    if (effectiveRefKind == RefKind.None)
+                    {
+                        continue;
+                    }
+                    // For a given argument `a` that is passed to parameter `p`:
+                    // 1. If `p` is `scoped ref` then `a` does not contribute *ref-safe-to-escape* when considering arguments.
+                    // 2. ...
+                    if (parameter?.EffectiveScope == DeclarationScope.RefScoped)
+                    {
+                        continue;
+                    }
+                    result.Add((parameter, argument, IsRefEscape: true));
+                }
+            }
+
+            argsAndParams.Free();
+
+            static bool hasRefStructType(Symbol symbol)
+            {
+                switch (symbol)
+                {
+                    case MethodSymbol method:
+                        return method.MethodKind == MethodKind.Constructor ?
+                            method.ContainingType.IsRefLikeType :
+                            method.ReturnType.IsRefLikeType;
+                    case PropertySymbol property:
+                        return property.Type.IsRefLikeType; // PROTOTYPE: This only makes sense if the getter is called, not the setter.
+                    default:
+                        return false;
+                }
+            }
+        }
+
+        private static string GetInvocationParameterName(ParameterSymbol? parameter)
+        {
+            if (parameter is null)
+            {
+                return "__arglist";
+            }
+            string parameterName = parameter.Name;
+            if (string.IsNullOrEmpty(parameterName))
+            {
+                parameterName = parameter.Ordinal.ToString();
+            }
+            return parameterName;
+        }
+
+        private static void ReportInvocationEscapeError(
+            SyntaxNode syntax,
+            Symbol symbol,
+            ParameterSymbol? parameter,
+            bool checkingReceiver,
+            BindingDiagnosticBag diagnostics)
+        {
+            ErrorCode errorCode = GetStandardCallEscapeError(checkingReceiver);
+            string parameterName = GetInvocationParameterName(parameter);
+            Error(diagnostics, errorCode, syntax, symbol, parameterName);
         }
 
         /// <summary>
@@ -1711,10 +1947,16 @@ moreArguments:
             BoundExpression? receiverOpt,
             ImmutableArray<ParameterSymbol> parameters,
             ImmutableArray<BoundExpression> argsOpt,
+            ImmutableArray<RefKind> argRefKindsOpt,
             ImmutableArray<int> argsToParamsOpt,
             uint scopeOfTheContainingExpression,
             BindingDiagnosticBag diagnostics)
         {
+            if (UseUpdatedEscapeRules)
+            {
+                return CheckInvocationArgMixingWithUpdatedRules(syntax, symbol, receiverOpt, parameters, argsOpt, argRefKindsOpt, argsToParamsOpt, scopeOfTheContainingExpression, diagnostics);
+            }
+
             // SPEC:
             // In a method invocation, the following constraints apply:
             // - If there is a ref or out argument of a ref struct type (including the receiver), with safe-to-escape E1, then
@@ -1731,88 +1973,53 @@ moreArguments:
 
             // collect all writeable ref-like arguments, including receiver
             var receiverType = receiverOpt?.Type;
-            if (receiverType?.IsRefLikeType == true && !isReceiverRefReadOnly(symbol))
+            if (receiverType?.IsRefLikeType == true && !IsReceiverRefReadOnly(symbol))
             {
                 escapeTo = GetValEscape(receiverOpt, scopeOfTheContainingExpression);
             }
 
-            if (!argsOpt.IsDefault)
+            var argsAndParams = ArrayBuilder<(ParameterSymbol? Parameter, BoundExpression Argument, RefKind RefKind)>.GetInstance();
+            GetInvocationArgumentsForEscape(
+                symbol,
+                receiver: null, // receiver handled explicitly below
+                parameters,
+                argsOpt,
+                argRefKindsOpt: default,
+                argsToParamsOpt,
+                ignoreArglistRefKinds: false,
+                argsAndParams);
+
+            try
             {
-                BoundArgListOperator? argList = null;
-                for (var argIndex = 0; argIndex < argsOpt.Length; argIndex++)
+                foreach (var (parameter, argument, refKind) in argsAndParams)
                 {
-                    var argument = argsOpt[argIndex];
-                    if (argument.Kind == BoundKind.ArgListOperator)
+                    if (refKind.IsWritableReference() && argument.Type?.IsRefLikeType == true)
                     {
-                        Debug.Assert(argIndex == argsOpt.Length - 1, "vararg must be the last");
-                        argList = (BoundArgListOperator)argument;
-                        break;
+                        escapeTo = Math.Min(escapeTo, GetValEscape(argument, scopeOfTheContainingExpression));
                     }
-
-                    var parameter = getParameter(parameters, argsToParamsOpt, argIndex);
-                    if (!considerParameter(parameter))
-                    {
-                        continue;
-                    }
-
-                    updateEscapeTo(argument, parameter.RefKind, scopeOfTheContainingExpression, ref escapeTo);
                 }
 
-                if (argList != null)
+                if (escapeTo == scopeOfTheContainingExpression)
                 {
-                    var argListArgs = argList.Arguments;
-                    var argListRefKindsOpt = argList.ArgumentRefKindsOpt;
-
-                    for (var argIndex = 0; argIndex < argListArgs.Length; argIndex++)
-                    {
-                        var argument = argListArgs[argIndex];
-                        var refKind = argListRefKindsOpt.IsDefault ? RefKind.None : argListRefKindsOpt[argIndex];
-                        updateEscapeTo(argument, refKind, scopeOfTheContainingExpression, ref escapeTo);
-                    }
+                    // cannot fail. common case.
+                    return true;
                 }
-            }
 
-            if (escapeTo == scopeOfTheContainingExpression)
-            {
-                // cannot fail. common case.
-                return true;
-            }
-
-            if (!argsOpt.IsDefault)
-            {
-moreArguments:
-                for (var argIndex = 0; argIndex < argsOpt.Length; argIndex++)
+                foreach (var (parameter, argument, _) in argsAndParams)
                 {
-                    // check val escape of all arguments
-                    var argument = argsOpt[argIndex];
-                    if (argument.Kind == BoundKind.ArgListOperator)
-                    {
-                        Debug.Assert(argIndex == argsOpt.Length - 1, "vararg must be the last");
-                        var argList = (BoundArgListOperator)argument;
-
-                        // unwrap varargs and process as more arguments
-                        argsOpt = argList.Arguments;
-                        parameters = ImmutableArray<ParameterSymbol>.Empty;
-                        argsToParamsOpt = default;
-
-                        goto moreArguments;
-                    }
-
-                    var parameter = (parameters.Length > 0) ? getParameter(parameters, argsToParamsOpt, argIndex) : null;
-                    if (!considerParameter(parameter))
-                    {
-                        continue;
-                    }
-
                     var valid = CheckValEscape(argument.Syntax, argument, scopeOfTheContainingExpression, escapeTo, false, diagnostics);
 
                     if (!valid)
                     {
-                        string parameterName = parameter is null ? "__arglist" : parameter.Name;
+                        string parameterName = GetInvocationParameterName(parameter);
                         Error(diagnostics, ErrorCode.ERR_CallArgMixing, syntax, symbol, parameterName);
                         return false;
                     }
                 }
+            }
+            finally
+            {
+                argsAndParams.Free();
             }
 
             // check val escape of receiver if ref-like
@@ -1823,47 +2030,124 @@ moreArguments:
             }
 
             return true;
+        }
 
-            static ParameterSymbol getParameter(ImmutableArray<ParameterSymbol> parameters, ImmutableArray<int> argsToParamsOpt, int argIndex)
+        private bool CheckInvocationArgMixingWithUpdatedRules(
+            SyntaxNode syntax,
+            Symbol symbol,
+            BoundExpression? receiverOpt,
+            ImmutableArray<ParameterSymbol> parameters,
+            ImmutableArray<BoundExpression> argsOpt,
+            ImmutableArray<RefKind> argRefKindsOpt,
+            ImmutableArray<int> argsToParamsOpt,
+            uint scopeOfTheContainingExpression,
+            BindingDiagnosticBag diagnostics)
+        {
+            // https://github.com/dotnet/csharplang/blob/main/proposals/low-level-struct-improvements.md#rules-method-invocation
+            //
+            // For any method invocation `e.M(a1, a2, ... aN)`
+            // 1. Calculate the *safe-to-escape* of the method return (for this rule assume it has a `ref struct` return type)
+            // 2. All `ref` or `out` arguments of `ref struct` types must be assignable by a value with that *safe-to-escape*.
+            //    This applies even when the `ref` argument matches a `scoped ref` parameter.
+
+            if (!symbol.RequiresInstanceReceiver())
             {
-                var paramIndex = argsToParamsOpt.IsDefault ? argIndex : argsToParamsOpt[argIndex];
-                return parameters[paramIndex];
+                // ignore receiver when symbol is static
+                receiverOpt = null;
             }
 
-            bool considerParameter(ParameterSymbol? parameter)
+            // 1. Calculate the *safe-to-escape* of the method return (for this rule assume it has a `ref struct` return type)
+            uint escapeScope = Binder.ExternalScope;
+            (ParameterSymbol? Parameter, BoundExpression Argument, bool IsRefEscape)? argAndParamToEscape = null;
+            var argsAndParamsAll = ArrayBuilder<(ParameterSymbol? Parameter, BoundExpression Argument, bool IsRefEscape)>.GetInstance();
+            GetInvocationArgumentsForEscapeWithUpdatedRules(
+                symbol,
+                receiverOpt,
+                parameters,
+                argsOpt,
+                argRefKindsOpt,
+                argsToParamsOpt,
+                isRefEscape: false,
+                assumeRefStructReturnType: true,
+                ignoreArglistRefKinds: false,
+                argsAndParamsAll);
+            foreach (var argAndParam in argsAndParamsAll)
             {
-                if (UseUpdatedEscapeRules)
+                var argument = argAndParam.Argument;
+                uint argEscape = argAndParam.IsRefEscape ?
+                    GetRefEscape(argument, scopeOfTheContainingExpression) :
+                    GetValEscape(argument, scopeOfTheContainingExpression);
+
+                if (argEscape > escapeScope)
                 {
-                    // SPEC: For a given argument `a` that is passed to parameter `p`:
-                    // SPEC: 1. ...
-                    // SPEC: 2. If `p` is `scoped` then `a` does not contribute *safe-to-escape* when considering arguments.
-                    if (parameter?.EffectiveScope == DeclarationScope.ValueScoped)
-                    {
-                        return false;
-                    }
+                    escapeScope = argEscape;
+                    argAndParamToEscape = argAndParam;
                 }
+            }
+            argsAndParamsAll.Free();
+
+            if (argAndParamToEscape is null)
+            {
                 return true;
             }
 
-            void updateEscapeTo(BoundExpression argument, RefKind refKind, uint scopeOfTheContainingExpression, ref uint escapeTo)
+            var argsAndParams = ArrayBuilder<(ParameterSymbol? Parameter, BoundExpression Argument, RefKind RefKind)>.GetInstance();
+            GetInvocationArgumentsForEscape(
+                symbol,
+                receiverOpt,
+                parameters,
+                argsOpt,
+                argRefKindsOpt: default,
+                argsToParamsOpt,
+                ignoreArglistRefKinds: false,
+                argsAndParams);
+
+            // 2. All `ref` or `out` arguments of `ref struct` types must be assignable by a value with that *safe-to-escape*.
+            //    This applies even when the `ref` argument matches a `scoped ref` parameter.
+            bool result = true;
+            foreach (var (parameter, argument, refKind) in argsAndParams)
             {
-                if (refKind.IsWritableReference() && argument.Type?.IsRefLikeType == true)
+                if (!refKind.IsWritableReference() || argument.Type?.IsRefLikeType != true)
                 {
-                    escapeTo = Math.Min(escapeTo, GetValEscape(argument, scopeOfTheContainingExpression));
+                    continue;
+                }
+
+                uint escapeTo = GetValEscape(argument, scopeOfTheContainingExpression);
+                var (parameterToEscape, argToEscape, isRefEscape) = argAndParamToEscape.GetValueOrDefault();
+
+                bool valid = isRefEscape ?
+                    CheckRefEscape(argToEscape.Syntax, argToEscape, scopeOfTheContainingExpression, escapeTo, false, diagnostics) :
+                    CheckValEscape(argToEscape.Syntax, argToEscape, scopeOfTheContainingExpression, escapeTo, false, diagnostics);
+
+                if (!valid)
+                {
+                    // For consistency with C#10 implementation, we don't report ERR_CallArgMixing
+                    // for the receiver. (In both implementations, the call to CheckValEscape() above
+                    // will have reported a specific escape error for the receiver though.)
+                    if ((object)argToEscape != receiverOpt)
+                    {
+                        string parameterName = GetInvocationParameterName(parameterToEscape);
+                        Error(diagnostics, ErrorCode.ERR_CallArgMixing, syntax, symbol, parameterName);
+                    }
+                    result = false;
+                    break;
                 }
             }
+            argsAndParams.Free();
 
-            static bool isReceiverRefReadOnly(Symbol methodOrPropertySymbol) => methodOrPropertySymbol switch
-            {
-                MethodSymbol m => m.IsEffectivelyReadOnly,
-                // TODO: val escape checks should be skipped for property accesses when
-                // we can determine the only accessors being called are readonly.
-                // For now we are pessimistic and check escape if any accessor is non-readonly.
-                // Tracking in https://github.com/dotnet/roslyn/issues/35606
-                PropertySymbol p => p.GetMethod?.IsEffectivelyReadOnly != false && p.SetMethod?.IsEffectivelyReadOnly != false,
-                _ => throw ExceptionUtilities.UnexpectedValue(methodOrPropertySymbol)
-            };
+            return result;
         }
+
+        private static bool IsReceiverRefReadOnly(Symbol methodOrPropertySymbol) => methodOrPropertySymbol switch
+        {
+            MethodSymbol m => m.IsEffectivelyReadOnly,
+            // TODO: val escape checks should be skipped for property accesses when
+            // we can determine the only accessors being called are readonly.
+            // For now we are pessimistic and check escape if any accessor is non-readonly.
+            // Tracking in https://github.com/dotnet/roslyn/issues/35606
+            PropertySymbol p => p.GetMethod?.IsEffectivelyReadOnly != false && p.SetMethod?.IsEffectivelyReadOnly != false,
+            _ => throw ExceptionUtilities.UnexpectedValue(methodOrPropertySymbol)
+        };
 
 #if DEBUG
         private static bool AllParametersConsideredInEscapeAnalysisHaveArguments(
@@ -1895,38 +2179,6 @@ moreArguments:
             return true;
         }
 #endif
-
-        /// <summary>
-        /// Gets "effective" ref kind of an argument.
-        /// 
-        /// NOTE: Generally we know if a formal argument is passed as ref/out/in by looking at the call site. 
-        /// However, 'in' may also be passed as an ordinary val argument so we need to take a look at corresponding parameter, if such exists. 
-        /// There are cases like params/vararg, when a corresponding parameter may not exist, then val cannot become 'in'.
-        /// </summary>
-        private static RefKind GetEffectiveRefKind(
-            int argIndex,
-            ImmutableArray<RefKind> argRefKindsOpt,
-            ImmutableArray<ParameterSymbol> parameters,
-            ImmutableArray<int> argsToParamsOpt,
-            out DeclarationScope scope)
-        {
-            int paramIndex = argIndex < parameters.Length ?
-                (argsToParamsOpt.IsDefault ? argIndex : argsToParamsOpt[argIndex]) :
-                -1;
-
-            var effectiveRefKind = argRefKindsOpt.IsDefault ? RefKind.None : argRefKindsOpt[argIndex];
-
-            if ((effectiveRefKind == RefKind.None || effectiveRefKind == RefKind.In) && paramIndex >= 0)
-            {
-                if (parameters[paramIndex].RefKind == RefKind.In)
-                {
-                    effectiveRefKind = RefKind.In;
-                }
-            }
-
-            scope = paramIndex >= 0 ? parameters[paramIndex].EffectiveScope : DeclarationScope.Unscoped;
-            return effectiveRefKind;
-        }
 
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1790,16 +1790,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return (null, receiver, RefKind.None);
                 }
                 var containingType = symbol.ContainingType;
-                var refKind = containingType.IsStructType() ?
-                    (IsReceiverRefReadOnly(symbol) ? RefKind.RefReadOnly : RefKind.Ref) :
-                    RefKind.None;
                 var method = symbol switch
                 {
                     MethodSymbol m => m,
                     PropertySymbol p => p.GetMethod ?? p.SetMethod,
                     _ => throw ExceptionUtilities.UnexpectedValue(symbol)
                 };
-                return (method?.ThisParameter, receiver, refKind);
+                var thisParameter = method?.ThisParameter;
+                var refKind = thisParameter?.RefKind ?? RefKind.None;
+                return (thisParameter, receiver, refKind);
             }
 
             static void getArgList(

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1549,7 +1549,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             uint escapeScope = Binder.ExternalScope;
 
             var argsAndParamsAll = ArrayBuilder<(ParameterSymbol? Parameter, BoundExpression Argument, bool IsRefEscape)>.GetInstance();
-            GetInvocationArgumentsForEscapeWithUpdatedRules(
+            GetFilteredInvocationArgumentsForEscapeWithUpdatedRules(
                 symbol,
                 receiver,
                 parameters,
@@ -1689,7 +1689,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool result = true;
 
             var argsAndParamsAll = ArrayBuilder<(ParameterSymbol? Parameter, BoundExpression Argument, bool IsRefEscape)>.GetInstance();
-            GetInvocationArgumentsForEscapeWithUpdatedRules(
+            GetFilteredInvocationArgumentsForEscapeWithUpdatedRules(
                 symbol,
                 receiver,
                 parameters,
@@ -1725,6 +1725,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
+        /// <summary>
+        /// Returns the set of arguments to be considered for escape analysis of a method invocation.
+        /// Each argument is returned with the correponding parameter and ref kind. Arguments are not
+        /// filtered - all arguments are included exactly once in the array, and the caller is responsible for
+        /// determining which arguments affect escape analysis. This method is used for method invocation
+        /// analysis, regardless of whether UseUpdatedEscapeRules is set.
+        /// </summary>
         private static void GetInvocationArgumentsForEscape(
             Symbol symbol,
             BoundExpression? receiver,
@@ -1765,11 +1772,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (!argRefKindsOpt.IsDefault)
                     {
                         refKind = argRefKindsOpt[argIndex];
-                        if (refKind == RefKind.None &&
-                            parameter?.RefKind == RefKind.In)
-                        {
-                            refKind = RefKind.In;
-                        }
+                    }
+                    if (refKind == RefKind.None &&
+                        parameter?.RefKind == RefKind.In)
+                    {
+                        refKind = RefKind.In;
                     }
 
                     argsAndParams.Add((parameter, argument, refKind));
@@ -1815,7 +1822,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// whether analysis should consider value or ref escape. Not all method arguments
         /// are included, and some arguments may be included twice - once for value, once for ref.
         /// </summary>
-        private void GetInvocationArgumentsForEscapeWithUpdatedRules(
+        private void GetFilteredInvocationArgumentsForEscapeWithUpdatedRules(
             Symbol symbol,
             BoundExpression? receiver,
             ImmutableArray<ParameterSymbol> parameters,
@@ -2060,7 +2067,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             uint escapeScope = Binder.ExternalScope;
             (ParameterSymbol? Parameter, BoundExpression Argument, bool IsRefEscape)? argAndParamToEscape = null;
             var argsAndParamsAll = ArrayBuilder<(ParameterSymbol? Parameter, BoundExpression Argument, bool IsRefEscape)>.GetInstance();
-            GetInvocationArgumentsForEscapeWithUpdatedRules(
+            GetFilteredInvocationArgumentsForEscapeWithUpdatedRules(
                 symbol,
                 receiverOpt,
                 parameters,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -4121,6 +4121,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             receiver,
                             resultMember.Parameters,
                             arguments,
+                            refKinds,
                             argsToParamsOpt,
                             this.LocalScopeDepth,
                             diagnostics);
@@ -5537,6 +5538,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         null,
                         method.Parameters,
                         arguments,
+                        refKinds,
                         argToParams,
                         this.LocalScopeDepth,
                         diagnostics);
@@ -8242,6 +8244,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         receiver,
                         property.Parameters,
                         arguments,
+                        argumentRefKinds,
                         argsToParams,
                         this.LocalScopeDepth,
                         diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1134,6 +1134,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     receiver,
                     method.Parameters,
                     args,
+                    argRefKinds,
                     argsToParams,
                     this.LocalScopeDepth,
                     diagnostics);
@@ -2065,6 +2066,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     receiverOpt: null,
                     funcPtr.Signature.Parameters,
                     args,
+                    refKinds,
                     methodResult.Result.ArgsToParamsOpt,
                     LocalScopeDepth,
                     diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
@@ -144,6 +144,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                         type = BindType(typeSyntax, diagnostics);
                         ParameterHelpers.CheckParameterModifiers(p, diagnostics, parsingFunctionPointerParams: false, parsingLambdaParams: true);
                         refKind = ParameterHelpers.GetModifiers(p.Modifiers, out _, out _, out _, out scope);
+
+                        if (scope == DeclarationScope.Unscoped &&
+                            ParameterHelpers.IsRefScopedByDefault(refKind, type))
+                        {
+                            scope = DeclarationScope.RefScoped;
+                        }
                     }
 
                     namesBuilder.Add(p.Identifier.ValueText);

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7206,7 +7206,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Types and aliases cannot be named 'scoped'.</value>
   </data>
   <data name="ERR_UnscopedRefAttributeUnsupportedTarget" xml:space="preserve">
-    <value>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</value>
+    <value>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</value>
   </data>
   <data name="ERR_RuntimeDoesNotSupportRefFields" xml:space="preserve">
     <value>Target runtime doesn't support ref fields.</value>

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1713,7 +1713,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         internal SynthesizedAttributeData SynthesizeScopedRefAttribute(ParameterSymbol symbol, DeclarationScope scope)
         {
             Debug.Assert(scope != DeclarationScope.Unscoped);
-            Debug.Assert(symbol.RefKind != RefKind.Out || scope == DeclarationScope.ValueScoped);
+            Debug.Assert(!ParameterHelpers.IsRefScopedByDefault(symbol) || scope == DeclarationScope.ValueScoped);
             Debug.Assert(!symbol.IsThis);
 
             if ((object)Compilation.SourceModule != symbol.ContainingModule)

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -612,13 +612,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 foreach (var param in symbol.Parameters)
                 {
                     // https://github.com/dotnet/roslyn/issues/61647: Use public API.
-                    Debug.Assert((param as Symbols.PublicModel.ParameterSymbol)?.GetSymbol<ParameterSymbol>().EffectiveScope switch
+#if DEBUG
+                    if ((param as Symbols.PublicModel.ParameterSymbol)?.GetSymbol<ParameterSymbol>() is var p)
                     {
-                        null => true,
-                        DeclarationScope.Unscoped => param.RefKind != RefKind.Out,
-                        DeclarationScope.RefScoped => param.RefKind == RefKind.Out,
-                        _ => false,
-                    });
+                        Debug.Assert((p.EffectiveScope, ParameterHelpers.IsRefScopedByDefault(p)) switch
+                        {
+                            (DeclarationScope.Unscoped, false) => true,
+                            (DeclarationScope.RefScoped, true) => true,
+                            _ => false,
+                        });
+                    }
+#endif
 
                     AddParameterRefKind(param.RefKind);
 
@@ -824,6 +828,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 AddPunctuation(SyntaxKind.CloseBracketToken);
             }
         }
+
+#nullable enable
 
         private static bool CanAddConstant(ITypeSymbol type, object value)
         {
@@ -1079,8 +1085,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (format.ParameterOptions.IncludesOption(SymbolDisplayParameterOptions.IncludeParamsRefOut))
             {
                 // https://github.com/dotnet/roslyn/issues/61647: Use public API.
-                if ((symbol as Symbols.PublicModel.ParameterSymbol)?.GetSymbol<ParameterSymbol>().EffectiveScope == DeclarationScope.RefScoped &&
-                    symbol.RefKind != RefKind.Out &&
+                if ((symbol as Symbols.PublicModel.ParameterSymbol)?.GetSymbol<ParameterSymbol>() is { } parameter &&
+                    parameter.EffectiveScope == DeclarationScope.RefScoped &&
+                    !ParameterHelpers.IsRefScopedByDefault(parameter) &&
+                    !parameter.IsThis &&
                     format.CompilerInternalOptions.IncludesOption(SymbolDisplayCompilerInternalOptions.IncludeScoped))
                 {
                     AddKeyword(SyntaxKind.ScopedKeyword);

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -613,7 +613,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // https://github.com/dotnet/roslyn/issues/61647: Use public API.
 #if DEBUG
-                    if ((param as Symbols.PublicModel.ParameterSymbol)?.GetSymbol<ParameterSymbol>() is var p)
+                    if ((param as Symbols.PublicModel.ParameterSymbol)?.GetSymbol<ParameterSymbol>() is { } p)
                     {
                         Debug.Assert((p.EffectiveScope, ParameterHelpers.IsRefScopedByDefault(p)) switch
                         {

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerParameterSymbol.cs
@@ -29,7 +29,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override int Ordinal { get; }
         public override Symbol ContainingSymbol => _containingSymbol;
         public override ImmutableArray<CustomModifier> RefCustomModifiers { get; }
-        internal override DeclarationScope DeclaredScope => RefKind == RefKind.Out ? DeclarationScope.RefScoped : DeclarationScope.Unscoped;
+
+        internal override DeclarationScope DeclaredScope
+            => ParameterHelpers.IsRefScopedByDefault(this) ? DeclarationScope.RefScoped : DeclarationScope.Unscoped;
         internal override DeclarationScope EffectiveScope => DeclaredScope;
 
         public override bool Equals(Symbol other, TypeCompareKind compareKind)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -317,6 +317,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         isBad = true;
                     }
                 }
+                else if (ParameterHelpers.IsRefScopedByDefault(refKind, typeWithAnnotations))
+                {
+                    scope = DeclarationScope.RefScoped;
+                }
             }
 
             _typeWithAnnotations = typeWithAnnotations;

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyParameterSymbol.cs
@@ -48,7 +48,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool IsDiscard { get { return false; } }
 
-        internal override DeclarationScope DeclaredScope => DeclarationScope.Unscoped;
+        internal override DeclarationScope DeclaredScope
+            => ParameterHelpers.IsRefScopedByDefault(this) ? DeclarationScope.RefScoped : DeclarationScope.Unscoped;
         internal override DeclarationScope EffectiveScope => DeclaredScope;
 
         #region Not used by MethodSignatureComparer

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -331,13 +331,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static bool IsRefScopedByDefault(RefKind refKind, TypeWithAnnotations parameterType)
         {
-            if (refKind == RefKind.Out)
+            switch (refKind)
             {
-                return true;
+                case RefKind.Out:
+                    return true;
+                case RefKind.Ref:
+                case RefKind.In:
+                    return parameterType.IsResolved &&
+                        parameterType.Type?.IsRefLikeType == true;
+                default:
+                    return false;
             }
-            return refKind == RefKind.Ref &&
-                parameterType.IsResolved &&
-                parameterType.Type?.IsRefLikeType == true;
         }
 
         internal static void EnsureScopedRefAttributeExists(PEModuleBuilder moduleBuilder, ImmutableArray<ParameterSymbol> parameters)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -145,10 +145,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     diagnostics.Add(ErrorCode.ERR_ThisInBadContext, thisKeyword.GetLocation());
                 }
-                if (refKind == RefKind.Out && scope == DeclarationScope.Unscoped)
-                {
-                    scope = DeclarationScope.RefScoped;
-                }
 
                 if (parameterSyntax is ParameterSyntax concreteParam)
                 {
@@ -190,6 +186,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     // error CS0631: ref and out are not valid in this context
                     diagnostics.Add(ErrorCode.ERR_IllegalRefParam, refnessKeyword.GetLocation());
+                }
+
+                if (scope == DeclarationScope.Unscoped &&
+                    IsRefScopedByDefault(refKind, parameterType))
+                {
+                    scope = DeclarationScope.RefScoped;
                 }
 
                 TParameterSymbol parameter = parameterCreationFunc(withTypeParametersBinder, owner, parameterType, parameterSyntax, refKind, parameterIndex, paramsKeyword, thisKeyword, addRefReadOnlyModifier, scope, diagnostics);
@@ -315,11 +317,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return false;
             }
-            if (parameter.RefKind == RefKind.Out)
+            if (IsRefScopedByDefault(parameter))
             {
                 return scope == DeclarationScope.ValueScoped;
             }
             return true;
+        }
+
+        internal static bool IsRefScopedByDefault(ParameterSymbol parameter)
+        {
+            return IsRefScopedByDefault(parameter.RefKind, parameter.TypeWithAnnotations);
+        }
+
+        internal static bool IsRefScopedByDefault(RefKind refKind, TypeWithAnnotations parameterType)
+        {
+            if (refKind == RefKind.Out)
+            {
+                return true;
+            }
+            return refKind == RefKind.Ref &&
+                parameterType.IsResolved &&
+                parameterType.Type?.IsRefLikeType == true;
         }
 
         internal static void EnsureScopedRefAttributeExists(PEModuleBuilder moduleBuilder, ImmutableArray<ParameterSymbol> parameters)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -337,8 +337,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return true;
                 case RefKind.Ref:
                 case RefKind.In:
-                    return parameterType.IsResolved &&
-                        parameterType.Type?.IsRefLikeType == true;
+                    return parameterType.IsRefLikeType();
                 default:
                     return false;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -827,16 +827,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private bool IsValidUnscopedRefAttributeTarget()
         {
-            switch (RefKind)
-            {
-                case RefKind.Out:
-                    return true;
-                case RefKind.Ref:
-                    var type = Type;
-                    return type is null || type.IsErrorTypeOrRefLikeType();
-                default:
-                    return false;
-            }
+            return ParameterHelpers.IsRefScopedByDefault(this);
         }
 
         private static bool? DecodeMaybeNullWhenOrNotNullWhenOrDoesNotReturnIfAttribute(AttributeDescription description, CSharpAttributeData attribute)

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1583,8 +1583,8 @@
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
       <trans-unit id="ERR_UnscopedRefAttributeUnsupportedTarget">
-        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
-        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
+        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
+        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsupportedCompilerFeature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1583,8 +1583,8 @@
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
       <trans-unit id="ERR_UnscopedRefAttributeUnsupportedTarget">
-        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
-        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
+        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
+        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsupportedCompilerFeature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1583,8 +1583,8 @@
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
       <trans-unit id="ERR_UnscopedRefAttributeUnsupportedTarget">
-        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
-        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
+        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
+        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsupportedCompilerFeature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1583,8 +1583,8 @@
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
       <trans-unit id="ERR_UnscopedRefAttributeUnsupportedTarget">
-        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
-        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
+        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
+        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsupportedCompilerFeature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1583,8 +1583,8 @@
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
       <trans-unit id="ERR_UnscopedRefAttributeUnsupportedTarget">
-        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
-        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
+        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
+        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsupportedCompilerFeature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1583,8 +1583,8 @@
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
       <trans-unit id="ERR_UnscopedRefAttributeUnsupportedTarget">
-        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
-        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
+        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
+        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsupportedCompilerFeature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1583,8 +1583,8 @@
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
       <trans-unit id="ERR_UnscopedRefAttributeUnsupportedTarget">
-        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
-        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
+        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
+        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsupportedCompilerFeature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1583,8 +1583,8 @@
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
       <trans-unit id="ERR_UnscopedRefAttributeUnsupportedTarget">
-        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
-        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
+        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
+        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsupportedCompilerFeature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1583,8 +1583,8 @@
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
       <trans-unit id="ERR_UnscopedRefAttributeUnsupportedTarget">
-        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
-        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
+        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
+        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsupportedCompilerFeature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1583,8 +1583,8 @@
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
       <trans-unit id="ERR_UnscopedRefAttributeUnsupportedTarget">
-        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
-        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
+        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
+        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsupportedCompilerFeature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1583,8 +1583,8 @@
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
       <trans-unit id="ERR_UnscopedRefAttributeUnsupportedTarget">
-        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
-        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
+        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
+        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsupportedCompilerFeature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1583,8 +1583,8 @@
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
       <trans-unit id="ERR_UnscopedRefAttributeUnsupportedTarget">
-        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
-        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
+        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
+        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsupportedCompilerFeature">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1583,8 +1583,8 @@
         <note>UnmanagedCallersOnly is not localizable.</note>
       </trans-unit>
       <trans-unit id="ERR_UnscopedRefAttributeUnsupportedTarget">
-        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
-        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
+        <source>UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</source>
+        <target state="new">UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_UnsupportedCompilerFeature">

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -10944,8 +10944,6 @@ unsafe
                 // (13,62): error CS8166: Cannot return a parameter by reference 'i' because it is not a ref parameter
                 //     static ref Span<int> ReturnByRef(ref Span<int> i) => ref i;
                 Diagnostic(ErrorCode.ERR_RefReturnParameter, "i").WithArguments("i").WithLocation(13, 62));
-
-            // https://github.com/dotnet/roslyn/issues/62780: Test with [UnscopedRef].
         }
 
         [Fact, WorkItem(49315, "https://github.com/dotnet/roslyn/issues/49315")]
@@ -10988,8 +10986,6 @@ unsafe
                 // (14,62): error CS8166: Cannot return a parameter by reference 'i' because it is not a ref parameter
                 //     static ref Span<int> ReturnByRef(ref Span<int> i) => ref i;
                 Diagnostic(ErrorCode.ERR_RefReturnParameter, "i").WithArguments("i").WithLocation(14, 62));
-
-            // https://github.com/dotnet/roslyn/issues/62780: Test with [UnscopedRef].
         }
 
         [Fact, WorkItem(49315, "https://github.com/dotnet/roslyn/issues/49315")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenFunctionPointersTests.cs
@@ -10914,7 +10914,7 @@ unsafe
         [Fact, WorkItem(49315, "https://github.com/dotnet/roslyn/issues/49315")]
         public void ReturnByRefFromRefReturningMethod_NotSafeToEscape()
         {
-            var comp = CreateCompilationWithSpan(@"
+            string source = @"
 using System;
 unsafe
 {
@@ -10927,8 +10927,9 @@ unsafe
     }
 
     static ref Span<int> ReturnByRef(ref Span<int> i) => ref i;
-}", options: TestOptions.UnsafeReleaseExe);
+}";
 
+            var comp = CreateCompilationWithSpan(source, parseOptions: TestOptions.Regular10, options: TestOptions.UnsafeReleaseExe);
             comp.VerifyDiagnostics(
                 // (10,20): error CS8347: Cannot use a result of 'delegate*<ref Span<int>, ref Span<int>>' in this context because it may expose variables referenced by parameter '0' outside of their declaration scope
                 //         return ref ptr(ref span);
@@ -10937,12 +10938,20 @@ unsafe
                 //         return ref ptr(ref span);
                 Diagnostic(ErrorCode.ERR_RefReturnLocal, "span").WithArguments("span").WithLocation(10, 28)
             );
+
+            comp = CreateCompilationWithSpan(source, options: TestOptions.UnsafeReleaseExe);
+            comp.VerifyDiagnostics(
+                // (13,62): error CS8166: Cannot return a parameter by reference 'i' because it is not a ref parameter
+                //     static ref Span<int> ReturnByRef(ref Span<int> i) => ref i;
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "i").WithArguments("i").WithLocation(13, 62));
+
+            // https://github.com/dotnet/roslyn/issues/62780: Test with [UnscopedRef].
         }
 
         [Fact, WorkItem(49315, "https://github.com/dotnet/roslyn/issues/49315")]
         public void ReturnByRefFromRefReturningMethod_SafeToEscape()
         {
-            var comp = CreateCompilationWithSpan(@"
+            string source = @"
 using System;
 unsafe
 {
@@ -10956,10 +10965,10 @@ unsafe
         => ref ptr(ref s);
 
     static ref Span<int> ReturnByRef(ref Span<int> i) => ref i;
-}", options: TestOptions.UnsafeReleaseExe);
+}";
 
+            var comp = CreateCompilationWithSpan(source, parseOptions: TestOptions.Regular10, options: TestOptions.UnsafeReleaseExe);
             var verifier = CompileAndVerify(comp, expectedOutput: "2", verify: Verification.Skipped);
-
             verifier.VerifyIL("Program.<<Main>$>g__ReturnPtrByRef|0_0(delegate*<ref System.Span<int>, ref System.Span<int>>, ref System.Span<int>)", @"
 {
   // Code size       10 (0xa)
@@ -10973,6 +10982,14 @@ unsafe
   IL_0009:  ret
 }
 ");
+
+            comp = CreateCompilationWithSpan(source, options: TestOptions.UnsafeReleaseExe);
+            comp.VerifyDiagnostics(
+                // (14,62): error CS8166: Cannot return a parameter by reference 'i' because it is not a ref parameter
+                //     static ref Span<int> ReturnByRef(ref Span<int> i) => ref i;
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "i").WithArguments("i").WithLocation(14, 62));
+
+            // https://github.com/dotnet/roslyn/issues/62780: Test with [UnscopedRef].
         }
 
         [Fact, WorkItem(49315, "https://github.com/dotnet/roslyn/issues/49315")]

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_LifetimeAnnotation.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_LifetimeAnnotation.cs
@@ -335,9 +335,6 @@ struct S
     [ScopedRef] ref System.Int32 i
 void S.F(R r)
     [ScopedRef] R r
-S S.op_Addition(S a, in R b)
-    S a
-    [ScopedRef] in R b
 System.Object S.this[in System.Int32 i].get
     [ScopedRef] in System.Int32 i
 ";
@@ -407,12 +404,10 @@ class Program
 }";
             var comp = CreateCompilation(source);
             var expected =
-@"void Program.F5(in R r)
-    [ScopedRef] in R r
-";
+@"";
             CompileAndVerify(comp, symbolValidator: module =>
             {
-                Assert.Equal("System.Runtime.CompilerServices.ScopedRefAttribute", GetScopedRefType(module).ToTestDisplayString());
+                Assert.Null(GetScopedRefType(module));
                 AssertScopedRefAttributes(module, expected);
             });
 

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_LifetimeAnnotation.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_LifetimeAnnotation.cs
@@ -137,7 +137,7 @@ using System.Runtime.CompilerServices;
     [ScopedRef] event EventHandler E;
     [ScopedRef] object P { get; }
     [ScopedRef] static object M1() => throw null;
-    [ScopedRef] static object M2() => throw null;
+    [return: ScopedRef] static object M2() => throw null;
     static void M3<[ScopedRef] T>() { }
 }
 namespace System.Runtime.CompilerServices

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_LifetimeAnnotation.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_LifetimeAnnotation.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 }";
             var comp = CreateCompilation(new[] { ScopedRefAttributeDefinition, source });
             var expected =
-@" void Program.F(ref System.Int32 i)
+@"void Program.F(ref System.Int32 i)
     [ScopedRef] ref System.Int32 i
 ";
             CompileAndVerify(comp, symbolValidator: module =>
@@ -264,7 +264,7 @@ ref struct R { }
             Assert.Equal(DeclarationScope.RefScoped, parameter.DeclaredScope);
 
             method = comp.GetMember<MethodSymbol>("A.F4");
-            Assert.Equal("void A.F4(scoped ref R r)", method.ToDisplayString(SymbolDisplayFormat.TestFormat.WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.IncludeScoped)));
+            Assert.Equal("void A.F4(ref R r)", method.ToDisplayString(SymbolDisplayFormat.TestFormat.WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.IncludeScoped)));
             parameter = method.Parameters[0];
             Assert.Equal(DeclarationScope.RefScoped, parameter.DeclaredScope);
         }
@@ -388,6 +388,35 @@ class Program
                 Assert.Null(GetScopedRefType(module));
                 AssertScopedRefAttributes(module, "");
             });
+        }
+
+        [Fact]
+        public void EmitAttribute_RefToRefStructParameters()
+        {
+            var source =
+@"ref struct R { }
+class Program
+{
+    public static void F0(R r) { }
+    public static void F1(ref R r) { }
+    public static void F2(in R r) { }
+    public static void F3(out R r) { r = default; }
+    public static void F4(scoped ref R r) { }
+    public static void F5(scoped in R r) { }
+    public static void F6(scoped out R r) { r = default; }
+}";
+            var comp = CreateCompilation(source);
+            var expected =
+@"void Program.F5(in R r)
+    [ScopedRef] in R r
+";
+            CompileAndVerify(comp, symbolValidator: module =>
+            {
+                Assert.Equal("System.Runtime.CompilerServices.ScopedRefAttribute", GetScopedRefType(module).ToTestDisplayString());
+                AssertScopedRefAttributes(module, expected);
+            });
+
+            // https://github.com/dotnet/roslyn/issues/62780: Test additional cases with [UnscopedRef].
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -10129,11 +10129,11 @@ class Program
 3
 <>f__AnonymousDelegate1
 4
-<>f__AnonymousDelegate2
+<>f__AnonymousDelegate1
 -5
-<>f__AnonymousDelegate3
+<>f__AnonymousDelegate2
 -6
-<>f__AnonymousDelegate3
+<>f__AnonymousDelegate2
 ");
 
             // https://github.com/dotnet/roslyn/issues/62780: Test with [UnscopedRef].

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -10088,7 +10088,10 @@ class Program
 {
     static R F1(ref R r) { Console.WriteLine(r._i); return new R(); }
     static R F2(scoped ref R r) { Console.WriteLine(r._i); return new R(); }
-    static R F4(scoped ref R r) { Console.WriteLine(r._i); return new R(); }
+    static R F3(in R r) { Console.WriteLine(r._i); return new R(); }
+    static R F4(scoped in R r) { Console.WriteLine(r._i); return new R(); }
+    static R F5(out R r) { r = new R(-5); Console.WriteLine(r._i); return new R(); }
+    static R F6(scoped out R r) { r = new R(-6); Console.WriteLine(r._i); return new R(); }
     static void Main()
     {
         var d1 = F1;
@@ -10099,10 +10102,22 @@ class Program
         var r2 = new R(2);
         d2(ref r2);
         Report(d2);
+        var d3 = F3;
+        var r3 = new R(3);
+        d3(r3);
+        Report(d3);
         var d4 = F4;
         var r4 = new R(4);
-        d4(ref r4);
+        d4(r4);
         Report(d4);
+        var d5 = F5;
+        var r5 = new R(5);
+        d5(out r5);
+        Report(d5);
+        var d6 = F6;
+        var r6 = new R(6);
+        d6(out r6);
+        Report(d6);
     }
     static void Report(Delegate d) => Console.WriteLine(d.GetType());
 }";
@@ -10110,10 +10125,18 @@ class Program
 @"1
 <>f__AnonymousDelegate0
 2
+<>f__AnonymousDelegate0
+3
 <>f__AnonymousDelegate1
 4
-<>f__AnonymousDelegate1
+<>f__AnonymousDelegate2
+-5
+<>f__AnonymousDelegate3
+-6
+<>f__AnonymousDelegate3
 ");
+
+            // https://github.com/dotnet/roslyn/issues/62780: Test with [UnscopedRef].
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -13604,31 +13604,21 @@ public ref struct S1
 }
 ";
 
-            var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, parseOptions: TestOptions.Regular10, targetFramework: TargetFramework.NetCoreApp);
-            comp.VerifyDiagnostics(
+            var expectedDiagnostics = new[]
+            {
                 // (17,9): error CS8350: This combination of arguments to 'CustomHandler.M2(ref S1, ref CustomHandler)' is disallowed because it may expose variables referenced by parameter 'handler' outside of their declaration scope
                 //         M2(ref s1, $"{s}");
                 Diagnostic(ErrorCode.ERR_CallArgMixing, @"M2(ref s1, " + expression + @")").WithArguments("CustomHandler.M2(ref S1, ref CustomHandler)", "handler").WithLocation(17, 9),
                 // (17,23): error CS8352: Cannot use variable 's' in this context because it may expose referenced variables outside of their declaration scope
                 //         M2(ref s1, $"{s}");
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "s").WithArguments("s").WithLocation(17, 23)
-            );
+            };
+
+            var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, parseOptions: TestOptions.Regular10, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyDiagnostics(expectedDiagnostics);
 
             comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, targetFramework: TargetFramework.NetCoreApp);
-            comp.VerifyDiagnostics(
-                // (17,9): error CS8350: This combination of arguments to 'CustomHandler.M2(ref S1, ref CustomHandler)' is disallowed because it may expose variables referenced by parameter 'handler' outside of their declaration scope
-                //         M2(ref s1, $"{s}");
-                Diagnostic(ErrorCode.ERR_CallArgMixing, @"M2(ref s1, " + expression + @")").WithArguments("CustomHandler.M2(ref S1, ref CustomHandler)", "handler").WithLocation(17, 9),
-                // (17,16): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
-                //         M2(ref s1, $"{s}");
-                Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "s1").WithLocation(17, 16),
-                // (17,20): error CS8347: Cannot use a result of 'CustomHandler.CustomHandler(int, int, ref S1)' in this context because it may expose variables referenced by parameter 's1' outside of their declaration scope
-                //         M2(ref s1, $"{s}");
-                Diagnostic(ErrorCode.ERR_EscapeCall, expression).WithArguments("CustomHandler.CustomHandler(int, int, ref S1)", "s1").WithLocation(17, 20),
-                // (17,23): error CS8352: Cannot use variable 's' in this context because it may expose referenced variables outside of their declaration scope
-                //         M2(ref s1, $"{s}");
-                Diagnostic(ErrorCode.ERR_EscapeVariable, "s").WithArguments("s").WithLocation(17, 23)
-            );
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Theory]
@@ -13775,6 +13765,20 @@ public ref struct CustomHandler
                 //         return c;
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "c").WithArguments("c").WithLocation(16, 16)
             );
+
+            // https://github.com/dotnet/roslyn/issues/62791: ErrorCode.ERR_CallArgMixing should not be reported.
+            comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyDiagnostics(
+                // (15,35): error CS8350: This combination of arguments to 'CustomHandler.M2(ref Span<char>, ref CustomHandler)' is disallowed because it may expose variables referenced by parameter 's' outside of their declaration scope
+                //         ref CustomHandler c = ref M2(ref s, $"");
+                Diagnostic(ErrorCode.ERR_CallArgMixing, @"M2(ref s, $"""")").WithArguments("CustomHandler.M2(ref System.Span<char>, ref CustomHandler)", "s").WithLocation(15, 35),
+                // (15,42): error CS8352: Cannot use variable 's' in this context because it may expose referenced variables outside of their declaration scope
+                //         ref CustomHandler c = ref M2(ref s, $"");
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "s").WithArguments("s").WithLocation(15, 42),
+                // (21,20): error CS8166: Cannot return a parameter by reference 'handler' because it is not a ref parameter
+                //         return ref handler;
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "handler").WithArguments("handler").WithLocation(21, 20)
+            );
         }
 
         [Fact]
@@ -13808,31 +13812,21 @@ public ref struct S1
 }
 ";
 
-            var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, parseOptions: TestOptions.Regular10, targetFramework: TargetFramework.NetCoreApp);
-            comp.VerifyDiagnostics(
+            var expectedDiagnostics = new[]
+            {
                 // (15,9): error CS8350: This combination of arguments to 'CustomHandler.M2(ref S1, CustomHandler)' is disallowed because it may expose variables referenced by parameter 'handler' outside of their declaration scope
                 //         M2(ref s1, $"{s2}");
                 Diagnostic(ErrorCode.ERR_CallArgMixing, @"M2(ref s1, $""{s2}"")").WithArguments("CustomHandler.M2(ref S1, CustomHandler)", "handler").WithLocation(15, 9),
                 // (15,23): error CS8352: Cannot use variable 's2' in this context because it may expose referenced variables outside of their declaration scope
                 //         M2(ref s1, $"{s2}");
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "s2").WithArguments("s2").WithLocation(15, 23)
-            );
+            };
+
+            var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, parseOptions: TestOptions.Regular10, targetFramework: TargetFramework.NetCoreApp);
+            comp.VerifyDiagnostics(expectedDiagnostics);
 
             comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, targetFramework: TargetFramework.NetCoreApp);
-            comp.VerifyDiagnostics(
-                // (15,9): error CS8350: This combination of arguments to 'CustomHandler.M2(ref S1, CustomHandler)' is disallowed because it may expose variables referenced by parameter 'handler' outside of their declaration scope
-                //         M2(ref s1, $"{s2}");
-                Diagnostic(ErrorCode.ERR_CallArgMixing, @"M2(ref s1, $""{s2}"")").WithArguments("CustomHandler.M2(ref S1, CustomHandler)", "handler").WithLocation(15, 9),
-                // (15,16): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
-                //         M2(ref s1, $"{s2}");
-                Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "s1").WithLocation(15, 16),
-                // (15,20): error CS8347: Cannot use a result of 'CustomHandler.CustomHandler(int, int, ref S1)' in this context because it may expose variables referenced by parameter 's1' outside of their declaration scope
-                //         M2(ref s1, $"{s2}");
-                Diagnostic(ErrorCode.ERR_EscapeCall, @"$""{s2}""").WithArguments("CustomHandler.CustomHandler(int, int, ref S1)", "s1").WithLocation(15, 20),
-                // (15,23): error CS8352: Cannot use variable 's2' in this context because it may expose referenced variables outside of their declaration scope
-                //         M2(ref s1, $"{s2}");
-                Diagnostic(ErrorCode.ERR_EscapeVariable, "s2").WithArguments("s2").WithLocation(15, 23)
-            );
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]
@@ -13864,13 +13858,7 @@ class Program
             comp.VerifyDiagnostics();
 
             comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, targetFramework: TargetFramework.NetCoreApp);
-            comp.VerifyDiagnostics(
-                // (17,15): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
-                //         M(ref s, $"{1}");
-                Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "s").WithLocation(17, 15),
-                // (17,18): error CS8347: Cannot use a result of 'CustomHandler.CustomHandler(int, int, ref S)' in this context because it may expose variables referenced by parameter 's' outside of their declaration scope
-                //         M(ref s, $"{1}");
-                Diagnostic(ErrorCode.ERR_EscapeCall, @"$""{1}""").WithArguments("CustomHandler.CustomHandler(int, int, ref S)", "s").WithLocation(17, 18));
+            comp.VerifyDiagnostics();
         }
 
         [WorkItem(63262, "https://github.com/dotnet/roslyn/issues/63262")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RawInterpolationTests_Handler.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RawInterpolationTests_Handler.cs
@@ -11098,12 +11098,6 @@ public ref struct S1
             // (17,9): error CS8350: This combination of arguments to 'CustomHandler.M2(ref S1, ref CustomHandler)' is disallowed because it may expose variables referenced by parameter 'handler' outside of their declaration scope
             //         M2(ref s1, $"{s}");
             Diagnostic(ErrorCode.ERR_CallArgMixing, @"M2(ref s1, " + expression + @")").WithArguments("CustomHandler.M2(ref S1, ref CustomHandler)", "handler").WithLocation(17, 9),
-            // (17,16): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
-            //         M2(ref s1, $"""{s}""" + $"""
-            Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "s1").WithLocation(17, 16),
-            // (17,20): error CS8347: Cannot use a result of 'CustomHandler.CustomHandler(int, int, ref S1)' in this context because it may expose variables referenced by parameter 's1' outside of their declaration scope
-            //         M2(ref s1, $"""{s}""" + $"""
-            Diagnostic(ErrorCode.ERR_EscapeCall, expression).WithArguments("CustomHandler.CustomHandler(int, int, ref S1)", "s1").WithLocation(17, 20),
             // (17,23): error CS8352: Cannot use variable 's' in this context because it may expose referenced variables outside of their declaration scope
             //         M2(ref s1, $"{s}");
             Diagnostic(ErrorCode.ERR_EscapeVariable, "s").WithArguments("s").WithLocation(17, 25));
@@ -11244,11 +11238,20 @@ public ref struct CustomHandler
 }
 ";
 
+        // https://github.com/dotnet/roslyn/issues/62791: ErrorCode.ERR_CallArgMixing should not be reported.
         var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, targetFramework: TargetFramework.NetCoreApp);
         comp.VerifyDiagnostics(
-            // (16,16): error CS8352: Cannot use variable 'c' in this context because it may expose referenced variables outside of their declaration scope
-            //         return c;
-            Diagnostic(ErrorCode.ERR_EscapeVariable, "c").WithArguments("c").WithLocation(18, 16));
+            // (15,35): error CS8350: This combination of arguments to 'CustomHandler.M2(ref Span<char>, ref CustomHandler)' is disallowed because it may expose variables referenced by parameter 's' outside of their declaration scope
+            //         ref CustomHandler c = ref M2(ref s, $"""
+            Diagnostic(ErrorCode.ERR_CallArgMixing, @"M2(ref s, $""""""
+
+"""""")").WithArguments("CustomHandler.M2(ref System.Span<char>, ref CustomHandler)", "s").WithLocation(15, 35),
+            // (15,42): error CS8352: Cannot use variable 's' in this context because it may expose referenced variables outside of their declaration scope
+            //         ref CustomHandler c = ref M2(ref s, $"""
+            Diagnostic(ErrorCode.ERR_EscapeVariable, "s").WithArguments("s").WithLocation(15, 42),
+            // (23,20): error CS8166: Cannot return a parameter by reference 'handler' because it is not a ref parameter
+            //         return ref handler;
+            Diagnostic(ErrorCode.ERR_RefReturnParameter, "handler").WithArguments("handler").WithLocation(23, 20));
     }
 
     [Fact]
@@ -11285,16 +11288,10 @@ public ref struct S1
         var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, targetFramework: TargetFramework.NetCoreApp);
         comp.VerifyDiagnostics(
             // (15,9): error CS8350: This combination of arguments to 'CustomHandler.M2(ref S1, CustomHandler)' is disallowed because it may expose variables referenced by parameter 'handler' outside of their declaration scope
-            //         M2(ref s1, $"{s2}");
+            //         M2(ref s1, $"""{s2}""");
             Diagnostic(ErrorCode.ERR_CallArgMixing, @"M2(ref s1, $""""""{s2}"""""")").WithArguments("CustomHandler.M2(ref S1, CustomHandler)", "handler").WithLocation(15, 9),
-            // (15,16): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
+            // (15,25): error CS8352: Cannot use variable 's2' in this context because it may expose referenced variables outside of their declaration scope
             //         M2(ref s1, $"""{s2}""");
-            Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "s1").WithLocation(15, 16),
-            // (15,20): error CS8347: Cannot use a result of 'CustomHandler.CustomHandler(int, int, ref S1)' in this context because it may expose variables referenced by parameter 's1' outside of their declaration scope
-            //         M2(ref s1, $"""{s2}""");
-            Diagnostic(ErrorCode.ERR_EscapeCall, @"$""""""{s2}""""""").WithArguments("CustomHandler.CustomHandler(int, int, ref S1)", "s1").WithLocation(15, 20),
-            // (15,23): error CS8352: Cannot use variable 's2' in this context because it may expose referenced variables outside of their declaration scope
-            //         M2(ref s1, $"{s2}");
             Diagnostic(ErrorCode.ERR_EscapeVariable, "s2").WithArguments("s2").WithLocation(15, 25));
     }
 
@@ -11324,13 +11321,7 @@ class Program
 }";
 
         var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, targetFramework: TargetFramework.NetCoreApp);
-        comp.VerifyDiagnostics(
-            // (17,15): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
-            //         M(ref s, $"""{1}""");
-            Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "s").WithLocation(17, 15),
-            // (17,18): error CS8347: Cannot use a result of 'CustomHandler.CustomHandler(int, int, ref S)' in this context because it may expose variables referenced by parameter 's' outside of their declaration scope
-            //         M(ref s, $"""{1}""");
-            Diagnostic(ErrorCode.ERR_EscapeCall, @"$""""""{1}""""""").WithArguments("CustomHandler.CustomHandler(int, int, ref S)", "s").WithLocation(17, 18));
+        comp.VerifyDiagnostics();
     }
 
     [Theory, WorkItem(54703, "https://github.com/dotnet/roslyn/issues/54703")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RawInterpolationTests_Handler.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RawInterpolationTests_Handler.cs
@@ -11096,10 +11096,10 @@ public ref struct S1
         var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, targetFramework: TargetFramework.NetCoreApp);
         comp.VerifyDiagnostics(
             // (17,9): error CS8350: This combination of arguments to 'CustomHandler.M2(ref S1, ref CustomHandler)' is disallowed because it may expose variables referenced by parameter 'handler' outside of their declaration scope
-            //         M2(ref s1, $"{s}");
+            //         M2(ref s1, $"""{s}""" + $"""
             Diagnostic(ErrorCode.ERR_CallArgMixing, @"M2(ref s1, " + expression + @")").WithArguments("CustomHandler.M2(ref S1, ref CustomHandler)", "handler").WithLocation(17, 9),
-            // (17,23): error CS8352: Cannot use variable 's' in this context because it may expose referenced variables outside of their declaration scope
-            //         M2(ref s1, $"{s}");
+            // (17,25): error CS8352: Cannot use variable 's' in this context because it may expose referenced variables outside of their declaration scope
+            //         M2(ref s1, $"""{s}""" + $"""
             Diagnostic(ErrorCode.ERR_EscapeVariable, "s").WithArguments("s").WithLocation(17, 25));
     }
 
@@ -11238,17 +11238,11 @@ public ref struct CustomHandler
 }
 ";
 
-        // https://github.com/dotnet/roslyn/issues/62791: ErrorCode.ERR_CallArgMixing should not be reported.
         var comp = CreateCompilation(new[] { code, InterpolatedStringHandlerAttribute, InterpolatedStringHandlerArgumentAttribute }, targetFramework: TargetFramework.NetCoreApp);
         comp.VerifyDiagnostics(
-            // (15,35): error CS8350: This combination of arguments to 'CustomHandler.M2(ref Span<char>, ref CustomHandler)' is disallowed because it may expose variables referenced by parameter 's' outside of their declaration scope
-            //         ref CustomHandler c = ref M2(ref s, $"""
-            Diagnostic(ErrorCode.ERR_CallArgMixing, @"M2(ref s, $""""""
-
-"""""")").WithArguments("CustomHandler.M2(ref System.Span<char>, ref CustomHandler)", "s").WithLocation(15, 35),
-            // (15,42): error CS8352: Cannot use variable 's' in this context because it may expose referenced variables outside of their declaration scope
-            //         ref CustomHandler c = ref M2(ref s, $"""
-            Diagnostic(ErrorCode.ERR_EscapeVariable, "s").WithArguments("s").WithLocation(15, 42),
+            // (18,16): error CS8352: Cannot use variable 'c' in this context because it may expose referenced variables outside of their declaration scope
+            //         return c;
+            Diagnostic(ErrorCode.ERR_EscapeVariable, "c").WithArguments("c").WithLocation(18, 16),
             // (23,20): error CS8166: Cannot return a parameter by reference 'handler' because it is not a ref parameter
             //         return ref handler;
             Diagnostic(ErrorCode.ERR_RefReturnParameter, "handler").WithArguments("handler").WithLocation(23, 20));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -7977,14 +7977,10 @@ class Program
                 Diagnostic(ErrorCode.ERR_EscapeCall, "MayWrap(ref local)").WithArguments("Program.MayWrap(ref System.Span<int>)", "arg").WithLocation(9, 14)
                 );
 
-            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
-                // (9,26): error CS8168: Cannot return local 'local' by reference because it is not a ref local
-                //         sp = MayWrap(ref local) with { }; // 1, 2
-                Diagnostic(ErrorCode.ERR_RefReturnLocal, "local").WithArguments("local").WithLocation(9, 26),
-                // (9,14): error CS8347: Cannot use a result of 'Program.MayWrap(ref Span<int>)' in this context because it may expose variables referenced by parameter 'arg' outside of their declaration scope
-                //         sp = MayWrap(ref local) with { }; // 1, 2
-                Diagnostic(ErrorCode.ERR_EscapeCall, "MayWrap(ref local)").WithArguments("Program.MayWrap(ref System.Span<int>)", "arg").WithLocation(9, 14)
-                );
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
+
+            // https://github.com/dotnet/roslyn/issues/62780: Include variant of test with:
+            // static S1 MayWrap([UnscopedRef] ref Span<int> arg) { ... }
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -163,9 +163,10 @@ class C
                 Diagnostic(ErrorCode.ERR_LockNeedsReference, "s").WithArguments("System.Span<int>").WithLocation(9, 15));
         }
 
-        [Fact]
-        public void RefStructEscapeInIterator()
-
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefStructEscapeInIterator(LanguageVersion languageVersion)
         {
             var comp = CreateCompilationWithMscorlibAndSpan(@"
 using System;
@@ -177,7 +178,7 @@ class C
         Span<int> s = stackalloc int[10];
         yield return s;
     }
-}");
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
             comp.VerifyDiagnostics(
                 // (9,22): error CS8352: Cannot use variable 's' in this context because it may expose referenced variables outside of their declaration scope
                 //         yield return s;
@@ -233,8 +234,10 @@ class C
             );
         }
 
-        [Fact()]
-        public void RefLikeReturnEscape1()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeReturnEscape1(LanguageVersion languageVersion)
         {
             var text = @"
     using System;
@@ -267,7 +270,7 @@ class C
         }
     }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (24,30): error CS8526: Cannot use variable 'sp' in this context because it may expose referenced variables outside of their declaration scope
                 //             return ref Test1(sp);
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "sp").WithArguments("sp").WithLocation(24, 30),
@@ -277,20 +280,18 @@ class C
             );
         }
 
-        [Theory]
-        [InlineData(LanguageVersion.CSharp10)]
-        [InlineData(LanguageVersion.CSharp11)]
-        public void RefLikeReturnEscapeWithRefLikes(LanguageVersion languageVersion)
+        [Fact]
+        public void RefLikeReturnEscapeWithRefLikes()
         {
-            var text = @"using System;
-    using System.Diagnostics.CodeAnalysis;
+            var text = @"
+    using System;
     class Program
     {
         static void Main()
         {
         }
 
-        static ref int Test1([UnscopedRef] ref S1 arg)
+        static ref int Test1(ref S1 arg)
         {
             return ref (new int[1])[0];
         }
@@ -318,7 +319,8 @@ class C
         }
     }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(new[] { text, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+            var comp = CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular10);
             comp.VerifyDiagnostics(
                 // (23,34): error CS8168: Cannot return local 'sp' by reference because it is not a ref local
                 //             return ref Test1(ref sp);    // error1
@@ -333,10 +335,23 @@ class C
                 //             return ref Test1(ref sp);    // error2
                 Diagnostic(ErrorCode.ERR_EscapeCall, "Test1(ref sp)").WithArguments("Program.Test1(ref Program.S1)", "arg").WithLocation(29, 24)
             );
+
+            // No error reported for "// error2" in C#11 because no refs are captured in Test4().
+            comp = CreateCompilationWithMscorlibAndSpan(text);
+            comp.VerifyDiagnostics(
+                // (23,34): error CS8352: Cannot use variable 'sp' in this context because it may expose referenced variables outside of their declaration scope
+                //             return ref Test1(ref sp);    // error1
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "sp").WithArguments("sp").WithLocation(23, 34),
+                // (23,24): error CS8347: Cannot use a result of 'Program.Test1(ref Program.S1)' in this context because it may expose variables referenced by parameter 'arg' outside of their declaration scope
+                //             return ref Test1(ref sp);    // error1
+                Diagnostic(ErrorCode.ERR_EscapeCall, "Test1(ref sp)").WithArguments("Program.Test1(ref Program.S1)", "arg").WithLocation(23, 24)
+            );
         }
 
-        [Fact()]
-        public void RefLikeReturnEscapeWithRefLikes1()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeReturnEscapeWithRefLikes1(LanguageVersion languageVersion)
         {
             var text = @"
     using System;
@@ -384,7 +399,8 @@ class C
         }
     }
 ";
-            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular10).VerifyDiagnostics(
+            var comp = CreateCompilationWithMscorlibAndSpan(new[] { text, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            comp.VerifyDiagnostics(
                 // (33,19): error CS8526: Cannot use variable 'spNr' in this context because it may expose referenced variables outside of their declaration scope
                 //             spR = spNr;
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "spNr").WithArguments("spNr").WithLocation(33, 19),
@@ -392,11 +408,6 @@ class C
                 //             spR = ternary;
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "ternary").WithArguments("ternary").WithLocation(39, 19)
             );
-
-            // The initializer for `var spR = MayWrap(Test1(ref sp));` has escape scope of
-            // the current method in C#11, rather than the calling method in C#10, so `spR`
-            // is not treated as returnable and there are no subsequent errors as a result.
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics();
         }
 
         [Theory]
@@ -503,8 +514,10 @@ class C
                 Diagnostic(ErrorCode.ERR_EscapeCall, "MayNotWrap()").WithArguments("Program.MayNotWrap(in int)", "arg").WithLocation(21, 30));
         }
 
-        [Fact()]
-        public void RefLikeScopeEscape()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeScopeEscape(LanguageVersion languageVersion)
         {
             var text = @"
     using System;
@@ -537,7 +550,7 @@ class C
         }
     }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (18,29): error CS8526: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
                 //                 x = MayWrap(inner);
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "inner").WithArguments("inner").WithLocation(18, 29),
@@ -547,8 +560,10 @@ class C
             );
         }
 
-        [Fact()]
-        public void RefLikeScopeEscapeVararg()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeScopeEscapeVararg(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -581,7 +596,7 @@ class Program
     }
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (18,35): error CS8352: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
                 //             x = MayWrap(__arglist(inner));
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "inner").WithArguments("inner").WithLocation(18, 35),
@@ -591,8 +606,10 @@ class Program
             );
         }
 
-        [Fact()]
-        public void RefScopeEscapeVararg()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefScopeEscapeVararg(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -625,7 +642,7 @@ class Program
         Span<int> local = stackalloc int[1];
         
         // error here;
-        return ref ReturnsRef1(__arglist(ref local));
+        return ref ReturnsRefSpan1(__arglist(ref local));
     }
 
     static ref int ReturnsRefSpan1(__arglist)
@@ -637,21 +654,23 @@ class Program
     }
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
-                // (24,20): error CS8156: An expression cannot be used in this context because it may not be returned by reference
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
+                // (24,20): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
                 //         return ref __refvalue(ai.GetNextArg(), int);
                 Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, "__refvalue(ai.GetNextArg(), int)").WithLocation(24, 20),
-                // (32,46): error CS8352: Cannot use variable 'local' in this context because it may expose referenced variables outside of their declaration scope
-                //         return ref ReturnsRef1(__arglist(ref local));
-                Diagnostic(ErrorCode.ERR_EscapeVariable, "local").WithArguments("local").WithLocation(32, 46),
-                // (32,20): error CS8347: Cannot use a result of 'Program.ReturnsRef1(__arglist)' in this context because it may expose variables referenced by parameter '__arglist' outside of their declaration scope
-                //         return ref ReturnsRef1(__arglist(ref local));
-                Diagnostic(ErrorCode.ERR_EscapeCall, "ReturnsRef1(__arglist(ref local))").WithArguments("Program.ReturnsRef1(__arglist)", "__arglist").WithLocation(32, 20)
+                // (32,50): error CS8352: Cannot use variable 'local' in this context because it may expose referenced variables outside of their declaration scope
+                //         return ref ReturnsRefSpan1(__arglist(ref local));
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "local").WithArguments("local").WithLocation(32, 50),
+                // (32,20): error CS8347: Cannot use a result of 'Program.ReturnsRefSpan1(__arglist)' in this context because it may expose variables referenced by parameter '__arglist' outside of their declaration scope
+                //         return ref ReturnsRefSpan1(__arglist(ref local));
+                Diagnostic(ErrorCode.ERR_EscapeCall, "ReturnsRefSpan1(__arglist(ref local))").WithArguments("Program.ReturnsRefSpan1(__arglist)", "__arglist").WithLocation(32, 20)
             );
         }
 
-        [Fact()]
-        public void ThrowExpression()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void ThrowExpression(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -676,12 +695,13 @@ class Program
 
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics();
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics();
         }
 
-
-        [Fact()]
-        public void UserDefinedLogical()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void UserDefinedLogical(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -723,7 +743,7 @@ ref struct S1
 }
 
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (22,18): error CS8352: Cannot use variable 'local' in this context because it may expose referenced variables outside of their declaration scope
                 //         global = local && global;
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "local").WithArguments("local").WithLocation(22, 18),
@@ -998,8 +1018,8 @@ class Program
         [InlineData(LanguageVersion.CSharp11)]
         public void RefLikeScopeEscapeReturnable(LanguageVersion languageVersion)
         {
-            var text = @"using System;
-    using System.Diagnostics.CodeAnalysis;
+            var text = @"
+    using System;
     class Program
     {
         static void Main()
@@ -1020,7 +1040,7 @@ class Program
             }
         }
 
-        static S1 MayWrap([UnscopedRef] ref Span<int> arg)
+        static S1 MayWrap(ref Span<int> arg)
         {
             return default;
         }
@@ -1030,7 +1050,7 @@ class Program
         }
     }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(new[] { text, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            var comp = CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
             comp.VerifyDiagnostics(
                 // (19,33): error CS8526: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
                 //                 x = MayWrap(ref inner);
@@ -1046,8 +1066,8 @@ class Program
         [InlineData(LanguageVersion.CSharp11)]
         public void RefLikeScopeEscapeThis(LanguageVersion languageVersion)
         {
-            var text = @"using System;
-    using System.Diagnostics.CodeAnalysis;
+            var text = @"
+    using System;
     class Program
     {
         static void Main()
@@ -1070,7 +1090,7 @@ class Program
             }
         }
 
-        static S1 MayWrap([UnscopedRef] ref Span<int> arg)
+        static S1 MayWrap(ref Span<int> arg)
         {
             return default;
         }
@@ -1083,7 +1103,7 @@ class Program
         }
     }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(new[] { text, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            var comp = CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
             comp.VerifyDiagnostics(
                 // (21,33): error CS8526: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
                 //                 x = MayWrap(ref inner).Slice(1);
@@ -1099,8 +1119,8 @@ class Program
         [InlineData(LanguageVersion.CSharp11)]
         public void RefLikeScopeEscapeThisRef(LanguageVersion languageVersion)
         {
-            var text = @"using System;
-using System.Diagnostics.CodeAnalysis;
+            var text = @"
+using System;
 class Program
 {
     static void Main()
@@ -1130,7 +1150,7 @@ class Program
         }
     }
 
-    static S1 MayWrap([UnscopedRef] ref Span<int> arg)
+    static S1 MayWrap(ref Span<int> arg)
     {
         return default;
     }
@@ -1141,13 +1161,13 @@ class Program
 
         public ref S1 this[S1 i] => throw null;
 
-        public ref S1 ReturnsRefArg(ref S1 arg) => ref arg;
+        public ref S1 ReturnsRefArg(ref S1 arg) => throw null;
 
         public S1 Slice(int x) => this;
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(new[] { text, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            var comp = CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
             comp.VerifyDiagnostics(
                 // (20,32): error CS8352: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
                 //             x[0] = MayWrap(ref inner).Slice(1)[0];
@@ -1170,8 +1190,10 @@ class Program
             );
         }
 
-        [Fact()]
-        public void RefLikeScopeEscapeField()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeScopeEscapeField(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -1211,7 +1233,7 @@ class Program
     }
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (18,31): error CS8526: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
                 //             x.field = MayWrap(inner).Slice(1).field;
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "inner").WithArguments("inner").WithLocation(18, 31),
@@ -1221,8 +1243,10 @@ class Program
             );
         }
 
-        [Fact()]
-        public void RefLikeEscapeParamsAndTopLevel()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeEscapeParamsAndTopLevel(LanguageVersion languageVersion)
         {
             var text = @"
     class Program
@@ -1255,13 +1279,15 @@ class Program
         }
     }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
             // no diagnostics expected
             );
         }
 
-        [Fact()]
-        public void RefLikeEscapeMixingCallSameArgValue()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeEscapeMixingCallSameArgValue(LanguageVersion languageVersion)
         {
             var text = @"
     using System;
@@ -1302,16 +1328,14 @@ class Program
         }
     }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics();
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics();
         }
 
-        [Theory]
-        [InlineData(LanguageVersion.CSharp10)]
-        [InlineData(LanguageVersion.CSharp11)]
-        public void RefLikeEscapeMixingCall(LanguageVersion languageVersion)
+        [Fact]
+        public void RefLikeEscapeMixingCall()
         {
-            var text = @"using System;
-    using System.Diagnostics.CodeAnalysis;
+            var text = @"
+    using System;
     class Program
     {
         static void Main()
@@ -1335,17 +1359,17 @@ class Program
             MayAssign(ref inner, ref rOuter);
         }
 
-        static void MayAssign([UnscopedRef] ref Span<int> arg1, [UnscopedRef] ref S1 arg2)
+        static void MayAssign(ref Span<int> arg1, ref S1 arg2)
         {
             arg2 = MayWrap(ref arg1);
         }
 
-        static void MayAssign([UnscopedRef] ref S1 arg1, [UnscopedRef] ref S1 arg2)
+        static void MayAssign(ref S1 arg1, ref S1 arg2)
         {
             arg1 = arg2;
         }
 
-        static S1 MayWrap([UnscopedRef] ref Span<int> arg)
+        static S1 MayWrap(ref Span<int> arg)
         {
             return default;
         }
@@ -1355,7 +1379,24 @@ class Program
         }
     }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(new[] { text, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+            var comp = CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(
+                // (20,39): error CS8526: Cannot use variable 'rInner' in this context because it may expose referenced variables outside of their declaration scope
+                //             MayAssign(ref rOuter, ref rInner);
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "rInner").WithArguments("rInner").WithLocation(20, 39),
+                // (20,13): error CS8524: This combination of arguments to 'Program.MayAssign(ref Program.S1, ref Program.S1)' is disallowed because it may expose variables referenced by parameter 'arg2' outside of their declaration scope
+                //             MayAssign(ref rOuter, ref rInner);
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "MayAssign(ref rOuter, ref rInner)").WithArguments("Program.MayAssign(ref Program.S1, ref Program.S1)", "arg2").WithLocation(20, 13),
+                // (23,27): error CS8526: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
+                //             MayAssign(ref inner, ref rOuter);
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "inner").WithArguments("inner").WithLocation(23, 27),
+                // (23,13): error CS8524: This combination of arguments to 'Program.MayAssign(ref Span<int>, ref Program.S1)' is disallowed because it may expose variables referenced by parameter 'arg1' outside of their declaration scope
+                //             MayAssign(ref inner, ref rOuter);
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "MayAssign(ref inner, ref rOuter)").WithArguments("Program.MayAssign(ref System.Span<int>, ref Program.S1)", "arg1").WithLocation(23, 13)
+            );
+
+            comp = CreateCompilationWithMscorlibAndSpan(text);
             comp.VerifyDiagnostics(
                 // (20,39): error CS8526: Cannot use variable 'rInner' in this context because it may expose referenced variables outside of their declaration scope
                 //             MayAssign(ref rOuter, ref rInner);
@@ -1372,7 +1413,7 @@ class Program
             );
         }
 
-        [Fact()]
+        [Fact]
         public void RefLikeEscapeMixingCallVararg()
         {
             var text = @"
@@ -1430,6 +1471,7 @@ class Program
     }
 }
 ";
+
             CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular10).VerifyDiagnostics(
                 // (20,46): error CS8352: Cannot use variable 'rInner' in this context because it may expose referenced variables outside of their declaration scope
                 //         MayAssign2(__arglist(ref rOuter, ref rInner));
@@ -1444,7 +1486,22 @@ class Program
                 //         MayAssign1(__arglist(ref inner, ref rOuter));
                 Diagnostic(ErrorCode.ERR_CallArgMixing, "MayAssign1(__arglist(ref inner, ref rOuter))").WithArguments("Program.MayAssign1(__arglist)", "__arglist").WithLocation(23, 9)
             );
+
+            // Breaking change in C#11: A ref to ref struct argument is considered
+            // an unscoped reference when passed to an __arglist.
             CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+                // (17,34): error CS8168: Cannot return local 'rOuter' by reference because it is not a ref local
+                //         MayAssign2(__arglist(ref rOuter, ref rOuter));
+                Diagnostic(ErrorCode.ERR_RefReturnLocal, "rOuter").WithArguments("rOuter").WithLocation(17, 34),
+                // (17,9): error CS8350: This combination of arguments to 'Program.MayAssign2(__arglist)' is disallowed because it may expose variables referenced by parameter '__arglist' outside of their declaration scope
+                //         MayAssign2(__arglist(ref rOuter, ref rOuter));
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "MayAssign2(__arglist(ref rOuter, ref rOuter))").WithArguments("Program.MayAssign2(__arglist)", "__arglist").WithLocation(17, 9),
+                // (20,46): error CS8352: Cannot use variable 'rInner' in this context because it may expose referenced variables outside of their declaration scope
+                //         MayAssign2(__arglist(ref rOuter, ref rInner));
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "rInner").WithArguments("rInner").WithLocation(20, 46),
+                // (20,9): error CS8350: This combination of arguments to 'Program.MayAssign2(__arglist)' is disallowed because it may expose variables referenced by parameter '__arglist' outside of their declaration scope
+                //         MayAssign2(__arglist(ref rOuter, ref rInner));
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "MayAssign2(__arglist(ref rOuter, ref rInner))").WithArguments("Program.MayAssign2(__arglist)", "__arglist").WithLocation(20, 9),
                 // (23,34): error CS8352: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
                 //         MayAssign1(__arglist(ref inner, ref rOuter));
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "inner").WithArguments("inner").WithLocation(23, 34),
@@ -1454,8 +1511,10 @@ class Program
             );
         }
 
-        [Fact()]
-        public void RefLikeEscapeMixingIndex()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeEscapeMixingIndex(LanguageVersion languageVersion)
         {
             var text = @"
 class Program
@@ -1511,7 +1570,7 @@ class Program
     }
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
             // no diagnostics
             );
         }
@@ -1521,8 +1580,8 @@ class Program
         [InlineData(LanguageVersion.CSharp11)]
         public void RefLikeEscapeMixingIndexOnRefLike(LanguageVersion languageVersion)
         {
-            var text = @"using System;
-using System.Diagnostics.CodeAnalysis;
+            var text = @"
+using System;
 class Program
 {
     static void Main()
@@ -1550,7 +1609,7 @@ class Program
         int dummy4 = rOuter[inner];
     }
 
-    static S1 MayWrap([UnscopedRef] in Span<int> arg)
+    static S1 MayWrap(in Span<int> arg)
     {
         return default;
     }
@@ -1559,7 +1618,7 @@ class Program
     {
         public Span<int> field;
 
-        public int this[[UnscopedRef] in Span<int> arg1]
+        public int this[in Span<int> arg1]
         {
             get
             {
@@ -1569,7 +1628,7 @@ class Program
             }
         }
 
-        public int this[[UnscopedRef] in S1 arg1]
+        public int this[in S1 arg1]
         {
             get
             {
@@ -1585,18 +1644,18 @@ class Program
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(new[] { text, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            var comp = CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
             comp.VerifyDiagnostics(
-                // (24,29): error CS8526: Cannot use variable 'rInner' in this context because it may expose referenced variables outside of their declaration scope
+                // (24,29): error CS8352: Cannot use variable 'rInner' in this context because it may expose referenced variables outside of their declaration scope
                 //         int dummy3 = rOuter[rInner];
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "rInner").WithArguments("rInner").WithLocation(24, 29),
-                // (24,22): error CS8524: This combination of arguments to 'Program.S1.this[in Program.S1]' is disallowed because it may expose variables referenced by parameter 'arg1' outside of their declaration scope
+                // (24,22): error CS8350: This combination of arguments to 'Program.S1.this[in Program.S1]' is disallowed because it may expose variables referenced by parameter 'arg1' outside of their declaration scope
                 //         int dummy3 = rOuter[rInner];
                 Diagnostic(ErrorCode.ERR_CallArgMixing, "rOuter[rInner]").WithArguments("Program.S1.this[in Program.S1]", "arg1").WithLocation(24, 22),
-                // (27,29): error CS8526: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
+                // (27,29): error CS8352: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
                 //         int dummy4 = rOuter[inner];
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "inner").WithArguments("inner").WithLocation(27, 29),
-                // (27,22): error CS8524: This combination of arguments to 'Program.S1.this[in Span<int>]' is disallowed because it may expose variables referenced by parameter 'arg1' outside of their declaration scope
+                // (27,22): error CS8350: This combination of arguments to 'Program.S1.this[in Span<int>]' is disallowed because it may expose variables referenced by parameter 'arg1' outside of their declaration scope
                 //         int dummy4 = rOuter[inner];
                 Diagnostic(ErrorCode.ERR_CallArgMixing, "rOuter[inner]").WithArguments("Program.S1.this[in System.Span<int>]", "arg1").WithLocation(27, 22)
             );
@@ -1607,16 +1666,16 @@ class Program
         [InlineData(LanguageVersion.CSharp11)]
         public void RefLikeEscapeMixingCtor(LanguageVersion languageVersion)
         {
-            var text = @"using System;
-    using System.Diagnostics.CodeAnalysis;
+            var text = @"
+    using System;
     class Program
     {
         static void Main()
         {
         }
 
-        delegate void D1([UnscopedRef]ref S1 arg1, [UnscopedRef]ref S1 arg2);
-        delegate void D2([UnscopedRef]ref Span<int> arg1, [UnscopedRef]ref S1 arg2);
+        delegate void D1(ref S1 arg1, ref S1 arg2);
+        delegate void D2(ref Span<int> arg1, ref S1 arg2);
 
         void Test1()
         {
@@ -1638,17 +1697,17 @@ class Program
             MayAssignDel2(ref inner, ref rOuter);
         }
 
-        static void MayAssign([UnscopedRef] ref Span<int> arg1, [UnscopedRef] ref S1 arg2)
+        static void MayAssign(ref Span<int> arg1, ref S1 arg2)
         {
             arg2 = MayWrap(ref arg1);
         }
 
-        static void MayAssign([UnscopedRef] ref S1 arg1, [UnscopedRef] ref S1 arg2)
+        static void MayAssign(ref S1 arg1, ref S1 arg2)
         {
             arg1 = arg2;
         }
 
-        static S1 MayWrap([UnscopedRef] ref Span<int> arg)
+        static S1 MayWrap(ref Span<int> arg)
         {
             return default;
         }
@@ -1658,25 +1717,27 @@ class Program
         }
     }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(new[] { text, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            var comp = CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
             comp.VerifyDiagnostics(
-                // (26,43): error CS8526: Cannot use variable 'rInner' in this context because it may expose referenced variables outside of their declaration scope
+                // (26,43): error CS8352: Cannot use variable 'rInner' in this context because it may expose referenced variables outside of their declaration scope
                 //             MayAssignDel1(ref rOuter, ref rInner);
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "rInner").WithArguments("rInner").WithLocation(26, 43),
-                // (26,13): error CS8524: This combination of arguments to 'Program.D1.Invoke(ref Program.S1, ref Program.S1)' is disallowed because it may expose variables referenced by parameter 'arg2' outside of their declaration scope
+                // (26,13): error CS8350: This combination of arguments to 'Program.D1.Invoke(ref Program.S1, ref Program.S1)' is disallowed because it may expose variables referenced by parameter 'arg2' outside of their declaration scope
                 //             MayAssignDel1(ref rOuter, ref rInner);
                 Diagnostic(ErrorCode.ERR_CallArgMixing, "MayAssignDel1(ref rOuter, ref rInner)").WithArguments("Program.D1.Invoke(ref Program.S1, ref Program.S1)", "arg2").WithLocation(26, 13),
-                // (29,31): error CS8526: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
+                // (29,31): error CS8352: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
                 //             MayAssignDel2(ref inner, ref rOuter);
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "inner").WithArguments("inner").WithLocation(29, 31),
-                // (29,13): error CS8524: This combination of arguments to 'Program.D2.Invoke(ref Span<int>, ref Program.S1)' is disallowed because it may expose variables referenced by parameter 'arg1' outside of their declaration scope
+                // (29,13): error CS8350: This combination of arguments to 'Program.D2.Invoke(ref Span<int>, ref Program.S1)' is disallowed because it may expose variables referenced by parameter 'arg1' outside of their declaration scope
                 //             MayAssignDel2(ref inner, ref rOuter);
                 Diagnostic(ErrorCode.ERR_CallArgMixing, "MayAssignDel2(ref inner, ref rOuter)").WithArguments("Program.D2.Invoke(ref System.Span<int>, ref Program.S1)", "arg1").WithLocation(29, 13)
             );
         }
 
-        [Fact()]
-        public void RefLikeObjInitializers()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeObjInitializers(LanguageVersion languageVersion)
         {
             var text = @"
     using System;
@@ -1729,7 +1790,7 @@ class Program
         }
     }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (16,47): error CS8352: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
                 //             return new S2() { Field1 = outer, Field2 = inner };
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "Field2 = inner").WithArguments("inner").WithLocation(16, 47),
@@ -1739,8 +1800,10 @@ class Program
             );
         }
 
-        [Fact()]
-        public void RefLikeObjInitializers1()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeObjInitializers1(LanguageVersion languageVersion)
         {
             var text = @"
     using System;
@@ -1796,7 +1859,7 @@ class Program
         }
     }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (18,20): error CS8352: Cannot use variable 'x1' in this context because it may expose referenced variables outside of their declaration scope
                 //             return x1;
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "x1").WithArguments("x1").WithLocation(18, 20),
@@ -1806,8 +1869,10 @@ class Program
             );
         }
 
-        [Fact()]
-        public void RefLikeObjInitializersIndexer()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeObjInitializersIndexer(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -1869,7 +1934,7 @@ class Program
     }
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (16,28): error CS8352: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
                 //         return new S2() { [inner] = outer, Field2 = outer };
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "inner").WithArguments("inner").WithLocation(16, 28),
@@ -1879,8 +1944,10 @@ class Program
                 );
         }
 
-        [Fact()]
-        public void RefLikeObjInitializersIndexer1()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeObjInitializersIndexer1(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -1951,7 +2018,7 @@ class Program
     }
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (18,16): error CS8352: Cannot use variable 'x1' in this context because it may expose referenced variables outside of their declaration scope
                 //         return x1;
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "x1").WithArguments("x1").WithLocation(18, 16),
@@ -1961,8 +2028,10 @@ class Program
                 );
         }
 
-        [Fact()]
-        public void RefLikeObjInitializersNested()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeObjInitializersNested(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -2039,7 +2108,7 @@ class Program
     }
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (15,38): error CS8352: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
                 //         return new S2() { Field2 = {[inner] = outer} };
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "inner").WithArguments("inner").WithLocation(15, 38),
@@ -2055,8 +2124,10 @@ class Program
                 );
         }
 
-        [Fact()]
-        public void RefLikeColInitializer()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeColInitializer(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -2076,11 +2147,13 @@ class X : List<int>
     }
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics();
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics();
         }
 
-        [Fact()]
-        public void RefLikeEscapeMixingDelegate()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeEscapeMixingDelegate(LanguageVersion languageVersion)
         {
             var text = @"
     using System;
@@ -2127,7 +2200,8 @@ class X : List<int>
         }
     }
 ";
-            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular10).VerifyDiagnostics(
+            var comp = CreateCompilationWithMscorlibAndSpan(new[] { text, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            comp.VerifyDiagnostics(
                 // (20,54): error CS8526: Cannot use variable 'rInner' in this context because it may expose referenced variables outside of their declaration scope
                 //             var dummy2 = new Program(ref rOuter, ref rInner);
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "rInner").WithArguments("rInner").WithLocation(20, 54),
@@ -2141,18 +2215,12 @@ class X : List<int>
                 //             var dummy3 = new Program(ref inner, ref rOuter);
                 Diagnostic(ErrorCode.ERR_CallArgMixing, "new Program(ref inner, ref rOuter)").WithArguments("Program.Program(ref System.Span<int>, ref Program.S1)", "arg1").WithLocation(23, 26)
             );
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
-                // (23,42): error CS8526: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
-                //             var dummy3 = new Program(ref inner, ref rOuter);
-                Diagnostic(ErrorCode.ERR_EscapeVariable, "inner").WithArguments("inner").WithLocation(23, 42),
-                // (23,26): error CS8524: This combination of arguments to 'Program.Program(ref Span<int>, ref Program.S1)' is disallowed because it may expose variables referenced by parameter 'arg1' outside of their declaration scope
-                //             var dummy3 = new Program(ref inner, ref rOuter);
-                Diagnostic(ErrorCode.ERR_CallArgMixing, "new Program(ref inner, ref rOuter)").WithArguments("Program.Program(ref System.Span<int>, ref Program.S1)", "arg1").WithLocation(23, 26)
-            );
         }
 
-        [Fact()]
-        public void RefLikeEscapeMixingCallOptionalIn()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeEscapeMixingCallOptionalIn(LanguageVersion languageVersion)
         {
             var text = @"
     using System;
@@ -2191,11 +2259,13 @@ class X : List<int>
         }
     }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics();
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics();
         }
 
-        [Fact()]
-        public void MismatchedRefTernaryEscape()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void MismatchedRefTernaryEscape(LanguageVersion languageVersion)
         {
             var text = @"
 class Program
@@ -2225,7 +2295,7 @@ class Program
     }
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (17,47): error CS8168: Cannot return local 'local' by reference because it is not a ref local
                 //             return ref true ? ref field : ref local;
                 Diagnostic(ErrorCode.ERR_RefReturnLocal, "local").WithArguments("local").WithLocation(17, 47),
@@ -2243,8 +2313,8 @@ class Program
         [InlineData(LanguageVersion.CSharp11)]
         public void MismatchedRefTernaryEscapeBlock(LanguageVersion languageVersion)
         {
-            var text = @"using System;
-using System.Diagnostics.CodeAnalysis;
+            var text = @"
+using System;
 class Program
 {
     static void Main()
@@ -2291,7 +2361,7 @@ class Program
         }
     }
 
-    static S1 MayWrap([UnscopedRef] ref Span<int> arg)
+    static S1 MayWrap(ref Span<int> arg)
     {
         return default;
     }
@@ -2302,7 +2372,7 @@ class Program
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(new[] { text, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            var comp = CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
             comp.VerifyDiagnostics(
                 // (27,44): error CS8526: Cannot use variable 'sInner' in this context because it may expose referenced variables outside of their declaration scope
                 //             ternarySame2 = true ? sOuter : sInner;
@@ -2331,8 +2401,10 @@ class Program
             );
         }
 
-        [Fact()]
-        public void StackallocEscape()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void StackallocEscape(LanguageVersion languageVersion)
         {
             var text = @"
     using System;
@@ -2369,7 +2441,7 @@ class Program
         }
     }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (19,26): error CS8352: Cannot use variable 'local' in this context because it may expose referenced variables outside of their declaration scope 
                 //             return true? local : default(Span<int>);
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "local").WithArguments("local").WithLocation(19, 26),
@@ -2438,8 +2510,10 @@ class Program
         }
 
         [WorkItem(21858, "https://github.com/dotnet/roslyn/issues/21858")]
-        [Fact()]
-        public void FieldOfRefLikeEscape()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void FieldOfRefLikeEscape(LanguageVersion languageVersion)
         {
             var text = @"
     class Program
@@ -2479,7 +2553,7 @@ class Program
 
     }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (31,28): error CS8170: Struct members cannot return 'this' or other instance members by reference
                 //                 return ref x;
                 Diagnostic(ErrorCode.ERR_RefReturnStructThis, "x").WithLocation(31, 28)
@@ -2487,8 +2561,10 @@ class Program
         }
 
         [WorkItem(21880, "https://github.com/dotnet/roslyn/issues/21880")]
-        [Fact()]
-        public void MemberOfReadonlyRefLikeEscape()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void MemberOfReadonlyRefLikeEscape(LanguageVersion languageVersion)
         {
             var text = @"
     using System;
@@ -2521,7 +2597,7 @@ class Program
         }
     }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (12,33): error CS8526: Cannot use variable 'value1' in this context because it may expose referenced variables outside of their declaration scope
                 //             new SW().TryGet(out value1);
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "value1").WithArguments("value1").WithLocation(12, 33),
@@ -2532,8 +2608,10 @@ class Program
         }
 
         [WorkItem(21911, "https://github.com/dotnet/roslyn/issues/21911")]
-        [Fact()]
-        public void MemberOfReadonlyRefLikeEscapeSpans()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void MemberOfReadonlyRefLikeEscapeSpans(LanguageVersion languageVersion)
         {
             var text = @"
     using System;
@@ -2565,7 +2643,7 @@ class Program
         }
     }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (17,43): error CS8352: Cannot use variable 'stackAllocated' in this context because it may expose referenced variables outside of their declaration scope
                 //             new NotReadOnly<int>().CopyTo(stackAllocated);
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "stackAllocated").WithArguments("stackAllocated").WithLocation(17, 43),
@@ -2575,8 +2653,11 @@ class Program
                 );
         }
 
-        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
-        public void ReadOnlyRefStruct_Method_RefLikeStructParameter()
+        [WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void ReadOnlyRefStruct_Method_RefLikeStructParameter(LanguageVersion languageVersion)
         {
             var csharp = @"
 using System;
@@ -2592,12 +2673,15 @@ public readonly ref struct S<T>
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilationWithMscorlibAndSpan(csharp, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics();
         }
 
-        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
-        public void ReadOnlyMethod_RefLikeStructParameter()
+        [WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void ReadOnlyMethod_RefLikeStructParameter(LanguageVersion languageVersion)
         {
             var csharp = @"
 using System;
@@ -2613,12 +2697,15 @@ public ref struct S<T>
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilationWithMscorlibAndSpan(csharp, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics();
         }
 
-        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
-        public void ReadOnlyRefStruct_RefLikeProperty()
+        [WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void ReadOnlyRefStruct_RefLikeProperty(LanguageVersion languageVersion)
         {
             var csharp = @"
 using System;
@@ -2634,15 +2721,18 @@ public readonly ref struct S<T>
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilationWithMscorlibAndSpan(csharp, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (11,15): error CS8352: Cannot use variable 'x' in this context because it may expose referenced variables outside of their declaration scope
                 //         b.P = x;
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "x").WithArguments("x").WithLocation(11, 15));
         }
 
-        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
-        public void ReadOnlyRefLikeProperty_01()
+        [WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void ReadOnlyRefLikeProperty_01(LanguageVersion languageVersion)
         {
             var csharp = @"
 using System;
@@ -2658,15 +2748,18 @@ public ref struct S<T>
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilationWithMscorlibAndSpan(csharp, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (11,15): error CS8352: Cannot use variable 'x' in this context because it may expose referenced variables outside of their declaration scope
                 //         b.P = x;
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "x").WithArguments("x").WithLocation(11, 15));
         }
 
-        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
-        public void ReadOnlyRefLikeProperty_02()
+        [WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void ReadOnlyRefLikeProperty_02(LanguageVersion languageVersion)
         {
             var csharp = @"
 using System;
@@ -2682,15 +2775,18 @@ public ref struct S<T>
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilationWithMscorlibAndSpan(csharp, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (11,15): error CS8352: Cannot use variable 'x' in this context because it may expose referenced variables outside of their declaration scope
                 //         b.P = x;
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "x").WithArguments("x").WithLocation(11, 15));
         }
 
-        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
-        public void ReadOnlyIndexer_RefLikeStructParameter_01()
+        [WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void ReadOnlyIndexer_RefLikeStructParameter_01(LanguageVersion languageVersion)
         {
             var csharp = @"
 using System;
@@ -2708,7 +2804,7 @@ public ref struct S<T>
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilationWithMscorlibAndSpan(csharp, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (13,16): error CS8347: Cannot use a result of 'S<byte>.this[Span<byte>]' in this context because it may expose variables referenced by parameter 'span' outside of their declaration scope
                 //         return b[x];
@@ -2718,8 +2814,11 @@ public ref struct S<T>
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "x").WithArguments("x").WithLocation(13, 18));
         }
 
-        [Fact, WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
-        public void ReadOnlyIndexer_RefLikeStructParameter_02()
+        [WorkItem(35146, "https://github.com/dotnet/roslyn/issues/35146")]
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void ReadOnlyIndexer_RefLikeStructParameter_02(LanguageVersion languageVersion)
         {
             var csharp = @"
 using System;
@@ -2735,7 +2834,7 @@ public ref struct S<T>
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(csharp, TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilationWithMscorlibAndSpan(csharp, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (10,13): error CS8350: This combination of arguments to 'S<byte>.this[Span<byte>]' is disallowed because it may expose variables referenced by parameter 'span' outside of their declaration scope
                 //         _ = b[x];
@@ -2752,8 +2851,10 @@ public ref struct S<T>
         }
 
         [WorkItem(22197, "https://github.com/dotnet/roslyn/issues/22197")]
-        [Fact()]
-        public void RefTernaryMustMatchValEscapes()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefTernaryMustMatchValEscapes(LanguageVersion languageVersion)
         {
             var text = @"
     using System;
@@ -2781,7 +2882,7 @@ public ref struct S<T>
         }
     }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (13,56): error CS8526: Cannot use variable 'local' in this context because it may expose referenced variables outside of their declaration scope
                 //             ref var r1 = ref (flag1 ? ref global : ref local);
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "local").WithArguments("local").WithLocation(13, 56),
@@ -2798,8 +2899,10 @@ public ref struct S<T>
         }
 
         [WorkItem(22197, "https://github.com/dotnet/roslyn/issues/22197")]
-        [Fact()]
-        public void RefTernaryMustMatchValEscapes1()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefTernaryMustMatchValEscapes1(LanguageVersion languageVersion)
         {
             var text = @"
     using System;
@@ -2818,7 +2921,7 @@ public ref struct S<T>
         }
     }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(text);
+            var comp = CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
             comp.VerifyDiagnostics();
 
             var compiled = CompileAndVerify(comp, verify: Verification.Passes);
@@ -2834,8 +2937,10 @@ public ref struct S<T>
 ");
         }
 
-        [Fact]
-        public void DeconstructionAssignmentToGlobal()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void DeconstructionAssignmentToGlobal(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -2865,7 +2970,7 @@ public static class Extensions
     }
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (10,28): error CS8352: Cannot use variable 'local' in this context because it may expose referenced variables outside of their declaration scope
                 //         (global, global) = local; // error 1
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "local").WithArguments("local").WithLocation(10, 28),
@@ -2878,8 +2983,10 @@ public static class Extensions
             );
         }
 
-        [Fact]
-        public void DeconstructionAssignmentToRefMethods()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void DeconstructionAssignmentToRefMethods(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -2899,15 +3006,17 @@ public static class Extensions
     public static void Deconstruct(this Span<int> self, out Span<int> x, out Span<int> y) => throw null;
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (9,22): error CS8352: Cannot use variable 'local' in this context because it may expose referenced variables outside of their declaration scope
                 //         (M(), M()) = local; // error
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "local").WithArguments("local").WithLocation(9, 22)
             );
         }
 
-        [Fact]
-        public void DeconstructionAssignmentWithRefExtension()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void DeconstructionAssignmentWithRefExtension(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -2925,7 +3034,7 @@ public static class Extensions
     public static void Deconstruct(ref this Span<int> self, out Span<int> x, out Span<int> y) => throw null;
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (8,9): error CS1510: A ref or out value must be an assignable variable
                 //         (global, global) = global;
                 Diagnostic(ErrorCode.ERR_RefLvalueExpected, "(global, global) = global").WithLocation(8, 9),
@@ -2938,8 +3047,10 @@ public static class Extensions
             );
         }
 
-        [Fact]
-        public void DeconstructionAssignmentWithRefReadonlyExtension()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void DeconstructionAssignmentWithRefReadonlyExtension(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -2959,7 +3070,7 @@ public static class Extensions
     public static void Deconstruct(in this Span<int> self, out Span<int> x, out Span<int> y) => throw null;
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (10,28): error CS8352: Cannot use variable 'local' in this context because it may expose referenced variables outside of their declaration scope
                 //         (global, global) = local; // error
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "local").WithArguments("local").WithLocation(10, 28)
@@ -3282,8 +3393,10 @@ namespace System
             );
         }
 
-        [Fact]
-        public void DeconstructionAssignmentToOuter()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void DeconstructionAssignmentToOuter(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -3310,11 +3423,13 @@ public static class Extensions
 }
 ";
 
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics();
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics();
         }
 
-        [Fact]
-        public void DeconstructionDeclaration()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void DeconstructionDeclaration(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -3339,7 +3454,7 @@ public static class Extensions
     public static void Deconstruct(this Span<int> self, out Span<int> x, out Span<int> y) => throw null;
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (10,18): error CS8352: Cannot use variable 'local1' in this context because it may expose referenced variables outside of their declaration scope
                 //         global = local1; // error 1
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "local1").WithArguments("local1").WithLocation(10, 18),
@@ -3349,8 +3464,10 @@ public static class Extensions
             );
         }
 
-        [Fact]
-        public void RefLikeForeach()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeForeach(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -3376,15 +3493,17 @@ public ref struct S
     public static implicit operator S(Span<int> s) => throw null;
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (11,22): error CS8352: Cannot use variable 'local' in this context because it may expose referenced variables outside of their declaration scope
                 //             global = local; // error
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "local").WithArguments("local").WithLocation(11, 22)
                 );
         }
 
-        [Fact]
-        public void RefLikeDeconstructionForeach()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeDeconstructionForeach(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -3412,7 +3531,7 @@ public ref struct S
     public void Deconstruct(out S s1, out S s2) => throw null;
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (11,22): error CS8352: Cannot use variable 'local1' in this context because it may expose referenced variables outside of their declaration scope
                 //             global = local1; // error 1
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "local1").WithArguments("local1").WithLocation(11, 22),
@@ -3422,9 +3541,11 @@ public ref struct S
                 );
         }
 
-        [Fact]
         [WorkItem(22361, "https://github.com/dotnet/roslyn/issues/22361")]
-        public void RefLikeOutVarFromLocal()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeOutVarFromLocal(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -3449,15 +3570,17 @@ public ref struct S
 ";
             // Tracking issue: https://github.com/dotnet/roslyn/issues/22361
 
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (9,9): error CS8352: Cannot use variable 'local1' in this context because it may expose referenced variables outside of their declaration scope
                 //         local1.M(out S local2);
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "local1").WithArguments("local1").WithLocation(9, 9)
                 );
         }
 
-        [Fact]
-        public void RefLikeOutVarFromGlobal()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefLikeOutVarFromGlobal(LanguageVersion languageVersion)
         {
             var text = @"
 using System;
@@ -3478,12 +3601,14 @@ public ref struct S
     public void M(out S s) => throw null;
 }
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics();
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics();
         }
 
         [WorkItem(22456, "https://github.com/dotnet/roslyn/issues/22456")]
-        [Fact]
-        public void InMatchesIn()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void InMatchesIn(LanguageVersion languageVersion)
         {
             var text = @"
 public class C
@@ -3519,12 +3644,14 @@ public class C
 }
 
 ";
-            CreateCompilationWithMscorlibAndSpan(text).VerifyDiagnostics();
+            CreateCompilationWithMscorlibAndSpan(text, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics();
         }
 
-        [Fact]
         [WorkItem(24776, "https://github.com/dotnet/roslyn/issues/24776")]
-        public void PointerElementAccess_RefStructPointer()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void PointerElementAccess_RefStructPointer(LanguageVersion languageVersion)
         {
             CreateCompilation(@"
 public ref struct TestStruct
@@ -3543,15 +3670,17 @@ public class C
             }
         }
     }
-}", options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (8,36): error CS0611: Array elements cannot be of type 'TestStruct'
                 //     public static unsafe void Test(TestStruct[] ar)
                 Diagnostic(ErrorCode.ERR_ArrayElementCantBeRefAny, "TestStruct").WithArguments("TestStruct").WithLocation(8, 36));
         }
 
-        [Fact]
         [WorkItem(24776, "https://github.com/dotnet/roslyn/issues/24776")]
-        public void PointerIndirectionOperator_RefStructPointer()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void PointerIndirectionOperator_RefStructPointer(LanguageVersion languageVersion)
         {
             CreateCompilation(@"
 public ref struct TestStruct
@@ -3567,15 +3696,17 @@ public class C
             var x = *p;
         }
     }
-}", options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (8,36): error CS0611: Array elements cannot be of type 'TestStruct'
                 //     public static unsafe void Test(TestStruct[] ar)
                 Diagnostic(ErrorCode.ERR_ArrayElementCantBeRefAny, "TestStruct").WithArguments("TestStruct").WithLocation(8, 36));
         }
 
-        [Fact]
         [WorkItem(25398, "https://github.com/dotnet/roslyn/issues/25398")]
-        public void AwaitRefStruct()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void AwaitRefStruct(LanguageVersion languageVersion)
         {
             CreateCompilation(@"
 using System.Threading.Tasks;
@@ -3597,7 +3728,7 @@ class C
     void M(S t, ref S t1)
     {
     }
-}", options: TestOptions.ReleaseDll).VerifyDiagnostics(
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.ReleaseDll).VerifyDiagnostics(
                 // (8,26): error CS0306: The type 'S' may not be used as a type argument
                 //     async Task M(Task<S> t)
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "t").WithArguments("S").WithLocation(8, 26),
@@ -3613,9 +3744,11 @@ class C
                 );
         }
 
-        [Fact]
         [WorkItem(25398, "https://github.com/dotnet/roslyn/issues/25398")]
-        public void CoalesceRefStruct()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void CoalesceRefStruct(LanguageVersion languageVersion)
         {
             CreateCompilation(@"
 ref struct S { }
@@ -3628,7 +3761,7 @@ class C
 
         var a = (S?)null ?? default;
     }
-}", options: TestOptions.ReleaseDll).VerifyDiagnostics(
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.ReleaseDll).VerifyDiagnostics(
                 // (8,14): error CS0306: The type 'S' may not be used as a type argument
                 //         _ = (S?)null ?? default;
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "S?").WithArguments("S").WithLocation(8, 14),
@@ -3638,9 +3771,11 @@ class C
                 );
         }
 
-        [Fact]
         [WorkItem(25398, "https://github.com/dotnet/roslyn/issues/25398")]
-        public void ArrayAccessRefStruct()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void ArrayAccessRefStruct(LanguageVersion languageVersion)
         {
             CreateCompilation(@"
 ref struct S { }
@@ -3653,7 +3788,7 @@ class C
 
         var a = ((S[])null)[0];
     }
-}", options: TestOptions.ReleaseDll).VerifyDiagnostics(
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.ReleaseDll).VerifyDiagnostics(
                 // (8,15): error CS0611: Array elements cannot be of type 'S'
                 //         _ = ((S[])null)[0];
                 Diagnostic(ErrorCode.ERR_ArrayElementCantBeRefAny, "S").WithArguments("S").WithLocation(8, 15),
@@ -3663,9 +3798,11 @@ class C
                 );
         }
 
-        [Fact]
         [WorkItem(25398, "https://github.com/dotnet/roslyn/issues/25398")]
-        public void ConditionalRefStruct()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void ConditionalRefStruct(LanguageVersion languageVersion)
         {
             CreateCompilation(@"
 ref struct S { }
@@ -3680,7 +3817,7 @@ class C
     }
     
     S Test() => default;        
-}", options: TestOptions.ReleaseDll).VerifyDiagnostics(
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.ReleaseDll).VerifyDiagnostics(
                 // (8,23): error CS8977: 'S' cannot be made nullable.
                 //         _ = ((C)null)?.Test();
                 Diagnostic(ErrorCode.ERR_CannotBeMadeNullable, ".Test()").WithArguments("S").WithLocation(8, 23),
@@ -3690,9 +3827,11 @@ class C
                 );
         }
 
-        [Fact]
         [WorkItem(25485, "https://github.com/dotnet/roslyn/issues/25485")]
-        public void ArrayAccess_CrashesEscapeRules()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void ArrayAccess_CrashesEscapeRules(LanguageVersion languageVersion)
         {
             CreateCompilationWithMscorlibAndSpan(@"
 using System;
@@ -3706,14 +3845,17 @@ public class Class1
 public struct Thing
 {
 }
-").VerifyDiagnostics(
+", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (5,21): error CS0611: Array elements cannot be of type 'Span<Thing>'
                 //     public void Foo(Span<Thing>[] first, Thing[] second)
                 Diagnostic(ErrorCode.ERR_ArrayElementCantBeRefAny, "Span<Thing>").WithArguments("System.Span<Thing>").WithLocation(5, 21));
         }
 
-        [Fact, WorkItem(26457, "https://github.com/dotnet/roslyn/issues/26457")]
-        public void RefThisAssignment_Class()
+        [WorkItem(26457, "https://github.com/dotnet/roslyn/issues/26457")]
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefThisAssignment_Class(LanguageVersion languageVersion)
         {
             CreateCompilation(@"
 class Test
@@ -3724,7 +3866,7 @@ class Test
         obj = ref this;
         this = ref obj;
     }
-}").VerifyDiagnostics(
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (6,9): error CS8373: The left-hand side of a ref assignment must be a ref variable.
                 //         this = ref this;
                 Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(6, 9),
@@ -3739,8 +3881,11 @@ class Test
                 Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(8, 9));
         }
 
-        [Fact, WorkItem(26457, "https://github.com/dotnet/roslyn/issues/26457")]
-        public void RefThisAssignment_Struct()
+        [WorkItem(26457, "https://github.com/dotnet/roslyn/issues/26457")]
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefThisAssignment_Struct(LanguageVersion languageVersion)
         {
             CreateCompilation(@"
 struct Test
@@ -3751,7 +3896,7 @@ struct Test
         obj = ref this;
         this = ref obj;
     }
-}").VerifyDiagnostics(
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (6,9): error CS8373: The left-hand side of a ref assignment must be a ref variable.
                 //         this = ref this;
                 Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(6, 9),
@@ -3763,8 +3908,11 @@ struct Test
                 Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(8, 9));
         }
 
-        [Fact, WorkItem(26457, "https://github.com/dotnet/roslyn/issues/26457")]
-        public void RefThisAssignment_ReadOnlyStruct()
+        [WorkItem(26457, "https://github.com/dotnet/roslyn/issues/26457")]
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefThisAssignment_ReadOnlyStruct(LanguageVersion languageVersion)
         {
             CreateCompilation(@"
 readonly struct Test
@@ -3775,7 +3923,7 @@ readonly struct Test
         obj = ref this;
         this = ref obj;
     }
-}").VerifyDiagnostics(
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (6,9): error CS8373: The left-hand side of a ref assignment must be a ref variable.
                 //         this = ref this;
                 Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(6, 9),
@@ -3787,7 +3935,8 @@ readonly struct Test
                 Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(8, 9));
         }
 
-        [Fact, WorkItem(26457, "https://github.com/dotnet/roslyn/issues/26457")]
+        [WorkItem(26457, "https://github.com/dotnet/roslyn/issues/26457")]
+        [Fact]
         public void RefThisAssignment_RefStruct()
         {
             var source = @"
@@ -3821,8 +3970,11 @@ ref struct Test
                 Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(8, 9));
         }
 
-        [Fact, WorkItem(26457, "https://github.com/dotnet/roslyn/issues/26457")]
-        public void RefThisAssignment_ReadOnlyRefStruct()
+        [WorkItem(26457, "https://github.com/dotnet/roslyn/issues/26457")]
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void RefThisAssignment_ReadOnlyRefStruct(LanguageVersion languageVersion)
         {
             CreateCompilation(@"
 readonly ref struct Test
@@ -3833,7 +3985,7 @@ readonly ref struct Test
         obj = ref this;
         this = ref obj;
     }
-}").VerifyDiagnostics(
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics(
                 // (6,9): error CS8373: The left-hand side of a ref assignment must be a ref variable.
                 //         this = ref this;
                 Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(6, 9),
@@ -3845,9 +3997,11 @@ readonly ref struct Test
                 Diagnostic(ErrorCode.ERR_RefLocalOrParamExpected, "this").WithLocation(8, 9));
         }
 
-        [Fact]
         [WorkItem(29927, "https://github.com/dotnet/roslyn/issues/29927")]
-        public void CoalesceSpanReturn()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void CoalesceSpanReturn(LanguageVersion languageVersion)
         {
             CreateCompilationWithMscorlibAndSpan(@"
 using System;
@@ -3857,12 +4011,14 @@ class C
     {       
         return null ?? new Span<byte>();
     }
-}", options: TestOptions.ReleaseDll).VerifyDiagnostics();
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.ReleaseDll).VerifyDiagnostics();
         }
 
-        [Fact]
         [WorkItem(29927, "https://github.com/dotnet/roslyn/issues/29927")]
-        public void CoalesceAssignSpanReturn()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void CoalesceAssignSpanReturn(LanguageVersion languageVersion)
         {
             CreateCompilationWithMscorlibAndSpan(@"
 using System;
@@ -3873,12 +4029,14 @@ class C
         var x = null ?? new Span<byte>();
         return x;
     }
-}", options: TestOptions.ReleaseDll).VerifyDiagnostics();
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.ReleaseDll).VerifyDiagnostics();
         }
 
-        [Fact]
         [WorkItem(29927, "https://github.com/dotnet/roslyn/issues/29927")]
-        public void CoalesceRefSpanReturn()
+        [Theory]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void CoalesceRefSpanReturn(LanguageVersion languageVersion)
         {
             CreateCompilationWithMscorlibAndSpan(@"
 using System;
@@ -3889,15 +4047,17 @@ class C
         Span<byte> x = stackalloc byte[10];
         return null ?? x;
     }
-}", options: TestOptions.ReleaseDll).VerifyDiagnostics(
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.ReleaseDll).VerifyDiagnostics(
                 // (8,24): error CS8352: Cannot use variable 'x' in this context because it may expose referenced variables outside of their declaration scope
                 //         return null ?? x;
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "x").WithArguments("x").WithLocation(8, 24)
                 );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/40583")]
-        public void ConvertedSpanReturn()
+        [Theory(Skip = "https://github.com/dotnet/roslyn/issues/40583")]
+        [InlineData(LanguageVersion.CSharp10)]
+        [InlineData(LanguageVersion.CSharp11)]
+        public void ConvertedSpanReturn(LanguageVersion languageVersion)
         {
             CreateCompilationWithMscorlibAndSpan(@"
 using System;
@@ -3910,7 +4070,7 @@ class D
 {
     public static implicit operator D(Span<byte> span) => new D();
 }
-", options: TestOptions.ReleaseDll).VerifyDiagnostics();
+", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.ReleaseDll).VerifyDiagnostics();
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -7378,7 +7378,7 @@ class Program
     }
     static ref R ReturnRef(ref R r) => throw null;
 }";
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, runtimeFeature: RuntimeFlag.ByRefFields);
             comp.VerifyDiagnostics();
 
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.ReturnRef").Parameters[0], "ref R r", RefKind.Ref, DeclarationScope.RefScoped);
@@ -14169,7 +14169,7 @@ class Program
     static void F3<T>([UnscopedRef] in R<T> r3) { }
     static void F4<T>([UnscopedRef] out R<T> r4) { r4 = default; }
 }";
-            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
+            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition }, runtimeFeature: RuntimeFlag.ByRefFields);
             comp.VerifyEmitDiagnostics(
                 // (8,24): error CS9063: UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.
                 //     static void F1<T>([UnscopedRef] R<T> r1) { }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -1277,10 +1277,10 @@ class Program
     static ref R F3(ref R r) => ref r; // 1
     static ref readonly C F4(in C c) => ref c;
     static ref readonly S F5(in S s) => ref s;
-    static ref readonly R F6(in R r) => ref r;
-    static ref C F7(out C c) { c = default; return ref c; } // 2
-    static ref S F8(out S s) { s = default; return ref s; } // 3
-    static ref R F9(out R r) { r = default; return ref r; } // 4
+    static ref readonly R F6(in R r) => ref r; // 2
+    static ref C F7(out C c) { c = default; return ref c; } // 3
+    static ref S F8(out S s) { s = default; return ref s; } // 4
+    static ref R F9(out R r) { r = default; return ref r; } // 5
 }";
 
             var expectedLegacyDiagnostics = new DiagnosticDescription[]
@@ -1292,14 +1292,17 @@ class Program
                 // (8,37): error CS8166: Cannot return a parameter by reference 'r' because it is not a ref parameter
                 //     static ref R F3(ref R r) => ref r; // 1
                 Diagnostic(ErrorCode.ERR_RefReturnParameter, "r").WithArguments("r").WithLocation(8, 37),
+                // (11,45): error CS8166: Cannot return a parameter by reference 'r' because it is not a ref parameter
+                //     static ref readonly R F6(in R r) => ref r; // 2
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "r").WithArguments("r").WithLocation(11, 45),
                 // (12,56): error CS8166: Cannot return a parameter by reference 'c' because it is not a ref parameter
-                //     static ref C F7(out C c) { c = default; return ref c; } // 2
+                //     static ref C F7(out C c) { c = default; return ref c; } // 3
                 Diagnostic(ErrorCode.ERR_RefReturnParameter, "c").WithArguments("c").WithLocation(12, 56),
                 // (13,56): error CS8166: Cannot return a parameter by reference 's' because it is not a ref parameter
-                //     static ref S F8(out S s) { s = default; return ref s; } // 3
+                //     static ref S F8(out S s) { s = default; return ref s; } // 4
                 Diagnostic(ErrorCode.ERR_RefReturnParameter, "s").WithArguments("s").WithLocation(13, 56),
                 // (14,56): error CS8166: Cannot return a parameter by reference 'r' because it is not a ref parameter
-                //     static ref R F9(out R r) { r = default; return ref r; } // 4
+                //     static ref R F9(out R r) { r = default; return ref r; } // 5
                 Diagnostic(ErrorCode.ERR_RefReturnParameter, "r").WithArguments("r").WithLocation(14, 56)
             };
 
@@ -6787,8 +6790,8 @@ public static class A
                 VerifyParameterSymbol(parameters[1], "ref R y2", RefKind.Ref, DeclarationScope.RefScoped);
 
                 parameters = comp.GetMember<MethodSymbol>("A.F3").Parameters;
-                VerifyParameterSymbol(parameters[0], "in R x3", RefKind.In, DeclarationScope.Unscoped); // PROTOTYPE: Should be RefScoped.
-                VerifyParameterSymbol(parameters[1], "scoped in R y3", RefKind.In, DeclarationScope.RefScoped); // PROTOTYPE: Should be "in R y3", ..., RefScoped.
+                VerifyParameterSymbol(parameters[0], "in R x3", RefKind.In, DeclarationScope.RefScoped);
+                VerifyParameterSymbol(parameters[1], "in R y3", RefKind.In, DeclarationScope.RefScoped);
 
                 parameters = comp.GetMember<MethodSymbol>("A.F4").Parameters;
                 VerifyParameterSymbol(parameters[0], "out R x4", RefKind.Out, DeclarationScope.RefScoped);
@@ -6898,8 +6901,8 @@ class Program
                 VerifyParameterSymbol(localFunctions[3].Parameters[1], "out System.Int32 y4", RefKind.Out, DeclarationScope.RefScoped);
                 VerifyParameterSymbol(localFunctions[4].Parameters[0], "ref R x5", RefKind.Ref, DeclarationScope.RefScoped);
                 VerifyParameterSymbol(localFunctions[4].Parameters[1], "ref R y5", RefKind.Ref, DeclarationScope.RefScoped);
-                VerifyParameterSymbol(localFunctions[5].Parameters[0], "in R x6", RefKind.In, DeclarationScope.Unscoped);
-                VerifyParameterSymbol(localFunctions[5].Parameters[1], "scoped in R y6", RefKind.In, DeclarationScope.RefScoped); // PROTOTYPE: "in R y6"
+                VerifyParameterSymbol(localFunctions[5].Parameters[0], "in R x6", RefKind.In, DeclarationScope.RefScoped);
+                VerifyParameterSymbol(localFunctions[5].Parameters[1], "in R y6", RefKind.In, DeclarationScope.RefScoped);
                 VerifyParameterSymbol(localFunctions[6].Parameters[0], "out R x7", RefKind.Out, DeclarationScope.RefScoped);
                 VerifyParameterSymbol(localFunctions[6].Parameters[1], "out R y7", RefKind.Out, DeclarationScope.RefScoped);
             }
@@ -6968,8 +6971,8 @@ class Program
                 verifyParameter(delegateTypesAndLambdas[3], 1, "out System.Int32", "y4", RefKind.Out, DeclarationScope.RefScoped);
                 verifyParameter(delegateTypesAndLambdas[4], 0, "ref R", "x5", RefKind.Ref, DeclarationScope.RefScoped);
                 verifyParameter(delegateTypesAndLambdas[4], 1, "ref R", "y5", RefKind.Ref, DeclarationScope.RefScoped);
-                verifyParameter(delegateTypesAndLambdas[5], 0, "in R", "x6", RefKind.In, DeclarationScope.Unscoped);
-                verifyParameter(delegateTypesAndLambdas[5], 1, "scoped in R", "y6", RefKind.In, DeclarationScope.RefScoped);
+                verifyParameter(delegateTypesAndLambdas[5], 0, "in R", "x6", RefKind.In, DeclarationScope.RefScoped);
+                verifyParameter(delegateTypesAndLambdas[5], 1, "in R", "y6", RefKind.In, DeclarationScope.RefScoped);
                 verifyParameter(delegateTypesAndLambdas[6], 0, "out R", "x7", RefKind.Out, DeclarationScope.RefScoped);
                 verifyParameter(delegateTypesAndLambdas[6], 1, "out R", "y7", RefKind.Out, DeclarationScope.RefScoped);
             }
@@ -7167,9 +7170,9 @@ class Program
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F1").Parameters[0], "ref R r", RefKind.Ref, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F2").Parameters[0], "ref R r", RefKind.Ref, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F3").Parameters[0], "ref R r", RefKind.Ref, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F4").Parameters[0], "in R r", RefKind.In, DeclarationScope.Unscoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F5").Parameters[0], "scoped in R r", RefKind.In, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F6").Parameters[0], "scoped in R r", RefKind.In, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F4").Parameters[0], "in R r", RefKind.In, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F5").Parameters[0], "in R r", RefKind.In, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F6").Parameters[0], "in R r", RefKind.In, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F7").Parameters[0], "out R r", RefKind.Out, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F8").Parameters[0], "out R r", RefKind.Out, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F9").Parameters[0], "out R r", RefKind.Out, DeclarationScope.RefScoped);
@@ -7241,9 +7244,9 @@ class Program
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F2").Parameters[0], "ref scoped s", RefKind.Ref, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F3").Parameters[0], "ref scoped s", RefKind.Ref, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F4").Parameters[0], "ref scoped s", RefKind.Ref, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F5").Parameters[0], "in scoped s", RefKind.In, DeclarationScope.Unscoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F6").Parameters[0], "in scoped s", RefKind.In, DeclarationScope.Unscoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F7").Parameters[0], "scoped in scoped s", RefKind.In, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F5").Parameters[0], "in scoped s", RefKind.In, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F6").Parameters[0], "in scoped s", RefKind.In, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F7").Parameters[0], "in scoped s", RefKind.In, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F8").Parameters[0], "out scoped s", RefKind.Out, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F9").Parameters[0], "out scoped s", RefKind.Out, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.FA").Parameters[0], "out scoped s", RefKind.Out, DeclarationScope.RefScoped);
@@ -7349,7 +7352,7 @@ public class A
             var parameters = comp.GetMember<MethodSymbol>("A.F").Parameters;
             VerifyParameterSymbol(parameters[0], "R a", RefKind.None, DeclarationScope.Unscoped);
             VerifyParameterSymbol(parameters[1], "ref R b", RefKind.Ref, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(parameters[2], "in R c", RefKind.In, DeclarationScope.Unscoped); // PROTOTYPE: Should be RefScoped.
+            VerifyParameterSymbol(parameters[2], "in R c", RefKind.In, DeclarationScope.RefScoped);
             VerifyParameterSymbol(parameters[3], "out R d", RefKind.Out, DeclarationScope.RefScoped);
 
             // https://github.com/dotnet/roslyn/issues/62780: Test additional cases with [UnscopedRef].
@@ -14061,7 +14064,7 @@ class B : A<int>
         }
 
         [Fact]
-        public void UnscopedRefAttribute_RefStructParameter()
+        public void UnscopedRefAttribute_RefStructParameter_01()
         {
             var source =
 @"using System.Diagnostics.CodeAnalysis;
@@ -14148,6 +14151,34 @@ class B : A<int>
             VerifyParameterSymbol(baseType.GetMethod("F2A").Parameters[0], "scoped R<System.Int32> r2", RefKind.None, DeclarationScope.ValueScoped);
             VerifyParameterSymbol(baseType.GetMethod("F3A").Parameters[0], "R<System.Int32> r3", RefKind.None, DeclarationScope.Unscoped);
             VerifyParameterSymbol(baseType.GetMethod("F4A").Parameters[0], "R<System.Int32> r4", RefKind.None, DeclarationScope.Unscoped);
+        }
+
+        [Fact]
+        public void UnscopedRefAttribute_RefStructParameter_02()
+        {
+            var source =
+@"using System.Diagnostics.CodeAnalysis;
+public ref struct R<T>
+{
+    public ref T F;
+}
+class Program
+{
+    static void F1<T>([UnscopedRef] R<T> r1) { }
+    static void F2<T>([UnscopedRef] ref R<T> r2) { }
+    static void F3<T>([UnscopedRef] in R<T> r3) { }
+    static void F4<T>([UnscopedRef] out R<T> r4) { r4 = default; }
+}";
+            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
+            comp.VerifyEmitDiagnostics(
+                // (8,24): error CS9063: UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.
+                //     static void F1<T>([UnscopedRef] R<T> r1) { }
+                Diagnostic(ErrorCode.ERR_UnscopedRefAttributeUnsupportedTarget, "UnscopedRef").WithLocation(8, 24));
+
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F1").Parameters[0], "R<T> r1", RefKind.None, DeclarationScope.Unscoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F2").Parameters[0], "ref R<T> r2", RefKind.Ref, DeclarationScope.Unscoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F3").Parameters[0], "in R<T> r3", RefKind.In, DeclarationScope.Unscoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F4").Parameters[0], "out R<T> r4", RefKind.Out, DeclarationScope.Unscoped);
         }
 
         [Fact]
@@ -14383,7 +14414,6 @@ class C4 : I<object>
 }
 ";
             var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
-            // PROTOTYPE: Expected errors should be reported when 'ref R<T>' is considered 'scoped ref'.
             comp.VerifyDiagnostics(
                 // (17,17): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     public void F1([UnscopedRef] ref R<int> r) { } // 1

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -2945,13 +2945,11 @@ ref struct R
 }
 class Program
 {
-    static void F1(bool b)
+    static void F1()
     {
         R r1 = default;
-        if (b)
-            F2(ref r1);
-        else
-            F3(ref r1); // 1
+        F2(ref r1);
+        F3(ref r1); // 1
     }
     static void F2(ref R r2)
     {
@@ -2962,12 +2960,12 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
             comp.VerifyDiagnostics(
-                // (14,13): error CS8350: This combination of arguments to 'Program.F3(ref R)' is disallowed because it may expose variables referenced by parameter 'r3' outside of their declaration scope
-                //             F3(ref r1); // 1
-                Diagnostic(ErrorCode.ERR_CallArgMixing, "F3(ref r1)").WithArguments("Program.F3(ref R)", "r3").WithLocation(14, 13),
-                // (14,20): error CS8168: Cannot return local 'r1' by reference because it is not a ref local
-                //             F3(ref r1); // 1
-                Diagnostic(ErrorCode.ERR_RefReturnLocal, "r1").WithArguments("r1").WithLocation(14, 20));
+                // (12,9): error CS8350: This combination of arguments to 'Program.F3(ref R)' is disallowed because it may expose variables referenced by parameter 'r3' outside of their declaration scope
+                //         F3(ref r1); // 1
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "F3(ref r1)").WithArguments("Program.F3(ref R)", "r3").WithLocation(12, 9),
+                // (12,16): error CS8168: Cannot return local 'r1' by reference because it is not a ref local
+                //         F3(ref r1); // 1
+                Diagnostic(ErrorCode.ERR_RefReturnLocal, "r1").WithArguments("r1").WithLocation(12, 16));
         }
 
         [Fact]
@@ -2981,14 +2979,12 @@ ref struct R
 }
 class Program
 {
-    static void F1(bool b)
+    static void F1()
     {
         R x1 = default;
         R y1 = default;
-        if (b)
-            F2(ref x1, ref y1); // 1
-        else
-            F2(ref y1, ref x1); // 2
+        F2(ref x1, ref y1); // 1
+        F2(ref y1, ref x1); // 2
     }
     static void F2(ref R x2, [UnscopedRef] ref R y2)
     {
@@ -2996,18 +2992,18 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
             comp.VerifyDiagnostics(
-                // (13,13): error CS8350: This combination of arguments to 'Program.F2(ref R, ref R)' is disallowed because it may expose variables referenced by parameter 'y2' outside of their declaration scope
-                //             F2(ref x1, ref y1); // 1
-                Diagnostic(ErrorCode.ERR_CallArgMixing, "F2(ref x1, ref y1)").WithArguments("Program.F2(ref R, ref R)", "y2").WithLocation(13, 13),
-                // (13,28): error CS8168: Cannot return local 'y1' by reference because it is not a ref local
-                //             F2(ref x1, ref y1); // 1
-                Diagnostic(ErrorCode.ERR_RefReturnLocal, "y1").WithArguments("y1").WithLocation(13, 28),
-                // (15,13): error CS8350: This combination of arguments to 'Program.F2(ref R, ref R)' is disallowed because it may expose variables referenced by parameter 'y2' outside of their declaration scope
-                //             F2(ref y1, ref x1); // 2
-                Diagnostic(ErrorCode.ERR_CallArgMixing, "F2(ref y1, ref x1)").WithArguments("Program.F2(ref R, ref R)", "y2").WithLocation(15, 13),
-                // (15,28): error CS8168: Cannot return local 'x1' by reference because it is not a ref local
-                //             F2(ref y1, ref x1); // 2
-                Diagnostic(ErrorCode.ERR_RefReturnLocal, "x1").WithArguments("x1").WithLocation(15, 28));
+                // (12,9): error CS8350: This combination of arguments to 'Program.F2(ref R, ref R)' is disallowed because it may expose variables referenced by parameter 'y2' outside of their declaration scope
+                //         F2(ref x1, ref y1); // 1
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "F2(ref x1, ref y1)").WithArguments("Program.F2(ref R, ref R)", "y2").WithLocation(12, 9),
+                // (12,24): error CS8168: Cannot return local 'y1' by reference because it is not a ref local
+                //         F2(ref x1, ref y1); // 1
+                Diagnostic(ErrorCode.ERR_RefReturnLocal, "y1").WithArguments("y1").WithLocation(12, 24),
+                // (13,9): error CS8350: This combination of arguments to 'Program.F2(ref R, ref R)' is disallowed because it may expose variables referenced by parameter 'y2' outside of their declaration scope
+                //         F2(ref y1, ref x1); // 2
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "F2(ref y1, ref x1)").WithArguments("Program.F2(ref R, ref R)", "y2").WithLocation(13, 9),
+                // (13,24): error CS8168: Cannot return local 'x1' by reference because it is not a ref local
+                //         F2(ref y1, ref x1); // 2
+                Diagnostic(ErrorCode.ERR_RefReturnLocal, "x1").WithArguments("x1").WithLocation(13, 24));
         }
 
         [Fact]
@@ -3020,15 +3016,13 @@ class Program
 }
 class Program
 {
-    static void F1(bool b)
+    static void F1()
     {
         R x1 = default;
         int i = 42;
-        scoped R y1 = new R(ref i);
-        if (b)
-            F2(ref x1, ref y1); // 1
-        else
-            F2(ref y1, ref x1); // 2
+        R y1 = new R(ref i); // implicitly scoped
+        F2(ref x1, ref y1); // 1
+        F2(ref y1, ref x1); // 2
     }
     static void F2(ref R x2, ref R y2)
     {
@@ -3036,18 +3030,18 @@ class Program
 }";
             var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
             comp.VerifyDiagnostics(
-                // (13,13): error CS8350: This combination of arguments to 'Program.F2(ref R, ref R)' is disallowed because it may expose variables referenced by parameter 'y2' outside of their declaration scope
-                //             F2(ref x1, ref y1); // 1
-                Diagnostic(ErrorCode.ERR_CallArgMixing, "F2(ref x1, ref y1)").WithArguments("Program.F2(ref R, ref R)", "y2").WithLocation(13, 13),
-                // (13,28): error CS8352: Cannot use variable 'y1' in this context because it may expose referenced variables outside of their declaration scope
-                //             F2(ref x1, ref y1); // 1
-                Diagnostic(ErrorCode.ERR_EscapeVariable, "y1").WithArguments("y1").WithLocation(13, 28),
-                // (15,13): error CS8350: This combination of arguments to 'Program.F2(ref R, ref R)' is disallowed because it may expose variables referenced by parameter 'x2' outside of their declaration scope
-                //             F2(ref y1, ref x1); // 2
-                Diagnostic(ErrorCode.ERR_CallArgMixing, "F2(ref y1, ref x1)").WithArguments("Program.F2(ref R, ref R)", "x2").WithLocation(15, 13),
-                // (15,20): error CS8352: Cannot use variable 'y1' in this context because it may expose referenced variables outside of their declaration scope
-                //             F2(ref y1, ref x1); // 2
-                Diagnostic(ErrorCode.ERR_EscapeVariable, "y1").WithArguments("y1").WithLocation(15, 20));
+                // (12,9): error CS8350: This combination of arguments to 'Program.F2(ref R, ref R)' is disallowed because it may expose variables referenced by parameter 'y2' outside of their declaration scope
+                //         F2(ref x1, ref y1); // 1
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "F2(ref x1, ref y1)").WithArguments("Program.F2(ref R, ref R)", "y2").WithLocation(12, 9),
+                // (12,24): error CS8352: Cannot use variable 'y1' in this context because it may expose referenced variables outside of their declaration scope
+                //         F2(ref x1, ref y1); // 1
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "y1").WithArguments("y1").WithLocation(12, 24),
+                // (13,9): error CS8350: This combination of arguments to 'Program.F2(ref R, ref R)' is disallowed because it may expose variables referenced by parameter 'x2' outside of their declaration scope
+                //         F2(ref y1, ref x1); // 2
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "F2(ref y1, ref x1)").WithArguments("Program.F2(ref R, ref R)", "x2").WithLocation(13, 9),
+                // (13,16): error CS8352: Cannot use variable 'y1' in this context because it may expose referenced variables outside of their declaration scope
+                //         F2(ref y1, ref x1); // 2
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "y1").WithArguments("y1").WithLocation(13, 16));
         }
 
         [Theory]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -6644,8 +6644,14 @@ class Program
     }
 }";
 
-            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
-            comp.VerifyEmitDiagnostics();
+            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            comp.VerifyEmitDiagnostics(
+                // (14,18): error CS8350: This combination of arguments to 'Program.F1<T>(ref S<T>)' is disallowed because it may expose variables referenced by parameter 'x1' outside of their declaration scope
+                //         var y2 = F1(ref x2);
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "F1(ref x2)").WithArguments("Program.F1<T>(ref S<T>)", "x1").WithLocation(14, 18),
+                // (14,25): error CS8166: Cannot return a parameter by reference 'x2' because it is not a ref parameter
+                //         var y2 = F1(ref x2);
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "x2").WithArguments("x2").WithLocation(14, 25));
         }
 
         [Theory]
@@ -6672,7 +6678,13 @@ class Program
 }";
 
             var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
-            comp.VerifyEmitDiagnostics();
+            comp.VerifyEmitDiagnostics(
+                // (14,18): error CS8350: This combination of arguments to 'Program.F1<T>(ref S<T>, ref S<T>)' is disallowed because it may expose variables referenced by parameter 'x1' outside of their declaration scope
+                //         var z1 = F1(ref x2, ref y2);
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "F1(ref x2, ref y2)").WithArguments("Program.F1<T>(ref S<T>, ref S<T>)", "x1").WithLocation(14, 18),
+                // (14,25): error CS8166: Cannot return a parameter by reference 'x2' because it is not a ref parameter
+                //         var z1 = F1(ref x2, ref y2);
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "x2").WithArguments("x2").WithLocation(14, 25));
         }
 
         [WorkItem(62098, "https://github.com/dotnet/roslyn/issues/62098")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -2824,8 +2824,6 @@ class Program
                 Diagnostic(ErrorCode.ERR_RefReturnParameter, "x").WithArguments("x").WithLocation(10, 72));
         }
 
-        // PROTOTYPE: Add to spec: ref to ref struct in __arglist is unscoped ref.
-
         /// <summary>
         /// ref to ref struct in __arglist is unscoped ref.
         /// </summary>
@@ -3071,7 +3069,6 @@ class Program
         return ref r;
     }
 }";
-            // PROTOTYPE: If the __arglist ref arguments are not scoped, why can't we return __refvalue() by ref?
             var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
             comp.VerifyEmitDiagnostics(
                 // (11,20): error CS8157: Cannot return 'r' by reference because it was initialized to a value that cannot be returned by reference

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -9522,10 +9522,10 @@ class B2 : A<string>
 {
     public override R<string> F1(scoped R<string> r) => default; // 1
     public override R<string> F2(R<string> r) => default; // 2
-    public override R<string> F3(scoped ref R<string> r) => default; // 3
-    public override R<string> F4(ref R<string> r) => default; // 4
-    public override object this[scoped R<string> r] { get { return null; } set { } } // 5
-    public override object this[int x, R<string> y] => null; // 6
+    public override R<string> F3(scoped ref R<string> r) => default;
+    public override R<string> F4(ref R<string> r) => default;
+    public override object this[scoped R<string> r] { get { return null; } set { } } // 3
+    public override object this[int x, R<string> y] => null; // 4
 }";
             comp = CreateCompilation(sourceB, references: new[] { refA });
             comp.VerifyEmitDiagnostics(
@@ -9536,10 +9536,10 @@ class B2 : A<string>
                 //     public override R<string> F2(R<string> r) => default; // 2
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(13, 31),
                 // (16,76): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
-                //     public override object this[scoped R<string> r] { get { return null; } set { } } // 5
+                //     public override object this[scoped R<string> r] { get { return null; } set { } } // 3
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "set").WithArguments("r").WithLocation(16, 76),
                 // (17,56): error CS8987: The 'scoped' modifier of parameter 'y' doesn't match overridden or implemented member.
-                //     public override object this[int x, R<string> y] => null; // 6
+                //     public override object this[int x, R<string> y] => null; // 4
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "null").WithArguments("y").WithLocation(17, 56));
         }
 
@@ -9576,10 +9576,10 @@ class C2 : I<string>
 {
     public R<string> F1(scoped R<string> r) => default; // 1
     public R<string> F2(R<string> r) => default; // 2
-    public R<string> F3(scoped ref R<string> r) => default; // 3
-    public R<string> F4(scoped ref R<string> r) => default;
-    public object this[scoped R<string> r] { get { return null; } set { } } // 4
-    public object this[int x, R<string> y] => null; // 5
+    public R<string> F3(scoped ref R<string> r) => default;
+    public R<string> F4(ref R<string> r) => default;
+    public object this[scoped R<string> r] { get { return null; } set { } } // 3
+    public object this[int x, R<string> y] => null; // 4
 }";
             comp = CreateCompilation(sourceB1, references: new[] { refA });
             comp.VerifyEmitDiagnostics(
@@ -9590,10 +9590,10 @@ class C2 : I<string>
                 //     public R<string> F2(R<string> r) => default; // 2
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(13, 22),
                 // (16,67): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
-                //     public object this[scoped R<string> r] { get { return null; } set { } } // 4
+                //     public object this[scoped R<string> r] { get { return null; } set { } } // 3
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "set").WithArguments("r").WithLocation(16, 67),
                 // (17,47): error CS8987: The 'scoped' modifier of parameter 'y' doesn't match overridden or implemented member.
-                //     public object this[int x, R<string> y] => null; // 5
+                //     public object this[int x, R<string> y] => null; // 4
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "null").WithArguments("y").WithLocation(17, 47));
 
             var sourceB2 =
@@ -9610,10 +9610,10 @@ class C4 : I<string>
 {
     R<string> I<string>.F1(scoped R<string> r) => default; // 1
     R<string> I<string>.F2(R<string> r) => default; // 2
-    R<string> I<string>.F3(scoped ref R<string> r) => default; // 3
-    R<string> I<string>.F4(scoped ref R<string> r) => default;
-    object I<string>.this[scoped R<string> r] { get { return null; } set { } } // 4
-    object I<string>.this[int x, R<string> y] => null; // 5
+    R<string> I<string>.F3(scoped ref R<string> r) => default;
+    R<string> I<string>.F4(ref R<string> r) => default;
+    object I<string>.this[scoped R<string> r] { get { return null; } set { } } // 3
+    object I<string>.this[int x, R<string> y] => null; // 4
 }";
             comp = CreateCompilation(sourceB2, references: new[] { refA });
             comp.VerifyEmitDiagnostics(
@@ -9624,10 +9624,10 @@ class C4 : I<string>
                 //     R<string> I<string>.F2(R<string> r) => default; // 2
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(13, 25),
                 // (16,70): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
-                //     object I<string>.this[scoped R<string> r] { get { return null; } set { } } // 4
+                //     object I<string>.this[scoped R<string> r] { get { return null; } set { } } // 3
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "set").WithArguments("r").WithLocation(16, 70),
                 // (17,50): error CS8987: The 'scoped' modifier of parameter 'y' doesn't match overridden or implemented member.
-                //     object I<string>.this[int x, R<string> y] => null; // 5
+                //     object I<string>.this[int x, R<string> y] => null; // 4
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "null").WithArguments("y").WithLocation(17, 50));
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -9557,6 +9557,8 @@ public interface I<T>
     R<T> F4(scoped ref R<T> r);
     object this[R<T> r] { get; set; }
     object this[int x, scoped R<T> y] { get; }
+    object this[object x, in R<T> y] { get; set; }
+    object this[scoped in R<T> x, int y] { get; }
 }";
             var comp = CreateCompilation(sourceA);
             comp.VerifyEmitDiagnostics();
@@ -9571,6 +9573,8 @@ public interface I<T>
     public R<int> F4(scoped ref R<int> r) => default;
     public object this[R<int> r] { get { return null; } set { } }
     public object this[int x, scoped R<int> y] => null;
+    public object this[object x, in R<int> y] { get { return null; } set { } }
+    public object this[scoped in R<int> x, int y] => null;
 }
 class C2 : I<string>
 {
@@ -9580,21 +9584,23 @@ class C2 : I<string>
     public R<string> F4(ref R<string> r) => default;
     public object this[scoped R<string> r] { get { return null; } set { } } // 3
     public object this[int x, R<string> y] => null; // 4
+    public object this[object x, scoped in R<string> y] { get { return null; } set { } }
+    public object this[in R<string> x, int y] => null;
 }";
             comp = CreateCompilation(sourceB1, references: new[] { refA });
             comp.VerifyEmitDiagnostics(
-                // (12,22): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
+                // (14,22): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     public R<string> F1(scoped R<string> r) => default; // 1
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("r").WithLocation(12, 22),
-                // (13,22): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("r").WithLocation(14, 22),
+                // (15,22): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     public R<string> F2(R<string> r) => default; // 2
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(13, 22),
-                // (16,67): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(15, 22),
+                // (18,67): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     public object this[scoped R<string> r] { get { return null; } set { } } // 3
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "set").WithArguments("r").WithLocation(16, 67),
-                // (17,47): error CS8987: The 'scoped' modifier of parameter 'y' doesn't match overridden or implemented member.
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "set").WithArguments("r").WithLocation(18, 67),
+                // (19,47): error CS8987: The 'scoped' modifier of parameter 'y' doesn't match overridden or implemented member.
                 //     public object this[int x, R<string> y] => null; // 4
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "null").WithArguments("y").WithLocation(17, 47));
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "null").WithArguments("y").WithLocation(19, 47));
 
             var sourceB2 =
 @"class C3 : I<int>
@@ -9605,6 +9611,8 @@ class C2 : I<string>
     R<int> I<int>.F4(scoped ref R<int> r) => default;
     object I<int>.this[R<int> r] { get { return null; } set { } }
     object I<int>.this[int x, scoped R<int> y] => null;
+    object I<int>.this[object x, in R<int> y] { get { return null; } set { } }
+    object I<int>.this[scoped in R<int> x, int y] => null;
 }
 class C4 : I<string>
 {
@@ -9614,21 +9622,23 @@ class C4 : I<string>
     R<string> I<string>.F4(ref R<string> r) => default;
     object I<string>.this[scoped R<string> r] { get { return null; } set { } } // 3
     object I<string>.this[int x, R<string> y] => null; // 4
+    object I<string>.this[object x, scoped in R<string> y] { get { return null; } set { } }
+    object I<string>.this[in R<string> x, int y] => null;
 }";
             comp = CreateCompilation(sourceB2, references: new[] { refA });
             comp.VerifyEmitDiagnostics(
-                // (12,25): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
+                // (14,25): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     R<string> I<string>.F1(scoped R<string> r) => default; // 1
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("r").WithLocation(12, 25),
-                // (13,25): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("r").WithLocation(14, 25),
+                // (15,25): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     R<string> I<string>.F2(R<string> r) => default; // 2
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(13, 25),
-                // (16,70): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(15, 25),
+                // (18,70): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     object I<string>.this[scoped R<string> r] { get { return null; } set { } } // 3
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "set").WithArguments("r").WithLocation(16, 70),
-                // (17,50): error CS8987: The 'scoped' modifier of parameter 'y' doesn't match overridden or implemented member.
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "set").WithArguments("r").WithLocation(18, 70),
+                // (19,50): error CS8987: The 'scoped' modifier of parameter 'y' doesn't match overridden or implemented member.
                 //     object I<string>.this[int x, R<string> y] => null; // 4
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "null").WithArguments("y").WithLocation(17, 50));
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "null").WithArguments("y").WithLocation(19, 50));
         }
 
         [CombinatorialData]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -1093,7 +1093,7 @@ class Program
         /// <summary>
         /// Ref fields of ref struct type are not supported.
         /// </summary>
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/62780: Needs [UnscopedRef]")]
         public void RefFieldTypeRefStruct_01()
         {
             var source =
@@ -1274,13 +1274,13 @@ class Program
 {
     static ref C F1(ref C c) => ref c;
     static ref S F2(ref S s) => ref s;
-    static ref R F3(ref R r) => ref r;
+    static ref R F3(ref R r) => ref r; // 1
     static ref readonly C F4(in C c) => ref c;
     static ref readonly S F5(in S s) => ref s;
     static ref readonly R F6(in R r) => ref r;
-    static ref C F7(out C c) { c = default; return ref c; } // 1
-    static ref S F8(out S s) { s = default; return ref s; } // 2
-    static ref R F9(out R r) { r = default; return ref r; } // 3
+    static ref C F7(out C c) { c = default; return ref c; } // 2
+    static ref S F8(out S s) { s = default; return ref s; } // 3
+    static ref R F9(out R r) { r = default; return ref r; } // 4
 }";
 
             var expectedLegacyDiagnostics = new DiagnosticDescription[]
@@ -1289,14 +1289,17 @@ class Program
 
             var expectedUpdatedDiagnostics = new DiagnosticDescription[]
             {
+                // (8,37): error CS8166: Cannot return a parameter by reference 'r' because it is not a ref parameter
+                //     static ref R F3(ref R r) => ref r; // 1
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "r").WithArguments("r").WithLocation(8, 37),
                 // (12,56): error CS8166: Cannot return a parameter by reference 'c' because it is not a ref parameter
-                //     static ref C F7(out C c) { c = default; return ref c; } // 1
+                //     static ref C F7(out C c) { c = default; return ref c; } // 2
                 Diagnostic(ErrorCode.ERR_RefReturnParameter, "c").WithArguments("c").WithLocation(12, 56),
                 // (13,56): error CS8166: Cannot return a parameter by reference 's' because it is not a ref parameter
-                //     static ref S F8(out S s) { s = default; return ref s; } // 2
+                //     static ref S F8(out S s) { s = default; return ref s; } // 3
                 Diagnostic(ErrorCode.ERR_RefReturnParameter, "s").WithArguments("s").WithLocation(13, 56),
                 // (14,56): error CS8166: Cannot return a parameter by reference 'r' because it is not a ref parameter
-                //     static ref R F9(out R r) { r = default; return ref r; } // 3
+                //     static ref R F9(out R r) { r = default; return ref r; } // 4
                 Diagnostic(ErrorCode.ERR_RefReturnParameter, "r").WithArguments("r").WithLocation(14, 56)
             };
 
@@ -2416,7 +2419,7 @@ class Program
             comp.VerifyEmitDiagnostics(expectedUpdatedDiagnostics);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/62780: Needs [UnscopedRef]")]
         public void MethodInvocation_Scoped_Lvalue()
         {
             var source =
@@ -5524,7 +5527,7 @@ class Program
 }");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/62780: Needs [UnscopedRef]")]
         public void ReadWriteNestedField()
         {
             var source =
@@ -6157,7 +6160,7 @@ class Program
 }");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/62780: Needs [UnscopedRef]")]
         public void InParamReorder()
         {
             var source =
@@ -6214,7 +6217,7 @@ class Program
 }");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/62780: Needs [UnscopedRef]")]
         public void ReturnRefToByValueParameter_01()
         {
             var source =
@@ -6240,7 +6243,7 @@ class Program
             comp.VerifyEmitDiagnostics();
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/62780: Needs [UnscopedRef]")]
         public void ReturnRefToByValueParameter_02()
         {
             var source =
@@ -6267,7 +6270,7 @@ class Program
         }
 
         [WorkItem(62098, "https://github.com/dotnet/roslyn/issues/62098")]
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/62780: Needs [UnscopedRef]")]
         public void RefToContainingType()
         {
             var source =
@@ -6780,12 +6783,12 @@ public static class A
                 VerifyParameterSymbol(parameters[1], "scoped R y1", RefKind.None, DeclarationScope.ValueScoped);
 
                 parameters = comp.GetMember<MethodSymbol>("A.F2").Parameters;
-                VerifyParameterSymbol(parameters[0], "ref R x2", RefKind.Ref, DeclarationScope.Unscoped);
-                VerifyParameterSymbol(parameters[1], "scoped ref R y2", RefKind.Ref, DeclarationScope.RefScoped);
+                VerifyParameterSymbol(parameters[0], "ref R x2", RefKind.Ref, DeclarationScope.RefScoped);
+                VerifyParameterSymbol(parameters[1], "ref R y2", RefKind.Ref, DeclarationScope.RefScoped);
 
                 parameters = comp.GetMember<MethodSymbol>("A.F3").Parameters;
-                VerifyParameterSymbol(parameters[0], "in R x3", RefKind.In, DeclarationScope.Unscoped);
-                VerifyParameterSymbol(parameters[1], "scoped in R y3", RefKind.In, DeclarationScope.RefScoped);
+                VerifyParameterSymbol(parameters[0], "in R x3", RefKind.In, DeclarationScope.Unscoped); // PROTOTYPE: Should be RefScoped.
+                VerifyParameterSymbol(parameters[1], "scoped in R y3", RefKind.In, DeclarationScope.RefScoped); // PROTOTYPE: Should be "in R y3", ..., RefScoped.
 
                 parameters = comp.GetMember<MethodSymbol>("A.F4").Parameters;
                 VerifyParameterSymbol(parameters[0], "out R x4", RefKind.Out, DeclarationScope.RefScoped);
@@ -6840,26 +6843,38 @@ class Program
     static void Main()
     {
 #pragma warning disable 8321
-        static void L1(scoped R x1) { }
-        static void L2(scoped ref int x2) { }
-        static void L3(scoped in int x3) { }
-        static void L4(scoped out int x4) { x4 = 0; }
+        static void L1(R x1, scoped R y1) { }
+        static void L2(ref int x2, scoped ref int y2) { }
+        static void L3(in int x3, scoped in int y3) { }
+        static void L4(out int x4, scoped out int y4) { x4 = 0; y4 = 0; }
+        static void L5(ref R x5, scoped ref R y5) { }
+        static void L6(in R x6, scoped in R y6) { }
+        static void L7(out R x7, scoped out R y7) { x7 = default; y7 = default; }
     }
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
             comp.VerifyEmitDiagnostics(
-                // (7,24): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
-                //         static void L1(scoped R x1) { }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(7, 24),
-                // (8,24): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
-                //         static void L2(scoped ref int x2) { }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(8, 24),
-                // (9,24): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
-                //         static void L3(scoped in int x3) { }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(9, 24),
-                // (10,24): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
-                //         static void L4(scoped out int x4) { x4 = 0; }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(10, 24));
+                // (7,30): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
+                //         static void L1(R x1, scoped R y1) { }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(7, 30),
+                // (8,36): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
+                //         static void L2(ref int x2, scoped ref int y2) { }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(8, 36),
+                // (9,35): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
+                //         static void L3(in int x3, scoped in int y3) { }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(9, 35),
+                // (10,36): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
+                //         static void L4(out int x4, scoped out int y4) { x4 = 0; y4 = 0; }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(10, 36),
+                // (11,34): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
+                //         static void L5(ref R x5, scoped ref R y5) { }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(11, 34),
+                // (12,33): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
+                //         static void L6(in R x6, scoped in R y6) { }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(12, 33),
+                // (13,34): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
+                //         static void L7(out R x7, scoped out R y7) { x7 = default; y7 = default; }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(13, 34));
             verify(comp);
 
             comp = CreateCompilation(source);
@@ -6873,10 +6888,20 @@ class Program
                 var decls = tree.GetRoot().DescendantNodes().OfType<LocalFunctionStatementSyntax>().ToArray();
                 var localFunctions = decls.Select(d => model.GetDeclaredSymbol(d).GetSymbol<LocalFunctionSymbol>()).ToArray();
 
-                VerifyParameterSymbol(localFunctions[0].Parameters[0], "scoped R x1", RefKind.None, DeclarationScope.ValueScoped);
-                VerifyParameterSymbol(localFunctions[1].Parameters[0], "scoped ref System.Int32 x2", RefKind.Ref, DeclarationScope.RefScoped);
-                VerifyParameterSymbol(localFunctions[2].Parameters[0], "scoped in System.Int32 x3", RefKind.In, DeclarationScope.RefScoped);
+                VerifyParameterSymbol(localFunctions[0].Parameters[0], "R x1", RefKind.None, DeclarationScope.Unscoped);
+                VerifyParameterSymbol(localFunctions[0].Parameters[1], "scoped R y1", RefKind.None, DeclarationScope.ValueScoped);
+                VerifyParameterSymbol(localFunctions[1].Parameters[0], "ref System.Int32 x2", RefKind.Ref, DeclarationScope.Unscoped);
+                VerifyParameterSymbol(localFunctions[1].Parameters[1], "scoped ref System.Int32 y2", RefKind.Ref, DeclarationScope.RefScoped);
+                VerifyParameterSymbol(localFunctions[2].Parameters[0], "in System.Int32 x3", RefKind.In, DeclarationScope.Unscoped);
+                VerifyParameterSymbol(localFunctions[2].Parameters[1], "scoped in System.Int32 y3", RefKind.In, DeclarationScope.RefScoped);
                 VerifyParameterSymbol(localFunctions[3].Parameters[0], "out System.Int32 x4", RefKind.Out, DeclarationScope.RefScoped);
+                VerifyParameterSymbol(localFunctions[3].Parameters[1], "out System.Int32 y4", RefKind.Out, DeclarationScope.RefScoped);
+                VerifyParameterSymbol(localFunctions[4].Parameters[0], "ref R x5", RefKind.Ref, DeclarationScope.RefScoped);
+                VerifyParameterSymbol(localFunctions[4].Parameters[1], "ref R y5", RefKind.Ref, DeclarationScope.RefScoped);
+                VerifyParameterSymbol(localFunctions[5].Parameters[0], "in R x6", RefKind.In, DeclarationScope.Unscoped);
+                VerifyParameterSymbol(localFunctions[5].Parameters[1], "scoped in R y6", RefKind.In, DeclarationScope.RefScoped); // PROTOTYPE: "in R y6"
+                VerifyParameterSymbol(localFunctions[6].Parameters[0], "out R x7", RefKind.Out, DeclarationScope.RefScoped);
+                VerifyParameterSymbol(localFunctions[6].Parameters[1], "out R y7", RefKind.Out, DeclarationScope.RefScoped);
             }
         }
 
@@ -6889,26 +6914,38 @@ class Program
 {
     static void Main()
     {
-        var f1 = (scoped R x1) => { };
-        var f2 = (scoped ref int x2) => { };
-        var f3 = (scoped in int x3) => { };
-        var f4 = (scoped out int x4) => { x4 = 0; };
+        var f1 = (R x1, scoped R y1) => { };
+        var f2 = (ref int x2, scoped ref int y2) => { };
+        var f3 = (in int x3, scoped in int y3) => { };
+        var f4 = (out int x4, scoped out int y4) => { x4 = 0; y4 = 0; };
+        var f5 = (ref R x5, scoped ref R y5) => { };
+        var f6 = (in R x6, scoped in R y6) => { };
+        var f7 = (out R x7, scoped out R y7) => { x7 = default; y7 = default; };
     }
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
             comp.VerifyEmitDiagnostics(
-                // (6,19): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
-                //         var f1 = (scoped R x1) => { };
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(6, 19),
-                // (7,19): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
-                //         var f2 = (scoped ref int x2) => { };
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(7, 19),
-                // (8,19): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
-                //         var f3 = (scoped in int x3) => { };
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(8, 19),
-                // (9,19): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
-                //         var f4 = (scoped out int x4) => { x4 = 0; };
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(9, 19));
+                // (6,25): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
+                //         var f1 = (R x1, scoped R y1) => { };
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(6, 25),
+                // (7,31): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
+                //         var f2 = (ref int x2, scoped ref int y2) => { };
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(7, 31),
+                // (8,30): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
+                //         var f3 = (in int x3, scoped in int y3) => { };
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(8, 30),
+                // (9,31): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
+                //         var f4 = (out int x4, scoped out int y4) => { x4 = 0; y4 = 0; };
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(9, 31),
+                // (10,29): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
+                //         var f5 = (ref R x5, scoped ref R y5) => { };
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(10, 29),
+                // (11,28): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
+                //         var f6 = (in R x6, scoped in R y6) => { };
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(11, 28),
+                // (12,29): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
+                //         var f7 = (out R x7, scoped out R y7) => { x7 = default; y7 = default; };
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(12, 29));
             verify(comp);
 
             comp = CreateCompilation(source);
@@ -6921,10 +6958,20 @@ class Program
                 var model = comp.GetSemanticModel(tree);
                 var delegateTypesAndLambdas = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Select(d => getDelegateTypeAndLambda(model, d)).ToArray();
 
-                verifyParameter(delegateTypesAndLambdas[0], 0, "scoped R", "x1", RefKind.None, DeclarationScope.ValueScoped);
-                verifyParameter(delegateTypesAndLambdas[1], 0, "scoped ref System.Int32", "x2", RefKind.Ref, DeclarationScope.RefScoped);
-                verifyParameter(delegateTypesAndLambdas[2], 0, "scoped in System.Int32", "x3", RefKind.In, DeclarationScope.RefScoped);
+                verifyParameter(delegateTypesAndLambdas[0], 0, "R", "x1", RefKind.None, DeclarationScope.Unscoped);
+                verifyParameter(delegateTypesAndLambdas[0], 1, "scoped R", "y1", RefKind.None, DeclarationScope.ValueScoped);
+                verifyParameter(delegateTypesAndLambdas[1], 0, "ref System.Int32", "x2", RefKind.Ref, DeclarationScope.Unscoped);
+                verifyParameter(delegateTypesAndLambdas[1], 1, "scoped ref System.Int32", "y2", RefKind.Ref, DeclarationScope.RefScoped);
+                verifyParameter(delegateTypesAndLambdas[2], 0, "in System.Int32", "x3", RefKind.In, DeclarationScope.Unscoped);
+                verifyParameter(delegateTypesAndLambdas[2], 1, "scoped in System.Int32", "y3", RefKind.In, DeclarationScope.RefScoped);
                 verifyParameter(delegateTypesAndLambdas[3], 0, "out System.Int32", "x4", RefKind.Out, DeclarationScope.RefScoped);
+                verifyParameter(delegateTypesAndLambdas[3], 1, "out System.Int32", "y4", RefKind.Out, DeclarationScope.RefScoped);
+                verifyParameter(delegateTypesAndLambdas[4], 0, "ref R", "x5", RefKind.Ref, DeclarationScope.RefScoped);
+                verifyParameter(delegateTypesAndLambdas[4], 1, "ref R", "y5", RefKind.Ref, DeclarationScope.RefScoped);
+                verifyParameter(delegateTypesAndLambdas[5], 0, "in R", "x6", RefKind.In, DeclarationScope.Unscoped);
+                verifyParameter(delegateTypesAndLambdas[5], 1, "scoped in R", "y6", RefKind.In, DeclarationScope.RefScoped);
+                verifyParameter(delegateTypesAndLambdas[6], 0, "out R", "x7", RefKind.Out, DeclarationScope.RefScoped);
+                verifyParameter(delegateTypesAndLambdas[6], 1, "out R", "y7", RefKind.Out, DeclarationScope.RefScoped);
             }
 
             static void verifyParameter((NamedTypeSymbol, LambdaSymbol) delegateTypeAndLambda, int parameterIndex, string expectedDisplayType, string expectedDisplayName, RefKind expectedRefKind, DeclarationScope expectedScope)
@@ -6968,7 +7015,7 @@ delegate void D2(scoped ref R r2);
             static void verify(CSharpCompilation comp)
             {
                 VerifyParameterSymbol(comp.GetMember<NamedTypeSymbol>("D1").DelegateInvokeMethod.Parameters[0], "scoped R r1", RefKind.None, DeclarationScope.ValueScoped);
-                VerifyParameterSymbol(comp.GetMember<NamedTypeSymbol>("D2").DelegateInvokeMethod.Parameters[0], "scoped ref R r2", RefKind.Ref, DeclarationScope.RefScoped);
+                VerifyParameterSymbol(comp.GetMember<NamedTypeSymbol>("D2").DelegateInvokeMethod.Parameters[0], "ref R r2", RefKind.Ref, DeclarationScope.RefScoped);
             }
         }
 
@@ -6981,10 +7028,12 @@ class Program
 {
     static void F1(scoped R r1) { }
     static void F2(ref scoped R x, scoped ref int y) { }
+    static ref R F3(ref R r) => throw null;
     static unsafe void Main()
     {
         delegate*<scoped R, void> f1 = &F1;
         delegate*<ref scoped R, scoped ref int, void> f2 = &F2;
+        delegate*<ref R, ref R> f3 = &F3;
     }
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.Regular10, options: TestOptions.UnsafeReleaseExe);
@@ -7001,21 +7050,21 @@ class Program
                 // (5,36): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
                 //     static void F2(ref scoped R x, scoped ref int y) { }
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(5, 36),
-                // (8,19): error CS8755: 'scoped' cannot be used as a modifier on a function pointer parameter.
+                // (9,19): error CS8755: 'scoped' cannot be used as a modifier on a function pointer parameter.
                 //         delegate*<scoped R, void> f1 = &F1;
-                Diagnostic(ErrorCode.ERR_BadFuncPointerParamModifier, "scoped").WithArguments("scoped").WithLocation(8, 19),
-                // (8,40): error CS8986: The 'scoped' modifier of parameter 'r1' doesn't match target 'delegate*<R, void>'.
+                Diagnostic(ErrorCode.ERR_BadFuncPointerParamModifier, "scoped").WithArguments("scoped").WithLocation(9, 19),
+                // (9,40): error CS8986: The 'scoped' modifier of parameter 'r1' doesn't match target 'delegate*<R, void>'.
                 //         delegate*<scoped R, void> f1 = &F1;
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "&F1").WithArguments("r1", "delegate*<R, void>").WithLocation(8, 40),
-                // (9,23): error CS8755: 'scoped' cannot be used as a modifier on a function pointer parameter.
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "&F1").WithArguments("r1", "delegate*<R, void>").WithLocation(9, 40),
+                // (10,23): error CS8755: 'scoped' cannot be used as a modifier on a function pointer parameter.
                 //         delegate*<ref scoped R, scoped ref int, void> f2 = &F2;
-                Diagnostic(ErrorCode.ERR_BadFuncPointerParamModifier, "scoped").WithArguments("scoped").WithLocation(9, 23),
-                // (9,33): error CS8755: 'scoped' cannot be used as a modifier on a function pointer parameter.
+                Diagnostic(ErrorCode.ERR_BadFuncPointerParamModifier, "scoped").WithArguments("scoped").WithLocation(10, 23),
+                // (10,33): error CS8755: 'scoped' cannot be used as a modifier on a function pointer parameter.
                 //         delegate*<ref scoped R, scoped ref int, void> f2 = &F2;
-                Diagnostic(ErrorCode.ERR_BadFuncPointerParamModifier, "scoped").WithArguments("scoped").WithLocation(9, 33),
-                // (9,60): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'delegate*<ref R, ref int, void>'.
+                Diagnostic(ErrorCode.ERR_BadFuncPointerParamModifier, "scoped").WithArguments("scoped").WithLocation(10, 33),
+                // (10,60): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'delegate*<ref R, ref int, void>'.
                 //         delegate*<ref scoped R, scoped ref int, void> f2 = &F2;
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "&F2").WithArguments("y", "delegate*<ref R, ref int, void>").WithLocation(9, 60));
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "&F2").WithArguments("y", "delegate*<ref R, ref int, void>").WithLocation(10, 60));
             verify(comp);
 
             comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseExe);
@@ -7023,21 +7072,21 @@ class Program
                 // (5,24): error CS8339:  The parameter modifier 'scoped' cannot follow 'ref'
                 //     static void F2(ref scoped R x, scoped ref int y) { }
                 Diagnostic(ErrorCode.ERR_BadParameterModifiersOrder, "scoped").WithArguments("scoped", "ref").WithLocation(5, 24),
-                // (8,19): error CS8755: 'scoped' cannot be used as a modifier on a function pointer parameter.
+                // (9,19): error CS8755: 'scoped' cannot be used as a modifier on a function pointer parameter.
                 //         delegate*<scoped R, void> f1 = &F1;
-                Diagnostic(ErrorCode.ERR_BadFuncPointerParamModifier, "scoped").WithArguments("scoped").WithLocation(8, 19),
-                // (8,40): error CS8986: The 'scoped' modifier of parameter 'r1' doesn't match target 'delegate*<R, void>'.
+                Diagnostic(ErrorCode.ERR_BadFuncPointerParamModifier, "scoped").WithArguments("scoped").WithLocation(9, 19),
+                // (9,40): error CS8986: The 'scoped' modifier of parameter 'r1' doesn't match target 'delegate*<R, void>'.
                 //         delegate*<scoped R, void> f1 = &F1;
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "&F1").WithArguments("r1", "delegate*<R, void>").WithLocation(8, 40),
-                // (9,23): error CS8755: 'scoped' cannot be used as a modifier on a function pointer parameter.
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "&F1").WithArguments("r1", "delegate*<R, void>").WithLocation(9, 40),
+                // (10,23): error CS8755: 'scoped' cannot be used as a modifier on a function pointer parameter.
                 //         delegate*<ref scoped R, scoped ref int, void> f2 = &F2;
-                Diagnostic(ErrorCode.ERR_BadFuncPointerParamModifier, "scoped").WithArguments("scoped").WithLocation(9, 23),
-                // (9,33): error CS8755: 'scoped' cannot be used as a modifier on a function pointer parameter.
+                Diagnostic(ErrorCode.ERR_BadFuncPointerParamModifier, "scoped").WithArguments("scoped").WithLocation(10, 23),
+                // (10,33): error CS8755: 'scoped' cannot be used as a modifier on a function pointer parameter.
                 //         delegate*<ref scoped R, scoped ref int, void> f2 = &F2;
-                Diagnostic(ErrorCode.ERR_BadFuncPointerParamModifier, "scoped").WithArguments("scoped").WithLocation(9, 33),
-                // (9,60): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'delegate*<ref R, ref int, void>'.
+                Diagnostic(ErrorCode.ERR_BadFuncPointerParamModifier, "scoped").WithArguments("scoped").WithLocation(10, 33),
+                // (10,60): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'delegate*<ref R, ref int, void>'.
                 //         delegate*<ref scoped R, scoped ref int, void> f2 = &F2;
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "&F2").WithArguments("y", "delegate*<ref R, ref int, void>").WithLocation(9, 60));
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "&F2").WithArguments("y", "delegate*<ref R, ref int, void>").WithLocation(10, 60));
             verify(comp);
 
             static void verify(CSharpCompilation comp)
@@ -7048,8 +7097,9 @@ class Program
                 var methods = decls.Select(d => ((FunctionPointerTypeSymbol)model.GetDeclaredSymbol(d).GetSymbol<LocalSymbol>().Type).Signature).ToArray();
 
                 VerifyParameterSymbol(methods[0].Parameters[0], "R", RefKind.None, DeclarationScope.Unscoped);
-                VerifyParameterSymbol(methods[1].Parameters[0], "ref R", RefKind.Ref, DeclarationScope.Unscoped);
+                VerifyParameterSymbol(methods[1].Parameters[0], "ref R", RefKind.Ref, DeclarationScope.RefScoped);
                 VerifyParameterSymbol(methods[1].Parameters[1], "ref System.Int32", RefKind.Ref, DeclarationScope.Unscoped);
+                VerifyParameterSymbol(methods[2].Parameters[0], "ref R", RefKind.Ref, DeclarationScope.RefScoped);
             }
         }
 
@@ -7114,9 +7164,9 @@ class Program
                 Diagnostic(ErrorCode.ERR_DupParamMod, "scoped").WithArguments("scoped").WithLocation(13, 27));
 
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F0").Parameters[0], "scoped R r", RefKind.None, DeclarationScope.ValueScoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F1").Parameters[0], "ref R r", RefKind.Ref, DeclarationScope.Unscoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F2").Parameters[0], "scoped ref R r", RefKind.Ref, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F3").Parameters[0], "scoped ref R r", RefKind.Ref, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F1").Parameters[0], "ref R r", RefKind.Ref, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F2").Parameters[0], "ref R r", RefKind.Ref, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F3").Parameters[0], "ref R r", RefKind.Ref, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F4").Parameters[0], "in R r", RefKind.In, DeclarationScope.Unscoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F5").Parameters[0], "scoped in R r", RefKind.In, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F6").Parameters[0], "scoped in R r", RefKind.In, DeclarationScope.RefScoped);
@@ -7188,9 +7238,9 @@ class Program
 
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F0").Parameters[0], "scoped s", RefKind.None, DeclarationScope.Unscoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F1").Parameters[0], "scoped scoped s", RefKind.None, DeclarationScope.ValueScoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F2").Parameters[0], "ref scoped s", RefKind.Ref, DeclarationScope.Unscoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F3").Parameters[0], "ref scoped s", RefKind.Ref, DeclarationScope.Unscoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F4").Parameters[0], "scoped ref scoped s", RefKind.Ref, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F2").Parameters[0], "ref scoped s", RefKind.Ref, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F3").Parameters[0], "ref scoped s", RefKind.Ref, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F4").Parameters[0], "ref scoped s", RefKind.Ref, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F5").Parameters[0], "in scoped s", RefKind.In, DeclarationScope.Unscoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F6").Parameters[0], "in scoped s", RefKind.In, DeclarationScope.Unscoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.F7").Parameters[0], "scoped in scoped s", RefKind.In, DeclarationScope.RefScoped);
@@ -7266,6 +7316,71 @@ class Program
             VerifyParameterSymbol(comp.GetMember<PEMethodSymbol>("A.F1").Parameters[0], "out System.Int32 i", RefKind.Out, DeclarationScope.RefScoped);
         }
 
+        [WorkItem(62691, "https://github.com/dotnet/roslyn/issues/62691")]
+        [CombinatorialData]
+        [Theory]
+        public void RefToRefStructParameter_01(bool useCompilationReference)
+        {
+            var sourceA =
+@"public ref struct R { }
+public class A
+{
+    public static void F(R a, ref R b, in R c, out R d) { d = default; }
+}";
+            var comp = CreateCompilation(sourceA);
+            comp.VerifyDiagnostics();
+            var refA = AsReference(comp, useCompilationReference);
+
+            var sourceB =
+@"class B
+{
+    static void Main()
+    {
+        R a = new R();
+        R b = new R();
+        R c = new R();
+        R d;
+        A.F(a, ref b, in c, out d);
+    }
+}";
+            comp = CreateCompilation(sourceB, references: new[] { refA });
+            comp.VerifyEmitDiagnostics();
+
+            var parameters = comp.GetMember<MethodSymbol>("A.F").Parameters;
+            VerifyParameterSymbol(parameters[0], "R a", RefKind.None, DeclarationScope.Unscoped);
+            VerifyParameterSymbol(parameters[1], "ref R b", RefKind.Ref, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(parameters[2], "in R c", RefKind.In, DeclarationScope.Unscoped); // PROTOTYPE: Should be RefScoped.
+            VerifyParameterSymbol(parameters[3], "out R d", RefKind.Out, DeclarationScope.RefScoped);
+
+            // https://github.com/dotnet/roslyn/issues/62780: Test additional cases with [UnscopedRef].
+        }
+
+        [WorkItem(62691, "https://github.com/dotnet/roslyn/issues/62691")]
+        [Fact]
+        public void RefToRefStructParameter_02()
+        {
+            var source =
+@"ref struct R
+{
+    public ref int F;
+    public R(ref int i) { F = ref i; }
+}
+class Program
+{
+    static ref R F()
+    {
+        int i = 42;
+        var r = new R(ref i);
+        return ref ReturnRef(ref r); // ok
+    }
+    static ref R ReturnRef(ref R r) => throw null;
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.ReturnRef").Parameters[0], "ref R r", RefKind.Ref, DeclarationScope.RefScoped);
+        }
+
         [Fact]
         public void ThisScope()
         {
@@ -7305,17 +7420,19 @@ readonly ref struct R2
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("C..ctor").ThisParameter, "C this", RefKind.None, DeclarationScope.Unscoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("C.F1").ThisParameter, "C this", RefKind.None, DeclarationScope.Unscoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("S1..ctor").ThisParameter, "out S1 this", RefKind.Out, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("S1.F1").ThisParameter, "scoped ref S1 this", RefKind.Ref, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("S1.F2").ThisParameter, "scoped in S1 this", RefKind.In, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("S1.F1").ThisParameter, "ref S1 this", RefKind.Ref, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("S1.F2").ThisParameter, "in S1 this", RefKind.In, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("R1..ctor").ThisParameter, "out R1 this", RefKind.Out, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("R1.F1").ThisParameter, "scoped ref R1 this", RefKind.Ref, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("R1.F2").ThisParameter, "scoped in R1 this", RefKind.In, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("R1.F1").ThisParameter, "ref R1 this", RefKind.Ref, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("R1.F2").ThisParameter, "in R1 this", RefKind.In, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("S2..ctor").ThisParameter, "out S2 this", RefKind.Out, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("S2.F1").ThisParameter, "scoped in S2 this", RefKind.In, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("S2.F2").ThisParameter, "scoped in S2 this", RefKind.In, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("S2.F1").ThisParameter, "in S2 this", RefKind.In, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("S2.F2").ThisParameter, "in S2 this", RefKind.In, DeclarationScope.RefScoped);
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("R2..ctor").ThisParameter, "out R2 this", RefKind.Out, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("R2.F1").ThisParameter, "scoped in R2 this", RefKind.In, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("R2.F2").ThisParameter, "scoped in R2 this", RefKind.In, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("R2.F1").ThisParameter, "in R2 this", RefKind.In, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<MethodSymbol>("R2.F2").ThisParameter, "in R2 this", RefKind.In, DeclarationScope.RefScoped);
+
+            // https://github.com/dotnet/roslyn/issues/62780: Test additional cases with [UnscopedRef].
         }
 
         [Fact]
@@ -7995,27 +8112,27 @@ class Program
                 // (10,17): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D2'.
                 //         D2 d2 = (R x, R y) => x;
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "(R x, R y) => x").WithArguments("y", "D2").WithLocation(10, 17),
-                // (11,17): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D5'.
+                // (11,43): error CS8166: Cannot return a parameter by reference 'x' because it is not a ref parameter
                 //         D5 d5 = (ref R x, ref R y) => ref x;
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "(ref R x, ref R y) => ref x").WithArguments("y", "D5").WithLocation(11, 17),
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "x").WithArguments("x").WithLocation(11, 43),
                 // (15,18): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D1'.
                 //         var d1 = (D1)((R x, scoped R y) => x);
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "(D1)((R x, scoped R y) => x)").WithArguments("y", "D1").WithLocation(15, 18),
                 // (16,18): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D2'.
                 //         var d2 = (D2)((R x, R y) => x);
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "(D2)((R x, R y) => x)").WithArguments("y", "D2").WithLocation(16, 18),
-                // (17,18): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D5'.
+                // (17,49): error CS8166: Cannot return a parameter by reference 'x' because it is not a ref parameter
                 //         var d5 = (D5)((ref R x, ref R y) => ref x);
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "(D5)((ref R x, ref R y) => ref x)").WithArguments("y", "D5").WithLocation(17, 18),
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "x").WithArguments("x").WithLocation(17, 49),
                 // (21,25): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D1'.
                 //         var d1 = new D1((R x, scoped R y) => x);
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "(R x, scoped R y) => x").WithArguments("y", "D1").WithLocation(21, 25),
                 // (22,25): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D2'.
                 //         var d2 = new D2((R x, R y) => x);
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "(R x, R y) => x").WithArguments("y", "D2").WithLocation(22, 25),
-                // (23,25): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D5'.
+                // (23,51): error CS8166: Cannot return a parameter by reference 'x' because it is not a ref parameter
                 //         var d5 = new D5((ref R x, ref R y) => ref x);
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "(ref R x, ref R y) => ref x").WithArguments("y", "D5").WithLocation(23, 25));
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "x").WithArguments("x").WithLocation(23, 51));
         }
 
         [Fact]
@@ -8053,33 +8170,30 @@ class Program
 }";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
+                // (9,46): error CS8166: Cannot return a parameter by reference 'x' because it is not a ref parameter
+                //     static ref R M3(ref R x, ref R y) => ref x;
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "x").WithArguments("x").WithLocation(9, 46),
+                // (10,53): error CS8166: Cannot return a parameter by reference 'x' because it is not a ref parameter
+                //     static ref R M5(ref R x, scoped ref R y) => ref x;
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "x").WithArguments("x").WithLocation(10, 53),
                 // (13,17): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D1'.
                 //         D1 dA = M2;
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "M2").WithArguments("y", "D1").WithLocation(13, 17),
                 // (14,17): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D2'.
                 //         D2 d2 = M1;
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "M1").WithArguments("y", "D2").WithLocation(14, 17),
-                // (15,17): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D5'.
-                //         D5 d5 = M3;
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "M3").WithArguments("y", "D5").WithLocation(15, 17),
                 // (19,18): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D1'.
                 //         var d1 = (D1)M2;
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "(D1)M2").WithArguments("y", "D1").WithLocation(19, 18),
                 // (20,18): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D2'.
                 //         var d2 = (D2)M1;
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "(D2)M1").WithArguments("y", "D2").WithLocation(20, 18),
-                // (21,18): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D5'.
-                //         var d5 = (D5)M3;
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "(D5)M3").WithArguments("y", "D5").WithLocation(21, 18),
                 // (25,25): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D1'.
                 //         var d1 = new D1(M2);
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "M2").WithArguments("y", "D1").WithLocation(25, 25),
                 // (26,25): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D2'.
                 //         var d2 = new D2(M1);
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "M1").WithArguments("y", "D2").WithLocation(26, 25),
-                // (27,25): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D5'.
-                //         var d5 = new D5(M3);
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "M3").WithArguments("y", "D5").WithLocation(27, 25));
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "M1").WithArguments("y", "D2").WithLocation(26, 25));
         }
 
         [Fact]
@@ -8217,27 +8331,27 @@ class Program
                 // (10,17): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D2'.
                 //         D2 d2 = delegate(R x, R y) { return x; };
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "delegate(R x, R y) { return x; }").WithArguments("y", "D2").WithLocation(10, 17),
-                // (11,17): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D5'.
+                // (11,57): error CS8166: Cannot return a parameter by reference 'x' because it is not a ref parameter
                 //         D5 d5 = delegate(ref R x, ref R y) { return ref x; };
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "delegate(ref R x, ref R y) { return ref x; }").WithArguments("y", "D5").WithLocation(11, 17),
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "x").WithArguments("x").WithLocation(11, 57),
                 // (15,18): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D1'.
                 //         var d1 = (D1)(delegate(R x, scoped R y) { return x; });
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "(D1)(delegate(R x, scoped R y) { return x; })").WithArguments("y", "D1").WithLocation(15, 18),
                 // (16,18): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D2'.
                 //         var d2 = (D2)(delegate(R x, R y) { return x; });
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "(D2)(delegate(R x, R y) { return x; })").WithArguments("y", "D2").WithLocation(16, 18),
-                // (17,18): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D5'.
+                // (17,63): error CS8166: Cannot return a parameter by reference 'x' because it is not a ref parameter
                 //         var d5 = (D5)(delegate(ref R x, ref R y) { return ref x; });
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "(D5)(delegate(ref R x, ref R y) { return ref x; })").WithArguments("y", "D5").WithLocation(17, 18),
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "x").WithArguments("x").WithLocation(17, 63),
                 // (21,25): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D1'.
                 //         var d1 = new D1(delegate(R x, scoped R y) { return x; });
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "delegate(R x, scoped R y) { return x; }").WithArguments("y", "D1").WithLocation(21, 25),
                 // (22,25): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D2'.
                 //         var d2 = new D2(delegate(R x, R y) { return x; });
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "delegate(R x, R y) { return x; }").WithArguments("y", "D2").WithLocation(22, 25),
-                // (23,25): error CS8986: The 'scoped' modifier of parameter 'y' doesn't match target 'D5'.
+                // (23,65): error CS8166: Cannot return a parameter by reference 'x' because it is not a ref parameter
                 //         var d5 = new D5(delegate(ref R x, ref R y) { return ref x; });
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "delegate(ref R x, ref R y) { return ref x; }").WithArguments("y", "D5").WithLocation(23, 25));
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "x").WithArguments("x").WithLocation(23, 65));
         }
 
         [Fact]
@@ -8373,19 +8487,23 @@ class Program
             var source =
 @"ref struct R { }
 delegate void D1(out int x, scoped out int y);
+delegate void D2(out R x, scoped out R y);
 class Program
 {
     static void Implicit()
     {
         D1 d1 = (scoped out int x, out int y) => { x = 0; y = 0; };
+        D2 d2 = (scoped out R x, out R y) => { x = default; y = default; };
     }
     static void Explicit()
     {
         var d1 = (D1)((scoped out int x, out int y) => { x = 0; y = 0; });
+        var d2 = (D2)((scoped out R x, out R y) => { x = default; y = default; });
     }
     static void New()
     {
         var d1 = new D1((scoped out int x, out int y) => { x = 0; y = 0; });
+        var d2 = new D2((scoped out R x, out R y) => { x = default; y = default; });
     }
 }";
             var comp = CreateCompilation(source);
@@ -8543,7 +8661,8 @@ partial class C
 {
     static partial void M1(scoped R<int> r) { } // 1
     static partial void M2(R<int> r) { } // 2
-    static partial void M5(ref R<int> r) { } // 3
+    static partial void M3(ref scoped R<int> r) { } // 3
+    static partial void M5(ref R<int> r) { }
 }";
             var comp = CreateCompilation(new[] { sourceA, sourceB1 });
             comp.VerifyEmitDiagnostics();
@@ -8556,9 +8675,9 @@ partial class C
                 // (4,25): error CS8988: The 'scoped' modifier of parameter 'r' doesn't match partial method declaration.
                 //     static partial void M2(R<int> r) { } // 2
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfPartial, "M2").WithArguments("r").WithLocation(4, 25),
-                // (5,25): error CS8988: The 'scoped' modifier of parameter 'r' doesn't match partial method declaration.
-                //     static partial void M5(ref R<int> r) { } // 3
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfPartial, "M5").WithArguments("r").WithLocation(5, 25)
+                // (5,32): error CS8339:  The parameter modifier 'scoped' cannot follow 'ref'
+                //     static partial void M3(ref scoped R<int> r) { } // 3
+                Diagnostic(ErrorCode.ERR_BadParameterModifiersOrder, "scoped").WithArguments("scoped", "ref").WithLocation(5, 32)
             };
 
             comp = CreateCompilation(new[] { sourceA, sourceB2 });
@@ -8684,12 +8803,6 @@ class B2 : A<string>
                 // (13,31): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     public override R<string> F2(R<string> r) => default; // 2
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(13, 31),
-                // (14,31): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
-                //     public override R<string> F3(scoped ref R<string> r) => default; // 3
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F3").WithArguments("r").WithLocation(14, 31),
-                // (15,31): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
-                //     public override R<string> F4(ref R<string> r) => default; // 4
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F4").WithArguments("r").WithLocation(15, 31),
                 // (16,76): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     public override object this[scoped R<string> r] { get { return null; } set { } } // 5
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "set").WithArguments("r").WithLocation(16, 76),
@@ -8744,9 +8857,6 @@ class C2 : I<string>
                 // (13,22): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     public R<string> F2(R<string> r) => default; // 2
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(13, 22),
-                // (14,22): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
-                //     public R<string> F3(scoped ref R<string> r) => default; // 3
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F3").WithArguments("r").WithLocation(14, 22),
                 // (16,67): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     public object this[scoped R<string> r] { get { return null; } set { } } // 4
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "set").WithArguments("r").WithLocation(16, 67),
@@ -8781,9 +8891,6 @@ class C4 : I<string>
                 // (13,25): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     R<string> I<string>.F2(R<string> r) => default; // 2
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(13, 25),
-                // (14,25): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
-                //     R<string> I<string>.F3(scoped ref R<string> r) => default; // 3
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F3").WithArguments("r").WithLocation(14, 25),
                 // (16,70): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     object I<string>.this[scoped R<string> r] { get { return null; } set { } } // 4
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "set").WithArguments("r").WithLocation(16, 70),
@@ -8864,6 +8971,77 @@ class C2 : I
 }";
             var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics();
+        }
+
+        [Fact]
+        public void OverridesAndInterfaceImplementations_Out_04()
+        {
+            var source =
+@"#nullable enable
+abstract class A
+{
+    public abstract void F1<T>(out T t);
+    public abstract void F2<T>(out T? t);
+}
+class B1 : A
+{
+    public override void F1<T>(out T t) { t = default!; }
+    public override void F2<T>(out T? t) where T : default { t = default; }
+}
+class B2 : A
+{
+    public override void F1<T>(out T? t) where T : default { t = default; }
+    public override void F2<T>(out T t) { t = default!; }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (14,26): warning CS8765: Nullability of type of parameter 't' doesn't match overridden member (possibly because of nullability attributes).
+                //     public override void F1<T>(out T? t) where T : default { t = default; }
+                Diagnostic(ErrorCode.WRN_TopLevelNullabilityMismatchInParameterTypeOnOverride, "F1").WithArguments("t").WithLocation(14, 26));
+
+            // https://github.com/dotnet/roslyn/issues/62780: Test with [UnscopedRef].
+        }
+
+        [Fact]
+        public void OverridesAndInterfaceImplementations_Out_05()
+        {
+            var source =
+@"#nullable enable
+interface I
+{
+    void F1<T>(out T t);
+    void F2<T>(out T? t);
+}
+class C1 : I
+{
+    public void F1<T>(out T t) { t = default!; }
+    public void F2<T>(out T? t) { t = default; }
+}
+class C2 : I
+{
+    public void F1<T>(out T? t) { t = default; }
+    public void F2<T>(out T t) { t = default!; }
+}
+class C3 : I
+{
+    void I.F1<T>(out T t) { t = default!; }
+    void I.F2<T>(out T? t) where T : default { t = default; }
+}
+class C4 : I
+{
+    void I.F1<T>(out T? t) where T : default { t = default; }
+    void I.F2<T>(out T t) { t = default!; }
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (14,17): warning CS8767: Nullability of reference types in type of parameter 't' of 'void C2.F1<T>(out T? t)' doesn't match implicitly implemented member 'void I.F1<T>(out T t)' (possibly because of nullability attributes).
+                //     public void F1<T>(out T? t) { t = default; }
+                Diagnostic(ErrorCode.WRN_TopLevelNullabilityMismatchInParameterTypeOnImplicitImplementation, "F1").WithArguments("t", "void C2.F1<T>(out T? t)", "void I.F1<T>(out T t)").WithLocation(14, 17),
+                // (24,12): warning CS8769: Nullability of reference types in type of parameter 't' doesn't match implemented member 'void I.F1<T>(out T t)' (possibly because of nullability attributes).
+                //     void I.F1<T>(out T? t) where T : default { t = default; }
+                Diagnostic(ErrorCode.WRN_TopLevelNullabilityMismatchInParameterTypeOnExplicitImplementation, "F1").WithArguments("t", "void I.F1<T>(out T t)").WithLocation(24, 12));
+
+            // https://github.com/dotnet/roslyn/issues/62780: Test with [UnscopedRef].
         }
 
         [Fact]
@@ -9011,7 +9189,7 @@ class Program
     {
         var f1 = new[] { (R r) => { }, (scoped R r) => { } }[0]; // 1
         var f2 = new[] { (scoped R r) => { }, (scoped R r) => { } }[0];
-        var f3 = new[] { (ref R r) => { }, (scoped ref R r) => { } }[0]; // 2 
+        var f3 = new[] { (ref R r) => { }, (scoped ref R r) => { } }[0];
         var f4 = new[] { (scoped ref R r) => { }, (scoped ref R r) => { } }[0];
     }
 }";
@@ -9019,10 +9197,7 @@ class Program
             comp.VerifyDiagnostics(
                 // (6,18): error CS0826: No best type found for implicitly-typed array
                 //         var f1 = new[] { (R r) => { }, (scoped R r) => { } }[0]; // 1
-                Diagnostic(ErrorCode.ERR_ImplicitlyTypedArrayNoBestType, "new[] { (R r) => { }, (scoped R r) => { } }").WithLocation(6, 18),
-                // (8,18): error CS0826: No best type found for implicitly-typed array
-                //         var f3 = new[] { (ref R r) => { }, (scoped ref R r) => { } }[0]; // 2 
-                Diagnostic(ErrorCode.ERR_ImplicitlyTypedArrayNoBestType, "new[] { (ref R r) => { }, (scoped ref R r) => { } }").WithLocation(8, 18));
+                Diagnostic(ErrorCode.ERR_ImplicitlyTypedArrayNoBestType, "new[] { (R r) => { }, (scoped R r) => { } }").WithLocation(6, 18));
         }
 
         [Fact]
@@ -9048,6 +9223,7 @@ class Program
     }
 }";
             var comp = CreateCompilation(source);
+            // https://github.com/dotnet/roslyn/issues/62768: Improve error message for `scoped ref` parameter returned by reference.
             comp.VerifyDiagnostics(
                 // (9,13): error CS8347: Cannot use a result of '<anonymous delegate>.Invoke(R, R)' in this context because it may expose variables referenced by parameter '0' outside of their declaration scope
                 //         z = f(y1, x1); // 1
@@ -9061,6 +9237,7 @@ class Program
             var decls = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Where(v => v.Identifier.Text == "f").ToArray();
             var delegateInvokeMethods = decls.Select(d => ((ILocalSymbol)model.GetDeclaredSymbol(d)).Type.GetSymbol<NamedTypeSymbol>().DelegateInvokeMethod).ToArray();
 
+            VerifyParameterSymbol(delegateInvokeMethods[0].Parameters[0], "R", RefKind.None, DeclarationScope.Unscoped);
             VerifyParameterSymbol(delegateInvokeMethods[0].Parameters[1], "scoped R", RefKind.None, DeclarationScope.ValueScoped);
             VerifyParameterSymbol(delegateInvokeMethods[1].Parameters[1], "scoped ref System.Int32", RefKind.Ref, DeclarationScope.RefScoped);
         }
@@ -9413,9 +9590,14 @@ class Program
                 // (5,51): error CS8166: Cannot return a parameter by reference 'r1' because it is not a ref parameter
                 //     static ref R<int> F1(scoped R<int> r1) => ref r1; // 2
                 Diagnostic(ErrorCode.ERR_RefReturnParameter, "r1").WithArguments("r1").WithLocation(5, 51),
+                // (6,48): error CS8166: Cannot return a parameter by reference 'r2' because it is not a ref parameter
+                //     static ref R<int> F2(ref R<int> r2) => ref r2;
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "r2").WithArguments("r2").WithLocation(6, 48),
                 // (7,55): error CS8166: Cannot return a parameter by reference 'r3' because it is not a ref parameter
                 //     static ref R<int> F3(scoped ref R<int> r3) => ref r3; // 3
                 Diagnostic(ErrorCode.ERR_RefReturnParameter, "r3").WithArguments("r3").WithLocation(7, 55));
+
+            // https://github.com/dotnet/roslyn/issues/62780: Test additional cases with [UnscopedRef].
         }
 
         [Fact]
@@ -9640,12 +9822,12 @@ class Program
     static ref R<int> F2(ref R<int> r2)
     {
         ref R<int> l2 = ref r2;
-        return ref l2;
+        return ref l2; // 3
     }
     static ref R<int> F3(scoped ref R<int> r3)
     {
         ref R<int> l3 = ref r3;
-        return ref l3; // 3
+        return ref l3; // 4
     }
 }";
             var comp = CreateCompilation(source);
@@ -9656,9 +9838,14 @@ class Program
                 // (12,20): error CS8157: Cannot return 'l1' by reference because it was initialized to a value that cannot be returned by reference
                 //         return ref l1; // 2
                 Diagnostic(ErrorCode.ERR_RefReturnNonreturnableLocal, "l1").WithArguments("l1").WithLocation(12, 20),
+                // (17,20): error CS8157: Cannot return 'l2' by reference because it was initialized to a value that cannot be returned by reference
+                //         return ref l2; // 3
+                Diagnostic(ErrorCode.ERR_RefReturnNonreturnableLocal, "l2").WithArguments("l2").WithLocation(17, 20),
                 // (22,20): error CS8157: Cannot return 'l3' by reference because it was initialized to a value that cannot be returned by reference
-                //         return ref l3; // 3
+                //         return ref l3; // 4
                 Diagnostic(ErrorCode.ERR_RefReturnNonreturnableLocal, "l3").WithArguments("l3").WithLocation(22, 20));
+
+            // https://github.com/dotnet/roslyn/issues/62780: Test additional cases with [UnscopedRef].
         }
 
         [Fact]
@@ -9856,9 +10043,14 @@ class Program
                 // (8,47): error CS8167: Cannot return by reference a member of parameter 'r1' because it is not a ref or out parameter
                 //     static ref T F1<T>(scoped R<T> r1) => ref r1.F; // 2
                 Diagnostic(ErrorCode.ERR_RefReturnParameter2, "r1").WithArguments("r1").WithLocation(8, 47),
+                // (9,44): error CS8167: Cannot return by reference a member of parameter 'r2' because it is not a ref or out parameter
+                //     static ref T F2<T>(ref R<T> r2) => ref r2.F;
+                Diagnostic(ErrorCode.ERR_RefReturnParameter2, "r2").WithArguments("r2").WithLocation(9, 44),
                 // (10,51): error CS8167: Cannot return by reference a member of parameter 'r3' because it is not a ref or out parameter
                 //     static ref T F3<T>(scoped ref R<T> r3) => ref r3.F; // 3
                 Diagnostic(ErrorCode.ERR_RefReturnParameter2, "r3").WithArguments("r3").WithLocation(10, 51));
+
+            // https://github.com/dotnet/roslyn/issues/62780: Test additional cases with [UnscopedRef].
         }
 
         [Theory]
@@ -10079,9 +10271,14 @@ class Program
                 // (14,52): error CS8167: Cannot return by reference a member of parameter 'r1' because it is not a ref or out parameter
                 //     static ref R0<T> F1<T>(scoped R1<T> r1) => ref r1.F1; // 2
                 Diagnostic(ErrorCode.ERR_RefReturnParameter2, "r1").WithArguments("r1").WithLocation(14, 52),
+                // (15,49): error CS8167: Cannot return by reference a member of parameter 'r2' because it is not a ref or out parameter
+                //     static ref R0<T> F2<T>(ref R1<T> r2) => ref r2.F1;
+                Diagnostic(ErrorCode.ERR_RefReturnParameter2, "r2").WithArguments("r2").WithLocation(15, 49),
                 // (16,56): error CS8167: Cannot return by reference a member of parameter 'r3' because it is not a ref or out parameter
                 //     static ref R0<T> F3<T>(scoped ref R1<T> r3) => ref r3.F1; // 3
                 Diagnostic(ErrorCode.ERR_RefReturnParameter2, "r3").WithArguments("r3").WithLocation(16, 56));
+
+            // https://github.com/dotnet/roslyn/issues/62780: Test additional cases with [UnscopedRef].
         }
 
         [Fact]
@@ -13318,8 +13515,8 @@ public ref struct R2<T>
 
             var type = types[0];
             Assert.Equal("R1<System.Int32>", type.ToTestDisplayString());
-            VerifyParameterSymbol(type.GetMethod("Get").ThisParameter, "scoped ref R1<System.Int32> this", RefKind.Ref, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(type.GetMethod("get_Item").ThisParameter, "scoped ref R1<System.Int32> this", RefKind.Ref, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(type.GetMethod("Get").ThisParameter, "ref R1<System.Int32> this", RefKind.Ref, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(type.GetMethod("get_Item").ThisParameter, "ref R1<System.Int32> this", RefKind.Ref, DeclarationScope.RefScoped);
 
             type = types[1];
             Assert.Equal("R2<System.Int32>", type.ToTestDisplayString());
@@ -13382,8 +13579,8 @@ public ref struct R2<T>
             var type = types[0];
             var underlyingType = (RetargetingNamedTypeSymbol)type.OriginalDefinition;
             Assert.Equal("R1<System.Int32>", type.ToTestDisplayString());
-            VerifyParameterSymbol(type.GetMethod("Get").ThisParameter, "scoped ref R1<System.Int32> this", RefKind.Ref, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(type.GetMethod("get_Item").ThisParameter, "scoped ref R1<System.Int32> this", RefKind.Ref, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(type.GetMethod("Get").ThisParameter, "ref R1<System.Int32> this", RefKind.Ref, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(type.GetMethod("get_Item").ThisParameter, "ref R1<System.Int32> this", RefKind.Ref, DeclarationScope.RefScoped);
 
             type = types[1];
             underlyingType = (RetargetingNamedTypeSymbol)type.OriginalDefinition;
@@ -13497,12 +13694,14 @@ class Program
             return ref y;
     }
 }";
-            // https://github.com/dotnet/roslyn/issues/62691: An error should be reported for 'return ref x;'.
             var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (8,24): error CS8166: Cannot return a parameter by reference 'x' because it is not a ref parameter
+                //             return ref x; // 1
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "x").WithArguments("x").WithLocation(8, 24));
 
             var parameters = comp.GetMember<MethodSymbol>("Program.ReturnRefStructRef").Parameters;
-            VerifyParameterSymbol(parameters[1], "ref R x", RefKind.Ref, DeclarationScope.Unscoped); // https://github.com/dotnet/roslyn/issues/62691: Should be DeclarationScope.RefScoped.
+            VerifyParameterSymbol(parameters[1], "ref R x", RefKind.Ref, DeclarationScope.RefScoped);
             VerifyParameterSymbol(parameters[2], "ref R y", RefKind.Ref, DeclarationScope.Unscoped);
         }
 
@@ -13547,52 +13746,45 @@ public class A<T>
     {
         int i = 1;
         var r = new R<int>(ref i);
-        return ref F1A(ref r); // 1
+        return ref F1A(ref r);
     }
     ref int F2B()
     {
         int i = 2;
         var r = new R<int>(ref i);
-        return ref F2A(ref r); // 2
+        return ref F2A(ref r);
     }
     ref int F3B()
     {
         int i = 3;
         var r = new R<int>(ref i);
-        return ref F3A(ref r); // 3
+        return ref F3A(ref r); // 1
     }
     ref int F4B()
     {
         int i = 4;
         var r = new R<int>(ref i);
-        return ref F4A(ref r); // 4
+        return ref F4A(ref r); // 2
     }
 }";
             comp = CreateCompilation(sourceB1, references: new[] { refA });
-            // https://github.com/dotnet/roslyn/issues/62791: Missing error // 2.
             comp.VerifyEmitDiagnostics(
-                // (7,20): error CS8347: Cannot use a result of 'A<int>.F1A(ref R<int>)' in this context because it may expose variables referenced by parameter 'r1' outside of their declaration scope
-                //         return ref F1A(ref r); // 1
-                Diagnostic(ErrorCode.ERR_EscapeCall, "F1A(ref r)").WithArguments("A<int>.F1A(ref R<int>)", "r1").WithLocation(7, 20),
-                // (7,28): error CS8168: Cannot return local 'r' by reference because it is not a ref local
-                //         return ref F1A(ref r); // 1
-                Diagnostic(ErrorCode.ERR_RefReturnLocal, "r").WithArguments("r").WithLocation(7, 28),
                 // (19,20): error CS8347: Cannot use a result of 'A<int>.F3A(ref R<int>)' in this context because it may expose variables referenced by parameter 'r3' outside of their declaration scope
-                //         return ref F3A(ref r); // 3
+                //         return ref F3A(ref r); // 1
                 Diagnostic(ErrorCode.ERR_EscapeCall, "F3A(ref r)").WithArguments("A<int>.F3A(ref R<int>)", "r3").WithLocation(19, 20),
                 // (19,28): error CS8168: Cannot return local 'r' by reference because it is not a ref local
-                //         return ref F3A(ref r); // 3
+                //         return ref F3A(ref r); // 1
                 Diagnostic(ErrorCode.ERR_RefReturnLocal, "r").WithArguments("r").WithLocation(19, 28),
                 // (25,20): error CS8347: Cannot use a result of 'A<int>.F4A(ref R<int>)' in this context because it may expose variables referenced by parameter 'r4' outside of their declaration scope
-                //         return ref F4A(ref r); // 4
+                //         return ref F4A(ref r); // 2
                 Diagnostic(ErrorCode.ERR_EscapeCall, "F4A(ref r)").WithArguments("A<int>.F4A(ref R<int>)", "r4").WithLocation(25, 20),
                 // (25,28): error CS8168: Cannot return local 'r' by reference because it is not a ref local
-                //         return ref F4A(ref r); // 4
+                //         return ref F4A(ref r); // 2
                 Diagnostic(ErrorCode.ERR_RefReturnLocal, "r").WithArguments("r").WithLocation(25, 28));
 
             var baseType = comp.GetMember<NamedTypeSymbol>("B1").BaseTypeNoUseSiteDiagnostics;
-            VerifyParameterSymbol(baseType.GetMethod("F1A").Parameters[0], "ref R<System.Int32> r1", RefKind.Ref, DeclarationScope.Unscoped);
-            VerifyParameterSymbol(baseType.GetMethod("F2A").Parameters[0], "scoped ref R<System.Int32> r2", RefKind.Ref, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(baseType.GetMethod("F1A").Parameters[0], "ref R<System.Int32> r1", RefKind.Ref, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(baseType.GetMethod("F2A").Parameters[0], "ref R<System.Int32> r2", RefKind.Ref, DeclarationScope.RefScoped);
             VerifyParameterSymbol(baseType.GetMethod("F3A").Parameters[0], "ref R<System.Int32> r3", RefKind.Ref, DeclarationScope.Unscoped);
             VerifyParameterSymbol(baseType.GetMethod("F4A").Parameters[0], "ref R<System.Int32> r4", RefKind.Ref, DeclarationScope.Unscoped);
 
@@ -13602,7 +13794,7 @@ public class A<T>
     ref int F1B(ref int i)
     {
         var r = new R<int>(ref i);
-        return ref F1A(ref r); // 1
+        return ref F1A(ref r);
     }
     ref int F2B(ref int i)
     {
@@ -13612,33 +13804,27 @@ public class A<T>
     ref int F3B(ref int i)
     {
         var r = new R<int>(ref i);
-        return ref F3A(ref r); // 2
+        return ref F3A(ref r); // 1
     }
     ref int F4B(ref int i)
     {
         var r = new R<int>(ref i);
-        return ref F4A(ref r); // 3
+        return ref F4A(ref r); // 2
     }
 }";
             comp = CreateCompilation(sourceB2, references: new[] { refA });
             comp.VerifyEmitDiagnostics(
-                // (6,20): error CS8347: Cannot use a result of 'A<int>.F1A(ref R<int>)' in this context because it may expose variables referenced by parameter 'r1' outside of their declaration scope
-                //         return ref F1A(ref r); // 1
-                Diagnostic(ErrorCode.ERR_EscapeCall, "F1A(ref r)").WithArguments("A<int>.F1A(ref R<int>)", "r1").WithLocation(6, 20),
-                // (6,28): error CS8168: Cannot return local 'r' by reference because it is not a ref local
-                //         return ref F1A(ref r); // 1
-                Diagnostic(ErrorCode.ERR_RefReturnLocal, "r").WithArguments("r").WithLocation(6, 28),
                 // (16,20): error CS8347: Cannot use a result of 'A<int>.F3A(ref R<int>)' in this context because it may expose variables referenced by parameter 'r3' outside of their declaration scope
-                //         return ref F3A(ref r); // 2
+                //         return ref F3A(ref r); // 1
                 Diagnostic(ErrorCode.ERR_EscapeCall, "F3A(ref r)").WithArguments("A<int>.F3A(ref R<int>)", "r3").WithLocation(16, 20),
                 // (16,28): error CS8168: Cannot return local 'r' by reference because it is not a ref local
-                //         return ref F3A(ref r); // 2
+                //         return ref F3A(ref r); // 1
                 Diagnostic(ErrorCode.ERR_RefReturnLocal, "r").WithArguments("r").WithLocation(16, 28),
                 // (21,20): error CS8347: Cannot use a result of 'A<int>.F4A(ref R<int>)' in this context because it may expose variables referenced by parameter 'r4' outside of their declaration scope
-                //         return ref F4A(ref r); // 3
+                //         return ref F4A(ref r); // 2
                 Diagnostic(ErrorCode.ERR_EscapeCall, "F4A(ref r)").WithArguments("A<int>.F4A(ref R<int>)", "r4").WithLocation(21, 20),
                 // (21,28): error CS8168: Cannot return local 'r' by reference because it is not a ref local
-                //         return ref F4A(ref r); // 3
+                //         return ref F4A(ref r); // 2
                 Diagnostic(ErrorCode.ERR_RefReturnLocal, "r").WithArguments("r").WithLocation(21, 28));
         }
 
@@ -14055,8 +14241,13 @@ class B2 : A<int>
 }
 ";
             var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
-            // https://github.com/dotnet/roslyn/issues/62691: Expected errors should be reported when 'ref R<T>' is considered 'scoped ref'.
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (17,28): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
+                //     internal override void F1([UnscopedRef] ref R<int> r) { } // 1
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("r").WithLocation(17, 28),
+                // (18,28): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
+                //     internal override void F2(ref R<int> r) { } // 2
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(18, 28));
         }
 
         [Fact]
@@ -14192,8 +14383,20 @@ class C4 : I<object>
 }
 ";
             var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
-            // https://github.com/dotnet/roslyn/issues/62691: Expected errors should be reported when 'ref R<T>' is considered 'scoped ref'.
-            comp.VerifyDiagnostics();
+            // PROTOTYPE: Expected errors should be reported when 'ref R<T>' is considered 'scoped ref'.
+            comp.VerifyDiagnostics(
+                // (17,17): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
+                //     public void F1([UnscopedRef] ref R<int> r) { } // 1
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("r").WithLocation(17, 17),
+                // (18,17): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
+                //     public void F2(ref R<int> r) { } // 2
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(18, 17),
+                // (27,20): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
+                //     void I<object>.F1([UnscopedRef] ref R<object> r) { } // 3
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("r").WithLocation(27, 20),
+                // (28,20): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
+                //     void I<object>.F2(ref R<object> r) { } // 4
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(28, 20));
         }
 
         [Fact]
@@ -14288,8 +14491,13 @@ class Program
     }
 }";
             var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
-            // https://github.com/dotnet/roslyn/issues/62691: Expected errors should be reported when 'ref R<T>' is considered 'scoped ref'.
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (11,14): error CS8986: The 'scoped' modifier of parameter 'r2' doesn't match target 'D1<int>'.
+                //         d1 = ([UnscopedRef] ref R<int> r2) => { }; // 1
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "([UnscopedRef] ref R<int> r2) => { }").WithArguments("r2", "D1<int>").WithLocation(11, 14),
+                // (13,14): error CS8986: The 'scoped' modifier of parameter 'r1' doesn't match target 'D2<object>'.
+                //         d2 = (ref R<object> r1) => { }; // 2
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfTarget, "(ref R<object> r1) => { }").WithArguments("r1", "D2<object>").WithLocation(13, 14));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -4296,7 +4296,7 @@ public unsafe class C
         [WorkItem(27772, "https://github.com/dotnet/roslyn/issues/27772")]
         public void RefReturnInvocationOfRefLikeTypeRefResult()
         {
-            CreateCompilationWithMscorlibAndSpan(@"
+            string source = @"
 class C
 {
     public ref long M(S receiver)
@@ -4318,20 +4318,38 @@ class C
 ref struct S
 {
     public ref long M(ref long x) => ref x;
-}").VerifyDiagnostics(
+}";
+
+            var comp = CreateCompilationWithMscorlibAndSpan(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(
                 // (8,20): error CS8157: Cannot return 'y' by reference because it was initialized to a value that cannot be returned by reference
                 //         return ref y;
                 Diagnostic(ErrorCode.ERR_RefReturnNonreturnableLocal, "y").WithArguments("y").WithLocation(8, 20),
                 // (16,24): error CS8157: Cannot return 'y' by reference because it was initialized to a value that cannot be returned by reference
                 //             return ref y;
                 Diagnostic(ErrorCode.ERR_RefReturnNonreturnableLocal, "y").WithArguments("y").WithLocation(16, 24));
+
+            comp = CreateCompilationWithMscorlibAndSpan(source);
+            comp.VerifyDiagnostics(
+                // (7,26): error CS8350: This combination of arguments to 'S.M(ref long)' is disallowed because it may expose variables referenced by parameter 'x' outside of their declaration scope
+                //         ref long y = ref receiver.M(ref x);
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "receiver.M(ref x)").WithArguments("S.M(ref long)", "x").WithLocation(7, 26),
+                // (7,41): error CS8168: Cannot return local 'x' by reference because it is not a ref local
+                //         ref long y = ref receiver.M(ref x);
+                Diagnostic(ErrorCode.ERR_RefReturnLocal, "x").WithArguments("x").WithLocation(7, 41),
+                // (15,30): error CS8350: This combination of arguments to 'S.M(ref long)' is disallowed because it may expose variables referenced by parameter 'x' outside of their declaration scope
+                //             ref long y = ref receiver.M(ref x);
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "receiver.M(ref x)").WithArguments("S.M(ref long)", "x").WithLocation(15, 30),
+                // (15,45): error CS8168: Cannot return local 'x' by reference because it is not a ref local
+                //             ref long y = ref receiver.M(ref x);
+                Diagnostic(ErrorCode.ERR_RefReturnLocal, "x").WithArguments("x").WithLocation(15, 45));
         }
 
         [Fact]
         [WorkItem(27772, "https://github.com/dotnet/roslyn/issues/27772")]
         public void RefReturnInvocationOfRefLikeTypeRefResult_Repro()
         {
-            CreateCompilationWithMscorlibAndSpan(@"
+            string source = @"
 using System;
 class C
 {
@@ -4366,10 +4384,23 @@ class C
 ref struct S
 {
   public ref long M(ref long x) => ref x;
-}").VerifyDiagnostics(
+}";
+
+            var comp = CreateCompilationWithMscorlibAndSpan(source, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(
                 // (19,18): error CS8157: Cannot return 'z' by reference because it was initialized to a value that cannot be returned by reference
                 //       return ref z;
                 Diagnostic(ErrorCode.ERR_RefReturnNonreturnableLocal, "z").WithArguments("z").WithLocation(19, 18));
+
+            // Breaking change in C#11: Instance method on ref struct instance may capture unscoped ref or in arguments.
+            comp = CreateCompilationWithMscorlibAndSpan(source);
+            comp.VerifyDiagnostics(
+                // (18,23): error CS8350: This combination of arguments to 'S.M(ref long)' is disallowed because it may expose variables referenced by parameter 'x' outside of their declaration scope
+                //       ref var z = ref receiver.M(ref y);
+                Diagnostic(ErrorCode.ERR_CallArgMixing, "receiver.M(ref y)").WithArguments("S.M(ref long)", "x").WithLocation(18, 23),
+                // (18,38): error CS8157: Cannot return 'y' by reference because it was initialized to a value that cannot be returned by reference
+                //       ref var z = ref receiver.M(ref y);
+                Diagnostic(ErrorCode.ERR_RefReturnNonreturnableLocal, "y").WithArguments("y").WithLocation(18, 38));
         }
 
         [Fact, WorkItem(49617, "https://github.com/dotnet/roslyn/issues/49617")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
@@ -1477,19 +1477,10 @@ class C
         return ref x;
     }
 }";
-            var comp = CreateCompilationWithMscorlibAndSpan(new[] { source, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            var comp = CreateCompilationWithMscorlibAndSpan(new[] { source, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 10
 10");
-
-            comp = CreateCompilationWithMscorlibAndSpan(source);
-            comp.VerifyDiagnostics(
-                // (16,20): error CS8157: Cannot return 'q' by reference because it was initialized to a value that cannot be returned by reference
-                //         return ref q;
-                Diagnostic(ErrorCode.ERR_RefReturnNonreturnableLocal, "q").WithArguments("q").WithLocation(16, 20),
-                // (21,20): error CS8166: Cannot return a parameter by reference 'x' because it is not a ref parameter
-                //         return ref x;
-                Diagnostic(ErrorCode.ERR_RefReturnParameter, "x").WithArguments("x").WithLocation(21, 20));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/Utf8StringsLiteralsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/Utf8StringsLiteralsTests.cs
@@ -3548,8 +3548,8 @@ class C
         [Fact]
         public void PassAround_02()
         {
-            var source = @"
-using System;
+            var source = @"using System;
+using System.Diagnostics.CodeAnalysis;
 class C
 {
     static ref readonly ReadOnlySpan<byte> Test2()
@@ -3557,10 +3557,10 @@ class C
         return ref Test3(""cat""u8);
     }
 
-    static ref readonly ReadOnlySpan<byte> Test3(in ReadOnlySpan<byte> x) => ref x;
+    static ref readonly ReadOnlySpan<byte> Test3([UnscopedRef] in ReadOnlySpan<byte> x) => ref x;
 }
 ";
-            var comp = CreateCompilation(source + HelpersSource, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.DebugDll);
+            var comp = CreateCompilation(new[] { source + HelpersSource, UnscopedRefAttributeDefinition }, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.DebugDll);
 
             comp.VerifyDiagnostics(
                 // (7,20): error CS8347: Cannot use a result of 'C.Test3(in ReadOnlySpan<byte>)' in this context because it may expose variables referenced by parameter 'x' outside of their declaration scope

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -8239,7 +8239,7 @@ class Program
                 "void Program.F(scoped R r1, R r2, R r3)");
 
             Verify(method.ToDisplayParts(formatTypeRefAndScoped),
-                "void Program.F(scoped R r1, ref R r2, scoped in R r3)", // PROTOTYPE: Should drop scoped from r3.
+                "void Program.F(scoped R r1, ref R r2, in R r3)",
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.ClassName,
@@ -8259,8 +8259,6 @@ class Program
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.ParameterName,
                 SymbolDisplayPartKind.Punctuation,
-                SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
@@ -8294,7 +8292,7 @@ delegate void D(scoped R r1, scoped ref R r2, scoped in R r3);
                 "delegate void D(scoped R r1, R r2, R r3)");
 
             Verify(delegateType.ToDisplayParts(formatTypeRefAndScoped),
-                "delegate void D(scoped R r1, ref R r2, scoped in R r3)"); // PROTOTYPE: Should drop scoped from r3.
+                "delegate void D(scoped R r1, ref R r2, in R r3)");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -8196,7 +8196,7 @@ ref struct S<T>
 @"ref struct R { }
 class Program
 {
-    static void F(scoped R r1, scoped ref R r3) { }
+    static void F(scoped R r1, scoped ref R r2, scoped in R r3) { }
 }";
 
             var comp = CreateCompilation(source);
@@ -8209,13 +8209,20 @@ class Program
             var formatTypeRefAndScoped = formatTypeOnly.AddParameterOptions(SymbolDisplayParameterOptions.IncludeParamsRefOut).WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.IncludeScoped); ;
 
             Verify(method.ToDisplayParts(formatTypeAndRef),
-                "void Program.F(R r1, ref R r3)",
+                "void Program.F(R r1, ref R r2, in R r3)",
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.ClassName,
                 SymbolDisplayPartKind.Punctuation,
                 SymbolDisplayPartKind.MethodName,
                 SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.StructName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.StructName,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.ParameterName,
@@ -8229,16 +8236,23 @@ class Program
                 SymbolDisplayPartKind.Punctuation);
 
             Verify(method.ToDisplayParts(formatTypeAndScoped),
-                "void Program.F(scoped R r1, R r3)");
+                "void Program.F(scoped R r1, R r2, R r3)");
 
             Verify(method.ToDisplayParts(formatTypeRefAndScoped),
-                "void Program.F(scoped R r1, scoped ref R r3)",
+                "void Program.F(scoped R r1, ref R r2, scoped in R r3)", // PROTOTYPE: Should drop scoped from r3.
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.ClassName,
                 SymbolDisplayPartKind.Punctuation,
                 SymbolDisplayPartKind.MethodName,
                 SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.StructName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.StructName,
@@ -8261,7 +8275,7 @@ class Program
         {
             var source =
 @"ref struct R { }
-delegate void D(scoped R r1, scoped ref R r3);
+delegate void D(scoped R r1, scoped ref R r2, scoped in R r3);
 ";
 
             var comp = CreateCompilation(source);
@@ -8274,13 +8288,13 @@ delegate void D(scoped R r1, scoped ref R r3);
             var formatTypeRefAndScoped = formatTypeOnly.AddParameterOptions(SymbolDisplayParameterOptions.IncludeParamsRefOut).WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.IncludeScoped);
 
             Verify(delegateType.ToDisplayParts(formatTypeAndRef),
-                "delegate void D(R r1, ref R r3)");
+                "delegate void D(R r1, ref R r2, in R r3)");
 
             Verify(delegateType.ToDisplayParts(formatTypeAndScoped),
-                "delegate void D(scoped R r1, R r3)");
+                "delegate void D(scoped R r1, R r2, R r3)");
 
             Verify(delegateType.ToDisplayParts(formatTypeRefAndScoped),
-                "delegate void D(scoped R r1, scoped ref R r3)");
+                "delegate void D(scoped R r1, ref R r2, scoped in R r3)"); // PROTOTYPE: Should drop scoped from r3.
         }
 
         [Fact]

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -2235,7 +2235,7 @@ namespace System.Diagnostics.CodeAnalysis
             return comp;
         }
 
-        protected static CSharpCompilation CreateCompilationWithMscorlibAndSpan(string text, CSharpCompilationOptions options = null, CSharpParseOptions parseOptions = null)
+        protected static CSharpCompilation CreateCompilationWithMscorlibAndSpan(CSharpTestSource text, CSharpCompilationOptions options = null, CSharpParseOptions parseOptions = null)
         {
             var reference = CreateEmptyCompilation(
                 SpanSource,


### PR DESCRIPTION
Updates the implementation of escape analysis rules for method invocation to match the recent spec changes - see #62791.

The updated rules are in effect when compiling with a corlib that includes `System.Runtime.CompilerServices.RuntimeFeature.ByRefFields`, or when compiling with `-langversion:11` or higher.

[Method invocation](https://github.com/dotnet/csharplang/blob/main/proposals/low-level-struct-improvements.md#rules-method-invocation):

> For a given argument `a` that is passed to parameter `p`:
> 
> > 1. If `p` is `scoped ref` then `a` does not contribute *ref-safe-to-escape* when considering arguments.
> > 2. If `p` is `scoped` then `a` does not contribute *safe-to-escape* when considering arguments. 

> > A value resulting from a method invocation `e1.M(e2, ...)` is *safe-to-escape* from the smallest of the following scopes:
> > 1. The *calling method*
> > 2. The *safe-to-escape* contributed by all argument expressions
> > 3. When the return is a `ref struct` then *ref-safe-to-escape* contributed by all `ref` arguments

> > A value resulting from a method invocation `ref e1.M(e2, ...)` is *ref-safe-to-escape* the smallest of the following scopes:
> > 1. The *safe-to-escape* of the rvalue of `e1.M(e2, ...)`
> > 2. The *ref-safe-to-escape* contributed by all `ref` arguments

[Method arguments must match](https://github.com/dotnet/csharplang/blob/main/proposals/low-level-struct-improvements.md#rules-method-arguments-must-match):

> > For any method invocation `e.M(a1, a2, ... aN)`
> > 1. Calculate the *safe-to-escape* of the method return (for this rule assume it has a `ref struct` return type)
> > 2. All `ref` or `out` arguments of `ref struct` types must be assignable by a value with that *safe-to-escape*. This applies even when the `ref` argument matches a `scoped ref` parameter.


The PR also includes a change to treat `ref` parameters to `ref struct` types as `scoped ref` by default - see #62691.


Fixes #62791
Fixes #62691
Fixes #63016