### PR TITLE
Features/decon switch target typing

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/SwitchExpressionBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchExpressionBinder.cs
@@ -288,18 +288,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             // We found null assigned to the value,
                             // so we might try recursing for the type's nullable counterpart
-                            //       Ideally this should be handled from the conversions part, so
-                            // TODO: toggle the lines if need be
-                            //if (tupleArgumentsWithNullLiteral[tupleArgumentIndex])
-                            //{
-                            //    var nullableType = Compilation.GetTypeByMetadataName("System.Nullable`1");
-                            //    //nullableType.TypeSubstitution.SubstituteType()
-                            //    //{
-                            //    //    types
-                            //    //}
-                            //    tupleNestedTypes[tupleArgumentIndex] = orderedType;
-                            //    recurseForTypes(tupleArgumentIndex + 1);
-                            //}
+                            // There is the possibility this could be handled from the conversions
+
+                            if (tupleArgumentsWithNullLiteral[tupleArgumentIndex])
+                            {
+                                var nullableOrderedType = Compilation.GetSpecialType(SpecialType.System_Nullable_T).Construct(orderedType);
+                                tupleNestedTypes[tupleArgumentIndex] = nullableOrderedType;
+                                recurseForTypes(tupleArgumentIndex + 1);
+                            }
                         }
                     }
                 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -671,4 +671,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
     }
+
+    internal partial class BoundTupleLiteral
+    {
+        internal BoundTupleLiteral WithArguments(ImmutableArray<BoundExpression> arguments)
+        {
+            return new BoundTupleLiteral(Syntax, arguments, ArgumentNamesOpt, InferredNamesOpt, Type, HasErrors);
+        }
+    }
 }

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6797,4 +6797,10 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_SimpleProgramIsEmpty" xml:space="preserve">
     <value>At least one top-level statement must be non-empty.</value>
   </data>
+  <data name="ERR_SwitchExpressionInferTupleTypeElementCountMismatch" xml:space="preserve">
+    <value>Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</value>
+  </data>
+  <data name="ERR_SwitchExpressionInferTupleTypeElementCountMismatch_Title" xml:space="preserve">
+    <value>Inconsistent tuple element counts returned in the switch expression.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1984,6 +1984,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #endregion
 
+        #region diagnostics introduced for C# 11.0
+
+        ERR_SwitchExpressionInferTupleTypeElementCountMismatch = 9100,
+
+        #endregion
+
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)
     }
 }

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1117,6 +1117,16 @@
         <target state="translated">Případ příkazu switch není dostupný. Už se zpracoval v jiném případu nebo není možné pro něj najít shodu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch">
+        <source>Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</source>
+        <target state="new">Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch_Title">
+        <source>Inconsistent tuple element counts returned in the switch expression.</source>
+        <target state="new">Inconsistent tuple element counts returned in the switch expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_SwitchExpressionNoBestType">
         <source>No best type was found for the switch expression.</source>
         <target state="translated">Pro výraz switch se nenašel žádný optimální typ.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1117,6 +1117,16 @@
         <target state="translated">Der Switch-Case kann nicht erreicht werden. Er wurde bereits von einem vorherigen Fall behandelt, oder es ist keine Übereinstimmung möglich.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch">
+        <source>Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</source>
+        <target state="new">Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch_Title">
+        <source>Inconsistent tuple element counts returned in the switch expression.</source>
+        <target state="new">Inconsistent tuple element counts returned in the switch expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_SwitchExpressionNoBestType">
         <source>No best type was found for the switch expression.</source>
         <target state="translated">Es wurde kein optimaler Typ für den switch-Ausdruck gefunden.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1117,6 +1117,16 @@
         <target state="translated">No se puede acceder a switch case. Ya se ha administrado con un caso anterior o no se puede hacer coincidir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch">
+        <source>Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</source>
+        <target state="new">Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch_Title">
+        <source>Inconsistent tuple element counts returned in the switch expression.</source>
+        <target state="new">Inconsistent tuple element counts returned in the switch expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_SwitchExpressionNoBestType">
         <source>No best type was found for the switch expression.</source>
         <target state="translated">No se encontró el mejor tipo para la expresión switch.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1117,6 +1117,16 @@
         <target state="translated">L'instruction switch case est inaccessible. Elle a déjà été traitée par un cas précédent ou la mise en correspondance est impossible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch">
+        <source>Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</source>
+        <target state="new">Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch_Title">
+        <source>Inconsistent tuple element counts returned in the switch expression.</source>
+        <target state="new">Inconsistent tuple element counts returned in the switch expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_SwitchExpressionNoBestType">
         <source>No best type was found for the switch expression.</source>
         <target state="translated">Il n'existe aucun meilleur type pour l'expression switch.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1117,6 +1117,16 @@
         <target state="translated">Lo switch case on è raggiungibile. È già stato gestito da un case precedente oppure non è possibile trovare una corrispondenza.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch">
+        <source>Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</source>
+        <target state="new">Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch_Title">
+        <source>Inconsistent tuple element counts returned in the switch expression.</source>
+        <target state="new">Inconsistent tuple element counts returned in the switch expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_SwitchExpressionNoBestType">
         <source>No best type was found for the switch expression.</source>
         <target state="translated">Non è stato trovato alcun tipo ottimale per l'espressione switch.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1117,6 +1117,16 @@
         <target state="translated">switch ケースに到達できません。以前のケースで既に処理されたか、一致させることができません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch">
+        <source>Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</source>
+        <target state="new">Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch_Title">
+        <source>Inconsistent tuple element counts returned in the switch expression.</source>
+        <target state="new">Inconsistent tuple element counts returned in the switch expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_SwitchExpressionNoBestType">
         <source>No best type was found for the switch expression.</source>
         <target state="translated">switch 式に最適な型が見つかりませんでした。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1117,6 +1117,16 @@
         <target state="translated">switch case에 연결할 수 없습니다. 이전 사례에서 이미 처리되었거나 일치시킬 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch">
+        <source>Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</source>
+        <target state="new">Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch_Title">
+        <source>Inconsistent tuple element counts returned in the switch expression.</source>
+        <target state="new">Inconsistent tuple element counts returned in the switch expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_SwitchExpressionNoBestType">
         <source>No best type was found for the switch expression.</source>
         <target state="translated">switch 식에 적합한 형식이 없습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1117,6 +1117,16 @@
         <target state="translated">Przypadek switch jest nieosiągalny. Został on już obsłużony przez poprzednią instrukcję case albo nie można go dopasować.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch">
+        <source>Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</source>
+        <target state="new">Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch_Title">
+        <source>Inconsistent tuple element counts returned in the switch expression.</source>
+        <target state="new">Inconsistent tuple element counts returned in the switch expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_SwitchExpressionNoBestType">
         <source>No best type was found for the switch expression.</source>
         <target state="translated">Nie znaleziono najlepszego typu dla wyrażenia switch.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1117,6 +1117,16 @@
         <target state="translated">O caso do comutador não está acessível. Ele já foi manipulado por um caso anterior ou não é possível fazer a correspondência.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch">
+        <source>Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</source>
+        <target state="new">Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch_Title">
+        <source>Inconsistent tuple element counts returned in the switch expression.</source>
+        <target state="new">Inconsistent tuple element counts returned in the switch expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_SwitchExpressionNoBestType">
         <source>No best type was found for the switch expression.</source>
         <target state="translated">Não foi encontrado um tipo melhor para a expressão switch.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1117,6 +1117,16 @@
         <target state="translated">Блок выражения switch case является недоступным. Он уже был обработан в предыдущем блоке или условие для него не может быть выполнено.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch">
+        <source>Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</source>
+        <target state="new">Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch_Title">
+        <source>Inconsistent tuple element counts returned in the switch expression.</source>
+        <target state="new">Inconsistent tuple element counts returned in the switch expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_SwitchExpressionNoBestType">
         <source>No best type was found for the switch expression.</source>
         <target state="translated">Не удалось найти лучший тип для выражения switch.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1117,6 +1117,16 @@
         <target state="translated">switch case'e ulaşılamıyor. Önceki bir case tarafından zaten işlenmiş ya da eşleştirilmesi mümkün değil.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch">
+        <source>Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</source>
+        <target state="new">Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch_Title">
+        <source>Inconsistent tuple element counts returned in the switch expression.</source>
+        <target state="new">Inconsistent tuple element counts returned in the switch expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_SwitchExpressionNoBestType">
         <source>No best type was found for the switch expression.</source>
         <target state="translated">Switch deyimi için en iyi tür bulunamadı.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1117,6 +1117,16 @@
         <target state="translated">该 switch case 不可访问。它已由上一 case 处理或无法匹配。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch">
+        <source>Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</source>
+        <target state="new">Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch_Title">
+        <source>Inconsistent tuple element counts returned in the switch expression.</source>
+        <target state="new">Inconsistent tuple element counts returned in the switch expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_SwitchExpressionNoBestType">
         <source>No best type was found for the switch expression.</source>
         <target state="translated">没有为 switch 表达式找到最佳类型。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1117,6 +1117,16 @@
         <target state="translated">無法使用此 switch 案例。switch 運算式的上一個 arm 已處理了此樣式，或其無法比對。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch">
+        <source>Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</source>
+        <target state="new">Failed to infer the correct tuple type in the switch expression; inconsistent tuple element counts returned from different arms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_SwitchExpressionInferTupleTypeElementCountMismatch_Title">
+        <source>Inconsistent tuple element counts returned in the switch expression.</source>
+        <target state="new">Inconsistent tuple element counts returned in the switch expression.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_SwitchExpressionNoBestType">
         <source>No best type was found for the switch expression.</source>
         <target state="translated">找不到 switch 運算式的最佳類型。</target>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -9685,73 +9685,75 @@ public class C
 
             verifier.VerifyIL("C.Main", @"
 {
-  // Code size      144 (0x90)
+  // Code size      115 (0x73)
   .maxstack  2
-  .locals init (int V_0, //expr
-                System.ValueTuple<int?, string> V_1,
-                int? V_2,
-                System.ValueTuple<int?, string> V_3)
-  IL_0000:  ldc.i4.1
+  .locals init (int V_0, //i
+                int V_1, //value
+                System.ValueTuple<int, string> V_2,
+                System.ValueTuple<int, string> V_3,
+                System.ValueTuple<int, string> V_4)
+  IL_0000:  ldc.i4.0
   IL_0001:  stloc.0
-  IL_0002:  ldloc.0
-  IL_0003:  ldc.i4.1
-  IL_0004:  sub
-  IL_0005:  switch    (
-        IL_0024,
-        IL_0033,
-        IL_0049,
-        IL_005b,
-        IL_006d,
-        IL_007f)
-  IL_0022:  br.s       IL_008b
-  IL_0024:  ldc.i4.1
-  IL_0025:  newobj     ""int?..ctor(int)""
-  IL_002a:  ldnull
-  IL_002b:  newobj     ""System.ValueTuple<int?, string>..ctor(int?, string)""
-  IL_0030:  stloc.1
-  IL_0031:  br.s       IL_008d
-  IL_0033:  ldloca.s   V_2
-  IL_0035:  initobj    ""int?""
-  IL_003b:  ldloc.2
-  IL_003c:  ldstr      ""another""
-  IL_0041:  newobj     ""System.ValueTuple<int?, string>..ctor(int?, string)""
-  IL_0046:  stloc.1
-  IL_0047:  br.s       IL_008d
-  IL_0049:  ldloca.s   V_2
-  IL_004b:  initobj    ""int?""
-  IL_0051:  ldloc.2
-  IL_0052:  ldnull
-  IL_0053:  newobj     ""System.ValueTuple<int?, string>..ctor(int?, string)""
-  IL_0058:  stloc.1
-  IL_0059:  br.s       IL_008d
-  IL_005b:  ldloca.s   V_2
-  IL_005d:  initobj    ""int?""
-  IL_0063:  ldloc.2
-  IL_0064:  ldnull
-  IL_0065:  newobj     ""System.ValueTuple<int?, string>..ctor(int?, string)""
-  IL_006a:  stloc.1
-  IL_006b:  br.s       IL_008d
-  IL_006d:  ldloca.s   V_2
-  IL_006f:  initobj    ""int?""
-  IL_0075:  ldloc.2
-  IL_0076:  ldnull
-  IL_0077:  newobj     ""System.ValueTuple<int?, string>..ctor(int?, string)""
-  IL_007c:  stloc.1
-  IL_007d:  br.s       IL_008d
-  IL_007f:  ldloca.s   V_3
-  IL_0081:  initobj    ""System.ValueTuple<int?, string>""
-  IL_0087:  ldloc.3
-  IL_0088:  stloc.1
-  IL_0089:  br.s       IL_008d
-  IL_008b:  ldnull
-  IL_008c:  throw
-  IL_008d:  ldloc.1
-  IL_008e:  pop
-  IL_008f:  ret
+  IL_0002:  ldc.i4.2
+  IL_0003:  stloc.1
+  IL_0004:  ldloc.1
+  IL_0005:  ldc.i4.1
+  IL_0006:  beq.s      IL_000e
+  IL_0008:  ldloc.1
+  IL_0009:  ldc.i4.2
+  IL_000a:  beq.s      IL_0018
+  IL_000c:  br.s       IL_0067
+  IL_000e:  ldc.i4.1
+  IL_000f:  ldnull
+  IL_0010:  newobj     ""System.ValueTuple<int, string>..ctor(int, string)""
+  IL_0015:  stloc.2
+  IL_0016:  br.s       IL_0069
+  IL_0018:  ldloc.0
+  IL_0019:  ldc.i4.1
+  IL_001a:  sub
+  IL_001b:  switch    (
+        IL_0032,
+        IL_003c,
+        IL_004a,
+        IL_0054)
+  IL_0030:  br.s       IL_0061
+  IL_0032:  ldc.i4.2
+  IL_0033:  ldnull
+  IL_0034:  newobj     ""System.ValueTuple<int, string>..ctor(int, string)""
+  IL_0039:  stloc.3
+  IL_003a:  br.s       IL_0063
+  IL_003c:  ldc.i4.0
+  IL_003d:  ldstr      ""ex""
+  IL_0042:  newobj     ""System.ValueTuple<int, string>..ctor(int, string)""
+  IL_0047:  stloc.3
+  IL_0048:  br.s       IL_0063
+  IL_004a:  ldc.i4.0
+  IL_004b:  ldnull
+  IL_004c:  newobj     ""System.ValueTuple<int, string>..ctor(int, string)""
+  IL_0051:  stloc.3
+  IL_0052:  br.s       IL_0063
+  IL_0054:  ldloca.s   V_4
+  IL_0056:  initobj    ""System.ValueTuple<int, string>""
+  IL_005c:  ldloc.s    V_4
+  IL_005e:  stloc.3
+  IL_005f:  br.s       IL_0063
+  IL_0061:  ldnull
+  IL_0062:  throw
+  IL_0063:  ldloc.3
+  IL_0064:  stloc.2
+  IL_0065:  br.s       IL_0069
+  IL_0067:  ldnull
+  IL_0068:  throw
+  IL_0069:  ldloc.2
+  IL_006a:  dup
+  IL_006b:  ldfld      ""int System.ValueTuple<int, string>.Item1""
+  IL_0070:  stloc.0
+  IL_0071:  pop
+  IL_0072:  ret
 }
 ");
         }
-        
+
         [Fact]
         public void AssigningConditional_OutParams()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -9534,6 +9534,110 @@ public class C
 ");
         }
 
+        [Fact, WorkItem(1394, "https://github.com/dotnet/csharplang/issues/1394")]
+        public void TestDeconstructSwitchInferredNullableIntTarget()
+        {
+            string source = @"
+public class C
+{
+    public static void Main()
+    {
+        int expr = 1;
+        
+        var (i, d) = expr switch
+        {
+            1 => (1, null),
+            2 => (default, ""another""),
+            3 => (null, default),
+            4 => (default, null),
+            5 => (null, null),
+            6 => default,
+            _ => throw null,
+        };
+    }
+}
+";
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp);
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var switchExpression = tree.GetRoot().DescendantNodes().OfType<SwitchExpressionSyntax>().First();
+
+            var resultingType = model.GetTypeInfo(switchExpression);
+            Assert.Equal("(System.Int32?, System.String)", resultingType.Type.ToTestDisplayString());
+            Assert.Equal("(System.Int32?, System.String)", resultingType.ConvertedType.ToTestDisplayString());
+
+            verifier.VerifyIL("C.Main", @"
+{
+  // Code size      144 (0x90)
+  .maxstack  2
+  .locals init (int V_0, //expr
+                System.ValueTuple<int?, string> V_1,
+                int? V_2,
+                System.ValueTuple<int?, string> V_3)
+  IL_0000:  ldc.i4.1
+  IL_0001:  stloc.0
+  IL_0002:  ldloc.0
+  IL_0003:  ldc.i4.1
+  IL_0004:  sub
+  IL_0005:  switch    (
+        IL_0024,
+        IL_0033,
+        IL_0049,
+        IL_005b,
+        IL_006d,
+        IL_007f)
+  IL_0022:  br.s       IL_008b
+  IL_0024:  ldc.i4.1
+  IL_0025:  newobj     ""int?..ctor(int)""
+  IL_002a:  ldnull
+  IL_002b:  newobj     ""System.ValueTuple<int?, string>..ctor(int?, string)""
+  IL_0030:  stloc.1
+  IL_0031:  br.s       IL_008d
+  IL_0033:  ldloca.s   V_2
+  IL_0035:  initobj    ""int?""
+  IL_003b:  ldloc.2
+  IL_003c:  ldstr      ""another""
+  IL_0041:  newobj     ""System.ValueTuple<int?, string>..ctor(int?, string)""
+  IL_0046:  stloc.1
+  IL_0047:  br.s       IL_008d
+  IL_0049:  ldloca.s   V_2
+  IL_004b:  initobj    ""int?""
+  IL_0051:  ldloc.2
+  IL_0052:  ldnull
+  IL_0053:  newobj     ""System.ValueTuple<int?, string>..ctor(int?, string)""
+  IL_0058:  stloc.1
+  IL_0059:  br.s       IL_008d
+  IL_005b:  ldloca.s   V_2
+  IL_005d:  initobj    ""int?""
+  IL_0063:  ldloc.2
+  IL_0064:  ldnull
+  IL_0065:  newobj     ""System.ValueTuple<int?, string>..ctor(int?, string)""
+  IL_006a:  stloc.1
+  IL_006b:  br.s       IL_008d
+  IL_006d:  ldloca.s   V_2
+  IL_006f:  initobj    ""int?""
+  IL_0075:  ldloc.2
+  IL_0076:  ldnull
+  IL_0077:  newobj     ""System.ValueTuple<int?, string>..ctor(int?, string)""
+  IL_007c:  stloc.1
+  IL_007d:  br.s       IL_008d
+  IL_007f:  ldloca.s   V_3
+  IL_0081:  initobj    ""System.ValueTuple<int?, string>""
+  IL_0087:  ldloc.3
+  IL_0088:  stloc.1
+  IL_0089:  br.s       IL_008d
+  IL_008b:  ldnull
+  IL_008c:  throw
+  IL_008d:  ldloc.1
+  IL_008e:  pop
+  IL_008f:  ret
+}
+");
+        }
+
         [Fact]
         public void AssigningConditional_OutParams()
         {


### PR DESCRIPTION
This implements target-typing, deconstructing and inferring tuple types in a switch expression. As per dotnet/csharplang#1394, this feature was laid back until this scenario was covered.

@jcouv (made the comment)

**NOTES:**
- Added a new error diagnostic for the case that tuple cardinalities do not match
- The term "cardinality" is being used to refer to the element count of a tuple, but could always change if need be
- The error message is subject to change