### PR TITLE
Renamed `ShouldShowItemsFromUnimportNamspaces` to `ShouldShowItemsFromUnimportedNamespaces`

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
                 var sessionData = CompletionSessionData.GetOrCreateSessionData(session);
 
-                if (!options.ShouldShowItemsFromUnimportNamspaces())
+                if (!options.ShouldShowItemsFromUnimportedNamespaces())
                 {
                     // No need to trigger expanded providers at all if the feature is disabled, just trigger core providers and return;
                     var (context, list) = await GetCompletionContextWorkerAsync(document, trigger, triggerLocation,

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// This takes into consideration the experiment we are running in addition to the value
         /// from user facing options.
         /// </summary>
-        public bool ShouldShowItemsFromUnimportNamspaces()
+        public bool ShouldShowItemsFromUnimportedNamespaces()
         {
             // Don't trigger import completion if the option value is "default" and the experiment is disabled for the user. 
             return ShowItemsFromUnimportedNamespaces ?? TypeImportCompletion;

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public override async Task ProvideCompletionsAsync(CompletionContext completionContext)
         {
-            if (!completionContext.CompletionOptions.ShouldShowItemsFromUnimportNamspaces())
+            if (!completionContext.CompletionOptions.ShouldShowItemsFromUnimportedNamespaces())
                 return;
 
             var cancellationToken = completionContext.CancellationToken;


### PR DESCRIPTION
Fixes #62177

Renamed `ShouldShowItemsFromUnimportNamspaces` to `ShouldShowItemsFromUnimportedNamespaces`