### PR TITLE
Single-thread crossgen InteractiveHost64 for determinism build

### DIFF
--- a/src/Interactive/HostProcess/InteractiveHost64.csproj
+++ b/src/Interactive/HostProcess/InteractiveHost64.csproj
@@ -12,6 +12,7 @@
 
     <!-- Publishing (only precompile binaries when building on CI to avoid slowing down dev builds by ~10s) -->
     <PublishReadyToRun Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</PublishReadyToRun>
+    <PublishReadyToRunCrossgen2ExtraArgs Condition="'$(DebugDeterminism)' == 'true' and '$(PublishReadyToRun)' == 'true'">--parallelism:1</PublishReadyToRunCrossgen2ExtraArgs>
     <SelfContained>false</SelfContained>    
     <PublishDocumentationFiles>false</PublishDocumentationFiles>
   </PropertyGroup>


### PR DESCRIPTION
We saw [determinism failure](https://dev.azure.com/dnceng/public/_build/results?buildId=1901006&view=logs&jobId=057c83a9-93f9-5bce-4899-deb8d06fc190&j=057c83a9-93f9-5bce-4899-deb8d06fc190&t=c5bfdee9-9599-5edf-2f50-077f25ca809b) caused by comparing R2R image of InteractiveHost64, which we suspect might be caused by compiling R2R image in parallel. 

We'd need to determine what we want to do with R2R images in terms of determinism, should we:
1. use single thread crossgen to achieve determinism for all our build?
2. or only single thread crossgen for determinism CI leg?
3. or exclude r2r iamge from determinism CI?	
4. or soemthing else?

Meanwhile, this change add a commandline argument for crossgen2 as a quick fix for the error:
``` 
--parallelism <arg>                         Maximum number of threads to use during compilation
```

which is passed through via [PublishReadyToRunCrossgen2ExtraArgs ](https://grep.app/search?q=Crossgen2ExtraCommandLineArgs&filter[repo][0]=dotnet/sdk)from SDK
