### PR TITLE
Do not access Workspace through HostWorkspaceServices

### DIFF
--- a/src/EditorFeatures/Core/Interactive/Completion/InteractiveCommandCompletionService.cs
+++ b/src/EditorFeatures/Core/Interactive/Completion/InteractiveCommandCompletionService.cs
@@ -22,11 +22,11 @@ namespace Microsoft.CodeAnalysis.Interactive
             }
 
             public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
-                => new InteractiveCommandCompletionService(languageServices.WorkspaceServices.Workspace);
+                => new InteractiveCommandCompletionService(languageServices.WorkspaceServices);
         }
 
-        private InteractiveCommandCompletionService(Workspace workspace)
-            : base(workspace)
+        private InteractiveCommandCompletionService(HostWorkspaceServices services)
+            : base(services)
         {
         }
 

--- a/src/EditorFeatures/Test2/IntelliSense/CompletionServiceTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CompletionServiceTests.vb
@@ -5,6 +5,7 @@
 Imports System.Composition
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
@@ -30,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
             Using workspace = TestWorkspace.Create(workspaceDefinition, composition:=composition)
                 Dim document = workspace.CurrentSolution.Projects.First.Documents.First
-                Dim completionService = New TestCompletionService(workspace)
+                Dim completionService = New TestCompletionService(workspace.Services)
 
                 Dim list = Await completionService.GetCompletionsAsync(
                     document, caretPosition:=0, CompletionOptions.Default, OptionValueSet.Empty, CompletionTrigger.Invoke)
@@ -44,8 +45,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Friend Class TestCompletionService
             Inherits CompletionService
 
-            Public Sub New(workspace As Workspace)
-                MyBase.New(workspace)
+            Public Sub New(services As HostWorkspaceServices)
+                MyBase.New(services)
             End Sub
 
             Public Overrides ReadOnly Property Language As String

--- a/src/EditorFeatures/Test2/IntelliSense/CompletionServiceTests_Exclusivitiy.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CompletionServiceTests_Exclusivitiy.vb
@@ -7,6 +7,7 @@ Imports System.Composition
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
@@ -37,7 +38,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
             Using workspace = TestWorkspace.Create(workspaceDefinition, composition:=composition)
                 Dim document = workspace.CurrentSolution.Projects.First.Documents.First
-                Dim completionService = New TestCompletionService(workspace)
+                Dim completionService = New TestCompletionService(workspace.Services)
 
                 Dim list = Await completionService.GetCompletionsAsync(
                     document, caretPosition:=0, CompletionOptions.Default, OptionValueSet.Empty, CompletionTrigger.Invoke)
@@ -52,8 +53,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Friend Class TestCompletionService
             Inherits CompletionService
 
-            Public Sub New(workspace As Workspace)
-                MyBase.New(workspace)
+            Public Sub New(services As HostWorkspaceServices)
+                MyBase.New(services)
             End Sub
 
             Public Overrides ReadOnly Property Language As String

--- a/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
+++ b/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
@@ -26,13 +26,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion
 
             [Obsolete(MefConstruction.FactoryMethodMessage, error: true)]
             public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
-                => new CSharpCompletionService(languageServices.WorkspaceServices.Workspace);
+                => new CSharpCompletionService(languageServices.WorkspaceServices);
         }
 
         private CompletionRules _latestRules = CompletionRules.Default;
 
-        private CSharpCompletionService(Workspace workspace)
-            : base(workspace)
+        private CSharpCompletionService(HostWorkspaceServices services)
+            : base(services)
         {
         }
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ImportCompletion/TypeImportCompletionServiceFactory.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ImportCompletion/TypeImportCompletionServiceFactory.cs
@@ -21,12 +21,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
-            => new CSharpTypeImportCompletionService(languageServices.WorkspaceServices.Workspace);
+            => new CSharpTypeImportCompletionService(languageServices.WorkspaceServices);
 
         private class CSharpTypeImportCompletionService : AbstractTypeImportCompletionService
         {
-            public CSharpTypeImportCompletionService(Workspace workspace)
-                : base(workspace)
+            public CSharpTypeImportCompletionService(HostWorkspaceServices services)
+                : base(services)
             {
             }
 

--- a/src/Features/CSharp/Portable/Structure/CSharpBlockStructureService.cs
+++ b/src/Features/CSharp/Portable/Structure/CSharpBlockStructureService.cs
@@ -23,12 +23,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
         }
 
         public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
-            => new CSharpBlockStructureService(languageServices.WorkspaceServices.Workspace);
+            => new CSharpBlockStructureService(languageServices.WorkspaceServices);
     }
 
     internal class CSharpBlockStructureService : BlockStructureServiceWithProviders
     {
-        public CSharpBlockStructureService(Workspace workspace) : base(workspace)
+        public CSharpBlockStructureService(HostWorkspaceServices services) : base(services)
         {
         }
 

--- a/src/Features/Core/Portable/Completion/CommonCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionService.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PatternMatching;
 using Microsoft.CodeAnalysis.Tags;
 
@@ -11,8 +12,8 @@ namespace Microsoft.CodeAnalysis.Completion
 {
     internal abstract partial class CommonCompletionService : CompletionService
     {
-        protected CommonCompletionService(Workspace workspace)
-            : base(workspace)
+        protected CommonCompletionService(HostWorkspaceServices services)
+            : base(services)
         {
         }
 

--- a/src/Features/Core/Portable/Completion/CompletionService.ProviderManager.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.ProviderManager.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 if (_lazyImportedProviders == null)
                 {
                     var language = _service.Language;
-                    var mefExporter = (IMefHostExportProvider)_service._workspace.Services.HostServices;
+                    var mefExporter = (IMefHostExportProvider)_service._services.HostServices;
 
                     var providers = ExtensionOrderer.Order(
                             mefExporter.GetExports<CompletionProvider, CompletionProviderMetadata>()

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Completion
     /// </summary>
     public abstract partial class CompletionService : ILanguageService
     {
-        private readonly Workspace _workspace;
+        private readonly HostWorkspaceServices _services;
         private readonly ProviderManager _providerManager;
 
         /// <summary>
@@ -39,9 +39,9 @@ namespace Microsoft.CodeAnalysis.Completion
         private bool _suppressPartialSemantics;
 
         // Prevent inheritance outside of Roslyn.
-        internal CompletionService(Workspace workspace)
+        internal CompletionService(HostWorkspaceServices services)
         {
-            _workspace = workspace;
+            _services = services;
             _providerManager = new(this);
         }
 
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Completion
             OptionSet? options = null)
         {
             var document = text.GetOpenDocumentInCurrentContextWithChanges();
-            var languageServices = document?.Project.LanguageServices ?? _workspace.Services.GetLanguageServices(Language);
+            var languageServices = document?.Project.LanguageServices ?? _services.GetLanguageServices(Language);
 
             // Publicly available options do not affect this API.
             var completionOptions = CompletionOptions.Default;

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
@@ -31,9 +32,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         protected abstract string Language { get; }
 
-        internal AbstractTypeImportCompletionService(Workspace workspace)
+        internal AbstractTypeImportCompletionService(HostWorkspaceServices services)
         {
-            CacheService = workspace.Services.GetRequiredService<IImportCompletionCacheService<TypeImportCompletionCacheEntry, TypeImportCompletionCacheEntry>>();
+            CacheService = services.GetRequiredService<IImportCompletionCacheService<TypeImportCompletionCacheEntry, TypeImportCompletionCacheEntry>>();
         }
 
         public void QueueCacheWarmUpTask(Project project)

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptCompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptCompletionServiceWithProviders.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PatternMatching;
 using Roslyn.Utilities;
 
@@ -13,7 +14,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
     internal abstract class VSTypeScriptCompletionServiceWithProviders : CompletionService
     {
         internal VSTypeScriptCompletionServiceWithProviders(Workspace workspace)
-            : base(workspace)
+            : base(workspace.Services)
         {
         }
 

--- a/src/Features/Core/Portable/Structure/BlockStructureServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Structure/BlockStructureServiceWithProviders.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -17,12 +18,12 @@ namespace Microsoft.CodeAnalysis.Structure
 {
     internal abstract class BlockStructureServiceWithProviders : BlockStructureService
     {
-        private readonly Workspace _workspace;
+        private readonly HostWorkspaceServices _services;
         private readonly ImmutableArray<BlockStructureProvider> _providers;
 
-        protected BlockStructureServiceWithProviders(Workspace workspace)
+        protected BlockStructureServiceWithProviders(HostWorkspaceServices services)
         {
-            _workspace = workspace;
+            _services = services;
             _providers = GetBuiltInProviders().Concat(GetImportedProviders());
         }
 
@@ -36,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Structure
         private ImmutableArray<BlockStructureProvider> GetImportedProviders()
         {
             var language = Language;
-            var mefExporter = (IMefHostExportProvider)_workspace.Services.HostServices;
+            var mefExporter = (IMefHostExportProvider)_services.HostServices;
 
             var providers = mefExporter.GetExports<BlockStructureProvider, LanguageMetadata>()
                                        .Where(lz => lz.Metadata.Language == language)

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionResolveTests.cs
@@ -181,7 +181,7 @@ class B : A
 
             var selectedItem = CodeAnalysis.Completion.CompletionItem.Create(displayText: "M");
             var textEdit = await CompletionResolveHandler.GenerateTextEditAsync(
-                document, new TestCaretOutOfScopeCompletionService(document.Project.Solution.Workspace), selectedItem, snippetsSupported: true, CancellationToken.None).ConfigureAwait(false);
+                document, new TestCaretOutOfScopeCompletionService(testLspServer.TestWorkspace.Services), selectedItem, snippetsSupported: true, CancellationToken.None).ConfigureAwait(false);
 
             Assert.Equal(@"public override void M()
     {
@@ -431,7 +431,7 @@ link text";
 
         private class TestCaretOutOfScopeCompletionService : CompletionService
         {
-            public TestCaretOutOfScopeCompletionService(Workspace workspace) : base(workspace)
+            public TestCaretOutOfScopeCompletionService(HostWorkspaceServices services) : base(services)
             {
             }
 

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ImportCompletionProvider/TypeImportCompletionServiceFactory.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ImportCompletionProvider/TypeImportCompletionServiceFactory.vb
@@ -19,14 +19,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
         End Sub
 
         Public Function CreateLanguageService(languageServices As HostLanguageServices) As ILanguageService Implements ILanguageServiceFactory.CreateLanguageService
-            Return New BasicTypeImportCompletionService(languageServices.WorkspaceServices.Workspace)
+            Return New BasicTypeImportCompletionService(languageServices.WorkspaceServices)
         End Function
 
         Private Class BasicTypeImportCompletionService
             Inherits AbstractTypeImportCompletionService
 
-            Public Sub New(workspace As Workspace)
-                MyBase.New(workspace)
+            Public Sub New(services As HostWorkspaceServices)
+                MyBase.New(services)
             End Sub
 
             Protected Overrides ReadOnly Property GenericTypeSuffix As String

--- a/src/Features/VisualBasic/Portable/Completion/VisualBasicCompletionService.vb
+++ b/src/Features/VisualBasic/Portable/Completion/VisualBasicCompletionService.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion
             End Sub
 
             Public Function CreateLanguageService(languageServices As HostLanguageServices) As ILanguageService Implements ILanguageServiceFactory.CreateLanguageService
-                Return New VisualBasicCompletionService(languageServices.WorkspaceServices.Workspace)
+                Return New VisualBasicCompletionService(languageServices.WorkspaceServices)
             End Function
         End Class
 
@@ -36,8 +36,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion
             defaultCommitCharacters:=CompletionRules.Default.DefaultCommitCharacters,
             defaultEnterKeyRule:=EnterKeyRule.Always)
 
-        Private Sub New(workspace As Workspace)
-            MyBase.New(workspace)
+        Private Sub New(services As HostWorkspaceServices)
+            MyBase.New(services)
         End Sub
 
         Public Overrides ReadOnly Property Language As String

--- a/src/Features/VisualBasic/Portable/Structure/VisualBasicBlockStructureService.vb
+++ b/src/Features/VisualBasic/Portable/Structure/VisualBasicBlockStructureService.vb
@@ -19,15 +19,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
         End Sub
 
         Public Function CreateLanguageService(languageServices As HostLanguageServices) As ILanguageService Implements ILanguageServiceFactory.CreateLanguageService
-            Return New VisualBasicBlockStructureService(languageServices.WorkspaceServices.Workspace)
+            Return New VisualBasicBlockStructureService(languageServices.WorkspaceServices)
         End Function
     End Class
 
     Friend Class VisualBasicBlockStructureService
         Inherits BlockStructureServiceWithProviders
 
-        Friend Sub New(workspace As Workspace)
-            MyBase.New(workspace)
+        Friend Sub New(services As HostWorkspaceServices)
+            MyBase.New(services)
         End Sub
 
         Public Overrides ReadOnly Property Language As String

--- a/src/Tools/ExternalAccess/FSharp/Completion/FSharpCompletionServiceWithProviders.cs
+++ b/src/Tools/ExternalAccess/FSharp/Completion/FSharpCompletionServiceWithProviders.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Completion
     internal abstract class FSharpCompletionServiceWithProviders : CompletionService
     {
         internal FSharpCompletionServiceWithProviders(Workspace workspace)
-            : base(workspace)
+            : base(workspace.Services)
         {
         }
 


### PR DESCRIPTION
We intend to add solutionInstance.Workspace to the banned api list for roslyn itself. It's highly problematic for OOP, as we have to try to replicate that concept, which isn't something sensical in that world. First, OOP cannot mutation things, so exposing the mutable workspace doesn't make much sense. Second, in VS you can have many workspaces, but in OOP we map that all back to one, which means we don't have a proper representation of VS state (for example, where you might have the VSWorkspace and the Metadata-as-source workspace). This means those features either cannot use OOP, or they try to use OOP and can end up with non-sensical results.

This is a series of PRs to get us off of that API so we can move to a much cleaner and simpler OOP model for the solution and services.