### PR TITLE
Remove prefer system hash code from EditorConfig UI

### DIFF
--- a/src/VisualStudio/CSharp/Test/EditorConfigSettings/DataProvider/DataProviderTests.cs
+++ b/src/VisualStudio/CSharp/Test/EditorConfigSettings/DataProvider/DataProviderTests.cs
@@ -112,12 +112,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditorConfigSettings.Da
             var model = new TestViewModel();
             settingsProvider.RegisterViewModel(model);
             var dataSnapShot = settingsProvider.GetCurrentDataSnapshot();
-            // We need to substract as a UI for arbitrary strings for:
-            //
+
+            // We need to substract for string options that are not yet supported.
             // CodeStyleOptions2.OperatorPlacementWhenWrapping
             // CodeStyleOptions2.FileHeaderTemplate
+            // CodeStyleOptions2.RemoveUnnecessarySuppressionExclusions
+            //
+            // We also subtract for this not-yet supported option, tracked by https://github.com/dotnet/roslyn/issues/62937
             // CodeStyleOptions2.ForEachExplicitCastInSource
-            var optionsCount = CodeStyleOptions2.AllOptions.Where(x => x.StorageLocations.Any(y => y is IEditorConfigStorageLocation2)).Count() - 3;
+            var optionsCount = CodeStyleOptions2.AllOptions.Where(x => x.StorageLocations.Any(y => y is IEditorConfigStorageLocation2)).Count() - 4;
             Assert.Equal(optionsCount, dataSnapShot.Length);
         }
 

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/DataProvider/CodeStyle/CommonCodeStyleSettingsProvider.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/DataProvider/CodeStyle/CommonCodeStyleSettingsProvider.cs
@@ -132,10 +132,6 @@ namespace Microsoft.CodeAnalysis.Editor.EditorConfigSettings.DataProvider.CodeSt
                 description: ServicesVSResources.analyzer_Prefer_auto_properties,
                 editorConfigOptions: options,
                 visualStudioOptions: visualStudioOptions, updater: updater, fileName: FileName);
-            yield return CodeStyleSetting.Create(option: CodeStyleOptions2.PreferSystemHashCode,
-                description: ServicesVSResources.Prefer_System_HashCode_in_GetHashCode,
-                editorConfigOptions: options,
-                visualStudioOptions: visualStudioOptions, updater: updater, fileName: FileName);
         }
 
         private IEnumerable<CodeStyleSetting> GetExpressionCodeStyleOptions(AnalyzerConfigOptions options, OptionSet visualStudioOptions, OptionUpdater updater)


### PR DESCRIPTION
The option doesn't have editorconfig storage location