### PR TITLE
Remove FailFast when rename tracking state is messed up

### DIFF
--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                             text.Container.GetType().FullName,
                             text.ToString()));
                         FatalError.ReportAndCatch(ex);
-                        return;
+                        return false;
                     }
 
                     if (textBuffer.Properties.TryGetProperty(typeof(StateMachine), out StateMachine stateMachine))

--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.cs
@@ -86,8 +86,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                     textBuffer = text.Container.TryGetTextBuffer();
                     if (textBuffer == null)
                     {
-                        throw new InvalidOperationException(string.Format("document with name {0} is open but textBuffer is null. Textcontainer is of type {1}. SourceText is: {2}",
-                                                            document.Name, text.Container.GetType().FullName, text.ToString()));
+                        var ex = new InvalidOperationException(string.Format(
+                            "document with name {0} is open but textBuffer is null. Textcontainer is of type {1}. SourceText is: {2}",
+                            document.Name,
+                            text.Container.GetType().FullName,
+                            text.ToString()));
+                        FatalError.ReportAndCatch(ex);
+                        return;
                     }
 
                     if (textBuffer.Properties.TryGetProperty(typeof(StateMachine), out StateMachine stateMachine))

--- a/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.cs
+++ b/src/EditorFeatures/Core/RenameTracking/RenameTrackingTaggerProvider.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                     textBuffer = text.Container.TryGetTextBuffer();
                     if (textBuffer == null)
                     {
-                        FailFast.Fail(string.Format("document with name {0} is open but textBuffer is null. Textcontainer is of type {1}. SourceText is: {2}",
+                        throw new InvalidOperationException(string.Format("document with name {0} is open but textBuffer is null. Textcontainer is of type {1}. SourceText is: {2}",
                                                             document.Name, text.Container.GetType().FullName, text.ToString()));
                     }
 


### PR DESCRIPTION
We're investigating a crash here in VSMac: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1558256/. We should fix the root cause, but it seems like this should just ~throw~ report and return instead of explicitly crashing the process.