### PR TITLE
Enable source build for ASP.NET external access project

### DIFF
--- a/src/Tools/ExternalAccess/AspNetCore/Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.csproj
+++ b/src/Tools/ExternalAccess/AspNetCore/Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.csproj
@@ -12,7 +12,7 @@
       A supporting package for ASP.NET Core:
       https://github.com/dotnet/aspnetcore
     </PackageDescription>
-
+    <!-- Referenced by dotnet/aspnetcore and included in SDK. Requires source build -->
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
   </PropertyGroup>
 

--- a/src/Tools/ExternalAccess/AspNetCore/Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.csproj
+++ b/src/Tools/ExternalAccess/AspNetCore/Microsoft.CodeAnalysis.ExternalAccess.AspNetCore.csproj
@@ -12,6 +12,8 @@
       A supporting package for ASP.NET Core:
       https://github.com/dotnet/aspnetcore
     </PackageDescription>
+
+    <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,10 +34,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />
-    <ProjectReference Include="..\..\..\EditorFeatures\Core\Microsoft.CodeAnalysis.EditorFeatures.csproj" />
     <ProjectReference Include="..\..\..\Features\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Features.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
-    <ProjectReference Include="..\..\..\Workspaces\Remote\Core\Microsoft.CodeAnalysis.Remote.Workspaces.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
~Also needs to be applied to the 17.3 branch.~ Roslyn appears to merge lower branches into higher, so this should go straight into 17.3 once approved.

**Change:**
Enable source build for `Microsoft.CodeAnalysis.ExternalAccess.AspNetCore`. This change requires removing some dependencies and functionality that don't support source build. They will be worked around on ASP.NET Core side.

**Reason for change:**
ASP.NET Core references `Microsoft.CodeAnalysis.ExternalAccess.AspNetCore` from an analyzer project. Because of aspnetcore's source build requirement, source build needs to be enabled for this project. The feature is targeting .NET 7 lines up with Microsoft.CodeAnalysis 4.3.x assemblies and dev17.3.

**Risk**:
Low. `Microsoft.CodeAnalysis.ExternalAccess.AspNetCore` is only referenced by ASP.NET Core code.

cc @CyrusNajmabadi 