### PR TITLE
Structural Error Cases for Lambda Default Parameters

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
@@ -50,6 +50,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             public override DeclarationScope Scope(int index) => DeclarationScope.Unscoped;
             public override MessageID MessageID { get { return MessageID.IDS_FeatureQueryExpression; } } // TODO: what is the correct ID here?
             public override Location ParameterLocation(int index) { return _parameters[index].Locations[0]; }
+
+            // Query lambdas don't have default values as part of their syntax
+            public override EqualsValueClauseSyntax DefaultValue(int index) => null;
+
+            // Query unbound lambdas don't have associated parameter list syntax
+            public override ParameterListSyntax ParamSyntax => null;
+
             public override TypeWithAnnotations ParameterTypeWithAnnotations(int index) { throw new ArgumentException(); } // implicitly typed
 
             public override void GenerateAnonymousFunctionConversionError(BindingDiagnosticBag diagnostics, TypeSymbol targetType)

--- a/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
@@ -50,10 +50,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             public override DeclarationScope Scope(int index) => DeclarationScope.Unscoped;
             public override MessageID MessageID { get { return MessageID.IDS_FeatureQueryExpression; } } // TODO: what is the correct ID here?
             public override Location ParameterLocation(int index) { return _parameters[index].Locations[0]; }
-            // Query lambdas don't have default values as part of their syntax
-            public override EqualsValueClauseSyntax DefaultValue(int index) => null;
             // Query unbound lambdas don't have associated parameter syntax
-            public override ParameterSyntax ParamSyntax(int index) => null;
+            public override ParameterSyntax ParameterSyntax(int index) => null;
             public override TypeWithAnnotations ParameterTypeWithAnnotations(int index) { throw new ArgumentException(); } // implicitly typed
 
             public override void GenerateAnonymousFunctionConversionError(BindingDiagnosticBag diagnostics, TypeSymbol targetType)

--- a/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Query lambdas don't have default values as part of their syntax
             public override EqualsValueClauseSyntax DefaultValue(int index) => null;
             // Query unbound lambdas don't have associated parameter syntax
-            public override ParameterSyntax? ParamSyntax(int index) => null;
+            public override ParameterSyntax ParamSyntax(int index) => null;
             public override TypeWithAnnotations ParameterTypeWithAnnotations(int index) { throw new ArgumentException(); } // implicitly typed
 
             public override void GenerateAnonymousFunctionConversionError(BindingDiagnosticBag diagnostics, TypeSymbol targetType)

--- a/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
@@ -50,13 +50,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             public override DeclarationScope Scope(int index) => DeclarationScope.Unscoped;
             public override MessageID MessageID { get { return MessageID.IDS_FeatureQueryExpression; } } // TODO: what is the correct ID here?
             public override Location ParameterLocation(int index) { return _parameters[index].Locations[0]; }
-
             // Query lambdas don't have default values as part of their syntax
             public override EqualsValueClauseSyntax DefaultValue(int index) => null;
-
             // Query unbound lambdas don't have associated parameter list syntax
             public override ParameterListSyntax ParamSyntax => null;
-
             public override TypeWithAnnotations ParameterTypeWithAnnotations(int index) { throw new ArgumentException(); } // implicitly typed
 
             public override void GenerateAnonymousFunctionConversionError(BindingDiagnosticBag diagnostics, TypeSymbol targetType)

--- a/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
@@ -52,8 +52,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             public override Location ParameterLocation(int index) { return _parameters[index].Locations[0]; }
             // Query lambdas don't have default values as part of their syntax
             public override EqualsValueClauseSyntax DefaultValue(int index) => null;
-            // Query unbound lambdas don't have associated parameter list syntax
-            public override ParameterListSyntax ParamSyntax => null;
+            // Query unbound lambdas don't have associated parameter syntax
+            public override ParameterSyntax? ParamSyntax(int index) => null;
             public override TypeWithAnnotations ParameterTypeWithAnnotations(int index) { throw new ArgumentException(); } // implicitly typed
 
             public override void GenerateAnonymousFunctionConversionError(BindingDiagnosticBag diagnostics, TypeSymbol targetType)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
@@ -225,6 +225,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
             }
+
         }
 
         private (RefKind, TypeWithAnnotations) BindExplicitLambdaReturnType(TypeSyntax syntax, BindingDiagnosticBag diagnostics)
@@ -259,12 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var hasTypes = parameterSyntaxList[0].Type != null;
 
-                // Implicitly typed default parameters are not allowed
-                if (!hasTypes && parameterSyntaxList[0].Default != null)
-                {
-                    diagnostics.Add(ErrorCode.ERR_ImplicitlyTypedDefaultParameter,
-                        parameterSyntaxList[0].Identifier.GetLocation(), parameterSyntaxList[0].Identifier.Text);
-                }
+                checkForImplicitDefault(hasTypes, parameterSyntaxList[0], diagnostics);
 
                 for (int i = 1, n = parameterSyntaxList.Count; i < n; i++)
                 {
@@ -282,13 +278,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 parameter.Type?.GetLocation() ?? parameter.Identifier.GetLocation());
                         }
 
-                        // Implicitly typed default parameters are not allowed
-                        if (!thisParameterHasType && parameter.Default != null)
-                        {
-                            diagnostics.Add(ErrorCode.ERR_ImplicitlyTypedDefaultParameter,
-                                parameter.Identifier.GetLocation(), parameter.Identifier.Text);
-                        }
+                        checkForImplicitDefault(thisParameterHasType, parameter, diagnostics);
                     }
+                }
+            }
+
+            static void checkForImplicitDefault(bool hasType, ParameterSyntax param, BindingDiagnosticBag diagnostics)
+            {
+                if (!hasType && param.Default != null)
+                {
+                    diagnostics.Add(ErrorCode.ERR_ImplicitlyTypedDefaultParameter,
+                        param.Identifier.GetLocation(), param.Identifier.Text);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
@@ -168,7 +168,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     scopes = scopesBuilder.ToImmutable();
                 }
 
-
                 if (attributesBuilder.Any(a => a.Count > 0))
                 {
                     parameterAttributes = attributesBuilder.ToImmutable();

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -393,6 +393,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(syntax.IsAnonymousFunction());
             bool hasErrors = !types.IsDefault && types.Any(static t => t.Type?.Kind == SymbolKind.ErrorType);
 
+            // If we have a parenthesized lambda or anonymous method expression,
+            // we could have default parameters and thus we include the parameter list syntax
+            // to re-use existing binder code for type-checking default params
             var paramSyntaxList = syntax switch
             {
                 ParenthesizedLambdaExpressionSyntax parenLam => parenLam.ParameterList,
@@ -467,9 +470,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public TypeWithAnnotations ParameterTypeWithAnnotations(int index) { return Data.ParameterTypeWithAnnotations(index); }
         public TypeSymbol ParameterType(int index) { return ParameterTypeWithAnnotations(index).Type; }
         public EqualsValueClauseSyntax? ParameterDefaultValue(int index) => Data.DefaultValue(index);
-
         public ParameterListSyntax? ParamSyntax => Data.ParamSyntax;
-
         public bool ParameterHasDefault(int index) => ParameterDefaultValue(index) != null;
         public Location ParameterLocation(int index) { return Data.ParameterLocation(index); }
         public string ParameterName(int index) { return Data.ParameterName(index); }
@@ -546,9 +547,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public abstract RefKind RefKind(int index);
         public abstract DeclarationScope Scope(int index);
         public abstract EqualsValueClauseSyntax? DefaultValue(int index);
-
         public abstract ParameterListSyntax? ParamSyntax { get; }
-
         protected abstract BoundBlock BindLambdaBody(LambdaSymbol lambdaSymbol, Binder lambdaBodyBinder, BindingDiagnosticBag diagnostics);
 
         /// <summary>
@@ -907,7 +906,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 block,
                 diagnostics.ToReadOnlyAndFree(),
                 lambdaBodyBinder,
-
                 delegateType,
                 inferredReturnType)
             { WasCompilerGenerated = _unboundLambda.WasCompilerGenerated };

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -399,7 +399,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 ParenthesizedLambdaExpressionSyntax parenLam => parenLam.ParameterList,
                 AnonymousMethodExpressionSyntax anonMethod => anonMethod.ParameterList,
-                _ => null
+                // Simple lambdas have no parameter list
+                SimpleLambdaExpressionSyntax simpleLam => null,
+                _ => throw ExceptionUtilities.UnexpectedValue(syntax)
             };
 
             var functionType = FunctionTypeSymbol.CreateIfFeatureEnabled(syntax, binder, static (binder, expr) => ((UnboundLambda)expr).Data.InferDelegateType());

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -661,7 +661,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         parameterDefaultValueBuilder.AddMany(null, i);
                     }
 
-                    parameterDefaultValueBuilder.Add(param.ExplicitDefaultConstantValue);
+                    parameterDefaultValueBuilder.Add(constVal);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -1475,14 +1475,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _parameterScopes.IsDefault ? DeclarationScope.Unscoped : _parameterScopes[index];
         }
 
-        /*
-        public override EqualsValueClauseSyntax? DefaultValue(int index)
-        {
-            Debug.Assert(_defaultValues.IsDefault || (0 <= index && index < _defaultValues.Length));
-            return _defaultValues.IsDefault ? null : _defaultValues[index];
-        }
-        */
-
         public override ParameterSyntax ParameterSyntax(int index)
         {
 

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7188,7 +7188,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Operator '{0}' cannot be applied to operands of type '{1}' and '{2}' that are not UTF-8 byte representations</value>
   </data>
   <data name="ERR_ImplicitlyTypedDefaultParameter" xml:space="preserve">
-    <value> Default not allowed for implicitly typed lambda parameter '{0}' </value>
+    <value>Implicitly typed lambda parameter '{0}' cannot have a default value.</value>
   </data>
   <data name="IDS_FeatureFileTypes" xml:space="preserve">
     <value>file types</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -7187,6 +7187,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_BadBinaryReadOnlySpanConcatenation" xml:space="preserve">
     <value>Operator '{0}' cannot be applied to operands of type '{1}' and '{2}' that are not UTF-8 byte representations</value>
   </data>
+  <data name="ERR_ImplicitlyTypedDefaultParameter" xml:space="preserve">
+    <value> Default not allowed for implicitly typed lambda parameter '{0}' </value>
+  </data>
   <data name="IDS_FeatureFileTypes" xml:space="preserve">
     <value>file types</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2114,9 +2114,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #endregion
 
-        // Note: you will need to do the following after adding any code:
-        //  1) Update ErrorFacts.IsBuildOnlyDiagnostic to handle the new error code.
-        // Additionally, after adding a new warning you will need to do the following:
+        #region diagnostics introduced for C# 12.0
+        ERR_ImplicitlyTypedDefaultParameter = 9063,
+        #endregion
+
+        // Note: you will need to do the following after adding warnings:
         //  1) Re-generate compiler code (eng\generate-compiler-code.cmd).
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2212,6 +2212,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case ErrorCode.ERR_CannotMatchOnINumberBase:
                 case ErrorCode.ERR_MisplacedScoped:
                 case ErrorCode.ERR_ScopedTypeNameDisallowed:
+                case ErrorCode.ERR_ImplicitlyTypedDefaultParameter:
                     return false;
                 default:
                     // NOTE: All error codes must be explicitly handled in this switch statement

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaParameterSymbol.cs
@@ -41,11 +41,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return false; }
         }
 
-        internal override bool HasDefaultArgumentSyntax
-        {
-            get { return false; }
-        }
-
         public override ImmutableArray<CustomModifier> RefCustomModifiers
         {
             get { return ImmutableArray<CustomModifier>.Empty; }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaParameterSymbol.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public LambdaParameterSymbol(
            LambdaSymbol owner,
+           SyntaxReference? syntaxRef,
            SyntaxList<AttributeListSyntax> attributeLists,
            TypeWithAnnotations parameterType,
            int ordinal,
@@ -22,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
            string name,
            bool isDiscard,
            ImmutableArray<Location> locations)
-           : base(owner, ordinal, parameterType, refKind, name, locations, syntaxRef: null, isParams: false, isExtensionMethodThis: false, scope)
+           : base(owner, ordinal, parameterType, refKind, name, locations, syntaxRef, isParams: false, isExtensionMethodThis: false, scope)
         {
             _attributeLists = attributeLists;
             IsDiscard = isDiscard;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -336,11 +336,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 TypeWithAnnotations type;
                 RefKind refKind;
                 DeclarationScope scope;
+                ParameterSyntax? paramSyntax = null;
                 if (hasExplicitlyTypedParameterList)
                 {
                     type = unboundLambda.ParameterTypeWithAnnotations(p);
                     refKind = unboundLambda.RefKind(p);
                     scope = unboundLambda.Scope(p);
+                    paramSyntax = unboundLambda.ParameterSyntax(p);
                 }
                 else if (p < numDelegateParameters)
                 {
@@ -364,7 +366,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var name = unboundLambda.ParameterName(p);
                 var location = unboundLambda.ParameterLocation(p);
                 var locations = location == null ? ImmutableArray<Location>.Empty : ImmutableArray.Create<Location>(location);
-                var paramSyntax = unboundLambda.ParamSyntax(p);
 
                 var parameter = new LambdaParameterSymbol(owner: this, paramSyntax?.GetReference(), attributeLists, type, ordinal: p, refKind, scope, name, unboundLambda.ParameterIsDiscard(p), locations);
                 builder.Add(parameter);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -324,7 +324,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var builder = ArrayBuilder<ParameterSymbol>.GetInstance(unboundLambda.ParameterCount);
             var hasExplicitlyTypedParameterList = unboundLambda.HasExplicitlyTypedParameterList;
             var numDelegateParameters = parameterTypes.Length;
-            var paramSyntaxList = unboundLambda.ParamSyntax?.Parameters.ToImmutableArray();
 
             for (int p = 0; p < unboundLambda.ParameterCount; ++p)
             {
@@ -365,7 +364,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var name = unboundLambda.ParameterName(p);
                 var location = unboundLambda.ParameterLocation(p);
                 var locations = location == null ? ImmutableArray<Location>.Empty : ImmutableArray.Create<Location>(location);
-                var paramSyntax = paramSyntaxList != null ? paramSyntaxList.Value[p] : null;
+                var paramSyntax = unboundLambda.ParamSyntax(p);
 
                 var parameter = new LambdaParameterSymbol(owner: this, paramSyntax?.GetReference(), attributeLists, type, ordinal: p, refKind, scope, name, unboundLambda.ParameterIsDiscard(p), locations);
                 builder.Add(parameter);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -324,6 +324,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var builder = ArrayBuilder<ParameterSymbol>.GetInstance(unboundLambda.ParameterCount);
             var hasExplicitlyTypedParameterList = unboundLambda.HasExplicitlyTypedParameterList;
             var numDelegateParameters = parameterTypes.Length;
+            var paramSyntaxList = unboundLambda.ParamSyntax?.Parameters.ToImmutableArray();
 
             for (int p = 0; p < unboundLambda.ParameterCount; ++p)
             {
@@ -364,8 +365,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var name = unboundLambda.ParameterName(p);
                 var location = unboundLambda.ParameterLocation(p);
                 var locations = location == null ? ImmutableArray<Location>.Empty : ImmutableArray.Create<Location>(location);
+                var paramSyntax = paramSyntaxList != null ? paramSyntaxList.Value[p] : null;
 
-                var parameter = new LambdaParameterSymbol(owner: this, attributeLists, type, ordinal: p, refKind, scope, name, unboundLambda.ParameterIsDiscard(p), locations);
+                var parameter = new LambdaParameterSymbol(owner: this, paramSyntax?.GetReference(), attributeLists, type, ordinal: p, refKind, scope, name, unboundLambda.ParameterIsDiscard(p), locations);
                 builder.Add(parameter);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 TParameterSymbol parameter = parameterCreationFunc(withTypeParametersBinder, owner, parameterType, parameterSyntax, refKind, parameterIndex, paramsKeyword, thisKeyword, addRefReadOnlyModifier, scope, diagnostics);
 
-                ReportParameterErrors(owner, parameterSyntax, parameter.Ordinal, parameter.IsParams, parameter.TypeWithAnnotations, 
+                ReportParameterErrors(owner, parameterSyntax, parameter.Ordinal, parameter.IsParams, parameter.TypeWithAnnotations,
                                       parameter.RefKind, parameter.Scope, parameter.ContainingSymbol, thisKeyword, paramsKeyword, firstDefault, diagnostics);
 
                 builder.Add(parameter);

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -733,8 +733,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
-        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
-        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <source>Implicitly typed lambda parameter '{0}' cannot have a default value.</source>
+        <target state="new">Implicitly typed lambda parameter '{0}' cannot have a default value.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -732,6 +732,11 @@
         <target state="translated">Volání implicitního indexeru rozsahů nemůže pojmenovat argument.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
+        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
+        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">Argumenty s modifikátorem in se nedají použít v dynamicky volaných výrazech.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -732,6 +732,11 @@
         <target state="translated">Durch den Aufruf des impliziten Bereichsindexers kann das Argument nicht benannt werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
+        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
+        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">Argumente mit dem Modifizierer "in" können nicht in dynamisch gebundenen Ausdrücken verwendet werden.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -733,8 +733,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
-        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
-        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <source>Implicitly typed lambda parameter '{0}' cannot have a default value.</source>
+        <target state="new">Implicitly typed lambda parameter '{0}' cannot have a default value.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -732,6 +732,11 @@
         <target state="translated">La invocación del indizador de rangos implícito no puede nombrar el argumento.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
+        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
+        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">No se pueden usar argumentos con el modificador "in" en expresiones distribuidas dinámicamente.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -733,8 +733,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
-        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
-        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <source>Implicitly typed lambda parameter '{0}' cannot have a default value.</source>
+        <target state="new">Implicitly typed lambda parameter '{0}' cannot have a default value.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -732,6 +732,11 @@
         <target state="translated">L'appel de l'indexeur de plage implicite ne peut pas nommer l'argument.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
+        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
+        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">Impossible d'utiliser les arguments avec le modificateur 'in' dans les expressions dispatchées dynamiquement.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -733,8 +733,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
-        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
-        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <source>Implicitly typed lambda parameter '{0}' cannot have a default value.</source>
+        <target state="new">Implicitly typed lambda parameter '{0}' cannot have a default value.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -732,6 +732,11 @@
         <target state="translated">La chiamata dell'indicizzatore di intervallo implicito non può assegnare un nome all'argomento.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
+        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
+        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">Non è possibile usare argomenti con il modificatore 'in' nelle espressioni inviate in modo dinamico.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -733,8 +733,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
-        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
-        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <source>Implicitly typed lambda parameter '{0}' cannot have a default value.</source>
+        <target state="new">Implicitly typed lambda parameter '{0}' cannot have a default value.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -732,6 +732,11 @@
         <target state="translated">暗黙的な範囲インデクサーの呼び出しでは、引数に名前を付けることはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
+        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
+        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">'in' 修飾子を持つ引数を、動的ディスパッチされる式で使用することはできません。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -733,8 +733,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
-        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
-        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <source>Implicitly typed lambda parameter '{0}' cannot have a default value.</source>
+        <target state="new">Implicitly typed lambda parameter '{0}' cannot have a default value.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -732,6 +732,11 @@
         <target state="translated">암시적 범위 인덱서 호출로 인수 이름을 지정할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
+        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
+        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">동적으로 디스패치된 식에서 'in' 한정자가 있는 인수를 사용할 수 없습니다.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -733,8 +733,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
-        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
-        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <source>Implicitly typed lambda parameter '{0}' cannot have a default value.</source>
+        <target state="new">Implicitly typed lambda parameter '{0}' cannot have a default value.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -732,6 +732,11 @@
         <target state="translated">W wywołaniu niejawnego indeksatora zakresu nie może być nazwy argumentu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
+        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
+        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">Nie można używać argumentów z modyfikatorem „in” w wyrażeniach przydzielanych dynamicznie.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -733,8 +733,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
-        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
-        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <source>Implicitly typed lambda parameter '{0}' cannot have a default value.</source>
+        <target state="new">Implicitly typed lambda parameter '{0}' cannot have a default value.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -732,6 +732,11 @@
         <target state="translated">A invocação do Indexador de Intervalo implícito não pode nomear o argumento.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
+        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
+        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">Os argumentos com o modificador 'in' não podem ser usados em expressões vinculadas dinamicamente.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -733,8 +733,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
-        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
-        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <source>Implicitly typed lambda parameter '{0}' cannot have a default value.</source>
+        <target state="new">Implicitly typed lambda parameter '{0}' cannot have a default value.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -733,8 +733,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
-        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
-        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <source>Implicitly typed lambda parameter '{0}' cannot have a default value.</source>
+        <target state="new">Implicitly typed lambda parameter '{0}' cannot have a default value.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -732,6 +732,11 @@
         <target state="translated">Вызов неявного индексатора для диапазона не может присвоить аргументу имя.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
+        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
+        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">Аргументы с модификатором "in" невозможно использовать в динамически диспетчеризируемых выражениях.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -732,6 +732,11 @@
         <target state="translated">Örtük Aralık Dizin Oluşturucu'nun çağrılması bağımsız değişkeni adlandıramaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
+        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
+        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">'in' değiştiricisine sahip bağımsız değişkenler dinamik olarak dağıtılan ifadelerde kullanılamaz.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -733,8 +733,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
-        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
-        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <source>Implicitly typed lambda parameter '{0}' cannot have a default value.</source>
+        <target state="new">Implicitly typed lambda parameter '{0}' cannot have a default value.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -732,6 +732,11 @@
         <target state="translated">无法通过对隐式范围索引器的调用为参数命名。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
+        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
+        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">带有 "in" 修饰符的参数不能用于动态调度的表达式。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -733,8 +733,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
-        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
-        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <source>Implicitly typed lambda parameter '{0}' cannot have a default value.</source>
+        <target state="new">Implicitly typed lambda parameter '{0}' cannot have a default value.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -732,6 +732,11 @@
         <target state="translated">隱含 Range 索引子的引動過程無法為引數命名。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
+        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
+        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">
         <source>Arguments with 'in' modifier cannot be used in dynamically dispatched expressions.</source>
         <target state="translated">具有 'in' 修飾元的引數不可用於動態分派的運算式。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -733,8 +733,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ERR_ImplicitlyTypedDefaultParameter">
-        <source> Default not allowed for implicitly typed lambda parameter '{0}' </source>
-        <target state="new"> Default not allowed for implicitly typed lambda parameter '{0}' </target>
+        <source>Implicitly typed lambda parameter '{0}' cannot have a default value.</source>
+        <target state="new">Implicitly typed lambda parameter '{0}' cannot have a default value.</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_InDynamicMethodArg">

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaDiscardParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaDiscardParametersTests.cs
@@ -341,13 +341,9 @@ public class C
 }");
 
             comp.VerifyDiagnostics(
-                // (6,51): error CS7014: Attributes are not valid in this context.
-                //         System.Func<int, int, long> f1 = delegate([System.Obsolete]int _, int _ = 0) { return 3L; };
-                Diagnostic(ErrorCode.ERR_AttributesNotAllowed, "[System.Obsolete]").WithLocation(6, 51),
-                // (6,81): error CS1065: Default values are not valid in this context.
-                //         System.Func<int, int, long> f1 = delegate([System.Obsolete]int _, int _ = 0) { return 3L; };
-                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(6, 81)
-                );
+                    // (6,51): error CS7014: Attributes are not valid in this context.
+                    //         System.Func<int, int, long> f1 = delegate([System.Obsolete]int _, int _ = 0) { return 3L; };
+                    Diagnostic(ErrorCode.ERR_AttributesNotAllowed, "[System.Obsolete]").WithLocation(6, 51));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -7324,6 +7324,7 @@ class Program
 """;
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
+                // PROTOTYPE: These usage warnings should go away
                 // (5,19): warning CS0219: The variable 'i1' is assigned but its value is never used
                 //         const int i1 = 1;
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i1").WithArguments("i1").WithLocation(5, 19),
@@ -7390,7 +7391,7 @@ class Program
         }
 
         [Fact]
-        public void LambdaWithDefaultParamsAndRefOutModifiers()
+        public void LambdaWithDefaultParametersAndRefOutModifiers()
         {
             var source = """
 class Program
@@ -7406,7 +7407,7 @@ class Program
         }
 
         [Fact]
-        public void AnonymousMethodWithDefaultParamsAndRefOutModifiers()
+        public void AnonymousMethodWithDefaultParametersAndRefOutModifiers()
         {
             var source = """
 class Program
@@ -7422,7 +7423,7 @@ class Program
         }
 
         [Fact]
-        public void LambdaWithMultipleDefaultParams()
+        public void LambdaWithMultipleDefaultParameters()
         {
             var source = """
 class Program
@@ -7451,6 +7452,8 @@ class Program
     static int M2(int j) => j;
 }
 """;
+
+            // PROTOTYPE: verify this case with DataFlowAnalysis APIs
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
                 // (5,25): error CS1736: Default parameter value for 'i' must be a compile-time constant
@@ -7459,7 +7462,7 @@ class Program
         }
 
         [Fact]
-        public void AnonymousMethodDefaultParamUsageAnalysis()
+        public void AnonymousMethodDefaultParameterUsageAnalysis()
         {
             var source = """
 class Program
@@ -7535,6 +7538,24 @@ class Program
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics();
         }
-    }
 
+        [Fact(Skip = "PROTOTYPE: Nullable walker code needs to be updated so that this doesn't cause a cycle")]
+        public void LambdaDefaultSelfReference()
+        {
+            var source = """
+using System;
+
+class Program
+{
+    public static void Main(string[] args)
+    {
+        var lam = (Delegate d = lam) => { };
+    }
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+
+        }
+    }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -7479,7 +7479,7 @@ class Program
         }
 
         [Fact]
-        public void LambdaWithinNestedScope()
+        public void LambdaDefaultWithinNestedScope()
         {
             var source = """
 class Program

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -632,7 +632,7 @@ public class Program
 }
 """;
             var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics( 
+            comp.VerifyDiagnostics(
                 // (6,20): error CS1601: Cannot make reference to variable of type 'TypedReference'
                 //         var lam = (ref TypedReference r) => {};
                 Diagnostic(ErrorCode.ERR_MethodArgCantBeRefAny, "ref TypedReference r").WithArguments("System.TypedReference").WithLocation(6, 20));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -7460,6 +7460,22 @@ class Program
         }
 
         [Fact]
+        public void LambdaWithMultipleDefaultParams()
+        {
+            var source = """
+class Program
+{
+    public static void Main()
+    {
+        var lam = (int u, string v, object w, int x = 10, int y = 3, int z = 4) => x + y + z; 
+    }
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void LambdaDefaultParamUsageAnalysis()
         {
             var source = """

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -7163,44 +7163,6 @@ class Program
         }
 
         [Fact]
-        public void LambdaWithDefaultTypeMismatchConstantExpression()
-        {
-            var source = """
-class Program
-{
-    public static void Main()
-    {
-        var lam = (string s = 7*9) => s.Split(' ');
-    }
-}
-""";
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                    // (5,27): error CS1750: A value of type 'int' cannot be used as a default parameter because there are no standard conversions to type 'string'
-                    //         var lam = (string s = 7*9) => s.Split(' ');
-                    Diagnostic(ErrorCode.ERR_NoConversionForDefaultParam, "s").WithArguments("int", "string").WithLocation(5, 27));
-        }
-
-        [Fact]
-        public void AnonymousMethodWithDefaultTypeMismatchConstantExpression()
-        {
-            var source = """
-class Program
-{
-    public static void Main()
-    {
-        var lam = delegate(string s = 7*9) { return s.Split(' '); };
-    }
-}
-""";
-            var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics(
-                // (5,35): error CS1750: A value of type 'int' cannot be used as a default parameter because there are no standard conversions to type 'string'
-                //         var lam = delegate(string s = 7*9) { return s.Split(' '); };
-                Diagnostic(ErrorCode.ERR_NoConversionForDefaultParam, "s").WithArguments("int", "string").WithLocation(5, 35));
-        }
-
-        [Fact]
         public void LambdaWithNonConstantDefault()
         {
             var source = """

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// PROTOTYPE: Address IOperationValidation support for lambda default params
+
 #nullable disable
 
 using System;
@@ -7308,7 +7310,7 @@ class Program
             comp.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void LambdaDefaultLocalConstantExpression()
         {
             var source = """
@@ -7333,7 +7335,7 @@ class Program
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i2").WithArguments("i2").WithLocation(6, 19));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void AnonymousMethodDefaultLocalConstantExpression()
         {
             var source = """
@@ -7520,7 +7522,7 @@ class Program
             comp.VerifyDiagnostics();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(NoIOperationValidation))]
         public void LambdaDefaultWithinNestedScope()
         {
             var source = """

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -33598,10 +33598,22 @@ class C
             // the scope of an expression variable introduced in the default expression
             // of a lambda parameter is that default expression.
             var compilation = CreateCompilationWithMscorlib45(text);
-            compilation.GetDiagnostics().Where(d => d.Code != (int)ErrorCode.ERR_DefaultValueNotAllowed).Verify(
+            compilation.GetDiagnostics().Verify(
+                // (7,58): error CS1736: Default parameter value for 'b' must be a compile-time constant
+                //                                                 bool b = M(M(out int z1), z1), 
+                Diagnostic(ErrorCode.ERR_DefaultValueMustBeConstant, "M(M(out int z1), z1)").WithArguments("b").WithLocation(7, 58),
+                // (8,58): error CS0103: The name 'z1' does not exist in the current context
+                //                                                 int s2 = z1) 
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z1").WithArguments("z1").WithLocation(8, 58),
                 // (9,55): error CS0103: The name 'z1' does not exist in the current context
                 //                                             { var t = z1; };
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z1").WithArguments("z1").WithLocation(9, 55),
+                // (11,58): error CS1736: Default parameter value for 'b' must be a compile-time constant
+                //                                                 bool b = M(M(out var z2), z2), 
+                Diagnostic(ErrorCode.ERR_DefaultValueMustBeConstant, "M(M(out var z2), z2)").WithArguments("b").WithLocation(11, 58),
+                // (12,58): error CS0103: The name 'z2' does not exist in the current context
+                //                                                 int s2 = z2)  
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(12, 58),
                 // (13,55): error CS0103: The name 'z2' does not exist in the current context
                 //                                             { var t = z2; };
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(13, 55),
@@ -33610,8 +33622,7 @@ class C
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z1").WithArguments("z1").WithLocation(15, 17),
                 // (15,22): error CS0103: The name 'z2' does not exist in the current context
                 //         int x = z1 + z2;
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(15, 22)
-                );
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(15, 22));
 
             var tree = compilation.SyntaxTrees[0];
             var model = compilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -8835,9 +8835,9 @@ class Program
 }";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (6,43): error CS9048: The 'scoped' modifier can be used for refs and ref struct values only.
+                // (6,34): error CS9048: The 'scoped' modifier can be used for refs and ref struct values only.
                 //         var f = (scoped ref E x, scoped E y) => { };
-                Diagnostic(ErrorCode.ERR_ScopedRefAndRefStructOnly, "y").WithLocation(6, 43),
+                Diagnostic(ErrorCode.ERR_ScopedRefAndRefStructOnly, "scoped E y").WithLocation(6, 34),
                 // (8,39): error CS9048: The 'scoped' modifier can be used for refs and ref struct values only.
                 //         static void L(scoped ref E x, scoped E y) { }
                 Diagnostic(ErrorCode.ERR_ScopedRefAndRefStructOnly, "scoped E y").WithLocation(8, 39));

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -5795,10 +5795,7 @@ class C {
             Assert.NotNull(file);
             Assert.Equal(0, file.Errors().Length);
 
-            CreateCompilation(text).VerifyDiagnostics(
-                // (5,28): error CS1065: Default values are not valid in this context.
-                //      F f = delegate (int x = 0) { };
-                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(5, 28));
+            CreateCompilation(text).VerifyDiagnostics();
         }
 
         [WorkItem(537865, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537865")]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -3233,6 +3233,35 @@ return 1;
                 Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "value"));
         }
 
+        [WorkItem(536956, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/536956")]
+        [Fact]
+        public void CS1065ERR_DefaultValueNotAllowed()
+        {
+            var test = @"
+class A
+{
+    delegate void D(int x);    
+    D d1 = delegate(int x = 42) { };
+}
+";
+
+            CreateCompilation(test).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void CS1065ERR_DefaultValueNotAllowed_2()
+        {
+            var test = @"
+class A
+{
+    delegate void D(int x, int y);    
+    D d1 = delegate(int x, int y = 42) { };
+}
+";
+
+            CreateCompilation(test).VerifyDiagnostics();
+        }
+
         [Fact, WorkItem(540251, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540251")]
         public void CS7014ERR_AttributesNotAllowed()
         {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -3233,41 +3233,6 @@ return 1;
                 Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "value"));
         }
 
-        [WorkItem(536956, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/536956")]
-        [Fact]
-        public void CS1065ERR_DefaultValueNotAllowed()
-        {
-            var test = @"
-class A
-{
-    delegate void D(int x);    
-    D d1 = delegate(int x = 42) { };
-}
-";
-
-            CreateCompilation(test).VerifyDiagnostics(
-                // (5,27): error CS1065: Default values are not valid in this context.
-                //     D d1 = delegate(int x = 42) { };
-                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(5, 27));
-        }
-
-        [Fact]
-        public void CS1065ERR_DefaultValueNotAllowed_2()
-        {
-            var test = @"
-class A
-{
-    delegate void D(int x, int y);    
-    D d1 = delegate(int x, int y = 42) { };
-}
-";
-
-            CreateCompilation(test).VerifyDiagnostics(
-                // (5,34): error CS1065: Default values are not valid in this context.
-                //     D d1 = delegate(int x, int y = 42) { };
-                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(5, 34));
-        }
-
         [Fact, WorkItem(540251, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540251")]
         public void CS7014ERR_AttributesNotAllowed()
         {


### PR DESCRIPTION
This is an incremental PR that adds the following error cases in the binder for lambda default parameters:

- Optional parameter before required parameter, i.e., `(int x = 3, int y) => x + y`
- Implicitly typed optional parameter, ex: `(x = 10) => x`
- Type mismatch in default parameter value, ex:  `(string s = 3) => s`
- Non-constant default parameter value, ex:  `(C c = new C()) => c`

The following is currently **Not** handled in the binder:
- Inferring the proper anonymous delegate type for lambdas with default parameters
- Any error cases related to assignment / delegate conversion for example, default value mismatch when a lambda is assigned to another lambda

Also, the refactoring around lambda parameter error checking resolves #62960.

Relates to test plan https://github.com/dotnet/roslyn/issues/62485