### PR TITLE
When pasting an unknown string into a string, if we decide to escape any characters, make sure we escape all characters

### DIFF
--- a/src/EditorFeatures/CSharp/StringCopyPaste/StringCopyPasteHelpers.cs
+++ b/src/EditorFeatures/CSharp/StringCopyPaste/StringCopyPasteHelpers.cs
@@ -415,6 +415,18 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.StringCopyPaste
         {
             using var _ = PooledStringBuilder.GetInstance(out var builder);
 
+            // First, go through and see if we're escaping *anything* in the original.  If so, then we'll escape
+            // everything.  In other words, say we're pasting `[SuppressMessage("", "CA2013")]`.  We technically don't
+            // need to escape the `""` (since that is legal in a verbatim string).  However, we will be escaping the
+            // quotes in teh `"CA2013"` to become `""CA2013""`.  Once we decide we're escaping some quotes, we should
+            // then realize that we *should* escape the `""` to `""""` to be consistent.
+
+            // So if we determine that we will be escaping all code, then just recurse, this time setting
+            // trySkipExistingEscapes to false.  That will prevent calling back into this check and it means whatever we
+            // run into we will escape.
+            if (trySkipExistingEscapes && WillEscapeAnyCharacters(isInterpolated, value))
+                return EscapeForNonRawVerbatimStringLiteral(isInterpolated, trySkipExistingEscapes: false, value);
+
             for (var i = 0; i < value.Length; i++)
             {
                 var ch = value[i];
@@ -426,21 +438,55 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.StringCopyPaste
                 // Otherwise, if it's not already escaped, then escape it.
                 if (ch == '"')
                 {
+                    builder.Append(ch);
+
                     if (trySkipExistingEscapes && nextCh == ch)
                         i++;
-                    else
-                        builder.Append(ch);
                 }
                 else if (isInterpolated && ch is '{' or '}')
                 {
+                    builder.Append(ch);
+
                     if (trySkipExistingEscapes && nextCh == ch)
                         i++;
-                    else
-                        builder.Append(ch);
                 }
             }
 
             return builder.ToString();
+
+            static bool WillEscapeAnyCharacters(bool isInterpolated, string value)
+            {
+                for (var i = 0; i < value.Length; i++)
+                {
+                    var ch = value[i];
+                    var nextCh = i == value.Length - 1 ? 0 : value[i + 1];
+
+                    if (ch == '"')
+                    {
+                        // we have an isolated quote.  we will need to escape it (and thus should escape everything in
+                        // the string.
+                        if (nextCh != ch)
+                            return true;
+
+                        // Quotes are paired.  This is already escaped fine.  Skip both quotes.
+                        i++;
+                    }
+                    else if (isInterpolated && ch is '{' or '}')
+                    {
+                        // we have an isolated brace.  we will need to escape it (and thus should escape everything in
+                        // the string.
+                        if (nextCh != ch)
+                            return true;
+
+                        // Braces are paired.  This is already escaped fine.  Skip both braces.
+                        i++;
+                    }
+
+                    // continue looking forward.
+                }
+
+                return false;
+            }
         }
 
         /// <summary>

--- a/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoVerbatimStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringCopyPaste/PasteUnknownSourceIntoVerbatimStringTests.cs
@@ -121,5 +121,32 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringCopyPaste
                 var x = @"[||]"
                 """);
         }
+
+        [WpfFact, WorkItem(62969, "https://github.com/dotnet/roslyn/issues/62969")]
+        public void TestNormalTextWithSomeQuotesToEscapeAndSomeToNotEscapeIntoVerbatimString()
+        {
+            // Because we're escaping the quotes in "CA2013", we should also escape teh `""`, even though `""` is legal
+            // to have in a verbatim string.
+            TestPasteUnknownSource(
+                pasteText: """
+                var lambda = [SuppressMessage("", "CA2013")] () => Object.ReferenceEquals(1, 2);
+                """,
+                """
+                string x = @"using System.Diagnostics.CodeAnalysis;
+
+                [||]";
+                """,
+                """"""
+                string x = @"using System.Diagnostics.CodeAnalysis;
+
+                var lambda = [SuppressMessage("""", ""CA2013"")] () => Object.ReferenceEquals(1, 2);[||]";
+                """""",
+                afterUndo:
+                """
+                string x = @"using System.Diagnostics.CodeAnalysis;
+
+                var lambda = [SuppressMessage("", "CA2013")] () => Object.ReferenceEquals(1, 2);[||]";
+                """);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/62969

The general issue here is that when text is being pasted in from an unknown source, we don't know escaped `""` mean.  Should we escape the text *again* within the destination?  or should we say that because it's a legal escape in teh destination taht we'll leave it alone.  Previously we had the logic that we woudl leave it alone.  However, this isn't great when you have a mix of quotes.  e.g.

This is the text on the clipboard: `[SuppressMessage("", "CA2013")]`

Here, we'll need to escape the quotes in `"CA2013"` to make the destination legal.  But if we're going to escape those, then we should realize that we should also escape `""` to `""""` (even though we technically don't have to).  But escaping inconsistently is far worse as it basically means we're treating different parts of the pasted text differently instead of uniformly.  