### PR TITLE
Obsolete ITemporaryStorageService public APIs

### DIFF
--- a/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/TextFactoryTests.cs
@@ -77,12 +77,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         {
             using var workspace = new AdhocWorkspace(EditorTestCompositions.EditorFeatures.GetHostServices());
 
-            var temporaryStorageService = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
+            var temporaryStorageService = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageServiceInternal>());
 
             var text = SourceText.From("Hello, World!");
 
             // Create a temporary storage location
-            using var temporaryStorage = temporaryStorageService.CreateTemporaryTextStorage(System.Threading.CancellationToken.None);
+            using var temporaryStorage = temporaryStorageService.CreateTemporaryTextStorage();
             // Write text into it
             await temporaryStorage.WriteTextAsync(text);
 
@@ -99,12 +99,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         {
             using var workspace = new AdhocWorkspace(EditorTestCompositions.EditorFeatures.GetHostServices());
 
-            var temporaryStorageService = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
+            var temporaryStorageService = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageServiceInternal>());
 
             var text = SourceText.From("Hello, World!", Encoding.ASCII);
 
             // Create a temporary storage location
-            using var temporaryStorage = temporaryStorageService.CreateTemporaryTextStorage(System.Threading.CancellationToken.None);
+            using var temporaryStorage = temporaryStorageService.CreateTemporaryTextStorage();
             // Write text into it
             await temporaryStorage.WriteTextAsync(text);
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.Snapshot.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.Snapshot.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             private string GetDebuggerDisplay()
                 => "Metadata File: " + FilePath;
 
-            public IEnumerable<ITemporaryStreamStorage> GetStorages()
+            public IEnumerable<ITemporaryStreamStorageInternal> GetStorages()
                 => _provider.GetStorages(this.FilePath, _timestamp.Value);
         }
     }

--- a/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.Factory.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.Factory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             if (_singleton == null)
             {
                 // If we're in VS we know we must be able to get a TemporaryStorageService
-                var temporaryStorage = (TemporaryStorageService)workspaceServices.GetRequiredService<ITemporaryStorageService>();
+                var temporaryStorage = (TemporaryStorageService)workspaceServices.GetRequiredService<ITemporaryStorageServiceInternal>();
                 Interlocked.CompareExchange(ref _singleton, new VisualStudioMetadataReferenceManager(_serviceProvider, temporaryStorage), null);
             }
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.RecoverableMetadataValueSource.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.RecoverableMetadataValueSource.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 _storages = storages;
             }
 
-            public IEnumerable<ITemporaryStreamStorage> GetStorages()
+            public IEnumerable<ITemporaryStreamStorageInternal> GetStorages()
                 => _storages;
 
             public override bool TryGetValue(out Optional<AssemblyMetadata> value)

--- a/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
     /// <remarks>
     /// They monitor changes in the underlying files and provide snapshot references (subclasses of <see cref="PortableExecutableReference"/>) 
     /// that can be passed to the compiler. These snapshot references serve the underlying metadata blobs from a VS-wide storage, if possible, 
-    /// from <see cref="ITemporaryStorageService"/>.
+    /// from <see cref="ITemporaryStorageServiceInternal"/>.
     /// </remarks>
     internal sealed partial class VisualStudioMetadataReferenceManager : IWorkspaceService
     {
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             Assumes.Present(_temporaryStorageService);
         }
 
-        internal IEnumerable<ITemporaryStreamStorage>? GetStorages(string fullPath, DateTime snapshotTimestamp)
+        internal IEnumerable<ITemporaryStreamStorageInternal>? GetStorages(string fullPath, DateTime snapshotTimestamp)
         {
             var key = new FileKey(fullPath, snapshotTimestamp);
             // check existing metadata

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
@@ -18,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private readonly VisualStudioProject _project;
         private readonly HostWorkspaceServices _workspaceServices;
         private readonly ICommandLineParserService _commandLineParserService;
-        private readonly ITemporaryStorageService _temporaryStorageService;
+        private readonly ITemporaryStorageServiceInternal _temporaryStorageService;
 
         /// <summary>
         /// Gate to guard all mutable fields in this class.
@@ -39,7 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// (especially in cases with many references).
         /// </summary>
         /// <remarks>Note: this will be null in the case that the command line is an empty array.</remarks>
-        private ITemporaryStreamStorage? _commandLineStorage;
+        private ITemporaryStreamStorageInternal? _commandLineStorage;
 
         private CommandLineArguments _commandLineArgumentsForCommandLine;
         private string? _explicitRuleSetFilePath;
@@ -52,7 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _project = project ?? throw new ArgumentNullException(nameof(project));
             _workspaceServices = workspaceServices;
             _commandLineParserService = workspaceServices.GetLanguageServices(project.Language).GetRequiredService<ICommandLineParserService>();
-            _temporaryStorageService = workspaceServices.GetRequiredService<ITemporaryStorageService>();
+            _temporaryStorageService = workspaceServices.GetRequiredService<ITemporaryStorageServiceInternal>();
 
             // Set up _commandLineArgumentsForCommandLine to a default. No lock taken since we're in
             // the constructor so nothing can race.

--- a/src/Workspaces/Core/Portable/Serialization/ISupportTemporaryStorage.cs
+++ b/src/Workspaces/Core/Portable/Serialization/ISupportTemporaryStorage.cs
@@ -13,6 +13,6 @@ namespace Microsoft.CodeAnalysis.Serialization
     /// </summary>
     internal interface ISupportTemporaryStorage
     {
-        IEnumerable<ITemporaryStreamStorage>? GetStorages();
+        IEnumerable<ITemporaryStreamStorageInternal>? GetStorages();
     }
 }

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Serialization
 
         private readonly HostWorkspaceServices _workspaceServices;
 
-        private readonly ITemporaryStorageService _storageService;
+        private readonly ITemporaryStorageServiceInternal _storageService;
         private readonly ITextFactoryService _textService;
         private readonly IDocumentationProviderService? _documentationService;
         private readonly IAnalyzerAssemblyLoaderProvider _analyzerLoaderProvider;
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Serialization
         {
             _workspaceServices = workspaceServices;
 
-            _storageService = workspaceServices.GetRequiredService<ITemporaryStorageService>();
+            _storageService = workspaceServices.GetRequiredService<ITemporaryStorageServiceInternal>();
             _textService = workspaceServices.GetRequiredService<ITextFactoryService>();
             _analyzerLoaderProvider = workspaceServices.GetRequiredService<IAnalyzerAssemblyLoaderProvider>();
             _documentationService = workspaceServices.GetService<IDocumentationProviderService>();

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Asset.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Asset.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Serialization
                 var offset = reader.ReadInt64();
                 var size = reader.ReadInt64();
 
-                var storage = storage2.AttachTemporaryTextStorage(name, offset, size, checksumAlgorithm, encoding, cancellationToken);
+                var storage = storage2.AttachTemporaryTextStorage(name, offset, size, checksumAlgorithm, encoding);
                 if (storage is ITemporaryTextStorageWithName storageWithName)
                 {
                     return new SerializableSourceText(storageWithName);

--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
@@ -354,7 +354,7 @@ namespace Microsoft.CodeAnalysis.Serialization
             return true;
         }
 
-        private (Metadata metadata, ImmutableArray<ITemporaryStreamStorage> storages)? TryReadMetadataFrom(
+        private (Metadata metadata, ImmutableArray<ITemporaryStreamStorageInternal> storages)? TryReadMetadataFrom(
             ObjectReader reader, SerializationKinds kind, CancellationToken cancellationToken)
         {
             var imageKind = reader.ReadInt32();
@@ -394,7 +394,7 @@ namespace Microsoft.CodeAnalysis.Serialization
             if (metadataKind == MetadataImageKind.Assembly)
             {
                 using var pooledMetadata = Creator.CreateList<ModuleMetadata>();
-                using var pooledStorage = Creator.CreateList<ITemporaryStreamStorage>();
+                using var pooledStorage = Creator.CreateList<ITemporaryStreamStorageInternal>();
 
                 var count = reader.ReadInt32();
                 for (var i = 0; i < count; i++)
@@ -417,7 +417,7 @@ namespace Microsoft.CodeAnalysis.Serialization
             return (moduleInfo.metadata, ImmutableArray.Create(moduleInfo.storage));
         }
 
-        private (ModuleMetadata metadata, ITemporaryStreamStorage storage) ReadModuleMetadataFrom(
+        private (ModuleMetadata metadata, ITemporaryStreamStorageInternal storage) ReadModuleMetadataFrom(
             ObjectReader reader, SerializationKinds kind, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -454,11 +454,11 @@ namespace Microsoft.CodeAnalysis.Serialization
         }
 
         private void GetTemporaryStorage(
-            ObjectReader reader, SerializationKinds kind, out ITemporaryStreamStorage storage, out long length, CancellationToken cancellationToken)
+            ObjectReader reader, SerializationKinds kind, out ITemporaryStreamStorageInternal storage, out long length, CancellationToken cancellationToken)
         {
             if (kind == SerializationKinds.Bits)
             {
-                storage = _storageService.CreateTemporaryStreamStorage(cancellationToken);
+                storage = _storageService.CreateTemporaryStreamStorage();
                 using var stream = SerializableBytes.CreateWritableStream();
 
                 CopyByteArrayToStream(reader, stream, cancellationToken);
@@ -479,7 +479,7 @@ namespace Microsoft.CodeAnalysis.Serialization
                 var offset = reader.ReadInt64();
                 var size = reader.ReadInt64();
 
-                storage = service2.AttachTemporaryStreamStorage(name, offset, size, cancellationToken);
+                storage = service2.AttachTemporaryStreamStorage(name, offset, size);
                 length = size;
 
                 return;
@@ -630,12 +630,12 @@ namespace Microsoft.CodeAnalysis.Serialization
         private sealed class SerializedMetadataReference : PortableExecutableReference, ISupportTemporaryStorage
         {
             private readonly Metadata _metadata;
-            private readonly ImmutableArray<ITemporaryStreamStorage> _storagesOpt;
+            private readonly ImmutableArray<ITemporaryStreamStorageInternal> _storagesOpt;
             private readonly DocumentationProvider _provider;
 
             public SerializedMetadataReference(
                 MetadataReferenceProperties properties, string? fullPath,
-                Metadata metadata, ImmutableArray<ITemporaryStreamStorage> storagesOpt, DocumentationProvider initialDocumentation)
+                Metadata metadata, ImmutableArray<ITemporaryStreamStorageInternal> storagesOpt, DocumentationProvider initialDocumentation)
                 : base(properties, fullPath, initialDocumentation)
             {
                 _metadata = metadata;
@@ -656,7 +656,7 @@ namespace Microsoft.CodeAnalysis.Serialization
             protected override PortableExecutableReference WithPropertiesImpl(MetadataReferenceProperties properties)
                 => new SerializedMetadataReference(properties, FilePath, _metadata, _storagesOpt, _provider);
 
-            public IEnumerable<ITemporaryStreamStorage>? GetStorages()
+            public IEnumerable<ITemporaryStreamStorageInternal>? GetStorages()
                 => _storagesOpt.IsDefault ? null : _storagesOpt;
         }
     }

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.Factory.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageService.Factory.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Host
 {
     internal partial class TemporaryStorageService
     {
-        [ExportWorkspaceServiceFactory(typeof(ITemporaryStorageService), ServiceLayer.Default), Shared]
+        [ExportWorkspaceServiceFactory(typeof(ITemporaryStorageServiceInternal), ServiceLayer.Default), Shared]
         internal partial class Factory : IWorkspaceServiceFactory
         {
             private readonly IWorkspaceThreadingService? _workspaceThreadingService;

--- a/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/TemporaryStorage/TemporaryStorageServiceFactory.cs
@@ -98,19 +98,19 @@ namespace Microsoft.CodeAnalysis.Host
             _textFactory = textFactory;
         }
 
-        public ITemporaryTextStorage CreateTemporaryTextStorage(CancellationToken cancellationToken)
+        public ITemporaryTextStorageInternal CreateTemporaryTextStorage()
             => new TemporaryTextStorage(this);
 
-        public ITemporaryTextStorage AttachTemporaryTextStorage(string storageName, long offset, long size, SourceHashAlgorithm checksumAlgorithm, Encoding? encoding, CancellationToken cancellationToken)
+        public ITemporaryTextStorageInternal AttachTemporaryTextStorage(string storageName, long offset, long size, SourceHashAlgorithm checksumAlgorithm, Encoding? encoding)
             => new TemporaryTextStorage(this, storageName, offset, size, checksumAlgorithm, encoding);
 
-        ITemporaryStreamStorage ITemporaryStorageService.CreateTemporaryStreamStorage(CancellationToken cancellationToken)
+        ITemporaryStreamStorageInternal ITemporaryStorageServiceInternal.CreateTemporaryStreamStorage()
             => CreateTemporaryStreamStorage();
 
         internal TemporaryStreamStorage CreateTemporaryStreamStorage()
             => new(this);
 
-        public ITemporaryStreamStorage AttachTemporaryStreamStorage(string storageName, long offset, long size, CancellationToken cancellationToken)
+        public ITemporaryStreamStorageInternal AttachTemporaryStreamStorage(string storageName, long offset, long size)
             => new TemporaryStreamStorage(this, storageName, offset, size);
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Host
         public static string CreateUniqueName(long size)
             => "Roslyn Temp Storage " + size.ToString() + " " + Guid.NewGuid().ToString("N");
 
-        private sealed class TemporaryTextStorage : ITemporaryTextStorage, ITemporaryTextStorageWithName
+        private sealed class TemporaryTextStorage : ITemporaryTextStorageInternal, ITemporaryTextStorageWithName
         {
             private readonly TemporaryStorageService _service;
             private SourceHashAlgorithm _checksumAlgorithm;
@@ -297,7 +297,7 @@ namespace Microsoft.CodeAnalysis.Host
             }
         }
 
-        internal class TemporaryStreamStorage : ITemporaryStreamStorage, ITemporaryStorageWithName
+        internal class TemporaryStreamStorage : ITemporaryStreamStorageInternal, ITemporaryStorageWithName
         {
             private readonly TemporaryStorageService _service;
             private MemoryMappedInfo? _memoryMappedInfo;
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.Host
                 _memoryMappedInfo = null;
             }
 
-            Stream ITemporaryStreamStorage.ReadStream(CancellationToken cancellationToken)
+            Stream ITemporaryStreamStorageInternal.ReadStream(CancellationToken cancellationToken)
                 => ReadStream(cancellationToken);
 
             public UnmanagedMemoryStream ReadStream(CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Workspace/Host/HostWorkspaceServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/HostWorkspaceServices.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Host
 
         /// <summary>
         /// Obsolete.  Roslyn no longer supports a mechanism to perform arbitrary persistence of data.  If such functionality
-        /// is needed, consumers are resonsible for providing it themselves with whatever semantics are needed.
+        /// is needed, consumers are responsible for providing it themselves with whatever semantics are needed.
         /// </summary>
         [Obsolete("Roslyn no longer exports a mechanism to perform persistence.", error: true)]
         public virtual IPersistentStorageService PersistentStorage
@@ -67,8 +67,10 @@ namespace Microsoft.CodeAnalysis.Host
         }
 
         /// <summary>
-        /// A service for storing information in a temporary location that only lasts for the duration of the process.
+        /// Obsolete.  Roslyn no longer supports a mechanism to store arbitrary data in-memory.  If such functionality
+        /// is needed, consumers are responsible for providing it themselves with whatever semantics are needed.
         /// </summary>
+        [Obsolete("Roslyn no longer exports a mechanism to store arbitrary data in-memory.")]
         public virtual ITemporaryStorageService TemporaryStorage
         {
             get { return this.GetRequiredService<ITemporaryStorageService>(); }

--- a/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Host
         internal sealed class RecoverableSyntaxRoot<TRoot> : WeaklyCachedRecoverableValueSource<TRoot>
             where TRoot : SyntaxNode
         {
-            private ITemporaryStreamStorage? _storage;
+            private ITemporaryStreamStorageInternal? _storage;
 
             private readonly IRecoverableSyntaxTree<TRoot> _containingTree;
             private readonly AbstractSyntaxTreeFactoryService _service;
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Host
                 root.SerializeTo(stream, cancellationToken);
                 stream.Position = 0;
 
-                _storage = _service.SolutionServices.GetRequiredService<ITemporaryStorageService>().CreateTemporaryStreamStorage(cancellationToken);
+                _storage = _service.SolutionServices.GetRequiredService<ITemporaryStorageServiceInternal>().CreateTemporaryStreamStorage();
                 await _storage.WriteStreamAsync(stream, cancellationToken).ConfigureAwait(false);
             }
 

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorage.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorage.cs
@@ -12,9 +12,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Host
 {
-    /// <summary>
-    /// TemporaryStorage can be used to read and write text to a temporary storage location.
-    /// </summary>
+    [Obsolete("Roslyn no longer exports a mechanism to store arbitrary data in-memory.")]
     public interface ITemporaryTextStorage : IDisposable
     {
         SourceText ReadText(CancellationToken cancellationToken = default);
@@ -23,7 +21,27 @@ namespace Microsoft.CodeAnalysis.Host
         Task WriteTextAsync(SourceText text, CancellationToken cancellationToken = default);
     }
 
+    [Obsolete("Roslyn no longer exports a mechanism to store arbitrary data in-memory.")]
     public interface ITemporaryStreamStorage : IDisposable
+    {
+        Stream ReadStream(CancellationToken cancellationToken = default);
+        Task<Stream> ReadStreamAsync(CancellationToken cancellationToken = default);
+        void WriteStream(Stream stream, CancellationToken cancellationToken = default);
+        Task WriteStreamAsync(Stream stream, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// TemporaryStorage can be used to read and write text to a temporary storage location.
+    /// </summary>
+    internal interface ITemporaryTextStorageInternal : IDisposable
+    {
+        SourceText ReadText(CancellationToken cancellationToken = default);
+        Task<SourceText> ReadTextAsync(CancellationToken cancellationToken = default);
+        void WriteText(SourceText text, CancellationToken cancellationToken = default);
+        Task WriteTextAsync(SourceText text, CancellationToken cancellationToken = default);
+    }
+
+    internal interface ITemporaryStreamStorageInternal : IDisposable
     {
         Stream ReadStream(CancellationToken cancellationToken = default);
         Task<Stream> ReadStreamAsync(CancellationToken cancellationToken = default);

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorageService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorageService.cs
@@ -2,18 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System;
 using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Host
 {
-    /// <summary>
-    /// This service allows you to access temporary storage.
-    /// </summary>
+    [Obsolete("API is no longer available")]
     public interface ITemporaryStorageService : IWorkspaceService
     {
         ITemporaryStreamStorage CreateTemporaryStreamStorage(CancellationToken cancellationToken = default);
         ITemporaryTextStorage CreateTemporaryTextStorage(CancellationToken cancellationToken = default);
+    }
+
+    internal interface ITemporaryStorageServiceInternal : IWorkspaceService
+    {
+        ITemporaryStreamStorageInternal CreateTemporaryStreamStorage();
+        ITemporaryTextStorageInternal CreateTemporaryTextStorage();
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorageService2.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStorageService2.cs
@@ -11,16 +11,16 @@ namespace Microsoft.CodeAnalysis.Host
     /// <summary>
     /// This service allows you to access temporary storage.
     /// </summary>
-    internal interface ITemporaryStorageService2 : ITemporaryStorageService
+    internal interface ITemporaryStorageService2 : ITemporaryStorageServiceInternal
     {
         /// <summary>
         /// Attach to existing <see cref="ITemporaryStreamStorage"/> with given name.
         /// </summary>
-        ITemporaryStreamStorage AttachTemporaryStreamStorage(string storageName, long offset, long size, CancellationToken cancellationToken = default);
+        ITemporaryStreamStorageInternal AttachTemporaryStreamStorage(string storageName, long offset, long size);
 
         /// <summary>
         /// Attach to existing <see cref="ITemporaryTextStorage"/> with given name.
         /// </summary>
-        ITemporaryTextStorage AttachTemporaryTextStorage(string storageName, long offset, long size, SourceHashAlgorithm checksumAlgorithm, Encoding? encoding, CancellationToken cancellationToken = default);
+        ITemporaryTextStorageInternal AttachTemporaryTextStorage(string storageName, long offset, long size, SourceHashAlgorithm checksumAlgorithm, Encoding? encoding);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStreamStorageExtensions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryStreamStorageExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Host
 {
     internal static class ITemporaryStreamStorageExtensions
     {
-        public static void WriteAllLines(this ITemporaryStreamStorage storage, ImmutableArray<string> values)
+        public static void WriteAllLines(this ITemporaryStreamStorageInternal storage, ImmutableArray<string> values)
         {
             using var stream = SerializableBytes.CreateWritableStream();
             using var writer = new StreamWriter(stream);
@@ -28,12 +28,12 @@ namespace Microsoft.CodeAnalysis.Host
             storage.WriteStream(stream);
         }
 
-        public static ImmutableArray<string> ReadLines(this ITemporaryStreamStorage storage)
+        public static ImmutableArray<string> ReadLines(this ITemporaryStreamStorageInternal storage)
         {
             return EnumerateLines(storage).ToImmutableArray();
         }
 
-        private static IEnumerable<string> EnumerateLines(ITemporaryStreamStorage storage)
+        private static IEnumerable<string> EnumerateLines(ITemporaryStreamStorageInternal storage)
         {
             using var stream = storage.ReadStream();
             using var reader = new StreamReader(stream);

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryTextStorageWithName.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/ITemporaryTextStorageWithName.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Host
     /// <summary>
     /// Represents a <see cref="ITemporaryStorageWithName"/> which is used to hold data for <see cref="SourceText"/>.
     /// </summary>
-    internal interface ITemporaryTextStorageWithName : ITemporaryTextStorage, ITemporaryStorageWithName
+    internal interface ITemporaryTextStorageWithName : ITemporaryTextStorageInternal, ITemporaryStorageWithName
     {
         /// <summary>
         /// Gets the value for the <see cref="SourceText.ChecksumAlgorithm"/> property for the <see cref="SourceText"/>

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/LegacyTemporaryStorageService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/LegacyTemporaryStorageService.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Host;
+
+/// <summary>
+/// Legacy implementation of obsolete public API <see cref="ITemporaryStorageService"/>.
+/// </summary>
+[Obsolete]
+[ExportWorkspaceService(typeof(ITemporaryStorageService)), Shared]
+internal sealed class LegacyTemporaryStorageService : ITemporaryStorageService
+{
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public LegacyTemporaryStorageService()
+    {
+    }
+
+    public ITemporaryStreamStorage CreateTemporaryStreamStorage(CancellationToken cancellationToken = default)
+        => new StreamStorage();
+
+    public ITemporaryTextStorage CreateTemporaryTextStorage(CancellationToken cancellationToken = default)
+        => new TextStorage();
+
+    private sealed class StreamStorage : ITemporaryStreamStorage
+    {
+        private MemoryStream? _stream;
+
+        public void Dispose()
+        {
+            _stream?.Dispose();
+            _stream = null;
+        }
+
+        public Stream ReadStream(CancellationToken cancellationToken = default)
+        {
+            var stream = _stream ?? throw new InvalidOperationException();
+
+            // Return a read-only view of the underlying buffer to prevent users from overwriting or directly
+            // disposing the backing storage.
+            return new MemoryStream(stream.GetBuffer(), 0, (int)stream.Length, writable: false);
+        }
+
+        public Task<Stream> ReadStreamAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(ReadStream(cancellationToken));
+        }
+
+        public void WriteStream(Stream stream, CancellationToken cancellationToken = default)
+        {
+            var newStream = new MemoryStream();
+            stream.CopyTo(newStream);
+            var existingValue = Interlocked.CompareExchange(ref _stream, newStream, null);
+            if (existingValue is not null)
+            {
+                throw new InvalidOperationException(WorkspacesResources.Temporary_storage_cannot_be_written_more_than_once);
+            }
+        }
+
+        public async Task WriteStreamAsync(Stream stream, CancellationToken cancellationToken = default)
+        {
+            var newStream = new MemoryStream();
+#if NETCOREAPP
+            await stream.CopyToAsync(newStream, cancellationToken).ConfigureAwait(false);
+# else
+            await stream.CopyToAsync(newStream).ConfigureAwait(false);
+#endif
+            var existingValue = Interlocked.CompareExchange(ref _stream, newStream, null);
+            if (existingValue is not null)
+            {
+                throw new InvalidOperationException(WorkspacesResources.Temporary_storage_cannot_be_written_more_than_once);
+            }
+        }
+    }
+
+    private sealed class TextStorage : ITemporaryTextStorage
+    {
+        private SourceText? _sourceText;
+
+        public void Dispose()
+            => _sourceText = null;
+
+        public SourceText ReadText(CancellationToken cancellationToken = default)
+            => _sourceText ?? throw new InvalidOperationException();
+
+        public Task<SourceText> ReadTextAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(ReadText(cancellationToken));
+
+        public void WriteText(SourceText text, CancellationToken cancellationToken = default)
+        {
+            // This is a trivial implementation, indeed. Note, however, that we retain a strong
+            // reference to the source text, which defeats the intent of RecoverableTextAndVersion, but
+            // is appropriate for this trivial implementation.
+            var existingValue = Interlocked.CompareExchange(ref _sourceText, text, null);
+            if (existingValue is not null)
+            {
+                throw new InvalidOperationException(WorkspacesResources.Temporary_storage_cannot_be_written_more_than_once);
+            }
+        }
+
+        public Task WriteTextAsync(SourceText text, CancellationToken cancellationToken = default)
+        {
+            WriteText(text, cancellationToken);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/TrivialTemporaryStorageService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/TemporaryStorage/TrivialTemporaryStorageService.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -13,7 +12,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis
 {
-    internal sealed class TrivialTemporaryStorageService : ITemporaryStorageService
+    internal sealed class TrivialTemporaryStorageService : ITemporaryStorageServiceInternal
     {
         public static readonly TrivialTemporaryStorageService Instance = new();
 
@@ -21,15 +20,15 @@ namespace Microsoft.CodeAnalysis
         {
         }
 
-        public ITemporaryStreamStorage CreateTemporaryStreamStorage(CancellationToken cancellationToken = default)
+        public ITemporaryStreamStorageInternal CreateTemporaryStreamStorage()
             => new StreamStorage();
 
-        public ITemporaryTextStorage CreateTemporaryTextStorage(CancellationToken cancellationToken = default)
+        public ITemporaryTextStorageInternal CreateTemporaryTextStorage()
             => new TextStorage();
 
-        private sealed class StreamStorage : ITemporaryStreamStorage
+        private sealed class StreamStorage : ITemporaryStreamStorageInternal
         {
-            private MemoryStream _stream;
+            private MemoryStream? _stream;
 
             public void Dispose()
             {
@@ -37,25 +36,21 @@ namespace Microsoft.CodeAnalysis
                 _stream = null;
             }
 
-            public Stream ReadStream(CancellationToken cancellationToken = default)
+            public Stream ReadStream(CancellationToken cancellationToken)
             {
-                var stream = _stream;
-                if (stream is null)
-                {
-                    throw new InvalidOperationException();
-                }
+                var stream = _stream ?? throw new InvalidOperationException();
 
                 // Return a read-only view of the underlying buffer to prevent users from overwriting or directly
                 // disposing the backing storage.
                 return new MemoryStream(stream.GetBuffer(), 0, (int)stream.Length, writable: false);
             }
 
-            public Task<Stream> ReadStreamAsync(CancellationToken cancellationToken = default)
+            public Task<Stream> ReadStreamAsync(CancellationToken cancellationToken)
             {
                 return Task.FromResult(ReadStream(cancellationToken));
             }
 
-            public void WriteStream(Stream stream, CancellationToken cancellationToken = default)
+            public void WriteStream(Stream stream, CancellationToken cancellationToken)
             {
                 var newStream = new MemoryStream();
                 stream.CopyTo(newStream);
@@ -66,7 +61,7 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            public async Task WriteStreamAsync(Stream stream, CancellationToken cancellationToken = default)
+            public async Task WriteStreamAsync(Stream stream, CancellationToken cancellationToken)
             {
                 var newStream = new MemoryStream();
 #if NETCOREAPP
@@ -82,20 +77,20 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        private sealed class TextStorage : ITemporaryTextStorage
+        private sealed class TextStorage : ITemporaryTextStorageInternal
         {
-            private SourceText _sourceText;
+            private SourceText? _sourceText;
 
             public void Dispose()
                 => _sourceText = null;
 
-            public SourceText ReadText(CancellationToken cancellationToken = default)
-                => _sourceText;
+            public SourceText ReadText(CancellationToken cancellationToken)
+                => _sourceText ?? throw new InvalidOperationException();
 
-            public Task<SourceText> ReadTextAsync(CancellationToken cancellationToken = default)
+            public Task<SourceText> ReadTextAsync(CancellationToken cancellationToken)
                 => Task.FromResult(ReadText(cancellationToken));
 
-            public void WriteText(SourceText text, CancellationToken cancellationToken = default)
+            public void WriteText(SourceText text, CancellationToken cancellationToken)
             {
                 // This is a trivial implementation, indeed. Note, however, that we retain a strong
                 // reference to the source text, which defeats the intent of RecoverableTextAndVersion, but

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
@@ -229,7 +229,7 @@ internal partial class SolutionState
             return false;
         }
 
-        private static ITemporaryStreamStorage? TryCreateMetadataStorage(Workspace workspace, Compilation compilation, CancellationToken cancellationToken)
+        private static ITemporaryStreamStorageInternal? TryCreateMetadataStorage(Workspace workspace, Compilation compilation, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -251,8 +251,8 @@ internal partial class SolutionState
                     {
                         workspace.LogTestMessage(static compilation => $"Successfully emitted a skeleton assembly for {compilation.AssemblyName}", compilation);
 
-                        var temporaryStorageService = workspace.Services.GetRequiredService<ITemporaryStorageService>();
-                        var storage = temporaryStorageService.CreateTemporaryStreamStorage(cancellationToken);
+                        var temporaryStorageService = workspace.Services.GetRequiredService<ITemporaryStorageServiceInternal>();
+                        var storage = temporaryStorageService.CreateTemporaryStreamStorage();
 
                         stream.Position = 0;
                         storage.WriteStream(stream, cancellationToken);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis
 
         protected static ValueSource<TextAndVersion> CreateRecoverableText(TextAndVersion text, HostWorkspaceServices services)
         {
-            var result = new RecoverableTextAndVersion(CreateStrongText(text), services.TemporaryStorage);
+            var result = new RecoverableTextAndVersion(CreateStrongText(text), services.GetRequiredService<ITemporaryStorageServiceInternal>());
 
             // This RecoverableTextAndVersion is created directly from a TextAndVersion instance. In its initial state,
             // the RecoverableTextAndVersion keeps a strong reference to the initial TextAndVersion, and only
@@ -117,10 +117,10 @@ namespace Microsoft.CodeAnalysis
                     asynchronousComputeFunction: cancellationToken => loader.LoadTextAsync(services.Workspace, documentId, cancellationToken),
                     synchronousComputeFunction: cancellationToken => loader.LoadTextSynchronously(services.Workspace, documentId, cancellationToken),
                     cacheResult: false),
-                services.TemporaryStorage);
+                services.GetRequiredService<ITemporaryStorageServiceInternal>());
         }
 
-        public ITemporaryTextStorage? Storage
+        public ITemporaryTextStorageInternal? Storage
         {
             get
             {

--- a/src/Workspaces/CoreTest/Host/WorkspaceServices/TestTemporaryStorageServiceFactory.cs
+++ b/src/Workspaces/CoreTest/Host/WorkspaceServices/TestTemporaryStorageServiceFactory.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.UnitTests.Persistence
 {
-    [ExportWorkspaceServiceFactory(typeof(ITemporaryStorageService), ServiceLayer.Test), Shared, PartNotDiscoverable]
+    [ExportWorkspaceServiceFactory(typeof(ITemporaryStorageServiceInternal), ServiceLayer.Test), Shared, PartNotDiscoverable]
     internal sealed class TestTemporaryStorageServiceFactory : IWorkspaceServiceFactory
     {
         [ImportingConstructor]

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -1943,14 +1943,14 @@ namespace Microsoft.CodeAnalysis.UnitTests
             // stop observing it and let GC reclaim it
             if (PlatformInformation.IsWindows || PlatformInformation.IsRunningOnMono)
             {
-                Assert.IsType<TemporaryStorageService>(workspace.Services.GetService<ITemporaryStorageService>());
+                Assert.IsType<TemporaryStorageService>(workspace.Services.GetService<ITemporaryStorageServiceInternal>());
                 observedText.AssertReleased();
             }
             else
             {
                 // If this assertion fails, it means a new target supports the true temporary storage service, and the
                 // condition above should be updated to ensure 'AssertReleased' is called for this target.
-                Assert.IsType<TrivialTemporaryStorageService>(workspace.Services.GetService<ITemporaryStorageService>());
+                Assert.IsType<TrivialTemporaryStorageService>(workspace.Services.GetService<ITemporaryStorageServiceInternal>());
             }
 
             // if we ask for the same text again we should get the original content

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/TemporaryStorageServiceTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
+            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageServiceInternal>());
 
             // test normal string
             var text = SourceText.From(new string(' ', 4096) + "public class A {}");
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
+            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageServiceInternal>());
             var temporaryStorage = service.CreateTemporaryStreamStorage();
 
             using var data = SerializableBytes.CreateWritableStream();
@@ -66,10 +66,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
         }
 
-        private static void TestTemporaryStorage(ITemporaryStorageService temporaryStorageService, SourceText text)
+        private static void TestTemporaryStorage(ITemporaryStorageServiceInternal temporaryStorageService, SourceText text)
         {
             // create a temporary storage location
-            var temporaryStorage = temporaryStorageService.CreateTemporaryTextStorage(System.Threading.CancellationToken.None);
+            var temporaryStorage = temporaryStorageService.CreateTemporaryTextStorage();
 
             // write text into it
             temporaryStorage.WriteTextAsync(text).Wait();
@@ -89,8 +89,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
-            var storage = service.CreateTemporaryTextStorage(CancellationToken.None);
+            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageServiceInternal>());
+            var storage = service.CreateTemporaryTextStorage();
 
             // Nothing has been written yet
             Assert.Throws<InvalidOperationException>(() => storage.ReadText());
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
+            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageServiceInternal>());
             var storage = service.CreateTemporaryStreamStorage();
 
             // Nothing has been written yet
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
+            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageServiceInternal>());
             var storage = service.CreateTemporaryStreamStorage();
 
             // 0 length streams are allowed
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
+            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageServiceInternal>());
             var buffer = new MemoryStream(257 * 1024 + 1);
             for (var i = 0; i < buffer.Length; i++)
             {
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             {
                 for (var j = 1; j < 5; j++)
                 {
-                    using ITemporaryStreamStorage storage1 = service.CreateTemporaryStreamStorage(),
+                    using ITemporaryStreamStorageInternal storage1 = service.CreateTemporaryStreamStorage(),
                                                   storage2 = service.CreateTemporaryStreamStorage();
                     var storage3 = service.CreateTemporaryStreamStorage(); // let the finalizer run for this instance
 
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             {
                 using var workspace = new AdhocWorkspace();
                 var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-                var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
+                var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageServiceInternal>());
 
                 using var data = SerializableBytes.CreateWritableStream();
                 for (var i = 0; i < 1024 * 128; i++)
@@ -211,7 +211,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
                 // Create 4GB of memory mapped files
                 var fileCount = (int)((long)4 * 1024 * 1024 * 1024 / data.Length);
-                var storageHandles = new List<ITemporaryStreamStorage>(fileCount);
+                var storageHandles = new List<ITemporaryStreamStorageInternal>(fileCount);
                 for (var i = 0; i < fileCount; i++)
                 {
                     var s = service.CreateTemporaryStreamStorage();
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
+            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageServiceInternal>());
             var storage = service.CreateTemporaryStreamStorage();
 
             using var expected = new MemoryStream();
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
+            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageServiceInternal>());
             var storage = service.CreateTemporaryStreamStorage();
 
             using var expected = new MemoryStream();
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
+            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageServiceInternal>());
             var storage = service.CreateTemporaryStreamStorage();
 
             using var expected = new MemoryStream();
@@ -335,7 +335,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             using var workspace = new AdhocWorkspace();
             var textFactory = Assert.IsType<TextFactoryService>(workspace.Services.GetService<ITextFactoryService>());
-            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageService>());
+            var service = Assert.IsType<TemporaryStorageService>(workspace.Services.GetRequiredService<ITemporaryStorageServiceInternal>());
 
             // test normal string
             var text = SourceText.From(new string(' ', 4096) + "public class A {}", Encoding.ASCII);

--- a/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
@@ -43,7 +43,6 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
             Assert.NotNull(workspace.Services.Workspace);
             Assert.Equal(workspace, workspace.Services.Workspace);
             Assert.NotNull(workspace.Services.HostServices);
-            Assert.NotNull(workspace.Services.TemporaryStorage);
             Assert.NotNull(workspace.Services.TextFactory);
         }
 


### PR DESCRIPTION
The API shouldn't have been public in the first place. Roslyn shouldn't expose public APIs that provide general abstraction over a memory map.

Exports a trivial implementation of the obsoleted public APIs (copy of TrivialTemporaryStorageService).

Separating the public and internal interfaces will allow us to clean up the implementation.