### PR TITLE
Rename `LifetimeAnnotationAttribute` to `ScopedRefAttribute` and simplify

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -744,7 +744,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, lambdaParameters, diagnostics, modifyCompilation: false);
-            ParameterHelpers.EnsureLifetimeAnnotationAttributeExists(compilation, lambdaParameters, diagnostics, modifyCompilation: false);
+            ParameterHelpers.EnsureScopedRefAttributeExists(compilation, lambdaParameters, diagnostics, modifyCompilation: false);
             ParameterHelpers.EnsureNullableAttributeExists(compilation, lambdaSymbol, lambdaParameters, diagnostics, modifyCompilation: false);
             // Note: we don't need to warn on annotations used in #nullable disable context for lambdas, as this is handled in binding already
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         private SynthesizedEmbeddedNullableContextAttributeSymbol _lazyNullableContextAttribute;
         private SynthesizedEmbeddedNullablePublicOnlyAttributeSymbol _lazyNullablePublicOnlyAttribute;
         private SynthesizedEmbeddedNativeIntegerAttributeSymbol _lazyNativeIntegerAttribute;
-        private SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol _lazyLifetimeAnnotationAttribute;
+        private SynthesizedEmbeddedScopedRefAttributeSymbol _lazyScopedRefAttribute;
 
         /// <summary>
         /// The behavior of the C# command-line compiler is as follows:
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             builder.AddIfNotNull(_lazyNullableContextAttribute);
             builder.AddIfNotNull(_lazyNullablePublicOnlyAttribute);
             builder.AddIfNotNull(_lazyNativeIntegerAttribute);
-            builder.AddIfNotNull(_lazyLifetimeAnnotationAttribute);
+            builder.AddIfNotNull(_lazyScopedRefAttribute);
 
             return builder.ToImmutableAndFree();
         }
@@ -251,17 +251,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return base.SynthesizeNativeIntegerAttribute(member, arguments);
         }
 
-        internal override SynthesizedAttributeData SynthesizeLifetimeAnnotationAttribute(WellKnownMember member, ImmutableArray<TypedConstant> arguments)
+        internal override SynthesizedAttributeData SynthesizeScopedRefAttribute(WellKnownMember member)
         {
-            if ((object)_lazyLifetimeAnnotationAttribute != null)
+            if ((object)_lazyScopedRefAttribute != null)
             {
                 return new SynthesizedAttributeData(
-                    _lazyLifetimeAnnotationAttribute.Constructors[0],
-                    arguments,
+                    _lazyScopedRefAttribute.Constructors[0],
+                    ImmutableArray<TypedConstant>.Empty,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
             }
 
-            return base.SynthesizeLifetimeAnnotationAttribute(member, arguments);
+            return base.SynthesizeScopedRefAttribute(member);
         }
 
         protected override SynthesizedAttributeData TrySynthesizeIsReadOnlyAttribute()
@@ -389,13 +389,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     CreateNativeIntegerAttributeSymbol);
             }
 
-            if ((needsAttributes & EmbeddableAttributes.LifetimeAnnotationAttribute) != 0)
+            if ((needsAttributes & EmbeddableAttributes.ScopedRefAttribute) != 0)
             {
                 CreateAttributeIfNeeded(
-                    ref _lazyLifetimeAnnotationAttribute,
+                    ref _lazyScopedRefAttribute,
                     diagnostics,
-                    AttributeDescription.LifetimeAnnotationAttribute,
-                    CreateLifetimeAnnotationAttributeSymbol);
+                    AttributeDescription.ScopedRefAttribute,
+                    CreateScopedRefAttributeSymbol);
             }
         }
 
@@ -438,13 +438,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     GetWellKnownType(WellKnownType.System_Attribute, diagnostics),
                     GetSpecialType(SpecialType.System_Boolean, diagnostics));
 
-        private SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol CreateLifetimeAnnotationAttributeSymbol(string name, NamespaceSymbol containingNamespace, BindingDiagnosticBag diagnostics)
-            => new SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol(
+        private SynthesizedEmbeddedScopedRefAttributeSymbol CreateScopedRefAttributeSymbol(string name, NamespaceSymbol containingNamespace, BindingDiagnosticBag diagnostics)
+            => new SynthesizedEmbeddedScopedRefAttributeSymbol(
                     name,
                     containingNamespace,
                     SourceModule,
-                    GetWellKnownType(WellKnownType.System_Attribute, diagnostics),
-                    GetSpecialType(SpecialType.System_Boolean, diagnostics));
+                    GetWellKnownType(WellKnownType.System_Attribute, diagnostics));
 
         private void CreateAttributeIfNeeded<T>(
             ref T symbol,

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1710,7 +1710,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return Compilation.TrySynthesizeAttribute(member, arguments, isOptionalUse: true);
         }
 
-        internal SynthesizedAttributeData SynthesizeLifetimeAnnotationAttribute(ParameterSymbol symbol, DeclarationScope scope)
+        internal SynthesizedAttributeData SynthesizeScopedRefAttribute(ParameterSymbol symbol, DeclarationScope scope)
         {
             Debug.Assert(scope != DeclarationScope.Unscoped);
             Debug.Assert(symbol.RefKind != RefKind.Out || scope == DeclarationScope.ValueScoped);
@@ -1722,20 +1722,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 return null;
             }
 
-            var booleanType = Compilation.GetSpecialType(SpecialType.System_Boolean);
-            Debug.Assert((object)booleanType != null);
-            return SynthesizeLifetimeAnnotationAttribute(
-                WellKnownMember.System_Runtime_CompilerServices_LifetimeAnnotationAttribute__ctor,
-                ImmutableArray.Create(
-                    new TypedConstant(booleanType, TypedConstantKind.Primitive, scope == DeclarationScope.RefScoped),
-                    new TypedConstant(booleanType, TypedConstantKind.Primitive, scope == DeclarationScope.ValueScoped)));
+            return SynthesizeScopedRefAttribute(WellKnownMember.System_Runtime_CompilerServices_ScopedRefAttribute__ctor);
         }
 
-        internal virtual SynthesizedAttributeData SynthesizeLifetimeAnnotationAttribute(WellKnownMember member, ImmutableArray<TypedConstant> arguments)
+        internal virtual SynthesizedAttributeData SynthesizeScopedRefAttribute(WellKnownMember member)
         {
             // For modules, this attribute should be present. Only assemblies generate and embed this type.
             // https://github.com/dotnet/roslyn/issues/30062 Should not be optional.
-            return Compilation.TrySynthesizeAttribute(member, arguments, isOptionalUse: true);
+            return Compilation.TrySynthesizeAttribute(member, isOptionalUse: true);
         }
 
         internal bool ShouldEmitNullablePublicOnlyAttribute()
@@ -1811,9 +1805,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             EnsureEmbeddableAttributeExists(EmbeddableAttributes.NativeIntegerAttribute);
         }
 
-        internal void EnsureLifetimeAnnotationAttributeExists()
+        internal void EnsureScopedRefAttributeExists()
         {
-            EnsureEmbeddableAttributeExists(EmbeddableAttributes.LifetimeAnnotationAttribute);
+            EnsureEmbeddableAttributeExists(EmbeddableAttributes.ScopedRefAttribute);
         }
 
 #nullable enable

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureMethod.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ParameterHelpers.EnsureNativeIntegerAttributeExists(moduleBuilder, Parameters);
             }
 
-            ParameterHelpers.EnsureLifetimeAnnotationAttributeExists(moduleBuilder, Parameters);
+            ParameterHelpers.EnsureScopedRefAttributeExists(moduleBuilder, Parameters);
 
             if (compilationState.Compilation.ShouldEmitNullableAttributes(this))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -388,8 +388,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<KeyValuePair<WellKnownMember, TypedConstant>> namedArguments = default,
             bool isOptionalUse = false)
         {
-            UseSiteInfo<AssemblySymbol> info;
-            var ctorSymbol = (MethodSymbol)Binder.GetWellKnownTypeMember(this, constructor, out info, isOptional: true);
+            var ctorSymbol = (MethodSymbol)Binder.GetWellKnownTypeMember(this, constructor, useSiteInfo: out _, isOptional: true);
 
             if ((object)ctorSymbol == null)
             {
@@ -413,7 +412,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var builder = new ArrayBuilder<KeyValuePair<string, TypedConstant>>(namedArguments.Length);
                 foreach (var arg in namedArguments)
                 {
-                    var wellKnownMember = Binder.GetWellKnownTypeMember(this, arg.Key, out info, isOptional: true);
+                    var wellKnownMember = Binder.GetWellKnownTypeMember(this, arg.Key, useSiteInfo: out _, isOptional: true);
                     if (wellKnownMember == null || wellKnownMember is ErrorTypeSymbol)
                     {
                         // if this assert fails, UseSiteErrors for "member" have not been checked before emitting ...
@@ -544,9 +543,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             EnsureEmbeddableAttributeExists(EmbeddableAttributes.NativeIntegerAttribute, diagnostics, location, modifyCompilation);
         }
 
-        internal void EnsureLifetimeAnnotationAttributeExists(BindingDiagnosticBag? diagnostics, Location location, bool modifyCompilation)
+        internal void EnsureScopedRefAttributeExists(BindingDiagnosticBag? diagnostics, Location location, bool modifyCompilation)
         {
-            EnsureEmbeddableAttributeExists(EmbeddableAttributes.LifetimeAnnotationAttribute, diagnostics, location, modifyCompilation);
+            EnsureEmbeddableAttributeExists(EmbeddableAttributes.ScopedRefAttribute, diagnostics, location, modifyCompilation);
         }
 
         internal bool CheckIfAttributeShouldBeEmbedded(EmbeddableAttributes attribute, BindingDiagnosticBag? diagnosticsOpt, Location locationOpt)
@@ -607,12 +606,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                         WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctor,
                         WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags);
 
-                case EmbeddableAttributes.LifetimeAnnotationAttribute:
+                case EmbeddableAttributes.ScopedRefAttribute:
                     return CheckIfAttributeShouldBeEmbedded(
                         diagnosticsOpt,
                         locationOpt,
-                        WellKnownType.System_Runtime_CompilerServices_LifetimeAnnotationAttribute,
-                        WellKnownMember.System_Runtime_CompilerServices_LifetimeAnnotationAttribute__ctor);
+                        WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute,
+                        WellKnownMember.System_Runtime_CompilerServices_ScopedRefAttribute__ctor);
 
                 default:
                     throw ExceptionUtilities.UnexpectedValue(attribute);

--- a/src/Compilers/CSharp/Portable/Symbols/DeclarationScope.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DeclarationScope.cs
@@ -6,7 +6,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     // https://github.com/dotnet/roslyn/issues/61647: Internally, scope is represented with this enum,
     // but the public API uses a pair of IsRefScoped and IsValueScoped bools (see ILocalSymbol,
-    // IParameterSymbol, and LifetimeAnnotationAttribute). We should have a common representation.
+    // IParameterSymbol, and ScopedRefAttribute). We should have a common representation.
     // And we should use common terms for the attribute and enum names.
     internal enum DeclarationScope : byte
     {

--- a/src/Compilers/CSharp/Portable/Symbols/EmbeddableAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EmbeddableAttributes.cs
@@ -16,6 +16,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         NullableContextAttribute = 0x10,
         NullablePublicOnlyAttribute = 0x20,
         NativeIntegerAttribute = 0x40,
-        LifetimeAnnotationAttribute = 0x80,
+        ScopedRefAttribute = 0x80,
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -304,16 +304,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         Debug.Assert(refKind != RefKind.None);
                         scope = DeclarationScope.RefScoped;
                     }
+                    else if (typeWithAnnotations.Type.IsRefLikeType)
+                    {
+                        scope = DeclarationScope.ValueScoped;
+                    }
                     else
                     {
-                        if (typeWithAnnotations.Type.IsRefLikeType)
-                        {
-                            scope = DeclarationScope.ValueScoped;
-                        }
-                        else
-                        {
-                            isBad = true;
-                        }
+                        isBad = true;
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var compilation = DeclaringCompilation;
             ParameterHelpers.EnsureIsReadOnlyAttributeExists(compilation, parameters, diagnostics, modifyCompilation: false);
             ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, parameters, diagnostics, modifyCompilation: false);
-            ParameterHelpers.EnsureLifetimeAnnotationAttributeExists(compilation, parameters, diagnostics, modifyCompilation: false);
+            ParameterHelpers.EnsureScopedRefAttributeExists(compilation, parameters, diagnostics, modifyCompilation: false);
             ParameterHelpers.EnsureNullableAttributeExists(compilation, this, parameters, diagnostics, modifyCompilation: false);
             // Note: we don't need to warn on annotations used in #nullable disable context for local functions, as this is handled in binding already
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal static bool RequiresLifetimeAnnotationAttribute(ParameterSymbol parameter)
+        internal static bool RequiresScopedRefAttribute(ParameterSymbol parameter)
         {
             Debug.Assert(!parameter.IsThis);
 
@@ -322,12 +322,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal static void EnsureLifetimeAnnotationAttributeExists(PEModuleBuilder moduleBuilder, ImmutableArray<ParameterSymbol> parameters)
+        internal static void EnsureScopedRefAttributeExists(PEModuleBuilder moduleBuilder, ImmutableArray<ParameterSymbol> parameters)
         {
-            EnsureLifetimeAnnotationAttributeExists(moduleBuilder.Compilation, parameters, diagnostics: null, modifyCompilation: false, moduleBuilder);
+            EnsureScopedRefAttributeExists(moduleBuilder.Compilation, parameters, diagnostics: null, modifyCompilation: false, moduleBuilder);
         }
 
-        internal static void EnsureLifetimeAnnotationAttributeExists(CSharpCompilation? compilation, ImmutableArray<ParameterSymbol> parameters, BindingDiagnosticBag diagnostics, bool modifyCompilation)
+        internal static void EnsureScopedRefAttributeExists(CSharpCompilation? compilation, ImmutableArray<ParameterSymbol> parameters, BindingDiagnosticBag diagnostics, bool modifyCompilation)
         {
             // These parameters might not come from a compilation (example: lambdas evaluated in EE).
             // During rewriting, lowering will take care of flagging the appropriate PEModuleBuilder instead.
@@ -336,22 +336,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return;
             }
 
-            EnsureLifetimeAnnotationAttributeExists(compilation, parameters, diagnostics, modifyCompilation, moduleBuilder: null);
+            EnsureScopedRefAttributeExists(compilation, parameters, diagnostics, modifyCompilation, moduleBuilder: null);
         }
 
-        private static void EnsureLifetimeAnnotationAttributeExists(CSharpCompilation compilation, ImmutableArray<ParameterSymbol> parameters, BindingDiagnosticBag? diagnostics, bool modifyCompilation, PEModuleBuilder? moduleBuilder)
+        private static void EnsureScopedRefAttributeExists(CSharpCompilation compilation, ImmutableArray<ParameterSymbol> parameters, BindingDiagnosticBag? diagnostics, bool modifyCompilation, PEModuleBuilder? moduleBuilder)
         {
             foreach (var parameter in parameters)
             {
-                if (RequiresLifetimeAnnotationAttribute(parameter))
+                if (RequiresScopedRefAttribute(parameter))
                 {
                     if (moduleBuilder is { })
                     {
-                        moduleBuilder.EnsureLifetimeAnnotationAttributeExists();
+                        moduleBuilder.EnsureScopedRefAttributeExists();
                     }
                     else
                     {
-                        compilation.EnsureLifetimeAnnotationAttributeExists(diagnostics, GetParameterLocation(parameter), modifyCompilation);
+                        compilation.EnsureScopedRefAttributeExists(diagnostics, GetParameterLocation(parameter), modifyCompilation);
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbolBase.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var compilation = DeclaringCompilation;
             ParameterHelpers.EnsureIsReadOnlyAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
             ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
-            ParameterHelpers.EnsureLifetimeAnnotationAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
+            ParameterHelpers.EnsureScopedRefAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
             ParameterHelpers.EnsureNullableAttributeExists(compilation, this, Parameters, diagnostics, modifyCompilation: true);
 
             foreach (var parameter in this.Parameters)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -340,7 +340,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
-                ParameterHelpers.EnsureLifetimeAnnotationAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
+                ParameterHelpers.EnsureScopedRefAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
 
                 if (compilation.ShouldEmitNullableAttributes(this) &&
                     ReturnTypeWithAnnotations.NeedsNullableAttribute())

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodOrUserDefinedOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodOrUserDefinedOperatorSymbol.cs
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
 
-            ParameterHelpers.EnsureLifetimeAnnotationAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
+            ParameterHelpers.EnsureScopedRefAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
 
             if (compilation.ShouldEmitNullableAttributes(this) && ReturnTypeWithAnnotations.NeedsNullableAttribute())
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbolBase.cs
@@ -99,9 +99,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNativeIntegerAttribute(this, type.Type));
             }
 
-            if (ParameterHelpers.RequiresLifetimeAnnotationAttribute(this))
+            if (ParameterHelpers.RequiresScopedRefAttribute(this))
             {
-                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeLifetimeAnnotationAttribute(this, Scope));
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeScopedRefAttribute(this, Scope));
             }
 
             if (type.Type.ContainsTupleNames())

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -835,7 +835,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
 
-            ParameterHelpers.EnsureLifetimeAnnotationAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
+            ParameterHelpers.EnsureScopedRefAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
 
             if (compilation.ShouldEmitNullableAttributes(this) &&
                 this.TypeWithAnnotations.NeedsNullableAttribute())

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 new SynthesizedEmbeddedAttributeConstructorWithBodySymbol(
                     this,
                     getParameters: m => ImmutableArray<ParameterSymbol>.Empty,
-                    getConstructorBody: (f, s, p) => { }));
+                    getConstructorBody: (_, _, _) => { }));
         }
 
         public override ImmutableArray<MethodSymbol> Constructors => _constructors;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol.cs
@@ -10,51 +10,27 @@ using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
-    internal sealed class SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol : SynthesizedEmbeddedAttributeSymbolBase
+    internal sealed class SynthesizedEmbeddedScopedRefAttributeSymbol : SynthesizedEmbeddedAttributeSymbolBase
     {
-        private readonly ImmutableArray<FieldSymbol> _fields;
         private readonly ImmutableArray<MethodSymbol> _constructors;
 
-        public SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol(
+        public SynthesizedEmbeddedScopedRefAttributeSymbol(
             string name,
             NamespaceSymbol containingNamespace,
             ModuleSymbol containingModule,
-            NamedTypeSymbol systemAttributeType,
-            TypeSymbol boolType)
+            NamedTypeSymbol systemAttributeType)
             : base(name, containingNamespace, containingModule, baseType: systemAttributeType)
         {
-            _fields = ImmutableArray.Create<FieldSymbol>(
-                new SynthesizedFieldSymbol(this, boolType, "IsRefScoped", isPublic: true, isReadOnly: true, isStatic: false),
-                new SynthesizedFieldSymbol(this, boolType, "IsValueScoped", isPublic: true, isReadOnly: true, isStatic: false));
-
             _constructors = ImmutableArray.Create<MethodSymbol>(
                 new SynthesizedEmbeddedAttributeConstructorWithBodySymbol(
                     this,
-                    m => ImmutableArray.Create(
-                        SynthesizedParameterSymbol.Create(m, TypeWithAnnotations.Create(boolType), 0, RefKind.None),
-                        SynthesizedParameterSymbol.Create(m, TypeWithAnnotations.Create(boolType), 1, RefKind.None)),
-                    (f, s, p) => GenerateConstructorBody(f, s, p)));
+                    getParameters: m => ImmutableArray<ParameterSymbol>.Empty,
+                    getConstructorBody: (f, s, p) => { }));
         }
-
-        internal override IEnumerable<FieldSymbol> GetFieldsToEmit() => _fields;
 
         public override ImmutableArray<MethodSymbol> Constructors => _constructors;
 
         internal override AttributeUsageInfo GetAttributeUsageInfo() =>
             new AttributeUsageInfo(AttributeTargets.Parameter, allowMultiple: false, inherited: false);
-
-        private void GenerateConstructorBody(SyntheticBoundNodeFactory factory, ArrayBuilder<BoundStatement> statements, ImmutableArray<ParameterSymbol> parameters)
-        {
-            statements.Add(
-                factory.ExpressionStatement(
-                    factory.AssignmentExpression(
-                        factory.Field(factory.This(), _fields[0]),
-                        factory.Parameter(parameters[0]))));
-            statements.Add(
-                factory.ExpressionStatement(
-                    factory.AssignmentExpression(
-                        factory.Field(factory.This(), _fields[1]),
-                        factory.Parameter(parameters[1]))));
-        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol.cs
@@ -3,10 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -160,9 +160,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNativeIntegerAttribute(this, type.Type));
             }
 
-            if (ParameterHelpers.RequiresLifetimeAnnotationAttribute(this))
+            if (ParameterHelpers.RequiresScopedRefAttribute(this))
             {
-                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeLifetimeAnnotationAttribute(this, Scope));
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeScopedRefAttribute(this, Scope));
             }
 
             if (type.Type.ContainsTupleNames() &&

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_LifetimeAnnotation.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_LifetimeAnnotation.cs
@@ -130,40 +130,24 @@ using System.Runtime.CompilerServices;
     [ScopedRef] static object M1() => throw null;
     [ScopedRef] static object M2() => throw null;
     static void M3<[ScopedRef] T>() { }
-}";
-            var comp = CreateCompilation(new[] { ScopedRefAttributeDefinition, source });
+}
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = false)]
+    public sealed class ScopedRefAttribute : Attribute
+    {
+    }
+}
+";
+            var comp = CreateCompilation(source);
             // https://github.com/dotnet/roslyn/issues/62124: Re-enable check for ScopedRefAttribute in ReportExplicitUseOfReservedAttributes.
             comp.VerifyDiagnostics(
-                // (3,10): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
-                // [module: ScopedRef]
-                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(3, 10),
-                // (4,2): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
-                // [ScopedRef] class Program
-                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(4, 2),
-                // (6,6): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
-                //     [ScopedRef] object F;
-                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(6, 6),
                 // (6,24): warning CS0169: The field 'Program.F' is never used
                 //     [ScopedRef] object F;
                 Diagnostic(ErrorCode.WRN_UnreferencedField, "F").WithArguments("Program.F").WithLocation(6, 24),
-                // (7,6): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
-                //     [ScopedRef] event EventHandler E;
-                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(7, 6),
                 // (7,36): warning CS0067: The event 'Program.E' is never used
                 //     [ScopedRef] event EventHandler E;
-                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("Program.E").WithLocation(7, 36),
-                // (8,6): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
-                //     [ScopedRef] object P { get; }
-                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(8, 6),
-                // (9,6): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
-                //     [ScopedRef] static object M1() => throw null;
-                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(9, 6),
-                // (10,6): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
-                //     [ScopedRef] static object M2() => throw null;
-                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(10, 6),
-                // (11,21): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
-                //     static void M3<[ScopedRef] T>() { }
-                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(11, 21));
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("Program.E").WithLocation(7, 36));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_LifetimeAnnotation.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_LifetimeAnnotation.cs
@@ -17,21 +17,14 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
-    public class AttributeTests_LifetimeAnnotation : CSharpTestBase
+    public class AttributeTests_ScopedRef : CSharpTestBase
     {
-        private const string LifetimeAnnotationAttributeDefinition =
+        private const string ScopedRefAttributeDefinition =
 @"namespace System.Runtime.CompilerServices
 {
-    [AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = false)]
-    public sealed class LifetimeAnnotationAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public sealed class ScopedRefAttribute : Attribute
     {
-        public LifetimeAnnotationAttribute(bool isRefScoped, bool isValueScoped)
-        {
-            IsRefScoped = isRefScoped;
-            IsValueScoped = isValueScoped;
-        }
-        public bool IsRefScoped { get; }
-        public bool IsValueScoped { get; }
     }
 }";
 
@@ -43,22 +36,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public static void F(scoped ref int i) { }
 }";
-            var comp = CreateCompilation(new[] { LifetimeAnnotationAttributeDefinition, source });
+            var comp = CreateCompilation(new[] { ScopedRefAttributeDefinition, source });
             var expected =
 @" void Program.F(ref System.Int32 i)
-    [LifetimeAnnotation(True, False)] ref System.Int32 i
+    [ScopedRef] ref System.Int32 i
 ";
             CompileAndVerify(comp, symbolValidator: module =>
             {
-                Assert.Equal("System.Runtime.CompilerServices.LifetimeAnnotationAttribute", GetLifetimeAnnotationType(module).ToTestDisplayString());
-                AssertLifetimeAnnotationAttributes(module, expected);
+                Assert.Equal("System.Runtime.CompilerServices.ScopedRefAttribute", GetScopedRefType(module).ToTestDisplayString());
+                AssertScopedRefAttributes(module, expected);
             });
         }
 
         [Fact]
         public void ExplicitAttribute_FromMetadata()
         {
-            var comp = CreateCompilation(LifetimeAnnotationAttributeDefinition);
+            var comp = CreateCompilation(ScopedRefAttributeDefinition);
             comp.VerifyDiagnostics();
             var ref0 = comp.EmitToImageReference();
 
@@ -70,38 +63,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             comp = CreateCompilation(source, references: new[] { ref0 });
             var expected =
 @"void Program.F(ref System.Int32 i)
-    [LifetimeAnnotation(True, False)] ref System.Int32 i
+    [ScopedRef] ref System.Int32 i
 ";
             CompileAndVerify(comp, symbolValidator: module =>
             {
-                Assert.Null(GetLifetimeAnnotationType(module));
-                AssertLifetimeAnnotationAttributes(module, expected);
+                Assert.Null(GetScopedRefType(module));
+                AssertScopedRefAttributes(module, expected);
             });
-        }
-
-        [Fact]
-        public void ExplicitAttribute_MissingConstructor()
-        {
-            var source1 =
-@"namespace System.Runtime.CompilerServices
-{
-    public sealed class LifetimeAnnotationAttribute : Attribute
-    {
-        public LifetimeAnnotationAttribute() { }
-        public bool IsRefScoped { get; }
-        public bool IsValueScoped { get; }
-    }
-}";
-            var source2 =
-@"class Program
-{
-    public static void F(scoped ref int i) { }
-}";
-            var comp = CreateCompilation(new[] { source1, source2 });
-            comp.VerifyEmitDiagnostics(
-                // (3,26): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.LifetimeAnnotationAttribute..ctor'
-                //     public static void F(scoped ref int i) { }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "scoped ref int i").WithArguments("System.Runtime.CompilerServices.LifetimeAnnotationAttribute", ".ctor").WithLocation(3, 26));
         }
 
         [WorkItem(62124, "https://github.com/dotnet/roslyn/issues/62124")]
@@ -110,16 +78,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var source =
 @"using System.Runtime.CompilerServices;
-delegate void D([LifetimeAnnotation(true, false)] ref int i);
+delegate void D([ScopedRef] ref int i);
 class Program
 {
-    public static void Main([LifetimeAnnotation(false, true)] string[] args)
+    public static void Main([ScopedRef] string[] args)
     {
-        D d = ([LifetimeAnnotation(true, false)] ref int i) => { };
+        D d = ([ScopedRef] ref int i) => { };
     }
 }";
-            var comp = CreateCompilation(new[] { LifetimeAnnotationAttributeDefinition, source });
-            // https://github.com/dotnet/roslyn/issues/62124: Re-enable check for LifetimeAnnotationAttribute in ReportExplicitUseOfReservedAttributes.
+            var comp = CreateCompilation(new[] { ScopedRefAttributeDefinition, source });
+            // https://github.com/dotnet/roslyn/issues/62124: Re-enable check for ScopedRefAttribute in ReportExplicitUseOfReservedAttributes.
             comp.VerifyDiagnostics();
         }
 
@@ -130,34 +98,58 @@ class Program
             var source =
 @"using System;
 using System.Runtime.CompilerServices;
-[module: LifetimeAnnotation(false, true)]
-[LifetimeAnnotation(false, true)] class Program
+[module: ScopedRef]
+[ScopedRef] class Program
 {
-    [LifetimeAnnotation(false, true)] object F;
-    [LifetimeAnnotation(false, true)] event EventHandler E;
-    [LifetimeAnnotation(false, true)] object P { get; }
-    [LifetimeAnnotation(false, true)] static object M1() => throw null;
-    [return: LifetimeAnnotation(false, true)] static object M2() => throw null;
-    static void M3<[LifetimeAnnotation(false, true)] T>() { }
+    [ScopedRef] object F;
+    [ScopedRef] event EventHandler E;
+    [ScopedRef] object P { get; }
+    [ScopedRef] static object M1() => throw null;
+    [ScopedRef] static object M2() => throw null;
+    static void M3<[ScopedRef] T>() { }
 }";
-            var comp = CreateCompilation(new[] { LifetimeAnnotationAttributeDefinition, source });
-            // https://github.com/dotnet/roslyn/issues/62124: Re-enable check for LifetimeAnnotationAttribute in ReportExplicitUseOfReservedAttributes.
+            var comp = CreateCompilation(new[] { ScopedRefAttributeDefinition, source });
+            // https://github.com/dotnet/roslyn/issues/62124: Re-enable check for ScopedRefAttribute in ReportExplicitUseOfReservedAttributes.
             comp.VerifyDiagnostics(
-                // (6,46): warning CS0169: The field 'Program.F' is never used
-                //     [LifetimeAnnotation(false, true)] object F;
-                Diagnostic(ErrorCode.WRN_UnreferencedField, "F").WithArguments("Program.F").WithLocation(6, 46),
-                // (7,58): warning CS0067: The event 'Program.E' is never used
-                //     [LifetimeAnnotation(false, true)] event EventHandler E;
-                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("Program.E").WithLocation(7, 58));
+                // (3,10): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
+                // [module: ScopedRef]
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(3, 10),
+                // (4,2): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
+                // [ScopedRef] class Program
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(4, 2),
+                // (6,6): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
+                //     [ScopedRef] object F;
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(6, 6),
+                // (6,24): warning CS0169: The field 'Program.F' is never used
+                //     [ScopedRef] object F;
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "F").WithArguments("Program.F").WithLocation(6, 24),
+                // (7,6): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
+                //     [ScopedRef] event EventHandler E;
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(7, 6),
+                // (7,36): warning CS0067: The event 'Program.E' is never used
+                //     [ScopedRef] event EventHandler E;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("Program.E").WithLocation(7, 36),
+                // (8,6): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
+                //     [ScopedRef] object P { get; }
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(8, 6),
+                // (9,6): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
+                //     [ScopedRef] static object M1() => throw null;
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(9, 6),
+                // (10,6): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
+                //     [ScopedRef] static object M2() => throw null;
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(10, 6),
+                // (11,21): error CS0592: Attribute 'ScopedRef' is not valid on this declaration type. It is only valid on 'parameter' declarations.
+                //     static void M3<[ScopedRef] T>() { }
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "ScopedRef").WithArguments("ScopedRef", "parameter").WithLocation(11, 21));
         }
 
         [Fact]
         public void ExplicitAttribute_UnexpectedParameterTargets()
         {
             var source0 =
-@".class private System.Runtime.CompilerServices.LifetimeAnnotationAttribute extends [mscorlib]System.Attribute
+@".class private System.Runtime.CompilerServices.ScopedRefAttribute extends [mscorlib]System.Attribute
 {
-  .method public hidebysig specialname rtspecialname instance void .ctor(bool isRefScoped, bool isValueScoped) cil managed { ret }
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { ret }
 }
 .class public sealed R extends [mscorlib]System.ValueType
 {
@@ -169,25 +161,25 @@ using System.Runtime.CompilerServices;
   .method public static void F1(valuetype R r)
   {
     .param [1]
-    .custom instance void System.Runtime.CompilerServices.LifetimeAnnotationAttribute::.ctor(bool, bool) = ( 01 00 01 00 00 00 ) // LifetimeAnnotationAttribute(isRefScoped: true, isValueScoped: false)
+    .custom instance void System.Runtime.CompilerServices.ScopedRefAttribute::.ctor() = ( 01 00 00 00 ) // ScopedRefAttribute()
     ret
   }
   .method public static void F2(int32 y)
   {
     .param [1]
-    .custom instance void System.Runtime.CompilerServices.LifetimeAnnotationAttribute::.ctor(bool, bool) = ( 01 00 00 01 00 00 ) // LifetimeAnnotationAttribute(isRefScoped: false, isValueScoped: true)
+    .custom instance void System.Runtime.CompilerServices.ScopedRefAttribute::.ctor() = ( 01 00 00 00 ) // ScopedRefAttribute()
     ret
   }
   .method public static void F3(object x, int32& y)
   {
     .param [2]
-    .custom instance void System.Runtime.CompilerServices.LifetimeAnnotationAttribute::.ctor(bool, bool) = ( 01 00 00 01 00 00 ) // LifetimeAnnotationAttribute(isRefScoped: false, isValueScoped: true)
+    .custom instance void System.Runtime.CompilerServices.ScopedRefAttribute::.ctor() = ( 01 00 00 00 ) // ScopedRefAttribute()
     ret
   }
   .method public static void F4(valuetype R& r)
   {
     .param [1]
-    .custom instance void System.Runtime.CompilerServices.LifetimeAnnotationAttribute::.ctor(bool, bool) = ( 01 00 01 01 00 00 ) // LifetimeAnnotationAttribute(isRefScoped: true, isValueScoped: true)
+    .custom instance void System.Runtime.CompilerServices.ScopedRefAttribute::.ctor() = ( 01 00 00 00 ) // ScopedRefAttribute()
     ret
   }
 }
@@ -210,29 +202,33 @@ using System.Runtime.CompilerServices;
 }";
             var comp = CreateCompilation(source1, references: new[] { ref0 });
             comp.VerifyDiagnostics(
-                // (6,11): error CS0570: 'A.F1(R)' is not supported by the language
-                //         A.F1(r);
-                Diagnostic(ErrorCode.ERR_BindToBogus, "F1").WithArguments("A.F1(R)").WithLocation(6, 11),
                 // (7,11): error CS0570: 'A.F2(int)' is not supported by the language
                 //         A.F2(2);
-                Diagnostic(ErrorCode.ERR_BindToBogus, "F2").WithArguments("A.F2(int)").WithLocation(7, 11),
-                // (10,11): error CS0570: 'A.F3(object, ref int)' is not supported by the language
-                //         A.F3(x, ref y);
-                Diagnostic(ErrorCode.ERR_BindToBogus, "F3").WithArguments("A.F3(object, ref int)").WithLocation(10, 11));
+                Diagnostic(ErrorCode.ERR_BindToBogus, "F2").WithArguments("A.F2(int)").WithLocation(7, 11));
 
-            var method = comp.GetMember<MethodSymbol>("A.F4");
-            Assert.Equal("void A.F4(ref scoped R r)", method.ToDisplayString(SymbolDisplayFormat.TestFormat.WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.IncludeScoped)));
+            var method = comp.GetMember<MethodSymbol>("A.F1");
+            Assert.Equal("void A.F1(scoped R r)", method.ToDisplayString(SymbolDisplayFormat.TestFormat.WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.IncludeScoped)));
             var parameter = method.Parameters[0];
             Assert.Equal(DeclarationScope.ValueScoped, parameter.Scope);
+
+            method = comp.GetMember<MethodSymbol>("A.F3");
+            Assert.Equal("void A.F3(System.Object x, scoped ref System.Int32 y)", method.ToDisplayString(SymbolDisplayFormat.TestFormat.WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.IncludeScoped)));
+            parameter = method.Parameters[1];
+            Assert.Equal(DeclarationScope.RefScoped, parameter.Scope);
+
+            method = comp.GetMember<MethodSymbol>("A.F4");
+            Assert.Equal("void A.F4(scoped ref R r)", method.ToDisplayString(SymbolDisplayFormat.TestFormat.WithCompilerInternalOptions(SymbolDisplayCompilerInternalOptions.IncludeScoped)));
+            parameter = method.Parameters[0];
+            Assert.Equal(DeclarationScope.RefScoped, parameter.Scope);
         }
 
         [Fact]
         public void ExplicitAttribute_UnexpectedAttributeConstructor()
         {
             var source0 =
-@".class private System.Runtime.CompilerServices.LifetimeAnnotationAttribute extends [mscorlib]System.Attribute
+@".class private System.Runtime.CompilerServices.ScopedRefAttribute extends [mscorlib]System.Attribute
 {
-  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { ret }
+  .method public hidebysig specialname rtspecialname instance void .ctor(bool isRefScoped, bool isValueScoped) cil managed { ret }
 }
 .class public sealed R extends [mscorlib]System.ValueType
 {
@@ -244,13 +240,13 @@ using System.Runtime.CompilerServices;
   .method public static void F1(valuetype R r)
   {
     .param [1]
-    .custom instance void System.Runtime.CompilerServices.LifetimeAnnotationAttribute::.ctor() = ( 01 00 00 00 ) // LifetimeAnnotationAttribute()
+    .custom instance void System.Runtime.CompilerServices.ScopedRefAttribute::.ctor(bool, bool) = ( 01 00 00 01 00 00 ) // ScopedRefAttribute(isRefScoped: false, isValueScoped: true)
     ret
   }
   .method public static void F2(object x, int32& y)
   {
     .param [2]
-    .custom instance void System.Runtime.CompilerServices.LifetimeAnnotationAttribute::.ctor() = ( 01 00 00 00 ) // LifetimeAnnotationAttribute()
+    .custom instance void System.Runtime.CompilerServices.ScopedRefAttribute::.ctor(bool, bool) = ( 01 00 01 00 00 00 ) // ScopedRefAttribute(isRefScoped: true, isValueScoped: false)
     ret
   }
 }
@@ -269,7 +265,7 @@ using System.Runtime.CompilerServices;
     }
 }";
             var comp = CreateCompilation(source1, references: new[] { ref0 });
-            // https://github.com/dotnet/roslyn/issues/61647: If the [LifetimeAnnotation] scoped value is an int
+            // https://github.com/dotnet/roslyn/issues/61647: If the [ScopedRef] scoped value is an int
             // rather than a pair of bools, the compiler should reject attribute values that it does not recognize.
             comp.VerifyDiagnostics();
         }
@@ -289,19 +285,19 @@ struct S
             var comp = CreateCompilation(source);
             var expected =
 @"S..ctor(ref System.Int32 i)
-    [LifetimeAnnotation(True, False)] ref System.Int32 i
+    [ScopedRef] ref System.Int32 i
 void S.F(R r)
-    [LifetimeAnnotation(False, True)] R r
+    [ScopedRef] R r
 S S.op_Addition(S a, in R b)
     S a
-    [LifetimeAnnotation(True, False)] in R b
+    [ScopedRef] in R b
 System.Object S.this[in System.Int32 i].get
-    [LifetimeAnnotation(True, False)] in System.Int32 i
+    [ScopedRef] in System.Int32 i
 ";
             CompileAndVerify(comp, symbolValidator: module =>
             {
-                Assert.Equal("System.Runtime.CompilerServices.LifetimeAnnotationAttribute", GetLifetimeAnnotationType(module).ToTestDisplayString());
-                AssertLifetimeAnnotationAttributes(module, expected);
+                Assert.Equal("System.Runtime.CompilerServices.ScopedRefAttribute", GetScopedRefType(module).ToTestDisplayString());
+                AssertScopedRefAttributes(module, expected);
             });
         }
 
@@ -321,8 +317,8 @@ class Program
             var comp = CreateCompilation(source);
             CompileAndVerify(comp, symbolValidator: module =>
             {
-                Assert.Null(GetLifetimeAnnotationType(module));
-                AssertLifetimeAnnotationAttributes(module, "");
+                Assert.Null(GetScopedRefType(module));
+                AssertScopedRefAttributes(module, "");
             });
         }
 
@@ -342,8 +338,8 @@ class Program
             var comp = CreateCompilation(source);
             CompileAndVerify(comp, symbolValidator: module =>
             {
-                Assert.Null(GetLifetimeAnnotationType(module));
-                AssertLifetimeAnnotationAttributes(module, "");
+                Assert.Null(GetScopedRefType(module));
+                AssertScopedRefAttributes(module, "");
             });
         }
 
@@ -357,15 +353,15 @@ delegate void D(scoped in int x, scoped R y);
             var comp = CreateCompilation(source);
             var expected =
 @"void D.Invoke(in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 x, R y)
-    [LifetimeAnnotation(True, False)] in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 x
-    [LifetimeAnnotation(False, True)] R y
+    [ScopedRef] in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 x
+    [ScopedRef] R y
 System.IAsyncResult D.BeginInvoke(in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 x, R y, System.AsyncCallback callback, System.Object @object)
-    [LifetimeAnnotation(True, False)] in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 x
-    [LifetimeAnnotation(False, True)] R y
+    [ScopedRef] in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 x
+    [ScopedRef] R y
     System.AsyncCallback callback
     System.Object @object
 void D.EndInvoke(in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 x, System.IAsyncResult result)
-    [LifetimeAnnotation(True, False)] in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 x
+    [ScopedRef] in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 x
     System.IAsyncResult result
 ";
             CompileAndVerify(
@@ -373,8 +369,8 @@ void D.EndInvoke(in modreq(System.Runtime.InteropServices.InAttribute) System.In
                 options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All),
                 symbolValidator: module =>
                 {
-                    Assert.Equal("System.Runtime.CompilerServices.LifetimeAnnotationAttribute", GetLifetimeAnnotationType(module).ToTestDisplayString());
-                    AssertLifetimeAnnotationAttributes(module, expected);
+                    Assert.Equal("System.Runtime.CompilerServices.ScopedRefAttribute", GetScopedRefType(module).ToTestDisplayString());
+                    AssertScopedRefAttributes(module, expected);
                 });
         }
 
@@ -394,25 +390,24 @@ class Program
             var comp = CreateCompilation(source);
             var expected =
 @"void D.Invoke(in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 i)
-    [LifetimeAnnotation(True, False)] in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 i
+    [ScopedRef] in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 i
 System.IAsyncResult D.BeginInvoke(in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 i, System.AsyncCallback callback, System.Object @object)
-    [LifetimeAnnotation(True, False)] in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 i
+    [ScopedRef] in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 i
     System.AsyncCallback callback
     System.Object @object
 void D.EndInvoke(in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 i, System.IAsyncResult result)
-    [LifetimeAnnotation(True, False)] in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 i
+    [ScopedRef] in modreq(System.Runtime.InteropServices.InAttribute) System.Int32 i
     System.IAsyncResult result
 void Program.<>c.<Main>b__0_0(in System.Int32 i)
-    [LifetimeAnnotation(True, False)] in System.Int32 i
-
+    [ScopedRef] in System.Int32 i
 ";
             CompileAndVerify(
                 source,
                 options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All),
                 symbolValidator: module =>
                 {
-                    Assert.Equal("System.Runtime.CompilerServices.LifetimeAnnotationAttribute", GetLifetimeAnnotationType(module).ToTestDisplayString());
-                    AssertLifetimeAnnotationAttributes(module, expected);
+                    Assert.Equal("System.Runtime.CompilerServices.ScopedRefAttribute", GetScopedRefType(module).ToTestDisplayString());
+                    AssertScopedRefAttributes(module, expected);
                 });
         }
 
@@ -431,15 +426,15 @@ void Program.<>c.<Main>b__0_0(in System.Int32 i)
             var comp = CreateCompilation(source);
             var expected =
 @"void Program.<M>g__L|0_0(in System.Int32 i)
-    [LifetimeAnnotation(True, False)] in System.Int32 i
+    [ScopedRef] in System.Int32 i
 ";
             CompileAndVerify(
                 source,
                 options: TestOptions.DebugDll.WithMetadataImportOptions(MetadataImportOptions.All),
                 symbolValidator: module =>
                 {
-                    Assert.Equal("System.Runtime.CompilerServices.LifetimeAnnotationAttribute", GetLifetimeAnnotationType(module).ToTestDisplayString());
-                    AssertLifetimeAnnotationAttributes(module, expected);
+                    Assert.Equal("System.Runtime.CompilerServices.ScopedRefAttribute", GetScopedRefType(module).ToTestDisplayString());
+                    AssertScopedRefAttributes(module, expected);
                 });
         }
 
@@ -461,13 +456,13 @@ class Program
             var comp = CreateCompilation(source);
             var expected =
 @"void <>f__AnonymousDelegate0.Invoke(in System.Int32 value)
-    [LifetimeAnnotation(True, False)] in System.Int32 value
+    [ScopedRef] in System.Int32 value
 R <>f__AnonymousDelegate1.Invoke(R value)
-    [LifetimeAnnotation(False, True)] R value
+    [ScopedRef] R value
 void Program.<>c.<Main>b__0_0(in System.Int32 i)
-    [LifetimeAnnotation(True, False)] in System.Int32 i
+    [ScopedRef] in System.Int32 i
 R Program.<>c.<Main>b__0_1(R r)
-    [LifetimeAnnotation(False, True)] R r
+    [ScopedRef] R r
 ";
             CompileAndVerify(
                 source,
@@ -475,20 +470,20 @@ R Program.<>c.<Main>b__0_1(R r)
                 verify: Verification.Skipped,
                 symbolValidator: module =>
                 {
-                    Assert.Equal("System.Runtime.CompilerServices.LifetimeAnnotationAttribute", GetLifetimeAnnotationType(module).ToTestDisplayString());
-                    AssertLifetimeAnnotationAttributes(module, expected);
+                    Assert.Equal("System.Runtime.CompilerServices.ScopedRefAttribute", GetScopedRefType(module).ToTestDisplayString());
+                    AssertScopedRefAttributes(module, expected);
                 });
         }
 
-        private static void AssertLifetimeAnnotationAttributes(ModuleSymbol module, string expected)
+        private static void AssertScopedRefAttributes(ModuleSymbol module, string expected)
         {
-            var actual = LifetimeAnnotationAttributesVisitor.GetString((PEModuleSymbol)module);
+            var actual = ScopedRefAttributesVisitor.GetString((PEModuleSymbol)module);
             AssertEx.AssertEqualToleratingWhitespaceDifferences(expected, actual);
         }
 
-        private static NamedTypeSymbol GetLifetimeAnnotationType(ModuleSymbol module)
+        private static NamedTypeSymbol GetScopedRefType(ModuleSymbol module)
         {
-            return module.GlobalNamespace.GetMember<NamedTypeSymbol>("System.Runtime.CompilerServices.LifetimeAnnotationAttribute");
+            return module.GlobalNamespace.GetMember<NamedTypeSymbol>("System.Runtime.CompilerServices.ScopedRefAttribute");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -6854,47 +6854,6 @@ class Program
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.FA").Parameters[0], "out scoped s", RefKind.Out, DeclarationScope.RefScoped);
         }
 
-        [Fact]
-        public void ParameterScope_10()
-        {
-            var source0 =
-@".class private System.Runtime.CompilerServices.LifetimeAnnotationAttribute extends [mscorlib]System.Attribute
-{
-  .method public hidebysig specialname rtspecialname instance void .ctor(bool isRefScoped, bool isValueScoped) cil managed { ret }
-}
-.class public sealed R extends [mscorlib]System.ValueType
-{
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (01 00 00 00)
-  .field public int32& modreq(int32) F
-}
-.class public A
-{
-  .method public static void F(valuetype R r)
-  {
-    .param [1]
-    .custom instance void System.Runtime.CompilerServices.LifetimeAnnotationAttribute::.ctor(bool, bool) = ( 01 00 00 00 00 00 ) // LifetimeAnnotationAttribute(isRefScoped: false, isValueScoped: false)
-    ret
-  }
-}
-";
-            var ref0 = CompileIL(source0);
-
-            var source1 =
-@"class Program
-{
-    static void Main()
-    {
-        var r = new R();
-        A.F(r);
-    }
-}";
-            var comp = CreateCompilation(source1, references: new[] { ref0 });
-            comp.VerifyDiagnostics();
-
-            var method = comp.GetMember<PEMethodSymbol>("A.F");
-            VerifyParameterSymbol(method.Parameters[0], "R r", RefKind.None, DeclarationScope.Unscoped);
-        }
-
         [WorkItem(62080, "https://github.com/dotnet/roslyn/issues/62080")]
         [Fact]
         public void ParameterScope_11()
@@ -6930,23 +6889,16 @@ class Program
         public void ParameterScope_12()
         {
             var source0 =
-@".class private System.Runtime.CompilerServices.LifetimeAnnotationAttribute extends [mscorlib]System.Attribute
+@".class private System.Runtime.CompilerServices.ScopedRefAttribute extends [mscorlib]System.Attribute
 {
-  .method public hidebysig specialname rtspecialname instance void .ctor(bool isRefScoped, bool isValueScoped) cil managed { ret }
+  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { ret }
 }
 .class public A
 {
   .method public static void F1([out] int32& i)
   {
     .param [1]
-    .custom instance void System.Runtime.CompilerServices.LifetimeAnnotationAttribute::.ctor(bool, bool) = ( 01 00 01 00 00 00 ) // LifetimeAnnotationAttribute(isRefScoped: true, isValueScoped: false)
-    ldnull
-    throw
-  }
-  .method public static void F2([out] int32& i)
-  {
-    .param [1]
-    .custom instance void System.Runtime.CompilerServices.LifetimeAnnotationAttribute::.ctor(bool, bool) = ( 01 00 00 00 00 00 ) // LifetimeAnnotationAttribute(isRefScoped: false, isValueScoped: false)
+    .custom instance void System.Runtime.CompilerServices.ScopedRefAttribute::.ctor() = ( 01 00 00 00 ) // ScopedRefAttribute()
     ldnull
     throw
   }
@@ -6961,14 +6913,12 @@ class Program
     {
         int i;
         A.F1(out i);
-        A.F2(out i);
     }
 }";
             var comp = CreateCompilation(source1, references: new[] { ref0 });
             comp.VerifyDiagnostics();
 
             VerifyParameterSymbol(comp.GetMember<PEMethodSymbol>("A.F1").Parameters[0], "out System.Int32 i", RefKind.Out, DeclarationScope.RefScoped);
-            VerifyParameterSymbol(comp.GetMember<PEMethodSymbol>("A.F2").Parameters[0], "out System.Int32 i", RefKind.Out, DeclarationScope.Unscoped);
         }
 
         [Fact]
@@ -7303,7 +7253,7 @@ public class A
             Assert.Equal(expectedScope, parameter.Scope);
             Assert.Equal(expectedDisplayString, parameter.ToDisplayString(displayFormatWithScoped));
 
-            var attribute = parameter.GetAttributes().FirstOrDefault(a => a.GetTargetAttributeSignatureIndex(parameter, AttributeDescription.LifetimeAnnotationAttribute) != -1);
+            var attribute = parameter.GetAttributes().FirstOrDefault(a => a.GetTargetAttributeSignatureIndex(parameter, AttributeDescription.ScopedRefAttribute) != -1);
             Assert.Null(attribute);
 
             VerifyParameterSymbol(parameter.GetPublicSymbol(), expectedDisplayString, expectedRefKind, expectedScope);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -614,7 +614,7 @@ namespace System
                     case WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler:
                     case WellKnownType.System_Runtime_CompilerServices_RequiredMemberAttribute:
                     case WellKnownType.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute:
-                    case WellKnownType.System_Runtime_CompilerServices_LifetimeAnnotationAttribute:
+                    case WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute:
                     case WellKnownType.System_MemoryExtensions:
                     case WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute:
                         // Not yet in the platform.
@@ -976,7 +976,7 @@ namespace System
                     case WellKnownMember.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear:
                     case WellKnownMember.System_Runtime_CompilerServices_RequiredMemberAttribute__ctor:
                     case WellKnownMember.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor:
-                    case WellKnownMember.System_Runtime_CompilerServices_LifetimeAnnotationAttribute__ctor:
+                    case WellKnownMember.System_Runtime_CompilerServices_ScopedRefAttribute__ctor:
                     case WellKnownMember.System_MemoryExtensions__SequenceEqual_Span_T:
                     case WellKnownMember.System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T:
                     case WellKnownMember.System_MemoryExtensions__AsSpan_String:

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1087,16 +1087,9 @@ namespace Microsoft.CodeAnalysis
             return TryExtractBoolArrayValueFromAttribute(info.Handle, out transformFlags);
         }
 
-        internal bool HasLifetimeAnnotationAttribute(EntityHandle token, out (bool IsRefScoped, bool IsValueScoped) value)
+        internal bool HasScopedRefAttribute(EntityHandle token)
         {
-            AttributeInfo info = FindTargetAttribute(token, AttributeDescription.LifetimeAnnotationAttribute);
-            if (!info.HasValue)
-            {
-                value = default;
-                return false;
-            }
-
-            return TryExtractValueFromAttribute(info.Handle, out value, CrackBoolAndBoolInAttributeValue);
+            return FindTargetAttribute(token, AttributeDescription.ScopedRefAttribute).HasValue;
         }
 
         internal bool HasTupleElementNamesAttribute(EntityHandle token, out ImmutableArray<string> tupleElementNames)

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -334,7 +334,6 @@ namespace Microsoft.CodeAnalysis
         private static readonly byte[][] s_signaturesOfNullableAttribute = { s_signature_HasThis_Void_Byte, s_signature_HasThis_Void_SzArray_Byte };
         private static readonly byte[][] s_signaturesOfNullableContextAttribute = { s_signature_HasThis_Void_Byte };
         private static readonly byte[][] s_signaturesOfNativeIntegerAttribute = { s_signature_HasThis_Void, s_signature_HasThis_Void_SzArray_Boolean };
-        private static readonly byte[][] s_signaturesOfScopedRefAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfInterpolatedStringArgumentAttribute = { s_signature_HasThis_Void_String, s_signature_HasThis_Void_SzArray_String };
 
         // early decoded attributes:
@@ -470,7 +469,7 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription EnumeratorCancellationAttribute = new AttributeDescription("System.Runtime.CompilerServices", "EnumeratorCancellationAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription SkipLocalsInitAttribute = new AttributeDescription("System.Runtime.CompilerServices", "SkipLocalsInitAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription NativeIntegerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NativeIntegerAttribute", s_signaturesOfNativeIntegerAttribute);
-        internal static readonly AttributeDescription ScopedRefAttribute = new AttributeDescription("System.Runtime.CompilerServices", "ScopedRefAttribute", s_signaturesOfScopedRefAttribute);
+        internal static readonly AttributeDescription ScopedRefAttribute = new AttributeDescription("System.Runtime.CompilerServices", "ScopedRefAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription ModuleInitializerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "ModuleInitializerAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription UnmanagedCallersOnlyAttribute = new AttributeDescription("System.Runtime.InteropServices", "UnmanagedCallersOnlyAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription InterpolatedStringHandlerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "InterpolatedStringHandlerAttribute", s_signatures_HasThis_Void_Only);

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -334,7 +334,7 @@ namespace Microsoft.CodeAnalysis
         private static readonly byte[][] s_signaturesOfNullableAttribute = { s_signature_HasThis_Void_Byte, s_signature_HasThis_Void_SzArray_Byte };
         private static readonly byte[][] s_signaturesOfNullableContextAttribute = { s_signature_HasThis_Void_Byte };
         private static readonly byte[][] s_signaturesOfNativeIntegerAttribute = { s_signature_HasThis_Void, s_signature_HasThis_Void_SzArray_Boolean };
-        private static readonly byte[][] s_signaturesOfLifetimeAnnotationAttribute = { s_signature_HasThis_Void_Boolean_Boolean };
+        private static readonly byte[][] s_signaturesOfScopedRefAttribute = { s_signature_HasThis_Void };
         private static readonly byte[][] s_signaturesOfInterpolatedStringArgumentAttribute = { s_signature_HasThis_Void_String, s_signature_HasThis_Void_SzArray_String };
 
         // early decoded attributes:
@@ -470,7 +470,7 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription EnumeratorCancellationAttribute = new AttributeDescription("System.Runtime.CompilerServices", "EnumeratorCancellationAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription SkipLocalsInitAttribute = new AttributeDescription("System.Runtime.CompilerServices", "SkipLocalsInitAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription NativeIntegerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NativeIntegerAttribute", s_signaturesOfNativeIntegerAttribute);
-        internal static readonly AttributeDescription LifetimeAnnotationAttribute = new AttributeDescription("System.Runtime.CompilerServices", "LifetimeAnnotationAttribute", s_signaturesOfLifetimeAnnotationAttribute);
+        internal static readonly AttributeDescription ScopedRefAttribute = new AttributeDescription("System.Runtime.CompilerServices", "ScopedRefAttribute", s_signaturesOfScopedRefAttribute);
         internal static readonly AttributeDescription ModuleInitializerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "ModuleInitializerAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription UnmanagedCallersOnlyAttribute = new AttributeDescription("System.Runtime.InteropServices", "UnmanagedCallersOnlyAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription InterpolatedStringHandlerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "InterpolatedStringHandlerAttribute", s_signatures_HasThis_Void_Only);

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -522,7 +522,7 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear,
         System_Runtime_CompilerServices_RequiredMemberAttribute__ctor,
         System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor,
-        System_Runtime_CompilerServices_LifetimeAnnotationAttribute__ctor,
+        System_Runtime_CompilerServices_ScopedRefAttribute__ctor,
 
         System_MemoryExtensions__SequenceEqual_Span_T,
         System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T,

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3583,14 +3583,12 @@ namespace Microsoft.CodeAnalysis
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
 
-                // System_Runtime_CompilerServices_LifetimeAnnotationAttribute__ctor
+                // System_Runtime_CompilerServices_ScopedRefAttribute__ctor
                 (byte)MemberFlags.Constructor,                                                                              // Flags
-                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_LifetimeAnnotationAttribute - WellKnownType.ExtSentinel),                                       // DeclaringTypeId
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute - WellKnownType.ExtSentinel), // DeclaringTypeId
                 0,                                                                                                          // Arity
-                    2,                                                                                                      // Method Signature
+                    0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean,
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean,
 
                 // System_MemoryExtensions__SequenceEqual_Span_T
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                               // Flags

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis
         System_Text_StringBuilder,
 
         System_Runtime_CompilerServices_DefaultInterpolatedStringHandler,
-        System_Runtime_CompilerServices_LifetimeAnnotationAttribute,
+        System_Runtime_CompilerServices_ScopedRefAttribute,
 
         System_ArgumentNullException,
 
@@ -633,7 +633,7 @@ namespace Microsoft.CodeAnalysis
 
             "System.Text.StringBuilder",
             "System.Runtime.CompilerServices.DefaultInterpolatedStringHandler",
-            "System.Runtime.CompilerServices.LifetimeAnnotationAttribute",
+            "System.Runtime.CompilerServices.ScopedRefAttribute",
             "System.ArgumentNullException",
 
             "System.Runtime.CompilerServices.RequiredMemberAttribute",

--- a/src/Compilers/Test/Utilities/CSharp/LifetimeAnnotationAttributesVisitor.cs
+++ b/src/Compilers/Test/Utilities/CSharp/LifetimeAnnotationAttributesVisitor.cs
@@ -14,19 +14,19 @@ using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 
 namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
 {
-    internal sealed class LifetimeAnnotationAttributesVisitor : CSharpSymbolVisitor
+    internal sealed class ScopedRefAttributesVisitor : CSharpSymbolVisitor
     {
         internal static string GetString(PEModuleSymbol module)
         {
             var builder = new StringBuilder();
-            var visitor = new LifetimeAnnotationAttributesVisitor(builder);
+            var visitor = new ScopedRefAttributesVisitor(builder);
             visitor.Visit(module);
             return builder.ToString();
         }
 
         private readonly StringBuilder _builder;
 
-        private LifetimeAnnotationAttributesVisitor(StringBuilder builder)
+        private ScopedRefAttributesVisitor(StringBuilder builder)
         {
             _builder = builder;
         }
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         public override void VisitMethod(MethodSymbol method)
         {
             var parameters = method.Parameters;
-            if (!parameters.Any(p => TryGetLifetimeAnnotationAttribute((PEParameterSymbol)p, out _)))
+            if (!parameters.Any(p => TryGetScopedRefAttribute((PEParameterSymbol)p)))
             {
                 return;
             }
@@ -81,18 +81,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             foreach (var parameter in parameters)
             {
                 _builder.Append("    ");
-                if (TryGetLifetimeAnnotationAttribute((PEParameterSymbol)parameter, out var pair))
+                if (TryGetScopedRefAttribute((PEParameterSymbol)parameter))
                 {
-                    _builder.Append($"[LifetimeAnnotation({pair.IsRefScoped}, {pair.IsValueScoped})] ");
+                    _builder.Append($"[ScopedRef] ");
                 }
                 _builder.AppendLine(parameter.ToTestDisplayString());
             }
         }
 
-        private bool TryGetLifetimeAnnotationAttribute(PEParameterSymbol parameter, out (bool IsRefScoped, bool IsValueScoped) pair)
+        private bool TryGetScopedRefAttribute(PEParameterSymbol parameter)
         {
             var module = ((PEModuleSymbol)parameter.ContainingModule).Module;
-            return module.HasLifetimeAnnotationAttribute(parameter.Handle, out pair);
+            return module.HasScopedRefAttribute(parameter.Handle);
         }
     }
 }

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -551,7 +551,7 @@ End Namespace
                          WellKnownType.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute,
                          WellKnownType.System_MemoryExtensions,
                          WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute,
-                         WellKnownType.System_Runtime_CompilerServices_LifetimeAnnotationAttribute,
+                         WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute,
                          WellKnownType.System_MemoryExtensions
                         ' Not available on all platforms.
                         Continue For
@@ -623,7 +623,7 @@ End Namespace
                          WellKnownType.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute,
                          WellKnownType.System_MemoryExtensions,
                          WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute,
-                         WellKnownType.System_Runtime_CompilerServices_LifetimeAnnotationAttribute
+                         WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel
@@ -715,7 +715,7 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear,
                          WellKnownMember.System_Runtime_CompilerServices_RequiredMemberAttribute__ctor,
                          WellKnownMember.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_LifetimeAnnotationAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_ScopedRefAttribute__ctor,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_Span_T,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T,
                          WellKnownMember.System_MemoryExtensions__AsSpan_String,
@@ -867,7 +867,7 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear,
                          WellKnownMember.System_Runtime_CompilerServices_RequiredMemberAttribute__ctor,
                          WellKnownMember.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_LifetimeAnnotationAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_ScopedRefAttribute__ctor,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_Span_T,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T,
                          WellKnownMember.System_MemoryExtensions__AsSpan_String,


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/62838