### PR TITLE
Deregister workspaces from LSP when they are disposed of

### DIFF
--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationEventListener.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationEventListener.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer;
 
 // Specify the VS workspaces we know we need (host, misc, metadata as source) and MSBuild for VSCode.
 [ExportEventListener(WellKnownEventListeners.Workspace, WorkspaceKind.Host, WorkspaceKind.MiscellaneousFiles, WorkspaceKind.MetadataAsSource, WorkspaceKind.MSBuild, WorkspaceKind.Interactive), Shared]
-internal class LspWorkspaceRegistrationEventListener : IEventListener<object>
+internal class LspWorkspaceRegistrationEventListener : IEventListener<object>, IEventListenerStoppable
 {
     private readonly LspWorkspaceRegistrationService _lspWorkspaceRegistrationService;
 
@@ -25,6 +25,11 @@ internal class LspWorkspaceRegistrationEventListener : IEventListener<object>
     public void StartListening(Workspace workspace, object _)
     {
         _lspWorkspaceRegistrationService.Register(workspace);
+    }
+
+    public void StopListening(Workspace workspace)
+    {
+        _lspWorkspaceRegistrationService.Deregister(workspace);
     }
 }
 

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationService.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationService.cs
@@ -45,12 +45,11 @@ internal abstract class LspWorkspaceRegistrationService : IDisposable
 
     public void Deregister(Workspace workspace)
     {
+        workspace.WorkspaceChanged -= OnLspWorkspaceChanged;
         lock (_gate)
         {
             _registrations = _registrations.Remove(workspace);
         }
-
-        workspace.WorkspaceChanged -= OnLspWorkspaceChanged;
     }
 
     private void OnLspWorkspaceChanged(object? sender, WorkspaceChangeEventArgs e)

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationService.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationService.cs
@@ -43,6 +43,16 @@ internal abstract class LspWorkspaceRegistrationService : IDisposable
         workspace.WorkspaceChanged += OnLspWorkspaceChanged;
     }
 
+    public void Deregister(Workspace workspace)
+    {
+        lock (_gate)
+        {
+            _registrations = _registrations.Remove(workspace);
+        }
+
+        workspace.WorkspaceChanged -= OnLspWorkspaceChanged;
+    }
+
     private void OnLspWorkspaceChanged(object? sender, WorkspaceChangeEventArgs e)
     {
         LspSolutionChanged?.Invoke(this, e);
@@ -56,6 +66,8 @@ internal abstract class LspWorkspaceRegistrationService : IDisposable
             {
                 workspace.WorkspaceChanged -= OnLspWorkspaceChanged;
             }
+
+            _registrations = _registrations.Clear();
         }
     }
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceRegistrationServiceTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceRegistrationServiceTests.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Composition;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Workspaces;
+public class LspWorkspaceRegistrationServiceTests : AbstractLanguageServerProtocolTests
+{
+    [Fact]
+    public async Task TestDisposedWorkspaceDeregistered()
+    {
+        var markup = "";
+        TestWorkspaceRegistrationService registrationService;
+        using (var testLspServer = await CreateTestLspServerAsync(markup))
+        {
+            registrationService = (TestWorkspaceRegistrationService)testLspServer.TestWorkspace.ExportProvider.GetExportedValue<LspWorkspaceRegistrationService>();
+        }
+
+        Assert.Empty(registrationService.GetAllRegistrations());
+    }
+}


### PR DESCRIPTION
Unlike vswindows, vsmac disposes of their host workspace when a solution is closed.  This can cause a leak because the LSP workspace registration service was holding onto all registered workspaces even if they are disposed.