### PR TITLE
Fix request snapshot bug for languages without an LSP server implementation

### DIFF
--- a/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineHelper.cs
+++ b/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineHelper.cs
@@ -60,8 +60,9 @@ namespace Microsoft.VisualStudio.LanguageServices.DocumentOutline
                 parameterFactory: ParameterFunction,
                 cancellationToken: cancellationToken).ConfigureAwait(false))?.Response;
 
-            Contract.ThrowIfNull(requestSnapshot);
-            return response is null ? null : (response, requestSnapshot);
+            // The request snapshot or response can be null if there is no LSP server implementation for
+            // the document symbol request for that language.
+            return requestSnapshot is null || response is null ? null : (response, requestSnapshot);
         }
 
         /// <summary>


### PR DESCRIPTION
For a language that doesn't have an LSP server implementation for the document symbol request, we will always throw since the request snapshot will be null. Instead of throwing, we should check whether the request snapshot or response is null.