### PR TITLE
Add IOperation test where IObjectCreationOperation.Constructor is null

### DIFF
--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -682,7 +682,9 @@ namespace Microsoft.CodeAnalysis.Operations
             ConstantValue? constantValue = boundObjectCreationExpression.ConstantValue;
             bool isImplicit = boundObjectCreationExpression.WasCompilerGenerated;
 
-            if (boundObjectCreationExpression.ResultKind == LookupResultKind.OverloadResolutionFailure || constructor == null || constructor.OriginalDefinition is ErrorMethodSymbol)
+            Debug.Assert(constructor is not null);
+
+            if (boundObjectCreationExpression.ResultKind == LookupResultKind.OverloadResolutionFailure || constructor.OriginalDefinition is ErrorMethodSymbol)
             {
                 var children = CreateFromArray<BoundNode, IOperation>(((IBoundInvalidNode)boundObjectCreationExpression).InvalidNodeChildren);
                 return new InvalidOperation(children, _semanticModel, syntax, type, constantValue, isImplicit);

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IObjectCreationExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IObjectCreationExpression.vb
@@ -1265,17 +1265,20 @@ Class D
         M(New C.S())'BIND:"New C.S()"
     End Sub
 End Class]]>.Value
+
             Dim expectedDiagnostics = <![CDATA[
 BC30389: 'C.S' is not accessible in this context because it is 'Protected'.
         M(New C.S())'BIND:"New C.S()"
               ~~~
 ]]>.Value
+
             Dim expectedOperationTree = <![CDATA[
 IObjectCreationOperation (Constructor: <null>) (OperationKind.ObjectCreation, Type: C.S, IsInvalid) (Syntax: 'New C.S()')
   Arguments(0)
   Initializer:
     null
 ]]>.Value
+
             VerifyOperationTreeAndDiagnosticsForTest(Of ObjectCreationExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics)
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IObjectCreationExpression.vb
+++ b/src/Compilers/VisualBasic/Test/IOperation/IOperation/IOperationTests_IObjectCreationExpression.vb
@@ -1252,6 +1252,33 @@ IObjectCreationOperation (Constructor: Sub S..ctor()) (OperationKind.ObjectCreat
             VerifyOperationTreeAndDiagnosticsForTest(Of ObjectCreationExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics)
         End Sub
 
+        <CompilerTrait(CompilerFeature.IOperation)>
+        <Fact()>
+        Public Sub ObjectCreationCollectionWithInaccessibleStructureConstructor()
+            Dim source = <![CDATA[
+Class C
+    Protected Structure S
+    End Structure
+End Class
+Class D
+    Shared Sub M(o)
+        M(New C.S())'BIND:"New C.S()"
+    End Sub
+End Class]]>.Value
+            Dim expectedDiagnostics = <![CDATA[
+BC30389: 'C.S' is not accessible in this context because it is 'Protected'.
+        M(New C.S())'BIND:"New C.S()"
+              ~~~
+]]>.Value
+            Dim expectedOperationTree = <![CDATA[
+IObjectCreationOperation (Constructor: <null>) (OperationKind.ObjectCreation, Type: C.S, IsInvalid) (Syntax: 'New C.S()')
+  Arguments(0)
+  Initializer:
+    null
+]]>.Value
+            VerifyOperationTreeAndDiagnosticsForTest(Of ObjectCreationExpressionSyntax)(source, expectedOperationTree, expectedDiagnostics)
+        End Sub
+
         <CompilerTrait(CompilerFeature.IOperation, CompilerFeature.Dataflow)>
         <Fact()>
         Public Sub ObjectCreationFlow_01()


### PR DESCRIPTION
There was no IOperation tests covering this case for VB.

For C#, it doesn't look like constructor can be null, so I added an assert.