### PR TITLE
Hot Reload: Fix reloadable type regression

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
@@ -4579,5 +4579,86 @@ class C
                 Row(4, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(1, TableIndex.Param, EditAndContinueOperation.Default));
         }
+
+        [Fact]
+        public void ReplaceTypeWithClosure()
+        {
+            var source0 = @"
+using System;
+class C 
+{
+    void F() { var x = new Action(() => {}); Console.WriteLine(1); }
+}
+";
+            var source1 = @"
+using System;
+class C
+{
+    void F() { var x = new Action(() => {}); Console.WriteLine(1); }
+}";
+
+            var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll, targetFramework: TargetFramework.NetStandard20);
+            var compilation1 = compilation0.WithSource(source1);
+
+            var c0 = compilation0.GetMember<NamedTypeSymbol>("C");
+            var c1 = compilation1.GetMember<NamedTypeSymbol>("C");
+
+            // Verify full metadata contains expected rows.
+            var bytes0 = compilation0.EmitToArray();
+            using var md0 = ModuleMetadata.CreateFromImage(bytes0);
+            var reader0 = md0.MetadataReader;
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, EmptyLocalsProvider);
+
+            // This update emulates "Reloadable" type behavior - a new type is generated instead of updating the existing one.
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    SemanticEdit.Create(SemanticEditKind.Replace, null, c1)));
+
+            // Verify delta metadata contains expected rows.
+            using var md1 = diff1.GetMetadata();
+            var reader1 = md1.Reader;
+            var readers = new[] { reader0, reader1 };
+
+            CheckNames(readers, reader1.GetTypeDefNames(), "C#1", "<>c");
+            CheckNames(readers, diff1.EmitResult.ChangedTypes, "C#1", "<>c");
+
+            // All definitions should be added, none should be updated:
+            CheckEncLogDefinitions(reader1,
+                Row(2, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
+                Row(4, TableIndex.TypeDef, EditAndContinueOperation.Default),
+                Row(5, TableIndex.TypeDef, EditAndContinueOperation.Default),
+                Row(5, TableIndex.TypeDef, EditAndContinueOperation.AddField),
+                Row(3, TableIndex.Field, EditAndContinueOperation.Default),
+                Row(5, TableIndex.TypeDef, EditAndContinueOperation.AddField),
+                Row(4, TableIndex.Field, EditAndContinueOperation.Default),
+                Row(4, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
+                Row(6, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(4, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
+                Row(7, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(5, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
+                Row(8, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(5, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
+                Row(9, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(5, TableIndex.TypeDef, EditAndContinueOperation.AddMethod),
+                Row(10, TableIndex.MethodDef, EditAndContinueOperation.Default),
+                Row(5, TableIndex.CustomAttribute, EditAndContinueOperation.Default),
+                Row(2, TableIndex.NestedClass, EditAndContinueOperation.Default));
+
+            CheckEncMapDefinitions(reader1,
+                Handle(4, TableIndex.TypeDef),
+                Handle(5, TableIndex.TypeDef),
+                Handle(3, TableIndex.Field),
+                Handle(4, TableIndex.Field),
+                Handle(6, TableIndex.MethodDef),
+                Handle(7, TableIndex.MethodDef),
+                Handle(8, TableIndex.MethodDef),
+                Handle(9, TableIndex.MethodDef),
+                Handle(10, TableIndex.MethodDef),
+                Handle(5, TableIndex.CustomAttribute),
+                Handle(2, TableIndex.StandAloneSig),
+                Handle(2, TableIndex.NestedClass));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.cs
@@ -4594,7 +4594,7 @@ class C
 using System;
 class C
 {
-    void F() { var x = new Action(() => {}); Console.WriteLine(1); }
+    void F() { var x = new Action(() => {}); Console.WriteLine(2); }
 }";
 
             var compilation0 = CreateCompilation(source0, options: TestOptions.DebugDll, targetFramework: TargetFramework.NetStandard20);

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -560,7 +560,7 @@ namespace Microsoft.CodeAnalysis.Emit
                 // deleted in a generation, and then "added" in a subsequent one, but that is an update
                 // even if the collections at hand can't track it as such
                 if (methodChange == SymbolChange.Added &&
-                    !_changes.IsReplaced(methodDef.ContainingTypeDefinition) &&
+                    !_changes.IsReplaced(methodDef.ContainingTypeDefinition, checkEnclosingTypes: true) &&
                     TryGetExistingMethodDefIndex(methodDef, out _))
                 {
                     methodChange = SymbolChange.Updated;

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -98,10 +98,26 @@ namespace Microsoft.CodeAnalysis.Emit
             return internalSymbols.ToImmutableAndFree();
         }
 
-        public bool IsReplaced(IDefinition definition)
+        public bool IsReplaced(IDefinition definition, bool checkEnclosingTypes = false)
         {
-            var symbol = definition.GetInternalSymbol();
-            return symbol is not null && _replacedSymbols.Contains(symbol.GetISymbol());
+            var symbol = definition.GetInternalSymbol()?.GetISymbol();
+
+            while (symbol != null)
+            {
+                if (_replacedSymbols.Contains(symbol))
+                {
+                    return true;
+                }
+
+                if (!checkEnclosingTypes)
+                {
+                    return false;
+                }
+
+                symbol = symbol.ContainingType;
+            }
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes regression https://github.com/dotnet/roslyn/issues/63103 introduced by https://github.com/dotnet/roslyn/pull/61806

Constructors of the synthesized type `C.<>c`, which is a nested synthesized type in a reloadable type `C` were updated instead of added.

VS Feedback: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1580286
Ask mode bug: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1581287