### PR TITLE
Use ToImmutableAndClear when using a pooled builder with a known length

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/ConvertSwitchStatementToExpression/ConvertSwitchStatementToExpressionCodeFixProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertSwitchStatementToExpression
             Document document, ImmutableArray<Diagnostic> diagnostics,
             SyntaxEditor editor, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken)
         {
-            using var spansDisposer = ArrayBuilder<TextSpan>.GetInstance(diagnostics.Length, out var spans);
+            using var _ = ArrayBuilder<TextSpan>.GetInstance(diagnostics.Length, out var spans);
             foreach (var diagnostic in diagnostics)
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/Analyzers/CSharp/CodeFixes/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/InlineDeclaration/CSharpInlineDeclarationCodeFixProvider.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
                 originalNodes,
                 t =>
                 {
-                    using var additionalNodesToTrackDisposer = ArrayBuilder<SyntaxNode>.GetInstance(capacity: 2, out var additionalNodesToTrack);
+                    using var _ = ArrayBuilder<SyntaxNode>.GetInstance(capacity: 2, out var additionalNodesToTrack);
                     additionalNodesToTrack.Add(t.identifier);
                     additionalNodesToTrack.Add(t.declarator);
 

--- a/src/Analyzers/CSharp/CodeFixes/UseImplicitOrExplicitType/UseExplicitTypeCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseImplicitOrExplicitType/UseExplicitTypeCodeFixProvider.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.CSharp.TypeStyle
             var elements = ((INamedTypeSymbol)typeSymbol).TupleElements;
             Debug.Assert(elements.Length == parensDesignation.Variables.Count);
 
-            using var builderDisposer = ArrayBuilder<SyntaxNode>.GetInstance(elements.Length, out var builder);
+            using var _ = ArrayBuilder<SyntaxNode>.GetInstance(elements.Length, out var builder);
             for (var i = 0; i < elements.Length; i++)
             {
                 var designation = parensDesignation.Variables[i];

--- a/src/Analyzers/Core/Analyzers/Helpers/DiagnosticHelper.cs
+++ b/src/Analyzers/Core/Analyzers/Helpers/DiagnosticHelper.cs
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
                 else
                 {
-                    using var argumentsBuilderDisposer = ArrayBuilder<string>.GetInstance(length, out var argumentsBuilder);
+                    using var _ = ArrayBuilder<string>.GetInstance(length, out var argumentsBuilder);
                     for (var i = 0; i < length; i++)
                     {
                         argumentsBuilder.Add(reader.ReadString());

--- a/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
+++ b/src/Features/Core/Portable/AddParameter/AbstractAddParameterCodeFixProvider.cs
@@ -244,7 +244,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
 
             ImmutableArray<CodeAction> NestByOverload()
             {
-                using var builderDisposer = ArrayBuilder<CodeAction>.GetInstance(codeFixData.Length, out var builder);
+                using var _ = ArrayBuilder<CodeAction>.GetInstance(codeFixData.Length, out var builder);
                 foreach (var data in codeFixData)
                 {
                     // We create the mandatory data.CreateChangedSolutionNonCascading fix first.
@@ -275,12 +275,12 @@ namespace Microsoft.CodeAnalysis.AddParameter
                     builder.Add(codeAction);
                 }
 
-                return builder.ToImmutable();
+                return builder.ToImmutableAndClear();
             }
 
             ImmutableArray<CodeAction> NestByCascading()
             {
-                using var builderDisposer = ArrayBuilder<CodeAction>.GetInstance(capacity: 2, out var builder);
+                using var _ = ArrayBuilder<CodeAction>.GetInstance(capacity: 2, out var builder);
 
                 var nonCascadingActions = codeFixData.SelectAsArray(data =>
                 {
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.AddParameter
             SeparatedSyntaxList<TArgumentSyntax> arguments,
             ImmutableArray<ArgumentInsertPositionData<TArgumentSyntax>> methodsAndArgumentsToAdd)
         {
-            using var builderDisposer = ArrayBuilder<CodeFixData>.GetInstance(methodsAndArgumentsToAdd.Length, out var builder);
+            using var _ = ArrayBuilder<CodeFixData>.GetInstance(methodsAndArgumentsToAdd.Length, out var builder);
 
             // Order by the furthest argument index to the nearest argument index.  The ones with
             // larger argument indexes mean that we matched more earlier arguments (and thus are

--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction.BatchFixer.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.RemoveSuppressionCodeAction.BatchFixer.cs
@@ -159,14 +159,14 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
 
                 private static async Task<ImmutableArray<SyntaxNode>> GetAttributeNodesToFixAsync(ImmutableArray<AttributeRemoveAction> attributeRemoveFixes, CancellationToken cancellationToken)
                 {
-                    using var builderDisposer = ArrayBuilder<SyntaxNode>.GetInstance(attributeRemoveFixes.Length, out var builder);
+                    using var _ = ArrayBuilder<SyntaxNode>.GetInstance(attributeRemoveFixes.Length, out var builder);
                     foreach (var attributeRemoveFix in attributeRemoveFixes)
                     {
                         var attributeToRemove = await attributeRemoveFix.GetAttributeToRemoveAsync(cancellationToken).ConfigureAwait(false);
                         builder.Add(attributeToRemove);
                     }
 
-                    return builder.ToImmutable();
+                    return builder.ToImmutableAndClear();
                 }
             }
         }

--- a/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/SyncNamespace/AbstractChangeNamespaceService.cs
@@ -277,8 +277,8 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
             // will return false. We use span of namespace declaration found in each document to decide if they are identical.            
 
             var documents = ids.SelectAsArray(solution.GetRequiredDocument);
-            using var containersDisposer = ArrayBuilder<(DocumentId, SyntaxNode)>.GetInstance(ids.Length, out var containers);
-            using var spanForContainersDisposer = PooledHashSet<TextSpan>.GetInstance(out var spanForContainers);
+            using var _1 = ArrayBuilder<(DocumentId, SyntaxNode)>.GetInstance(ids.Length, out var containers);
+            using var _2 = PooledHashSet<TextSpan>.GetInstance(out var spanForContainers);
 
             foreach (var document in documents)
             {
@@ -401,13 +401,11 @@ namespace Microsoft.CodeAnalysis.ChangeNamespace
         private static ImmutableArray<SyntaxNode> CreateImports(Document document, ImmutableArray<string> names, bool withFormatterAnnotation)
         {
             var generator = SyntaxGenerator.GetGenerator(document);
-            using var builderDisposer = ArrayBuilder<SyntaxNode>.GetInstance(names.Length, out var builder);
+            using var _ = ArrayBuilder<SyntaxNode>.GetInstance(names.Length, out var builder);
             for (var i = 0; i < names.Length; ++i)
-            {
                 builder.Add(CreateImport(generator, names[i], withFormatterAnnotation));
-            }
 
-            return builder.ToImmutable();
+            return builder.ToImmutableAndClear();
         }
 
         private static SyntaxNode CreateImport(SyntaxGenerator syntaxGenerator, string name, bool withFormatterAnnotation)

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.SymbolComputer.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.SymbolComputer.cs
@@ -521,7 +521,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 receiverTypeNamesBuilder.Add(FindSymbols.Extensions.ComplexReceiverTypeName);
                 receiverTypeNamesBuilder.Add(FindSymbols.Extensions.ComplexArrayReceiverTypeName);
 
-                return receiverTypeNamesBuilder.ToImmutable();
+                return receiverTypeNamesBuilder.ToImmutableAndClear();
             }
 
             private static string GetReceiverTypeName(ITypeSymbol typeSymbol)

--- a/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
+++ b/src/Features/Core/Portable/DocumentHighlighting/AbstractDocumentHighlightsService.cs
@@ -261,19 +261,17 @@ namespace Microsoft.CodeAnalysis.DocumentHighlighting
                 await AddLocationSpanAsync(location, solution, spanSet, tagMap, HighlightSpanKind.Reference, cancellationToken).ConfigureAwait(false);
             }
 
-            using var listDisposer = ArrayBuilder<DocumentHighlights>.GetInstance(tagMap.Count, out var list);
+            using var _1 = ArrayBuilder<DocumentHighlights>.GetInstance(tagMap.Count, out var list);
             foreach (var kvp in tagMap)
             {
-                using var spansDisposer = ArrayBuilder<HighlightSpan>.GetInstance(kvp.Value.Count, out var spans);
+                using var _2 = ArrayBuilder<HighlightSpan>.GetInstance(kvp.Value.Count, out var spans);
                 foreach (var span in kvp.Value)
-                {
                     spans.Add(span);
-                }
 
-                list.Add(new DocumentHighlights(kvp.Key, spans.ToImmutable()));
+                list.Add(new DocumentHighlights(kvp.Key, spans.ToImmutableAndClear()));
             }
 
-            return list.ToImmutable();
+            return list.ToImmutableAndClear();
         }
 
         private static bool ShouldIncludeDefinition(ISymbol symbol)

--- a/src/Features/Core/Portable/ExtractClass/ExtractClassWithDialogCodeAction.cs
+++ b/src/Features/Core/Portable/ExtractClass/ExtractClassWithDialogCodeAction.cs
@@ -152,8 +152,8 @@ namespace Microsoft.CodeAnalysis.ExtractClass
             ImmutableArray<ExtractClassMemberAnalysisResult> memberAnalysisResults,
             CancellationToken cancellationToken)
         {
-            using var _ = ArrayBuilder<(ISymbol member, bool makeAbstract)>.GetInstance(out var pullMembersBuilder);
-            using var _1 = ArrayBuilder<ExtractClassMemberAnalysisResult>.GetInstance(memberAnalysisResults.Length, out var remainingResults);
+            using var _1 = ArrayBuilder<(ISymbol member, bool makeAbstract)>.GetInstance(out var pullMembersBuilder);
+            using var _2 = ArrayBuilder<ExtractClassMemberAnalysisResult>.GetInstance(memberAnalysisResults.Length, out var remainingResults);
             remainingResults.AddRange(memberAnalysisResults);
 
             // For each document in the symbol mappings, we want to find the annotated nodes
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.ExtractClass
                 var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
                 var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                 var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-                using var _2 = ArrayBuilder<ExtractClassMemberAnalysisResult>.GetInstance(remainingResults.Count, out var resultsToRemove);
+                using var _3 = ArrayBuilder<ExtractClassMemberAnalysisResult>.GetInstance(remainingResults.Count, out var resultsToRemove);
 
                 // Out of the remaining members that we need to move, does this
                 // document contain the definition for that symbol? If so, add it to the builder

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateDeconstructMethodService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateDeconstructMethodService.State.cs
@@ -94,14 +94,14 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 }
 
                 var tupleElements = ((INamedTypeSymbol)targetType).TupleElements;
-                using var builderDisposer = ArrayBuilder<IParameterSymbol>.GetInstance(tupleElements.Length, out var builder);
+                using var _ = ArrayBuilder<IParameterSymbol>.GetInstance(tupleElements.Length, out var builder);
                 foreach (var element in tupleElements)
                 {
                     builder.Add(CodeGenerationSymbolFactory.CreateParameterSymbol(
                         attributes: default, RefKind.Out, isParams: false, element.Type, element.Name));
                 }
 
-                return builder.ToImmutable();
+                return builder.ToImmutableAndClear();
             }
         }
     }

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.cs
@@ -198,8 +198,8 @@ namespace Microsoft.CodeAnalysis.GenerateType
 
             // For anything that was a type parameter, just use the name (if we haven't already
             // used it).  Otherwise, synthesize new names for the parameters.
-            using var namesDisposer = ArrayBuilder<string>.GetInstance(arity, out var names);
-            using var isFixedDisposer = ArrayBuilder<bool>.GetInstance(arity, out var isFixed);
+            using var _1 = ArrayBuilder<string>.GetInstance(arity, out var names);
+            using var _2 = ArrayBuilder<bool>.GetInstance(arity, out var isFixed);
             for (var i = 0; i < arity; i++)
             {
                 var argument = i < arguments.Count ? arguments[i] : null;

--- a/src/Features/Core/Portable/Wrapping/ChainedExpression/AbstractChainedExpressionWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/ChainedExpression/AbstractChainedExpressionWrapper.cs
@@ -230,13 +230,11 @@ namespace Microsoft.CodeAnalysis.Wrapping.ChainedExpression
         private static ImmutableArray<SyntaxNodeOrToken> GetSubRange(
             ArrayBuilder<SyntaxNodeOrToken> pieces, int start, int end)
         {
-            using var resultDisposer = ArrayBuilder<SyntaxNodeOrToken>.GetInstance(end - start, out var result);
+            using var _ = ArrayBuilder<SyntaxNodeOrToken>.GetInstance(end - start, out var result);
             for (var i = start; i < end; i++)
-            {
                 result.Add(pieces[i]);
-            }
 
-            return result.ToImmutable();
+            return result.ToImmutableAndClear();
         }
 
         private bool IsDecomposableChainPart(SyntaxNode? node)

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DocumentAnalysisExecutor.cs
@@ -376,7 +376,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 builder.Add(DiagnosticData.Create(diagnostic, textDocument));
             }
 
-            return builder.ToImmutable();
+            return builder.ToImmutableAndClear();
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
+++ b/src/Features/LanguageServer/Protocol/Features/UnifiedSuggestions/UnifiedSuggestedActionsSource.cs
@@ -158,7 +158,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
                     var set = new UnifiedSuggestedActionSet(
                         originalSolution,
                         categoryName: null,
-                        actions: unifiedNestedActions.ToImmutable(),
+                        actions: unifiedNestedActions.ToImmutableAndClear(),
                         title: null,
                         priority: GetUnifiedSuggestedActionSetPriority(action.Priority),
                         applicableToSpan: fix.PrimaryDiagnostic.Location.SourceSpan);
@@ -453,7 +453,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
                 orderedRefactorings.Add(orderedRefactoring);
             }
 
-            return orderedRefactorings.ToImmutable();
+            return orderedRefactorings.ToImmutableAndClear();
         }
 
         private static ImmutableArray<CodeRefactoring> FilterOnAnyThread(
@@ -548,7 +548,7 @@ namespace Microsoft.CodeAnalysis.UnifiedSuggestions
                     var set = new UnifiedSuggestedActionSet(
                         originalSolution,
                         categoryName: null,
-                        actions: nestedActions.ToImmutable(),
+                        actions: nestedActions.ToImmutableAndClear(),
                         title: null,
                         priority: GetUnifiedSuggestedActionSetPriority(codeAction.Priority),
                         applicableToSpan: applicableToSpan);

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
@@ -439,7 +439,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
             }
 
-            return builder.ToImmutable();
+            return builder.ToImmutableAndClear();
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.Rename
             foreach (var loc in this.Locations)
                 locBuilder.Add(await loc.RehydrateAsync(solution, cancellationToken).ConfigureAwait(false));
 
-            return locBuilder.ToImmutable();
+            return locBuilder.ToImmutableAndClear();
         }
     }
 

--- a/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/AssetProvider.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Remote
             foreach (var checksum in checksums)
                 list.Add(ValueTuple.Create(checksum, await GetAssetAsync<T>(checksum, cancellationToken).ConfigureAwait(false)));
 
-            return list.ToImmutable();
+            return list.ToImmutableAndClear();
         }
 
         public async ValueTask SynchronizeSolutionAssetsAsync(Checksum solutionChecksum, CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     }
                 }
 
-                return classifiedSpans.ToImmutable();
+                return classifiedSpans.ToImmutableAndClear();
             }
             catch
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ImmutableArrayExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ImmutableArrayExtensions.cs
@@ -33,7 +33,7 @@ namespace Roslyn.Utilities
             for (var i = 0; i < count; i++)
                 result.Add(array[i]);
 
-            return result.ToImmutable();
+            return result.ToImmutableAndClear();
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ObjectWriterExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ObjectWriterExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             for (var i = 0; i < length; i++)
                 builder.Add(read(reader));
 
-            return builder.ToImmutable();
+            return builder.ToImmutableAndClear();
         }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/NameGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Utilities/NameGenerator.cs
@@ -66,15 +66,15 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             Func<string, bool>? canUse = null,
             bool isCaseSensitive = true)
         {
-            using var isFixedDisposer = ArrayBuilder<bool>.GetInstance(names.Length, out var isFixedBuilder);
-            isFixedBuilder.AddRange(isFixed);
+            using var _1 = ArrayBuilder<bool>.GetInstance(names.Length, out var isFixedBuilder);
+            using var _2 = ArrayBuilder<string>.GetInstance(names.Length, out var result);
 
-            var result = ArrayBuilder<string>.GetInstance(names.Length);
+            isFixedBuilder.AddRange(isFixed);
             result.AddRange(names);
 
             EnsureUniquenessInPlace(result, isFixedBuilder, canUse, isCaseSensitive);
 
-            return result.ToImmutableAndFree();
+            return result.ToImmutableAndClear();
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         {
             canUse ??= Functions<string>.True;
 
-            using var disposer = ArrayBuilder<int>.GetInstance(out var collisionIndices);
+            using var _ = ArrayBuilder<int>.GetInstance(out var collisionIndices);
 
             // Don't enumerate as we will be modifying the collection in place.
             for (var i = 0; i < names.Count; i++)


### PR DESCRIPTION
ToImmutableAndClear has two benefits over ToImmutable when the ArrayBuilder was given a known length.

1. if the number of elements in the builder is the same as the number requested, then this becomes a MoveToImmutable call, which avoids needing to make a new array that hte values are copied to.
2. the MoveToImmutable then sets teh internal array of the builder back to an empty array with a Count of 0.  This means that this ArrayBuilder will always go back to the pool, even if hte number of elements that were added exceed our normal pool cap.  e.g. our normal pool cap is 128 elements.  But this means that we could add far above that amount, and still get pooling (since we're going to safely pool a builder with 0 elements in it)

So this is best of all worlds.  No additional intermediary arrays.  No copies.  And we always pool, no matter how many elements we computed while using hte scratch array.

Note: i only updated the usages where i could trivially validate that the number of elements added was equal to the number of elements requested.