### PR TITLE
Select SuggestionItem if there's no match in the list

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
             private readonly Action<IReadOnlyList<(RoslynCompletionItem, PatternMatch?)>, string, IList<RoslynCompletionItem>> _filterMethod;
 
-            private bool ShouldSelectSuggestionItem
+            private bool ShouldSelectSuggestionItemWhenNoItemMatchesFilterText
                 => _snapshotData.DisplaySuggestionItem && _filterText.Length > 0;
 
             private CompletionTriggerReason InitialTriggerReason => _snapshotData.InitialTrigger.Reason;
@@ -274,7 +274,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     {
                         // When we are in suggestion mode and there's nothing in the list matches what user has typed in any ways,
                         // we should select the SuggestionItem instead.
-                        if (ShouldSelectSuggestionItem)
+                        if (ShouldSelectSuggestionItemWhenNoItemMatchesFilterText)
                             return new ItemSelection(SelectedItemIndex: SuggestionItemIndex, SelectionHint: UpdateSelectionHint.SoftSelected, UniqueItem: null);
 
                         // We do not have matches: pick the one with longest common prefix.
@@ -412,7 +412,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                         return null;
 
                     // If we are in suggestion mode and nothing matches filter text, we should soft select SuggestionItem.
-                    if (ShouldSelectSuggestionItem)
+                    if (ShouldSelectSuggestionItemWhenNoItemMatchesFilterText)
                         indexToSelect = SuggestionItemIndex;
                 }
                 else
@@ -494,7 +494,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 }
 
                 // If we are in suggestion mode then we should select the SuggestionItem instead.
-                var selectedItemIndex = ShouldSelectSuggestionItem ? SuggestionItemIndex : 0;
+                var selectedItemIndex = ShouldSelectSuggestionItemWhenNoItemMatchesFilterText ? SuggestionItemIndex : 0;
 
                 // If the user has turned on some filtering states, and we filtered down to
                 // nothing, then we do want the UI to show that to them.  That way the user

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
@@ -266,6 +266,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     MatchResult<VSCompletionItem> bestOrFirstMatchResult;
                     if (filteredItemsBuilder.Count == 0)
                     {
+                        // When we are in suggestion mode and there's nothing in the list matches what user has typed in any ways,
+                        // we should select the SuggestionItem instead.
+                        if (_snapshotData.DisplaySuggestionItem)
+                            return new ItemSelection(SelectedItemIndex: -1, SelectionHint: UpdateSelectionHint.SoftSelected, UniqueItem: null);
+
                         // We do not have matches: pick the one with longest common prefix.
                         // If we can't find such an item, just return the first item from the list.
                         selectedItemIndex = 0;
@@ -389,7 +394,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     }
                 }
 
-                if (UpdateTriggerReason == CompletionTriggerReason.Insertion && bestMatchResult is null)
+                if (bestMatchResult is null)
                 {
                     // The user has typed something, but nothing in the actual list matched what
                     // they were typing.  In this case, we want to dismiss completion entirely.
@@ -397,10 +402,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     // to help them when they typed delete (in case they wanted to pick another
                     // item).  However, they're typing something that doesn't seem to match at all
                     // The completion list is just distracting at this point.
-                    return null;
-                }
+                    if (UpdateTriggerReason == CompletionTriggerReason.Insertion)
+                        return null;
 
-                if (bestMatchResult is not null)
+                    // If we are in suggestion mode and nothing matches filter text, we should soft select SuggestionItem.
+                    if (_snapshotData.DisplaySuggestionItem)
+                        indexToSelect = -1;
+                }
+                else
                 {
                     // Only hard select this result if it's a prefix match
                     // We need to do this so that
@@ -478,6 +487,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     }
                 }
 
+                // If we are in suggestion mode then we should select the SuggestionItem instead.
+                var selectedItemIndex = _snapshotData.DisplaySuggestionItem ? -1 : 0;
+
                 // If the user has turned on some filtering states, and we filtered down to
                 // nothing, then we do want the UI to show that to them.  That way the user
                 // can turn off filters they don't want and get the right set of items.
@@ -486,7 +498,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 // model (and all the previously filtered items), but switch over to soft
                 // selection.
                 return new FilteredCompletionModel(
-                    items: ImmutableArray<CompletionItemWithHighlight>.Empty, selectedItemIndex: 0,
+                    items: ImmutableArray<CompletionItemWithHighlight>.Empty, selectedItemIndex,
                     filters: _snapshotData.SelectedFilters, selectionHint: UpdateSelectionHint.SoftSelected, centerSelection: true, uniqueItem: null);
             }
 
@@ -670,8 +682,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
             private ItemSelection UpdateSelectionBasedOnSuggestedDefaults(IReadOnlyList<MatchResult<VSCompletionItem>> items, ItemSelection itemSelection, CancellationToken cancellationToken)
             {
-                // Editor doesn't provide us a list of "default" items.
-                if (_snapshotData.Defaults.IsDefaultOrEmpty)
+                // Editor doesn't provide us a list of "default" items, or we select SuggestionItem (because we are in suggestion mode and have no match in the list)
+                if (_snapshotData.Defaults.IsDefaultOrEmpty || itemSelection.SelectedItemIndex < 0)
                     return itemSelection;
 
                 // "Preselect" is only used when we have high confidence with the selection, so don't override it.

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -5975,15 +5975,18 @@ class C
     {
         switch (true)
         {
-            case identifier $$
+            case identifier$$
         }
     }
 }
                               </Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.SendTypeChars("z")
+                state.SendTypeChars(" ")
                 Await state.AssertSelectedCompletionItem(displayText:="identifier", isHardSelected:=False)
+
+                state.SendTypeChars("z")
+                state.AssertSuggestedItemSelected(displayText:="z")
 
                 state.SendBackspace()
                 state.SendTypeChars("i")
@@ -6288,12 +6291,12 @@ class C
 
                 state.SendTypeChars("xyzz")
                 Await state.AssertCompletionSession()
-                state.AssertSuggestedItemSelected()
+                state.AssertSuggestedItemSelected(displayText:="xyzz")
                 Await state.AssertSelectedCompletionItem(displayText:="sxyzz", isSoftSelected:=True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
-                state.AssertSuggestedItemSelected()
+                state.AssertSuggestedItemSelected(displayText:="xyz")
                 Await state.AssertSelectedCompletionItem(displayText:="sxyz", isSoftSelected:=True)
 
                 state.SendBackspace()

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -6285,6 +6285,23 @@ class C
                 Await state.AssertCompletionSession()
                 Assert.True(state.HasSuggestedItem())
                 Await state.AssertSelectedCompletionItem(displayText:="sbyte", isSoftSelected:=True)
+
+                state.SendTypeChars("xyzz")
+                Await state.AssertCompletionSession()
+                state.AssertSuggestedItemSelected()
+                Await state.AssertSelectedCompletionItem(displayText:="sxyzz", isSoftSelected:=True)
+
+                state.SendBackspace()
+                Await state.AssertCompletionSession()
+                state.AssertSuggestedItemSelected()
+                Await state.AssertSelectedCompletionItem(displayText:="sxyz", isSoftSelected:=True)
+
+                state.SendBackspace()
+                state.SendBackspace()
+                state.SendBackspace()
+                Await state.AssertCompletionSession()
+                Assert.True(state.HasSuggestedItem())
+                Await state.AssertSelectedCompletionItem(displayText:="sbyte", isSoftSelected:=True)
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -5975,17 +5975,15 @@ class C
     {
         switch (true)
         {
-            case identifier$$
+            case identifier $$
         }
     }
 }
                               </Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.SendTypeChars(" ")
-                Await state.AssertSelectedCompletionItem(displayText:="identifier", isHardSelected:=False)
-
                 state.SendTypeChars("z")
+                Await state.AssertCompletionItemsContain(displayText:="identifier", displayTextSuffix:=Nothing)
                 state.AssertSuggestedItemSelected(displayText:="z")
 
                 state.SendBackspace()
@@ -6291,12 +6289,12 @@ class C
 
                 state.SendTypeChars("xyzz")
                 Await state.AssertCompletionSession()
-                state.AssertSuggestedItemSelected(displayText:="xyzz")
+                state.AssertSuggestedItemSelected(displayText:="sxyzz")
                 Await state.AssertSelectedCompletionItem(displayText:="sxyzz", isSoftSelected:=True)
 
                 state.SendBackspace()
                 Await state.AssertCompletionSession()
-                state.AssertSuggestedItemSelected(displayText:="xyz")
+                state.AssertSuggestedItemSelected(displayText:="sxyz")
                 Await state.AssertSelectedCompletionItem(displayText:="sxyz", isSoftSelected:=True)
 
                 state.SendBackspace()

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
@@ -531,12 +531,13 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Return computedItems.SuggestionItem IsNot Nothing
         End Function
 
-        Public Function AssertSuggestedItemSelected() As Boolean
+        Public Sub AssertSuggestedItemSelected(displayText As String)
             Dim session = GetExportedValue(Of IAsyncCompletionBroker)().GetSession(TextView)
             Assert.NotNull(session)
             Dim computedItems = session.GetComputedItems(CancellationToken.None)
             Assert.True(computedItems.SuggestionItemSelected)
-        End Function
+            Assert.Equal(computedItems.SuggestionItem.DisplayText, displayText)
+        End Sub
 
         Public Function IsSoftSelected() As Boolean
             Dim session = GetExportedValue(Of IAsyncCompletionBroker)().GetSession(TextView)

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
@@ -531,6 +531,13 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Return computedItems.SuggestionItem IsNot Nothing
         End Function
 
+        Public Function AssertSuggestedItemSelected() As Boolean
+            Dim session = GetExportedValue(Of IAsyncCompletionBroker)().GetSession(TextView)
+            Assert.NotNull(session)
+            Dim computedItems = session.GetComputedItems(CancellationToken.None)
+            Assert.True(computedItems.SuggestionItemSelected)
+        End Function
+
         Public Function IsSoftSelected() As Boolean
             Dim session = GetExportedValue(Of IAsyncCompletionBroker)().GetSession(TextView)
             Assert.NotNull(session)


### PR DESCRIPTION
Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1423475

When we are in suggestion-mode (either by toggling suggestion mode or in naming context,) select the SuggestionItem if there's no CompletionItem in the list that matches the filter text in anyway.

Note the change of selection box in the screen recording below
![SelectSuggestion](https://user-images.githubusercontent.com/788783/182270284-f97732b9-6369-4a5a-b5de-32f879a62ce8.gif)