### PR TITLE
Ensure we don't call out into arbitrary code directly when setting up our cache state

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.InFlightSolution.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.InFlightSolution.cs
@@ -102,9 +102,9 @@ namespace Microsoft.CodeAnalysis.Remote
                 if (_primaryBranchTask != null)
                     return;
 
-                // Grab the cancellation token up front.  We don't want to potentially grab it at some undefined point
-                // at the future when this type has already had its in-flight-count reduced to 0 and thus had our CTS be
-                // disposed.
+                // Grab the cancellation token up front while we know we are holding the lock and mutating state.  We
+                // don't want to potentially grab it at some undefined point at the future when this type has already
+                // had its in-flight-count reduced to 0 and thus had our CTS be disposed.
                 var token = this.CancellationToken;
                 _primaryBranchTask = ComputePrimaryBranchAsync(token);
                 return;
@@ -138,8 +138,8 @@ namespace Microsoft.CodeAnalysis.Remote
                 if (InFlightCount != 0)
                     return ImmutableArray<Task>.Empty;
 
-                _cancellationTokenSource.Cancel();
-                _cancellationTokenSource.Dispose();
+                _cancellationTokenSource_doNotAccessDirectly.Cancel();
+                _cancellationTokenSource_doNotAccessDirectly.Dispose();
 
                 // If we're going away, then we absolutely must not be pointed at in the _lastRequestedSolution field.
                 Contract.ThrowIfTrue(_workspace._lastAnyBranchSolution == this);

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.InFlightSolution.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.InFlightSolution.cs
@@ -112,6 +112,8 @@ namespace Microsoft.CodeAnalysis.Remote
                 async Task<Solution> ComputePrimaryBranchAsync(CancellationToken cancellationToken)
                 {
                     var solution = await _disconnectedSolutionTask.ConfigureAwait(false);
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     return await updatePrimaryBranchAsync(solution, cancellationToken).ConfigureAwait(false);
                 }
             }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -119,6 +119,9 @@ namespace Microsoft.CodeAnalysis.Remote
                 inFlightSolution = GetOrCreateSolutionAndAddInFlightCount_NoLock(
                     assetProvider, solutionChecksum, workspaceVersion, updatePrimaryBranch);
                 solutionTask = inFlightSolution.PreferredSolutionTask_NoLock;
+
+                // We must have at least 1 for the in-flight-count (representing this current in-flight call).
+                Contract.ThrowIfTrue(inFlightSolution.InFlightCount < 1);
             }
 
             try

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 //
                 // Use a NoThrowAwaitable as we want to await all tasks here regardless of how individual ones may cancel.
                 foreach (var task in solutionComputationTasks)
-                    await task.NoThrowAwaitable();
+                    await task.NoThrowAwaitable(false);
             }
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace_SolutionCaching.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace_SolutionCaching.cs
@@ -35,6 +35,9 @@ namespace Microsoft.CodeAnalysis.Remote
         /// </summary>
         private readonly Dictionary<Checksum, InFlightSolution> _solutionChecksumToSolution = new();
 
+        /// <summary>
+        /// Deliberately not cancellable.  This code must always run fully to completion.
+        /// </summary>
         private InFlightSolution GetOrCreateSolutionAndAddInFlightCount_NoLock(
             AssetProvider assetProvider,
             Checksum solutionChecksum,


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/63131