### PR TITLE
Emit MetadataUpdateOriginalTypeAttribute

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -1611,11 +1611,20 @@ next:;
             // Add MetadataUpdateOriginalTypeAttribute when a reloadable type is emitted to EnC delta
             if (moduleBuilder.EncSymbolChanges?.IsReplaced(((ISymbolInternal)this).GetISymbol()) == true)
             {
+                // Note that we use this source named type symbol in the attribute argument (of System.Type).
+                // We do not have access to the original symbol from this compilation. However, System.Type
+                // is encoded in the attribute as a string containing a fully qualified type name.
+                // The name of the current type symbol as provided by ISymbol.Name is the same as the name of
+                // the original type symbol that is being replaced by this type symbol.
+                // The "#{generation}" suffix is appended to the TypeDef name in the metadata writer,
+                // but not to the attribute value.
+                var originalType = this;
+
                 AddSynthesizedAttribute(
                     ref attributes,
                     compilation.TrySynthesizeAttribute(
                         WellKnownMember.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute__ctor,
-                        ImmutableArray.Create(new TypedConstant(compilation.GetWellKnownType(WellKnownType.System_Type), TypedConstantKind.Type, this)),
+                        ImmutableArray.Create(new TypedConstant(compilation.GetWellKnownType(WellKnownType.System_Type), TypedConstantKind.Type, originalType)),
                         isOptionalUse: true));
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Symbols;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -1605,6 +1606,17 @@ next:;
                 AddSynthesizedAttribute(
                     ref attributes,
                     compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_RequiredMemberAttribute__ctor));
+            }
+
+            // Add MetadataUpdateOriginalTypeAttribute when a reloadable type is emitted to EnC delta
+            if (moduleBuilder.EncSymbolChanges?.IsReplaced(((ISymbolInternal)this).GetISymbol()) == true)
+            {
+                AddSynthesizedAttribute(
+                    ref attributes,
+                    compilation.TrySynthesizeAttribute(
+                        WellKnownMember.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute__ctor,
+                        ImmutableArray.Create(new TypedConstant(compilation.GetWellKnownType(WellKnownType.System_Type), TypedConstantKind.Type, this)),
+                        isOptionalUse: true));
             }
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTestBase.cs
@@ -145,27 +145,48 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
         internal static bool IsDefinition(HandleKind kind)
             => kind is not (HandleKind.AssemblyReference or HandleKind.ModuleReference or HandleKind.TypeReference or HandleKind.MemberReference or HandleKind.TypeSpecification or HandleKind.MethodSpecification);
 
+        /// <summary>
+        /// Checks that the EncLog contains specified rows.
+        /// Any default values in the expected <paramref name="rows"/> are ignored to facilitate conditional code.
+        /// </summary>
         internal static void CheckEncLog(MetadataReader reader, params EditAndContinueLogEntry[] rows)
         {
-            AssertEx.Equal(rows, reader.GetEditAndContinueLogEntries(), itemInspector: EncLogRowToString);
+            AssertEx.Equal(
+                rows.Where(r => r.Handle != default),
+                reader.GetEditAndContinueLogEntries(), itemInspector: EncLogRowToString);
         }
 
         /// <summary>
         /// Checks that the EncLog contains specified definition rows. References are ignored as they are usually not interesting to validate. They are emitted as needed.
+        /// Any default values in the expected <paramref name="rows"/> are ignored to facilitate conditional code.
         /// </summary>
         internal static void CheckEncLogDefinitions(MetadataReader reader, params EditAndContinueLogEntry[] rows)
         {
-            AssertEx.Equal(rows, reader.GetEditAndContinueLogEntries().Where(e => IsDefinition(e.Handle.Kind)), itemInspector: EncLogRowToString);
+            AssertEx.Equal(
+                rows.Where(r => r.Handle != default),
+                reader.GetEditAndContinueLogEntries().Where(e => IsDefinition(e.Handle.Kind)), itemInspector: EncLogRowToString);
         }
 
+        /// <summary>
+        /// Checks that the EncMap contains specified handles.
+        /// Any default values in the expected <paramref name="handles"/> are ignored to facilitate conditional code.
+        /// </summary>
         internal static void CheckEncMap(MetadataReader reader, params EntityHandle[] handles)
         {
-            AssertEx.Equal(handles, reader.GetEditAndContinueMapEntries(), itemInspector: EncMapRowToString);
+            AssertEx.Equal(
+                handles.Where(h => h != default),
+                reader.GetEditAndContinueMapEntries(), itemInspector: EncMapRowToString);
         }
 
+        /// <summary>
+        /// Checks that the EncMap contains specified definition handles. References are ignored as they are usually not interesting to validate. They are emitted as needed.
+        /// Any default values in the expected <paramref name="handles"/> are ignored to facilitate conditional code.
+        /// </summary>
         internal static void CheckEncMapDefinitions(MetadataReader reader, params EntityHandle[] handles)
         {
-            AssertEx.Equal(handles, reader.GetEditAndContinueMapEntries().Where(e => IsDefinition(e.Kind)), itemInspector: EncMapRowToString);
+            AssertEx.Equal(
+                handles.Where(h => h != default),
+                reader.GetEditAndContinueMapEntries().Where(e => IsDefinition(e.Kind)), itemInspector: EncMapRowToString);
         }
 
         internal static void CheckAttributes(MetadataReader reader, params CustomAttributeRow[] rows)
@@ -203,7 +224,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             Func<THandle, Handle> toHandle,
             string[] expectedNames)
         {
-            var aggregator = new MetadataAggregator(readers[0], readers.Skip(1).ToArray());
+            var aggregator = GetAggregator(readers);
 
             AssertEx.Equal(expectedNames, entityHandles.Select(handle =>
             {
@@ -214,6 +235,27 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
                 return readers[nameGeneration].GetString(genNameHandle);
             }));
         }
+
+        public static void CheckBlobValue(IList<MetadataReader> readers, BlobHandle valueHandle, byte[] expectedValue)
+        {
+            var aggregator = GetAggregator(readers);
+
+            var genHandle = (BlobHandle)aggregator.GetGenerationHandle(valueHandle, out int blobGeneration);
+            var attributeData = readers[blobGeneration].GetBlobBytes(genHandle);
+            AssertEx.Equal(expectedValue, attributeData);
+        }
+
+        public static void CheckStringValue(IList<MetadataReader> readers, StringHandle valueHandle, string expectedValue)
+        {
+            var aggregator = GetAggregator(readers);
+
+            var genHandle = (StringHandle)aggregator.GetGenerationHandle(valueHandle, out int blobGeneration);
+            var attributeData = readers[blobGeneration].GetString(genHandle);
+            AssertEx.Equal(expectedValue, attributeData);
+        }
+
+        public static MetadataAggregator GetAggregator(IList<MetadataReader> readers)
+            => new MetadataAggregator(readers[0], readers.Skip(1).ToArray());
 
         internal static string EncLogRowToString(EditAndContinueLogEntry row)
         {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -618,6 +618,7 @@ namespace System
                     case WellKnownType.System_MemoryExtensions:
                     case WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute:
                     case WellKnownType.System_Diagnostics_CodeAnalysis_UnscopedRefAttribute:
+                    case WellKnownType.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute:
                         // Not yet in the platform.
                         continue;
                     case WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation:
@@ -983,6 +984,7 @@ namespace System
                     case WellKnownMember.System_MemoryExtensions__AsSpan_String:
                     case WellKnownMember.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute__ctor:
                     case WellKnownMember.System_Diagnostics_CodeAnalysis_UnscopedRefAttribute__ctor:
+                    case WellKnownMember.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute__ctor:
                         // Not yet in the platform.
                         continue;
                     case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile:

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -98,10 +98,13 @@ namespace Microsoft.CodeAnalysis.Emit
             return internalSymbols.ToImmutableAndFree();
         }
 
+        public bool IsReplaced(ISymbol symbol)
+            => _replacedSymbols.Contains(symbol);
+
         public bool IsReplaced(IDefinition definition)
         {
             var symbol = definition.GetInternalSymbol();
-            return symbol is not null && _replacedSymbols.Contains(symbol.GetISymbol());
+            return symbol is not null && IsReplaced(symbol.GetISymbol());
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -532,6 +532,7 @@ namespace Microsoft.CodeAnalysis
         System_Diagnostics_CodeAnalysis_UnscopedRefAttribute__ctor,
 
         System_MissingMethodException__ctor,
+        System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute__ctor,
 
         Count
 

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3653,6 +3653,13 @@ namespace Microsoft.CodeAnalysis
                     0,                                                                                                                       // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
 
+                // MetadataUpdateOriginalTypeAttribute__ctor
+                (byte)MemberFlags.Constructor,                                                                                               // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute - WellKnownType.ExtSentinel),            // DeclaringTypeId
+                 0,                                                                                                                          // Arity
+                    1,                                                                                                                       // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,                                                       // Return Type
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Type,
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -4103,13 +4110,14 @@ namespace Microsoft.CodeAnalysis
                 "ToStringAndClear",                         // System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear
                 ".ctor",                                    // System_Runtime_CompilerServices_RequiredMemberAttribute__ctor
                 ".ctor",                                    // System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor
-                ".ctor",                         // System_Runtime_CompilerServices_LifetimeAttribute__ctor
+                ".ctor",                                    // System_Runtime_CompilerServices_LifetimeAttribute__ctor
                 "SequenceEqual",                            // System_MemoryExtensions__SequenceEqual_Span_T
                 "SequenceEqual",                            // System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T
                 "AsSpan",                                   // System_MemoryExtensions__AsSpan_String
                 ".ctor",                                    // System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute_ctor
                 ".ctor",                                    // System_Diagnostics_CodeAnalysis_UnscopedRefAttribute__ctor
                 ".ctor",                                    // System_MissingMethodException__ctor
+                ".ctor",                                    // System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -326,6 +326,7 @@ namespace Microsoft.CodeAnalysis
         System_Diagnostics_CodeAnalysis_UnscopedRefAttribute,
 
         System_MissingMethodException,
+        System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute,
 
         NextAvailable,
         // Remember to update the AllWellKnownTypes tests when making changes here
@@ -643,6 +644,7 @@ namespace Microsoft.CodeAnalysis
             "System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute",
             "System.Diagnostics.CodeAnalysis.UnscopedRefAttribute",
             "System.MissingMethodException",
+            "System.Runtime.CompilerServices.MetadataUpdateOriginalTypeAttribute",
         };
 
         private static readonly Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -553,7 +553,8 @@ End Namespace
                          WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute,
                          WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute,
                          WellKnownType.System_Diagnostics_CodeAnalysis_UnscopedRefAttribute,
-                         WellKnownType.System_MemoryExtensions
+                         WellKnownType.System_MemoryExtensions,
+                         WellKnownType.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel
@@ -625,7 +626,8 @@ End Namespace
                          WellKnownType.System_MemoryExtensions,
                          WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute,
                          WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute,
-                         WellKnownType.System_Diagnostics_CodeAnalysis_UnscopedRefAttribute
+                         WellKnownType.System_Diagnostics_CodeAnalysis_UnscopedRefAttribute,
+                         WellKnownType.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel
@@ -722,7 +724,8 @@ End Namespace
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T,
                          WellKnownMember.System_MemoryExtensions__AsSpan_String,
                          WellKnownMember.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute__ctor,
-                         WellKnownMember.System_Diagnostics_CodeAnalysis_UnscopedRefAttribute__ctor
+                         WellKnownMember.System_Diagnostics_CodeAnalysis_UnscopedRefAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute__ctor
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,
@@ -875,7 +878,8 @@ End Namespace
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T,
                          WellKnownMember.System_MemoryExtensions__AsSpan_String,
                          WellKnownMember.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute__ctor,
-                         WellKnownMember.System_Diagnostics_CodeAnalysis_UnscopedRefAttribute__ctor
+                         WellKnownMember.System_Diagnostics_CodeAnalysis_UnscopedRefAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute__ctor
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                     Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile,


### PR DESCRIPTION
The attribute, if defined, is emitted into EnC deltas on reloadable types.

Fixes https://github.com/dotnet/roslyn/issues/59954