### PR TITLE
Revert "Rename `LifetimeAnnotationAttribute` to `ScopedRefAttribute` and simplify (#63009)"

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -744,7 +744,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, lambdaParameters, diagnostics, modifyCompilation: false);
-            ParameterHelpers.EnsureScopedRefAttributeExists(compilation, lambdaParameters, diagnostics, modifyCompilation: false);
+            ParameterHelpers.EnsureLifetimeAnnotationAttributeExists(compilation, lambdaParameters, diagnostics, modifyCompilation: false);
             ParameterHelpers.EnsureNullableAttributeExists(compilation, lambdaSymbol, lambdaParameters, diagnostics, modifyCompilation: false);
             // Note: we don't need to warn on annotations used in #nullable disable context for lambdas, as this is handled in binding already
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         private SynthesizedEmbeddedNullableContextAttributeSymbol _lazyNullableContextAttribute;
         private SynthesizedEmbeddedNullablePublicOnlyAttributeSymbol _lazyNullablePublicOnlyAttribute;
         private SynthesizedEmbeddedNativeIntegerAttributeSymbol _lazyNativeIntegerAttribute;
-        private SynthesizedEmbeddedScopedRefAttributeSymbol _lazyScopedRefAttribute;
+        private SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol _lazyLifetimeAnnotationAttribute;
 
         /// <summary>
         /// The behavior of the C# command-line compiler is as follows:
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             builder.AddIfNotNull(_lazyNullableContextAttribute);
             builder.AddIfNotNull(_lazyNullablePublicOnlyAttribute);
             builder.AddIfNotNull(_lazyNativeIntegerAttribute);
-            builder.AddIfNotNull(_lazyScopedRefAttribute);
+            builder.AddIfNotNull(_lazyLifetimeAnnotationAttribute);
 
             return builder.ToImmutableAndFree();
         }
@@ -251,17 +251,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return base.SynthesizeNativeIntegerAttribute(member, arguments);
         }
 
-        internal override SynthesizedAttributeData SynthesizeScopedRefAttribute(WellKnownMember member)
+        internal override SynthesizedAttributeData SynthesizeLifetimeAnnotationAttribute(WellKnownMember member, ImmutableArray<TypedConstant> arguments)
         {
-            if ((object)_lazyScopedRefAttribute != null)
+            if ((object)_lazyLifetimeAnnotationAttribute != null)
             {
                 return new SynthesizedAttributeData(
-                    _lazyScopedRefAttribute.Constructors[0],
-                    ImmutableArray<TypedConstant>.Empty,
+                    _lazyLifetimeAnnotationAttribute.Constructors[0],
+                    arguments,
                     ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
             }
 
-            return base.SynthesizeScopedRefAttribute(member);
+            return base.SynthesizeLifetimeAnnotationAttribute(member, arguments);
         }
 
         protected override SynthesizedAttributeData TrySynthesizeIsReadOnlyAttribute()
@@ -389,13 +389,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     CreateNativeIntegerAttributeSymbol);
             }
 
-            if ((needsAttributes & EmbeddableAttributes.ScopedRefAttribute) != 0)
+            if ((needsAttributes & EmbeddableAttributes.LifetimeAnnotationAttribute) != 0)
             {
                 CreateAttributeIfNeeded(
-                    ref _lazyScopedRefAttribute,
+                    ref _lazyLifetimeAnnotationAttribute,
                     diagnostics,
-                    AttributeDescription.ScopedRefAttribute,
-                    CreateScopedRefAttributeSymbol);
+                    AttributeDescription.LifetimeAnnotationAttribute,
+                    CreateLifetimeAnnotationAttributeSymbol);
             }
         }
 
@@ -438,12 +438,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     GetWellKnownType(WellKnownType.System_Attribute, diagnostics),
                     GetSpecialType(SpecialType.System_Boolean, diagnostics));
 
-        private SynthesizedEmbeddedScopedRefAttributeSymbol CreateScopedRefAttributeSymbol(string name, NamespaceSymbol containingNamespace, BindingDiagnosticBag diagnostics)
-            => new SynthesizedEmbeddedScopedRefAttributeSymbol(
+        private SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol CreateLifetimeAnnotationAttributeSymbol(string name, NamespaceSymbol containingNamespace, BindingDiagnosticBag diagnostics)
+            => new SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol(
                     name,
                     containingNamespace,
                     SourceModule,
-                    GetWellKnownType(WellKnownType.System_Attribute, diagnostics));
+                    GetWellKnownType(WellKnownType.System_Attribute, diagnostics),
+                    GetSpecialType(SpecialType.System_Boolean, diagnostics));
 
         private void CreateAttributeIfNeeded<T>(
             ref T symbol,

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureMethod.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ParameterHelpers.EnsureNativeIntegerAttributeExists(moduleBuilder, Parameters);
             }
 
-            ParameterHelpers.EnsureScopedRefAttributeExists(moduleBuilder, Parameters);
+            ParameterHelpers.EnsureLifetimeAnnotationAttributeExists(moduleBuilder, Parameters);
 
             if (compilationState.Compilation.ShouldEmitNullableAttributes(this))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -388,7 +388,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<KeyValuePair<WellKnownMember, TypedConstant>> namedArguments = default,
             bool isOptionalUse = false)
         {
-            var ctorSymbol = (MethodSymbol)Binder.GetWellKnownTypeMember(this, constructor, useSiteInfo: out _, isOptional: true);
+            UseSiteInfo<AssemblySymbol> info;
+            var ctorSymbol = (MethodSymbol)Binder.GetWellKnownTypeMember(this, constructor, out info, isOptional: true);
 
             if ((object)ctorSymbol == null)
             {
@@ -412,7 +413,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var builder = new ArrayBuilder<KeyValuePair<string, TypedConstant>>(namedArguments.Length);
                 foreach (var arg in namedArguments)
                 {
-                    var wellKnownMember = Binder.GetWellKnownTypeMember(this, arg.Key, useSiteInfo: out _, isOptional: true);
+                    var wellKnownMember = Binder.GetWellKnownTypeMember(this, arg.Key, out info, isOptional: true);
                     if (wellKnownMember == null || wellKnownMember is ErrorTypeSymbol)
                     {
                         // if this assert fails, UseSiteErrors for "member" have not been checked before emitting ...
@@ -543,9 +544,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             EnsureEmbeddableAttributeExists(EmbeddableAttributes.NativeIntegerAttribute, diagnostics, location, modifyCompilation);
         }
 
-        internal void EnsureScopedRefAttributeExists(BindingDiagnosticBag? diagnostics, Location location, bool modifyCompilation)
+        internal void EnsureLifetimeAnnotationAttributeExists(BindingDiagnosticBag? diagnostics, Location location, bool modifyCompilation)
         {
-            EnsureEmbeddableAttributeExists(EmbeddableAttributes.ScopedRefAttribute, diagnostics, location, modifyCompilation);
+            EnsureEmbeddableAttributeExists(EmbeddableAttributes.LifetimeAnnotationAttribute, diagnostics, location, modifyCompilation);
         }
 
         internal bool CheckIfAttributeShouldBeEmbedded(EmbeddableAttributes attribute, BindingDiagnosticBag? diagnosticsOpt, Location locationOpt)
@@ -606,12 +607,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                         WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctor,
                         WellKnownMember.System_Runtime_CompilerServices_NativeIntegerAttribute__ctorTransformFlags);
 
-                case EmbeddableAttributes.ScopedRefAttribute:
+                case EmbeddableAttributes.LifetimeAnnotationAttribute:
                     return CheckIfAttributeShouldBeEmbedded(
                         diagnosticsOpt,
                         locationOpt,
-                        WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute,
-                        WellKnownMember.System_Runtime_CompilerServices_ScopedRefAttribute__ctor);
+                        WellKnownType.System_Runtime_CompilerServices_LifetimeAnnotationAttribute,
+                        WellKnownMember.System_Runtime_CompilerServices_LifetimeAnnotationAttribute__ctor);
 
                 default:
                     throw ExceptionUtilities.UnexpectedValue(attribute);

--- a/src/Compilers/CSharp/Portable/Symbols/DeclarationScope.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DeclarationScope.cs
@@ -6,7 +6,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     // https://github.com/dotnet/roslyn/issues/61647: Internally, scope is represented with this enum,
     // but the public API uses a pair of IsRefScoped and IsValueScoped bools (see ILocalSymbol,
-    // IParameterSymbol, and ScopedRefAttribute). We should have a common representation.
+    // IParameterSymbol, and LifetimeAnnotationAttribute). We should have a common representation.
     // And we should use common terms for the attribute and enum names.
     internal enum DeclarationScope : byte
     {

--- a/src/Compilers/CSharp/Portable/Symbols/EmbeddableAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EmbeddableAttributes.cs
@@ -16,6 +16,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         NullableContextAttribute = 0x10,
         NullablePublicOnlyAttribute = 0x20,
         NativeIntegerAttribute = 0x40,
-        ScopedRefAttribute = 0x80,
+        LifetimeAnnotationAttribute = 0x80,
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var compilation = DeclaringCompilation;
             ParameterHelpers.EnsureIsReadOnlyAttributeExists(compilation, parameters, diagnostics, modifyCompilation: false);
             ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, parameters, diagnostics, modifyCompilation: false);
-            ParameterHelpers.EnsureScopedRefAttributeExists(compilation, parameters, diagnostics, modifyCompilation: false);
+            ParameterHelpers.EnsureLifetimeAnnotationAttributeExists(compilation, parameters, diagnostics, modifyCompilation: false);
             ParameterHelpers.EnsureNullableAttributeExists(compilation, this, parameters, diagnostics, modifyCompilation: false);
             // Note: we don't need to warn on annotations used in #nullable disable context for local functions, as this is handled in binding already
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal static bool RequiresScopedRefAttribute(ParameterSymbol parameter)
+        internal static bool RequiresLifetimeAnnotationAttribute(ParameterSymbol parameter)
         {
             Debug.Assert(!parameter.IsThis);
 
@@ -322,12 +322,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return true;
         }
 
-        internal static void EnsureScopedRefAttributeExists(PEModuleBuilder moduleBuilder, ImmutableArray<ParameterSymbol> parameters)
+        internal static void EnsureLifetimeAnnotationAttributeExists(PEModuleBuilder moduleBuilder, ImmutableArray<ParameterSymbol> parameters)
         {
-            EnsureScopedRefAttributeExists(moduleBuilder.Compilation, parameters, diagnostics: null, modifyCompilation: false, moduleBuilder);
+            EnsureLifetimeAnnotationAttributeExists(moduleBuilder.Compilation, parameters, diagnostics: null, modifyCompilation: false, moduleBuilder);
         }
 
-        internal static void EnsureScopedRefAttributeExists(CSharpCompilation? compilation, ImmutableArray<ParameterSymbol> parameters, BindingDiagnosticBag diagnostics, bool modifyCompilation)
+        internal static void EnsureLifetimeAnnotationAttributeExists(CSharpCompilation? compilation, ImmutableArray<ParameterSymbol> parameters, BindingDiagnosticBag diagnostics, bool modifyCompilation)
         {
             // These parameters might not come from a compilation (example: lambdas evaluated in EE).
             // During rewriting, lowering will take care of flagging the appropriate PEModuleBuilder instead.
@@ -336,22 +336,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return;
             }
 
-            EnsureScopedRefAttributeExists(compilation, parameters, diagnostics, modifyCompilation, moduleBuilder: null);
+            EnsureLifetimeAnnotationAttributeExists(compilation, parameters, diagnostics, modifyCompilation, moduleBuilder: null);
         }
 
-        private static void EnsureScopedRefAttributeExists(CSharpCompilation compilation, ImmutableArray<ParameterSymbol> parameters, BindingDiagnosticBag? diagnostics, bool modifyCompilation, PEModuleBuilder? moduleBuilder)
+        private static void EnsureLifetimeAnnotationAttributeExists(CSharpCompilation compilation, ImmutableArray<ParameterSymbol> parameters, BindingDiagnosticBag? diagnostics, bool modifyCompilation, PEModuleBuilder? moduleBuilder)
         {
             foreach (var parameter in parameters)
             {
-                if (RequiresScopedRefAttribute(parameter))
+                if (RequiresLifetimeAnnotationAttribute(parameter))
                 {
                     if (moduleBuilder is { })
                     {
-                        moduleBuilder.EnsureScopedRefAttributeExists();
+                        moduleBuilder.EnsureLifetimeAnnotationAttributeExists();
                     }
                     else
                     {
-                        compilation.EnsureScopedRefAttributeExists(diagnostics, GetParameterLocation(parameter), modifyCompilation);
+                        compilation.EnsureLifetimeAnnotationAttributeExists(diagnostics, GetParameterLocation(parameter), modifyCompilation);
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbolBase.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var compilation = DeclaringCompilation;
             ParameterHelpers.EnsureIsReadOnlyAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
             ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
-            ParameterHelpers.EnsureScopedRefAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
+            ParameterHelpers.EnsureLifetimeAnnotationAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
             ParameterHelpers.EnsureNullableAttributeExists(compilation, this, Parameters, diagnostics, modifyCompilation: true);
 
             foreach (var parameter in this.Parameters)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -340,7 +340,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
-                ParameterHelpers.EnsureScopedRefAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
+                ParameterHelpers.EnsureLifetimeAnnotationAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
 
                 if (compilation.ShouldEmitNullableAttributes(this) &&
                     ReturnTypeWithAnnotations.NeedsNullableAttribute())

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodOrUserDefinedOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodOrUserDefinedOperatorSymbol.cs
@@ -261,7 +261,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
 
-            ParameterHelpers.EnsureScopedRefAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
+            ParameterHelpers.EnsureLifetimeAnnotationAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
 
             if (compilation.ShouldEmitNullableAttributes(this) && ReturnTypeWithAnnotations.NeedsNullableAttribute())
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbolBase.cs
@@ -99,9 +99,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNativeIntegerAttribute(this, type.Type));
             }
 
-            if (ParameterHelpers.RequiresScopedRefAttribute(this))
+            if (ParameterHelpers.RequiresLifetimeAnnotationAttribute(this))
             {
-                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeScopedRefAttribute(this, Scope));
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeLifetimeAnnotationAttribute(this, Scope));
             }
 
             if (type.Type.ContainsTupleNames())

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -835,7 +835,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             ParameterHelpers.EnsureNativeIntegerAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
 
-            ParameterHelpers.EnsureScopedRefAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
+            ParameterHelpers.EnsureLifetimeAnnotationAttributeExists(compilation, Parameters, diagnostics, modifyCompilation: true);
 
             if (compilation.ShouldEmitNullableAttributes(this) &&
                 this.TypeWithAnnotations.NeedsNullableAttribute())

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol.cs
@@ -3,31 +3,58 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
-    internal sealed class SynthesizedEmbeddedScopedRefAttributeSymbol : SynthesizedEmbeddedAttributeSymbolBase
+    internal sealed class SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol : SynthesizedEmbeddedAttributeSymbolBase
     {
+        private readonly ImmutableArray<FieldSymbol> _fields;
         private readonly ImmutableArray<MethodSymbol> _constructors;
 
-        public SynthesizedEmbeddedScopedRefAttributeSymbol(
+        public SynthesizedEmbeddedLifetimeAnnotationAttributeSymbol(
             string name,
             NamespaceSymbol containingNamespace,
             ModuleSymbol containingModule,
-            NamedTypeSymbol systemAttributeType)
+            NamedTypeSymbol systemAttributeType,
+            TypeSymbol boolType)
             : base(name, containingNamespace, containingModule, baseType: systemAttributeType)
         {
+            _fields = ImmutableArray.Create<FieldSymbol>(
+                new SynthesizedFieldSymbol(this, boolType, "IsRefScoped", isPublic: true, isReadOnly: true, isStatic: false),
+                new SynthesizedFieldSymbol(this, boolType, "IsValueScoped", isPublic: true, isReadOnly: true, isStatic: false));
+
             _constructors = ImmutableArray.Create<MethodSymbol>(
                 new SynthesizedEmbeddedAttributeConstructorWithBodySymbol(
                     this,
-                    getParameters: m => ImmutableArray<ParameterSymbol>.Empty,
-                    getConstructorBody: (_, _, _) => { }));
+                    m => ImmutableArray.Create(
+                        SynthesizedParameterSymbol.Create(m, TypeWithAnnotations.Create(boolType), 0, RefKind.None),
+                        SynthesizedParameterSymbol.Create(m, TypeWithAnnotations.Create(boolType), 1, RefKind.None)),
+                    (f, s, p) => GenerateConstructorBody(f, s, p)));
         }
+
+        internal override IEnumerable<FieldSymbol> GetFieldsToEmit() => _fields;
 
         public override ImmutableArray<MethodSymbol> Constructors => _constructors;
 
         internal override AttributeUsageInfo GetAttributeUsageInfo() =>
             new AttributeUsageInfo(AttributeTargets.Parameter, allowMultiple: false, inherited: false);
+
+        private void GenerateConstructorBody(SyntheticBoundNodeFactory factory, ArrayBuilder<BoundStatement> statements, ImmutableArray<ParameterSymbol> parameters)
+        {
+            statements.Add(
+                factory.ExpressionStatement(
+                    factory.AssignmentExpression(
+                        factory.Field(factory.This(), _fields[0]),
+                        factory.Parameter(parameters[0]))));
+            statements.Add(
+                factory.ExpressionStatement(
+                    factory.AssignmentExpression(
+                        factory.Field(factory.This(), _fields[1]),
+                        factory.Parameter(parameters[1]))));
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -160,9 +160,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeNativeIntegerAttribute(this, type.Type));
             }
 
-            if (ParameterHelpers.RequiresScopedRefAttribute(this))
+            if (ParameterHelpers.RequiresLifetimeAnnotationAttribute(this))
             {
-                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeScopedRefAttribute(this, Scope));
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeLifetimeAnnotationAttribute(this, Scope));
             }
 
             if (type.Type.ContainsTupleNames() &&

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -6854,6 +6854,47 @@ class Program
             VerifyParameterSymbol(comp.GetMember<MethodSymbol>("Program.FA").Parameters[0], "out scoped s", RefKind.Out, DeclarationScope.RefScoped);
         }
 
+        [Fact]
+        public void ParameterScope_10()
+        {
+            var source0 =
+@".class private System.Runtime.CompilerServices.LifetimeAnnotationAttribute extends [mscorlib]System.Attribute
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor(bool isRefScoped, bool isValueScoped) cil managed { ret }
+}
+.class public sealed R extends [mscorlib]System.ValueType
+{
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (01 00 00 00)
+  .field public int32& modreq(int32) F
+}
+.class public A
+{
+  .method public static void F(valuetype R r)
+  {
+    .param [1]
+    .custom instance void System.Runtime.CompilerServices.LifetimeAnnotationAttribute::.ctor(bool, bool) = ( 01 00 00 00 00 00 ) // LifetimeAnnotationAttribute(isRefScoped: false, isValueScoped: false)
+    ret
+  }
+}
+";
+            var ref0 = CompileIL(source0);
+
+            var source1 =
+@"class Program
+{
+    static void Main()
+    {
+        var r = new R();
+        A.F(r);
+    }
+}";
+            var comp = CreateCompilation(source1, references: new[] { ref0 });
+            comp.VerifyDiagnostics();
+
+            var method = comp.GetMember<PEMethodSymbol>("A.F");
+            VerifyParameterSymbol(method.Parameters[0], "R r", RefKind.None, DeclarationScope.Unscoped);
+        }
+
         [WorkItem(62080, "https://github.com/dotnet/roslyn/issues/62080")]
         [Fact]
         public void ParameterScope_11()
@@ -6889,16 +6930,23 @@ class Program
         public void ParameterScope_12()
         {
             var source0 =
-@".class private System.Runtime.CompilerServices.ScopedRefAttribute extends [mscorlib]System.Attribute
+@".class private System.Runtime.CompilerServices.LifetimeAnnotationAttribute extends [mscorlib]System.Attribute
 {
-  .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { ret }
+  .method public hidebysig specialname rtspecialname instance void .ctor(bool isRefScoped, bool isValueScoped) cil managed { ret }
 }
 .class public A
 {
   .method public static void F1([out] int32& i)
   {
     .param [1]
-    .custom instance void System.Runtime.CompilerServices.ScopedRefAttribute::.ctor() = ( 01 00 00 00 ) // ScopedRefAttribute()
+    .custom instance void System.Runtime.CompilerServices.LifetimeAnnotationAttribute::.ctor(bool, bool) = ( 01 00 01 00 00 00 ) // LifetimeAnnotationAttribute(isRefScoped: true, isValueScoped: false)
+    ldnull
+    throw
+  }
+  .method public static void F2([out] int32& i)
+  {
+    .param [1]
+    .custom instance void System.Runtime.CompilerServices.LifetimeAnnotationAttribute::.ctor(bool, bool) = ( 01 00 00 00 00 00 ) // LifetimeAnnotationAttribute(isRefScoped: false, isValueScoped: false)
     ldnull
     throw
   }
@@ -6913,12 +6961,14 @@ class Program
     {
         int i;
         A.F1(out i);
+        A.F2(out i);
     }
 }";
             var comp = CreateCompilation(source1, references: new[] { ref0 });
             comp.VerifyDiagnostics();
 
             VerifyParameterSymbol(comp.GetMember<PEMethodSymbol>("A.F1").Parameters[0], "out System.Int32 i", RefKind.Out, DeclarationScope.RefScoped);
+            VerifyParameterSymbol(comp.GetMember<PEMethodSymbol>("A.F2").Parameters[0], "out System.Int32 i", RefKind.Out, DeclarationScope.Unscoped);
         }
 
         [Fact]
@@ -7253,7 +7303,7 @@ public class A
             Assert.Equal(expectedScope, parameter.Scope);
             Assert.Equal(expectedDisplayString, parameter.ToDisplayString(displayFormatWithScoped));
 
-            var attribute = parameter.GetAttributes().FirstOrDefault(a => a.GetTargetAttributeSignatureIndex(parameter, AttributeDescription.ScopedRefAttribute) != -1);
+            var attribute = parameter.GetAttributes().FirstOrDefault(a => a.GetTargetAttributeSignatureIndex(parameter, AttributeDescription.LifetimeAnnotationAttribute) != -1);
             Assert.Null(attribute);
 
             VerifyParameterSymbol(parameter.GetPublicSymbol(), expectedDisplayString, expectedRefKind, expectedScope);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -614,7 +614,7 @@ namespace System
                     case WellKnownType.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler:
                     case WellKnownType.System_Runtime_CompilerServices_RequiredMemberAttribute:
                     case WellKnownType.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute:
-                    case WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute:
+                    case WellKnownType.System_Runtime_CompilerServices_LifetimeAnnotationAttribute:
                     case WellKnownType.System_MemoryExtensions:
                     case WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute:
                         // Not yet in the platform.
@@ -976,7 +976,7 @@ namespace System
                     case WellKnownMember.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear:
                     case WellKnownMember.System_Runtime_CompilerServices_RequiredMemberAttribute__ctor:
                     case WellKnownMember.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor:
-                    case WellKnownMember.System_Runtime_CompilerServices_ScopedRefAttribute__ctor:
+                    case WellKnownMember.System_Runtime_CompilerServices_LifetimeAnnotationAttribute__ctor:
                     case WellKnownMember.System_MemoryExtensions__SequenceEqual_Span_T:
                     case WellKnownMember.System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T:
                     case WellKnownMember.System_MemoryExtensions__AsSpan_String:

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1087,9 +1087,16 @@ namespace Microsoft.CodeAnalysis
             return TryExtractBoolArrayValueFromAttribute(info.Handle, out transformFlags);
         }
 
-        internal bool HasScopedRefAttribute(EntityHandle token)
+        internal bool HasLifetimeAnnotationAttribute(EntityHandle token, out (bool IsRefScoped, bool IsValueScoped) value)
         {
-            return FindTargetAttribute(token, AttributeDescription.ScopedRefAttribute).HasValue;
+            AttributeInfo info = FindTargetAttribute(token, AttributeDescription.LifetimeAnnotationAttribute);
+            if (!info.HasValue)
+            {
+                value = default;
+                return false;
+            }
+
+            return TryExtractValueFromAttribute(info.Handle, out value, CrackBoolAndBoolInAttributeValue);
         }
 
         internal bool HasTupleElementNamesAttribute(EntityHandle token, out ImmutableArray<string> tupleElementNames)

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -334,6 +334,7 @@ namespace Microsoft.CodeAnalysis
         private static readonly byte[][] s_signaturesOfNullableAttribute = { s_signature_HasThis_Void_Byte, s_signature_HasThis_Void_SzArray_Byte };
         private static readonly byte[][] s_signaturesOfNullableContextAttribute = { s_signature_HasThis_Void_Byte };
         private static readonly byte[][] s_signaturesOfNativeIntegerAttribute = { s_signature_HasThis_Void, s_signature_HasThis_Void_SzArray_Boolean };
+        private static readonly byte[][] s_signaturesOfLifetimeAnnotationAttribute = { s_signature_HasThis_Void_Boolean_Boolean };
         private static readonly byte[][] s_signaturesOfInterpolatedStringArgumentAttribute = { s_signature_HasThis_Void_String, s_signature_HasThis_Void_SzArray_String };
 
         // early decoded attributes:
@@ -469,7 +470,7 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription EnumeratorCancellationAttribute = new AttributeDescription("System.Runtime.CompilerServices", "EnumeratorCancellationAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription SkipLocalsInitAttribute = new AttributeDescription("System.Runtime.CompilerServices", "SkipLocalsInitAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription NativeIntegerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NativeIntegerAttribute", s_signaturesOfNativeIntegerAttribute);
-        internal static readonly AttributeDescription ScopedRefAttribute = new AttributeDescription("System.Runtime.CompilerServices", "ScopedRefAttribute", s_signatures_HasThis_Void_Only);
+        internal static readonly AttributeDescription LifetimeAnnotationAttribute = new AttributeDescription("System.Runtime.CompilerServices", "LifetimeAnnotationAttribute", s_signaturesOfLifetimeAnnotationAttribute);
         internal static readonly AttributeDescription ModuleInitializerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "ModuleInitializerAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription UnmanagedCallersOnlyAttribute = new AttributeDescription("System.Runtime.InteropServices", "UnmanagedCallersOnlyAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription InterpolatedStringHandlerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "InterpolatedStringHandlerAttribute", s_signatures_HasThis_Void_Only);

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -522,7 +522,7 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear,
         System_Runtime_CompilerServices_RequiredMemberAttribute__ctor,
         System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor,
-        System_Runtime_CompilerServices_ScopedRefAttribute__ctor,
+        System_Runtime_CompilerServices_LifetimeAnnotationAttribute__ctor,
 
         System_MemoryExtensions__SequenceEqual_Span_T,
         System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T,

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3583,12 +3583,14 @@ namespace Microsoft.CodeAnalysis
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
 
-                // System_Runtime_CompilerServices_ScopedRefAttribute__ctor
+                // System_Runtime_CompilerServices_LifetimeAnnotationAttribute__ctor
                 (byte)MemberFlags.Constructor,                                                                              // Flags
-                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute - WellKnownType.ExtSentinel), // DeclaringTypeId
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_LifetimeAnnotationAttribute - WellKnownType.ExtSentinel),                                       // DeclaringTypeId
                 0,                                                                                                          // Arity
-                    0,                                                                                                      // Method Signature
+                    2,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean,
 
                 // System_MemoryExtensions__SequenceEqual_Span_T
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                               // Flags

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis
         System_Text_StringBuilder,
 
         System_Runtime_CompilerServices_DefaultInterpolatedStringHandler,
-        System_Runtime_CompilerServices_ScopedRefAttribute,
+        System_Runtime_CompilerServices_LifetimeAnnotationAttribute,
 
         System_ArgumentNullException,
 
@@ -633,7 +633,7 @@ namespace Microsoft.CodeAnalysis
 
             "System.Text.StringBuilder",
             "System.Runtime.CompilerServices.DefaultInterpolatedStringHandler",
-            "System.Runtime.CompilerServices.ScopedRefAttribute",
+            "System.Runtime.CompilerServices.LifetimeAnnotationAttribute",
             "System.ArgumentNullException",
 
             "System.Runtime.CompilerServices.RequiredMemberAttribute",

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -551,7 +551,7 @@ End Namespace
                          WellKnownType.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute,
                          WellKnownType.System_MemoryExtensions,
                          WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute,
-                         WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute,
+                         WellKnownType.System_Runtime_CompilerServices_LifetimeAnnotationAttribute,
                          WellKnownType.System_MemoryExtensions
                         ' Not available on all platforms.
                         Continue For
@@ -623,7 +623,7 @@ End Namespace
                          WellKnownType.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute,
                          WellKnownType.System_MemoryExtensions,
                          WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute,
-                         WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute
+                         WellKnownType.System_Runtime_CompilerServices_LifetimeAnnotationAttribute
                         ' Not available on all platforms.
                         Continue For
                     Case WellKnownType.ExtSentinel
@@ -715,7 +715,7 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear,
                          WellKnownMember.System_Runtime_CompilerServices_RequiredMemberAttribute__ctor,
                          WellKnownMember.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_ScopedRefAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_LifetimeAnnotationAttribute__ctor,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_Span_T,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T,
                          WellKnownMember.System_MemoryExtensions__AsSpan_String,
@@ -867,7 +867,7 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear,
                          WellKnownMember.System_Runtime_CompilerServices_RequiredMemberAttribute__ctor,
                          WellKnownMember.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor,
-                         WellKnownMember.System_Runtime_CompilerServices_ScopedRefAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_LifetimeAnnotationAttribute__ctor,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_Span_T,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T,
                          WellKnownMember.System_MemoryExtensions__AsSpan_String,


### PR DESCRIPTION
This reverts commit 7915cb743238090f744c7bab21063263b5dd16a1.