### PR TITLE
Revert "Merge pull request #62854 from CyrusNajmabadi/renameOOP5"

### DIFF
--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -87,13 +87,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public InlineRenameFileRenameInfo FileRenameInfo { get; }
 
         /// <summary>
-        /// Task used to hold a session alive with the OOP server.  This allows us to pin the initial solution snapshot
-        /// over on the oop side, which is valuable for preventing it from constantly being dropped/synced on every
-        /// conflict resolution step.
-        /// </summary>
-        private readonly Task _keepAliveSessionTask;
-
-        /// <summary>
         /// The task which computes the main rename locations against the original workspace
         /// snapshot.
         /// </summary>
@@ -103,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         /// The cancellation token for most work being done by the inline rename session. This
         /// includes the <see cref="_allRenameLocationsTask"/> tasks.
         /// </summary>
-        private readonly CancellationTokenSource _cancellationTokenSource = new();
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
         /// <summary>
         /// This task is a continuation of the <see cref="_allRenameLocationsTask"/> that is the result of computing
@@ -186,9 +179,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 FileRenameInfo = InlineRenameFileRenameInfo.NotAllowed;
             }
 
-            // Open a session to oop, syncing our solution to it and pinning it there.  The connection will close once
-            // _cancellationTokenSource is canceled (which we always do when the session is finally ended).
-            _keepAliveSessionTask = Renamer.CreateRemoteKeepAliveSessionAsync(_baseSolution, _cancellationTokenSource.Token);
             InitializeOpenBuffers(triggerSpan);
         }
 
@@ -314,9 +304,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             _allRenameLocationsTask = _threadingContext.JoinableTaskFactory.RunAsync(async () =>
             {
-                // Ensure that our keep-alive session is up and running.
-                await _keepAliveSessionTask.ConfigureAwait(false);
-
                 // Join prior work before proceeding, since it performs a required state update.
                 // https://github.com/dotnet/roslyn/pull/34254#discussion_r267024593
                 if (currentRenameLocationsTask != null)

--- a/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
@@ -29,18 +29,7 @@ namespace Microsoft.CodeAnalysis.Rename
         internal interface ICallback // : IRemoteOptionsCallback<CodeCleanupOptions>
         {
             ValueTask<CodeCleanupOptions> GetOptionsAsync(RemoteServiceCallbackId callbackId, string language, CancellationToken cancellationToken);
-            ValueTask KeepAliveAsync(RemoteServiceCallbackId callbackId, CancellationToken cancellationToken);
         }
-
-        /// <summary>
-        /// Keeps alive this solution in the OOP process until the cancellation token is triggered.  Used so that we can
-        /// call FindRenameLocationsAsync followed by many calls to ResolveConflictsAsync, knowing that things will stay 
-        /// hydrated and alive on the OOP side.
-        /// </summary>
-        ValueTask KeepAliveAsync(
-            Checksum solutionChecksum,
-            RemoteServiceCallbackId callbackId,
-            CancellationToken cancellationToken);
 
         /// <summary>
         /// Runs the entire rename operation OOP and returns the final result. More efficient (due to less back and
@@ -84,12 +73,6 @@ namespace Microsoft.CodeAnalysis.Rename
 
         public ValueTask<CodeCleanupOptions> GetOptionsAsync(RemoteServiceCallbackId callbackId, string language, CancellationToken cancellationToken)
             => ((RemoteOptionsProvider<CodeCleanupOptions>)GetCallback(callbackId)).GetOptionsAsync(language, cancellationToken);
-
-        public ValueTask KeepAliveAsync(RemoteServiceCallbackId callbackId, CancellationToken cancellationToken)
-        {
-            ((TaskCompletionSource<bool>)GetCallback(callbackId)).TrySetResult(true);
-            return default;
-        }
     }
 
     [DataContract]
@@ -203,6 +186,8 @@ namespace Microsoft.CodeAnalysis.Rename
     {
         [DataMember(Order = 0)]
         public readonly SymbolRenameOptions Options;
+
+        // We use arrays so we can represent default immutable arrays.
 
         [DataMember(Order = 1)]
         public readonly ImmutableArray<SerializableRenameLocation> Locations;

--- a/src/Workspaces/Remote/ServiceHub/Services/Renamer/RemoteRenamerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Renamer/RemoteRenamerService.cs
@@ -2,14 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.CodeCleanup;
-using Microsoft.CodeAnalysis.Elfie.Diagnostics;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.Rename.ConflictEngine;
+using Microsoft.CodeAnalysis.Simplification;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -33,27 +37,6 @@ namespace Microsoft.CodeAnalysis.Remote
         private CodeCleanupOptionsProvider GetClientOptionsProvider(RemoteServiceCallbackId callbackId)
             => new ClientCodeCleanupOptionsProvider(
                 (callbackId, language, cancellationToken) => _callback.InvokeAsync((callback, cancellationToken) => callback.GetOptionsAsync(callbackId, language, cancellationToken), cancellationToken), callbackId);
-
-        public ValueTask KeepAliveAsync(
-            Checksum solutionChecksum,
-            RemoteServiceCallbackId callbackId,
-            CancellationToken cancellationToken)
-        {
-            // First get the solution, ensuring that it is currently pinned.
-            return RunServiceAsync(solutionChecksum, async solution =>
-            {
-                // Once we have it, let our caller know so that it can proceed to it's next steps.
-                await _callback.InvokeAsync((callback, cancellationToken) =>
-                    callback.KeepAliveAsync(callbackId, cancellationToken), cancellationToken).ConfigureAwait(false);
-
-                // Finally wait for our caller to tell us to cancel.  That way we can release this solution and allow it
-                // to be collected if not needed anymore.
-                var taskCompletionSource = new TaskCompletionSource<bool>();
-                cancellationToken.Register(() => taskCompletionSource.TrySetCanceled(cancellationToken));
-
-                await taskCompletionSource.Task.ConfigureAwait(false);
-            }, cancellationToken);
-        }
 
         public ValueTask<SerializableConflictResolution?> RenameSymbolAsync(
             Checksum solutionChecksum,


### PR DESCRIPTION
This reverts commit 28a9bc8dd1e22afbd1efbec0f9a4b35347c1896a, reversing
changes made to 8909116aa33ae0e7b1ab602cd518998108c1fd2b.

I believe this to be the cause of the failing rename integration tests, currently seeing
```
Roslyn.VisualStudio.IntegrationTests.VisualBasic.BasicRename.VerifyAttributeCapitalizedRename
Roslyn.VisualStudio.IntegrationTests.VisualBasic.BasicRename.VerifyAttributeNotCapitalizedRename
Roslyn.VisualStudio.IntegrationTests.CSharp.CSharpRename.VerifyAttributeRename
Roslyn.VisualStudio.IntegrationTests.CSharp.CSharpRename.VerifyAttributeRenameWhileRenameClasss
Roslyn.VisualStudio.IntegrationTests.CSharp.CSharpRename.VerifyRenameCancellation
```

all start failing occasionally beginning with the build from https://github.com/dotnet/roslyn/pull/62854.  The symptom is a timeout in waiting for the rename async operation to complete.  These failures appear to occur only in builds with this change and errors in these tests before that are entirely different and less frequent, so I'm quite confident this is the cause.

https://dev.azure.com/dnceng/public/_build/results?buildId=1918864&view=ms.vss-test-web.build-test-results-tab&runId=49719056&resultId=100362 

```
Server stack trace: 
   at System.Threading.CancellationToken.ThrowOperationCanceledException()
   at System.Threading.ManualResetEventSlim.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.SpinThenBlockingWait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.InternalWait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at Roslyn.Hosting.Diagnostics.Waiters.TestWaitingService.WaitForTask(Task task, CancellationToken cancellationToken) in /_/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TestWaitingService.cs:line 84
   at Roslyn.Hosting.Diagnostics.Waiters.TestWaitingService.WaitForAsyncOperations(TimeSpan timeout, String featureName, Boolean waitForWorkspaceFirst) in /_/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/TestWaitingService.cs:line 46
   at Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess.VisualStudioWorkspace_InProc.WaitForAsyncOperations(TimeSpan timeout, String featuresToWaitFor, Boolean waitForWorkspaceFirst) in /_/src/VisualStudio/IntegrationTest/TestUtilities/InProcess/VisualStudioWorkspace_InProc.cs:line 79
   at System.Runtime.Remoting.Messaging.StackBuilderSink._PrivateProcessMessage(IntPtr md, Object[] args, Object server, Object[]& outArgs)
   at System.Runtime.Remoting.Messaging.StackBuilderSink.SyncProcessMessage(IMessage msg)

Exception rethrown at [0]: 
   at System.Runtime.Remoting.Proxies.RealProxy.HandleReturnMessage(IMessage reqMsg, IMessage retMsg)
   at System.Runtime.Remoting.Proxies.RealProxy.PrivateInvoke(MessageData& msgData, Int32 type)
   at Microsoft.VisualStudio.IntegrationTest.Utilities.InProcess.VisualStudioWorkspace_InProc.WaitForAsyncOperations(TimeSpan timeout, String featuresToWaitFor, Boolean waitForWorkspaceFirst)
   at Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess.VisualStudioWorkspace_OutOfProc.WaitForAsyncOperations(TimeSpan timeout, String featuresToWaitFor, Boolean waitForWorkspaceFirst) in /_/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/VisualStudioWorkspace_OutOfProc.cs:line 35
   at Microsoft.VisualStudio.IntegrationTest.Utilities.OutOfProcess.InlineRenameDialog_OutOfProc.Invoke() in /_/src/VisualStudio/IntegrationTest/TestUtilities/OutOfProcess/InlineRenameDialog_OutOfProc.cs:line 23
   at Roslyn.VisualStudio.IntegrationTests.CSharp.CSharpRename.VerifyRenameCancellation() in /_/src/VisualStudio/IntegrationTest/IntegrationTests/CSharp/CSharpRename.cs:line 466
```

![image](https://user-images.githubusercontent.com/5749229/182743330-eb09ea5f-3817-4b73-838b-bdd5391165a6.png)

