### PR TITLE
Keep the host solution pinned on the remote workspace side while performing an inline-rename session

### DIFF
--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -87,11 +87,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public InlineRenameFileRenameInfo FileRenameInfo { get; }
 
         /// <summary>
-        /// Task used to hold a session alive with the OOP server.  This allows us to pin the initial solution snapshot
-        /// over on the oop side, which is valuable for preventing it from constantly being dropped/synced on every
-        /// conflict resolution step.
+        /// Rename session held alive with the OOP server.  This allows us to pin the initial solution snapshot over on
+        /// the oop side, which is valuable for preventing it from constantly being dropped/synced on every conflict
+        /// resolution step.
         /// </summary>
-        private readonly JoinableTask _keepAliveSessionTask;
+        private readonly IRemoteRenameKeepAliveSession _keepAliveSession;
 
         /// <summary>
         /// The task which computes the main rename locations against the original workspace
@@ -188,8 +188,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             // Open a session to oop, syncing our solution to it and pinning it there.  The connection will close once
             // _cancellationTokenSource is canceled (which we always do when the session is finally ended).
-            _keepAliveSessionTask = _threadingContext.JoinableTaskFactory.RunAsync(() =>
-                Renamer.CreateRemoteKeepAliveSessionAsync(_baseSolution, _cancellationTokenSource.Token));
+            _keepAliveSession = Renamer.CreateRemoteKeepAliveSession(_baseSolution, asyncListener);
             InitializeOpenBuffers(triggerSpan);
         }
 
@@ -671,6 +670,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             // We're about to perform the final commit action.  No need to do any of our BG work to find-refs or compute conflicts.
             _cancellationTokenSource.Cancel();
             _conflictResolutionTaskCancellationSource.Cancel();
+
+            // Close the keep alive session we have open with OOP, allowing it to release the solution it is holding onto.
+            _keepAliveSession.Dispose();
 
             // Perform the actual commit step if we've been asked to.
             if (finalCommitAction != null)

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -315,9 +315,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             _allRenameLocationsTask = _threadingContext.JoinableTaskFactory.RunAsync(async () =>
             {
-                // Ensure that our keep-alive session is up and running.
-                await _keepAliveSessionTask.JoinAsync(cancellationToken).ConfigureAwait(false);
-
                 // Join prior work before proceeding, since it performs a required state update.
                 // https://github.com/dotnet/roslyn/pull/34254#discussion_r267024593
                 if (currentRenameLocationsTask != null)

--- a/src/Workspaces/Core/Portable/Rename/IRemoteRenameKeepAliveSession.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRemoteRenameKeepAliveSession.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Rename
+{
+    internal interface IRemoteRenameKeepAliveSession : IDisposable
+    {
+
+    }
+}

--- a/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
@@ -29,7 +29,6 @@ namespace Microsoft.CodeAnalysis.Rename
         internal interface ICallback // : IRemoteOptionsCallback<CodeCleanupOptions>
         {
             ValueTask<CodeCleanupOptions> GetOptionsAsync(RemoteServiceCallbackId callbackId, string language, CancellationToken cancellationToken);
-            ValueTask KeepAliveAsync(RemoteServiceCallbackId callbackId, CancellationToken cancellationToken);
         }
 
         /// <summary>
@@ -82,12 +81,6 @@ namespace Microsoft.CodeAnalysis.Rename
 
         public ValueTask<CodeCleanupOptions> GetOptionsAsync(RemoteServiceCallbackId callbackId, string language, CancellationToken cancellationToken)
             => ((RemoteOptionsProvider<CodeCleanupOptions>)GetCallback(callbackId)).GetOptionsAsync(language, cancellationToken);
-
-        public ValueTask KeepAliveAsync(RemoteServiceCallbackId callbackId, CancellationToken cancellationToken)
-        {
-            ((TaskCompletionSource<bool>)GetCallback(callbackId)).TrySetResult(true);
-            return default;
-        }
     }
 
     [DataContract]

--- a/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
+++ b/src/Workspaces/Core/Portable/Rename/IRemoteRenamerService.cs
@@ -38,9 +38,7 @@ namespace Microsoft.CodeAnalysis.Rename
         /// hydrated and alive on the OOP side.
         /// </summary>
         ValueTask KeepAliveAsync(
-            Checksum solutionChecksum,
-            RemoteServiceCallbackId callbackId,
-            CancellationToken cancellationToken);
+            Checksum solutionChecksum, CancellationToken cancellationToken);
 
         /// <summary>
         /// Runs the entire rename operation OOP and returns the final result. More efficient (due to less back and

--- a/src/Workspaces/Core/Portable/Rename/Renamer.cs
+++ b/src/Workspaces/Core/Portable/Rename/Renamer.cs
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis.Rename
                 var unused = client.TryInvokeAsync<IRemoteRenamerService>(
                     solution,
                     (service, solutionInfo, cancellationToken) => service.KeepAliveAsync(solutionInfo, cancellationToken),
-                    cancellationToken);
+                    cancellationToken).AsTask();
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Rename/Renamer.cs
+++ b/src/Workspaces/Core/Portable/Rename/Renamer.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ChangeNamespace;

--- a/src/Workspaces/Core/Portable/Rename/Renamer.cs
+++ b/src/Workspaces/Core/Portable/Rename/Renamer.cs
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.Rename
             var client = await RemoteHostClient.TryGetClientAsync(solution.Services, cancellationToken).ConfigureAwait(false);
             if (client != null)
             {
-                _ = client.TryInvokeAsync<IRemoteRenamerService>(
+                var unused = client.TryInvokeAsync<IRemoteRenamerService>(
                     solution,
                     (service, solutionInfo, cancellationToken) => service.KeepAliveAsync(solutionInfo, cancellationToken),
                     cancellationToken);

--- a/src/Workspaces/Core/Portable/Rename/Renamer.cs
+++ b/src/Workspaces/Core/Portable/Rename/Renamer.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ChangeNamespace;
@@ -17,6 +18,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Rename.ConflictEngine;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Rename
@@ -221,23 +223,61 @@ namespace Microsoft.CodeAnalysis.Rename
         }
 
         /// <summary>
-        /// Creates a session between the host and OOP, effectively pinning this <paramref name="solution"/> until the
-        /// supplied <paramref name="cancellationToken"/> is canceled..  By pinning the solution we ensure that all
-        /// calls to OOP for the same solution during the life of this rename session do not need to resync the
-        /// solution.  Nor do they then need to rebuild any compilations they've already built due to the solution going
-        /// away and then coming back.
+        /// Creates a session between the host and OOP, effectively pinning this <paramref name="solution"/> until <see
+        /// cref="IDisposable.Dispose"/> is called on it.  By pinning the solution we ensure that all calls to OOP for
+        /// the same solution during the life of this rename session do not need to resync the solution.  Nor do they
+        /// then need to rebuild any compilations they've already built due to the solution going away and then coming
+        /// back.
         /// </summary>
-        internal static async Task CreateRemoteKeepAliveSessionAsync(
+        internal static IRemoteRenameKeepAliveSession CreateRemoteKeepAliveSession(
             Solution solution,
-            CancellationToken cancellationToken)
+            IAsynchronousOperationListener listener)
         {
-            var client = await RemoteHostClient.TryGetClientAsync(solution.Services, cancellationToken).ConfigureAwait(false);
-            if (client != null)
+            return new RemoteRenameKeepAliveSession(solution, listener);
+        }
+
+        private sealed class RemoteRenameKeepAliveSession : IRemoteRenameKeepAliveSession
+        {
+            private readonly CancellationTokenSource _cancellationTokenSource = new();
+
+            public RemoteRenameKeepAliveSession(Solution solution, IAsynchronousOperationListener listener)
             {
-                var unused = client.TryInvokeAsync<IRemoteRenamerService>(
-                    solution,
-                    (service, solutionInfo, cancellationToken) => service.KeepAliveAsync(solutionInfo, cancellationToken),
-                    cancellationToken).AsTask();
+                var cancellationToken = _cancellationTokenSource.Token;
+                var token = listener.BeginAsyncOperation(nameof(RemoteRenameKeepAliveSession));
+
+                var task = CreateClientAndKeepAliveAsync();
+                task.CompletesAsyncOperation(token);
+
+                return;
+
+                async Task CreateClientAndKeepAliveAsync()
+                {
+                    var client = await RemoteHostClient.TryGetClientAsync(solution.Services, cancellationToken).ConfigureAwait(false);
+                    if (client is null)
+                        return;
+
+                    // Now kick off the keep-alive work.  We don't wait on this as this will stick on the OOP side until
+                    // the cancellation token triggers.
+                    var unused = client.TryInvokeAsync<IRemoteRenamerService>(
+                        solution,
+                        (service, solutionInfo, cancellationToken) => service.KeepAliveAsync(solutionInfo, cancellationToken),
+                        cancellationToken).AsTask();
+                }
+            }
+
+            ~RemoteRenameKeepAliveSession()
+            {
+                if (Environment.HasShutdownStarted)
+                    return;
+
+                Contract.Fail($@"Should have been disposed!");
+            }
+
+            public void Dispose()
+            {
+                GC.SuppressFinalize(this);
+                _cancellationTokenSource.Cancel();
+                _cancellationTokenSource.Dispose();
             }
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Services/Renamer/RemoteRenamerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Renamer/RemoteRenamerService.cs
@@ -43,10 +43,9 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 // Wait for our caller to tell us to cancel.  That way we can release this solution and allow it
                 // to be collected if not needed anymore.
-                var taskCompletionSource = new TaskCompletionSource<bool>();
-                cancellationToken.Register(() => taskCompletionSource.TrySetCanceled(cancellationToken));
-
-                await taskCompletionSource.Task.ConfigureAwait(false);
+                //
+                // This was provided by stoub as an idiomatic way to wait indefinitely until a cancellation token triggers.
+                await Task.Delay(-1, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
         }
 

--- a/src/Workspaces/Remote/ServiceHub/Services/Renamer/RemoteRenamerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/Renamer/RemoteRenamerService.cs
@@ -36,17 +36,12 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public ValueTask KeepAliveAsync(
             Checksum solutionChecksum,
-            RemoteServiceCallbackId callbackId,
             CancellationToken cancellationToken)
         {
             // First get the solution, ensuring that it is currently pinned.
             return RunServiceAsync(solutionChecksum, async solution =>
             {
-                // Once we have it, let our caller know so that it can proceed to it's next steps.
-                await _callback.InvokeAsync((callback, cancellationToken) =>
-                    callback.KeepAliveAsync(callbackId, cancellationToken), cancellationToken).ConfigureAwait(false);
-
-                // Finally wait for our caller to tell us to cancel.  That way we can release this solution and allow it
+                // Wait for our caller to tell us to cancel.  That way we can release this solution and allow it
                 // to be collected if not needed anymore.
                 var taskCompletionSource = new TaskCompletionSource<bool>();
                 cancellationToken.Register(() => taskCompletionSource.TrySetCanceled(cancellationToken));


### PR DESCRIPTION
Inline rename needs to first sync over the solution to OOP to find all the locations to update. Then as a user is typing the new name, we need to issue requests to OOP to determine what edits to make and what conflicts each of the new names they're trying may cause.

This is problemaitc with our current architecture because we have the following set of operations:

Inline rename session starts.
It makes call to oop to find rename locations using solution snapshot S1.
User edits symbol name to something new.
Host syncs to oop solution snapshot S2.
Inline rename calls to oop to find edit/conflict information for snapshot S1 using the new symbol name.
Because 4 and 5 S1 can be dropped. This gets worse as steps 3-5 repeat as the user is typing a new name, so it becomes almost certain that solution snapshot S1 will go away on OOP. THat means that each call to 5 much resync S1 (which is cheap) and then recompute things like compilations for all the projects involved in the rename operation (which is expensive).

Augments the above with the following steps:

After step 1: After session starts, inline-rename calls over to OOP and asks it to pin solution S1.
End: WHen the session ends, we let OOP know it can release S1.

By doing this we ensure that S1 never drops during all the repeats of steps 3-5. This keeps it available in OOP and ensures we don't drop expensive compilations.