### PR TITLE
Fix analyzer action state tracking for partial analysis

### DIFF
--- a/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -3570,8 +3570,9 @@ class C
             }
         }
 
-        [Fact, WorkItem(63205, "https://github.com/dotnet/roslyn/issues/63205")]
-        public async Task TestGetAnalysisResultWithFilterSpanAsync()
+        [Theory, WorkItem(63205, "https://github.com/dotnet/roslyn/issues/63205")]
+        [CombinatorialData]
+        public async Task TestGetAnalysisResultWithFilterSpanAsync(bool testSyntaxNodeAction)
         {
             string source = @"
 class B
@@ -3591,7 +3592,7 @@ class B
             var tree = compilation.SyntaxTrees[0];
             var localDecl1 = tree.GetRoot().DescendantNodes().OfType<LocalDeclarationStatementSyntax>().First();
             var semanticModel = compilation.GetSemanticModel(tree);
-            var analyzer1 = new VariableDeclarationAnalyzer("ID0001");
+            var analyzer1 = new VariableDeclarationAnalyzer("ID0001", testSyntaxNodeAction);
             var analyzer2 = new CSharpCompilerDiagnosticAnalyzer();
             var allAnalyzers = ImmutableArray.Create<DiagnosticAnalyzer>(analyzer1, analyzer2);
             var compilationWithAnalyzers = compilation.WithAnalyzers(allAnalyzers);

--- a/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -3570,6 +3570,70 @@ class C
             }
         }
 
+        [Fact, WorkItem(63205, "https://github.com/dotnet/roslyn/issues/63205")]
+        public async Task TestGetAnalysisResultWithFilterSpanAsync()
+        {
+            string source = @"
+class B
+{
+    void M1()
+    {
+        int local1 = 1;
+    }
+
+    void M2()
+    {
+        int local2 = 1;
+    }
+}";
+
+            var compilation = CreateCompilationWithMscorlib45(new[] { source });
+            var tree = compilation.SyntaxTrees[0];
+            var localDecl1 = tree.GetRoot().DescendantNodes().OfType<LocalDeclarationStatementSyntax>().First();
+            var semanticModel = compilation.GetSemanticModel(tree);
+            var analyzer1 = new VariableDeclarationAnalyzer("ID0001");
+            var analyzer2 = new CSharpCompilerDiagnosticAnalyzer();
+            var allAnalyzers = ImmutableArray.Create<DiagnosticAnalyzer>(analyzer1, analyzer2);
+            var compilationWithAnalyzers = compilation.WithAnalyzers(allAnalyzers);
+
+            // Invoke "GetAnalysisResultAsync" for a a sub-span and then
+            // for the entire tree span and verify no duplicate diagnostics.
+
+            var analysisResult = await compilationWithAnalyzers.GetAnalysisResultAsync(
+                semanticModel,
+                filterSpan: localDecl1.FullSpan,
+                CancellationToken.None);
+
+            var diagnostics1 = analysisResult.SemanticDiagnostics[tree][analyzer1];
+            diagnostics1.Verify(
+                Diagnostic("ID0001", "int local1 = 1").WithLocation(6, 9));
+
+            var diagnostics2 = analysisResult.SemanticDiagnostics[tree][analyzer2];
+            diagnostics2.Verify(
+                // (6,13): warning CS0219: The variable 'local1' is assigned but its value is never used
+                //         int local1 = 1;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "local1").WithArguments("local1").WithLocation(6, 13));
+
+            analysisResult = await compilationWithAnalyzers.GetAnalysisResultAsync(
+                semanticModel,
+                filterSpan: null,
+                CancellationToken.None);
+
+            diagnostics1 = analysisResult.SemanticDiagnostics[tree][analyzer1];
+            diagnostics1.Verify(
+                Diagnostic("ID0001", "int local1 = 1").WithLocation(6, 9),
+                Diagnostic("ID0001", "int local2 = 1").WithLocation(11, 9));
+
+            diagnostics2 = analysisResult.SemanticDiagnostics[tree][analyzer2];
+            diagnostics2.Verify(
+                // (6,13): warning CS0219: The variable 'local1' is assigned but its value is never used
+                //         int local1 = 1;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "local1").WithArguments("local1").WithLocation(6, 13),
+                // (11,13): warning CS0219: The variable 'local2' is assigned but its value is never used
+                //         int local2 = 1;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "local2").WithArguments("local2").WithLocation(11, 13));
+        }
+
         [Theory, CombinatorialData]
         public async Task TestAdditionalFileAnalyzer(bool registerFromInitialize)
         {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.SyntaxReferenceAnalyzerStateData.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.SyntaxReferenceAnalyzerStateData.cs
@@ -73,10 +73,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 ProcessedNodes = new HashSet<SyntaxNode>();
             }
 
-            public void ClearNodeAnalysisState()
+            public void OnAllActionsExecutedForNode(SyntaxNode node)
             {
                 CurrentNode = null;
                 ProcessedActions.Clear();
+                ProcessedNodes.Add(node);
             }
 
             public override void Free()
@@ -101,10 +102,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 ProcessedOperations = new HashSet<IOperation>();
             }
 
-            public void ClearNodeAnalysisState()
+            public void OnAllActionsExecutedForOperation(IOperation operation)
             {
                 CurrentOperation = null;
                 ProcessedActions.Clear();
+                ProcessedOperations.Add(operation);
             }
 
             public override void Free()

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -1397,7 +1397,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
             }
 
-            analyzerState?.ClearNodeAnalysisState();
+            analyzerState?.OnAllActionsExecutedForNode(node);
         }
 
         internal static ImmutableSegmentedDictionary<OperationKind, ImmutableArray<OperationAnalyzerAction>> GetOperationActionsByKind(IEnumerable<OperationAnalyzerAction> operationActions)
@@ -1532,7 +1532,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
             }
 
-            analyzerState?.ClearNodeAnalysisState();
+            analyzerState?.OnAllActionsExecutedForOperation(operation);
         }
 
         internal static bool CanHaveExecutableCodeBlock(ISymbol symbol)

--- a/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -2372,8 +2372,10 @@ namespace Microsoft.CodeAnalysis
         [DiagnosticAnalyzer(LanguageNames.CSharp)]
         public sealed class VariableDeclarationAnalyzer : DiagnosticAnalyzer
         {
-            public VariableDeclarationAnalyzer(string diagnosticId)
+            private readonly bool _testSyntaxNodeAction;
+            public VariableDeclarationAnalyzer(string diagnosticId, bool testSyntaxNodeAction)
             {
+                _testSyntaxNodeAction = testSyntaxNodeAction;
                 Descriptor = new DiagnosticDescriptor(
                     diagnosticId,
                     "Title",
@@ -2389,9 +2391,18 @@ namespace Microsoft.CodeAnalysis
 
             public override void Initialize(AnalysisContext context)
             {
-                context.RegisterOperationAction(
-                    context => context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Operation.Syntax.GetLocation())),
-                    OperationKind.VariableDeclaration);
+                if (_testSyntaxNodeAction)
+                {
+                    context.RegisterSyntaxNodeAction<SyntaxKind>(
+                        context => context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Node.GetLocation())),
+                        SyntaxKind.VariableDeclaration);
+                }
+                else
+                {
+                    context.RegisterOperationAction(
+                        context => context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Operation.Syntax.GetLocation())),
+                        OperationKind.VariableDeclaration);
+                }
             }
         }
     }

--- a/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -2368,5 +2368,31 @@ namespace Microsoft.CodeAnalysis
                 });
             }
         }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp)]
+        public sealed class VariableDeclarationAnalyzer : DiagnosticAnalyzer
+        {
+            public VariableDeclarationAnalyzer(string diagnosticId)
+            {
+                Descriptor = new DiagnosticDescriptor(
+                    diagnosticId,
+                    "Title",
+                    "Message",
+                    "Category",
+                    defaultSeverity: DiagnosticSeverity.Warning,
+                    isEnabledByDefault: true);
+            }
+
+            public DiagnosticDescriptor Descriptor { get; }
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+            public override void Initialize(AnalysisContext context)
+            {
+                context.RegisterOperationAction(
+                    context => context.ReportDiagnostic(Diagnostic.Create(Descriptor, context.Operation.Syntax.GetLocation())),
+                    OperationKind.VariableDeclaration);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #63205

While executing analyzers for a tree sub-span on CompilationWithAnalyzers, we were not adding to the set of processed nodes/operations after all the actions have been executed for it. This meant that all actions would be re-executed for this node/operation when analyzer diagnostics are subsequently queried on the same CompilationWithAnalyzers instance.