### PR TITLE
Change the renamer benchmark to rename SyntaxNode

### DIFF
--- a/src/Tools/IdeCoreBenchmarks/RenameBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/RenameBenchmarks.cs
@@ -2,33 +2,38 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
+using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.CodeAnalysis.Rename;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace IdeCoreBenchmarks
 {
     [MemoryDiagnoser]
     public class RenameBenchmarks
     {
-
-        private Solution _solution;
-        private ISymbol _symbol;
-        private string _csFilePath;
+        private Solution? _solution;
+        private ISymbol? _symbol;
+        private string? _solutionPath;
+        private const string RenamedTypeName = "Microsoft.CodeAnalysis.SyntaxNode";
 
         [GlobalSetup]
         public void GlobalSetup()
         {
-            var roslynRoot = Environment.GetEnvironmentVariable(Program.RoslynRootPathEnvVariableName);
-            _csFilePath = Path.Combine(roslynRoot, @"src\Compilers\CSharp\Portable\Generated\BoundNodes.xml.Generated.cs");
+            var msBuildInstance = MSBuildLocator.QueryVisualStudioInstances().OrderByDescending(x => x.Version).First();
+            MSBuildLocator.RegisterInstance(msBuildInstance);
+            var roslynRoot = Environment.GetEnvironmentVariable(Program.RoslynRootPathEnvVariableName)!;
+            _solutionPath = Path.Combine(roslynRoot, @"src\Tools\IdeCoreBenchmarks\Assets\Microsoft.CodeAnalysis.sln");
 
-            if (!File.Exists(_csFilePath))
+            if (!File.Exists(_solutionPath))
             {
                 throw new ArgumentException();
             }
@@ -37,22 +42,21 @@ namespace IdeCoreBenchmarks
         [IterationSetup]
         public void IterationSetup()
         {
-            var projectId = ProjectId.CreateNewId();
-            var documentId = DocumentId.CreateNewId(projectId);
+            var assemblies = MSBuildMefHostServices.DefaultAssemblies;
+            var hostService = MefHostServices.Create(assemblies);
+            using var workspace = MSBuildWorkspace.Create(hostService);
+            _solution = workspace.OpenSolutionAsync(_solutionPath!).Result;
 
-            _solution = new AdhocWorkspace().CurrentSolution
-                .AddProject(projectId, "ProjectName", "AssemblyName", LanguageNames.CSharp)
-                .AddDocument(documentId, "DocumentName", File.ReadAllText(_csFilePath));
-
-            var project = _solution.Projects.First();
-            var compilation = project.GetCompilationAsync().Result;
-            _symbol = compilation.GetTypeByMetadataName("Microsoft.CodeAnalysis.CSharp.BoundKind");
+            // Microsoft.CodeAnalysis is multi-targeting
+            var project = _solution.Projects.First(project => project.Name.StartsWith("Microsoft.CodeAnalysis"));
+            var compilation = project.GetRequiredCompilationAsync(CancellationToken.None).Result;
+            _symbol = compilation.GetBestTypeByMetadataName(RenamedTypeName);
         }
 
         [Benchmark]
-        public void RenameNodes()
+        public async Task RenameNodes()
         {
-            _ = Renamer.RenameSymbolAsync(_solution, _symbol, new SymbolRenameOptions(), "NewName");
+            await Renamer.RenameSymbolAsync(_solution!, _symbol!, new SymbolRenameOptions(), "SyntaxNode2");
         }
 
         [IterationCleanup]


### PR DESCRIPTION
I am trying to test the perf impact of my change around renamer.
But the current benchmark runs too fast so it can't provide much useful information.
The result:
![image](https://user-images.githubusercontent.com/24360909/183216813-226fa798-f838-4628-a52f-ea4bc1eb4996.png)


This PR changes the benchmark to let it renames `SyntaxNode`.
The benchmark results look like:
![image](https://user-images.githubusercontent.com/24360909/183215925-5a382960-a42f-4b12-939f-93af0cd2e1ff.png)
