### PR TITLE
Enable adding attributes to to generic types

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -1178,6 +1178,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 ParameterSyntax parameter => parameter.WithAttributeLists(attributeLists),
                 CompilationUnitSyntax compilationUnit => compilationUnit.WithAttributeLists(AsAssemblyAttributes(attributeLists)),
                 StatementSyntax statement => statement.WithAttributeLists(attributeLists),
+                TypeParameterSyntax typeParameter => typeParameter.WithAttributeLists(attributeLists),
                 _ => declaration,
             };
 

--- a/src/Workspaces/Core/Portable/Editing/SyntaxEditorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxEditorExtensions.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Editing
             => editor.ReplaceNode(declaration, (d, g) => g.AddAttributes(d, new[] { attribute }));
 
         public static void AddReturnAttribute(this SyntaxEditor editor, SyntaxNode declaration, SyntaxNode attribute)
-            => editor.ReplaceNode(declaration, (d, g) => g.AddAttributes(d, new[] { attribute }));
+            => editor.ReplaceNode(declaration, (d, g) => g.AddReturnAttributes(d, new[] { attribute }));
 
         public static void AddAttributeArgument(this SyntaxEditor editor, SyntaxNode attributeDeclaration, SyntaxNode attributeArgument)
             => editor.ReplaceNode(attributeDeclaration, (d, g) => g.AddAttributeArguments(d, new[] { attributeArgument }));

--- a/src/Workspaces/CoreTest/Editing/SyntaxEditorTests.cs
+++ b/src/Workspaces/CoreTest/Editing/SyntaxEditorTests.cs
@@ -480,5 +480,136 @@ public class C
     public string Y;
 }");
         }
+
+        [Fact]
+        public void TestAddAttribute()
+        {
+            var code = """
+using System;
+using System.CodeAnalysis;
+
+public class C
+{
+    Type Main(Type t)
+    {
+    }
+}
+""";
+            var fixedCode = """
+using System;
+using System.CodeAnalysis;
+
+public class C
+{
+    Type Main([Example(Sample.Attribute)] Type t)
+    {
+    }
+}
+""";
+
+            var cu = SyntaxFactory.ParseCompilationUnit(code);
+            var cls = cu.Members[0];
+
+            var editor = GetEditor(cu);
+            var methodX = (MethodDeclarationSyntax)editor.Generator.GetMembers(cls)[0];
+
+            var param = methodX.ParameterList.Parameters[0];
+
+            var syntaxGenerator = editor.Generator;
+            var args = new[] { syntaxGenerator.AttributeArgument(syntaxGenerator.MemberAccessExpression(syntaxGenerator.DottedName("Sample"), "Attribute")) };
+            var attribute = syntaxGenerator.Attribute("Example", args);
+            editor.AddAttribute(param, attribute);
+            var newRoot = editor.GetChangedRoot();
+
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot, fixedCode);
+        }
+
+        [Fact]
+        public void TestAddGenericAttribute()
+        {
+            var code = """
+using System;
+using System.CodeAnalysis;
+
+public class C
+{
+    Type Main<T>()
+    {
+    }
+}
+""";
+            var fixedCode = """
+using System;
+using System.CodeAnalysis;
+
+public class C
+{
+    Type Main<[Example(Sample.Attribute)] T>()
+    {
+    }
+}
+""";
+
+            var cu = SyntaxFactory.ParseCompilationUnit(code);
+            var cls = cu.Members[0];
+
+            var editor = GetEditor(cu);
+            var methodX = (MethodDeclarationSyntax)editor.Generator.GetMembers(cls)[0];
+            
+            var typeParam = methodX.TypeParameterList.Parameters[0];
+
+            var syntaxGenerator = editor.Generator;
+            var args = new[] { syntaxGenerator.AttributeArgument(syntaxGenerator.MemberAccessExpression(syntaxGenerator.DottedName("Sample"), "Attribute")) };
+            var attribute = syntaxGenerator.Attribute("Example", args);
+            editor.AddAttribute(typeParam, attribute);
+            var newRoot = editor.GetChangedRoot();
+
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot, fixedCode);
+        }
+
+        [Fact]
+        public void TestAddReturnAttribute()
+        {
+            var code = """
+using System;
+using System.CodeAnalysis;
+
+public class C
+{
+    Type Main(Type t)
+    {
+    }
+}
+""";
+            var fixedCode = """
+using System;
+using System.CodeAnalysis;
+
+public class C
+{
+    [return: Example(Sample.Attribute)]
+    Type Main(Type t)
+    {
+    }
+}
+""";
+
+            var cu = SyntaxFactory.ParseCompilationUnit(code);
+            var cls = cu.Members[0];
+
+            var editor = GetEditor(cu);
+            var methodX = editor.Generator.GetMembers(cls)[0];
+
+            var syntaxGenerator = editor.Generator;
+            var args = new[] { syntaxGenerator.AttributeArgument(syntaxGenerator.MemberAccessExpression(syntaxGenerator.DottedName("Sample"), "Attribute")) };
+            var attribute = syntaxGenerator.Attribute("Example", args);
+            editor.AddReturnAttribute(methodX, attribute);
+            var newRoot = editor.GetChangedRoot();
+
+            VerifySyntax<CompilationUnitSyntax>(
+                newRoot, fixedCode);
+        }
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxNodeExtensions.cs
@@ -289,6 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 AccessorDeclarationSyntax accessor => accessor.AttributeLists,
                 ParameterSyntax parameter => parameter.AttributeLists,
                 CompilationUnitSyntax compilationUnit => compilationUnit.AttributeLists,
+                TypeParameterSyntax typeParameter => typeParameter.AttributeLists,
                 _ => default,
             };
 


### PR DESCRIPTION
/cc: @jkoritzinsky @agocke

Found while writing Code Fix provider for DynamicallyAccessedMembers trimmer warnings

https://github.com/dotnet/roslyn/issues/63281