### PR TITLE
Fixes EnC slot mapping for certain kinds of synthesized variables lifted to state machine fields

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpDefinitionMap.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpDefinitionMap.cs
@@ -157,6 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
                         case GeneratedNameKind.HoistedLocalField:
                         case GeneratedNameKind.HoistedSynthesizedLocalField:
+                        case GeneratedNameKind.DisplayClassLocalOrField:
                             if (GeneratedNameParser.TryParseSlotIndex(name, out slotIndex))
                             {
                                 var field = (FieldSymbol)member;

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -10384,7 +10384,7 @@ class C
 
     public async void F(string? x)
     <N:4>{</N:4>
-        var <N:2>y = await G(<N:0>() => new { A = id(x) }</N:0>)</N:2>;
+        var <N:2>y = <N:5>await G(<N:0>() => new { A = id(x) }</N:0>)</N:5></N:2>;
         var <N:3>z = H(<N:1>() => y.A</N:1>)</N:3>;
     }
 }
@@ -10403,7 +10403,7 @@ class C
     public async void F(string? x)
     <N:4>{</N:4>
         if (x is null) throw new Exception();
-        var <N:2>y = await G(<N:0>() => new { A = id(x) }</N:0>)</N:2>;
+        var <N:2>y = <N:5>await G(<N:0>() => new { A = id(x) }</N:0>)</N:5></N:2>;
         var <N:3>z = H(<N:1>() => y.A</N:1>)</N:3>;
     }
 }
@@ -10439,7 +10439,7 @@ class C
                 "C: {<>c__DisplayClass3_0, <F>d__3}",
                 "<global namespace>: {Microsoft, System, System}",
                 "System: {Runtime, Runtime}",
-                "C.<F>d__3: {<>1__state, <>t__builder, x, <>4__this, <>8__4, <z>5__2, <>s__5, <>u__1, MoveNext, SetStateMachine}");
+                "C.<F>d__3: {<>1__state, <>t__builder, x, <>4__this, <>8__1, <z>5__2, <>s__3, <>u__1, MoveNext, SetStateMachine}");
 
             diff1.VerifyIL("C.<>c__DisplayClass3_0.<F>b__1()", @"
 {

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -9,7 +9,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using ICSharpCode.Decompiler.TypeSystem;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.CSharp.UnitTests;
@@ -8161,6 +8160,7 @@ static class C
 ", options: PdbValidationOptions.ExcludeDocuments | PdbValidationOptions.ExcludeSequencePoints | PdbValidationOptions.ExcludeNamespaces | PdbValidationOptions.ExcludeScopes);
 
             CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "C", "<>c__DisplayClass0_0", "<M>d__0");
+            CheckNames(reader0, reader0.GetFieldDefNames(), "num", "<>1__state", "<>t__builder", "<>8__1", "<>u__1");
 
             var diff1 = compilation1.EmitDifference(
                 generation0,

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
@@ -259,7 +259,9 @@ namespace Microsoft.CodeAnalysis.Emit
                 ITypeSymbolInternal? stateMachineType = TryGetStateMachineType(previousHandle);
                 if (stateMachineType != null)
                 {
-                    // method is async/iterator kickoff method
+                    // Method is async/iterator kickoff method.
+
+                    // Use local slots stored in CDI (encLocalSlotMap) to calculate map of local variables hoisted to fields of the state machine.
                     var localSlotDebugInfo = debugInfo.LocalSlots.NullToEmpty();
                     GetStateMachineFieldMapFromMetadata(stateMachineType, localSlotDebugInfo, out hoistedLocalMap, out awaiterMap, out awaiterSlotCount);
                     hoistedLocalSlotCount = localSlotDebugInfo.Length;
@@ -296,6 +298,8 @@ namespace Microsoft.CodeAnalysis.Emit
                             return null;
                         }
                     }
+
+                    // Calculate local slot mapping for the current method (might be the MoveNext method of a state machine).
 
                     try
                     {

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicDefinitionMap.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicDefinitionMap.vb
@@ -165,11 +165,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                             End If
 
                         Case GeneratedNameKind.HoistedSynthesizedLocalField,
-                             GeneratedNameKind.StateMachineHoistedUserVariableField
+                             GeneratedNameKind.HoistedWithLocalPrefix,
+                             GeneratedNameKind.StateMachineHoistedUserVariableOrDisplayClassField
 
-                            Dim _name As String = Nothing
+                            Dim variableName As String = Nothing
                             If GeneratedNameParser.TryParseSlotIndex(GeneratedNameConstants.HoistedSynthesizedLocalPrefix, name, slotIndex) OrElse
-                               GeneratedNameParser.TryParseStateMachineHoistedUserVariableName(name, _name, slotIndex) Then
+                               GeneratedNameParser.TryParseSlotIndex(GeneratedNameConstants.HoistedWithLocalPrefix, name, slotIndex) OrElse
+                               GeneratedNameParser.TryParseStateMachineHoistedUserVariableOrDisplayClassName(name, variableName, slotIndex) Then
                                 Dim field = DirectCast(member, FieldSymbol)
                                 If slotIndex >= localSlotDebugInfo.Length Then
                                     ' Invalid metadata

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.vb
@@ -342,9 +342,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Select Case local.SynthesizedKind
                 Case SynthesizedLocalKind.LambdaDisplayClass
-                    proxyName = GeneratedNameConstants.StateMachineHoistedUserVariablePrefix & GeneratedNameConstants.ClosureVariablePrefix & "$" & slotIndex
+                    proxyName = GeneratedNameConstants.StateMachineHoistedUserVariableOrDisplayClassPrefix & GeneratedNameConstants.ClosureVariablePrefix & "$" & slotIndex
                 Case SynthesizedLocalKind.UserDefined
-                    proxyName = GeneratedNameConstants.StateMachineHoistedUserVariablePrefix & local.Name & "$" & slotIndex
+                    proxyName = GeneratedNameConstants.StateMachineHoistedUserVariableOrDisplayClassPrefix & local.Name & "$" & slotIndex
                 Case SynthesizedLocalKind.With
                     proxyName = GeneratedNameConstants.HoistedWithLocalPrefix & slotIndex
                 Case Else

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/GeneratedNameConstants.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/GeneratedNameConstants.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Const HoistedUserVariablePrefix As String = "$VB$Local_"
         Friend Const HoistedSpecialVariablePrefix As String = "$VB$NonLocal_" ' prefixes Me and Closure variables when hoisted
         Friend Const HoistedWithLocalPrefix As String = "$W"
-        Friend Const StateMachineHoistedUserVariablePrefix As String = "$VB$ResumableLocal_"
+        Friend Const StateMachineHoistedUserVariableOrDisplayClassPrefix As String = "$VB$ResumableLocal_"
         Friend Const ClosureVariablePrefix As String = "$VB$Closure_"
         Friend Const DisplayClassPrefix As String = "_Closure$__"
         Friend Const StateMachineTypeNamePrefix As String = "VB$StateMachine_"

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/GeneratedNameKind.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/GeneratedNameKind.vb
@@ -17,7 +17,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         IteratorParameterProxyField
         StateMachineAwaiterField
         StateMachineStateField
-        StateMachineHoistedUserVariableField
+        StateMachineHoistedUserVariableOrDisplayClassField
+        HoistedWithLocalPrefix
         StaticLocalField
         TransparentIdentifier
         AnonymousTransparentIdentifier

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/GeneratedNameParser.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/GeneratedNameParser.vb
@@ -26,8 +26,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return GeneratedNameKind.IteratorParameterProxyField
             ElseIf name.StartsWith(GeneratedNameConstants.StateMachineAwaiterFieldPrefix, StringComparison.Ordinal) Then
                 Return GeneratedNameKind.StateMachineAwaiterField
-            ElseIf name.StartsWith(GeneratedNameConstants.StateMachineHoistedUserVariablePrefix, StringComparison.Ordinal) Then
-                Return GeneratedNameKind.StateMachineHoistedUserVariableField
+            ElseIf name.StartsWith(GeneratedNameConstants.HoistedWithLocalPrefix, StringComparison.Ordinal) Then
+                Return GeneratedNameKind.HoistedWithLocalPrefix
+            ElseIf name.StartsWith(GeneratedNameConstants.StateMachineHoistedUserVariableOrDisplayClassPrefix, StringComparison.Ordinal) Then
+                Return GeneratedNameKind.StateMachineHoistedUserVariableOrDisplayClassField
             ElseIf name.StartsWith(GeneratedNameConstants.AnonymousTypeTemplateNamePrefix, StringComparison.Ordinal) Then
                 Return GeneratedNameKind.AnonymousType
             ElseIf name.StartsWith(GeneratedNameConstants.DisplayClassPrefix, StringComparison.Ordinal) Then
@@ -83,16 +85,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <summary>
         ''' Try to parse the local name and return <paramref name="variableName"/> and <paramref name="index"/> if successful.
         ''' </summary>
-        Public Shared Function TryParseStateMachineHoistedUserVariableName(proxyName As String, <Out> ByRef variableName As String, <Out()> ByRef index As Integer) As Boolean
+        Public Shared Function TryParseStateMachineHoistedUserVariableOrDisplayClassName(proxyName As String, <Out> ByRef variableName As String, <Out()> ByRef index As Integer) As Boolean
             variableName = Nothing
             index = 0
 
             ' All names should start with "$VB$ResumableLocal_"
-            If Not proxyName.StartsWith(GeneratedNameConstants.StateMachineHoistedUserVariablePrefix, StringComparison.Ordinal) Then
+            If Not proxyName.StartsWith(GeneratedNameConstants.StateMachineHoistedUserVariableOrDisplayClassPrefix, StringComparison.Ordinal) Then
                 Return False
             End If
 
-            Dim prefixLen As Integer = GeneratedNameConstants.StateMachineHoistedUserVariablePrefix.Length
+            Dim prefixLen As Integer = GeneratedNameConstants.StateMachineHoistedUserVariableOrDisplayClassPrefix.Length
             Dim separator As Integer = proxyName.LastIndexOf("$"c)
             If separator <= prefixLen Then
                 Return False

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
@@ -8321,7 +8321,7 @@ End Class")
                 ImmutableArray.Create(
                     SemanticEdit.Create(SemanticEditKind.Update, m0, m1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
 
-                ' Notice that we reused field "$VB$ResumableLocal_$VB$Closure_$0" (there is no "$VB$ResumableLocal_$VB$Closure_$1"), which stores the local function closure pointer.
+                ' Notice that we reused field "$VB$ResumableLocal_$VB$Closure_$0" (there is no "$VB$ResumableLocal_$VB$Closure_$1"), which stores the closure pointer.
                 diff1.VerifySynthesizedMembers(
                     "C: {VB$StateMachine_1_M, _Closure$__1-0}",
                     "C.VB$StateMachine_1_M: {$State, $Builder, $VB$ResumableLocal_$VB$Closure_$0, $A0, MoveNext, System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine}",
@@ -8431,7 +8431,7 @@ End Class")
                 ImmutableArray.Create(
                     SemanticEdit.Create(SemanticEditKind.Update, m0, m1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
 
-                ' Notice that we reused field "$W0" (there is no "$W1"), which stores the local function closure pointer.
+                ' Notice that we reused field "$W0" (there is no "$W1"), which stores the closure pointer.
                 diff1.VerifySynthesizedMembers(
                     "C: {VB$StateMachine_3_M}",
                     "C.VB$StateMachine_3_M: {$State, $Builder, $W0, $A0, MoveNext, System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine}")

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
@@ -8217,6 +8217,227 @@ End Class")
 
         End Sub
 
+        <Fact>
+        Public Sub LiftedClosure()
+            Dim source0 = MarkedSource("
+Imports System
+Imports System.Threading.Tasks
+Class C
+    <N:0>Shared Async Function M() As Task 
+        Dim <N:1>num</N:1> As Integer = 1
+                        
+        <N:2>Await Task.Delay(1)</N:2>
+                        
+        G(<N:3>Function() num</N:3>)
+    End Function</N:0>
+
+    Shared Sub G(f As Func(Of Integer))
+    End Sub
+End Class")
+
+            Dim source1 = MarkedSource("
+Imports System
+Imports System.Threading.Tasks
+Class C
+    <N:0>Shared Async Function M() As Task 
+        Dim <N:1>num</N:1> As Integer = 1
+                        
+        <N:2>Await Task.Delay(2)</N:2>
+                        
+        G(<N:3>Function() num</N:3>)
+    End Function</N:0>
+    
+    Shared Sub G(f As Func(Of Integer))
+    End Sub
+End Class")
+            Dim compilation0 = CreateCompilationWithMscorlib45AndVBRuntime({source0.Tree}, options:=ComSafeDebugDll)
+            Dim compilation1 = compilation0.WithSource(source1.Tree)
+
+            Dim m0 = compilation0.GetMember(Of MethodSymbol)("C.M")
+            Dim m1 = compilation1.GetMember(Of MethodSymbol)("C.M")
+
+            Dim v0 = CompileAndVerify(compilation0)
+            Using md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+
+                Dim reader0 = md0.MetadataReader
+                Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
+
+                ' Notice encLocalSlotMap CDI on both M and MoveNext methods.
+                ' The former is used to calculate mapping for variables lifted to fields of the state machine,
+                ' the latter is used to map local variable slots in the MoveNext method.
+                ' Here, the variable lifted to the state machine field is the closure pointer storage.
+                v0.VerifyPdb("
+<symbols>
+  <methods>
+    <method containingType=""C"" name=""M"">
+      <customDebugInfo>
+        <forwardIterator name=""VB$StateMachine_1_M"" />
+        <encLocalSlotMap>
+          <slot kind=""30"" offset=""-1"" />
+        </encLocalSlotMap>
+        <encLambdaMap>
+          <methodOrdinal>1</methodOrdinal>
+          <closure offset=""-1"" />
+          <lambda offset=""142"" closure=""0"" />
+        </encLambdaMap>
+        <encStateMachineStateMap>
+          <state number=""0"" offset=""74"" />
+        </encStateMachineStateMap>
+      </customDebugInfo>
+    </method>
+    <method containingType=""C+VB$StateMachine_1_M"" name=""MoveNext"">
+      <customDebugInfo>
+        <hoistedLocalScopes>
+          <slot startOffset=""0x0"" endOffset=""0xe3"" />
+        </hoistedLocalScopes>
+        <encLocalSlotMap>
+          <slot kind=""27"" offset=""-1"" />
+          <slot kind=""33"" offset=""74"" />
+          <slot kind=""temp"" />
+          <slot kind=""temp"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+      <asyncInfo>
+        <kickoffMethod declaringType=""C"" methodName=""M"" />
+        <await yield=""0x44"" resume=""0x62"" declaringType=""C+VB$StateMachine_1_M"" methodName=""MoveNext"" />
+      </asyncInfo>
+    </method>
+    <method containingType=""C+_Closure$__1-0"" name=""_Lambda$__0"">
+      <customDebugInfo>
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""142"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+    </method>
+  </methods>
+</symbols>
+", options:=PdbValidationOptions.ExcludeDocuments Or PdbValidationOptions.ExcludeSequencePoints Or PdbValidationOptions.ExcludeNamespaces Or PdbValidationOptions.ExcludeScopes,
+   format:=DebugInformationFormat.PortablePdb)
+
+                CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "C", "VB$StateMachine_1_M", "_Closure$__1-0")
+
+                Dim diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    SemanticEdit.Create(SemanticEditKind.Update, m0, m1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+                ' Notice that we reused field "$VB$ResumableLocal_$VB$Closure_$0" (there is no "$VB$ResumableLocal_$VB$Closure_$1"), which stores the local function closure pointer.
+                diff1.VerifySynthesizedMembers(
+                    "C: {VB$StateMachine_1_M, _Closure$__1-0}",
+                    "C.VB$StateMachine_1_M: {$State, $Builder, $VB$ResumableLocal_$VB$Closure_$0, $A0, MoveNext, System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine}",
+                    "C._Closure$__1-0: {_Lambda$__0}")
+            End Using
+        End Sub
+
+        <Fact>
+        Public Sub LiftedWithStatementVariable()
+            Dim source0 = MarkedSource("
+Imports System
+Imports System.Threading.Tasks
+Class C
+    Private X As Integer = 1
+    Private Y As Integer = 2
+
+    Shared Async Function M() As Task
+        <N:0>With New C()</N:0>
+            <N:1>Await G()</N:1>
+            Console.Write(.X)
+        End With
+    End Function
+
+    Shared Function G() As Task(Of Integer)
+        Return Task.FromResult(1)
+    End Function
+End Class")
+
+            Dim source1 = MarkedSource("
+Imports System
+Imports System.Threading.Tasks
+Class C
+    Private X As Integer = 1
+    Private Y As Integer = 2
+
+    Shared Async Function M() As Task
+        <N:0>With New C()</N:0>
+            <N:1>Await G()</N:1>
+            Console.Write(.Y)
+        End With
+    End Function
+
+    Shared Function G() As Task(Of Integer)
+        Return Task.FromResult(1)
+    End Function
+End Class")
+            Dim compilation0 = CreateCompilationWithMscorlib45AndVBRuntime({source0.Tree}, options:=ComSafeDebugDll)
+            Dim compilation1 = compilation0.WithSource(source1.Tree)
+
+            Dim m0 = compilation0.GetMember(Of MethodSymbol)("C.M")
+            Dim m1 = compilation1.GetMember(Of MethodSymbol)("C.M")
+
+            Dim v0 = CompileAndVerify(compilation0)
+            Using md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+
+                Dim reader0 = md0.MetadataReader
+                Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
+
+                ' Notice encLocalSlotMap CDI on both M and MoveNext methods.
+                ' The former is used to calculate mapping for variables lifted to fields of the state machine,
+                ' the latter is used to map local variable slots in the MoveNext method.
+                ' Here, the variable lifted to the state machine field is the With statement storage.
+                v0.VerifyPdb("
+<symbols>
+  <methods>
+    <method containingType=""C"" name=""M"">
+      <customDebugInfo>
+        <encLocalSlotMap>
+          <slot kind=""10"" offset=""0"" />
+        </encLocalSlotMap>
+        <encStateMachineStateMap>
+          <state number=""0"" offset=""37"" />
+        </encStateMachineStateMap>
+      </customDebugInfo>
+    </method>
+    <method containingType=""C"" name=""G"">
+      <customDebugInfo>
+        <encLocalSlotMap>
+          <slot kind=""0"" offset=""-1"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+    </method>
+    <method containingType=""C+VB$StateMachine_3_M"" name=""MoveNext"">
+      <customDebugInfo>
+        <encLocalSlotMap>
+          <slot kind=""27"" offset=""-1"" />
+          <slot kind=""33"" offset=""37"" />
+          <slot kind=""temp"" />
+          <slot kind=""temp"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+      <asyncInfo>
+        <kickoffMethod declaringType=""C"" methodName=""M"" />
+        <await yield=""0x38"" resume=""0x56"" declaringType=""C+VB$StateMachine_3_M"" methodName=""MoveNext"" />
+      </asyncInfo>
+    </method>
+  </methods>
+</symbols>
+", options:=PdbValidationOptions.ExcludeDocuments Or PdbValidationOptions.ExcludeSequencePoints Or PdbValidationOptions.ExcludeNamespaces Or PdbValidationOptions.ExcludeScopes,
+   format:=DebugInformationFormat.PortablePdb)
+
+                CheckNames(reader0, reader0.GetTypeDefNames(), "<Module>", "C", "VB$StateMachine_3_M")
+                CheckNames(reader0, reader0.GetFieldDefNames(), "X", "Y", "$State", "$Builder", "$W0", "$A0")
+
+                Dim diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    SemanticEdit.Create(SemanticEditKind.Update, m0, m1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+                ' Notice that we reused field "$W0" (there is no "$W1"), which stores the local function closure pointer.
+                diff1.VerifySynthesizedMembers(
+                    "C: {VB$StateMachine_3_M}",
+                    "C.VB$StateMachine_3_M: {$State, $Builder, $W0, $A0, MoveNext, System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine}")
+            End Using
+        End Sub
+
         <Fact, WorkItem(1170899, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1170899")>
         Public Sub HoistedAnonymousTypes1()
             Dim source0 = MarkedSource("

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -1144,7 +1144,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Private Shared Function IsDisplayClassInstanceFieldName(name As String) As Boolean
             Debug.Assert(name IsNot Nothing) ' Verified by caller.
             Return name.StartsWith(GeneratedNameConstants.HoistedSpecialVariablePrefix & GeneratedNameConstants.ClosureVariablePrefix, StringComparison.Ordinal) OrElse
-                name.StartsWith(GeneratedNameConstants.StateMachineHoistedUserVariablePrefix & GeneratedNameConstants.ClosureVariablePrefix, StringComparison.Ordinal) OrElse
+                name.StartsWith(GeneratedNameConstants.StateMachineHoistedUserVariableOrDisplayClassPrefix & GeneratedNameConstants.ClosureVariablePrefix, StringComparison.Ordinal) OrElse
                 name.StartsWith(GeneratedNameConstants.HoistedSpecialVariablePrefix & GeneratedNameConstants.DisplayClassPrefix, StringComparison.Ordinal) ' Async lambda case
         End Function
 
@@ -1247,7 +1247,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                     Debug.Assert(Not field.IsShared)
                     variableKind = DisplayClassVariableKind.Local
                     variableName = fieldName.Substring(GeneratedNameConstants.HoistedSpecialVariablePrefix.Length)
-                ElseIf GeneratedNameParser.TryParseStateMachineHoistedUserVariableName(fieldName, hoistedLocalName, hoistedLocalSlotIndex) Then
+                ElseIf GeneratedNameParser.TryParseStateMachineHoistedUserVariableOrDisplayClassName(fieldName, hoistedLocalName, hoistedLocalSlotIndex) Then
                     Debug.Assert(Not field.IsShared)
 
                     If Not inScopeHoistedLocalSlots.Contains(hoistedLocalSlotIndex) Then

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -181,7 +181,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End If
 
             Dim localNames = debugInfo.LocalVariableNames.WhereAsArray(
-                Function(name) name Is Nothing OrElse Not name.StartsWith(GeneratedNameConstants.StateMachineHoistedUserVariablePrefix, StringComparison.Ordinal))
+                Function(name) name Is Nothing OrElse Not name.StartsWith(GeneratedNameConstants.StateMachineHoistedUserVariableOrDisplayClassPrefix, StringComparison.Ordinal))
 
             Dim localsBuilder = ArrayBuilder(Of LocalSymbol).GetInstance()
             MethodDebugInfo(Of TypeSymbol, LocalSymbol).GetLocals(localsBuilder, symbolProvider, localNames, localInfo, Nothing, debugInfo.TupleLocalMap)
@@ -204,7 +204,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             For Each localName In allLocalNames
                 Dim hoistedLocalName As String = Nothing
                 Dim hoistedLocalSlot As Integer = 0
-                If localName IsNot Nothing AndAlso GeneratedNameParser.TryParseStateMachineHoistedUserVariableName(localName, hoistedLocalName, hoistedLocalSlot) Then
+                If localName IsNot Nothing AndAlso GeneratedNameParser.TryParseStateMachineHoistedUserVariableOrDisplayClassName(localName, hoistedLocalName, hoistedLocalSlot) Then
                     builder.Add(hoistedLocalSlot)
                 End If
             Next


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/63294

In C#, we were not correctly mapping slots for variables holding on closures that were lifted to state machine fields.
In VB, we were accidentally mapping these correctly but were not mapping lifted variables that store values of `With` statements.