### PR TITLE
Always use filter text to select between keyword and type item for special types

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -10064,6 +10064,39 @@ class Class
             End Using
         End Function
 
+        <WpfTheory>
+        <InlineData("string", "string")>
+        <InlineData("string", "String")>
+        <InlineData("String", "string")>
+        <InlineData("String", "String")>
+        <Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestSpecialTypeKeywordSelection(first As String, second As String) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                  <Document>
+using System;
+class Class
+{
+    public void M()
+    {
+        $$
+    }
+}</Document>)
+
+                ' filter text decides selection when no type can be inferred.
+                state.SendTypeChars(first)
+                Await state.AssertCompletionItemsContainAll(first, second)
+                Await state.AssertSelectedCompletionItem(displayText:=first, isHardSelected:=True)
+                state.SendTab()
+
+                state.SendTypeChars(" x =")
+
+                ' We should let what user has typed to dictate whether to select keyword or type form, even when we can infer the type.
+                state.SendTypeChars(second.Substring(0, 3))
+                Await state.AssertCompletionItemsContainAll(first, second)
+                Await state.AssertSelectedCompletionItem(displayText:=second, isHardSelected:=True)
+            End Using
+        End Function
+
         <ExportCompletionProvider(NameOf(TestProvider), LanguageNames.CSharp)>
         <[Shared]>
         <PartNotDiscoverable>

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
@@ -4,6 +4,7 @@
 
 using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
@@ -20,6 +21,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 
         protected abstract SpecialType SpecialType { get; }
         protected abstract bool IsValidContextWorker(int position, CSharpSyntaxContext context, CancellationToken cancellationToken);
+
+        // When the keyword is the inferred type in this context, we should treat it like its corresponding type symbol
+        // in terms of MatchPripority, so the selection can be determined by how well it matches the filter text instead,
+        // e.g. selecting "string" over "String" when user typed "str".
+        protected override int PreselectMatchPriority => SymbolMatchPriority.PreferType;
 
         protected override bool ShouldPreselect(CSharpSyntaxContext context, CancellationToken cancellationToken)
             => context.InferredTypes.Any(static (t, self) => t.SpecialType == self.SpecialType, this);

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSyntacticSingleKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSyntacticSingleKeywordRecommender.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
         /// </summary>
         protected virtual int DefaultMatchPriority => MatchPriority.Default;
 
+        protected virtual int PreselectMatchPriority => SymbolMatchPriority.Keyword;
+
         protected AbstractSyntacticSingleKeywordRecommender(
             SyntaxKind keywordKind,
             bool isValidInPreprocessorContext = false,
@@ -34,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             _keywordPriorityRecommendedKeywords = ImmutableArray.Create(
                 new RecommendedKeyword(SyntaxFacts.GetText(keywordKind),
                 shouldFormatOnCommit: shouldFormatOnCommit,
-                matchPriority: SymbolMatchPriority.Keyword));
+                matchPriority: PreselectMatchPriority));
             _defaultPriorityRecommendedKeywords = ImmutableArray.Create(
                 new RecommendedKeyword(SyntaxFacts.GetText(keywordKind),
                 shouldFormatOnCommit: shouldFormatOnCommit,


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/62079, which turns out to be a bug, not some MRU issue I originally thought it was.