### PR TITLE
Backport some integration test skips to 17.3

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpUpdateProjectToAllowUnsafe.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpUpdateProjectToAllowUnsafe.cs
@@ -35,7 +35,7 @@ unsafe class C
             }
         }
 
-        [IdeFact]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/63026")]
         public async Task CPSProject_GeneralPropertyGroupUpdated()
         {
             var project = ProjectName;
@@ -48,7 +48,7 @@ unsafe class C
             VerifyPropertyOutsideConfiguration(await GetProjectFileElementAsync(project, HangMitigatingCancellationToken), "AllowUnsafeBlocks", "true");
         }
 
-        [IdeFact]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/63026")]
         public async Task LegacyProject_AllConfigurationsUpdated()
         {
             var project = ProjectName;
@@ -60,7 +60,7 @@ unsafe class C
             VerifyPropertyInEachConfiguration(await GetProjectFileElementAsync(project, HangMitigatingCancellationToken), "AllowUnsafeBlocks", "true");
         }
 
-        [IdeFact]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/63026")]
         [WorkItem(23342, "https://github.com/dotnet/roslyn/issues/23342")]
         public async Task LegacyProject_MultiplePlatforms_AllConfigurationsUpdated()
         {

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpUpgradeProject.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpUpgradeProject.cs
@@ -47,7 +47,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp
             VerifyPropertyOutsideConfiguration(await GetProjectFileElementAsync(project, HangMitigatingCancellationToken), "LangVersion", "latest");
         }
 
-        [IdeFact]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/63026")]
         public async Task LegacyProject_AllConfigurationsUpdated()
         {
             var project = ProjectName;
@@ -96,7 +96,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp
             VerifyPropertyInEachConfiguration(await GetProjectFileElementAsync(project, HangMitigatingCancellationToken), "LangVersion", "7.3");
         }
 
-        [IdeFact]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/63026")]
         [WorkItem(23342, "https://github.com/dotnet/roslyn/issues/23342")]
         public async Task LegacyProject_MultiplePlatforms_AllConfigurationsUpdated()
         {


### PR DESCRIPTION
These are skipped in main, and should also be skipped in 17.3, otherwise they will prevent code 17.3 servicing changes
e.g. https://github.com/dotnet/roslyn/pull/63244