### PR TITLE
Don't provide refactoring for VB Move Static Members when IncompleteMemberSyntax is found

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
@@ -5,7 +5,6 @@
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.MoveStaticMembers
 Imports Microsoft.CodeAnalysis.Test.Utilities.MoveStaticMembers
-Imports Microsoft.CodeAnalysis.Testing
 Imports VerifyVB = Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.VisualBasicCodeRefactoringVerifier(Of
     Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.MoveStaticMembers.VisualBasicMoveStaticMembersRefactoringProvider)
 
@@ -2853,6 +2852,22 @@ End Namespace"
 Namespace TestNs
     Public Class Class1
         Public Sha[||] {|BC30205:TestField|} As Integer = 0
+    End Class
+End Namespace"
+
+            Await New Test("", ImmutableArray(Of String).Empty, "") With
+            {
+                .TestCode = initialMarkup,
+                .FixedCode = initialMarkup
+            }.RunAsync().ConfigureAwait(False)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>
+        Public Async Function TestSelectNonEmptySpanInIncompleteField_NoAction() As Task
+            Dim initialMarkup = "
+Namespace TestNs
+    Public Class Class1
+        [|Public|]{|BC30203:|}
     End Class
 End Namespace"
 

--- a/src/EditorFeatures/VisualBasicTest/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
@@ -2879,6 +2879,24 @@ End Namespace"
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>
+        Public Async Function TestSelectNonEmptySpanInsideMethodBlock_NoAction() As Task
+            Dim initialMarkup = "
+Namespace TestNs
+    Public Class Class1
+        Public Shared Function Foo() As Integer
+            [|Return 0|]
+        End Function
+    End Class
+End Namespace"
+
+            Await New Test("", ImmutableArray(Of String).Empty, "") With
+            {
+                .TestCode = initialMarkup,
+                .FixedCode = initialMarkup
+            }.RunAsync().ConfigureAwait(False)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>
         Public Async Function TestSelectNonSharedProperty_NoAction() As Task
             Dim initialMarkup = "
 Namespace TestNs
@@ -2895,7 +2913,7 @@ End Namespace"
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>
-        Public Async Function TestSelectPropertyGetter_NoAction() As Task
+        Public Async Function TestSelectPropertyGetter_NoAction1() As Task
             Dim initialMarkup = "
 Namespace TestNs
     Public Class Class1
@@ -2908,6 +2926,56 @@ Namespace TestNs
 End Namespace"
 
             Await TestNoRefactoringAsync(initialMarkup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>
+        Public Async Function TestSelectPropertyGetter_NoAction2() As Task
+            Dim initialMarkup = "
+Namespace TestNs
+    Public Class Class1
+        Public Shared ReadOnly Property TestProperty As Integer
+            [|Get|]
+                Return 0
+            End Get
+        End Property
+    End Class
+End Namespace"
+
+            Await TestNoRefactoringAsync(initialMarkup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>
+        Public Async Function TestMovePropertyWithNonEmptySelection() As Task
+            Dim initialMarkup = "
+Namespace TestNs
+    Public Class Class1
+        Public Shared ReadOnly Property Test[|Property As Integer
+            Get
+                Return 0
+            End Get|]
+        End Property
+    End Class
+End Namespace"
+            Dim newTypeName = "Class1Helpers"
+            Dim newFileName = "Class1Helpers.vb"
+            Dim selection = ImmutableArray.Create("TestProperty")
+            Dim expectedText1 = "
+Namespace TestNs
+    Public Class Class1
+    End Class
+End Namespace"
+            Dim expectedText2 = "Namespace TestNs
+    Class Class1Helpers
+        Public Shared ReadOnly Property TestProperty As Integer
+            Get
+                Return 0
+            End Get
+        End Property
+    End Class
+End Namespace
+"
+
+            Await TestMovementNewFileAsync(initialMarkup, expectedText1, expectedText2, newFileName, selection, newTypeName)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveStaticMembers)>

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/NodeSelectionHelpers.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/NodeSelectionHelpers.vb
@@ -44,9 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings
                 Dim tree = Await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(False)
                 Dim selectedMembers = Await VisualBasicSelectedMembers.Instance.
                     GetSelectedMembersAsync(tree, span, allowPartialSelection:=True, cancellationToken).ConfigureAwait(False)
-                If selectedMembers.Any(Function(member)
-                                           Return TypeOf member Is IncompleteMemberSyntax
-                                       End Function) Then
+                If selectedMembers.OfType(Of IncompleteMemberSyntax)().Any() Then
                     Return ImmutableArray(Of SyntaxNode).Empty
                 Else
                     Return selectedMembers

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/NodeSelectionHelpers.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/NodeSelectionHelpers.vb
@@ -42,7 +42,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings
                 ' pick up on keywords before the declaration, such as "public static int".
                 ' We could potentially use it for every case if that behavior changes
                 Dim tree = Await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(False)
-                Return Await VisualBasicSelectedMembers.Instance.GetSelectedMembersAsync(tree, span, allowPartialSelection:=True, cancellationToken).ConfigureAwait(False)
+                Dim selectedMembers = Await VisualBasicSelectedMembers.Instance.
+                    GetSelectedMembersAsync(tree, span, allowPartialSelection:=True, cancellationToken).ConfigureAwait(False)
+                If selectedMembers.Any(Function(member)
+                                           Return TypeOf member Is IncompleteMemberSyntax
+                                       End Function) Then
+                    Return ImmutableArray(Of SyntaxNode).Empty
+                Else
+                    Return selectedMembers
+                End If
             End If
         End Function
     End Module


### PR DESCRIPTION
Fixes #63287

The `VisualBasicSelectedMembers` uses `StatementSyntax` for its member declaration type parameter, which is the last common base ancestor of `MethodBaseSyntax` and `ModifiedIdentifierSyntax` but is a fairly broad definition for a member declaration. Luckily, only syntaxes defined as members of the containing type are considered for selection, which limits the syntaxes that can actually be provided to `MethodBaseSyntax`, `ModifiedIdentifierSyntax`, and `IncompleteMemberSyntax` AFAIK. We can just do a similar thing that C# does, which is to return no members if the `AbstractSelectedMembers` gives us an `IncompleteMemberSyntax` as a member of its return list.