### PR TITLE
Add ExternalAccess for INavigateToSearcherService

### DIFF
--- a/src/Tools/ExternalAccess/OmniSharp/NavigateTo/OmniSharpNavigateToSearchResult.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/NavigateTo/OmniSharpNavigateToSearchResult.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Navigation;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.NavigateTo;
+
+internal readonly record struct OmniSharpNavigateToSearchResult(
+    string AdditionalInformation,
+    string Kind,
+    OmniSharpNavigateToMatchKind MatchKind,
+    bool IsCaseSensitive,
+    string Name,
+    ImmutableArray<TextSpan> NameMatchSpans,
+    string SecondarySort,
+    string Summary,
+    OmniSharpNavigableItem NavigableItem);
+
+internal enum OmniSharpNavigateToMatchKind
+{
+    Exact = 0,
+    Prefix = 1,
+    Substring = 2,
+    Regular = 3,
+    None = 4,
+    CamelCaseExact = 5,
+    CamelCasePrefix = 6,
+    CamelCaseNonContiguousPrefix = 7,
+    CamelCaseSubstring = 8,
+    CamelCaseNonContiguousSubstring = 9,
+    Fuzzy = 10
+}

--- a/src/Tools/ExternalAccess/OmniSharp/NavigateTo/OmniSharpNavigateToSearchService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/NavigateTo/OmniSharpNavigateToSearchService.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Navigation;
+using Microsoft.CodeAnalysis.NavigateTo;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.NavigateTo;
+
+internal static class OmniSharpNavigateToSearcher
+{
+    public delegate Task OmniSharpNavigateToCallback(Project project, in OmniSharpNavigateToSearchResult result, CancellationToken cancellationToken);
+
+    public static Task SearchAsync(
+        Solution solution,
+        OmniSharpNavigateToCallback callback,
+        string searchPattern,
+        IImmutableSet<string> kinds,
+        CancellationToken cancellationToken)
+    {
+        var searcher = NavigateToSearcher.Create(
+            solution,
+            AsynchronousOperationListenerProvider.NullListener,
+            new OmniSharpNavigateToCallbackImpl(callback),
+            searchPattern,
+            kinds,
+            disposalToken: CancellationToken.None);
+
+        return searcher.SearchAsync(searchCurrentDocument: false, cancellationToken);
+    }
+
+    private class OmniSharpNavigateToCallbackImpl : INavigateToSearchCallback
+    {
+        private readonly OmniSharpNavigateToCallback _callback;
+
+        public OmniSharpNavigateToCallbackImpl(OmniSharpNavigateToCallback callback)
+        {
+            _callback = callback;
+        }
+
+        public Task AddItemAsync(Project project, INavigateToSearchResult result, CancellationToken cancellationToken)
+        {
+            var omniSharpResult = new OmniSharpNavigateToSearchResult(
+                result.AdditionalInformation,
+                result.Kind,
+                (OmniSharpNavigateToMatchKind)result.MatchKind,
+                result.IsCaseSensitive,
+                result.Name,
+                result.NameMatchSpans,
+                result.SecondarySort,
+                result.Summary,
+                new(result.NavigableItem.DisplayTaggedParts, result.NavigableItem.Document, result.NavigableItem.SourceSpan));
+
+            return _callback(project, omniSharpResult, cancellationToken);
+        }
+
+        public void Done(bool isFullyLoaded)
+        {
+        }
+
+        public void ReportProgress(int current, int maximum)
+        {
+        }
+    }
+}

--- a/src/Tools/ExternalAccess/OmniSharp/NavigateTo/OmniSharpNavigateToSearchService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/NavigateTo/OmniSharpNavigateToSearchService.cs
@@ -36,7 +36,7 @@ internal static class OmniSharpNavigateToSearcher
         return searcher.SearchAsync(searchCurrentDocument: false, cancellationToken);
     }
 
-    private class OmniSharpNavigateToCallbackImpl : INavigateToSearchCallback
+    private sealed class OmniSharpNavigateToCallbackImpl : INavigateToSearchCallback
     {
         private readonly OmniSharpNavigateToCallback _callback;
 

--- a/src/Tools/ExternalAccess/OmniSharpTest/EnumTests.cs
+++ b/src/Tools/ExternalAccess/OmniSharpTest/EnumTests.cs
@@ -6,8 +6,11 @@ using System;
 using System.Linq;
 using Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.ExtractInterface;
 using Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.ImplementType;
+using Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.NavigateTo;
 using Microsoft.CodeAnalysis.ExtractInterface;
 using Microsoft.CodeAnalysis.ImplementType;
+using Microsoft.CodeAnalysis.NavigateTo;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.UnitTests
@@ -19,6 +22,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.UnitTests
                     typeof(OmniSharpExtractInterfaceOptionsResult.OmniSharpExtractLocation))]
         [InlineData(typeof(ImplementTypeInsertionBehavior), typeof(OmniSharpImplementTypeInsertionBehavior))]
         [InlineData(typeof(ImplementTypePropertyGenerationBehavior), typeof(OmniSharpImplementTypePropertyGenerationBehavior))]
+        [InlineData(typeof(NavigateToMatchKind), typeof(OmniSharpNavigateToMatchKind))]
         public void AssertEnumsInSync(Type internalType, Type externalType)
         {
             var internalValues = Enum.GetValues(internalType).Cast<int>().ToArray();
@@ -26,8 +30,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.UnitTests
             var externalValues = Enum.GetValues(externalType).Cast<int>().ToArray();
             var externalNames = Enum.GetNames(externalType);
 
-            Assert.Equal(internalValues, externalValues);
-            Assert.Equal(internalNames, externalNames);
+            AssertEx.Equal(internalValues, externalValues);
+            AssertEx.Equal(internalNames, externalNames);
         }
     }
 }


### PR DESCRIPTION
Because of https://github.com/dotnet/roslyn/issues/63375, O# cannot currently use SymbolFinder for finding all symbols for a pattern in the workspace. As a workaround, expose INavigateToSearcherService via EA to unblock the workspace symbol service.
