### PR TITLE
Relax assert in CodeGenerator.EmitConversion()

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                         default:
                             Debug.Assert(IsNumeric(fromType));
                             Debug.Assert(
-                                (toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.IntPtr || toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.UIntPtr) && !toType.IsNativeIntegerType ||
+                                (toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.IntPtr || toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.UIntPtr) && !toType.IsNativeIntegerWrapperType ||
                                 toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.Pointer ||
                                 toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.FunctionPointer);
                             break;

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -11484,6 +11484,75 @@ static class C
 ");
         }
 
+        [WorkItem(63348, "https://github.com/dotnet/roslyn/issues/63348")]
+        [Fact]
+        public void ConditionalStackalloc()
+        {
+            var source =
+@"using System;
+class Program
+{
+    static int F(int n)
+    {
+        Span<char> s = n < 10 ? stackalloc char[n] : new char[n];
+        return s[n - 1];
+    }
+    static void Main()
+    {
+        Console.Write(F(1));
+        Console.Write(F(11));
+    }
+}";
+
+            var comp = CreateCompilation(new[] { SpanSource, source }, options: TestOptions.UnsafeReleaseExe);
+            verify(comp);
+
+            comp = CreateNumericIntPtrCompilation(new[] { SpanSource, source }, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.UnsafeReleaseExe);
+            verify(comp);
+
+            void verify(CSharpCompilation comp)
+            {
+                comp.VerifyEmitDiagnostics();
+                var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: "00");
+                verifier.VerifyIL("Program.F", """
+{
+  // Code size       48 (0x30)
+  .maxstack  3
+  .locals init (System.Span<char> V_0, //s
+                System.Span<char> V_1,
+                int V_2)
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.s   10
+  IL_0003:  bge.s      IL_0016
+  IL_0005:  ldarg.0
+  IL_0006:  stloc.2
+  IL_0007:  ldloc.2
+  IL_0008:  conv.u
+  IL_0009:  ldc.i4.2
+  IL_000a:  mul.ovf.un
+  IL_000b:  localloc
+  IL_000d:  ldloc.2
+  IL_000e:  newobj     "System.Span<char>..ctor(void*, int)"
+  IL_0013:  stloc.1
+  IL_0014:  br.s       IL_0022
+  IL_0016:  ldarg.0
+  IL_0017:  newarr     "char"
+  IL_001c:  call       "System.Span<char> System.Span<char>.op_Implicit(char[])"
+  IL_0021:  stloc.1
+  IL_0022:  ldloc.1
+  IL_0023:  stloc.0
+  IL_0024:  ldloca.s   V_0
+  IL_0026:  ldarg.0
+  IL_0027:  ldc.i4.1
+  IL_0028:  sub
+  IL_0029:  call       "ref char System.Span<char>.this[int].get"
+  IL_002e:  ldind.u2
+  IL_002f:  ret
+}
+""");
+            }
+        }
+
         private void VerifyNoNativeIntegerAttributeEmitted(CSharpCompilation comp)
         {
             // PEVerify is skipped because it reports "Type load failed" because of the above corlib,


### PR DESCRIPTION
See second assert failure in #63348.