### PR TITLE
only publish build validation logs on failure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -322,6 +322,7 @@ jobs:
         ArtifactName: 'BuildValidator_DebugOut'
         publishLocation: Container
       continueOnError: true
+      condition: failed()
 
     - template: eng/pipelines/publish-logs.yml
       parameters:


### PR DESCRIPTION
This appears to be an oversight on my part. These logs only exist if there is a validation failure