### PR TITLE
Fix crash in ref escape around missing this param

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1796,8 +1796,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                     PropertySymbol p => p.GetMethod ?? p.SetMethod,
                     _ => throw ExceptionUtilities.UnexpectedValue(symbol)
                 };
-                var thisParameter = method?.ThisParameter;
-                var refKind = thisParameter?.RefKind ?? RefKind.None;
+
+                var refKind = RefKind.None;
+                ParameterSymbol? thisParameter = null;
+                if (method is not null &&
+                    method.TryGetThisParameter(out thisParameter) &&
+                    thisParameter is not null)
+                {
+                    refKind = thisParameter.RefKind;
+                }
+
                 return (thisParameter, receiver, refKind);
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -4058,5 +4058,22 @@ class D
 }
 ", parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.ReleaseDll).VerifyDiagnostics();
         }
+
+        [WorkItem(63384, "https://github.com/dotnet/roslyn/issues/63384")]
+        [Theory]
+        [InlineData("nuint")]
+        [InlineData("nint")]
+        public void NativeIntegerThis(string type)
+        {
+            var compilation = CreateCompilationWithMscorlibAndSpan(
+    $$"""
+        ref struct S
+        {
+            static int M({{type}} ptr) => ptr.GetHashCode();
+        }
+    """);
+
+            compilation.VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -4065,7 +4065,7 @@ class D
         [InlineData("nint")]
         public void NativeIntegerThis(string type)
         {
-            var compilation = CreateCompilationWithMscorlibAndSpan(
+            var compilation = CreateCompilation(
     $$"""
         ref struct S
         {


### PR DESCRIPTION
Not all symbols support a `this` parameter in our symbol model. The
`ref` escapes code needs to account for this and use
`TryGetThisParameter`.

closes #63384