### PR TITLE
Remove bogus assert

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.Caching.cs
@@ -112,9 +112,6 @@ namespace Microsoft.CodeAnalysis.Remote
             var solution = document.Project.Solution;
             var persistenceService = solution.Services.GetPersistentStorageService();
 
-            // we should never use no-op storage in OOP
-            Contract.ThrowIfTrue(persistenceService is NoOpPersistentStorageService);
-
             var storage = await persistenceService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), cancellationToken).ConfigureAwait(false);
             await using var _1 = storage.ConfigureAwait(false);
             if (storage == null)


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1590655

We were asserting we always get a db service back.  However, it's totally possible for that to not happen for any number of reasons.  For example, sqlite may not load, or may run into an IO exception when tryign to create the db.