### PR TITLE
[LSP] Fix fading diagnostics

### DIFF
--- a/src/EditorFeatures/Core/Diagnostics/DiagnosticsClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Diagnostics/DiagnosticsClassificationTaggerProvider.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Features.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Workspaces;
@@ -76,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // want to fade out multiple locations which are encoded as
                 // additional location indices in the diagnostic's property bag
                 // without the 'Unnecessary' custom tag. 
-                Debug.Assert(!TryGetUnnecessaryLocationIndices(data, out _));
+                Debug.Assert(!data.TryGetUnnecessaryLocationIndices(out _));
 
                 return false;
             }
@@ -94,47 +95,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         protected internal override ITagSpan<ClassificationTag> CreateTagSpan(Workspace workspace, bool isLiveUpdate, SnapshotSpan span, DiagnosticData data)
             => new TagSpan<ClassificationTag>(span, _classificationTag);
 
-        private static bool TryGetUnnecessaryLocationIndices(
-            DiagnosticData diagnosticData, [NotNullWhen(true)] out string? unnecessaryIndices)
-        {
-            unnecessaryIndices = null;
-
-            return diagnosticData.AdditionalLocations.Length > 0
-                && diagnosticData.Properties != null
-                && diagnosticData.Properties.TryGetValue(WellKnownDiagnosticTags.Unnecessary, out unnecessaryIndices)
-                && unnecessaryIndices != null;
-        }
-
         protected internal override ImmutableArray<DiagnosticDataLocation> GetLocationsToTag(DiagnosticData diagnosticData)
         {
-            // If there are 'unnecessary' locations specified in the property bag, use those instead of the main diagnostic location.
-            if (TryGetUnnecessaryLocationIndices(diagnosticData, out var unnecessaryIndices))
+            if (diagnosticData.TryGetUnnecessaryDataLocations(out var locationsToTag))
             {
-                using var _ = PooledObjects.ArrayBuilder<DiagnosticDataLocation>.GetInstance(out var locationsToTag);
-
-                foreach (var index in GetLocationIndices(unnecessaryIndices))
-                    locationsToTag.Add(diagnosticData.AdditionalLocations[index]);
-
-                return locationsToTag.ToImmutable();
+                return locationsToTag.Value;
             }
 
             // Default to the base implementation for the diagnostic data
             return base.GetLocationsToTag(diagnosticData);
-
-            static IEnumerable<int> GetLocationIndices(string indicesProperty)
-            {
-                try
-                {
-                    using var stream = new MemoryStream(Encoding.UTF8.GetBytes(indicesProperty));
-                    var serializer = new DataContractJsonSerializer(typeof(IEnumerable<int>));
-                    var result = serializer.ReadObject(stream) as IEnumerable<int>;
-                    return result ?? Array.Empty<int>();
-                }
-                catch (Exception e) when (FatalError.ReportAndCatch(e))
-                {
-                    return ImmutableArray<int>.Empty;
-                }
-            }
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticDataExtensions.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticDataExtensions.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.ErrorReporting;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Runtime.Serialization.Json;
+using System.Text;
+using System;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Features.Diagnostics;
+internal static class DiagnosticDataExtensions
+{
+    internal static bool TryGetUnnecessaryDataLocations(this DiagnosticData diagnosticData, [NotNullWhen(true)] out ImmutableArray<DiagnosticDataLocation>? unnecessaryLocations)
+    {
+        // If there are 'unnecessary' locations specified in the property bag, use those instead of the main diagnostic location.
+        if (diagnosticData.TryGetUnnecessaryLocationIndices(out var unnecessaryIndices))
+        {
+            using var _ = PooledObjects.ArrayBuilder<DiagnosticDataLocation>.GetInstance(out var locationsToTag);
+
+            foreach (var index in GetLocationIndices(unnecessaryIndices))
+                locationsToTag.Add(diagnosticData.AdditionalLocations[index]);
+
+            unnecessaryLocations = locationsToTag.ToImmutable();
+            return true;
+        }
+
+        unnecessaryLocations = null;
+        return false;
+
+        static IEnumerable<int> GetLocationIndices(string indicesProperty)
+        {
+            try
+            {
+                using var stream = new MemoryStream(Encoding.UTF8.GetBytes(indicesProperty));
+                var serializer = new DataContractJsonSerializer(typeof(IEnumerable<int>));
+                var result = serializer.ReadObject(stream) as IEnumerable<int>;
+                return result ?? Array.Empty<int>();
+            }
+            catch (Exception e) when (FatalError.ReportAndCatch(e))
+            {
+                return ImmutableArray<int>.Empty;
+            }
+        }
+    }
+
+    internal static bool TryGetUnnecessaryLocationIndices(
+            this DiagnosticData diagnosticData, [NotNullWhen(true)] out string? unnecessaryIndices)
+    {
+        unnecessaryIndices = null;
+
+        return diagnosticData.AdditionalLocations.Length > 0
+            && diagnosticData.Properties != null
+            && diagnosticData.Properties.TryGetValue(WellKnownDiagnosticTags.Unnecessary, out unnecessaryIndices)
+            && unnecessaryIndices != null;
+    }
+}

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -8,12 +8,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.EditAndContinue;
-using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.LanguageServer.Features.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -254,7 +252,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             context.TraceInformation($"Found {diagnostics.Length} diagnostics for {diagnosticSource.GetUri()}");
 
             foreach (var diagnostic in diagnostics)
-                result.Add(ConvertDiagnostic(diagnosticSource, diagnostic, clientCapabilities));
+                result.AddRange(ConvertDiagnostic(diagnosticSource, diagnostic, clientCapabilities));
 
             return CreateReport(new LSP.TextDocumentIdentifier { Uri = diagnosticSource.GetUri() }, result.ToArray(), resultId);
         }
@@ -273,37 +271,54 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             }
         }
 
-        private LSP.Diagnostic ConvertDiagnostic(IDiagnosticSource diagnosticSource, DiagnosticData diagnosticData, ClientCapabilities capabilities)
+        private ImmutableArray<LSP.Diagnostic> ConvertDiagnostic(IDiagnosticSource diagnosticSource, DiagnosticData diagnosticData, ClientCapabilities capabilities)
         {
-            Contract.ThrowIfNull(diagnosticData.Message, $"Got a document diagnostic that did not have a {nameof(diagnosticData.Message)}");
-
             var project = diagnosticSource.GetProject();
+            var diagnostic = CreateLspDiagnostic(diagnosticData, project, capabilities);
 
-            if (!capabilities.HasVisualStudioLspCapability())
+            // Check if we need to handle the unnecessary tag (fading).
+            if (!diagnosticData.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary))
             {
-                var diagnostic = CreateBaseLspDiagnostic();
-                return diagnostic;
-            }
-            else
-            {
-                var vsDiagnostic = CreateBaseLspDiagnostic();
-                vsDiagnostic.DiagnosticType = diagnosticData.Category;
-                vsDiagnostic.Projects = new[]
-                {
-                    new VSDiagnosticProjectInformation
-                    {
-                        ProjectIdentifier = project.Id.Id.ToString(),
-                        ProjectName = project.Name,
-                    },
-                };
-
-                return vsDiagnostic;
+                return ImmutableArray.Create<LSP.Diagnostic>(diagnostic);
             }
 
-            // We can just use VSDiagnostic as it doesn't have any default properties set that
-            // would get automatically serialized.
-            LSP.VSDiagnostic CreateBaseLspDiagnostic()
+            // DiagnosticId supports fading, check if the corresponding VS option is turned on.
+            if (!SupportsFadingOption(diagnosticData))
             {
+                return ImmutableArray.Create<LSP.Diagnostic>(diagnostic);
+            }
+
+            // Check to see if there are specific locations marked to fade.
+            if (!diagnosticData.TryGetUnnecessaryDataLocations(out var unnecessaryLocations))
+            {
+                // There are no specific fading locations, just mark the whole diagnostic span as unnecessary.
+                diagnostic.Tags = diagnostic.Tags?.Append(DiagnosticTag.Unnecessary);
+                return ImmutableArray.Create<LSP.Diagnostic>(diagnostic);
+            }
+
+            // Roslyn produces unnecessary diagnostics by using additional locations, however LSP doesn't support tagging
+            // additional locations separately.  Instead we just create multiple hidden diagnostics for unnecessary squiggling.
+            using var _ = ArrayBuilder<LSP.Diagnostic>.GetInstance(out var diagnosticsBuilder);
+            diagnosticsBuilder.Add(diagnostic);
+            foreach (var location in unnecessaryLocations)
+            {
+                var additionalDiagnostic = CreateLspDiagnostic(diagnosticData, project, capabilities);
+                additionalDiagnostic.Range = GetRange(location);
+                additionalDiagnostic.Tags = new DiagnosticTag[] { DiagnosticTag.Unnecessary, VSDiagnosticTags.HiddenInEditor, VSDiagnosticTags.HiddenInErrorList, VSDiagnosticTags.SuppressEditorToolTip };
+                diagnosticsBuilder.Add(additionalDiagnostic);
+            }
+
+            return diagnosticsBuilder.ToImmutableArray();
+
+            LSP.VSDiagnostic CreateLspDiagnostic(
+                DiagnosticData diagnosticData,
+                Project project,
+                ClientCapabilities capabilities)
+            {
+                Contract.ThrowIfNull(diagnosticData.Message, $"Got a document diagnostic that did not have a {nameof(diagnosticData.Message)}");
+
+                // We can just use VSDiagnostic as it doesn't have any default properties set that
+                // would get automatically serialized.
                 var diagnostic = new LSP.VSDiagnostic
                 {
                     Source = "Roslyn",
@@ -313,22 +328,29 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
                     Severity = ConvertDiagnosticSeverity(diagnosticData.Severity),
                     Tags = ConvertTags(diagnosticData),
                 };
-                var range = GetRange(diagnosticData.DataLocation);
-                if (range != null)
+                if (diagnosticData.DataLocation != null)
                 {
-                    diagnostic.Range = range;
+                    diagnostic.Range = GetRange(diagnosticData.DataLocation);
+                }
+
+                if (capabilities.HasVisualStudioLspCapability())
+                {
+                    diagnostic.DiagnosticType = diagnosticData.Category;
+                    diagnostic.Projects = new[]
+                    {
+                        new VSDiagnosticProjectInformation
+                        {
+                            ProjectIdentifier = project.Id.Id.ToString(),
+                            ProjectName = project.Name,
+                        },
+                    };
                 }
 
                 return diagnostic;
             }
 
-            static Range? GetRange(DiagnosticDataLocation? dataLocation)
+            static LSP.Range GetRange(DiagnosticDataLocation dataLocation)
             {
-                if (dataLocation == null)
-                {
-                    return null;
-                }
-
                 // We currently do not map diagnostics spans as
                 //   1.  Razor handles span mapping for razor files on their side.
                 //   2.  LSP does not allow us to report document pull diagnostics for a different file path.
@@ -337,7 +359,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 
                 // We also do not adjust the diagnostic locations to ensure they are in bounds because we've
                 // explicitly requested up to date diagnostics as of the snapshot we were passed in.
-                return new Range
+                return new LSP.Range
                 {
                     Start = new Position
                     {
@@ -391,13 +413,21 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
                 ? VSDiagnosticTags.BuildError
                 : VSDiagnosticTags.IntellisenseError);
 
-            if (diagnosticData.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary))
-                result.Add(DiagnosticTag.Unnecessary);
-
             if (diagnosticData.CustomTags.Contains(WellKnownDiagnosticTags.EditAndContinue))
                 result.Add(VSDiagnosticTags.EditAndContinueError);
 
             return result.ToArray();
+        }
+
+        private bool SupportsFadingOption(DiagnosticData diagnosticData)
+        {
+            if (IDEDiagnosticIdToOptionMappingHelper.TryGetMappedFadingOption(diagnosticData.Id, out var fadingOption))
+            {
+                return diagnosticData.Language != null
+                    && GlobalOptions.GetOption(fadingOption, diagnosticData.Language);
+            }
+
+            return true;
         }
     }
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
@@ -8,6 +8,8 @@ using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryImports;
+using Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryParentheses;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
@@ -29,8 +31,20 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
 
     public abstract class AbstractPullDiagnosticTestsBase : AbstractLanguageServerProtocolTests
     {
-        private protected override TestAnalyzerReferenceByLanguage TestAnalyzerReferences => new(DiagnosticExtensions.GetCompilerDiagnosticAnalyzersMap()
-            .Add(InternalLanguageNames.TypeScript, ImmutableArray.Create<DiagnosticAnalyzer>(new MockTypescriptDiagnosticAnalyzer())));
+        private protected override TestAnalyzerReferenceByLanguage TestAnalyzerReferences
+        {
+            get
+            {
+                var builder = ImmutableDictionary.CreateBuilder<string, ImmutableArray<DiagnosticAnalyzer>>();
+                builder.Add(LanguageNames.CSharp, ImmutableArray.Create(
+                    DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.CSharp),
+                    new CSharpRemoveUnnecessaryImportsDiagnosticAnalyzer(),
+                    new CSharpRemoveUnnecessaryExpressionParenthesesDiagnosticAnalyzer()));
+                builder.Add(LanguageNames.VisualBasic, ImmutableArray.Create(DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.VisualBasic)));
+                builder.Add(InternalLanguageNames.TypeScript, ImmutableArray.Create<DiagnosticAnalyzer>(new MockTypescriptDiagnosticAnalyzer()));
+                return new(builder.ToImmutableDictionary());
+            }
+        }
 
         protected override TestComposition Composition => base.Composition.AddParts(typeof(MockTypescriptDiagnosticAnalyzer));
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -7,8 +7,10 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
+using System.ServiceModel.Syndication;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Editor.Test;
@@ -527,6 +529,97 @@ class B {";
 
             var diagnostic = Assert.Single(results.Single().Diagnostics);
             Assert.Equal(DiagnosticProducingGenerator.Descriptor.Id, diagnostic.Code);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestDocumentDiagnosticsWithFadingOptionOn(bool useVSDiagnostics)
+        {
+            var markup =
+@"
+{|first:using System.Linq;
+using System.Threading;|}
+class A
+{
+}";
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles, useVSDiagnostics);
+            var firstLocation = testLspServer.GetLocations("first").Single().Range;
+            testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(new OptionKey(FadingOptions.FadeOutUnusedImports, LanguageNames.CSharp), true);
+
+            var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
+
+            await OpenDocumentAsync(testLspServer, document);
+
+            var results = await RunGetDocumentPullDiagnosticsAsync(
+                testLspServer, document.GetURI(), useVSDiagnostics);
+
+            // We should have an unnecessary diagnostic marking all the usings.
+            Assert.True(results.Single().Diagnostics![0].Tags!.Contains(DiagnosticTag.Unnecessary));
+            Assert.Equal(firstLocation, results.Single().Diagnostics![1].Range);
+
+            // We should have a regular diagnostic marking all the usings that doesn't fade.
+            Assert.False(results.Single().Diagnostics![1].Tags!.Contains(DiagnosticTag.Unnecessary));
+            Assert.Equal(firstLocation, results.Single().Diagnostics![1].Range);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestDocumentDiagnosticsWithFadingOptionOff(bool useVSDiagnostics)
+        {
+            var markup =
+@"
+{|first:using System.Linq;
+using System.Threading;|}
+class A
+{
+}";
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles, useVSDiagnostics);
+            var firstLocation = testLspServer.GetLocations("first").Single().Range;
+            testLspServer.TestWorkspace.GlobalOptions.SetGlobalOption(new OptionKey(FadingOptions.FadeOutUnusedImports, LanguageNames.CSharp), false);
+
+            var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
+
+            await OpenDocumentAsync(testLspServer, document);
+
+            var results = await RunGetDocumentPullDiagnosticsAsync(
+                testLspServer, document.GetURI(), useVSDiagnostics);
+
+            Assert.All(results.Single().Diagnostics, d => Assert.False(d.Tags!.Contains(DiagnosticTag.Unnecessary)));
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestDocumentDiagnosticsWithNotConfigurableFading(bool useVSDiagnostics)
+        {
+            var markup =
+@"class A
+{
+    void M()
+    {
+        _ = {|line:{|open:(|}1 + 2 +|}
+            3 + 4{|close:)|};
+    }
+}";
+            using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(markup, BackgroundAnalysisScope.OpenFiles, useVSDiagnostics);
+            var openLocation = testLspServer.GetLocations("open").Single().Range;
+            var closeLocation = testLspServer.GetLocations("close").Single().Range;
+            var lineLocation = testLspServer.GetLocations("line").Single().Range;
+
+            var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
+
+            await OpenDocumentAsync(testLspServer, document);
+
+            var results = await RunGetDocumentPullDiagnosticsAsync(
+                testLspServer, document.GetURI(), useVSDiagnostics);
+
+            // The first line should have a diagnostic on it that is not marked as unnecessary.
+            Assert.False(results.Single().Diagnostics![0].Tags!.Contains(DiagnosticTag.Unnecessary));
+            Assert.Equal(lineLocation, results.Single().Diagnostics![0].Range);
+
+            // The open paren should have an unnecessary diagnostic.
+            Assert.True(results.Single().Diagnostics![1].Tags!.Contains(DiagnosticTag.Unnecessary));
+            Assert.Equal(openLocation, results.Single().Diagnostics![1].Range);
+
+            // The close paren should have an unnecessary diagnostic.
+            Assert.True(results.Single().Diagnostics![2].Tags!.Contains(DiagnosticTag.Unnecessary));
+            Assert.Equal(closeLocation, results.Single().Diagnostics![2].Range);
         }
 
         #endregion


### PR DESCRIPTION
The logic for fading diagnostics changed to use additional locations instead of always creating multiple diagnostics with different spans.  This updates LSP to read the new diagnostic data and itself create multiple diagnostic reports for the unnecessary locations.  LSP does not yet support having additional locations with different tags.

LSP diagnostics should now appropriately respect severities and tools options for fading.  Also added tests to verify LSP behavior.

In the screenshot, usings and unreachable code are fully faded.  Unnecessary parens fades the parens and warns on the first line when configured to warning severity.
![image](https://user-images.githubusercontent.com/5749229/184800436-fb23075e-da89-49ae-af6e-72a8396b3ba5.png)


Resolves https://github.com/dotnet/roslyn/issues/63147