### PR TITLE
Handle nested non-deconstruction conversions in DeconstructionInfo

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/DeconstructionInfo.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/DeconstructionInfo.cs
@@ -61,6 +61,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
+                if (_conversion.Kind != ConversionKind.Deconstruction)
+                {
+                    return ImmutableArray<DeconstructionInfo>.Empty;
+                }
+
                 var deconstructConversionInfo = _conversion.DeconstructConversionInfo;
 
                 return deconstructConversionInfo.IsDefault

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -6532,7 +6532,7 @@ class C
 ");
         }
 
-        [Fact]
+        [Fact, WorkItem(61332, "https://github.com/dotnet/roslyn/issues/61332")]
         public void NestedNullableConversions()
         {
             var code = """

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -6531,5 +6531,27 @@ class C
 }
 ");
         }
+
+        [Fact]
+        public void NestedNullableConversions()
+        {
+            var code = """
+            float? _startScrollPosition, _endScrollPosition;
+            (_startScrollPosition, _endScrollPosition) = GetScrollPositions();
+
+            (float, float) GetScrollPositions() => (0, 0);
+            """;
+
+            var comp = CreateCompilation(code);
+            comp.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var assignment = tree.GetRoot().DescendantNodes().OfType<AssignmentExpressionSyntax>().Single();
+            var deconstructionInfo = model.GetDeconstructionInfo(assignment);
+            var nestedConversions = deconstructionInfo.Nested;
+            Assert.Equal(2, nestedConversions.Length);
+            Assert.All(nestedConversions,  n => Assert.Empty(n.Nested));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -6551,7 +6551,7 @@ class C
             var deconstructionInfo = model.GetDeconstructionInfo(assignment);
             var nestedConversions = deconstructionInfo.Nested;
             Assert.Equal(2, nestedConversions.Length);
-            Assert.All(nestedConversions,  n => Assert.Empty(n.Nested));
+            Assert.All(nestedConversions, n => Assert.Empty(n.Nested));
         }
     }
 }


### PR DESCRIPTION
If there were nested non-deconstruction conversions in a deconstruction, then we'd blindly recurse. Previous to https://github.com/dotnet/roslyn/pull/57175, we'd have non-terminal conversion nodes in the info tree, which was equally broken, though it didn't crash, just returned potentially incorrect results. Fixes https://github.com/dotnet/roslyn/issues/61332.
