### PR TITLE
Add assert back

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -247,6 +247,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             foreach (var oldParam in sourceMethod.Parameters)
             {
+                Debug.Assert(!(oldParam is SynthesizedComplexParameterSymbol));
                 //same properties as the old one, just change the owner
                 builder.Add(Create(
                     destinationMethod,


### PR DESCRIPTION
This was removed in https://github.com/dotnet/roslyn/pull/63293
If everything is passing, we should keep the assert. Otherwise, I'll take a closer look to see if removing the assert is the correct action.

The reason I'm concerned about this assert is we pass null in the next line for `baseParameterForAttributes`. It looks like if the assert fails we might not want to pass null, but pass `oldParam as SynthesizedComplexParameterSymbol`.

FYI @adamperlin @cston @333fred