### PR TITLE
Enable UTF8 raw multiline column guides

### DIFF
--- a/src/EditorFeatures/CSharpTest/StringIndentation/StringIndentationTests.cs
+++ b/src/EditorFeatures/CSharpTest/StringIndentation/StringIndentationTests.cs
@@ -66,226 +66,256 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.StringIndentation
         public async Task TestEmptyFile()
             => await TestAsync(string.Empty);
 
-        [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]
-        public async Task TestLiteralError1()
+        [Theory, Trait(Traits.Feature, Traits.Features.StringIndentation)]
+        [InlineData("")]
+        [InlineData("u8")]
+        public async Task TestLiteralError1(string suffix)
         {
-            await TestAsync(@"class C
-{
+            await TestAsync($@"class C
+{{
     void M()
-    {
+    {{
         // not enough lines in literal
         var v = """"""
-                """""";
-    }
-}");
+                """"""{suffix};
+    }}
+}}");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]
-        public async Task TestLiteralError2()
+        [Theory, Trait(Traits.Feature, Traits.Features.StringIndentation)]
+        [InlineData("")]
+        [InlineData("u8")]
+        public async Task TestLiteralError2(string suffix)
         {
-            await TestAsync(@"class C
-{
+            await TestAsync($@"class C
+{{
     void M()
-    {
+    {{
         // invalid literal
         var v = """"""
             text too early
-                """""";
-    }
-}");
+                """"""{suffix};
+    }}
+}}");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]
-        public async Task TestZeroColumn1()
+        [Theory, Trait(Traits.Feature, Traits.Features.StringIndentation)]
+        [InlineData("")]
+        [InlineData("u8")]
+        public async Task TestZeroColumn1(string suffix)
         {
-            await TestAsync(@"class C
-{
+            await TestAsync($@"class C
+{{
     void M()
-    {
+    {{
         var v = """"""
 goo
-"""""";
-    }
-}");
+""""""{suffix};
+    }}
+}}");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]
-        public async Task TestZeroColumn2()
+        [Theory, Trait(Traits.Feature, Traits.Features.StringIndentation)]
+        [InlineData("")]
+        [InlineData("u8")]
+        public async Task TestZeroColumn2(string suffix)
         {
-            await TestAsync(@"class C
-{
+            await TestAsync($@"class C
+{{
     void M()
-    {
+    {{
         var v = """"""
     goo
-"""""";
-    }
-}");
+""""""{suffix};
+    }}
+}}");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]
-        public async Task TestOneColumn1()
+        [Theory, Trait(Traits.Feature, Traits.Features.StringIndentation)]
+        [InlineData("")]
+        [InlineData("u8")]
+        public async Task TestOneColumn1(string suffix)
         {
-            await TestAsync(@"class C
-{
+            await TestAsync($@"class C
+{{
     void M()
-    {
+    {{
         var v = """"""
 |goo
- """""";
-    }
-}");
+ """"""{suffix};
+    }}
+}}");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]
-        public async Task TestOneColumn2()
+        [Theory, Trait(Traits.Feature, Traits.Features.StringIndentation)]
+        [InlineData("")]
+        [InlineData("u8")]
+        public async Task TestOneColumn2(string suffix)
         {
-            await TestAsync(@"class C
-{
+            await TestAsync($@"class C
+{{
     void M()
-    {
+    {{
         var v = """"""
 |   goo
- """""";
-    }
-}");
+ """"""{suffix};
+    }}
+}}");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]
-        public async Task TestCase1()
+        [Theory, Trait(Traits.Feature, Traits.Features.StringIndentation)]
+        [InlineData("")]
+        [InlineData("u8")]
+        public async Task TestCase1(string suffix)
         {
-            await TestAsync(@"class C
-{
+            await TestAsync($@"class C
+{{
     void M()
-    {
+    {{
         var v = """"""
                |goo
-                """""";
-    }
-}");
+                """"""{suffix};
+    }}
+}}");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]
-        public async Task TestCase2()
+        [Theory, Trait(Traits.Feature, Traits.Features.StringIndentation)]
+        [InlineData("")]
+        [InlineData("u8")]
+        public async Task TestCase2(string suffix)
         {
-            await TestAsync(@"class C
-{
+            await TestAsync($@"class C
+{{
     void M()
-    {
+    {{
         var v = """"""
                |goo
                |bar
-                """""";
-    }
-}");
+                """"""{suffix};
+    }}
+}}");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]
-        public async Task TestCase3()
+        [Theory, Trait(Traits.Feature, Traits.Features.StringIndentation)]
+        [InlineData("")]
+        [InlineData("u8")]
+        public async Task TestCase3(string suffix)
         {
-            await TestAsync(@"class C
-{
+            await TestAsync($@"class C
+{{
     void M()
-    {
+    {{
         var v = """"""
                |goo
                |bar
                |baz
-                """""";
-    }
-}");
+                """"""{suffix};
+    }}
+}}");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]
-        public async Task TestCase4()
+        [Theory, Trait(Traits.Feature, Traits.Features.StringIndentation)]
+        [InlineData("")]
+        [InlineData("u8")]
+        public async Task TestCase4(string suffix)
         {
-            await TestAsync(@"class C
-{
+            await TestAsync($@"class C
+{{
     void M()
-    {
+    {{
         var v = """"""
                |goo
                |
                |baz
-                """""";
-    }
-}");
+                """"""{suffix};
+    }}
+}}");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]
-        public async Task TestCase5()
+        [Theory, Trait(Traits.Feature, Traits.Features.StringIndentation)]
+        [InlineData("")]
+        [InlineData("u8")]
+        public async Task TestCase5(string suffix)
         {
-            await TestAsync(@"class C
-{
+            await TestAsync($@"class C
+{{
     void M()
-    {
+    {{
         var v = """"""
            |    goo
            |
            |    baz
-            """""";
-    }
-}");
+            """"""{suffix};
+    }}
+}}");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]
-        public async Task TestCase6()
+        [Theory, Trait(Traits.Feature, Traits.Features.StringIndentation)]
+        [InlineData("")]
+        [InlineData("u8")]
+        public async Task TestCase6(string suffix)
         {
-            await TestAsync(@"class C
-{
+            await TestAsync($@"class C
+{{
     void M()
-    {
+    {{
         var v =
             $""""""
            |goo
-            """""";
-    }
-}");
+            """"""{suffix};
+    }}
+}}");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]
-        public async Task TestCase7()
+        [Theory, Trait(Traits.Feature, Traits.Features.StringIndentation)]
+        [InlineData("")]
+        [InlineData("u8")]
+        public async Task TestCase7(string suffix)
         {
-            await TestAsync(@"class C
-{
+            await TestAsync($@"class C
+{{
     void M()
-    {
+    {{
         var v =
             $""""""
             |goo
-             """""";
-    }
-}");
+             """"""{suffix};
+    }}
+}}");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]
-        public async Task TestCase8()
+        [Theory, Trait(Traits.Feature, Traits.Features.StringIndentation)]
+        [InlineData("")]
+        [InlineData("u8")]
+        public async Task TestCase8(string suffix)
         {
-            await TestAsync(@"class C
-{
+            await TestAsync($@"class C
+{{
     void M()
-    {
+    {{
         var v =
             $""""""""
             |goo
-             """""""";
-    }
-}");
+             """"""""{suffix};
+    }}
+}}");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]
-        public async Task TestCase9()
+        [Theory, Trait(Traits.Feature, Traits.Features.StringIndentation)]
+        [InlineData("")]
+        [InlineData("u8")]
+        public async Task TestCase9(string suffix)
         {
-            await TestAsync(@"class C
-{
+            await TestAsync($@"class C
+{{
     void M()
-    {
+    {{
         var v =
              """"""""
             |goo
-             """""""";
-    }
-}");
+             """"""""{suffix};
+    }}
+}}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.StringIndentation)]

--- a/src/Features/CSharp/Portable/StringIndentation/CSharpStringIndentationService.cs
+++ b/src/Features/CSharp/Portable/StringIndentation/CSharpStringIndentationService.cs
@@ -82,7 +82,8 @@ namespace Microsoft.CodeAnalysis.CSharp.LineSeparators
                         // Break out of the 'for' loop, which effectively continues the containing 'while' loop
                         break;
                     }
-                    else if (child.IsKind(SyntaxKind.MultiLineRawStringLiteralToken))
+                    else if (child.IsKind(SyntaxKind.MultiLineRawStringLiteralToken) ||
+                             child.IsKind(SyntaxKind.Utf8MultiLineRawStringLiteralToken))
                     {
                         ProcessMultiLineRawStringLiteralToken(text, child.AsToken(), result, cancellationToken);
                     }


### PR DESCRIPTION
Closes #63428

This PR enables showing column guides for UTF8 raw multiline string literals as well.

cc. @CyrusNajmabadi @Youssef1313 