### PR TITLE
Support RefSafetyRulesAttribute for interop with existing assemblies

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1458,7 +1458,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(AllParametersConsideredInEscapeAnalysisHaveArguments(argsOpt, parameters, argsToParamsOpt));
 #endif
 
-            if (UseUpdatedEscapeRules)
+            if (UseUpdatedEscapeRulesForInvocation(symbol))
             {
                 return GetInvocationEscapeWithUpdatedRules(symbol, receiver, parameters, argsOpt, argRefKindsOpt, argsToParamsOpt, scopeOfTheContainingExpression, isRefEscape);
             }
@@ -1606,7 +1606,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(AllParametersConsideredInEscapeAnalysisHaveArguments(argsOpt, parameters, argsToParamsOpt));
 #endif
 
-            if (UseUpdatedEscapeRules)
+            if (UseUpdatedEscapeRulesForInvocation(symbol))
             {
                 return CheckInvocationEscapeWithUpdatedRules(syntax, symbol, receiver, parameters, argsOpt, argRefKindsOpt, argsToParamsOpt, checkingReceiver, escapeFrom, escapeTo, diagnostics, isRefEscape);
             }
@@ -1789,7 +1789,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     return (null, receiver, RefKind.None);
                 }
-                var containingType = symbol.ContainingType;
                 var method = symbol switch
                 {
                     MethodSymbol m => m,
@@ -1951,6 +1950,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             Error(diagnostics, errorCode, syntax, symbol, parameterName);
         }
 
+        private bool UseUpdatedEscapeRulesForInvocation(Symbol symbol)
+        {
+            var method = symbol switch
+            {
+                MethodSymbol m => m,
+                PropertySymbol p => p.GetMethod ?? p.SetMethod,
+                _ => throw ExceptionUtilities.UnexpectedValue(symbol)
+            };
+            return method?.UseUpdatedEscapeRules == true;
+        }
+
         /// <summary>
         /// Validates whether the invocation is valid per no-mixing rules.
         /// Returns <see langword="false"/> when it is not valid and produces diagnostics (possibly more than one recursively) that helps to figure the reason.
@@ -1966,7 +1976,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             uint scopeOfTheContainingExpression,
             BindingDiagnosticBag diagnostics)
         {
-            if (UseUpdatedEscapeRules)
+            if (UseUpdatedEscapeRulesForInvocation(symbol))
             {
                 return CheckInvocationArgMixingWithUpdatedRules(syntax, symbol, receiverOpt, parameters, argsOpt, argRefKindsOpt, argsToParamsOpt, scopeOfTheContainingExpression, diagnostics);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -156,8 +156,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        internal bool UseUpdatedEscapeRules => Compilation.IsFeatureEnabled(MessageID.IDS_FeatureRefFields) ||
-            Compilation.Assembly.RuntimeSupportsByRefFields;
+        internal bool UseUpdatedEscapeRules => Compilation.SourceModule.UseUpdatedEscapeRules;
 
         /// <summary>
         /// Some nodes have special binders for their contents (like Blocks)

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -618,7 +618,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var refKind = RefKind(i);
                 var scope = Scope(i);
                 var type = ParameterTypeWithAnnotations(i);
-                if (scope == DeclarationScope.Unscoped && ParameterHelpers.IsRefScopedByDefault(refKind, type))
+                if (scope == DeclarationScope.Unscoped &&
+                    ParameterHelpers.IsRefScopedByDefault(Binder.UseUpdatedEscapeRules, refKind, type))
                 {
                     scope = DeclarationScope.RefScoped;
                 }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
@@ -41,6 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         private SynthesizedEmbeddedNullablePublicOnlyAttributeSymbol _lazyNullablePublicOnlyAttribute;
         private SynthesizedEmbeddedNativeIntegerAttributeSymbol _lazyNativeIntegerAttribute;
         private SynthesizedEmbeddedScopedRefAttributeSymbol _lazyScopedRefAttribute;
+        private SynthesizedEmbeddedRefSafetyRulesAttributeSymbol _lazyRefSafetyRulesAttribute;
 
         /// <summary>
         /// The behavior of the C# command-line compiler is as follows:
@@ -100,6 +101,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             builder.AddIfNotNull(_lazyNullablePublicOnlyAttribute);
             builder.AddIfNotNull(_lazyNativeIntegerAttribute);
             builder.AddIfNotNull(_lazyScopedRefAttribute);
+            builder.AddIfNotNull(_lazyRefSafetyRulesAttribute);
 
             return builder.ToImmutableAndFree();
         }
@@ -264,6 +266,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return base.SynthesizeScopedRefAttribute(member);
         }
 
+        internal override SynthesizedAttributeData SynthesizeRefSafetyRulesAttribute(ImmutableArray<TypedConstant> arguments)
+        {
+            if ((object)_lazyRefSafetyRulesAttribute != null)
+            {
+                return new SynthesizedAttributeData(
+                    _lazyRefSafetyRulesAttribute.Constructors[0],
+                    arguments,
+                    ImmutableArray<KeyValuePair<string, TypedConstant>>.Empty);
+            }
+
+            return base.SynthesizeRefSafetyRulesAttribute(arguments);
+        }
+
         protected override SynthesizedAttributeData TrySynthesizeIsReadOnlyAttribute()
         {
             if ((object)_lazyIsReadOnlyAttribute != null)
@@ -312,7 +327,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             {
                 needsAttributes |= EmbeddableAttributes.NullablePublicOnlyAttribute;
             }
-            else if (needsAttributes == 0)
+
+            if (((SourceModuleSymbol)Compilation.SourceModule).RequiresRefSafetyRulesAttribute() &&
+                Compilation.CheckIfAttributeShouldBeEmbedded(EmbeddableAttributes.RefSafetyRulesAttribute, diagnostics, Location.None))
+            {
+                needsAttributes |= EmbeddableAttributes.RefSafetyRulesAttribute;
+            }
+
+            if (needsAttributes == 0)
             {
                 return;
             }
@@ -397,6 +419,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     AttributeDescription.ScopedRefAttribute,
                     CreateScopedRefAttributeSymbol);
             }
+
+            if ((needsAttributes & EmbeddableAttributes.RefSafetyRulesAttribute) != 0)
+            {
+                CreateAttributeIfNeeded(
+                    ref _lazyRefSafetyRulesAttribute,
+                    diagnostics,
+                    AttributeDescription.RefSafetyRulesAttribute,
+                    CreateRefSafetyRulesAttributeSymbol);
+            }
         }
 
         private SynthesizedEmbeddedAttributeSymbol CreateParameterlessEmbeddedAttributeSymbol(string name, NamespaceSymbol containingNamespace, BindingDiagnosticBag diagnostics)
@@ -444,6 +475,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     containingNamespace,
                     SourceModule,
                     GetWellKnownType(WellKnownType.System_Attribute, diagnostics));
+
+        private SynthesizedEmbeddedRefSafetyRulesAttributeSymbol CreateRefSafetyRulesAttributeSymbol(string name, NamespaceSymbol containingNamespace, BindingDiagnosticBag diagnostics)
+            => new SynthesizedEmbeddedRefSafetyRulesAttributeSymbol(
+                    name,
+                    containingNamespace,
+                    SourceModule,
+                    GetWellKnownType(WellKnownType.System_Attribute, diagnostics),
+                    GetSpecialType(SpecialType.System_Int32, diagnostics));
 
         private void CreateAttributeIfNeeded<T>(
             ref T symbol,

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -1732,6 +1732,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return Compilation.TrySynthesizeAttribute(member, isOptionalUse: true);
         }
 
+        internal virtual SynthesizedAttributeData SynthesizeRefSafetyRulesAttribute(ImmutableArray<TypedConstant> arguments)
+        {
+            // For modules, this attribute should be present. Only assemblies generate and embed this type.
+            // https://github.com/dotnet/roslyn/issues/30062 Should not be optional.
+            return Compilation.TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_RefSafetyRulesAttribute__ctor, arguments, isOptionalUse: true);
+        }
+
         internal bool ShouldEmitNullablePublicOnlyAttribute()
         {
             // No need to look at this.GetNeedsGeneratedAttributes() since those bits are

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -188,10 +188,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // If all parameter types and return type are valid type arguments, construct
             // the delegate type from a generic template. Otherwise, use a non-generic template.
-            if (allValidTypeArguments(typeDescr))
+            bool useUpdatedEscapeRules = Compilation.SourceModule.UseUpdatedEscapeRules;
+            if (allValidTypeArguments(useUpdatedEscapeRules, typeDescr))
             {
                 var fields = typeDescr.Fields;
-                Debug.Assert(fields.All(f => hasDefaultScope(f)));
+                Debug.Assert(fields.All(f => hasDefaultScope(useUpdatedEscapeRules, f)));
 
                 bool returnsVoid = fields.Last().Type.IsVoidType();
                 int nTypeArguments = fields.Length - (returnsVoid ? 1 : 0);
@@ -243,24 +244,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     template.Construct(typeParameters);
             }
 
-            static bool allValidTypeArguments(AnonymousTypeDescriptor typeDescr)
+            static bool allValidTypeArguments(bool useUpdatedEscapeRules, AnonymousTypeDescriptor typeDescr)
             {
                 var fields = typeDescr.Fields;
                 int n = fields.Length;
                 for (int i = 0; i < n - 1; i++)
                 {
-                    if (!isValidTypeArgument(fields[i]))
+                    if (!isValidTypeArgument(useUpdatedEscapeRules, fields[i]))
                     {
                         return false;
                     }
                 }
                 var returnParameter = fields[n - 1];
-                return returnParameter.Type.IsVoidType() || isValidTypeArgument(returnParameter);
+                return returnParameter.Type.IsVoidType() || isValidTypeArgument(useUpdatedEscapeRules, returnParameter);
             }
 
-            static bool hasDefaultScope(AnonymousTypeField field)
+            static bool hasDefaultScope(bool useUpdatedEscapeRules, AnonymousTypeField field)
             {
-                return (field.Scope, ParameterHelpers.IsRefScopedByDefault(field.RefKind, field.TypeWithAnnotations)) switch
+                return (field.Scope, ParameterHelpers.IsRefScopedByDefault(useUpdatedEscapeRules, field.RefKind, field.TypeWithAnnotations)) switch
                 {
                     (DeclarationScope.Unscoped, false) => true,
                     (DeclarationScope.RefScoped, true) => true,
@@ -268,9 +269,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 };
             }
 
-            static bool isValidTypeArgument(AnonymousTypeField field)
+            static bool isValidTypeArgument(bool useUpdatedEscapeRules, AnonymousTypeField field)
             {
-                return hasDefaultScope(field) &&
+                return hasDefaultScope(useUpdatedEscapeRules, field) &&
                     field.Type is { } type &&
                     !type.IsPointerOrFunctionPointer() &&
                     !type.IsRestrictedType();

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -613,6 +613,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                         WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute,
                         WellKnownMember.System_Runtime_CompilerServices_ScopedRefAttribute__ctor);
 
+                case EmbeddableAttributes.RefSafetyRulesAttribute:
+                    return CheckIfAttributeShouldBeEmbedded(
+                        diagnosticsOpt,
+                        locationOpt,
+                        WellKnownType.System_Runtime_CompilerServices_RefSafetyRulesAttribute,
+                        WellKnownMember.System_Runtime_CompilerServices_RefSafetyRulesAttribute__ctor);
+
                 default:
                     throw ExceptionUtilities.UnexpectedValue(attribute);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/EmbeddableAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EmbeddableAttributes.cs
@@ -17,5 +17,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         NullablePublicOnlyAttribute = 0x20,
         NativeIntegerAttribute = 0x40,
         ScopedRefAttribute = 0x80,
+        RefSafetyRulesAttribute = 0x100,
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorMethodSymbol.cs
@@ -286,5 +286,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal sealed override bool HasUnscopedRefAttribute => false;
+
+        internal sealed override bool UseUpdatedEscapeRules => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
@@ -102,7 +102,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 syntax,
                 typeBinder,
                 diagnostics,
-                suppressUseSiteDiagnostics);
+                suppressUseSiteDiagnostics,
+                useUpdatedEscapeRules: typeBinder.UseUpdatedEscapeRules);
 
             static CallingConvention getCallingConvention(CSharpCompilation compilation, FunctionPointerCallingConventionSyntax? callingConventionSyntax, ArrayBuilder<CustomModifier> customModifiers, BindingDiagnosticBag diagnostics)
             {
@@ -323,8 +324,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return CSharpCustomModifier.CreateRequired(attributeType);
         }
 
-        public static FunctionPointerMethodSymbol CreateFromMetadata(CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> retAndParamTypes)
-            => new FunctionPointerMethodSymbol(callingConvention, retAndParamTypes);
+        public static FunctionPointerMethodSymbol CreateFromMetadata(ModuleSymbol containingModule, CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> retAndParamTypes)
+            => new FunctionPointerMethodSymbol(callingConvention, retAndParamTypes, useUpdatedEscapeRules: containingModule.UseUpdatedEscapeRules);
 
         public FunctionPointerMethodSymbol SubstituteParameterSymbols(
             TypeWithAnnotations substitutedReturnType,
@@ -338,7 +339,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 refCustomModifiers.IsDefault ? this.RefCustomModifiers : refCustomModifiers,
                 this.Parameters,
                 substitutedParameterTypes,
-                paramRefCustomModifiers);
+                paramRefCustomModifiers,
+                this.UseUpdatedEscapeRules);
 
         internal FunctionPointerMethodSymbol MergeEquivalentTypes(FunctionPointerMethodSymbol signature, VarianceKind variance)
         {
@@ -440,7 +442,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<CustomModifier> refCustomModifiers,
             ImmutableArray<ParameterSymbol> originalParameters,
             ImmutableArray<TypeWithAnnotations> substitutedParameterTypes,
-            ImmutableArray<ImmutableArray<CustomModifier>> substitutedRefCustomModifiers)
+            ImmutableArray<ImmutableArray<CustomModifier>> substitutedRefCustomModifiers,
+            bool useUpdatedEscapeRules)
         {
             Debug.Assert(originalParameters.Length == substitutedParameterTypes.Length);
             Debug.Assert(substitutedRefCustomModifiers.IsDefault || originalParameters.Length == substitutedRefCustomModifiers.Length);
@@ -448,6 +451,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             CallingConvention = callingConvention;
             RefKind = refKind;
             ReturnTypeWithAnnotations = returnType;
+            UseUpdatedEscapeRules = useUpdatedEscapeRules;
 
             if (originalParameters.Length > 0)
             {
@@ -493,6 +497,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             RefKind = refKind;
             CallingConvention = callingConvention;
             ReturnTypeWithAnnotations = returnTypeWithAnnotations;
+            UseUpdatedEscapeRules = compilation.SourceModule.UseUpdatedEscapeRules;
+
             _parameters = parameterTypes.ZipAsArray(parameterRefKinds, (Method: this, Comp: compilation, ParamRefCustomModifiers: parameterRefCustomModifiers),
                 (type, refKind, i, arg) =>
                 {
@@ -513,13 +519,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             FunctionPointerTypeSyntax syntax,
             Binder typeBinder,
             BindingDiagnosticBag diagnostics,
-            bool suppressUseSiteDiagnostics)
+            bool suppressUseSiteDiagnostics,
+            bool useUpdatedEscapeRules)
         {
             RefCustomModifiers = refCustomModifiers;
             CallingConvention = callingConvention;
             RefKind = refKind;
             ReturnTypeWithAnnotations = returnType;
-
+            UseUpdatedEscapeRules = useUpdatedEscapeRules;
             _parameters = syntax.ParameterList.Parameters.Count > 1
                 ? ParameterHelpers.MakeFunctionPointerParameters(
                     typeBinder,
@@ -530,7 +537,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 : ImmutableArray<FunctionPointerParameterSymbol>.Empty;
         }
 
-        private FunctionPointerMethodSymbol(CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> retAndParamTypes)
+        private FunctionPointerMethodSymbol(CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> retAndParamTypes, bool useUpdatedEscapeRules)
         {
             Debug.Assert(retAndParamTypes.Length > 0);
 
@@ -542,6 +549,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ReturnTypeWithAnnotations = returnType;
             RefKind = getRefKind(retInfo, RefCustomModifiers, RefKind.RefReadOnly, RefKind.Ref);
             Debug.Assert(RefKind != RefKind.Out);
+            UseUpdatedEscapeRules = useUpdatedEscapeRules;
             _parameters = makeParametersFromMetadata(retAndParamTypes.AsSpan()[1..], this);
 
             static ImmutableArray<FunctionPointerParameterSymbol> makeParametersFromMetadata(ReadOnlySpan<ParamInfo<TypeSymbol>> parameterTypes, FunctionPointerMethodSymbol parent)
@@ -832,5 +840,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsNullableAnalysisEnabled() => throw ExceptionUtilities.Unreachable;
         protected sealed override bool HasSetsRequiredMembersImpl => throw ExceptionUtilities.Unreachable;
         internal sealed override bool HasUnscopedRefAttribute => false;
+        internal override bool UseUpdatedEscapeRules { get; }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
@@ -757,6 +757,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             => Hash.Combine(ReturnType, Hash.Combine(CallingConvention.GetHashCode(), FunctionPointerTypeSymbol.GetRefKindForHashCode(RefKind).GetHashCode()));
 
         internal override CallingConvention CallingConvention { get; }
+        internal override bool UseUpdatedEscapeRules { get; }
+
         public override bool ReturnsVoid => ReturnTypeWithAnnotations.IsVoidType();
         public override RefKind RefKind { get; }
         public override TypeWithAnnotations ReturnTypeWithAnnotations { get; }
@@ -840,6 +842,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override bool IsNullableAnalysisEnabled() => throw ExceptionUtilities.Unreachable;
         protected sealed override bool HasSetsRequiredMembersImpl => throw ExceptionUtilities.Unreachable;
         internal sealed override bool HasUnscopedRefAttribute => false;
-        internal override bool UseUpdatedEscapeRules { get; }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerParameterSymbol.cs
@@ -33,6 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override DeclarationScope DeclaredScope
             => ParameterHelpers.IsRefScopedByDefault(this) ? DeclarationScope.RefScoped : DeclarationScope.Unscoped;
         internal override DeclarationScope EffectiveScope => DeclaredScope;
+        internal override bool UseUpdatedEscapeRules => _containingSymbol.UseUpdatedEscapeRules;
 
         public override bool Equals(Symbol other, TypeCompareKind compareKind)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerTypeSymbol.cs
@@ -52,9 +52,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             CSharpCompilation compilation)
             => new FunctionPointerTypeSymbol(FunctionPointerMethodSymbol.CreateFromParts(callingConvention, callingConventionModifiers, returnType, returnRefKind, parameterTypes, parameterRefKinds, compilation));
 
-        public static FunctionPointerTypeSymbol CreateFromMetadata(Cci.CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> retAndParamTypes)
+        public static FunctionPointerTypeSymbol CreateFromMetadata(ModuleSymbol containingModule, Cci.CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> retAndParamTypes)
             => new FunctionPointerTypeSymbol(
-                FunctionPointerMethodSymbol.CreateFromMetadata(callingConvention, retAndParamTypes));
+                FunctionPointerMethodSymbol.CreateFromMetadata(containingModule, callingConvention, retAndParamTypes));
 
         public FunctionPointerTypeSymbol SubstituteTypeSymbol(
             TypeWithAnnotations substitutedReturnType,

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -1639,5 +1639,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return _packedFlags.IsUnscopedRef;
             }
         }
+
+        internal sealed override bool UseUpdatedEscapeRules => ContainingModule.UseUpdatedEscapeRules;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -796,7 +796,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         private bool CalculateUseUpdatedRules()
         {
             // [RefSafetyRules(version)], regardless of version.
-            if (_module.HasRefSafetyRulesAttribute(Token, out int _))
+            if (_module.HasRefSafetyRulesAttribute(Token, out _))
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -819,7 +819,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             {
                 identity = module.ReadAssemblyIdentityOrThrow();
             }
-            catch (Exception)
+            catch (BadImageFormatException)
             {
                 identity = null;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -795,8 +795,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         private bool CalculateUseUpdatedRules()
         {
-            // [RefSafetyRules(11)]
-            if (_module.HasRefSafetyRulesAttribute(Token, out int rulesVersion) && rulesVersion == 11)
+            // [RefSafetyRules(version)], regardless of version.
+            if (_module.HasRefSafetyRulesAttribute(Token, out int _))
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -102,6 +102,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         private NullableMemberMetadata _lazyNullableMemberMetadata;
 
+        private ThreeState _lazyUseUpdatedEscapeRules;
+
 #nullable enable
         private DiagnosticInfo? _lazyCachedCompilerFeatureRequiredDiagnosticInfo = CSDiagnosticInfo.EmptyErrorInfo;
 #nullable disable
@@ -429,7 +431,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         /// <param name="token"></param>
         /// <param name="foundExtension">True if we found an extension method, false otherwise.</param>
         /// <returns>The attributes on the token, minus any ExtensionAttributes.</returns>
-        internal ImmutableArray<CSharpAttributeData> GetCustomAttributesFilterCompilerAttributes(EntityHandle token, out bool foundExtension, out bool foundReadOnly)
+        private ImmutableArray<CSharpAttributeData> GetCustomAttributesFilterCompilerAttributes(EntityHandle token, out bool foundExtension, out bool foundReadOnly)
         {
             var result = GetCustomAttributesForToken(
                 token,
@@ -777,5 +779,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         public override bool HasUnsupportedMetadata
             => GetCompilerFeatureRequiredDiagnostic()?.Code == (int)ErrorCode.ERR_UnsupportedCompilerFeature || base.HasUnsupportedMetadata;
+
+        internal override bool UseUpdatedEscapeRules
+        {
+            get
+            {
+                if (_lazyUseUpdatedEscapeRules == ThreeState.Unknown)
+                {
+                    bool value = _module.HasRefSafetyRulesAttribute(Token, out int version) && version == 11;
+                    _lazyUseUpdatedEscapeRules = value.ToThreeState();
+                }
+                return _lazyUseUpdatedEscapeRules == ThreeState.True;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -317,7 +317,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         isBad = true;
                     }
                 }
-                else if (ParameterHelpers.IsRefScopedByDefault(refKind, typeWithAnnotations))
+                else if (ParameterHelpers.IsRefScopedByDefault(_moduleSymbol.UseUpdatedEscapeRules, refKind, typeWithAnnotations))
                 {
                     scope = DeclarationScope.RefScoped;
                 }
@@ -996,6 +996,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         internal sealed override DeclarationScope DeclaredScope => _packedFlags.Scope;
 
         internal sealed override DeclarationScope EffectiveScope => DeclaredScope;
+
+        internal sealed override bool UseUpdatedEscapeRules => _moduleSymbol.UseUpdatedEscapeRules;
 
         public override ImmutableArray<CSharpAttributeData> GetAttributes()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/SymbolFactory.cs
@@ -46,9 +46,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return new PointerTypeSymbol(CreateType(type, customModifiers));
         }
 
-        internal override TypeSymbol MakeFunctionPointerTypeSymbol(Cci.CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> retAndParamTypes)
+        internal override TypeSymbol MakeFunctionPointerTypeSymbol(PEModuleSymbol moduleSymbol, Cci.CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> retAndParamTypes)
         {
-            return FunctionPointerTypeSymbol.CreateFromMetadata(callingConvention, retAndParamTypes);
+            return FunctionPointerTypeSymbol.CreateFromMetadata(moduleSymbol, callingConvention, retAndParamTypes);
         }
 
         internal override TypeSymbol GetEnumUnderlyingType(PEModuleSymbol moduleSymbol, TypeSymbol type)

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -588,6 +588,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract bool HasUnscopedRefAttribute { get; }
 
+        internal abstract bool UseUpdatedEscapeRules { get; }
+
         /// <summary>
         /// Some method kinds do not participate in overriding/hiding (e.g. constructors).
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
@@ -7,13 +7,13 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
-using System.Diagnostics;
-using System.Reflection.PortableExecutable;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -194,6 +194,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get { throw ExceptionUtilities.Unreachable; }
         }
+
+        internal sealed override bool UseUpdatedEscapeRules => false;
     }
 
     internal sealed class MissingModuleSymbolWithName : MissingModuleSymbol

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -325,6 +325,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal abstract bool HasAssemblyRuntimeCompatibilityAttribute { get; }
 
+        internal abstract bool UseUpdatedEscapeRules { get; }
+
         /// <summary>
         /// Default char set for contained types, or null if not specified.
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -426,6 +426,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal abstract DeclarationScope EffectiveScope { get; }
 
+        internal abstract bool UseUpdatedEscapeRules { get; }
+
         protected sealed override bool IsHighestPriorityUseSiteErrorCode(int code) => code is (int)ErrorCode.ERR_UnsupportedCompilerFeature or (int)ErrorCode.ERR_BogusType;
 
         public override bool HasUnsupportedMetadata

--- a/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ReducedExtensionMethodSymbol.cs
@@ -592,6 +592,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override bool HasUnscopedRefAttribute => false;
 
+        internal sealed override bool UseUpdatedEscapeRules => _reducedFrom.UseUpdatedEscapeRules;
+
 #nullable enable
 
         private sealed class ReducedExtensionMethodParameterSymbol : WrappedParameterSymbol

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
@@ -312,5 +312,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                 throw ExceptionUtilities.Unreachable;
             }
         }
+
+        internal override bool UseUpdatedEscapeRules => _underlyingModule.UseUpdatedEscapeRules;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyMethodSymbol.cs
@@ -176,6 +176,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override bool HasUnscopedRefAttribute => false;
 
+        internal sealed override bool UseUpdatedEscapeRules => false;
+
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyParameterSymbol.cs
@@ -52,6 +52,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             => ParameterHelpers.IsRefScopedByDefault(this) ? DeclarationScope.RefScoped : DeclarationScope.Unscoped;
         internal override DeclarationScope EffectiveScope => DeclaredScope;
 
+        internal override bool UseUpdatedEscapeRules => false;
+
         #region Not used by MethodSignatureComparer
 
         internal override bool IsMetadataIn { get { throw ExceptionUtilities.Unreachable; } }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -320,11 +320,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal static bool IsRefScopedByDefault(ParameterSymbol parameter)
         {
-            return IsRefScopedByDefault(parameter.RefKind, parameter.TypeWithAnnotations);
+            return IsRefScopedByDefault(parameter.UseUpdatedEscapeRules, parameter.RefKind, parameter.TypeWithAnnotations);
         }
 
-        internal static bool IsRefScopedByDefault(RefKind refKind, TypeWithAnnotations parameterType)
+        internal static bool IsRefScopedByDefault(bool useUpdatedEscapeRules, RefKind refKind, TypeWithAnnotations parameterType)
         {
+            if (!useUpdatedEscapeRules)
+            {
+                return false;
+            }
+
             switch (refKind)
             {
                 case RefKind.Out:

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceClonedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceClonedParameterSymbol.cs
@@ -61,6 +61,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override DeclarationScope DeclaredScope => _originalParam.DeclaredScope;
         internal sealed override DeclarationScope EffectiveScope => _originalParam.EffectiveScope;
 
+        internal sealed override bool UseUpdatedEscapeRules => _originalParam.UseUpdatedEscapeRules;
+
         internal override ConstantValue ExplicitDefaultConstantValue
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -1168,10 +1168,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         overridingMethod,
                         diagnostics,
                         static (diagnostics, _, _, overridingParameter, _, location) =>
-                            diagnostics.Add(
-                                ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation,
-                                location,
-                                new FormattedSymbol(overridingParameter, SymbolDisplayFormat.ShortFormat)),
+                            {
+                                // https://github.com/dotnet/roslyn/issues/62340: Avoid reporting errors for
+                                // overrides or interface implementations until variance is supported.
+                                //diagnostics.Add(
+                                //    ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation,
+                                //    location,
+                                //    new FormattedSymbol(overridingParameter, SymbolDisplayFormat.ShortFormat));
+                            },
                         overridingMemberLocation);
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbol.cs
@@ -81,5 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         protected override bool HasSetsRequiredMembersImpl => throw ExceptionUtilities.Unreachable;
+
+        internal sealed override bool UseUpdatedEscapeRules => ContainingModule.UseUpdatedEscapeRules;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -9,6 +9,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -44,6 +45,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private NamespaceSymbol _globalNamespace;
 
         private bool _hasBadAttributes;
+
+        private ThreeState _lazyUseUpdatedEscapeRules;
+        private ThreeState _lazyRequiresRefSafetyRulesAttribute;
 
         internal SourceModuleSymbol(
             SourceAssemblySymbol assemblySymbol,
@@ -520,12 +524,94 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
             else if (ReportExplicitUseOfReservedAttributes(in arguments,
-                ReservedAttributes.NullableContextAttribute | ReservedAttributes.NullablePublicOnlyAttribute))
+                ReservedAttributes.NullableContextAttribute | ReservedAttributes.NullablePublicOnlyAttribute | ReservedAttributes.RefSafetyRulesAttribute))
             {
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SkipLocalsInitAttribute))
             {
                 CSharpAttributeData.DecodeSkipLocalsInitAttribute<ModuleWellKnownAttributeData>(DeclaringCompilation, ref arguments);
+            }
+        }
+
+#nullable enable
+
+        internal bool RequiresRefSafetyRulesAttribute()
+        {
+            if (_lazyRequiresRefSafetyRulesAttribute == ThreeState.Unknown)
+            {
+                bool value = UseUpdatedEscapeRules &&
+                    !_assemblySymbol.DeclaringCompilation.Options.OutputKind.IsApplication() && // No need to emit attribute for .exe
+                    namespaceIncludesRefs(GlobalNamespace);
+                _lazyRequiresRefSafetyRulesAttribute = value.ToThreeState();
+            }
+            return _lazyRequiresRefSafetyRulesAttribute.Value();
+
+            static bool namespaceIncludesRefs(NamespaceSymbol ns)
+            {
+                foreach (var member in ns.GetMembersUnordered())
+                {
+                    switch (member.Kind)
+                    {
+                        case SymbolKind.Namespace:
+                            if (namespaceIncludesRefs((NamespaceSymbol)member))
+                            {
+                                return true;
+                            }
+                            break;
+                        case SymbolKind.NamedType:
+                            if (typeIncludesRefs((NamedTypeSymbol)member))
+                            {
+                                return true;
+                            }
+                            break;
+                        default:
+                            throw ExceptionUtilities.UnexpectedValue(member.Kind);
+                    }
+                }
+                return false;
+            }
+
+            static bool typeIncludesRefs(NamedTypeSymbol type)
+            {
+                if (type.IsRefLikeType)
+                {
+                    return true;
+                }
+                foreach (var member in type.GetMembersUnordered())
+                {
+                    switch (member.Kind)
+                    {
+                        case SymbolKind.NamedType:
+                            if (typeIncludesRefs((NamedTypeSymbol)member))
+                            {
+                                return true;
+                            }
+                            break;
+                        case SymbolKind.Method:
+                            if (methodIncludesRefs((MethodSymbol)member))
+                            {
+                                return true;
+                            }
+                            break;
+                    }
+                }
+                return false;
+            }
+
+            static bool methodIncludesRefs(MethodSymbol method)
+            {
+                if (method.RefKind != RefKind.None ||
+                    method.ReturnType.IsRefLikeType)
+                {
+                    return true;
+                }
+                return method.Parameters.Any(p => parameterIncludesRef(p));
+            }
+
+            static bool parameterIncludesRef(ParameterSymbol parameter)
+            {
+                return parameter.RefKind != RefKind.None ||
+                    parameter.Type.IsRefLikeType;
             }
         }
 
@@ -542,6 +628,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     AddSynthesizedAttribute(ref attributes, compilation.TrySynthesizeAttribute(
                         WellKnownMember.System_Security_UnverifiableCodeAttribute__ctor));
                 }
+            }
+
+            if (RequiresRefSafetyRulesAttribute())
+            {
+                var version = ImmutableArray.Create(new TypedConstant(compilation.GetSpecialType(SpecialType.System_Int32), TypedConstantKind.Primitive, 11));
+                AddSynthesizedAttribute(ref attributes, moduleBuilder.SynthesizeRefSafetyRulesAttribute(version));
             }
 
             if (moduleBuilder.ShouldEmitNullablePublicOnlyAttribute())
@@ -588,6 +680,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override ModuleMetadata GetMetadata() => null;
+        public override ModuleMetadata? GetMetadata() => null;
+
+        internal override bool UseUpdatedEscapeRules
+        {
+            get
+            {
+                if (_lazyUseUpdatedEscapeRules == ThreeState.Unknown)
+                {
+                    var compilation = _assemblySymbol.DeclaringCompilation;
+                    bool value = compilation.IsFeatureEnabled(MessageID.IDS_FeatureRefFields) || _assemblySymbol.RuntimeSupportsByRefFields;
+                    _lazyUseUpdatedEscapeRules = value.ToThreeState();
+                }
+                return _lazyUseUpdatedEscapeRules == ThreeState.True;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceModuleSymbol.cs
@@ -539,9 +539,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (_lazyRequiresRefSafetyRulesAttribute == ThreeState.Unknown)
             {
-                bool value = UseUpdatedEscapeRules &&
-                    !_assemblySymbol.DeclaringCompilation.Options.OutputKind.IsApplication() && // No need to emit attribute for .exe
-                    namespaceIncludesRefs(GlobalNamespace);
+                bool value = UseUpdatedEscapeRules && namespaceIncludesRefs(GlobalNamespace);
                 _lazyRequiresRefSafetyRulesAttribute = value.ToThreeState();
             }
             return _lazyRequiresRefSafetyRulesAttribute.Value();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceParameterSymbol.cs
@@ -226,6 +226,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal abstract override DeclarationScope EffectiveScope { get; }
 
+        internal sealed override bool UseUpdatedEscapeRules => ContainingModule.UseUpdatedEscapeRules;
+
         public sealed override string Name
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
@@ -205,6 +205,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal sealed override bool UseUpdatedEscapeRules => _containingMethod?.UseUpdatedEscapeRules ?? false;
+        internal sealed override bool UseUpdatedEscapeRules
+            => _containingMethod?.UseUpdatedEscapeRules ?? _containingType.ContainingModule.UseUpdatedEscapeRules;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ThisParameterSymbol.cs
@@ -204,5 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
         }
+
+        internal sealed override bool UseUpdatedEscapeRules => _containingMethod?.UseUpdatedEscapeRules ?? false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol.cs
@@ -1379,6 +1379,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             CaseSensitiveExtensionAttribute = 1 << 10,
             RequiredMemberAttribute = 1 << 11,
             ScopedRefAttribute = 1 << 12,
+            RefSafetyRulesAttribute = 1 << 13,
         }
 
         internal bool ReportExplicitUseOfReservedAttributes(in DecodeWellKnownAttributeArguments<AttributeSyntax, CSharpAttributeData, AttributeLocation> arguments, ReservedAttributes reserved)
@@ -1444,6 +1445,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // Do not use 'System.Runtime.CompilerServices.ScopedRefAttribute'. Use the 'scoped' keyword instead.
                 diagnostics.Add(ErrorCode.ERR_ExplicitScopedRef, arguments.AttributeSyntaxOpt.Location);
+            }
+            else if ((reserved & ReservedAttributes.RefSafetyRulesAttribute) != 0 &&
+                reportExplicitUseOfReservedAttribute(attribute, arguments, AttributeDescription.RefSafetyRulesAttribute))
+            {
             }
             else
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedRefSafetyRulesAttributeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEmbeddedRefSafetyRulesAttributeSymbol.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal sealed class SynthesizedEmbeddedRefSafetyRulesAttributeSymbol : SynthesizedEmbeddedAttributeSymbolBase
+    {
+        private readonly ImmutableArray<FieldSymbol> _fields;
+        private readonly ImmutableArray<MethodSymbol> _constructors;
+
+        public SynthesizedEmbeddedRefSafetyRulesAttributeSymbol(
+            string name,
+            NamespaceSymbol containingNamespace,
+            ModuleSymbol containingModule,
+            NamedTypeSymbol systemAttributeType,
+            TypeSymbol int32Type)
+            : base(name, containingNamespace, containingModule, baseType: systemAttributeType)
+        {
+            _fields = ImmutableArray.Create<FieldSymbol>(
+                new SynthesizedFieldSymbol(
+                    this,
+                    int32Type,
+                    "Version",
+                    isPublic: true,
+                    isReadOnly: true,
+                    isStatic: false));
+
+            _constructors = ImmutableArray.Create<MethodSymbol>(
+                new SynthesizedEmbeddedAttributeConstructorWithBodySymbol(
+                    this,
+                    m => ImmutableArray.Create(SynthesizedParameterSymbol.Create(m, TypeWithAnnotations.Create(int32Type), 0, RefKind.None)),
+                    GenerateConstructorBody));
+        }
+
+        internal override IEnumerable<FieldSymbol> GetFieldsToEmit() => _fields;
+
+        public override ImmutableArray<MethodSymbol> Constructors => _constructors;
+
+        internal override AttributeUsageInfo GetAttributeUsageInfo()
+        {
+            return new AttributeUsageInfo(AttributeTargets.Module, allowMultiple: false, inherited: false);
+        }
+
+        private void GenerateConstructorBody(SyntheticBoundNodeFactory factory, ArrayBuilder<BoundStatement> statements, ImmutableArray<ParameterSymbol> parameters)
+        {
+            statements.Add(
+                factory.ExpressionStatement(
+                    factory.AssignmentExpression(
+                        factory.Field(factory.This(), _fields.Single()),
+                        factory.Parameter(parameters.Single()))));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -311,6 +311,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override bool HasUnscopedRefAttribute => false;
 
+        internal sealed override bool UseUpdatedEscapeRules => ContainingModule.UseUpdatedEscapeRules;
+
         /// <summary> A synthesized entrypoint that forwards all calls to an async Main Method </summary>
         internal sealed class AsyncForwardEntryPoint : SynthesizedEntryPointSymbol
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedGlobalMethodSymbol.cs
@@ -339,5 +339,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         protected sealed override bool HasSetsRequiredMembersImpl => throw ExceptionUtilities.Unreachable;
 
         internal sealed override bool HasUnscopedRefAttribute => false;
+
+        internal sealed override bool UseUpdatedEscapeRules => _containingModule.UseUpdatedEscapeRules;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceMethodSymbol.cs
@@ -80,5 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal override bool IsNullableAnalysisEnabled() => false;
 
         internal sealed override bool HasUnscopedRefAttribute => false;
+
+        internal sealed override bool UseUpdatedEscapeRules => ContainingModule.UseUpdatedEscapeRules;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
@@ -427,6 +427,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override bool HasUnscopedRefAttribute => false;
 
+        internal sealed override bool UseUpdatedEscapeRules => false;
+
         public override bool Equals(Symbol obj, TypeCompareKind compareKind)
         {
             if (obj == (object)this)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -191,6 +191,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override DeclarationScope DeclaredScope => _scope;
 
         internal sealed override DeclarationScope EffectiveScope => ParameterHelpers.CalculateEffectiveScopeIgnoringAttributes(this);
+
+        internal sealed override bool UseUpdatedEscapeRules => _container?.UseUpdatedEscapeRules ?? false;
     }
 
     internal sealed class SynthesizedParameterSymbol : SynthesizedParameterSymbolBase

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedStaticConstructor.cs
@@ -432,5 +432,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         protected sealed override bool HasSetsRequiredMembersImpl => throw ExceptionUtilities.Unreachable;
 
         internal sealed override bool HasUnscopedRefAttribute => false;
+
+        internal sealed override bool UseUpdatedEscapeRules => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -1850,10 +1850,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 implementingMethod,
                                 diagnostics,
                                 static (diagnostics, implementedMethod, implementingMethod, implementingParameter, _, arg) =>
-                                    diagnostics.Add(
-                                        ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation,
-                                        GetImplicitImplementationDiagnosticLocation(implementedMethod, arg.implementingType, implementingMethod),
-                                        new FormattedSymbol(implementingParameter, SymbolDisplayFormat.ShortFormat)),
+                                    {
+                                        // https://github.com/dotnet/roslyn/issues/62340: Avoid reporting errors for
+                                        // overrides or interface implementations until variance is supported.
+                                        //diagnostics.Add(
+                                        //    ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation,
+                                        //    GetImplicitImplementationDiagnosticLocation(implementedMethod, arg.implementingType, implementingMethod),
+                                        //    new FormattedSymbol(implementingParameter, SymbolDisplayFormat.ShortFormat));
+                                    },
                                 (implementingType, isExplicit));
                         }
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedMethodSymbol.cs
@@ -362,5 +362,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         protected sealed override bool HasSetsRequiredMembersImpl => UnderlyingMethod.HasSetsRequiredMembers;
 
         internal sealed override bool HasUnscopedRefAttribute => UnderlyingMethod.HasUnscopedRefAttribute;
+
+        internal sealed override bool UseUpdatedEscapeRules => UnderlyingMethod.UseUpdatedEscapeRules;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedParameterSymbol.cs
@@ -156,6 +156,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override DeclarationScope EffectiveScope => _underlyingParameter.EffectiveScope;
 
+        internal sealed override bool UseUpdatedEscapeRules => _underlyingParameter.UseUpdatedEscapeRules;
+
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -4725,6 +4725,14 @@ namespace System
     public class ValueType { }
     public class Enum { }
     public struct Void { }
+    public class Attribute { }
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets t) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public enum AttributeTargets { }
 }
 
 namespace System.Threading.Tasks
@@ -4780,15 +4788,15 @@ class C
             compilation.VerifyEmitDiagnostics(
                 // warning CS8021: No value for RuntimeMetadataVersion found. No assembly containing System.Object was found nor was a value for RuntimeMetadataVersion specified through options.
                 Diagnostic(ErrorCode.WRN_NoRuntimeMetadataVersion).WithLocation(1, 1),
-                // (62,37): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Create'
+                // (70,37): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Create'
                 //     async Task GetNumber(Task task) { await task; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await task; }").WithArguments("System.Runtime.CompilerServices.AsyncTaskMethodBuilder", "Create").WithLocation(62, 37),
-                // (62,37): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await task; }").WithArguments("System.Runtime.CompilerServices.AsyncTaskMethodBuilder", "Create").WithLocation(70, 37),
+                // (70,37): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext'
                 //     async Task GetNumber(Task task) { await task; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await task; }").WithArguments("System.Runtime.CompilerServices.IAsyncStateMachine", "MoveNext").WithLocation(62, 37),
-                // (62,37): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await task; }").WithArguments("System.Runtime.CompilerServices.IAsyncStateMachine", "MoveNext").WithLocation(70, 37),
+                // (70,37): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.IAsyncStateMachine.SetStateMachine'
                 //     async Task GetNumber(Task task) { await task; }
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await task; }").WithArguments("System.Runtime.CompilerServices.IAsyncStateMachine", "SetStateMachine").WithLocation(62, 37));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await task; }").WithArguments("System.Runtime.CompilerServices.IAsyncStateMachine", "SetStateMachine").WithLocation(70, 37));
         }
 
         [Fact, WorkItem(16531, "https://github.com/dotnet/roslyn/issues/16531")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenMscorlib.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenMscorlib.cs
@@ -391,7 +391,15 @@ public class C1
     public struct Int32 { }
     public struct Boolean { }
     public struct Decimal { }
-    public class Attribute{ }
+    public class Attribute { }
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets t) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public struct Enum { }
+    public enum AttributeTargets { }
     public class ObsoleteAttribute: Attribute
     {
         public ObsoleteAttribute(string message, bool error){}
@@ -978,6 +986,15 @@ namespace System
     public struct Char { }
     public struct Boolean { }
     public class Exception { }
+    public class Attribute { }
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets t) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public struct Enum { }
+    public enum AttributeTargets { }
 
     public class String 
     { 
@@ -1086,6 +1103,15 @@ namespace System
     public struct Char { }
     public struct Boolean { }
     public class Exception { }
+    public class Attribute { }
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets t) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public struct Enum { }
+    public enum AttributeTargets { }
 
     public class String 
     { 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -3158,14 +3158,14 @@ class Test
             var refs = new System.Collections.Generic.List<MetadataReference>() { asm01, asm02 };
 
             var comp1 = CreateCompilation(text1, references: refs, assemblyName: "OHI_GenericDDeriveBaseInMetadata001",
-                            options: TestOptions.ReleaseDll);
+                            parseOptions: TestOptions.Regular10, options: TestOptions.ReleaseDll);
             // better output with error info if any
             comp1.VerifyDiagnostics(); // No Errors
 
             refs.Add(new CSharpCompilationReference(comp1));
 
             var comp2 = CreateCompilation(text2, references: refs, assemblyName: "OHI_GenericDDeriveBaseInMetadata002",
-                            options: TestOptions.ReleaseDll);
+                            parseOptions: TestOptions.Regular10, options: TestOptions.ReleaseDll);
             Assert.Equal(0, comp2.GetDiagnostics().Count());
             refs.Add(new CSharpCompilationReference(comp2));
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicAnalysisResourceTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicAnalysisResourceTests.cs
@@ -72,7 +72,7 @@ public class C
         [ConditionalFact(typeof(WindowsOnly), Reason = ConditionalSkipReason.TestExecutionHasNewLineDependency)]
         public void TestSpansPresentInResource()
         {
-            var c = CreateCompilation(Parse(ExampleSource + InstrumentationHelperSource, @"C:\myproject\doc1.cs"));
+            var c = CreateCompilation(Parse(ExampleSource + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { RefSafetyRulesAttributeLib });
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
 
             var peReader = new PEReader(peImage);
@@ -216,7 +216,7 @@ public class C
 }
 ";
 
-            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"));
+            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { RefSafetyRulesAttributeLib });
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
 
             var peReader = new PEReader(peImage);
@@ -336,7 +336,7 @@ public class C
 }
 ";
 
-            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"));
+            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { RefSafetyRulesAttributeLib });
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
 
             var peReader = new PEReader(peImage);
@@ -430,7 +430,7 @@ class Teacher : Person { public string Subject; }
 class Student : Person { public double GPA; }
 ";
 
-            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"));
+            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { RefSafetyRulesAttributeLib });
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
 
             var peReader = new PEReader(peImage);
@@ -487,7 +487,7 @@ public class C
 }
 ";
 
-            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"));
+            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { RefSafetyRulesAttributeLib });
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
 
             var peReader = new PEReader(peImage);
@@ -526,7 +526,7 @@ public class C
     }
 }
 ";
-            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"));
+            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { RefSafetyRulesAttributeLib });
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
 
             var peReader = new PEReader(peImage);
@@ -557,7 +557,7 @@ public class C
     }
 }
 ";
-            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"));
+            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { RefSafetyRulesAttributeLib });
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
 
             var peReader = new PEReader(peImage);
@@ -597,7 +597,7 @@ public class C
     }
 }
 ";
-            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"));
+            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { RefSafetyRulesAttributeLib });
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
 
             var peReader = new PEReader(peImage);
@@ -665,7 +665,7 @@ public class C
 }
 ";
 
-            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"));
+            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { RefSafetyRulesAttributeLib });
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
 
             var peReader = new PEReader(peImage);
@@ -746,7 +746,7 @@ public class C
 }
 ";
 
-            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"));
+            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { RefSafetyRulesAttributeLib });
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
 
             var peReader = new PEReader(peImage);
@@ -827,7 +827,7 @@ partial struct E
 }
 ";
 
-            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"));
+            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { RefSafetyRulesAttributeLib });
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
 
             var peReader = new PEReader(peImage);
@@ -921,7 +921,7 @@ public class D
 }
 ";
 
-            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"));
+            var c = CreateCompilation(Parse(source + InstrumentationHelperSource, @"C:\myproject\doc1.cs"), references: new[] { RefSafetyRulesAttributeLib });
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)));
 
             var peReader = new PEReader(peImage);

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -33,11 +33,11 @@ public class Program
 ";
 
             string expectedOutput = @"Flushing
-Method 1
+Method 3
 File 1
 True
 True
-Method 4
+Method 6
 File 1
 True
 True
@@ -340,24 +340,8 @@ public class Program
             string expectedOutput = @"goo
 bar
 Flushing
-Method 1
-File 1
-True
-True
-True
-Method 2
-File 1
-True
-True
-True
-False
-True
-True
-True
 Method 3
 File 1
-True
-True
 True
 True
 True
@@ -369,19 +353,35 @@ True
 False
 True
 True
+True
 Method 5
 File 1
 True
 True
 True
-False
-False
-False
+True
+True
 Method 6
 File 1
 True
 True
-Method 9
+True
+False
+True
+True
+Method 7
+File 1
+True
+True
+True
+False
+False
+False
+Method 8
+File 1
+True
+True
+Method 11
 File 1
 True
 True
@@ -519,26 +519,15 @@ public class Program
     }
 }
 ";
-            // All instrumentation points in method 2 are True because they are covered by at least one specialization.
+            // All instrumentation points in method 4 are True because they are covered by at least one specialization.
             //
             // This test verifies that the payloads of methods of generic types are in terms of method definitions and
             // not method references -- the indices for the methods would be different for references.
             string expectedOutput = @"null
 Hello
 Flushing
-Method 1
-File 1
-True
-True
-Method 2
-File 1
-True
-True
-True
-True
 Method 3
 File 1
-True
 True
 True
 Method 4
@@ -547,8 +536,19 @@ True
 True
 True
 True
+Method 5
+File 1
 True
-Method 7
+True
+True
+Method 6
+File 1
+True
+True
+True
+True
+True
+Method 9
 File 1
 True
 True
@@ -716,19 +716,19 @@ public class Program
 " + InstrumentationHelperSource;
 
             var checker = new CSharpInstrumentationChecker();
-            checker.Method(3, 1, "public int Prop3")
+            checker.Method(5, 1, "public int Prop3")
                 .True("get");
-            checker.Method(4, 1, "public int Prop3")
+            checker.Method(6, 1, "public int Prop3")
                 .True("set");
-            checker.Method(5, 1, "public Program()")
+            checker.Method(7, 1, "public Program()")
                 .True("25")
                 .True("Prop = 12;")
                 .True("Prop3 = 12;")
                 .True("Prop2 = Prop3;");
-            checker.Method(6, 1, "public static void Main")
+            checker.Method(8, 1, "public static void Main")
                 .True("new Program();")
                 .True("Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();");
-            checker.Method(8, 1)
+            checker.Method(10, 1)
                 .True()
                 .False()
                 .True()
@@ -793,28 +793,20 @@ public class Program
     // Method 11 is a synthesized static constructor.
 }
 ";
-            // There is no entry for method '8' since it's a Prop2_set which is never called.
+            // There is no entry for method '10' since it's a Prop2_set which is never called.
             string expectedOutput = @"Flushing
-Method 1
-File 1
-True
-True
-True
-Method 2
-File 1
-True
-True
-True
-True
-True
-True
-True
 Method 3
 File 1
 True
 True
+True
 Method 4
 File 1
+True
+True
+True
+True
+True
 True
 True
 Method 5
@@ -829,6 +821,10 @@ Method 7
 File 1
 True
 True
+Method 8
+File 1
+True
+True
 Method 9
 File 1
 True
@@ -836,7 +832,11 @@ True
 Method 11
 File 1
 True
+True
 Method 13
+File 1
+True
+Method 15
 File 1
 True
 True
@@ -914,12 +914,12 @@ public class D
 " + InstrumentationHelperSource;
 
             var checker = new CSharpInstrumentationChecker();
-            checker.Method(1, 1, "public static void Main")
+            checker.Method(3, 1, "public static void Main")
                 .True("TestMain();")
                 .True("Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();");
-            checker.Method(2, 1, "static void TestMain")
+            checker.Method(4, 1, "static void TestMain")
                 .True("new D().M1();");
-            checker.Method(4, 1, "public void M1()")
+            checker.Method(6, 1, "public void M1()")
                 .True("L1();")
                 .True("1")
                 .True("var f = new Func<int>")
@@ -931,8 +931,8 @@ public class D
                 .True("var f3 = new Func<int, int>")
                 .True("f();")
                 .True("f3(2);");
-            checker.Method(5, 1, snippet: null, expectBodySpan: false);
-            checker.Method(7, 1)
+            checker.Method(7, 1, snippet: null, expectBodySpan: false);
+            checker.Method(9, 1)
                 .True()
                 .False()
                 .True()
@@ -995,24 +995,24 @@ public class Program
 ";
 
             string expectedOutput = @"Flushing
-Method 1
+Method 3
 File 1
 True
 True
 True
-Method 2
+Method 4
 File 2
 True
 True
 True
 True
-Method 3
+Method 5
 File 3
 True
 True
-Method 4
-File 4
 Method 6
+File 4
+Method 8
 File 5
 True
 True
@@ -1084,21 +1084,8 @@ public class Program
 }
 ";
             string expectedOutput = @"Flushing
-Method 1
-File 1
-True
-True
-True
-Method 2
-File 1
-True
-True
-True
 Method 3
 File 1
-True
-True
-True
 True
 True
 True
@@ -1107,11 +1094,24 @@ File 1
 True
 True
 True
+Method 5
+File 1
+True
+True
+True
+True
+True
+True
+Method 6
+File 1
+True
+True
+True
 False
 False
 False
 True
-Method 7
+Method 9
 File 1
 True
 True
@@ -1187,12 +1187,12 @@ public class Program
 }
 ";
             string expectedOutput = @"Flushing
-Method 1
+Method 3
 File 1
 True
 True
 True
-Method 2
+Method 4
 File 1
 True
 True
@@ -1209,7 +1209,7 @@ True
 True
 True
 True
-Method 5
+Method 7
 File 1
 True
 True
@@ -1349,56 +1349,56 @@ public class Program
 ";
             string expectedOutput = @"103
 Flushing
-Method 1
-File 1
-True
-True
-True
-Method 2
-File 1
-True
-True
-True
 Method 3
 File 1
-True
-True
-False
-True
-False
-False
-True
-True
-False
-True
-True
-True
-True
-True
-True
-True
-True
-True
-True
-True
-True
-True
-True
-True
-False
-True
-True
-True
-True
-True
-False
 True
 True
 True
 Method 4
 File 1
 True
-Method 7
+True
+True
+Method 5
+File 1
+True
+True
+False
+True
+False
+False
+True
+True
+False
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+False
+True
+True
+True
+True
+True
+False
+True
+True
+True
+Method 6
+File 1
+True
+Method 9
 File 1
 True
 True
@@ -1464,35 +1464,35 @@ class Person { public string Name; }
 class Teacher : Person { public string Subject; }
 class Student : Person { public double GPA; }
 
-    // Methods 5 and 7 are implicit constructors.
+    // Methods 7 and 9 are implicit constructors.
 ";
             string expectedOutput = @"Flushing
-Method 1
-File 1
-True
-True
-True
-Method 2
-File 1
-True
-True
-True
-True
-True
 Method 3
 File 1
 True
 True
-False
 True
-False
-False
+Method 4
+File 1
+True
+True
+True
+True
 True
 Method 5
 File 1
+True
+True
+False
+True
+False
+False
+True
 Method 7
 File 1
 Method 9
+File 1
+Method 11
 File 1
 True
 True
@@ -1554,18 +1554,18 @@ public class C
 }
 ";
             string expectedOutput = @"Flushing
-Method 1
-File 1
-True
-True
-True
-Method 2
-File 1
-True
-True
 Method 3
 File 1
 True
+True
+True
+Method 4
+File 1
+True
+True
+Method 5
+File 1
+True
 False
 True
 False
@@ -1573,7 +1573,7 @@ False
 True
 False
 True
-Method 6
+Method 8
 File 1
 True
 True
@@ -1631,24 +1631,24 @@ public class C
 }
 ";
             string expectedOutput = @"Flushing
-Method 1
+Method 3
 File 1
 True
-True
-True
-Method 2
-File 1
 True
 True
 Method 4
 File 1
 True
-Method 5
+True
+Method 6
+File 1
+True
+Method 7
 File 1
 True
 True
 True
-Method 7
+Method 9
 File 1
 True
 True
@@ -1713,31 +1713,31 @@ public class C
 }
 ";
             string expectedOutput = @"Flushing
-Method 1
-File 1
-True
-True
-True
-True
-Method 2
-File 1
-True
-True
-True
 Method 3
 File 1
 True
-False
-False
+True
+True
+True
 Method 4
 File 1
+True
+True
 True
 Method 5
 File 1
 True
-True
+False
+False
+Method 6
+File 1
 True
 Method 7
+File 1
+True
+True
+True
+Method 9
 File 1
 True
 True
@@ -1796,12 +1796,12 @@ public class Program
 ";
             string expectedOutput = @"OK
 Flushing
-Method 1
+Method 3
 File 1
 True
 True
 True
-Method 2
+Method 4
 File 1
 True
 True
@@ -1813,7 +1813,7 @@ True
 True
 False
 True
-Method 5
+Method 7
 File 1
 True
 True
@@ -1887,18 +1887,8 @@ public class Program
 ";
             string expectedOutput = @"GooGooGlueGooGoo
 Flushing
-Method 1
-File 1
-True
-True
-True
-Method 2
-File 1
-True
-True
 Method 3
 File 1
-True
 True
 True
 True
@@ -1906,10 +1896,20 @@ Method 4
 File 1
 True
 True
+Method 5
+File 1
+True
+True
+True
+True
+Method 6
+File 1
+True
+True
 True
 False
 True
-Method 5
+Method 7
 File 1
 True
 True
@@ -1918,7 +1918,7 @@ False
 True
 True
 True
-Method 8
+Method 10
 File 1
 True
 True
@@ -1988,25 +1988,25 @@ public class Program
 3
 4
 Flushing
-Method 1
-File 1
-True
-True
-True
-Method 2
-File 1
-True
-True
-True
-True
-True
 Method 3
 File 1
 True
 True
 True
+Method 4
+File 1
 True
-Method 6
+True
+True
+True
+True
+Method 5
+File 1
+True
+True
+True
+True
+Method 8
 File 1
 True
 True
@@ -2084,18 +2084,9 @@ public class C
 ";
             string expectedOutput = @"
 Flushing
-Method 1
-File 1
-True
-True
-True
-Method 2
-File 1
-True
-True
-True
 Method 3
 File 1
+True
 True
 True
 Method 4
@@ -2103,9 +2094,11 @@ File 1
 True
 True
 True
-True
-True
 Method 5
+File 1
+True
+True
+Method 6
 File 1
 True
 True
@@ -2119,7 +2112,14 @@ True
 True
 True
 True
-Method 11
+Method 9
+File 1
+True
+True
+True
+True
+True
+Method 13
 File 1
 True
 True
@@ -2180,32 +2180,32 @@ public class C
 ";
             string expectedOutput = @"
 Flushing
-Method 1
-File 1
-True
-True
-True
-Method 2
-File 1
-True
-True
-True
 Method 3
 File 1
 True
 True
-Method 6
+True
+Method 4
 File 1
 True
 True
 True
-Method 7
+Method 5
 File 1
 True
+True
+Method 8
+File 1
 True
 True
 True
 Method 9
+File 1
+True
+True
+True
+True
+Method 11
 File 1
 True
 True
@@ -2297,40 +2297,40 @@ partial struct E
 ";
             string expectedOutput = @"
 Flushing
-Method 1
-File 1
-True
-True
-True
-Method 2
-File 1
-True
-True
-True
-True
-True
-True
 Method 3
 File 1
+True
 True
 True
 Method 4
 File 1
 True
 True
+True
+True
+True
+True
 Method 5
 File 1
-True
-True
 True
 True
 Method 6
 File 1
 True
+True
+Method 7
+File 1
+True
+True
+True
+True
+Method 8
+File 1
+True
 False
 True
 True
-Method 9
+Method 11
 File 1
 True
 True
@@ -3000,25 +3000,25 @@ public class Program
 " + InstrumentationHelperSource;
 
             var checker = new CSharpInstrumentationChecker();
-            checker.Method(1, 1, "partial void Method1<U>(int x)")
+            checker.Method(3, 1, "partial void Method1<U>(int x)")
                 .True(@"Console.WriteLine($""Method1: x = {x}"");")
                 .True(@"Console.WriteLine(""Method1: x > 0"");")
                 .True("Method1<U>(0);")
                 .False(@"Console.WriteLine(""Method1: x < 0"");")
                 .True("x < 0)")
                 .True("x > 0)");
-            checker.Method(2, 1, "public void Method2(int x)")
+            checker.Method(4, 1, "public void Method2(int x)")
                 .True(@"Console.WriteLine($""Method2: x = {x}"");")
                 .True("Method1<T>(x);");
-            checker.Method(3, 1, ".ctor()", expectBodySpan: false);
-            checker.Method(4, 1, "public static void Main(string[] args)")
+            checker.Method(5, 1, ".ctor()", expectBodySpan: false);
+            checker.Method(6, 1, "public static void Main(string[] args)")
                 .True("Test();")
                 .True("Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();");
-            checker.Method(5, 1, "static void Test()")
+            checker.Method(7, 1, "static void Test()")
                 .True(@"Console.WriteLine(""Test"");")
                 .True("var c = new Class1<int>();")
                 .True("c.Method2(1);");
-            checker.Method(8, 1)
+            checker.Method(10, 1)
                 .True()
                 .False()
                 .True()
@@ -3085,17 +3085,17 @@ public class Program
 " + InstrumentationHelperSource;
 
             var checker = new CSharpInstrumentationChecker();
-            checker.Method(1, 1, "public void Method2(int x)")
+            checker.Method(3, 1, "public void Method2(int x)")
                 .True(@"Console.WriteLine($""Method2: x = {x}"");");
-            checker.Method(2, 1, ".ctor()", expectBodySpan: false);
-            checker.Method(3, 1, "public static void Main(string[] args)")
+            checker.Method(4, 1, ".ctor()", expectBodySpan: false);
+            checker.Method(5, 1, "public static void Main(string[] args)")
                 .True("Test();")
                 .True("Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();");
-            checker.Method(4, 1, "static void Test()")
+            checker.Method(6, 1, "static void Test()")
                 .True(@"Console.WriteLine(""Test"");")
                 .True("var c = new Class1<int>();")
                 .True("c.Method2(1);");
-            checker.Method(7, 1)
+            checker.Method(9, 1)
                 .True()
                 .False()
                 .True()
@@ -3195,14 +3195,14 @@ public partial class Class1<T>
 2
 3
 Flushing
-Method 1
+Method 3
 File 1
 True
 True
 True
 True
 True
-Method 2
+Method 4
 File 1
 File 2
 File 3
@@ -3211,18 +3211,18 @@ True
 True
 True
 True
-Method 3
+Method 5
 File 2
 True
 True
 True
-Method 4
+Method 6
 File 2
 True
 True
 True
 True
-Method 7
+Method 9
 File 2
 True
 True
@@ -3319,16 +3319,16 @@ public partial class Class1<T>
 2
 3
 Flushing
-Method 1
+Method 3
 File 1
 True
 True
 True
 True
 True
-Method 2
+Method 4
 File 2
-Method 3
+Method 5
 File 1
 File 2
 File 3
@@ -3337,18 +3337,18 @@ True
 True
 True
 True
-Method 4
+Method 6
 File 2
 True
 True
 True
-Method 5
+Method 7
 File 2
 True
 True
 True
 True
-Method 8
+Method 10
 File 2
 True
 True
@@ -3408,12 +3408,12 @@ Hidden
 Visible
 End
 Flushing
-Method 1
+Method 3
 File 1
 True
 True
 True
-Method 2
+Method 4
 File 1
 File 2
 File 3
@@ -3422,7 +3422,7 @@ True
 True
 True
 True
-Method 5
+Method 7
 File 3
 True
 True

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.cs
@@ -2502,7 +2502,7 @@ namespace N
     }
 }";
 
-            var compilation0 = CreateCompilation(source0, options: ComSafeDebugDll);
+            var compilation0 = CreateCompilation(source0, references: new[] { RefSafetyRulesAttributeLib }, options: ComSafeDebugDll);
             var compilation1 = compilation0.WithSource(source1);
             var compilation2 = compilation1.WithSource(source2);
             var compilation3 = compilation2.WithSource(source3);
@@ -11084,7 +11084,7 @@ public class Program
             <N:1>select a is int <N:2>x</N:2> && x == 0</N:1></N:0>;
     }
 }");
-            var compilation0 = CreateCompilation(source0.Tree, options: ComSafeDebugDll);
+            var compilation0 = CreateCompilation(source0.Tree, references: new[] { RefSafetyRulesAttributeLib }, options: ComSafeDebugDll);
             var compilation1 = compilation0.WithSource(source1.Tree);
             var compilation2 = compilation1.WithSource(source0.Tree);
 
@@ -11967,7 +11967,7 @@ public class C : Base
     static int M2(System.Func<int> x) => throw null;
 }" + baseClass);
 
-            var compilation0 = CreateCompilation(source0.Tree, options: ComSafeDebugDll);
+            var compilation0 = CreateCompilation(source0.Tree, references: new[] { RefSafetyRulesAttributeLib }, options: ComSafeDebugDll);
             var compilation1 = compilation0.WithSource(source1.Tree);
             var compilation2 = compilation1.WithSource(source0.Tree);
 
@@ -12131,7 +12131,7 @@ public class C
     static int M2(System.Func<int> x) => throw null;
 }");
 
-            var compilation0 = CreateCompilation(source0.Tree, options: ComSafeDebugDll);
+            var compilation0 = CreateCompilation(source0.Tree, references: new[] { RefSafetyRulesAttributeLib }, options: ComSafeDebugDll);
             var compilation1 = compilation0.WithSource(source1.Tree);
             var compilation2 = compilation1.WithSource(source0.Tree);
 
@@ -12381,7 +12381,7 @@ public class C
     static int M2(System.Func<int> x) => throw null;
 }");
 
-            var compilation0 = CreateCompilation(source0.Tree, options: ComSafeDebugDll);
+            var compilation0 = CreateCompilation(source0.Tree, references: new[] { RefSafetyRulesAttributeLib }, options: ComSafeDebugDll);
             var compilation1 = compilation0.WithSource(source1.Tree);
             var compilation2 = compilation1.WithSource(source0.Tree);
 
@@ -12544,7 +12544,7 @@ public class Program
             <N:1>select M(a, out int <N:2>x</N:2>) + x</N:1></N:0>;
     }
 }");
-            var compilation0 = CreateCompilation(source0.Tree, options: ComSafeDebugDll);
+            var compilation0 = CreateCompilation(source0.Tree, references: new[] { RefSafetyRulesAttributeLib }, options: ComSafeDebugDll);
             var compilation1 = compilation0.WithSource(source1.Tree);
             var compilation2 = compilation1.WithSource(source0.Tree);
 
@@ -12748,7 +12748,7 @@ public class Program
             <N:1>select <N:2>M(a, out int <N:3>x</N:3>) + M2(<N:4>() => x - 1</N:4>)</N:2></N:1></N:0>;
     }
 }");
-            var compilation0 = CreateCompilation(source0.Tree, options: ComSafeDebugDll);
+            var compilation0 = CreateCompilation(source0.Tree, references: new[] { RefSafetyRulesAttributeLib }, options: ComSafeDebugDll);
             var compilation1 = compilation0.WithSource(source1.Tree);
             var compilation2 = compilation1.WithSource(source0.Tree);
 
@@ -12996,7 +12996,7 @@ public class Program
 
     static int N(out int x) { x = 1; return 0; }
 }");
-            var compilation0 = CreateCompilation(source0.Tree, options: ComSafeDebugDll);
+            var compilation0 = CreateCompilation(source0.Tree, references: new[] { RefSafetyRulesAttributeLib }, options: ComSafeDebugDll);
             var compilation1 = compilation0.WithSource(source1.Tree);
             var compilation2 = compilation1.WithSource(source0.Tree);
 
@@ -13255,7 +13255,7 @@ namespace N
 }
 ";
 
-            var compilation0 = CreateCompilation(new[] { source0, IsExternalInitTypeDefinition }, options: ComSafeDebugDll);
+            var compilation0 = CreateCompilation(new[] { source0, IsExternalInitTypeDefinition }, references: new[] { RefSafetyRulesAttributeLib }, options: ComSafeDebugDll);
             var compilation1 = compilation0.WithSource(new[] { source1, IsExternalInitTypeDefinition });
 
             var printMembers0 = compilation0.GetMember<MethodSymbol>("N.R.PrintMembers");
@@ -13314,26 +13314,26 @@ namespace N
             CheckNames(readers, reader1.GetMethodDefNames(), "PrintMembers");
 
             CheckEncLog(reader1,
-                Row(2, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
-                Row(20, TableIndex.TypeRef, EditAndContinueOperation.Default),
+                Row(3, TableIndex.AssemblyRef, EditAndContinueOperation.Default),
                 Row(21, TableIndex.TypeRef, EditAndContinueOperation.Default),
                 Row(22, TableIndex.TypeRef, EditAndContinueOperation.Default),
+                Row(23, TableIndex.TypeRef, EditAndContinueOperation.Default),
                 Row(4, TableIndex.TypeSpec, EditAndContinueOperation.Default),
                 Row(3, TableIndex.StandAloneSig, EditAndContinueOperation.Default),
-                Row(10, TableIndex.MethodDef, EditAndContinueOperation.Default), // R.PrintMembers
+                Row(10, TableIndex.MethodDef, EditAndContinueOperation.Default),
                 Row(3, TableIndex.Param, EditAndContinueOperation.Default),
-                Row(22, TableIndex.CustomAttribute, EditAndContinueOperation.Default));
+                Row(23, TableIndex.CustomAttribute, EditAndContinueOperation.Default));
 
             CheckEncMap(reader1,
-                Handle(20, TableIndex.TypeRef),
                 Handle(21, TableIndex.TypeRef),
                 Handle(22, TableIndex.TypeRef),
+                Handle(23, TableIndex.TypeRef),
                 Handle(10, TableIndex.MethodDef),
                 Handle(3, TableIndex.Param),
-                Handle(22, TableIndex.CustomAttribute),
+                Handle(23, TableIndex.CustomAttribute),
                 Handle(3, TableIndex.StandAloneSig),
                 Handle(4, TableIndex.TypeSpec),
-                Handle(2, TableIndex.AssemblyRef));
+                Handle(3, TableIndex.AssemblyRef));
         }
 
         [Fact]
@@ -13362,7 +13362,7 @@ namespace N
 }
 ";
 
-            var compilation0 = CreateCompilation(new[] { source0, IsExternalInitTypeDefinition }, options: ComSafeDebugDll);
+            var compilation0 = CreateCompilation(new[] { source0, IsExternalInitTypeDefinition }, references: new[] { RefSafetyRulesAttributeLib }, options: ComSafeDebugDll);
             var compilation1 = compilation0.WithSource(new[] { source1, IsExternalInitTypeDefinition });
 
             var method0 = compilation0.GetMember<MethodSymbol>("N.R.PrintMembers");

--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadataTests.cs
@@ -471,7 +471,7 @@ abstract public class A
                 Assert.Same(m5.TypeParameters[0], m5.Parameters[0].Type);
                 Assert.Same(m5.TypeParameters[1], m5.Parameters[1].Type);
 
-                Assert.Equal(6, ((PEModuleSymbol)module).Module.GetMetadataReader().TypeReferences.Count);
+                Assert.Equal(10, ((PEModuleSymbol)module).Module.GetMetadataReader().TypeReferences.Count);
             });
         }
 

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_Embedded.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_Embedded.cs
@@ -309,6 +309,8 @@ namespace System
 {
     public class Object {}
     public class Void {}
+    public class ValueType {}
+    public struct Int32 { }
 }
 public class Test
 {
@@ -319,7 +321,15 @@ public class Test
                 // error CS0518: Predefined type 'System.Attribute' is not defined or imported
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Attribute").WithLocation(1, 1),
                 // error CS0518: Predefined type 'System.Attribute' is not defined or imported
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Attribute").WithLocation(1, 1));
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Attribute").WithLocation(1, 1),
+                // error CS0518: Predefined type 'System.Attribute' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Attribute").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute..ctor'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", ".ctor").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute.AllowMultiple'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", "AllowMultiple").WithLocation(1, 1),
+                // error CS0656: Missing compiler required member 'System.AttributeUsageAttribute.Inherited'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.AttributeUsageAttribute", "Inherited").WithLocation(1, 1));
         }
 
         [Fact]
@@ -329,7 +339,18 @@ public class Test
 namespace System
 {
     public class Attribute {}
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets t) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public class ValueType { }
+    public struct Enum { }
+    public enum AttributeTargets { }
     public class Void {}
+    public struct Int32 { }
+    public struct Boolean { }
 }
 public class Test
 {
@@ -337,30 +358,39 @@ public class Test
 }";
 
             CreateEmptyCompilation(code).VerifyEmitDiagnostics(CodeAnalysis.Emit.EmitOptions.Default.WithRuntimeMetadataVersion("v4.0.30319"),
-                // (5,18): error CS0518: Predefined type 'System.Object' is not defined or imported
-                //     public class Void {}
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "Void").WithArguments("System.Object").WithLocation(5, 18),
-                // (7,14): error CS0518: Predefined type 'System.Object' is not defined or imported
-                // public class Test
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "Test").WithArguments("System.Object").WithLocation(7, 14),
                 // (4,18): error CS0518: Predefined type 'System.Object' is not defined or imported
                 //     public class Attribute {}
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "Attribute").WithArguments("System.Object").WithLocation(4, 18),
-                // (9,24): error CS0518: Predefined type 'System.Object' is not defined or imported
+                // (11,18): error CS0518: Predefined type 'System.Object' is not defined or imported
+                //     public class ValueType { }
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "ValueType").WithArguments("System.Object").WithLocation(11, 18),
+                // (14,18): error CS0518: Predefined type 'System.Object' is not defined or imported
+                //     public class Void {}
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "Void").WithArguments("System.Object").WithLocation(14, 18),
+                // (18,14): error CS0518: Predefined type 'System.Object' is not defined or imported
+                // public class Test
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "Test").WithArguments("System.Object").WithLocation(18, 14),
+                // (20,24): error CS0518: Predefined type 'System.Object' is not defined or imported
                 //     public object M(in object x) { return x; } // should trigger synthesizing IsReadOnly
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "object").WithArguments("System.Object").WithLocation(9, 24),
-                // (9,12): error CS0518: Predefined type 'System.Object' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "object").WithArguments("System.Object").WithLocation(20, 24),
+                // (20,12): error CS0518: Predefined type 'System.Object' is not defined or imported
                 //     public object M(in object x) { return x; } // should trigger synthesizing IsReadOnly
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "object").WithArguments("System.Object").WithLocation(9, 12),
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "object").WithArguments("System.Object").WithLocation(20, 12),
+                // (7,40): error CS0518: Predefined type 'System.Object' is not defined or imported
+                //         public AttributeUsageAttribute(AttributeTargets t) { }
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "AttributeTargets").WithArguments("System.Object").WithLocation(7, 40),
+                // (14,18): error CS1729: 'object' does not contain a constructor that takes 0 arguments
+                //     public class Void {}
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "Void").WithArguments("object", "0").WithLocation(14, 18),
                 // (4,18): error CS1729: 'object' does not contain a constructor that takes 0 arguments
                 //     public class Attribute {}
                 Diagnostic(ErrorCode.ERR_BadCtorArgCount, "Attribute").WithArguments("object", "0").WithLocation(4, 18),
-                // (5,18): error CS1729: 'object' does not contain a constructor that takes 0 arguments
-                //     public class Void {}
-                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "Void").WithArguments("object", "0").WithLocation(5, 18),
-                // (7,14): error CS1729: 'object' does not contain a constructor that takes 0 arguments
+                // (11,18): error CS1729: 'object' does not contain a constructor that takes 0 arguments
+                //     public class ValueType { }
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "ValueType").WithArguments("object", "0").WithLocation(11, 18),
+                // (18,14): error CS1729: 'object' does not contain a constructor that takes 0 arguments
                 // public class Test
-                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "Test").WithArguments("object", "0").WithLocation(7, 14));
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "Test").WithArguments("object", "0").WithLocation(18, 14));
         }
 
         [Fact]
@@ -370,6 +400,17 @@ public class Test
 namespace System
 {
     public class Attribute {}
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets t) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public class ValueType { }
+    public struct Int32 { }
+    public struct Boolean { }
+    public struct Enum { }
+    public enum AttributeTargets { }
     public class Object {}
 }
 public class Test
@@ -378,12 +419,29 @@ public class Test
 }";
 
             CreateEmptyCompilation(code).VerifyEmitDiagnostics(CodeAnalysis.Emit.EmitOptions.Default.WithRuntimeMetadataVersion("v4.0.30319"),
+                // (8,42): error CS0518: Predefined type 'System.Void' is not defined or imported
+                //         public bool AllowMultiple { get; set; }
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "set;").WithArguments("System.Void").WithLocation(8, 42),
+                // (9,38): error CS0518: Predefined type 'System.Void' is not defined or imported
+                //         public bool Inherited { get; set; }
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "set;").WithArguments("System.Void").WithLocation(9, 38),
+                // (7,9): error CS0518: Predefined type 'System.Void' is not defined or imported
+                //         public AttributeUsageAttribute(AttributeTargets t) { }
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "public AttributeUsageAttribute(AttributeTargets t) { }").WithArguments("System.Void").WithLocation(7, 9),
                 // (4,18): error CS0518: Predefined type 'System.Void' is not defined or imported
                 //     public class Attribute {}
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "Attribute").WithArguments("System.Void").WithLocation(4, 18),
-                // (7,14): error CS0518: Predefined type 'System.Void' is not defined or imported
+                // (11,18): error CS0518: Predefined type 'System.Void' is not defined or imported
+                //     public class ValueType { }
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "ValueType").WithArguments("System.Void").WithLocation(11, 18),
+                // (18,14): error CS0518: Predefined type 'System.Void' is not defined or imported
                 // public class Test
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "Test").WithArguments("System.Void").WithLocation(7, 14),
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "Test").WithArguments("System.Void").WithLocation(18, 14),
+                // (7,16): error CS0518: Predefined type 'System.Void' is not defined or imported
+                //         public AttributeUsageAttribute(AttributeTargets t) { }
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "AttributeUsageAttribute").WithArguments("System.Void").WithLocation(7, 16),
+                // error CS0518: Predefined type 'System.Void' is not defined or imported
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Void").WithLocation(1, 1),
                 // error CS0518: Predefined type 'System.Void' is not defined or imported
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound).WithArguments("System.Void").WithLocation(1, 1),
                 // error CS0518: Predefined type 'System.Void' is not defined or imported
@@ -398,10 +456,21 @@ namespace System
 {
     public class Object {}
     public class Void {}
+    public class ValueType { }
+    public struct Int32 { }
+    public struct Boolean { }
     public class Attribute
     {
         public Attribute(object p) { }
     }
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets t) : base(null) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public struct Enum { }
+    public enum AttributeTargets { }
 }
 public class Test
 {
@@ -409,6 +478,8 @@ public class Test
 }";
 
             CreateEmptyCompilation(code).VerifyEmitDiagnostics(CodeAnalysis.Emit.EmitOptions.Default.WithRuntimeMetadataVersion("v4.0.30319"),
+                // error CS1729: 'Attribute' does not contain a constructor that takes 0 arguments
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount).WithArguments("System.Attribute", "0").WithLocation(1, 1),
                 // error CS1729: 'Attribute' does not contain a constructor that takes 0 arguments
                 Diagnostic(ErrorCode.ERR_BadCtorArgCount).WithArguments("System.Attribute", "0").WithLocation(1, 1),
                 // error CS1729: 'Attribute' does not contain a constructor that takes 0 arguments

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_IsByRefLike.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_IsByRefLike.cs
@@ -491,7 +491,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Passes, symbolValidator: module =>
+            CompileAndVerify(text, references: new[] { RefSafetyRulesAttributeLib }, verify: Verification.Passes, symbolValidator: module =>
             {
                 Assert.Null(module.ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName));
             });
@@ -967,7 +967,14 @@ namespace System
     {
         public ObsoleteAttribute(string message, bool error){}
     }
-
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets validOn) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public struct Enum { }
+    public enum AttributeTargets { }
     public ref struct TypedReference { }
     public ref struct ArgIterator { }
     public ref struct RuntimeArgumentHandle { }

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_IsUnmanaged.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_IsUnmanaged.cs
@@ -841,8 +841,9 @@ class Test<T> where T : unmanaged
 
                 case Accessibility.Public:
                     {
-                        Assert.Null(attributeType.ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName));
-
+                        var refSafetyRulesAttribute = attributeType.ContainingAssembly.GetTypeByMetadataName(AttributeDescription.RefSafetyRulesAttribute.FullName);
+                        var embeddedAttribute = attributeType.ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName);
+                        Assert.Equal(refSafetyRulesAttribute is null, embeddedAttribute is null);
                         break;
                     }
 

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_LifetimeAnnotation.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_LifetimeAnnotation.cs
@@ -189,7 +189,16 @@ ref struct R { }
         public void ExplicitAttribute_UnexpectedParameterTargets()
         {
             var source0 =
-@".class private System.Runtime.CompilerServices.ScopedRefAttribute extends [mscorlib]System.Attribute
+@".assembly extern mscorlib { .ver 4:0:0:0 .publickeytoken = (B7 7A 5C 56 19 34 E0 89) }
+.assembly '<<GeneratedFileName>>' { }
+.module '<<GeneratedFileName>>.dll'
+.custom instance void System.Runtime.CompilerServices.RefSafetyRulesAttribute::.ctor(int32) = { int32(11) }
+.class private System.Runtime.CompilerServices.RefSafetyRulesAttribute extends [mscorlib]System.Attribute
+{
+  .method public hidebysig specialname rtspecialname instance void .ctor(int32 version) cil managed { ret }
+  .field public int32 Version
+}
+.class private System.Runtime.CompilerServices.ScopedRefAttribute extends [mscorlib]System.Attribute
 {
   .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { ret }
 }
@@ -226,7 +235,7 @@ ref struct R { }
   }
 }
 ";
-            var ref0 = CompileIL(source0);
+            var ref0 = CompileIL(source0, prependDefaultHeader: false);
 
             var source1 =
 @"class Program

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_RefReadOnly.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_RefReadOnly.cs
@@ -1208,7 +1208,7 @@ class Test
 }
 ";
 
-            CompileAndVerify(text, verify: Verification.Fails, symbolValidator: module =>
+            CompileAndVerify(text, references: new[] { RefSafetyRulesAttributeLib }, verify: Verification.Fails, symbolValidator: module =>
             {
                 Assert.Null(module.ContainingAssembly.GetTypeByMetadataName(AttributeDescription.CodeAnalysisEmbeddedAttribute.FullName));
             });

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_RefSafetyRules.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_RefSafetyRules.cs
@@ -1,0 +1,211 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public class AttributeTests_RefSafetyRules : CSharpTestBase
+    {
+        [Fact]
+        public void ExplicitAttribute_FromSource()
+        {
+            var source =
+@"public class A
+{
+    public static ref T F<T>(out T t) => throw null;
+}";
+
+            var comp = CreateCompilation(new[] { source, RefSafetyRulesAttributeDefinition }, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(comp, symbolValidator: m => AssertRefSafetyRulesAttribute(m, includesAttributeDefinition: true, includesAttributeUse: false, publicDefinition: true));
+
+            comp = CreateCompilation(new[] { source, RefSafetyRulesAttributeDefinition });
+            CompileAndVerify(comp, symbolValidator: m => AssertRefSafetyRulesAttribute(m, includesAttributeDefinition: true, includesAttributeUse: true, publicDefinition: true));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void ExplicitAttribute_FromMetadata(bool useCompilationReference)
+        {
+            var comp = CreateCompilation(RefSafetyRulesAttributeDefinition, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(comp, symbolValidator: m => AssertRefSafetyRulesAttribute(m, includesAttributeDefinition: true, includesAttributeUse: false, publicDefinition: true));
+            var ref1 = AsReference(comp, useCompilationReference);
+
+            var source =
+@"public class A
+{
+    public static ref T F<T>(out T t) => throw null;
+}";
+
+            comp = CreateCompilation(source, references: new[] { ref1 }, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(comp, symbolValidator: m => AssertRefSafetyRulesAttribute(m, includesAttributeDefinition: false, includesAttributeUse: false, publicDefinition: true));
+
+            comp = CreateCompilation(source, references: new[] { ref1 });
+            CompileAndVerify(comp, symbolValidator: m => AssertRefSafetyRulesAttribute(m, includesAttributeDefinition: false, includesAttributeUse: true, publicDefinition: true));
+        }
+
+        [Fact]
+        public void ExplicitAttribute_MissingConstructor()
+        {
+            var source1 =
+@"namespace System.Runtime.CompilerServices
+{
+    public sealed class RefSafetyRulesAttribute : Attribute { }
+}";
+            var source2 =
+@"public class A
+{
+    public static ref T F<T>(out T t) => throw null;
+}";
+
+            var comp = CreateCompilation(new[] { source1, source2 }, parseOptions: TestOptions.Regular10);
+            comp.VerifyEmitDiagnostics();
+
+            comp = CreateCompilation(new[] { source1, source2 });
+            comp.VerifyEmitDiagnostics(
+                // error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.RefSafetyRulesAttribute..ctor'
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember).WithArguments("System.Runtime.CompilerServices.RefSafetyRulesAttribute", ".ctor").WithLocation(1, 1));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void ExplicitAttribute_ReferencedInSource(
+            [CombinatorialValues(LanguageVersion.CSharp10, LanguageVersion.CSharp11)] LanguageVersion languageVersion,
+            bool useCompilationReference)
+        {
+            var comp = CreateCompilation(RefSafetyRulesAttributeDefinition);
+            comp.VerifyDiagnostics();
+            var ref1 = AsReference(comp, useCompilationReference);
+
+            var source =
+@"using System.Runtime.CompilerServices;
+[assembly: RefSafetyRules(11)]
+[module: RefSafetyRules(11)]
+";
+
+            comp = CreateCompilation(source, references: new[] { ref1 }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+            comp.VerifyDiagnostics(
+                // (3,10): error CS8335: Do not use 'System.Runtime.CompilerServices.RefSafetyRulesAttribute'. This is reserved for compiler usage.
+                // [module: RefSafetyRules(11)]
+                Diagnostic(ErrorCode.ERR_ExplicitReservedAttr, "RefSafetyRules(11)").WithArguments("System.Runtime.CompilerServices.RefSafetyRulesAttribute").WithLocation(3, 10));
+        }
+
+        [Theory]
+        [InlineData("interface I { T F<T>(); }", false)]
+        [InlineData("interface I { ref T F<T>(); }", true)]
+        [InlineData("interface I { void F<T>(T t); }", false)]
+        [InlineData("interface I { void F<T>(ref T t); }", true)]
+        [InlineData("interface I { void F<T>(in T t); }", true)]
+        [InlineData("interface I { void F<T>(out T t); }", true)]
+        [InlineData("interface I { }", false)]
+        [InlineData("class C { }", false)]
+        [InlineData("struct S { }", false)]
+        [InlineData("ref struct R { }", true)]
+        public void EmitAttribute_01(string source, bool requiresAttribute)
+        {
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(comp, symbolValidator: m => AssertRefSafetyRulesAttribute(m, includesAttributeDefinition: false, includesAttributeUse: false, publicDefinition: false));
+
+            comp = CreateCompilation(source);
+            CompileAndVerify(comp, symbolValidator: m => AssertRefSafetyRulesAttribute(m, includesAttributeDefinition: requiresAttribute, includesAttributeUse: requiresAttribute, publicDefinition: false));
+        }
+
+        [Theory]
+        [InlineData("class B { I F() => default; }", false)]
+        [InlineData("class B { A F() => default; }", false)]
+        [InlineData("class B { S F() => default; }", false)]
+        [InlineData("class B { R F() => default; }", true)]
+        [InlineData("class B { void F(I i) { } }", false)]
+        [InlineData("class B { void F(A a) { } }", false)]
+        [InlineData("class B { void F(S s) { } }", false)]
+        [InlineData("class B { void F(R r) { } }", true)]
+        public void EmitAttribute_02(string source, bool requiresAttribute)
+        {
+            var sourceA =
+@"public interface I { }
+public class A { }
+public struct S { }
+public ref struct R { }
+";
+            var refA = CreateCompilation(sourceA, parseOptions: TestOptions.Regular10).EmitToImageReference();
+
+            var comp = CreateCompilation(source, references: new[] { refA }, parseOptions: TestOptions.Regular10);
+            CompileAndVerify(comp, verify: Verification.Skipped, symbolValidator: m => AssertRefSafetyRulesAttribute(m, includesAttributeDefinition: false, includesAttributeUse: false, publicDefinition: false));
+
+            comp = CreateCompilation(source, references: new[] { refA });
+            CompileAndVerify(comp, verify: Verification.Skipped, symbolValidator: m => AssertRefSafetyRulesAttribute(m, includesAttributeDefinition: requiresAttribute, includesAttributeUse: requiresAttribute, publicDefinition: false));
+        }
+
+        [Fact]
+        public void AttributeField()
+        {
+            var sourceA =
+@"using System;
+using System.Linq;
+using System.Reflection;
+public class A
+{
+    public static void GetAttributeValue(out int value)
+    {
+        var module = typeof(A).Assembly.Modules.First();
+        var attribute = module.GetCustomAttributes(false).Single(a => a.GetType().Name == ""RefSafetyRulesAttribute"");
+        var field = attribute.GetType().GetField(""Version"");
+        value = (int)field.GetValue(attribute);
+    }
+}";
+            var refA = CreateCompilation(sourceA).EmitToImageReference();
+
+            var sourceB =
+@"using System;
+class B : A
+{
+    static void Main()
+    {
+        GetAttributeValue(out int value);
+        Console.WriteLine(value);
+    }
+}";
+            CompileAndVerify(sourceB, references: new[] { refA }, expectedOutput: "11");
+        }
+
+        private static void AssertRefSafetyRulesAttribute(ModuleSymbol module, bool includesAttributeDefinition, bool includesAttributeUse, bool publicDefinition)
+        {
+            const string attributeName = "System.Runtime.CompilerServices.RefSafetyRulesAttribute";
+            var type = (NamedTypeSymbol)module.GlobalNamespace.GetMember(attributeName);
+            var attribute = module.GetAttributes().SingleOrDefault();
+            if (includesAttributeDefinition)
+            {
+                Assert.NotNull(type);
+            }
+            else
+            {
+                Assert.Null(type);
+                if (includesAttributeUse)
+                {
+                    type = attribute.AttributeClass;
+                }
+            }
+            if (type is { })
+            {
+                Assert.Equal(publicDefinition ? Accessibility.Public : Accessibility.Internal, type.DeclaredAccessibility);
+            }
+            if (includesAttributeUse)
+            {
+                Assert.Equal(type, attribute.AttributeClass);
+            }
+            else
+            {
+                Assert.Null(attribute);
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_RefSafetyRules.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_RefSafetyRules.cs
@@ -106,6 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [InlineData("interface I { void F<T>(ref T t); }", true)]
         [InlineData("interface I { void F<T>(in T t); }", true)]
         [InlineData("interface I { void F<T>(out T t); }", true)]
+        [InlineData("interface I { ref int P { get; } }", true)]
         [InlineData("interface I { }", false)]
         [InlineData("class C { }", false)]
         [InlineData("struct S { }", false)]
@@ -128,6 +129,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [InlineData("class B { void F(A a) { } }", false)]
         [InlineData("class B { void F(S s) { } }", false)]
         [InlineData("class B { void F(R r) { } }", true)]
+        [InlineData("class B { R P => default; }", true)]
+        [InlineData("class B { R P { set { } } }", true)]
         public void EmitAttribute_02(string source, bool requiresAttribute)
         {
             var sourceA =

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -217,6 +217,15 @@ class Program
             return false;
         }
     }
+    public class Attribute { }
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets validOn) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public struct Enum { }
+    public enum AttributeTargets { }
 }
 " + RuntimeFeature_NumericIntPtr;
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -2857,6 +2857,15 @@ class Program
     public struct Boolean { }
     public struct Int32 { }
     public struct IntPtr { }
+    public class Attribute { }
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets t) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public struct Enum { }
+    public enum AttributeTargets { }
 }";
             var sourceB =
 @"class Program

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -9303,7 +9303,7 @@ class Program
                 var reader = assembly.GetMetadataReader();
                 var actualTypes = reader.GetTypeDefNames().Select(h => reader.GetString(h)).ToArray();
 
-                string[] expectedTypes = new[] { "<Module>", "Program", "<>c", };
+                string[] expectedTypes = new[] { "<Module>", "EmbeddedAttribute", "RefSafetyRulesAttribute", "Program", "<>c", };
                 AssertEx.Equal(expectedTypes, actualTypes);
             }
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NativeIntegerTests.cs
@@ -1667,6 +1667,15 @@ namespace System
             return false;
         }
     }
+    public class Attribute { }
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets validOn) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public struct Enum { }
+    public enum AttributeTargets { }
 }";
             var comp = CreateEmptyCompilation(sourceA);
             comp.VerifyDiagnostics();

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -2305,6 +2305,14 @@ namespace System
         public bool X { get; set; }
     }
     public class Attribute { }
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets t) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public struct Enum { }
+    public enum AttributeTargets { }
     public class String { }
     public struct Void { }
     public struct Boolean { }
@@ -2399,6 +2407,14 @@ namespace System
         public static bool X { get; set; }
     }
     public class Attribute { }
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets t) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public struct Enum { }
+    public enum AttributeTargets { }
     public class String { }
     public struct Void { }
     public struct Boolean { }
@@ -7971,14 +7987,23 @@ class Program
 }
 ";
             var comp = CreateCompilationWithMscorlibAndSpan(new[] { text, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
-            comp.VerifyDiagnostics(
+            var expectedDiagnostics = new[]
+            {
                 // (9,26): error CS8352: Cannot use variable 'local' in this context because it may expose referenced variables outside of their declaration scope
                 //         sp = MayWrap(ref local) with { }; // 1, 2
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "local").WithArguments("local").WithLocation(9, 26),
                 // (9,14): error CS8347: Cannot use a result of 'Program.MayWrap(ref Span<int>)' in this context because it may expose variables referenced by parameter 'arg' outside of their declaration scope
                 //         sp = MayWrap(ref local) with { }; // 1, 2
                 Diagnostic(ErrorCode.ERR_EscapeCall, "MayWrap(ref local)").WithArguments("Program.MayWrap(ref System.Span<int>)", "arg").WithLocation(9, 14)
-                );
+            };
+            if (languageVersion == LanguageVersion.CSharp10)
+            {
+                expectedDiagnostics = expectedDiagnostics.Append(
+                    // (12,24): error CS9063: UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.
+                    //     static S1 MayWrap([UnscopedRef] ref Span<int> arg)
+                    Diagnostic(ErrorCode.ERR_UnscopedRefAttributeUnsupportedTarget, "UnscopedRef").WithLocation(12, 24));
+            }
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
@@ -1168,7 +1169,8 @@ class Program
 }
 ";
             var comp = CreateCompilationWithMscorlibAndSpan(new[] { text, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
-            comp.VerifyDiagnostics(
+            var expectedDiagnostics = new[]
+            {
                 // (20,32): error CS8352: Cannot use variable 'inner' in this context because it may expose referenced variables outside of their declaration scope
                 //             x[0] = MayWrap(ref inner).Slice(1)[0];
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "inner").WithArguments("inner").WithLocation(20, 32),
@@ -1187,7 +1189,15 @@ class Program
                 // (28,38): error CS8347: Cannot use a result of 'Program.MayWrap(ref Span<int>)' in this context because it may expose variables referenced by parameter 'arg' outside of their declaration scope
                 //             x.ReturnsRefArg(ref x) = MayWrap(ref inner).Slice(1)[0];
                 Diagnostic(ErrorCode.ERR_EscapeCall, "MayWrap(ref inner)").WithArguments("Program.MayWrap(ref System.Span<int>)", "arg").WithLocation(28, 38)
-            );
+            };
+            if (languageVersion == LanguageVersion.CSharp10)
+            {
+                expectedDiagnostics = expectedDiagnostics.Append(
+                    // (43,38): error CS9063: UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.
+                    //         public ref S1 ReturnsRefArg([System.Diagnostics.CodeAnalysis.UnscopedRef] ref S1 arg) => throw null;
+                    Diagnostic(ErrorCode.ERR_UnscopedRefAttributeUnsupportedTarget, "System.Diagnostics.CodeAnalysis.UnscopedRef").WithLocation(43, 38));
+            }
+            comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
         [Theory]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -9655,7 +9655,9 @@ class B2 : A<string>
     public override object this[int x, R<string> y] => null; // 4
 }";
             comp = CreateCompilation(sourceB, references: new[] { refA });
-            comp.VerifyEmitDiagnostics(
+            // https://github.com/dotnet/roslyn/issues/62340: Avoid reporting errors for
+            // overrides or interface implementations until variance is supported.
+            comp.VerifyEmitDiagnostics(/*
                 // (12,31): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     public override R<string> F1(scoped R<string> r) => default; // 1
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("r").WithLocation(12, 31),
@@ -9667,7 +9669,7 @@ class B2 : A<string>
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "set").WithArguments("r").WithLocation(16, 76),
                 // (17,56): error CS8987: The 'scoped' modifier of parameter 'y' doesn't match overridden or implemented member.
                 //     public override object this[int x, R<string> y] => null; // 4
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "null").WithArguments("y").WithLocation(17, 56));
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "null").WithArguments("y").WithLocation(17, 56)*/);
         }
 
         [CombinatorialData]
@@ -9715,7 +9717,9 @@ class C2 : I<string>
     public object this[in R<string> x, int y] => null;
 }";
             comp = CreateCompilation(sourceB1, references: new[] { refA });
-            comp.VerifyEmitDiagnostics(
+            // https://github.com/dotnet/roslyn/issues/62340: Avoid reporting errors for
+            // overrides or interface implementations until variance is supported.
+            comp.VerifyEmitDiagnostics(/*
                 // (14,22): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     public R<string> F1(scoped R<string> r) => default; // 1
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("r").WithLocation(14, 22),
@@ -9727,7 +9731,7 @@ class C2 : I<string>
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "set").WithArguments("r").WithLocation(18, 67),
                 // (19,47): error CS8987: The 'scoped' modifier of parameter 'y' doesn't match overridden or implemented member.
                 //     public object this[int x, R<string> y] => null; // 4
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "null").WithArguments("y").WithLocation(19, 47));
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "null").WithArguments("y").WithLocation(19, 47)*/);
 
             var sourceB2 =
 @"class C3 : I<int>
@@ -9753,7 +9757,9 @@ class C4 : I<string>
     object I<string>.this[in R<string> x, int y] => null;
 }";
             comp = CreateCompilation(sourceB2, references: new[] { refA });
-            comp.VerifyEmitDiagnostics(
+            // https://github.com/dotnet/roslyn/issues/62340: Avoid reporting errors for
+            // overrides or interface implementations until variance is supported.
+            comp.VerifyEmitDiagnostics(/*
                 // (14,25): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     R<string> I<string>.F1(scoped R<string> r) => default; // 1
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("r").WithLocation(14, 25),
@@ -9765,7 +9771,7 @@ class C4 : I<string>
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "set").WithArguments("r").WithLocation(18, 70),
                 // (19,50): error CS8987: The 'scoped' modifier of parameter 'y' doesn't match overridden or implemented member.
                 //     object I<string>.this[int x, R<string> y] => null; // 4
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "null").WithArguments("y").WithLocation(19, 50));
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "null").WithArguments("y").WithLocation(19, 50)*/);
         }
 
         [CombinatorialData]
@@ -9951,13 +9957,15 @@ class Program
     }
 }";
             var comp = CreateCompilation(source, runtimeFeature: RuntimeFlag.ByRefFields);
-            comp.VerifyEmitDiagnostics(
+            // https://github.com/dotnet/roslyn/issues/62340: Avoid reporting errors for
+            // overrides or interface implementations until variance is supported.
+            comp.VerifyEmitDiagnostics(/*
                 // (13,23): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     public override R F1(R r) => r;
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("r").WithLocation(13, 23),
                 // (14,23): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     public override R F2(scoped R r) => default;
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(14, 23));
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(14, 23)*/);
         }
 
         [Fact]
@@ -15343,13 +15351,15 @@ class B2 : A<int>
 ";
             var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
             // https://github.com/dotnet/roslyn/issues/62340: Should allow removing [UnscopedRef] rather than reporting error 2.
-            comp.VerifyDiagnostics(
+            // https://github.com/dotnet/roslyn/issues/62340: Avoid reporting errors for
+            // overrides or interface implementations until variance is supported.
+            comp.VerifyDiagnostics(/*
                 // (14,28): error CS8987: The 'scoped' modifier of parameter 'i' doesn't match overridden or implemented member.
                 //     internal override void F1([UnscopedRef] out int i) { i = 0; } // 1
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("i").WithLocation(14, 28),
                 // (15,28): error CS8987: The 'scoped' modifier of parameter 'i' doesn't match overridden or implemented member.
                 //     internal override void F2(out int i) { i = 0; } // 2
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("i").WithLocation(15, 28));
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("i").WithLocation(15, 28)*/);
         }
 
         [Fact]
@@ -15411,13 +15421,15 @@ class B2 : A<int>
 }
 ";
             var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
-            comp.VerifyDiagnostics(
+            // https://github.com/dotnet/roslyn/issues/62340: Avoid reporting errors for
+            // overrides or interface implementations until variance is supported.
+            comp.VerifyDiagnostics(/*
                 // (17,28): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     internal override void F1([UnscopedRef] ref R<int> r) { } // 1
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("r").WithLocation(17, 28),
                 // (18,28): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     internal override void F2(ref R<int> r) { } // 2
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(18, 28));
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(18, 28)*/);
         }
 
         [Fact]
@@ -15453,7 +15465,9 @@ class C4 : I<object>
 ";
             var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
             // https://github.com/dotnet/roslyn/issues/62340: Should allow removing [UnscopedRef] rather than reporting error 2 and 4.
-            comp.VerifyDiagnostics(
+            // https://github.com/dotnet/roslyn/issues/62340: Avoid reporting errors for
+            // overrides or interface implementations until variance is supported.
+            comp.VerifyDiagnostics(/*
                 // (14,17): error CS8987: The 'scoped' modifier of parameter 'i' doesn't match overridden or implemented member.
                 //     public void F1([UnscopedRef] out int i) { i = 0; } // 1
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("i").WithLocation(14, 17),
@@ -15465,7 +15479,7 @@ class C4 : I<object>
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("o").WithLocation(24, 20),
                 // (25,20): error CS8987: The 'scoped' modifier of parameter 'o' doesn't match overridden or implemented member.
                 //     void I<object>.F2(out object o) { o = null; } // 4
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("o").WithLocation(25, 20));
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("o").WithLocation(25, 20)*/);
         }
 
         [Fact]
@@ -15553,7 +15567,9 @@ class C4 : I<object>
 }
 ";
             var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
-            comp.VerifyDiagnostics(
+            // https://github.com/dotnet/roslyn/issues/62340: Avoid reporting errors for
+            // overrides or interface implementations until variance is supported.
+            comp.VerifyDiagnostics(/*
                 // (17,17): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     public void F1([UnscopedRef] ref R<int> r) { } // 1
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("r").WithLocation(17, 17),
@@ -15565,7 +15581,7 @@ class C4 : I<object>
                 Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("r").WithLocation(27, 20),
                 // (28,20): error CS8987: The 'scoped' modifier of parameter 'r' doesn't match overridden or implemented member.
                 //     void I<object>.F2(ref R<object> r) { } // 4
-                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(28, 20));
+                Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F2").WithArguments("r").WithLocation(28, 20)*/);
         }
 
         [Fact]
@@ -16123,11 +16139,11 @@ public abstract class A<T>
             var sourceB =
 @"class B : A<int>
 {
-    public override void F1(out int i1) { i1 = 0; }
+    public override void F1(out int i1) { i1 = 0; } // 1
     public override void F2(R<int> r2) { }
-    public override void F3(ref R<int> r3) { }
-    public override void F4(in R<int> r4) { }
-    public override void F5(out R<int> r5) { r5 = default; }
+    public override void F3(ref R<int> r3) { } // 2
+    public override void F4(in R<int> r4) { } // 3
+    public override void F5(out R<int> r5) { r5 = default; } // 4
 }";
             comp = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersionB));
             if (languageVersionA == languageVersionB)
@@ -16136,19 +16152,9 @@ public abstract class A<T>
             }
             else
             {
-                comp.VerifyEmitDiagnostics(
-                    // (3,26): error CS8987: The 'scoped' modifier of parameter 'i1' doesn't match overridden or implemented member.
-                    //     public override void F1(out int i1) { i1 = 0; }
-                    Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("i1").WithLocation(3, 26),
-                    // (5,26): error CS8987: The 'scoped' modifier of parameter 'r3' doesn't match overridden or implemented member.
-                    //     public override void F3(ref R<int> r3) { }
-                    Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F3").WithArguments("r3").WithLocation(5, 26),
-                    // (6,26): error CS8987: The 'scoped' modifier of parameter 'r4' doesn't match overridden or implemented member.
-                    //     public override void F4(in R<int> r4) { }
-                    Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F4").WithArguments("r4").WithLocation(6, 26),
-                    // (7,26): error CS8987: The 'scoped' modifier of parameter 'r5' doesn't match overridden or implemented member.
-                    //     public override void F5(out R<int> r5) { r5 = default; }
-                    Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F5").WithArguments("r5").WithLocation(7, 26));
+                // https://github.com/dotnet/roslyn/issues/62340: Avoid reporting errors for
+                // overrides or interface implementations until variance is supported.
+                comp.VerifyEmitDiagnostics();
             }
         }
 
@@ -16178,19 +16184,19 @@ public interface I<T>
             var sourceB =
 @"class B1 : I<int>
 {
-    public void F1(out int i1) { i1 = 0; }
+    public void F1(out int i1) { i1 = 0; } // 1
     public void F2(R<int> r2) { }
-    public void F3(ref R<int> r3) { }
-    public void F4(in R<int> r4) { }
-    public void F5(out R<int> r5) { r5 = default; }
+    public void F3(ref R<int> r3) { } // 2
+    public void F4(in R<int> r4) { } // 3
+    public void F5(out R<int> r5) { r5 = default; } // 4
 }
 class B2 : I<object>
 {
-    void I<object>.F1(out object o1) { o1 = null; }
+    void I<object>.F1(out object o1) { o1 = null; } // 5
     void I<object>.F2(R<object> r2) { }
-    void I<object>.F3(ref R<object> r3) { }
-    void I<object>.F4(in R<object> r4) { }
-    void I<object>.F5(out R<object> r5) { r5 = default; }
+    void I<object>.F3(ref R<object> r3) { } // 6
+    void I<object>.F4(in R<object> r4) { } // 7
+    void I<object>.F5(out R<object> r5) { r5 = default; } // 8
 }";
             comp = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersionB));
             if (languageVersionA == languageVersionB)
@@ -16199,31 +16205,9 @@ class B2 : I<object>
             }
             else
             {
-                comp.VerifyEmitDiagnostics(
-                    // (3,17): error CS8987: The 'scoped' modifier of parameter 'i1' doesn't match overridden or implemented member.
-                    //     public void F1(out int i1) { i1 = 0; }
-                    Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("i1").WithLocation(3, 17),
-                    // (5,17): error CS8987: The 'scoped' modifier of parameter 'r3' doesn't match overridden or implemented member.
-                    //     public void F3(ref R<int> r3) { }
-                    Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F3").WithArguments("r3").WithLocation(5, 17),
-                    // (6,17): error CS8987: The 'scoped' modifier of parameter 'r4' doesn't match overridden or implemented member.
-                    //     public void F4(in R<int> r4) { }
-                    Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F4").WithArguments("r4").WithLocation(6, 17),
-                    // (7,17): error CS8987: The 'scoped' modifier of parameter 'r5' doesn't match overridden or implemented member.
-                    //     public void F5(out R<int> r5) { r5 = default; }
-                    Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F5").WithArguments("r5").WithLocation(7, 17),
-                    // (11,20): error CS8987: The 'scoped' modifier of parameter 'o1' doesn't match overridden or implemented member.
-                    //     void I<object>.F1(out object o1) { o1 = null; }
-                    Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F1").WithArguments("o1").WithLocation(11, 20),
-                    // (13,20): error CS8987: The 'scoped' modifier of parameter 'r3' doesn't match overridden or implemented member.
-                    //     void I<object>.F3(ref R<object> r3) { }
-                    Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F3").WithArguments("r3").WithLocation(13, 20),
-                    // (14,20): error CS8987: The 'scoped' modifier of parameter 'r4' doesn't match overridden or implemented member.
-                    //     void I<object>.F4(in R<object> r4) { }
-                    Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F4").WithArguments("r4").WithLocation(14, 20),
-                    // (15,20): error CS8987: The 'scoped' modifier of parameter 'r5' doesn't match overridden or implemented member.
-                    //     void I<object>.F5(out R<object> r5) { r5 = default; }
-                    Diagnostic(ErrorCode.ERR_ScopedMismatchInParameterOfOverrideOrImplementation, "F5").WithArguments("r5").WithLocation(15, 20));
+                // https://github.com/dotnet/roslyn/issues/62340: Avoid reporting errors for
+                // overrides or interface implementations until variance is supported.
+                comp.VerifyEmitDiagnostics();
             }
         }
     }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SpanStackSafetyTests.cs
@@ -482,10 +482,8 @@ class Program
             );
         }
 
-        [Theory]
-        [InlineData(LanguageVersion.CSharp10)]
-        [InlineData(LanguageVersion.CSharp11)]
-        public void ByrefParam(LanguageVersion languageVersion)
+        [Fact]
+        public void ByrefParam()
         {
             var text = @"using System;
 using System.Diagnostics.CodeAnalysis;
@@ -528,7 +526,24 @@ class Program
     static ref TypedReference M1(ref TypedReference ss) => ref ss;
 }
 ";
-            var comp = CreateCompilationWithMscorlibAndSpan(new[] { text, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+            var comp = CreateCompilationWithMscorlibAndSpan(new[] { text, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular10);
+            comp.VerifyDiagnostics(
+                // (39,34): error CS1601: Cannot make reference to variable of type 'TypedReference'
+                //     static ref TypedReference M1(ref TypedReference ss) => ref ss;
+                Diagnostic(ErrorCode.ERR_MethodArgCantBeRefAny, "ref TypedReference ss").WithArguments("System.TypedReference").WithLocation(39, 34),
+                // (39,12): error CS1599: The return type of a method, delegate, or function pointer cannot be 'TypedReference'
+                //     static ref TypedReference M1(ref TypedReference ss) => ref ss;
+                Diagnostic(ErrorCode.ERR_MethodReturnCantBeRefAny, "ref TypedReference").WithArguments("System.TypedReference").WithLocation(39, 12),
+                // (32,33): error CS9063: UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.
+                //     static ref Span<string> M4([UnscopedRef] ref Span<string> ss) { return ref ss; }
+                Diagnostic(ErrorCode.ERR_UnscopedRefAttributeUnsupportedTarget, "UnscopedRef").WithLocation(32, 33),
+                // (35,42): error CS9063: UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.
+                //     static ref readonly Span<string> M5([UnscopedRef] ref Span<string> ss) => ref ss;
+                Diagnostic(ErrorCode.ERR_UnscopedRefAttributeUnsupportedTarget, "UnscopedRef").WithLocation(35, 42)
+            );
+
+            comp = CreateCompilationWithMscorlibAndSpan(new[] { text, UnscopedRefAttributeDefinition });
             comp.VerifyDiagnostics(
                 // (39,34): error CS1601: Cannot make reference to variable of type 'TypedReference'
                 //     static ref TypedReference M1(ref TypedReference ss) => ref ss;
@@ -1449,10 +1464,50 @@ class Program
         }
 
         [WorkItem(27874, "https://github.com/dotnet/roslyn/issues/27874")]
-        [Theory]
-        [InlineData(LanguageVersion.CSharp10)]
-        [InlineData(LanguageVersion.CSharp11)]
-        public void PassingSpansToLocals_EscapeScope(LanguageVersion languageVersion)
+        [Fact]
+        public void PassingSpansToLocals_EscapeScope_01()
+        {
+            var source = @"using System;
+class C
+{
+    static void Main()
+    {
+        Span<int> x = stackalloc int [10];
+        
+        Console.WriteLine(M1(ref x).Length);
+        Console.WriteLine(M2(ref x).Length);
+    }
+    
+    static ref Span<int> M1(ref Span<int> x)
+    {
+        ref Span<int> q = ref x;
+        return ref q;
+    }
+    
+    static ref Span<int> M2(ref Span<int> x)
+    {
+        return ref x;
+    }
+}";
+
+            var comp = CreateCompilationWithMscorlibAndSpan(source, parseOptions: TestOptions.Regular10, options: TestOptions.ReleaseExe);
+            CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
+10
+10");
+
+            comp = CreateCompilationWithMscorlibAndSpan(source, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics(
+                // (15,20): error CS8157: Cannot return 'q' by reference because it was initialized to a value that cannot be returned by reference
+                //         return ref q;
+                Diagnostic(ErrorCode.ERR_RefReturnNonreturnableLocal, "q").WithArguments("q").WithLocation(15, 20),
+                // (20,20): error CS8166: Cannot return a parameter by reference 'x' because it is not a ref parameter
+                //         return ref x;
+                Diagnostic(ErrorCode.ERR_RefReturnParameter, "x").WithArguments("x").WithLocation(20, 20));
+        }
+
+        [WorkItem(27874, "https://github.com/dotnet/roslyn/issues/27874")]
+        [Fact]
+        public void PassingSpansToLocals_EscapeScope_02()
         {
             var source = @"using System;
 using System.Diagnostics.CodeAnalysis;
@@ -1477,7 +1532,17 @@ class C
         return ref x;
     }
 }";
-            var comp = CreateCompilationWithMscorlibAndSpan(new[] { source, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion), options: TestOptions.ReleaseExe);
+
+            var comp = CreateCompilationWithMscorlibAndSpan(new[] { source, UnscopedRefAttributeDefinition }, parseOptions: TestOptions.Regular10, options: TestOptions.ReleaseExe);
+            comp.VerifyDiagnostics(
+                // (13,30): error CS9063: UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.
+                //     static ref Span<int> M1([UnscopedRef] ref Span<int> x)
+                Diagnostic(ErrorCode.ERR_UnscopedRefAttributeUnsupportedTarget, "UnscopedRef").WithLocation(13, 30),
+                // (19,30): error CS9063: UnscopedRefAttribute can only be applied to 'out' parameters, 'ref' and 'in' parameters that refer to 'ref struct' types, and instance methods and properties on 'struct' types other than constructors and 'init' accessors.
+                //     static ref Span<int> M2([UnscopedRef] ref Span<int> x)
+                Diagnostic(ErrorCode.ERR_UnscopedRefAttributeUnsupportedTarget, "UnscopedRef").WithLocation(19, 30));
+
+            comp = CreateCompilationWithMscorlibAndSpan(new[] { source, UnscopedRefAttributeDefinition }, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, verify: Verification.Fails, expectedOutput: @"
 10
 10");

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UserDefinedConversionTests.cs
@@ -1705,7 +1705,16 @@ namespace System
     public ref struct Int32 {}
     public struct Nullable<T> where T : struct { public Nullable(T value) {} }
     public struct Int64 {}
-    public class Attribute {}
+    public struct Boolean { }
+    public class Attribute { }
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets t) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public struct Enum { }
+    public enum AttributeTargets { }
 }
 ";
 
@@ -1749,7 +1758,16 @@ namespace System
     public struct Int32 {}
     public struct Nullable<T> where T : struct { public T Value { get => throw null; } }
     public ref struct Int64 {}
-    public class Attribute {}
+    public struct Boolean { }
+    public class Attribute { }
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets t) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public struct Enum { }
+    public enum AttributeTargets { }
 }
 ";
 
@@ -1797,7 +1815,16 @@ namespace System
     public ref struct Int32 {}
     public struct Nullable<T> where T : struct { public Nullable(T value) {} }
     public struct Int64 {}
-    public class Attribute {}
+    public struct Boolean { }
+    public class Attribute { }
+    public class AttributeUsageAttribute : Attribute
+    {
+        public AttributeUsageAttribute(AttributeTargets t) { }
+        public bool AllowMultiple { get; set; }
+        public bool Inherited { get; set; }
+    }
+    public struct Enum { }
+    public enum AttributeTargets { }
 }
 ";
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/Utf8StringsLiteralsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/Utf8StringsLiteralsTests.cs
@@ -3121,7 +3121,9 @@ class C
             var comp = CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.ReleaseDll);
             var verifier = CompileAndVerify(comp, verify: Verification.Fails).VerifyDiagnostics();
 
-            string blobId = ExecutionConditionUtil.IsWindows ? "I_000025B8" : "I_00002600";
+            string blobId = ExecutionConditionUtil.IsWindows ?
+                (ExecutionConditionUtil.IsCoreClr ? "I_000026F8" : "I_000026F4") :
+                "I_00002738";
 
             verifier.VerifyTypeIL("<PrivateImplementationDetails>", @"
 .class private auto ansi sealed '<PrivateImplementationDetails>'
@@ -3165,7 +3167,9 @@ class C
   IL_000b:  ret
 }
 ");
-            string blobId = ExecutionConditionUtil.IsWindows ? "I_000025B8" : "I_00002600";
+            string blobId = ExecutionConditionUtil.IsWindows ?
+                (ExecutionConditionUtil.IsCoreClr ? "I_000026F8" : "I_000026F4") :
+                "I_00002738";
 
             verifier.VerifyTypeIL("<PrivateImplementationDetails>", @"
 .class private auto ansi sealed '<PrivateImplementationDetails>'

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtendedPartialMethodsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtendedPartialMethodsTests.cs
@@ -2428,38 +2428,43 @@ public partial class D : C
                 var verifier = CompileAndVerify(source2, references: new[] { reference }, parseOptions: TestOptions.RegularWithExtendedPartialMethods);
                 verifier.VerifyTypeIL("D", @"
 .class public auto ansi beforefieldinit D
-        extends [C]C
+	extends [C]C
 {
-        // Methods
-        .method public hidebysig virtual
-                instance void M (
-                        [in] object& modreq([netstandard]System.Runtime.InteropServices.InAttribute) x
-                ) cil managed
-        {
-                .param [1]
-                        .custom instance void System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = (
-                                01 00 00 00
-                        )
-                // Method begins at RVA 0x2058
-                // Code size 9 (0x9)
-                .maxstack 8
-                IL_0000: ldarg.1
-                IL_0001: ldind.ref
-                IL_0002: callvirt instance string [netstandard]System.Object::ToString()
-                IL_0007: pop
-                IL_0008: ret
-        } // end of method D::M
-        .method public hidebysig specialname rtspecialname
-                instance void .ctor () cil managed
-        {
-                // Method begins at RVA 0x2062
-                // Code size 7 (0x7)
-                .maxstack 8
-                IL_0000: ldarg.0
-                IL_0001: call instance void [C]C::.ctor()
-                IL_0006: ret
-        } // end of method D::.ctor
-} // end of class D");
+	// Methods
+	.method public hidebysig virtual 
+		instance void M (
+			[in] object& modreq([netstandard]System.Runtime.InteropServices.InAttribute) x
+		) cil managed 
+	{
+		.param [1]
+			.custom instance void System.Runtime.CompilerServices.IsReadOnlyAttribute::.ctor() = (
+				01 00 00 00
+			)
+		// Method begins at RVA 0x2067
+		// Code size 9 (0x9)
+		.maxstack 8
+
+		IL_0000: ldarg.1
+		IL_0001: ldind.ref
+		IL_0002: callvirt instance string [netstandard]System.Object::ToString()
+		IL_0007: pop
+		IL_0008: ret
+	} // end of method D::M
+
+	.method public hidebysig specialname rtspecialname 
+		instance void .ctor () cil managed 
+	{
+		// Method begins at RVA 0x2071
+		// Code size 7 (0x7)
+		.maxstack 8
+
+		IL_0000: ldarg.0
+		IL_0001: call instance void [C]C::.ctor()
+		IL_0006: ret
+	} // end of method D::.ctor
+
+} // end of class D
+");
             }
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/IndexedPropertyTests.cs
@@ -2502,7 +2502,7 @@ class D : CodeModule
     public string get_ProcOfLine(int line, out Microsoft.Vbe.Interop.vbext_ProcKind procKind) { throw null; }
 }
 ";
-            var comp = CreateCompilationWithILAndMscorlib40(source, il);
+            var comp = CreateCompilationWithILAndMscorlib40(source, il, parseOptions: TestOptions.Regular10);
             comp.VerifyDiagnostics(
                 // (4,7): error CS0535: 'C' does not implement interface member 'Microsoft.Vbe.Interop._CodeModule.ProcOfLine[int, out Microsoft.Vbe.Interop.vbext_ProcKind].get'
                 // class C : CodeModule

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -414,6 +414,17 @@ namespace System
 
     public class ValueType {{ }}
     public struct Void {{ }}
+    public struct Int32 {{ }}
+    public struct Boolean {{ }}
+    public class Attribute {{ }}
+    public class AttributeUsageAttribute : Attribute
+    {{
+        public AttributeUsageAttribute(AttributeTargets t) {{ }}
+        public bool AllowMultiple {{ get; set; }}
+        public bool Inherited {{ get; set; }}
+    }}
+    public struct Enum {{ }}
+    public enum AttributeTargets {{ }}
 }}
 ";
             Action<CSharpCompilation> validate = comp =>
@@ -615,6 +626,7 @@ namespace System
                     case WellKnownType.System_Runtime_CompilerServices_RequiredMemberAttribute:
                     case WellKnownType.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute:
                     case WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute:
+                    case WellKnownType.System_Runtime_CompilerServices_RefSafetyRulesAttribute:
                     case WellKnownType.System_MemoryExtensions:
                     case WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute:
                     case WellKnownType.System_Diagnostics_CodeAnalysis_UnscopedRefAttribute:
@@ -979,6 +991,7 @@ namespace System
                     case WellKnownMember.System_Runtime_CompilerServices_RequiredMemberAttribute__ctor:
                     case WellKnownMember.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor:
                     case WellKnownMember.System_Runtime_CompilerServices_ScopedRefAttribute__ctor:
+                    case WellKnownMember.System_Runtime_CompilerServices_RefSafetyRulesAttribute__ctor:
                     case WellKnownMember.System_MemoryExtensions__SequenceEqual_Span_T:
                     case WellKnownMember.System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T:
                     case WellKnownMember.System_MemoryExtensions__AsSpan_String:

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -2538,6 +2538,11 @@ namespace Microsoft.CodeAnalysis
             return default(AssemblyReferenceHandle);
         }
 
+        internal AssemblyReference GetAssemblyRef(AssemblyReferenceHandle assemblyRef)
+        {
+            return MetadataReader.GetAssemblyReference(assemblyRef);
+        }
+
         /// <summary>
         /// Returns MetadataToken for type ref matching resolution scope and name
         /// </summary>

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1097,6 +1097,22 @@ namespace Microsoft.CodeAnalysis
             return FindTargetAttribute(token, AttributeDescription.UnscopedRefAttribute).HasValue;
         }
 
+        internal bool HasRefSafetyRulesAttribute(EntityHandle token, out int version)
+        {
+            AttributeInfo info = FindTargetAttribute(token, AttributeDescription.RefSafetyRulesAttribute);
+            if (info.HasValue)
+            {
+                Debug.Assert(info.SignatureIndex == 0);
+                if (TryExtractValueFromAttribute(info.Handle, out int value, s_attributeIntValueExtractor))
+                {
+                    version = value;
+                    return true;
+                }
+            }
+            version = 0;
+            return false;
+        }
+
         internal bool HasTupleElementNamesAttribute(EntityHandle token, out ImmutableArray<string> tupleElementNames)
         {
             var info = FindTargetAttribute(token, AttributeDescription.TupleElementNamesAttribute);

--- a/src/Compilers/Core/Portable/MetadataReader/SymbolFactory.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/SymbolFactory.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis
         internal abstract TypeSymbol SubstituteTypeParameters(ModuleSymbol moduleSymbol, TypeSymbol generic, ImmutableArray<KeyValuePair<TypeSymbol, ImmutableArray<ModifierInfo<TypeSymbol>>>> arguments, ImmutableArray<bool> refersToNoPiaLocalType);
 
         internal abstract TypeSymbol MakePointerTypeSymbol(ModuleSymbol moduleSymbol, TypeSymbol type, ImmutableArray<ModifierInfo<TypeSymbol>> customModifiers);
-        internal abstract TypeSymbol MakeFunctionPointerTypeSymbol(Cci.CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> returnAndParamTypes);
+        internal abstract TypeSymbol MakeFunctionPointerTypeSymbol(ModuleSymbol moduleSymbol, Cci.CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> returnAndParamTypes);
         internal abstract TypeSymbol GetSpecialType(ModuleSymbol moduleSymbol, SpecialType specialType);
         internal abstract TypeSymbol GetSystemTypeSymbol(ModuleSymbol moduleSymbol);
         internal abstract TypeSymbol GetEnumUnderlyingType(ModuleSymbol moduleSymbol, TypeSymbol type);

--- a/src/Compilers/Core/Portable/MetadataReader/TypeNameDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/TypeNameDecoder.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis
 
         protected TypeSymbol MakeFunctionPointerTypeSymbol(Cci.CallingConvention callingConvention, ImmutableArray<ParamInfo<TypeSymbol>> retAndParamInfos)
         {
-            return _factory.MakeFunctionPointerTypeSymbol(callingConvention, retAndParamInfos);
+            return _factory.MakeFunctionPointerTypeSymbol(this.moduleSymbol, callingConvention, retAndParamInfos);
         }
 
         protected TypeSymbol GetSpecialType(SpecialType specialType)

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -334,6 +334,7 @@ namespace Microsoft.CodeAnalysis
         private static readonly byte[][] s_signaturesOfNullableAttribute = { s_signature_HasThis_Void_Byte, s_signature_HasThis_Void_SzArray_Byte };
         private static readonly byte[][] s_signaturesOfNullableContextAttribute = { s_signature_HasThis_Void_Byte };
         private static readonly byte[][] s_signaturesOfNativeIntegerAttribute = { s_signature_HasThis_Void, s_signature_HasThis_Void_SzArray_Boolean };
+        private static readonly byte[][] s_signaturesOfRefSafetyRulesAttribute = { s_signature_HasThis_Void_Int32 };
         private static readonly byte[][] s_signaturesOfInterpolatedStringArgumentAttribute = { s_signature_HasThis_Void_String, s_signature_HasThis_Void_SzArray_String };
 
         // early decoded attributes:
@@ -470,6 +471,7 @@ namespace Microsoft.CodeAnalysis
         internal static readonly AttributeDescription SkipLocalsInitAttribute = new AttributeDescription("System.Runtime.CompilerServices", "SkipLocalsInitAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription NativeIntegerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "NativeIntegerAttribute", s_signaturesOfNativeIntegerAttribute);
         internal static readonly AttributeDescription ScopedRefAttribute = new AttributeDescription("System.Runtime.CompilerServices", "ScopedRefAttribute", s_signatures_HasThis_Void_Only);
+        internal static readonly AttributeDescription RefSafetyRulesAttribute = new AttributeDescription("System.Runtime.CompilerServices", "RefSafetyRulesAttribute", s_signaturesOfRefSafetyRulesAttribute);
         internal static readonly AttributeDescription ModuleInitializerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "ModuleInitializerAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription UnmanagedCallersOnlyAttribute = new AttributeDescription("System.Runtime.InteropServices", "UnmanagedCallersOnlyAttribute", s_signatures_HasThis_Void_Only);
         internal static readonly AttributeDescription InterpolatedStringHandlerAttribute = new AttributeDescription("System.Runtime.CompilerServices", "InterpolatedStringHandlerAttribute", s_signatures_HasThis_Void_Only);

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -523,6 +523,7 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_RequiredMemberAttribute__ctor,
         System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor,
         System_Runtime_CompilerServices_ScopedRefAttribute__ctor,
+        System_Runtime_CompilerServices_RefSafetyRulesAttribute__ctor,
 
         System_MemoryExtensions__SequenceEqual_Span_T,
         System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T,

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3590,6 +3590,14 @@ namespace Microsoft.CodeAnalysis
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
 
+                // System_Runtime_CompilerServices_RefSafetyRulesAttribute__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_RefSafetyRulesAttribute - WellKnownType.ExtSentinel), // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void, // Return Type
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+
                 // System_MemoryExtensions__SequenceEqual_Span_T
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                               // Flags
                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_MemoryExtensions - WellKnownType.ExtSentinel),    // DeclaringTypeId
@@ -4110,7 +4118,8 @@ namespace Microsoft.CodeAnalysis
                 "ToStringAndClear",                         // System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear
                 ".ctor",                                    // System_Runtime_CompilerServices_RequiredMemberAttribute__ctor
                 ".ctor",                                    // System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor
-                ".ctor",                                    // System_Runtime_CompilerServices_LifetimeAttribute__ctor
+                ".ctor",                                    // System_Runtime_CompilerServices_ScopedRefAttribute__ctor
+                ".ctor",                                    // System_Runtime_CompilerServices_RefSafetyRulesAttribute__ctor
                 "SequenceEqual",                            // System_MemoryExtensions__SequenceEqual_Span_T
                 "SequenceEqual",                            // System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T
                 "AsSpan",                                   // System_MemoryExtensions__AsSpan_String

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -315,6 +315,7 @@ namespace Microsoft.CodeAnalysis
 
         System_Runtime_CompilerServices_DefaultInterpolatedStringHandler,
         System_Runtime_CompilerServices_ScopedRefAttribute,
+        System_Runtime_CompilerServices_RefSafetyRulesAttribute,
 
         System_ArgumentNullException,
 
@@ -636,6 +637,7 @@ namespace Microsoft.CodeAnalysis
             "System.Text.StringBuilder",
             "System.Runtime.CompilerServices.DefaultInterpolatedStringHandler",
             "System.Runtime.CompilerServices.ScopedRefAttribute",
+            "System.Runtime.CompilerServices.RefSafetyRulesAttribute",
             "System.ArgumentNullException",
 
             "System.Runtime.CompilerServices.RequiredMemberAttribute",

--- a/src/Compilers/Test/Core/Metadata/MetadataValidation.cs
+++ b/src/Compilers/Test/Core/Metadata/MetadataValidation.cs
@@ -33,6 +33,12 @@ namespace Roslyn.Test.Utilities
                 var name = metadataReader.GetTypeReference((TypeReferenceHandle)container).Name;
                 return metadataReader.GetString(name);
             }
+            else if (ctorHandle.Kind == HandleKind.MethodDefinition)
+            {
+                var container = metadataReader.GetMethodDefinition((MethodDefinitionHandle)ctorHandle).GetDeclaringType();
+                var name = metadataReader.GetTypeDefinition(container).Name;
+                return metadataReader.GetString(name);
+            }
             else
             {
                 Assert.True(false, "not impl");

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -986,7 +986,6 @@ namespace System.Diagnostics.CodeAnalysis
                 source,
                 (s, _) =>
                 {
-                    if (s == "Version") return null;
                     Assert.True(expectedBlobs.ContainsKey(s), "Expecting marshalling blob for " + (isField ? "field " : "parameter ") + s);
                     return expectedBlobs[s];
                 },

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -640,6 +640,19 @@ namespace System.Runtime.CompilerServices
     }
 }";
 
+        protected const string RefSafetyRulesAttributeDefinition =
+@"namespace System.Runtime.CompilerServices
+{
+    public sealed class RefSafetyRulesAttribute : Attribute
+    {
+        public RefSafetyRulesAttribute(int version) { Version = version; }
+        public int Version;
+    }
+}";
+
+        protected static readonly MetadataReference RefSafetyRulesAttributeLib =
+            CreateCompilation(RefSafetyRulesAttributeDefinition).EmitToImageReference();
+
         protected const string RequiredMemberAttribute = @"
 namespace System.Runtime.CompilerServices
 {
@@ -973,6 +986,7 @@ namespace System.Diagnostics.CodeAnalysis
                 source,
                 (s, _) =>
                 {
+                    if (s == "Version") return null;
                     Assert.True(expectedBlobs.ContainsKey(s), "Expecting marshalling blob for " + (isField ? "field " : "parameter ") + s);
                     return expectedBlobs[s];
                 },

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/SymbolFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/SymbolFactory.vb
@@ -145,7 +145,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Return If(namedType IsNot Nothing AndAlso namedType.IsGenericType, UnboundGenericType.Create(namedType), type)
         End Function
 
-        Friend Overrides Function MakeFunctionPointerTypeSymbol(callingConvention As Cci.CallingConvention, retAndParamTypes As ImmutableArray(Of ParamInfo(Of TypeSymbol))) As TypeSymbol
+        Friend Overrides Function MakeFunctionPointerTypeSymbol(moduleSymbol As PEModuleSymbol, callingConvention As Cci.CallingConvention, retAndParamTypes As ImmutableArray(Of ParamInfo(Of TypeSymbol))) As TypeSymbol
             Return New UnsupportedMetadataTypeSymbol()
         End Function
     End Class

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -552,6 +552,7 @@ End Namespace
                          WellKnownType.System_MemoryExtensions,
                          WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute,
                          WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute,
+                         WellKnownType.System_Runtime_CompilerServices_RefSafetyRulesAttribute,
                          WellKnownType.System_Diagnostics_CodeAnalysis_UnscopedRefAttribute,
                          WellKnownType.System_MemoryExtensions,
                          WellKnownType.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute
@@ -626,6 +627,7 @@ End Namespace
                          WellKnownType.System_MemoryExtensions,
                          WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute,
                          WellKnownType.System_Runtime_CompilerServices_ScopedRefAttribute,
+                         WellKnownType.System_Runtime_CompilerServices_RefSafetyRulesAttribute,
                          WellKnownType.System_Diagnostics_CodeAnalysis_UnscopedRefAttribute,
                          WellKnownType.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute
                         ' Not available on all platforms.
@@ -720,6 +722,7 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_RequiredMemberAttribute__ctor,
                          WellKnownMember.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor,
                          WellKnownMember.System_Runtime_CompilerServices_ScopedRefAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_RefSafetyRulesAttribute__ctor,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_Span_T,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T,
                          WellKnownMember.System_MemoryExtensions__AsSpan_String,
@@ -873,6 +876,7 @@ End Namespace
                          WellKnownMember.System_Runtime_CompilerServices_DefaultInterpolatedStringHandler__ToStringAndClear,
                          WellKnownMember.System_Runtime_CompilerServices_RequiredMemberAttribute__ctor,
                          WellKnownMember.System_Diagnostics_CodeAnalysis_SetsRequiredMembersAttribute__ctor,
+                         WellKnownMember.System_Runtime_CompilerServices_RefSafetyRulesAttribute__ctor,
                          WellKnownMember.System_Runtime_CompilerServices_ScopedRefAttribute__ctor,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_Span_T,
                          WellKnownMember.System_MemoryExtensions__SequenceEqual_ReadOnlySpan_T,

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -436,6 +436,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal override bool HasUnscopedRefAttribute => false;
 
+        internal override bool UseUpdatedEscapeRules => false;
+
         internal ResultProperties ResultProperties
         {
             get { return _lazyResultProperties; }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderMethodSymbol.cs
@@ -220,6 +220,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal override bool HasUnscopedRefAttribute => false;
 
+        internal override bool UseUpdatedEscapeRules => false;
+
         internal override bool RequiresSecurityObject
         {
             get { return false; }


### PR DESCRIPTION
Add a new module-level `RefSafetyRulesAttribute` to enable improved interoperability with existing assemblies.

When compiling with `-langversion:11` or when compiling with a corlib containing `RuntimeFeatures.ByRefFields`, a `[module: RefSafetyRules(11)]` attribute is emitted to the module. The attribute argument indicates the version of the ref safety rules used when compiling the module, and is currently fixed at `11`.

When the C#11 compiler _analyzes a method call_:
- If the module containing the method declaration includes `[module: RefSafetyRules(version)]`, regardless of `version`, the method call is analyzed with C#11 rules.
- If the module containing the method declaration is from source, and compiled with `-langversion:11` or with a corlib containing the feature flag for `ref` fields, the method call is analyzed with C#11 rules.
- _If the module containing the method declaration references `System.Runtime { ver: 7.0 }`, the method call is analyzed with C#11 rules. This rule is a temporary mitigation for modules compiled with earlier previews of C#11 and .NET 7 and may be removed later._
- Otherwise, the method call is analyzed with C#7.2 rules.

The attribute and details above are included in https://github.com/dotnet/csharplang/pull/6382.

The PR _disables verification_ of `scoped` for parameters across overrides and interface implementations. Currently, we require that `scoped` matches exactly when overriding or implementing which is too restrictive and is a breaking change _with this PR_ for a method with an `out` parameter where the base class or interface is defined in an existing, pre-C#11 assembly since `out` parameters are implicitly `scoped out` in C#11. The verification of `scoped` will be re-enabled when variance is supported: see https://github.com/dotnet/roslyn/issues/62340.