### PR TITLE
Fix regression in analyzer partial analysis state tracking

### DIFF
--- a/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -13,7 +13,6 @@ using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using ICSharpCode.Decompiler.TypeSystem;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.SyntaxReferenceAnalyzerStateData.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.SyntaxReferenceAnalyzerStateData.cs
@@ -26,8 +26,21 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             /// <summary>
             /// Partial analysis state for operation block actions executed on the declaration.
+            /// 
+            /// NOTE: This state tracks operations actions registered inside operation block start context.
+            /// Operation actions registered outside operation block start context are tracked
+            /// with <see cref="OperationAnalysisState"/>.
             /// </summary>
             public OperationBlockAnalyzerStateData OperationBlockAnalysisState { get; }
+
+            /// <summary>
+            /// Partial analysis state for operation actions executed on the declaration.
+            /// 
+            /// NOTE: This state tracks operations actions registered outside of operation block start context.
+            /// Operation actions registered inside operation block start context are tracked
+            /// with <see cref="OperationBlockAnalyzerStateData"/>.
+            /// </summary>
+            public OperationAnalyzerStateData OperationAnalysisState { get; }
 
             public static new readonly DeclarationAnalyzerStateData FullyProcessedInstance = CreateFullyProcessedInstance();
 
@@ -35,6 +48,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 CodeBlockAnalysisState = new CodeBlockAnalyzerStateData();
                 OperationBlockAnalysisState = new OperationBlockAnalyzerStateData();
+                OperationAnalysisState = new OperationAnalyzerStateData();
             }
 
             private static DeclarationAnalyzerStateData CreateFullyProcessedInstance()
@@ -48,6 +62,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 CodeBlockAnalysisState.SetStateKind(stateKind);
                 OperationBlockAnalysisState.SetStateKind(stateKind);
+                OperationAnalysisState.SetStateKind(stateKind);
                 base.SetStateKind(stateKind);
             }
 
@@ -56,6 +71,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 base.Free();
                 CodeBlockAnalysisState.Free();
                 OperationBlockAnalysisState.Free();
+                OperationAnalysisState.Free();
             }
         }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -1449,7 +1449,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 if (TryStartAnalyzingDeclaration(declaredSymbol, declarationIndex, analyzer, analysisScope, analysisState, out analyzerState))
                 {
-                    ExecuteOperationActionsCore(operationsToAnalyze, operationActionsByKind, analyzer, declaredSymbol, model, filterSpan, analyzerState?.OperationBlockAnalysisState.ExecutableNodesAnalysisState, isGeneratedCode);
+                    ExecuteOperationActionsCore(operationsToAnalyze, operationActionsByKind, analyzer, declaredSymbol, model, filterSpan, analyzerState?.OperationAnalysisState, isGeneratedCode);
                     return true;
                 }
 


### PR DESCRIPTION
Fixes #63466

My recent PR #63206 fixed partial analysis state tracking where we were making duplicate operation/syntax node callbacks into analyzers across multiple calls to CompilationWithAnalyzers.GetAnalysisResultAsync. However, that introduced a regression #63466 for analyzers that register operation actions both inside and outside an OperationBlockStartAnalysisContext. We execute the operation actions registered in OperationBlockStartAnalysisContext separately from those registered outside of it, but we were incorrectly sharing the same analyzer state for both. This led to skipping one set of analyzer actions. This PR fixes this regression by using separate states for these.

Note that we were already using separate states for syntax node actions registered inside and outside of CodeBlockStartAnalysisContext, so this bug does not affect syntax node based analyzers with similar registration pattern.

Verified that the added unit test fails prior to the fix when Operation actions are used in the test analyzer. The added unit test passes prior to the fix when SyntaxNode actions are used. Also verified that CA1822 regression scenarios in #63466 are also fixed with this change.