### PR TITLE
Revert and fix the stackoverflow when search local function.

### DIFF
--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -669,6 +669,113 @@ testHost, composition, @"public interface IGoo
 
         [Theory]
         [CombinatorialData]
+        public async Task FindTopLevelLocalFunction(TestHost testHost, Composition composition)
+        {
+            await TestAsync(
+testHost, composition, @"void Goo()
+{
+}", async w =>
+{
+    var item = (await _aggregator.GetItemsAsync("Goo")).Single();
+    VerifyNavigateToResultItem(item, "Goo", "[|Goo|]()", PatternMatchKind.Exact, NavigateToItemKind.Method, Glyph.MethodPrivate);
+});
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task FindTopLevelLocalFunction_WithParameters(TestHost testHost, Composition composition)
+        {
+            await TestAsync(
+testHost, composition, @"void Goo(int i)
+{
+}", async w =>
+{
+    var item = (await _aggregator.GetItemsAsync("Goo")).Single();
+    VerifyNavigateToResultItem(item, "Goo", "[|Goo|](int)", PatternMatchKind.Exact, NavigateToItemKind.Method, Glyph.MethodPrivate);
+});
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task FindTopLevelLocalFunction_WithTypeArgumentsAndParameters(TestHost testHost, Composition composition)
+        {
+            await TestAsync(
+testHost, composition, @"void Goo<T>(int i)
+{
+}", async w =>
+{
+    var item = (await _aggregator.GetItemsAsync("Goo")).Single();
+    VerifyNavigateToResultItem(item, "Goo", "[|Goo|]<T>(int)", PatternMatchKind.Exact, NavigateToItemKind.Method, Glyph.MethodPrivate);
+});
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task FindNestedLocalFunctionTopLevelStatements(TestHost testHost, Composition composition)
+        {
+            await TestAsync(
+testHost, composition, @"void Goo()
+{
+    void Bar()
+    {
+    }
+}", async w =>
+{
+    var item = (await _aggregator.GetItemsAsync("Bar")).Single();
+    VerifyNavigateToResultItem(item, "Bar", "[|Bar|]()", PatternMatchKind.Exact, NavigateToItemKind.Method, Glyph.MethodPrivate);
+});
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task FindLocalFunctionInMethod(TestHost testHost, Composition composition)
+        {
+            await TestAsync(
+testHost, composition, @"
+class C
+{
+    void M()
+    {
+        void Goo()
+        {
+            void Bar()
+            {
+            }
+        }
+    }
+}", async w =>
+{
+    var item = (await _aggregator.GetItemsAsync("Goo")).Single();
+    VerifyNavigateToResultItem(item, "Goo", "[|Goo|]()", PatternMatchKind.Exact, NavigateToItemKind.Method, Glyph.MethodPrivate);
+});
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task FindNestedLocalFunctionInMethod(TestHost testHost, Composition composition)
+        {
+            await TestAsync(
+testHost, composition, @"
+class C
+{
+    void M()
+    {
+        void Goo()
+        {
+            void Bar()
+            {
+            }
+        }
+    }
+}", async w =>
+{
+    var item = (await _aggregator.GetItemsAsync("Bar")).Single();
+    VerifyNavigateToResultItem(item, "Bar", "[|Bar|]()", PatternMatchKind.Exact, NavigateToItemKind.Method, Glyph.MethodPrivate);
+});
+        }
+
+        [Theory]
+        [CombinatorialData]
         public async Task FindDelegateInNamespace(TestHost testHost, Composition composition)
         {
             await TestAsync(

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -31,6 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
         BaseNamespaceDeclarationSyntax,
         TypeDeclarationSyntax,
         EnumDeclarationSyntax,
+        MethodDeclarationSyntax,
         MemberDeclarationSyntax,
         NameSyntax,
         QualifiedNameSyntax,
@@ -157,72 +158,117 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
             }
         }
 
-        protected override void AddDeclaredSymbolInfosWorker(
-            SyntaxNode container,
-            MemberDeclarationSyntax node,
+        protected override void AddLocalFunctionInfos(
+            MemberDeclarationSyntax memberDeclaration,
             StringTable stringTable,
             ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos,
-            Dictionary<string, string> aliases,
-            Dictionary<string, ArrayBuilder<int>> extensionMethodInfo,
             string containerDisplayName,
             string fullyQualifiedContainerName,
             CancellationToken cancellationToken)
+        {
+            AddLocalFunctionInfosRecurse(memberDeclaration);
+
+            return;
+
+            void AddLocalFunctionInfosRecurse(SyntaxNode node)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                foreach (var child in node.ChildNodesAndTokens())
+                {
+                    if (child.IsNode)
+                        AddLocalFunctionInfosRecurse(child.AsNode()!);
+                }
+
+                if (node is LocalFunctionStatementSyntax localFunction)
+                {
+                    declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
+                        stringTable,
+                        localFunction.Identifier.ValueText, GetMethodSuffix(localFunction),
+                        containerDisplayName,
+                        fullyQualifiedContainerName,
+                        isPartial: false,
+                        DeclaredSymbolInfoKind.Method,
+                        Accessibility.Private,
+                        localFunction.Identifier.Span,
+                        inheritanceNames: ImmutableArray<string>.Empty,
+                        parameterCount: localFunction.ParameterList.Parameters.Count,
+                        typeParameterCount: localFunction.TypeParameterList?.Parameters.Count ?? 0));
+                }
+            }
+        }
+
+        protected override DeclaredSymbolInfo? GetTypeDeclarationInfo(
+            SyntaxNode container,
+            TypeDeclarationSyntax typeDeclaration,
+            StringTable stringTable,
+            string containerDisplayName,
+            string fullyQualifiedContainerName)
         {
             // If this is a part of partial type that only contains nested types, then we don't make an info type for
             // it. That's because we effectively think of this as just being a virtual container just to hold the nested
             // types, and not something someone would want to explicitly navigate to itself.  Similar to how we think of
             // namespaces.
-            if (node is TypeDeclarationSyntax typeDeclaration &&
-                typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword) &&
+            if (typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword) &&
                 typeDeclaration.Members.Any() &&
                 typeDeclaration.Members.All(m => m is BaseTypeDeclarationSyntax))
             {
-                return;
+                return null;
             }
 
+            return DeclaredSymbolInfo.Create(
+                stringTable,
+                typeDeclaration.Identifier.ValueText,
+                GetTypeParameterSuffix(typeDeclaration.TypeParameterList),
+                containerDisplayName,
+                fullyQualifiedContainerName,
+                typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword),
+                typeDeclaration.Kind() switch
+                {
+                    SyntaxKind.ClassDeclaration => DeclaredSymbolInfoKind.Class,
+                    SyntaxKind.InterfaceDeclaration => DeclaredSymbolInfoKind.Interface,
+                    SyntaxKind.StructDeclaration => DeclaredSymbolInfoKind.Struct,
+                    SyntaxKind.RecordDeclaration => DeclaredSymbolInfoKind.Record,
+                    SyntaxKind.RecordStructDeclaration => DeclaredSymbolInfoKind.RecordStruct,
+                    _ => throw ExceptionUtilities.UnexpectedValue(typeDeclaration.Kind()),
+                },
+                GetAccessibility(container, typeDeclaration.Modifiers),
+                typeDeclaration.Identifier.Span,
+                GetInheritanceNames(stringTable, typeDeclaration.BaseList),
+                IsNestedType(typeDeclaration));
+        }
+
+        protected override DeclaredSymbolInfo GetEnumDeclarationInfo(
+            SyntaxNode container,
+            EnumDeclarationSyntax enumDeclaration,
+            StringTable stringTable,
+            string containerDisplayName,
+            string fullyQualifiedContainerName)
+        {
+            return DeclaredSymbolInfo.Create(
+                stringTable,
+                enumDeclaration.Identifier.ValueText, null,
+                containerDisplayName,
+                fullyQualifiedContainerName,
+                enumDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword),
+                DeclaredSymbolInfoKind.Enum,
+                GetAccessibility(container, enumDeclaration.Modifiers),
+                enumDeclaration.Identifier.Span,
+                inheritanceNames: ImmutableArray<string>.Empty,
+                isNestedType: IsNestedType(enumDeclaration));
+        }
+
+        protected override void AddMemberDeclarationInfos(
+            SyntaxNode container,
+            MemberDeclarationSyntax node,
+            StringTable stringTable,
+            ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos,
+            string containerDisplayName,
+            string fullyQualifiedContainerName)
+        {
+            Contract.ThrowIfTrue(node is TypeDeclarationSyntax);
             switch (node.Kind())
             {
-                case SyntaxKind.ClassDeclaration:
-                case SyntaxKind.InterfaceDeclaration:
-                case SyntaxKind.StructDeclaration:
-                case SyntaxKind.RecordDeclaration:
-                case SyntaxKind.RecordStructDeclaration:
-                    var typeDecl = (TypeDeclarationSyntax)node;
-                    declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
-                        stringTable,
-                        typeDecl.Identifier.ValueText,
-                        GetTypeParameterSuffix(typeDecl.TypeParameterList),
-                        containerDisplayName,
-                        fullyQualifiedContainerName,
-                        typeDecl.Modifiers.Any(SyntaxKind.PartialKeyword),
-                        node.Kind() switch
-                        {
-                            SyntaxKind.ClassDeclaration => DeclaredSymbolInfoKind.Class,
-                            SyntaxKind.InterfaceDeclaration => DeclaredSymbolInfoKind.Interface,
-                            SyntaxKind.StructDeclaration => DeclaredSymbolInfoKind.Struct,
-                            SyntaxKind.RecordDeclaration => DeclaredSymbolInfoKind.Record,
-                            SyntaxKind.RecordStructDeclaration => DeclaredSymbolInfoKind.RecordStruct,
-                            _ => throw ExceptionUtilities.UnexpectedValue(node.Kind()),
-                        },
-                        GetAccessibility(container, typeDecl.Modifiers),
-                        typeDecl.Identifier.Span,
-                        GetInheritanceNames(stringTable, typeDecl.BaseList),
-                        IsNestedType(typeDecl)));
-                    return;
-                case SyntaxKind.EnumDeclaration:
-                    var enumDecl = (EnumDeclarationSyntax)node;
-                    declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
-                        stringTable,
-                        enumDecl.Identifier.ValueText, null,
-                        containerDisplayName,
-                        fullyQualifiedContainerName,
-                        enumDecl.Modifiers.Any(SyntaxKind.PartialKeyword),
-                        DeclaredSymbolInfoKind.Enum,
-                        GetAccessibility(container, enumDecl.Modifiers),
-                        enumDecl.Identifier.Span,
-                        inheritanceNames: ImmutableArray<string>.Empty,
-                        isNestedType: IsNestedType(enumDecl)));
-                    return;
                 case SyntaxKind.ConstructorDeclaration:
                     var ctorDecl = (ConstructorDeclarationSyntax)node;
                     declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
@@ -306,8 +352,6 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                         inheritanceNames: ImmutableArray<string>.Empty,
                         parameterCount: method.ParameterList?.Parameters.Count ?? 0,
                         typeParameterCount: method.TypeParameterList?.Parameters.Count ?? 0));
-                    if (isExtensionMethod)
-                        AddExtensionMethodInfo(method, aliases, declaredSymbolInfos.Count - 1, extensionMethodInfo);
                     return;
                 case SyntaxKind.PropertyDeclaration:
                     var property = (PropertyDeclarationSyntax)node;
@@ -436,6 +480,10 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
                 : GetSuffix('(', ')', constructor.ParameterList.Parameters);
 
         private static string GetMethodSuffix(MethodDeclarationSyntax method)
+            => GetTypeParameterSuffix(method.TypeParameterList) +
+               GetSuffix('(', ')', method.ParameterList.Parameters);
+
+        private static string GetMethodSuffix(LocalFunctionStatementSyntax method)
             => GetTypeParameterSuffix(method.TypeParameterList) +
                GetSuffix('(', ')', method.ParameterList.Parameters);
 
@@ -622,9 +670,8 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
             return false;
         }
 
-        protected override string GetReceiverTypeName(MemberDeclarationSyntax node)
+        protected override string GetReceiverTypeName(MethodDeclarationSyntax methodDeclaration)
         {
-            var methodDeclaration = (MethodDeclarationSyntax)node;
             Debug.Assert(IsExtensionMethod(methodDeclaration));
 
             var typeParameterNames = methodDeclaration.TypeParameterList?.Parameters.SelectAsArray(p => p.Identifier.Text);

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -38,6 +38,8 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
         QualifiedNameSyntax,
         IdentifierNameSyntax>
     {
+        private static readonly ObjectPool<Queue<SyntaxNodeOrToken>> s_queuePool = SharedPools.Default<Queue<SyntaxNodeOrToken>>();
+
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CSharpDeclaredSymbolInfoFactoryService()
@@ -167,7 +169,8 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
             string fullyQualifiedContainerName,
             CancellationToken cancellationToken)
         {
-            var queue = new Queue<SyntaxNodeOrToken>();
+            using var pooledQueue = s_queuePool.GetPooledObject();
+            var queue = pooledQueue.Object;
             queue.Enqueue(memberDeclaration);
             while (!queue.IsEmpty())
             {

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -166,21 +167,21 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
             string fullyQualifiedContainerName,
             CancellationToken cancellationToken)
         {
-            AddLocalFunctionInfosRecurse(memberDeclaration);
-
-            return;
-
-            void AddLocalFunctionInfosRecurse(SyntaxNode node)
+            var queue = new Queue<SyntaxNodeOrToken>();
+            queue.Enqueue(memberDeclaration);
+            while (!queue.IsEmpty())
             {
                 cancellationToken.ThrowIfCancellationRequested();
-
+                var node = queue.Dequeue();
                 foreach (var child in node.ChildNodesAndTokens())
                 {
                     if (child.IsNode)
-                        AddLocalFunctionInfosRecurse(child.AsNode()!);
+                    {
+                        queue.Enqueue(child);
+                    }
                 }
 
-                if (node is LocalFunctionStatementSyntax localFunction)
+                if (node.AsNode() is LocalFunctionStatementSyntax localFunction)
                 {
                     declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
                         stringTable,

--- a/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/CSharp/Portable/FindSymbols/CSharpDeclaredSymbolInfoFactoryService.cs
@@ -38,8 +38,6 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
         QualifiedNameSyntax,
         IdentifierNameSyntax>
     {
-        private static readonly ObjectPool<Queue<SyntaxNodeOrToken>> s_queuePool = SharedPools.Default<Queue<SyntaxNodeOrToken>>();
-
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CSharpDeclaredSymbolInfoFactoryService()
@@ -169,7 +167,7 @@ namespace Microsoft.CodeAnalysis.CSharp.FindSymbols
             string fullyQualifiedContainerName,
             CancellationToken cancellationToken)
         {
-            using var pooledQueue = s_queuePool.GetPooledObject();
+            using var pooledQueue = SharedPools.Default<Queue<SyntaxNodeOrToken>>().GetPooledObject();
             var queue = pooledQueue.Object;
             queue.Enqueue(memberDeclaration);
             while (!queue.IsEmpty())

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
@@ -19,7 +19,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal partial class AbstractSyntaxIndex<TIndex> : IObjectWritable
     {
         private static readonly string s_persistenceName = typeof(TIndex).Name;
-
         private static readonly Checksum s_serializationFormatChecksum = Checksum.Create("31");
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/DeclaredSymbolFactoryService/AbstractDeclaredSymbolInfoFactoryService.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.LanguageService
         TNamespaceDeclarationSyntax,
         TTypeDeclarationSyntax,
         TEnumDeclarationSyntax,
+        TMethodDeclarationSyntax,
         TMemberDeclarationSyntax,
         TNameSyntax,
         TQualifiedNameSyntax,
@@ -26,6 +27,7 @@ namespace Microsoft.CodeAnalysis.LanguageService
         where TNamespaceDeclarationSyntax : TMemberDeclarationSyntax
         where TTypeDeclarationSyntax : TMemberDeclarationSyntax
         where TEnumDeclarationSyntax : TMemberDeclarationSyntax
+        where TMethodDeclarationSyntax : TMemberDeclarationSyntax
         where TMemberDeclarationSyntax : SyntaxNode
         where TNameSyntax : SyntaxNode
         where TQualifiedNameSyntax : TNameSyntax
@@ -62,8 +64,14 @@ namespace Microsoft.CodeAnalysis.LanguageService
         protected abstract string GetContainerDisplayName(TMemberDeclarationSyntax namespaceDeclaration);
         protected abstract string GetFullyQualifiedContainerName(TMemberDeclarationSyntax memberDeclaration, string rootNamespace);
 
-        protected abstract void AddDeclaredSymbolInfosWorker(
-            SyntaxNode container, TMemberDeclarationSyntax memberDeclaration, StringTable stringTable, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, Dictionary<string, string?> aliases, Dictionary<string, ArrayBuilder<int>> extensionMethodInfo, string containerDisplayName, string fullyQualifiedContainerName, CancellationToken cancellationToken);
+        protected abstract DeclaredSymbolInfo? GetTypeDeclarationInfo(
+            SyntaxNode container, TTypeDeclarationSyntax typeDeclaration, StringTable stringTable, string containerDisplayName, string fullyQualifiedContainerName);
+        protected abstract DeclaredSymbolInfo GetEnumDeclarationInfo(
+            SyntaxNode container, TEnumDeclarationSyntax enumDeclaration, StringTable stringTable, string containerDisplayName, string fullyQualifiedContainerName);
+        protected abstract void AddMemberDeclarationInfos(
+            SyntaxNode container, TMemberDeclarationSyntax memberDeclaration, StringTable stringTable, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, string containerDisplayName, string fullyQualifiedContainerName);
+        protected abstract void AddLocalFunctionInfos(
+            TMemberDeclarationSyntax memberDeclaration, StringTable stringTable, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, string containerDisplayName, string fullyQualifiedContainerName, CancellationToken cancellationToken);
         protected abstract void AddSynthesizedDeclaredSymbolInfos(
             SyntaxNode container, TMemberDeclarationSyntax memberDeclaration, StringTable stringTable, ArrayBuilder<DeclaredSymbolInfo> declaredSymbolInfos, string containerDisplayName, string fullyQualifiedContainerName, CancellationToken cancellationToken);
 
@@ -73,7 +81,7 @@ namespace Microsoft.CodeAnalysis.LanguageService
         /// `DeclaredSymbolInfo` of kind `ExtensionMethod`. If the return value is null, then it means this is a
         /// "complex" method (as described at <see cref="TopLevelSyntaxTreeIndex.ExtensionMethodInfo"/>).
         /// </summary>
-        protected abstract string GetReceiverTypeName(TMemberDeclarationSyntax node);
+        protected abstract string GetReceiverTypeName(TMethodDeclarationSyntax node);
         protected abstract bool TryGetAliasesFromUsingDirective(TUsingDirectiveSyntax node, out ImmutableArray<(string aliasName, string name)> aliases);
         protected abstract string GetRootNamespace(CompilationOptions compilationOptions);
 
@@ -183,7 +191,6 @@ namespace Microsoft.CodeAnalysis.LanguageService
                 AddNamespaceDeclaredSymbolInfos(GetName(namespaceDeclaration), fullyQualifiedContainerName);
 
                 var innerContainerDisplayName = GetContainerDisplayName(memberDeclaration);
-                var innerFullyQualifiedContainerName = GetFullyQualifiedContainerName(memberDeclaration, rootNamespace);
 
                 foreach (var usingAlias in GetUsingAliases(namespaceDeclaration))
                 {
@@ -191,6 +198,7 @@ namespace Microsoft.CodeAnalysis.LanguageService
                         AddAliases(aliases, current);
                 }
 
+                var innerFullyQualifiedContainerName = GetFullyQualifiedContainerName(memberDeclaration, rootNamespace);
                 foreach (var child in GetChildren(namespaceDeclaration))
                 {
                     AddDeclaredSymbolInfos(
@@ -198,17 +206,20 @@ namespace Microsoft.CodeAnalysis.LanguageService
                         innerContainerDisplayName, innerFullyQualifiedContainerName, cancellationToken);
                 }
             }
-            else if (memberDeclaration is TTypeDeclarationSyntax baseTypeDeclaration)
+            else if (memberDeclaration is TTypeDeclarationSyntax typeDeclaration)
             {
                 var innerContainerDisplayName = GetContainerDisplayName(memberDeclaration);
-                var innerFullyQualifiedContainerName = GetFullyQualifiedContainerName(memberDeclaration, rootNamespace);
-                foreach (var child in GetChildren(baseTypeDeclaration))
-                {
-                    AddDeclaredSymbolInfos(
-                        memberDeclaration, child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo,
-                        innerContainerDisplayName, innerFullyQualifiedContainerName, cancellationToken);
-                }
 
+                // Add the item for the type itself:
+                declaredSymbolInfos.AddIfNotNull(GetTypeDeclarationInfo(
+                    container,
+                    typeDeclaration,
+                    stringTable,
+                    containerDisplayName,
+                    fullyQualifiedContainerName));
+
+                // Then any synthesized members in that type (for example, synthesized properties in a record):
+                var innerFullyQualifiedContainerName = GetFullyQualifiedContainerName(memberDeclaration, rootNamespace);
                 AddSynthesizedDeclaredSymbolInfos(
                     container,
                     memberDeclaration,
@@ -217,10 +228,28 @@ namespace Microsoft.CodeAnalysis.LanguageService
                     innerContainerDisplayName,
                     innerFullyQualifiedContainerName,
                     cancellationToken);
+
+                // Then recurse into the children and add those.
+                foreach (var child in GetChildren(typeDeclaration))
+                {
+                    AddDeclaredSymbolInfos(
+                        memberDeclaration, child, stringTable, rootNamespace, declaredSymbolInfos, aliases, extensionMethodInfo,
+                        innerContainerDisplayName, innerFullyQualifiedContainerName, cancellationToken);
+                }
             }
             else if (memberDeclaration is TEnumDeclarationSyntax enumDeclaration)
             {
                 var innerContainerDisplayName = GetContainerDisplayName(memberDeclaration);
+
+                // Add the item for the type itself:
+                declaredSymbolInfos.Add(GetEnumDeclarationInfo(
+                    container,
+                    enumDeclaration,
+                    stringTable,
+                    containerDisplayName,
+                    fullyQualifiedContainerName));
+
+                // Then recurse into the children and add those.
                 var innerFullyQualifiedContainerName = GetFullyQualifiedContainerName(memberDeclaration, rootNamespace);
                 foreach (var child in GetChildren(enumDeclaration))
                 {
@@ -229,17 +258,35 @@ namespace Microsoft.CodeAnalysis.LanguageService
                         innerContainerDisplayName, innerFullyQualifiedContainerName, cancellationToken);
                 }
             }
+            else
+            {
+                // For anything that isn't a namespace/type/enum (generally a member), try to add the information about that
+                var count = declaredSymbolInfos.Count;
+                AddMemberDeclarationInfos(
+                    container,
+                    memberDeclaration,
+                    stringTable,
+                    declaredSymbolInfos,
+                    containerDisplayName,
+                    fullyQualifiedContainerName);
 
-            AddDeclaredSymbolInfosWorker(
-                container,
-                memberDeclaration,
-                stringTable,
-                declaredSymbolInfos,
-                aliases,
-                extensionMethodInfo,
-                containerDisplayName,
-                fullyQualifiedContainerName,
-                cancellationToken);
+                // If the AddSingle call added an item, and that item was an extension method, then go and add the
+                // information about this extension method to our 
+                if (declaredSymbolInfos.Count != count &&
+                    declaredSymbolInfos.Last().Kind == DeclaredSymbolInfoKind.ExtensionMethod &&
+                    memberDeclaration is TMethodDeclarationSyntax methodDeclaration)
+                {
+                    AddExtensionMethodInfo(methodDeclaration);
+                }
+
+                AddLocalFunctionInfos(
+                    memberDeclaration,
+                    stringTable,
+                    declaredSymbolInfos,
+                    containerDisplayName,
+                    fullyQualifiedContainerName,
+                    cancellationToken);
+            }
 
             return;
 
@@ -278,39 +325,37 @@ namespace Microsoft.CodeAnalysis.LanguageService
                     return fullyQualifiedContainerName;
                 }
             }
-        }
 
-        protected void AddExtensionMethodInfo(
-            TMemberDeclarationSyntax node,
-            Dictionary<string, string> aliases,
-            int declaredSymbolInfoIndex,
-            Dictionary<string, ArrayBuilder<int>> extensionMethodsInfoBuilder)
-        {
-            var receiverTypeName = this.GetReceiverTypeName(node);
-
-            // Target type is an alias
-            if (aliases.TryGetValue(receiverTypeName, out var originalName))
+            void AddExtensionMethodInfo(TMethodDeclarationSyntax methodDeclaration)
             {
-                // it is an alias of multiple with identical name,
-                // simply treat it as a complex method.
-                if (originalName == null)
-                {
-                    receiverTypeName = FindSymbols.Extensions.ComplexReceiverTypeName;
-                }
-                else
-                {
-                    // replace the alias with its original name.
-                    receiverTypeName = originalName;
-                }
-            }
+                var declaredSymbolInfoIndex = declaredSymbolInfos.Count - 1;
 
-            if (!extensionMethodsInfoBuilder.TryGetValue(receiverTypeName, out var arrayBuilder))
-            {
-                arrayBuilder = ArrayBuilder<int>.GetInstance();
-                extensionMethodsInfoBuilder[receiverTypeName] = arrayBuilder;
-            }
+                var receiverTypeName = this.GetReceiverTypeName(methodDeclaration);
 
-            arrayBuilder.Add(declaredSymbolInfoIndex);
+                // Target type is an alias
+                if (aliases.TryGetValue(receiverTypeName, out var originalName))
+                {
+                    // it is an alias of multiple with identical name,
+                    // simply treat it as a complex method.
+                    if (originalName == null)
+                    {
+                        receiverTypeName = FindSymbols.Extensions.ComplexReceiverTypeName;
+                    }
+                    else
+                    {
+                        // replace the alias with its original name.
+                        receiverTypeName = originalName;
+                    }
+                }
+
+                if (!extensionMethodInfo.TryGetValue(receiverTypeName, out var arrayBuilder))
+                {
+                    arrayBuilder = ArrayBuilder<int>.GetInstance();
+                    extensionMethodInfo[receiverTypeName] = arrayBuilder;
+                }
+
+                arrayBuilder.Add(declaredSymbolInfoIndex);
+            }
         }
 
         private static void AddAliases(Dictionary<string, string?> allAliases, ImmutableArray<(string aliasName, string name)> aliases)

--- a/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
+++ b/src/Workspaces/VisualBasic/Portable/FindSymbols/VisualBasicDeclaredSymbolInfoFactoryService.vb
@@ -23,6 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
             NamespaceBlockSyntax,
             TypeBlockSyntax,
             EnumBlockSyntax,
+            DeclarationStatementSyntax,
             StatementSyntax,
             NameSyntax,
             QualifiedNameSyntax,
@@ -126,33 +127,75 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
             Return VisualBasicSyntaxFacts.Instance.GetDisplayName(node, DisplayNameOptions.IncludeNamespaces, rootNamespace)
         End Function
 
+        Protected Overrides Sub AddLocalFunctionInfos(node As StatementSyntax, stringTable As StringTable, declaredSymbolInfos As ArrayBuilder(Of DeclaredSymbolInfo), containerDisplayName As String, fullyQualifiedContainerName As String, cancellationToken As CancellationToken)
+            ' VB doesn't have local functions.
+        End Sub
+
         Protected Overrides Sub AddSynthesizedDeclaredSymbolInfos(container As SyntaxNode, memberDeclaration As StatementSyntax, stringTable As StringTable, declaredSymbolInfos As ArrayBuilder(Of DeclaredSymbolInfo), containerDisplayName As String, fullyQualifiedContainerName As String, cancellationToken As CancellationToken)
             ' Nothing to do in VB.
         End Sub
 
-        Protected Overrides Sub AddDeclaredSymbolInfosWorker(
+        Protected Overrides Function GetTypeDeclarationInfo(
                 container As SyntaxNode,
-                node As StatementSyntax,
+                typeDeclaration As TypeBlockSyntax,
                 stringTable As StringTable,
-                declaredSymbolInfos As ArrayBuilder(Of DeclaredSymbolInfo),
-                aliases As Dictionary(Of String, String),
-                extensionMethodInfo As Dictionary(Of String, ArrayBuilder(Of Integer)),
                 containerDisplayName As String,
-                fullyQualifiedContainerName As String,
-                cancellationToken As CancellationToken)
+                fullyQualifiedContainerName As String) As DeclaredSymbolInfo?
 
             ' If this Is a part of partial type that only contains nested types, then we don't make an info type for it.
             ' That's because we effectively think of this as just being a virtual container just to hold the nested
             ' types, And Not something someone would want to explicitly navigate to itself.  Similar to how we think of
             ' namespaces.
-            Dim typeDecl = TryCast(node, TypeBlockSyntax)
-            If typeDecl IsNot Nothing AndAlso
-               typeDecl.BlockStatement.Modifiers.Any(SyntaxKind.PartialKeyword) AndAlso
-               typeDecl.Members.Any() AndAlso
-               typeDecl.Members.All(Function(m) TypeOf m Is TypeBlockSyntax) Then
+            If typeDeclaration.BlockStatement.Modifiers.Any(SyntaxKind.PartialKeyword) AndAlso
+               typeDeclaration.Members.Any() AndAlso
+               typeDeclaration.Members.All(Function(m) TypeOf m Is TypeBlockSyntax) Then
 
-                Return
+                Return Nothing
             End If
+
+            Return DeclaredSymbolInfo.Create(
+                stringTable,
+                typeDeclaration.BlockStatement.Identifier.ValueText,
+                GetTypeParameterSuffix(typeDeclaration.BlockStatement.TypeParameterList),
+                containerDisplayName,
+                fullyQualifiedContainerName,
+                typeDeclaration.BlockStatement.Modifiers.Any(SyntaxKind.PartialKeyword),
+                If(typeDeclaration.Kind() = SyntaxKind.ClassBlock, DeclaredSymbolInfoKind.Class,
+                   If(typeDeclaration.Kind() = SyntaxKind.InterfaceBlock, DeclaredSymbolInfoKind.Interface,
+                      If(typeDeclaration.Kind() = SyntaxKind.ModuleBlock, DeclaredSymbolInfoKind.Module, DeclaredSymbolInfoKind.Struct))),
+                GetAccessibility(container, typeDeclaration, typeDeclaration.BlockStatement.Modifiers),
+                typeDeclaration.BlockStatement.Identifier.Span,
+                GetInheritanceNames(stringTable, typeDeclaration),
+                IsNestedType(typeDeclaration))
+        End Function
+
+        Protected Overrides Function GetEnumDeclarationInfo(
+                container As SyntaxNode,
+                enumDeclaration As EnumBlockSyntax,
+                stringTable As StringTable,
+                containerDisplayName As String,
+                fullyQualifiedContainerName As String) As DeclaredSymbolInfo
+
+            Return DeclaredSymbolInfo.Create(
+                stringTable,
+                enumDeclaration.EnumStatement.Identifier.ValueText, Nothing,
+                containerDisplayName,
+                fullyQualifiedContainerName,
+                enumDeclaration.EnumStatement.Modifiers.Any(SyntaxKind.PartialKeyword),
+                DeclaredSymbolInfoKind.Enum,
+                GetAccessibility(container, enumDeclaration, enumDeclaration.EnumStatement.Modifiers),
+                enumDeclaration.EnumStatement.Identifier.Span,
+                ImmutableArray(Of String).Empty,
+                IsNestedType(enumDeclaration))
+        End Function
+
+        Protected Overrides Sub AddMemberDeclarationInfos(
+                container As SyntaxNode,
+                node As StatementSyntax,
+                stringTable As StringTable,
+                declaredSymbolInfos As ArrayBuilder(Of DeclaredSymbolInfo),
+                containerDisplayName As String,
+                fullyQualifiedContainerName As String)
 
             If node.Kind() = SyntaxKind.PropertyBlock Then
                 node = DirectCast(node, PropertyBlockSyntax).PropertyStatement
@@ -164,38 +207,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
 
             Dim kind = node.Kind()
             Select Case kind
-                Case SyntaxKind.ClassBlock, SyntaxKind.InterfaceBlock, SyntaxKind.ModuleBlock, SyntaxKind.StructureBlock
-                    Dim typeBlock = CType(node, TypeBlockSyntax)
-                    declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
-                        stringTable,
-                        typeDecl.BlockStatement.Identifier.ValueText,
-                        GetTypeParameterSuffix(typeBlock.BlockStatement.TypeParameterList),
-                        containerDisplayName,
-                        fullyQualifiedContainerName,
-                        typeBlock.BlockStatement.Modifiers.Any(SyntaxKind.PartialKeyword),
-                        If(kind = SyntaxKind.ClassBlock, DeclaredSymbolInfoKind.Class,
-                        If(kind = SyntaxKind.InterfaceBlock, DeclaredSymbolInfoKind.Interface,
-                        If(kind = SyntaxKind.ModuleBlock, DeclaredSymbolInfoKind.Module,
-                        DeclaredSymbolInfoKind.Struct))),
-                        GetAccessibility(container, typeBlock, typeBlock.BlockStatement.Modifiers),
-                        typeBlock.BlockStatement.Identifier.Span,
-                        GetInheritanceNames(stringTable, typeBlock),
-                        IsNestedType(typeBlock)))
-                    Return
-                Case SyntaxKind.EnumBlock
-                    Dim enumDecl = DirectCast(node, EnumBlockSyntax)
-                    declaredSymbolInfos.Add(DeclaredSymbolInfo.Create(
-                        stringTable,
-                        enumDecl.EnumStatement.Identifier.ValueText, Nothing,
-                        containerDisplayName,
-                        fullyQualifiedContainerName,
-                        enumDecl.EnumStatement.Modifiers.Any(SyntaxKind.PartialKeyword),
-                        DeclaredSymbolInfoKind.Enum,
-                        GetAccessibility(container, enumDecl, enumDecl.EnumStatement.Modifiers),
-                        enumDecl.EnumStatement.Identifier.Span,
-                        ImmutableArray(Of String).Empty,
-                        IsNestedType(enumDecl)))
-                    Return
                 Case SyntaxKind.SubNewStatement
                     Dim constructor = DirectCast(node, SubNewStatementSyntax)
                     Dim typeBlock = TryCast(container, TypeBlockSyntax)
@@ -271,9 +282,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
                         ImmutableArray(Of String).Empty,
                         parameterCount:=If(funcDecl.ParameterList?.Parameters.Count, 0),
                         typeParameterCount:=If(funcDecl.TypeParameterList?.Parameters.Count, 0)))
-                    If isExtension Then
-                        AddExtensionMethodInfo(funcDecl, aliases, declaredSymbolInfos.Count - 1, extensionMethodInfo)
-                    End If
 
                     Return
                 Case SyntaxKind.PropertyStatement
@@ -516,7 +524,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.FindSymbols
             Next
         End Sub
 
-        Protected Overrides Function GetReceiverTypeName(node As StatementSyntax) As String
+        Protected Overrides Function GetReceiverTypeName(node As DeclarationStatementSyntax) As String
+            node = If(TryCast(node, MethodBlockBaseSyntax)?.BlockStatement, node)
+
             Dim funcDecl = DirectCast(node, MethodStatementSyntax)
             Debug.Assert(IsExtensionMethod(funcDecl))
 


### PR DESCRIPTION
Three commit:
1. Revert https://github.com/dotnet/roslyn/pull/63372/commits/2fe5202eb97b8309b5ca2c787d8c960feafa81bd  This is the revert checked in 17.3 branch. 
2 & 3. Fix the issue in the original commit. They are cherry-picked from https://github.com/dotnet/roslyn/pull/63338