### PR TITLE
Revert "Pass SolutionServices in more places"

### DIFF
--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueWorkspaceServiceTests.cs
@@ -4471,7 +4471,7 @@ class C
                 loader: new FileTextLoader(sourceFileA.Path, Encoding.UTF8),
                 filePath: sourceFileA.Path));
 
-            var hotReload = new WatchHotReloadService(workspace.Services.SolutionServices, ImmutableArray.Create("Baseline", "AddDefinitionToExistingType", "NewTypeDefinition"));
+            var hotReload = new WatchHotReloadService(workspace.Services, ImmutableArray.Create("Baseline", "AddDefinitionToExistingType", "NewTypeDefinition"));
 
             await hotReload.StartSessionAsync(solution, CancellationToken.None);
 
@@ -4538,7 +4538,7 @@ class C
                 loader: new FileTextLoader(sourceFileA.Path, Encoding.UTF8),
                 filePath: sourceFileA.Path));
 
-            var hotReload = new UnitTestingHotReloadService(workspace.Services.SolutionServices);
+            var hotReload = new UnitTestingHotReloadService(workspace.Services);
 
             await hotReload.StartSessionAsync(solution, ImmutableArray.Create("Baseline", "AddDefinitionToExistingType", "NewTypeDefinition"), CancellationToken.None);
 

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingHotReloadService.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
         private readonly IEditAndContinueWorkspaceService _encService;
         private DebuggingSessionId _sessionId;
 
-        public UnitTestingHotReloadService(SolutionServices services)
+        public UnitTestingHotReloadService(HostWorkspaceServices services)
             => _encService = services.GetRequiredService<IEditAndContinueWorkspaceService>();
 
         /// <summary>

--- a/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/Watch/Api/WatchHotReloadService.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Watch.Api
         private DebuggingSessionId _sessionId;
         private readonly ImmutableArray<string> _capabilities;
 
-        public WatchHotReloadService(SolutionServices services, ImmutableArray<string> capabilities)
+        public WatchHotReloadService(HostWorkspaceServices services, ImmutableArray<string> capabilities)
             => (_encService, _capabilities) = (services.GetRequiredService<IEditAndContinueWorkspaceService>(), capabilities);
 
         /// <summary>


### PR DESCRIPTION
This reverts commit 31c64ef87d507f50f22669371ef9a5098ab0cca3. This changed external access APIs which broke external consumers.