### PR TITLE
Break out src/Tools in the CODEOWNERs file for more granular ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,8 +30,18 @@ src/Interactive/ @dotnet/roslyn-interactive
 src/NuGet/ @dotnet/roslyn-infrastructure
 src/Scripting/ @dotnet/roslyn-interactive
 src/Setup/ @dotnet/roslyn-infrastructure
-src/Tools/ @dotnet/roslyn-infrastructure
+src/Tools/AnalyzerRunner @dotnet/roslyn-ide
+src/Tools/BuildActionTelemetryTable @dotnet/roslyn-infrastructure
+src/Tools/BuildBoss @dotnet/roslyn-infrastructure
+src/Tools/BuildValidator @dotnet/roslyn-infrastructure
+src/Tools/dotnet-format @dotnet/roslyn-infrastructure
+src/Tools/ExternalAccess @dotnet/roslyn-ide
+src/Tools/IdeBenchmarks @dotnet/roslyn-ide
+src/Tools/IdeCoreBenchmarks @dotnet/roslyn-ide
+src/Tools/ManifestGenerator @dotnet/roslyn-infrastructure
+src/Tools/PrepareTests @dotnet/roslyn-infrastructure
 src/Tools/Source/CompilerGeneratorTools/ @dotnet/roslyn-compiler
+src/Tools/Source/RunTests @dotnet/roslyn-infrastructure
 src/VisualStudio/ @dotnet/roslyn-ide
 src/VisualStudio/LiveShare @dotnet/roslyn-ide @daytonellwanger @srivatsn @aletsdelarosa
 src/Workspaces/ @dotnet/roslyn-ide


### PR DESCRIPTION
I'm tired of getting every EA pr in my list of things to review, so I'm breaking up the broad `Tools` onwership into more granular ownership for the roles that actually own them. Will leave inline comments for the things that now have different ownership.