### PR TITLE
Remove explicit ownership of LiveShare

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,7 +43,6 @@ src/Tools/PrepareTests @dotnet/roslyn-infrastructure
 src/Tools/Source/CompilerGeneratorTools/ @dotnet/roslyn-compiler
 src/Tools/Source/RunTests @dotnet/roslyn-infrastructure
 src/VisualStudio/ @dotnet/roslyn-ide
-src/VisualStudio/LiveShare @dotnet/roslyn-ide @daytonellwanger @srivatsn @aletsdelarosa
 src/Workspaces/ @dotnet/roslyn-ide
 
 src/Compilers/**/PublicAPI.Unshipped.txt @dotnet/roslyn-api-owners


### PR DESCRIPTION
GitHub is flagging this since these people don't have current permissions to the repo; in either case we don't have separate ownership anymore.