### PR TITLE
Filter out `RequiredMemberAttribute` from metadata symbols

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -581,20 +581,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             {
                 var containingPEModuleSymbol = (PEModuleSymbol)this.ContainingModule;
 
-                if (FilterOutDecimalConstantAttribute())
-                {
-                    // filter out DecimalConstantAttribute
-                    var attributes = containingPEModuleSymbol.GetCustomAttributesForToken(
-                        _handle,
-                        out _,
-                        AttributeDescription.DecimalConstantAttribute);
+                var attributes = containingPEModuleSymbol.GetCustomAttributesForToken(
+                    _handle,
+                    out _,
+                    FilterOutDecimalConstantAttribute() ? AttributeDescription.DecimalConstantAttribute : default,
+                    out _,
+                    IsRequired ? AttributeDescription.RequiredMemberAttribute : default);
 
-                    ImmutableInterlocked.InterlockedInitialize(ref _lazyCustomAttributes, attributes);
-                }
-                else
-                {
-                    containingPEModuleSymbol.LoadCustomAttributes(_handle, ref _lazyCustomAttributes);
-                }
+                ImmutableInterlocked.InterlockedInitialize(ref _lazyCustomAttributes, attributes);
             }
             return _lazyCustomAttributes;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEFieldSymbol.cs
@@ -585,10 +585,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     _handle,
                     out _,
                     FilterOutDecimalConstantAttribute() ? AttributeDescription.DecimalConstantAttribute : default,
-                    out _,
-                    IsRequired ? AttributeDescription.RequiredMemberAttribute : default);
+                    out CustomAttributeHandle required,
+                    AttributeDescription.RequiredMemberAttribute);
 
                 ImmutableInterlocked.InterlockedInitialize(ref _lazyCustomAttributes, attributes);
+                _packedFlags.SetHasRequiredMemberAttribute(!required.IsNil);
             }
             return _lazyCustomAttributes;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEMethodSymbol.cs
@@ -982,7 +982,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         filteredOutAttribute4: out _,
                         filterOut4: (checkForRequiredMembers && ObsoleteAttributeData is null) ? AttributeDescription.ObsoleteAttribute : default,
                         filteredOutAttribute5: out _,
-                        filterOut5: default);
+                        filterOut5: default,
+                        filteredOutAttribute6: out _,
+                        filterOut6: default);
 
                     isExtensionMethod = !extensionAttribute.IsNil;
                     isReadOnly = !isReadOnlyAttribute.IsNil;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -294,11 +294,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             out CustomAttributeHandle filteredOutAttribute1,
             AttributeDescription filterOut1)
         {
-            return GetCustomAttributesForToken(token, out filteredOutAttribute1, filterOut1, out _, default, out _, default, out _, default, out _, default);
+            return GetCustomAttributesForToken(token, out filteredOutAttribute1, filterOut1, out _, default, out _, default, out _, default, out _, default, out _, default);
+        }
+
+        internal ImmutableArray<CSharpAttributeData> GetCustomAttributesForToken(EntityHandle token,
+            out CustomAttributeHandle filteredOutAttribute1,
+            AttributeDescription filterOut1,
+            out CustomAttributeHandle filteredOutAttribute2,
+            AttributeDescription filterOut2)
+        {
+            return GetCustomAttributesForToken(token, out filteredOutAttribute1, filterOut1, out filteredOutAttribute2, filterOut2, out _, default, out _, default, out _, default, out _, default);
         }
 
         /// <summary>
-        /// Returns attributes with up-to four filters applied. For each filter, the last application of the
+        /// Returns attributes with up-to 6 filters applied. For each filter, the last application of the
         /// attribute will be tracked and returned.
         /// </summary>
         internal ImmutableArray<CSharpAttributeData> GetCustomAttributesForToken(EntityHandle token,
@@ -311,13 +320,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             out CustomAttributeHandle filteredOutAttribute4,
             AttributeDescription filterOut4,
             out CustomAttributeHandle filteredOutAttribute5,
-            AttributeDescription filterOut5)
+            AttributeDescription filterOut5,
+            out CustomAttributeHandle filteredOutAttribute6,
+            AttributeDescription filterOut6)
         {
             filteredOutAttribute1 = default;
             filteredOutAttribute2 = default;
             filteredOutAttribute3 = default;
             filteredOutAttribute4 = default;
             filteredOutAttribute5 = default;
+            filteredOutAttribute6 = default;
             ArrayBuilder<CSharpAttributeData> customAttributesBuilder = null;
 
             try
@@ -354,6 +366,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     if (matchesFilter(customAttributeHandle, filterOut5))
                     {
                         filteredOutAttribute5 = customAttributeHandle;
+                        continue;
+                    }
+
+                    if (matchesFilter(customAttributeHandle, filterOut6))
+                    {
+                        filteredOutAttribute6 = customAttributeHandle;
                         continue;
                     }
 
@@ -436,10 +454,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 filteredOutAttribute1: out CustomAttributeHandle extensionAttribute,
                 filterOut1: AttributeDescription.CaseSensitiveExtensionAttribute,
                 filteredOutAttribute2: out CustomAttributeHandle isReadOnlyAttribute,
-                filterOut2: AttributeDescription.IsReadOnlyAttribute,
-                filteredOutAttribute3: out _, filterOut3: default,
-                filteredOutAttribute4: out _, filterOut4: default,
-                filteredOutAttribute5: out _, filterOut5: default);
+                filterOut2: AttributeDescription.IsReadOnlyAttribute);
 
             foundExtension = !extensionAttribute.IsNil;
             foundReadOnly = !isReadOnlyAttribute.IsNil;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -680,7 +680,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     IsRefLikeType ? AttributeDescription.IsByRefLikeAttribute : default,
                     out _,
                     // Filter out [CompilerFeatureRequired]
-                    (IsRefLikeType && DeriveCompilerFeatureRequiredDiagnostic() is null) ? AttributeDescription.CompilerFeatureRequiredAttribute : default);
+                    (IsRefLikeType && DeriveCompilerFeatureRequiredDiagnostic() is null) ? AttributeDescription.CompilerFeatureRequiredAttribute : default,
+                    out _,
+                    // Filter out [RequiredMember]
+                    HasDeclaredRequiredMembers ? AttributeDescription.RequiredMemberAttribute : default);
 
                 ImmutableInterlocked.InterlockedInitialize(ref uncommon.lazyCustomAttributes, loadedCustomAttributes);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -681,11 +681,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     out _,
                     // Filter out [CompilerFeatureRequired]
                     (IsRefLikeType && DeriveCompilerFeatureRequiredDiagnostic() is null) ? AttributeDescription.CompilerFeatureRequiredAttribute : default,
-                    out _,
+                    out CustomAttributeHandle requiredHandle,
                     // Filter out [RequiredMember]
-                    HasDeclaredRequiredMembers ? AttributeDescription.RequiredMemberAttribute : default);
+                    AttributeDescription.RequiredMemberAttribute);
 
                 ImmutableInterlocked.InterlockedInitialize(ref uncommon.lazyCustomAttributes, loadedCustomAttributes);
+
+                if (!uncommon.lazyHasRequiredMembers.HasValue())
+                {
+                    uncommon.lazyHasRequiredMembers = (!requiredHandle.IsNil).ToThreeState();
+                }
+
+                Debug.Assert(uncommon.lazyHasRequiredMembers.Value() != requiredHandle.IsNil);
             }
 
             return uncommon.lazyCustomAttributes;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEParameterSymbol.cs
@@ -1040,6 +1040,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         out _,
                         AttributeDescription.ScopedRefAttribute,
                         out _,
+                        default,
+                        out _,
                         default);
 
                 if (!paramArrayAttribute.IsNil || !constantAttribute.IsNil)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -643,10 +643,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                       _handle,
                       out _,
                       this.RefKind == RefKind.RefReadOnly ? AttributeDescription.IsReadOnlyAttribute : default,
-                      out _,
-                      IsRequired ? AttributeDescription.RequiredMemberAttribute : default);
+                      out CustomAttributeHandle required,
+                      AttributeDescription.RequiredMemberAttribute);
 
                 ImmutableInterlocked.InterlockedInitialize(ref _lazyCustomAttributes, attributes);
+                _flags.SetHasRequiredMemberAttribute(!required.IsNil);
             }
             return _lazyCustomAttributes;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEPropertySymbol.cs
@@ -642,7 +642,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 ImmutableArray<CSharpAttributeData> attributes = containingPEModuleSymbol.GetCustomAttributesForToken(
                       _handle,
                       out _,
-                      this.RefKind == RefKind.RefReadOnly ? AttributeDescription.IsReadOnlyAttribute : default);
+                      this.RefKind == RefKind.RefReadOnly ? AttributeDescription.IsReadOnlyAttribute : default,
+                      out _,
+                      IsRequired ? AttributeDescription.RequiredMemberAttribute : default);
 
                 ImmutableInterlocked.InterlockedInitialize(ref _lazyCustomAttributes, attributes);
             }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -4955,8 +4955,10 @@ public class Derived : Base
         var comp = CreateCompilationWithRequiredMembers("""
             public class C
             {
-                public required int Field;
-                public required int Property { get; set; }
+                public required int Field1;
+                public required int Property1 { get; set; }
+                public int Field2;
+                public int Property2 { get; set; }
             }
             """);
 
@@ -4964,8 +4966,10 @@ public class Derived : Base
         {
             var c = module.ContainingAssembly.GetTypeByMetadataName("C");
             AssertEx.NotNull(c);
-            FieldSymbol fieldSymbol = c.GetMember<FieldSymbol>("Field");
-            PropertySymbol propertySymbol = c.GetMember<PropertySymbol>("Property");
+            FieldSymbol field1 = c.GetMember<FieldSymbol>("Field1");
+            PropertySymbol property1 = c.GetMember<PropertySymbol>("Property1");
+            FieldSymbol field2 = c.GetMember<FieldSymbol>("Field2");
+            PropertySymbol property2 = c.GetMember<PropertySymbol>("Property2");
 
             if (accessAttributesFirst)
             {
@@ -4981,15 +4985,19 @@ public class Derived : Base
             void assertIsRequired()
             {
                 Assert.True(c.HasDeclaredRequiredMembers);
-                Assert.True(fieldSymbol.IsRequired);
-                Assert.True(propertySymbol.IsRequired);
+                Assert.True(field1.IsRequired);
+                Assert.True(property1.IsRequired);
+                Assert.False(field2.IsRequired);
+                Assert.False(property2.IsRequired);
             }
 
             void assertAttributesEmpty()
             {
                 Assert.Empty(c.GetAttributes());
-                Assert.Empty(fieldSymbol.GetAttributes());
-                Assert.Empty(propertySymbol.GetAttributes());
+                Assert.Empty(field1.GetAttributes());
+                Assert.Empty(property1.GetAttributes());
+                Assert.Empty(field2.GetAttributes());
+                Assert.Empty(property2.GetAttributes());
             }
         });
     }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -56,14 +56,7 @@ End Namespace";
                 AssertEx.NotNull(member, $"Member {memberPath} was not found");
                 Assert.True(member is PropertySymbol or FieldSymbol, $"Unexpected member symbol type {member.Kind}");
                 Assert.True(member.IsRequired());
-                if (module is SourceModuleSymbol)
-                {
-                    Assert.All(member.GetAttributes(), attr => AssertEx.NotEqual("System.Runtime.CompilerServices.RequiredMemberAttribute", attr.AttributeClass.ToTestDisplayString()));
-                }
-                else
-                {
-                    AssertEx.Any(member.GetAttributes(), attr => attr.AttributeClass.ToTestDisplayString() == "System.Runtime.CompilerServices.RequiredMemberAttribute");
-                }
+                Assert.All(member.GetAttributes(), attr => AssertEx.NotEqual("System.Runtime.CompilerServices.RequiredMemberAttribute", attr.AttributeClass.ToTestDisplayString()));
 
                 requiredTypes.Add((NamedTypeSymbol)member.ContainingType);
             }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -4964,30 +4964,32 @@ public class Derived : Base
         {
             var c = module.ContainingAssembly.GetTypeByMetadataName("C");
             AssertEx.NotNull(c);
+            FieldSymbol fieldSymbol = c.GetMember<FieldSymbol>("Field");
+            PropertySymbol propertySymbol = c.GetMember<PropertySymbol>("Property");
 
             if (accessAttributesFirst)
             {
-                AssertAttributesEmpty();
-                AssertIsRequired();
+                assertAttributesEmpty();
+                assertIsRequired();
             }
             else
             {
-                AssertIsRequired();
-                AssertAttributesEmpty();
+                assertIsRequired();
+                assertAttributesEmpty();
             }
 
-            void AssertIsRequired()
+            void assertIsRequired()
             {
                 Assert.True(c.HasDeclaredRequiredMembers);
-                Assert.True(c.GetMember<FieldSymbol>("Field").IsRequired);
-                Assert.True(c.GetMember<PropertySymbol>("Property").IsRequired);
+                Assert.True(fieldSymbol.IsRequired);
+                Assert.True(propertySymbol.IsRequired);
             }
 
-            void AssertAttributesEmpty()
+            void assertAttributesEmpty()
             {
                 Assert.Empty(c.GetAttributes());
-                Assert.Empty(c.GetMember<FieldSymbol>("Field").GetAttributes());
-                Assert.Empty(c.GetMember<PropertySymbol>("Property").GetAttributes());
+                Assert.Empty(fieldSymbol.GetAttributes());
+                Assert.Empty(propertySymbol.GetAttributes());
             }
         });
     }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -4957,6 +4957,10 @@ public class Derived : Base
             {
                 public required int Field1;
                 public required int Property1 { get; set; }
+            }
+
+            public class D
+            {
                 public int Field2;
                 public int Property2 { get; set; }
             }
@@ -4968,8 +4972,10 @@ public class Derived : Base
             AssertEx.NotNull(c);
             FieldSymbol field1 = c.GetMember<FieldSymbol>("Field1");
             PropertySymbol property1 = c.GetMember<PropertySymbol>("Property1");
-            FieldSymbol field2 = c.GetMember<FieldSymbol>("Field2");
-            PropertySymbol property2 = c.GetMember<PropertySymbol>("Property2");
+            var d = module.ContainingAssembly.GetTypeByMetadataName("D");
+            AssertEx.NotNull(d);
+            FieldSymbol field2 = d.GetMember<FieldSymbol>("Field2");
+            PropertySymbol property2 = d.GetMember<PropertySymbol>("Property2");
 
             if (accessAttributesFirst)
             {
@@ -4987,6 +4993,7 @@ public class Derived : Base
                 Assert.True(c.HasDeclaredRequiredMembers);
                 Assert.True(field1.IsRequired);
                 Assert.True(property1.IsRequired);
+                Assert.False(d.HasDeclaredRequiredMembers);
                 Assert.False(field2.IsRequired);
                 Assert.False(property2.IsRequired);
             }
@@ -4996,6 +5003,7 @@ public class Derived : Base
                 Assert.Empty(c.GetAttributes());
                 Assert.Empty(field1.GetAttributes());
                 Assert.Empty(property1.GetAttributes());
+                Assert.Empty(d.GetAttributes());
                 Assert.Empty(field2.GetAttributes());
                 Assert.Empty(property2.GetAttributes());
             }

--- a/src/Compilers/Test/Utilities/CSharp/RequiredMemberAttributesVisitor.cs
+++ b/src/Compilers/Test/Utilities/CSharp/RequiredMemberAttributesVisitor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Reflection.Metadata;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
@@ -24,6 +25,47 @@ internal class RequiredMemberAttributesVisitor : TestAttributesVisitor
     }
 
     protected override SymbolDisplayFormat DisplayFormat => SymbolDisplayFormat.TestFormat;
+
+    protected override void ReportSymbol(Symbol symbol)
+    {
+        EntityHandle handle;
+        PEModule module;
+
+        switch (symbol)
+        {
+            case PENamedTypeSymbol namedType:
+                handle = namedType.Handle;
+                module = ((PEModuleSymbol)namedType.ContainingModule).Module;
+                break;
+
+            case PEFieldSymbol field:
+                handle = field.Handle;
+                module = ((PEModuleSymbol)field.ContainingModule).Module;
+                break;
+
+            case PEPropertySymbol property:
+                handle = property.Handle;
+                module = ((PEModuleSymbol)property.ContainingModule).Module;
+                break;
+
+            default:
+                base.ReportSymbol(symbol);
+                return;
+        }
+
+        var attribute = module.GetAttributeHandle(handle, AttributeDescription.RequiredMemberAttribute);
+
+        if (attribute.IsNil)
+        {
+            return;
+        }
+
+        ReportContainingSymbols(symbol);
+        _builder.Append(GetIndentString(symbol));
+        _builder.Append("[RequiredMember] ");
+        _builder.AppendLine(symbol.ToDisplayString(DisplayFormat));
+        _reported.Add(symbol);
+    }
 
     protected override CSharpAttributeData? GetTargetAttribute(ImmutableArray<CSharpAttributeData> attributes)
         => GetAttribute(attributes, "System.Runtime.CompilerServices", "RequiredMemberAttribute");

--- a/src/Compilers/Test/Utilities/CSharp/RequiredMemberAttributesVisitor.cs
+++ b/src/Compilers/Test/Utilities/CSharp/RequiredMemberAttributesVisitor.cs
@@ -65,6 +65,9 @@ internal class RequiredMemberAttributesVisitor : TestAttributesVisitor
         _builder.Append("[RequiredMember] ");
         _builder.AppendLine(symbol.ToDisplayString(DisplayFormat));
         _reported.Add(symbol);
+
+        // If attributes aren't filtered out, this will print extra data and cause an error in test assertion.
+        base.ReportSymbol(symbol);
     }
 
     protected override CSharpAttributeData? GetTargetAttribute(ImmutableArray<CSharpAttributeData> attributes)

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.CSharp.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.CSharp.cs
@@ -758,7 +758,11 @@ public class C
             public async Task TestRequiredProperty(bool signaturesOnly)
             {
                 var metadataSource = """
-                    public class C { public required int Property { get; set; } }
+                    public class C
+                    {
+                        public required int Property { get; set; }
+                        public required int Field;
+                    }
                     namespace System.Runtime.CompilerServices
                     {
                         public sealed class RequiredMemberAttribute : Attribute { }
@@ -783,14 +787,12 @@ public class C
 // {CodeAnalysisResources.InMemoryAssembly}
 #endregion
 
-using System.Runtime.CompilerServices;
-
-[RequiredMember]
 public class [|C|]
 {{
+    public required int Field;
+
     public C();
 
-    [RequiredMember]
     public required int Property {{ get; set; }}
 }}",
                     false => $@"#region {FeaturesResources.Assembly} ReferencedAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
@@ -804,6 +806,9 @@ using System.Runtime.CompilerServices;
 [RequiredMember]
 public class [|C|]
 {{
+    [RequiredMember]
+    public int Field;
+
     [RequiredMember]
     public int Property {{ get; set; }}
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/61511.
