### PR TITLE
Move Windows builds to new images

### DIFF
--- a/azure-pipelines-integration-lsp.yml
+++ b/azure-pipelines-integration-lsp.yml
@@ -22,7 +22,7 @@ jobs:
 - job: VS_Integration_LSP
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+    demands: ImageOverride -equals windows.vs2022preview.amd64.open
   timeoutInMinutes: 135
 
   steps:

--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -18,7 +18,7 @@ jobs:
 - job: VS_Integration
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Open
+    demands: ImageOverride -equals windows.vs2022.amd64.open
   strategy:
     maxParallel: 4
     matrix:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -79,7 +79,7 @@ stages:
   displayName: Build and Test
   pool:
     name: NetCore1ESPool-Svc-Internal
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022
+    demands: ImageOverride -equals windows.vs2022.amd64
 
   jobs:
   - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/dev17.1-vs-deps') }}:

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -20,7 +20,7 @@ jobs:
 - job: RichCodeNav_Indexing
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+    demands: ImageOverride -equals windows.vs2022preview.amd64.open
   variables:
     EnableRichCodeNavigation: true
   timeoutInMinutes: 200

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,14 +21,14 @@ jobs:
     jobName: Build_Windows_Debug
     testArtifactName: Transport_Artifacts_Windows_Debug
     configuration: Debug
-    queueName: Build.Windows.Amd64.VS2022.Open
+    queueName: windows.vs2022.amd64.open
 
 - template: eng/pipelines/build-windows-job.yml
   parameters:
     jobName: Build_Windows_Release
     testArtifactName: Transport_Artifacts_Windows_Release
     configuration: Release
-    queueName: Build.Windows.Amd64.VS2022.Open
+    queueName: windows.vs2022.amd64.open
 
 - template: eng/pipelines/test-windows-job.yml
   parameters:
@@ -154,7 +154,7 @@ jobs:
 - job: Correctness_Determinism
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Open
+    demands: ImageOverride -equals windows.vs2022.amd64.open
   timeoutInMinutes: 90
   steps:
     - template: eng/pipelines/checkout-windows-task.yml
@@ -170,7 +170,7 @@ jobs:
 - job: Correctness_Build
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Open
+    demands: ImageOverride -equals windows.vs2022.amd64.open
   timeoutInMinutes: 90
   steps:
     - template: eng/pipelines/checkout-windows-task.yml
@@ -202,7 +202,7 @@ jobs:
 - job: Correctness_Rebuild
   pool:
     name: NetCore1ESPool-Svc-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Open
+    demands: ImageOverride -equals windows.vs2022.amd64.open
   timeoutInMinutes: 90
   steps:
     - template: eng/pipelines/checkout-windows-task.yml

--- a/eng/pipelines/test-windows-job-single-machine.yml
+++ b/eng/pipelines/test-windows-job-single-machine.yml
@@ -20,7 +20,7 @@ parameters:
   default: ''
 - name: queueName
   type: string
-  default: 'Build.Windows.10.Amd64.Open'
+  default: 'windows.vs2022.amd64.open'
 
 jobs:
 - job: ${{ parameters.jobName }}


### PR DESCRIPTION
The vs2022 version of these changes https://github.com/dotnet/roslyn/pull/63482