### PR TITLE
Trigger keyword completions in compiler directives when typing

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -7996,6 +7996,22 @@ namespace NS
             End Using
         End Function
 
+        <WorkItem(38289, "https://github.com/dotnet/roslyn/issues/38289")>
+        <WpfTheory, CombinatorialData>
+        <Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestCompletionsWhenTypingCompilerDirective_DoNotCrashOnDocumentStart(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                  <Document><![CDATA[nullable$$]]></Document>,
+                  showCompletionInArgumentLists:=showCompletionInArgumentLists)
+
+                state.SendTypeChars(" ")
+                Await state.WaitForAsynchronousOperationsAsync()
+
+                ' This assertion would fail if any unhandled exception was thrown during computing completions
+                Await state.AssertCompletionItemsDoNotContainAny("disable", "enable", "restore")
+            End Using
+        End Function
+
         <ExportCompletionProvider(NameOf(MultipleChangeCompletionProvider), LanguageNames.CSharp)>
         <[Shared]>
         <PartNotDiscoverable>

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -7962,6 +7962,40 @@ namespace NS
             End Using
         End Function
 
+        <WorkItem(38289, "https://github.com/dotnet/roslyn/issues/38289")>
+        <WpfTheory, CombinatorialData>
+        <Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestShowCompletionsWhenTypingCompilerDirective_SingleDirectiveWord(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                  <Document><![CDATA[
+#nullable$$
+]]></Document>,
+                  showCompletionInArgumentLists:=showCompletionInArgumentLists)
+
+                state.SendTypeChars(" ")
+                Await state.WaitForAsynchronousOperationsAsync()
+
+                Await state.AssertCompletionItemsContainAll("disable", "enable", "restore")
+            End Using
+        End Function
+
+        <WorkItem(38289, "https://github.com/dotnet/roslyn/issues/38289")>
+        <WpfTheory, CombinatorialData>
+        <Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestShowCompletionsWhenTypingCompilerDirective_MultipleDirectiveWords(showCompletionInArgumentLists As Boolean) As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                  <Document><![CDATA[
+#pragma warning$$
+]]></Document>,
+                  showCompletionInArgumentLists:=showCompletionInArgumentLists)
+
+                state.SendTypeChars(" ")
+                Await state.WaitForAsynchronousOperationsAsync()
+
+                Await state.AssertCompletionItemsContainAll("disable", "enable", "restore")
+            End Using
+        End Function
+
         <ExportCompletionProvider(NameOf(MultipleChangeCompletionProvider), LanguageNames.CSharp)>
         <[Shared]>
         <PartNotDiscoverable>

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CompletionUtilities.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CompletionUtilities.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         /// </summary>
         internal static bool IsCompilerDirectiveTriggerCharacter(SourceText text, int characterPosition)
         {
-            while (char.IsWhiteSpace(text[characterPosition]) ||
+            while (text[characterPosition] == ' ' ||
                    char.IsLetter(text[characterPosition]))
             {
                 characterPosition--;

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CompletionUtilities.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CompletionUtilities.cs
@@ -96,31 +96,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         /// </summary>
         internal static bool IsCompilerDirectiveTriggerCharacter(SourceText text, int characterPosition)
         {
-            // First we check if current character is space
-            var ch = text[characterPosition--];
-            if (ch != ' ')
-            {
-                return false;
-            }
-
-            // Then step back while "current" character is letter
-            while (char.IsLetter(text[characterPosition]))
+            while (char.IsWhiteSpace(text[characterPosition]) ||
+                   char.IsLetter(text[characterPosition]))
             {
                 characterPosition--;
+
+                if (characterPosition < 0)
+                    return false;
             }
 
-            // Possible case:
-            // #nullable $$
-            // ^ - characterPosition is here
-            if (text[characterPosition] == '#')
-            {
-                return true;
-            }
-
-            // Possible case:
-            // #pragma warning $$
-            //        ^ - characterPosition is here (between words)
-            return IsCompilerDirectiveTriggerCharacter(text, characterPosition);
+            return text[characterPosition] == '#';
         }
 
         internal static ImmutableHashSet<char> CommonTriggerCharacters { get; } = ImmutableHashSet.Create('.', '#', '>', ':');

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CompletionUtilities.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CompletionUtilities.cs
@@ -91,6 +91,38 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             return false;
         }
 
+        /// <summary>
+        /// Tells if we are in positions like this: <c>#nullable $$</c> or <c>#pragma warning $$</c>
+        /// </summary>
+        internal static bool IsCompilerDirectiveTriggerCharacter(SourceText text, int characterPosition)
+        {
+            // First we check if current character is space
+            var ch = text[characterPosition--];
+            if (ch != ' ')
+            {
+                return false;
+            }
+
+            // Then step back while "current" character is letter
+            while (char.IsLetter(text[characterPosition]))
+            {
+                characterPosition--;
+            }
+
+            // Possible case:
+            // #nullable $$
+            // ^ - characterPosition is here
+            if (text[characterPosition] == '#')
+            {
+                return true;
+            }
+
+            // Possible case:
+            // #pragma warning $$
+            //        ^ - characterPosition is here (between words)
+            return IsCompilerDirectiveTriggerCharacter(text, characterPosition);
+        }
+
         internal static ImmutableHashSet<char> CommonTriggerCharacters { get; } = ImmutableHashSet.Create('.', '#', '>', ':');
 
         internal static ImmutableHashSet<char> CommonTriggerCharactersWithArgumentList { get; } = ImmutableHashSet.Create('.', '#', '>', ':', '(', '[', ' ');

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
@@ -174,9 +174,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         internal override string Language => LanguageNames.CSharp;
 
         public override bool IsInsertionTrigger(SourceText text, int characterPosition, CompletionOptions options)
-            => CompletionUtilities.IsTriggerCharacter(text, characterPosition, options);
+            => CompletionUtilities.IsTriggerCharacter(text, characterPosition, options) ||
+               CompletionUtilities.IsCompilerDirectiveTriggerCharacter(text, characterPosition);
 
-        public override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.CommonTriggerCharacters;
+        public override ImmutableHashSet<char> TriggerCharacters { get; } = CompletionUtilities.CommonTriggerCharacters.Add(' ');
 
         private static readonly CompletionItemRules s_tupleRules = CompletionItemRules.Default.
            WithCommitCharacterRule(CharacterSetModificationRule.Create(CharacterSetModificationKind.Remove, ':'));


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/38289

Results:
![DYLwcxPD37](https://user-images.githubusercontent.com/70431552/185802465-0ec7a608-147a-44dd-bc9e-e1fa2673651f.gif)
_Here I didn't trigger any completion manually. All of them automatically appeared after I typed space_

Also I didn't find any test infrastructure to assert such cases. There is a `KeywordCompletionProviderTest`, but it "triggers" completions manually, so having case like `#nullable $$` works as expected regardless of my changes. If I missed something, please point me to it