### PR TITLE
CSharp.DeclarationTable – avoid realizing lazy roots during add/remove operations.

### DIFF
--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationTable.Cache.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationTable.Cache.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         Interlocked.CompareExchange(
                             ref _mergedRoot,
-                            MergedNamespaceDeclaration.Create(_table._allOlderRootDeclarations.InInsertionOrder.AsImmutable<SingleNamespaceDeclaration>()),
+                            MergedNamespaceDeclaration.Create(_table._allOlderRootDeclarations.InInsertionOrder.Select(static lazyRoot => lazyRoot.Value).AsImmutable<SingleNamespaceDeclaration>()),
                             comparand: null);
                     }
 


### PR DESCRIPTION
Related to [AB#1436225](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1436225).