### PR TITLE
Semantic Snippets - fix tabstop location for cursor in blocks

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpIfSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpIfSnippetCompletionProviderTests.cs
@@ -39,7 +39,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     public void Method()
     {
         if (true)
-        {$$
+        {
+            $$
         }
     }
 }";

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpIfSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpIfSnippetCompletionProviderTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public void Method()
     {
-        Ins$$
+        $$
     }
 }";
 
@@ -56,7 +56,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 
             var expectedCodeAfterCommit =
 @"if (true)
-{$$
+{
+    $$
 }
 ";
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
@@ -117,7 +118,8 @@ class Program
     {
         var x = 5;
         if (true)
-        {$$
+        {
+            $$
         }
     }
 }";
@@ -149,7 +151,8 @@ class Program
         void LocalMethod()
         {
             if (true)
-            {$$
+            {
+                $$
             }
         }
     }
@@ -178,7 +181,8 @@ static void Main(string[] args)
 {
     Print print = delegate(int val) {
         if (true)
-        {$$
+        {
+            $$
         }
     };
 
@@ -200,7 +204,8 @@ static void Main(string[] args)
 @"Func<int, int, bool> testForEquality = (x, y) =>
 {
     if (true)
-    {$$
+    {
+        $$
     }
 
     return x == y;
@@ -346,7 +351,8 @@ class Test
     public void Method()
     {
         if (true)
-        {$$
+        {
+            $$
         }
     }
 }";
@@ -371,7 +377,8 @@ class Test
     public void Method()
     {
         if (true)
-        {$$
+        {
+            $$
         }
     }
 }";

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Snippets;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Snippets
 {
@@ -27,16 +28,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
         {
         }
 
-        protected override void GetIfStatementConditionAndCursorPosition(SyntaxNode node, out SyntaxNode condition, out int cursorPosition)
+        protected override void GetIfStatementCursorPosition(SourceText sourceText, SyntaxNode node, out int cursorPosition)
         {
             var ifStatement = (IfStatementSyntax)node;
-            condition = ifStatement.Condition;
             var blockStatement = (BlockSyntax)ifStatement.Statement;
 
             var triviaSpan = blockStatement.CloseBraceToken.LeadingTrivia.Span;
-
+            var x = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
             // Getting the midpoint location of the trivia's span to get the midway position between the set of curly braces.
             cursorPosition = ((triviaSpan.Start + triviaSpan.End) / 2) + 1;
+        }
+
+        protected override void GetIfStatementCondition(SyntaxNode node, out SyntaxNode condition)
+        {
+            var ifStatement = (IfStatementSyntax)node;
+            condition = ifStatement.Condition;
         }
 
         private static string GetIndentation(Document document, SyntaxNode node, SyntaxFormattingOptions syntaxFormattingOptions, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -34,9 +34,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             var blockStatement = (BlockSyntax)ifStatement.Statement;
 
             var triviaSpan = blockStatement.CloseBraceToken.LeadingTrivia.Span;
-            var x = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
+            var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
             // Getting the midpoint location of the trivia's span to get the midway position between the set of curly braces.
-            cursorPosition = ((triviaSpan.Start + triviaSpan.End) / 2) + 1;
+            cursorPosition = x.Span.End;
         }
 
         protected override void GetIfStatementCondition(SyntaxNode node, out SyntaxNode condition)

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -3,25 +3,18 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp.Extensions;
-using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Indentation;
+using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
-using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Snippets;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Snippets
 {
@@ -38,7 +31,45 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
         {
             var ifStatement = (IfStatementSyntax)node;
             condition = ifStatement.Condition;
-            cursorPositionNode = ifStatement.Statement.SpanStart + 1;
+            var blockStatement = (BlockSyntax)ifStatement.Statement;
+            cursorPositionNode = blockStatement.CloseBraceToken.SpanStart;
+        }
+
+        protected override string? GetIndentation(Document document, SyntaxNode node, SyntaxFormattingOptions syntaxFormattingOptions, CancellationToken cancellationToken)
+        {
+            var parsedDocument = ParsedDocument.CreateSynchronously(document, cancellationToken);
+            var ifStatementSyntax = (IfStatementSyntax)node;
+            var openBraceLine = parsedDocument.Text.Lines.GetLineFromPosition(ifStatementSyntax.Statement.SpanStart).LineNumber;
+
+            var indentationOptions = new IndentationOptions(syntaxFormattingOptions);
+            var newLine = indentationOptions.FormattingOptions.NewLine;
+
+            var indentationService = parsedDocument.LanguageServices.GetRequiredService<IIndentationService>();
+            var indentation = indentationService.GetIndentation(parsedDocument, openBraceLine + 1, indentationOptions, cancellationToken);
+            var newIndentation = new IndentationResult(indentation.BasePosition, indentation.Offset + syntaxFormattingOptions.TabSize);
+            return newIndentation.GetIndentationString(parsedDocument.Text, syntaxFormattingOptions.UseTabs, syntaxFormattingOptions.TabSize) + newLine;
+        }
+
+        protected override async Task<Document> AddIndentationToDocumentAsync(Document document, int position, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
+        {
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var nearestStatement = FindAddedSnippetSyntaxNode(root, position, syntaxFacts);
+            var syntaxFormattingOptions = await document.GetSyntaxFormattingOptionsAsync(fallbackOptions: null, cancellationToken).ConfigureAwait(false);
+
+            var indentationString = GetIndentation(document, nearestStatement, syntaxFormattingOptions, cancellationToken);
+
+            if (indentationString is null)
+            {
+                return document;
+            }
+
+            var ifStatementSyntax = (IfStatementSyntax)nearestStatement;
+            var blockStatement = (BlockSyntax)ifStatementSyntax.Statement;
+            blockStatement = blockStatement.WithCloseBraceToken(blockStatement.CloseBraceToken.WithPrependedLeadingTrivia(SyntaxFactory.SyntaxTrivia(SyntaxKind.WhitespaceTrivia, indentationString)));
+            var newIfStatementSyntax = ifStatementSyntax.ReplaceNode(ifStatementSyntax.Statement, blockStatement);
+
+            var newRoot = root.ReplaceNode(ifStatementSyntax, newIfStatementSyntax);
+            return document.WithSyntaxRoot(newRoot);
         }
     }
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
         {
         }
 
-        protected override void GetIfStatementConditionAndCursorPosition(SyntaxNode node, out SyntaxNode condition, out int cursorPositionNode)
+        protected override void GetIfStatementConditionAndCursorPosition(SyntaxNode node, out SyntaxNode condition, out int cursorPosition)
         {
             var ifStatement = (IfStatementSyntax)node;
             condition = ifStatement.Condition;
@@ -35,8 +35,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
             var triviaSpan = blockStatement.CloseBraceToken.LeadingTrivia.Span;
 
-            // Getting the midpoint location of the trivia to find where the cursor shoudl end up
-            cursorPositionNode = triviaSpan.Start + (triviaSpan.Length / 2) + 1;
+            // Getting the midpoint location of the trivia's span to get the midway position between the set of curly braces.
+            cursorPosition = ((triviaSpan.Start + triviaSpan.End) / 2) + 1;
         }
 
         private static string GetIndentation(Document document, SyntaxNode node, SyntaxFormattingOptions syntaxFormattingOptions, CancellationToken cancellationToken)
@@ -50,6 +50,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
             var indentationService = parsedDocument.LanguageServices.GetRequiredService<IIndentationService>();
             var indentation = indentationService.GetIndentation(parsedDocument, openBraceLine + 1, indentationOptions, cancellationToken);
+
+            // Adding the offset calculated with one tab so that it is indented once past the line containing the opening brace
             var newIndentation = new IndentationResult(indentation.BasePosition, indentation.Offset + syntaxFormattingOptions.TabSize);
             return newIndentation.GetIndentationString(parsedDocument.Text, syntaxFormattingOptions.UseTabs, syntaxFormattingOptions.TabSize) + newLine;
         }

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -58,8 +58,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
         {
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var nearestStatement = FindAddedSnippetSyntaxNode(root, position, syntaxFacts);
-            var syntaxFormattingOptions = await document.GetSyntaxFormattingOptionsAsync(fallbackOptions: null, cancellationToken).ConfigureAwait(false);
 
+            if (nearestStatement is null)
+            {
+                return document;
+            }
+
+            var syntaxFormattingOptions = await document.GetSyntaxFormattingOptionsAsync(fallbackOptions: null, cancellationToken).ConfigureAwait(false);
             var indentationString = GetIndentation(document, nearestStatement, syntaxFormattingOptions, cancellationToken);
 
             var ifStatementSyntax = (IfStatementSyntax)nearestStatement;

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -32,7 +32,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             var ifStatement = (IfStatementSyntax)node;
             condition = ifStatement.Condition;
             var blockStatement = (BlockSyntax)ifStatement.Statement;
-            cursorPositionNode = blockStatement.CloseBraceToken.SpanStart;
+
+            // Getting the starting location of the leading trivia
+            cursorPositionNode = blockStatement.CloseBraceToken.LeadingTrivia.Span.Start + (blockStatement.CloseBraceToken.LeadingTrivia.Span.Length / 2) + 1;
         }
 
         protected override string? GetIndentation(Document document, SyntaxNode node, SyntaxFormattingOptions syntaxFormattingOptions, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -35,8 +35,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
             var triviaSpan = blockStatement.CloseBraceToken.LeadingTrivia.Span;
             var line = sourceText.Lines.GetLineFromPosition(triviaSpan.Start);
-            // Getting the midpoint location of the trivia's span to get the midway position between the set of curly braces.
-            cursorPosition = x.Span.End;
+            // Getting the location at the end of the line before the newline.
+            cursorPosition = line.Span.End;
         }
 
         protected override void GetIfStatementCondition(SyntaxNode node, out SyntaxNode condition)

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -33,8 +33,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             condition = ifStatement.Condition;
             var blockStatement = (BlockSyntax)ifStatement.Statement;
 
-            // Getting the starting location of the leading trivia
-            cursorPositionNode = blockStatement.CloseBraceToken.LeadingTrivia.Span.Start + (blockStatement.CloseBraceToken.LeadingTrivia.Span.Length / 2) + 1;
+            var triviaSpan = blockStatement.CloseBraceToken.LeadingTrivia.Span;
+
+            // Getting the midpoint location of the trivia to find where the cursor shoudl end up
+            cursorPositionNode = triviaSpan.Start + (triviaSpan.Length / 2) + 1;
         }
 
         protected override string? GetIndentation(Document document, SyntaxNode node, SyntaxFormattingOptions syntaxFormattingOptions, CancellationToken cancellationToken)

--- a/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpIfSnippetProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             cursorPositionNode = triviaSpan.Start + (triviaSpan.Length / 2) + 1;
         }
 
-        protected override string? GetIndentation(Document document, SyntaxNode node, SyntaxFormattingOptions syntaxFormattingOptions, CancellationToken cancellationToken)
+        private static string GetIndentation(Document document, SyntaxNode node, SyntaxFormattingOptions syntaxFormattingOptions, CancellationToken cancellationToken)
         {
             var parsedDocument = ParsedDocument.CreateSynchronously(document, cancellationToken);
             var ifStatementSyntax = (IfStatementSyntax)node;
@@ -61,11 +61,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             var syntaxFormattingOptions = await document.GetSyntaxFormattingOptionsAsync(fallbackOptions: null, cancellationToken).ConfigureAwait(false);
 
             var indentationString = GetIndentation(document, nearestStatement, syntaxFormattingOptions, cancellationToken);
-
-            if (indentationString is null)
-            {
-                return document;
-            }
 
             var ifStatementSyntax = (IfStatementSyntax)nearestStatement;
             var blockStatement = (BlockSyntax)ifStatementSyntax.Statement;

--- a/src/Features/Core/Portable/Snippets/RoslynLSPSnippetConverter.cs
+++ b/src/Features/Core/Portable/Snippets/RoslynLSPSnippetConverter.cs
@@ -100,17 +100,6 @@ namespace Microsoft.CodeAnalysis.Snippets
             }
         }
 
-        /*private static string GenerateStringOfSpaces(string textChangeText, char charToConsider)
-        {
-            var spacesString = "";
-            if (charToConsider == '{')
-            {
-                spacesString += 
-            }
-
-            return spacesString;
-        }*/
-
         /// <summary>
         /// We need to extend the snippet's TextChange if any of the placeholders or
         /// if the caret position comes before or after the span of the TextChange.

--- a/src/Features/Core/Portable/Snippets/RoslynLSPSnippetConverter.cs
+++ b/src/Features/Core/Portable/Snippets/RoslynLSPSnippetConverter.cs
@@ -100,6 +100,17 @@ namespace Microsoft.CodeAnalysis.Snippets
             }
         }
 
+        /*private static string GenerateStringOfSpaces(string textChangeText, char charToConsider)
+        {
+            var spacesString = "";
+            if (charToConsider == '{')
+            {
+                spacesString += 
+            }
+
+            return spacesString;
+        }*/
+
         /// <summary>
         /// We need to extend the snippet's TextChange if any of the placeholders or
         /// if the caret position comes before or after the span of the TextChange.

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Snippets
         /// Tries to get the location after the open parentheses in the argument list.
         /// If it can't, then we default to the end of the snippet's span.
         /// </summary>
-        protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget)
+        protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
         {
             var invocationExpression = caretTarget.DescendantNodes().Where(syntaxFacts.IsInvocationExpression).FirstOrDefault();
             if (invocationExpression is null)

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
@@ -28,7 +28,8 @@ namespace Microsoft.CodeAnalysis.Snippets
 
         public override ImmutableArray<string> AdditionalFilterTexts { get; } = ImmutableArray.Create("statement");
 
-        protected abstract void GetIfStatementConditionAndCursorPosition(SyntaxNode node, out SyntaxNode condition, out int cursorPosition);
+        protected abstract void GetIfStatementCondition(SyntaxNode node, out SyntaxNode condition);
+        protected abstract void GetIfStatementCursorPosition(SourceText text, SyntaxNode node, out int position);
 
         protected override async Task<bool> IsValidSnippetLocationAsync(Document document, int position, CancellationToken cancellationToken)
         {
@@ -52,9 +53,9 @@ namespace Microsoft.CodeAnalysis.Snippets
             return new TextChange(TextSpan.FromBounds(position, position), ifStatement.ToFullString());
         }
 
-        protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget)
+        protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
         {
-            GetIfStatementConditionAndCursorPosition(caretTarget, out _, out var cursorPosition);
+            GetIfStatementCursorPosition(sourceText, caretTarget, out var cursorPosition);
 
             // Place at the end of the node specified for cursor position.
             // Is the statement node in C# and the "Then" keyword
@@ -79,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Snippets
         protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
         {
             using var _ = ArrayBuilder<SnippetPlaceholder>.GetInstance(out var arrayBuilder);
-            GetIfStatementConditionAndCursorPosition(node, out var condition, out var unusedVariable);
+            GetIfStatementCondition(node, out var condition);
             arrayBuilder.Add(new SnippetPlaceholder(identifier: condition.ToString(), placeholderPositions: ImmutableArray.Create(condition.SpanStart)));
 
             return arrayBuilder.ToImmutableArray();

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractIfSnippetProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Snippets
 
         public override ImmutableArray<string> AdditionalFilterTexts { get; } = ImmutableArray.Create("statement");
 
-        protected abstract void GetIfStatementConditionAndCursorPosition(SyntaxNode node, out SyntaxNode condition, out int cursorPositionNode);
+        protected abstract void GetIfStatementConditionAndCursorPosition(SyntaxNode node, out SyntaxNode condition, out int cursorPosition);
 
         protected override async Task<bool> IsValidSnippetLocationAsync(Document document, int position, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -214,6 +214,11 @@ namespace Microsoft.CodeAnalysis.Snippets
             return document;
         }
 
+        /// <summary>
+        /// Certain snippets require more indentation - snippets with blocks.
+        /// The SyntaxGenerator does not insert this space for us nor does the LSP Snippet Expander.
+        /// We need to manually add that spacing to snippets containing blocks.
+        /// </summary>
         protected virtual async Task<Document> AddIndentationToDocumentAsync(Document document, int position, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
         {
             return await Task.FromResult(document).ConfigureAwait(false);

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Snippets
             // All the changes from the original document to the most updated. Will later be
             // collpased into one collapsed TextChange.
             var changesArray = changes.ToImmutableArray();
-            Contract.ThrowIfFalse(annotatedReformattedDocument.TryGetText(out var sourceText));
+            var sourceText = await annotatedReformattedDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             return new SnippetChange(
                 textChanges: changesArray,

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -210,14 +210,9 @@ namespace Microsoft.CodeAnalysis.Snippets
             return document;
         }
 
-        protected virtual string? GetIndentation(Document document, SyntaxNode node, SyntaxFormattingOptions syntaxFormattingOptions, CancellationToken cancellationToken)
+        protected virtual async Task<Document> AddIndentationToDocumentAsync(Document document, int position, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
         {
-            return null;
-        }
-
-        protected async virtual Task<Document> AddIndentationToDocumentAsync(Document document, int position, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)
-        {
-            return document;
+            return await Task.FromResult(document).ConfigureAwait(false);
         }
     }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Immutable;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.AddImport;


### PR DESCRIPTION
Gets the indentation of the line containing the opening brace and finds the indentation for the next line. Inserts that indentation as prepended leading trivia to the closing brace.