### PR TITLE
Skip integration tests on PRs for compiler-only changes

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -22,12 +22,13 @@ pr:
       - eng/config/PublishData.json
       - .vscode/*
       - .github/*
-      - .devcontainer/
+      - .devcontainer/*
       - .git-blame-ignore-revs
       - .vsconfig
       - CODE-OF-CONDUCT.md
       - CONTRIBUTING.md
       - README.md
+      - src/Compilers/*
 
 jobs:
 - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:


### PR DESCRIPTION
When a change is just changing the compiler layer, failures are caught by IDE unit tests. The integration tests do not catch additional failures, and running them just adds time and flakiness to Compiler-only changes. We do not trigger them if the compiler is the only thing that changed.
