### PR TITLE
Extract Base Record Pass 1 

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
@@ -198,7 +198,7 @@ partial class Test
         }
 
         [Fact]
-        public async Task TestRecord()
+        public async Task TestRecord_Method()
         {
             var input = """
                 record R(string S)
@@ -242,7 +242,87 @@ partial class Test
         }
 
         [Fact]
-        public async Task TestRecord2()
+        public async Task TestRecord_Property()
+        {
+            var input = """
+                record R
+                {
+                    public string $$S { get; set; }
+                }
+                """;
+
+            var expected1 = """
+                record R : MyBase
+                {
+                }
+                """;
+
+            var expected2 = """
+                internal record MyBase
+                {
+                    public string S { get; set; }
+                }
+
+                """;
+
+            await new Test
+            {
+                TestCode = input,
+                LanguageVersion = LanguageVersion.CSharp9,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2,
+                    }
+                },
+            }.RunAsync();
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/62415")]
+        public async Task TestRecord_PropertyAndImplicitField()
+        {
+            var input = """
+                record R(string S)
+                {
+                    public string $$S { get; set; } = S;
+                }
+                """;
+
+            var expected1 = """
+                record R(string S) : MyBase(S)
+                {
+                }
+                """;
+
+            var expected2 = """
+                record MyBase(string S)
+                {
+                    public string S { get; set; } = S;
+                }
+
+                """;
+
+            await new Test
+            {
+                TestCode = input,
+                LanguageVersion = LanguageVersion.CSharp9,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2,
+                    }
+                },
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestRecordParam()
         {
             // https://github.com/dotnet/roslyn/issues/62415 to make this scenario work
             var input = """
@@ -256,6 +336,27 @@ partial class Test
                 TestCode = input,
                 FixedCode = input,
                 LanguageVersion = LanguageVersion.CSharp9,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestRecordStruct()
+        {
+            var input = """
+                record struct R(string S)
+                {
+                    void $$M()
+                    {
+                    }
+                }
+                """;
+
+            await new Test
+            {
+                TestCode = input,
+                FixedCode = input,
+                LanguageVersion = LanguageVersion.CSharp10,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             }.RunAsync();
         }

--- a/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
@@ -198,6 +198,69 @@ partial class Test
         }
 
         [Fact]
+        public async Task TestRecord()
+        {
+            var input = """
+                record R(string S)
+                {
+                    void $$M()
+                    {
+                    }
+                }
+                """;
+
+            var expected1 = """
+                record R(string S) : MyBase
+                {
+                }
+                """;
+
+            var expected2 = """
+                internal record MyBase
+                {
+                    void M()
+                    {
+                    }
+                }
+
+                """;
+
+            await new Test
+            {
+                TestCode = input,
+                LanguageVersion = LanguageVersion.CSharp9,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2,
+                    }
+                },
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestRecord2()
+        {
+            // https://github.com/dotnet/roslyn/issues/62415 to make this scenario work
+            var input = """
+                record R(string $$S)
+                {
+                }
+                """;
+
+            await new Test
+            {
+                TestCode = input,
+                FixedCode = input,
+                LanguageVersion = LanguageVersion.CSharp9,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task TestInNamespace()
         {
             var input = @"

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -3159,6 +3159,6 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   </data>
   <data name="Extract_base_record" xml:space="preserve">
     <value>Extract base record...</value>
-    <comment>"record" is a language construct and should be left the same</comment>
+    <comment>{Locked="record"} "record" is a language construct for C# and should not be localized.</comment>
   </data>
 </root>

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -3157,4 +3157,8 @@ Zero-width positive lookbehind assertions are typically used at the beginning of
   <data name="Deleting_0_requires_restarting_the_application_because_is_not_supported_by_the_runtime" xml:space="preserve">
     <value>Deleting {0} requires restarting the application because is not supported by the runtime.</value>
   </data>
+  <data name="Extract_base_record" xml:space="preserve">
+    <value>Extract base record...</value>
+    <comment>"record" is a language construct and should be left the same</comment>
+  </data>
 </root>

--- a/src/Features/Core/Portable/PullMemberUp/MemberAndDestinationValidator.cs
+++ b/src/Features/Core/Portable/PullMemberUp/MemberAndDestinationValidator.cs
@@ -29,6 +29,11 @@ namespace Microsoft.CodeAnalysis.PullMemberUp
 
         public static bool IsMemberValid(ISymbol member)
         {
+            if (member.IsImplicitlyDeclared)
+            {
+                return false;
+            }
+
             // Static, abstract and accessiblity are not checked here but in PullMembersUpOptionsBuilder.cs since there are
             // two refactoring options provided for pull members up,
             // 1. Quick Action (Only allow members that don't cause error)
@@ -36,8 +41,7 @@ namespace Microsoft.CodeAnalysis.PullMemberUp
             return member switch
             {
                 IMethodSymbol methodSymbol => methodSymbol.MethodKind == MethodKind.Ordinary,
-                IFieldSymbol fieldSymbol => !fieldSymbol.IsImplicitlyDeclared,
-                _ => member.IsKind(SymbolKind.Property) || member.IsKind(SymbolKind.Event),
+                _ => member.IsKind(SymbolKind.Property) || member.IsKind(SymbolKind.Event) || member.IsKind(SymbolKind.Field),
             };
         }
     }

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -715,6 +715,11 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
         <target state="translated">Extrahovat základní třídu...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_base_record">
+        <source>Extract base record...</source>
+        <target state="new">Extract base record...</target>
+        <note>"record" is a language construct and should be left the same</note>
+      </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>
         <target state="translated">Extrahovat rozhraní...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.cs.xlf
@@ -718,7 +718,7 @@ Ujistěte se, že specifikátor tt použijete pro jazyky, pro které je nezbytn�
       <trans-unit id="Extract_base_record">
         <source>Extract base record...</source>
         <target state="new">Extract base record...</target>
-        <note>"record" is a language construct and should be left the same</note>
+        <note>{Locked="record"} "record" is a language construct for C# and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -718,7 +718,7 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
       <trans-unit id="Extract_base_record">
         <source>Extract base record...</source>
         <target state="new">Extract base record...</target>
-        <note>"record" is a language construct and should be left the same</note>
+        <note>{Locked="record"} "record" is a language construct for C# and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.de.xlf
@@ -715,6 +715,11 @@ Stellen Sie sicher, dass Sie den Bezeichner "tt" für Sprachen verwenden, für d
         <target state="translated">Basisklasse extrahieren...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_base_record">
+        <source>Extract base record...</source>
+        <target state="new">Extract base record...</target>
+        <note>"record" is a language construct and should be left the same</note>
+      </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>
         <target state="translated">Schnittstelle extrahieren...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -718,7 +718,7 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
       <trans-unit id="Extract_base_record">
         <source>Extract base record...</source>
         <target state="new">Extract base record...</target>
-        <note>"record" is a language construct and should be left the same</note>
+        <note>{Locked="record"} "record" is a language construct for C# and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.es.xlf
@@ -715,6 +715,11 @@ Asegúrese de usar el especificador "tt" para los idiomas para los que es necesa
         <target state="translated">Extraer clase base...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_base_record">
+        <source>Extract base record...</source>
+        <target state="new">Extract base record...</target>
+        <note>"record" is a language construct and should be left the same</note>
+      </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>
         <target state="translated">Extraer interfaz...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -715,6 +715,11 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
         <target state="translated">Extraire la classe de base...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_base_record">
+        <source>Extract base record...</source>
+        <target state="new">Extract base record...</target>
+        <note>"record" is a language construct and should be left the same</note>
+      </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>
         <target state="translated">Extraire l'interface...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.fr.xlf
@@ -718,7 +718,7 @@ Veillez à utiliser le spécificateur "tt" pour les langues où il est nécessai
       <trans-unit id="Extract_base_record">
         <source>Extract base record...</source>
         <target state="new">Extract base record...</target>
-        <note>"record" is a language construct and should be left the same</note>
+        <note>{Locked="record"} "record" is a language construct for C# and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -715,6 +715,11 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
         <target state="translated">Estrai classe di base...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_base_record">
+        <source>Extract base record...</source>
+        <target state="new">Extract base record...</target>
+        <note>"record" is a language construct and should be left the same</note>
+      </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>
         <target state="translated">Estrai interfaccia...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.it.xlf
@@ -718,7 +718,7 @@ Assicurarsi di usare l'identificatore "tt" per le lingue per le quali è necessa
       <trans-unit id="Extract_base_record">
         <source>Extract base record...</source>
         <target state="new">Extract base record...</target>
-        <note>"record" is a language construct and should be left the same</note>
+        <note>{Locked="record"} "record" is a language construct for C# and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -715,6 +715,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">基底クラスの抽出...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_base_record">
+        <source>Extract base record...</source>
+        <target state="new">Extract base record...</target>
+        <note>"record" is a language construct and should be left the same</note>
+      </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>
         <target state="translated">インターフェイスの抽出...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ja.xlf
@@ -718,7 +718,7 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Extract_base_record">
         <source>Extract base record...</source>
         <target state="new">Extract base record...</target>
-        <note>"record" is a language construct and should be left the same</note>
+        <note>{Locked="record"} "record" is a language construct for C# and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -715,6 +715,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">기본 클래스 추출...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_base_record">
+        <source>Extract base record...</source>
+        <target state="new">Extract base record...</target>
+        <note>"record" is a language construct and should be left the same</note>
+      </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>
         <target state="translated">인터페이스 추출...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ko.xlf
@@ -718,7 +718,7 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Extract_base_record">
         <source>Extract base record...</source>
         <target state="new">Extract base record...</target>
-        <note>"record" is a language construct and should be left the same</note>
+        <note>{Locked="record"} "record" is a language construct for C# and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -715,6 +715,11 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
         <target state="translated">Wyodrębnij klasę bazową...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_base_record">
+        <source>Extract base record...</source>
+        <target state="new">Extract base record...</target>
+        <note>"record" is a language construct and should be left the same</note>
+      </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>
         <target state="translated">Wyodrębnij interfejs...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pl.xlf
@@ -718,7 +718,7 @@ Pamiętaj, aby nie używać specyfikatora „tt” dla wszystkich języków, w k
       <trans-unit id="Extract_base_record">
         <source>Extract base record...</source>
         <target state="new">Extract base record...</target>
-        <note>"record" is a language construct and should be left the same</note>
+        <note>{Locked="record"} "record" is a language construct for C# and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -718,7 +718,7 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
       <trans-unit id="Extract_base_record">
         <source>Extract base record...</source>
         <target state="new">Extract base record...</target>
-        <note>"record" is a language construct and should be left the same</note>
+        <note>{Locked="record"} "record" is a language construct for C# and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.pt-BR.xlf
@@ -715,6 +715,11 @@ Verifique se o especificador "tt" foi usado para idiomas para os quais é necess
         <target state="translated">Extrair a classe base...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_base_record">
+        <source>Extract base record...</source>
+        <target state="new">Extract base record...</target>
+        <note>"record" is a language construct and should be left the same</note>
+      </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>
         <target state="translated">Extrair a interface...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -715,6 +715,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">Извлечь базовый класс...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_base_record">
+        <source>Extract base record...</source>
+        <target state="new">Extract base record...</target>
+        <note>"record" is a language construct and should be left the same</note>
+      </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>
         <target state="translated">Извлечение интерфейса…</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.ru.xlf
@@ -718,7 +718,7 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Extract_base_record">
         <source>Extract base record...</source>
         <target state="new">Extract base record...</target>
-        <note>"record" is a language construct and should be left the same</note>
+        <note>{Locked="record"} "record" is a language construct for C# and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -715,6 +715,11 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
         <target state="translated">Temel sınıfı ayıkla...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_base_record">
+        <source>Extract base record...</source>
+        <target state="new">Extract base record...</target>
+        <note>"record" is a language construct and should be left the same</note>
+      </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>
         <target state="translated">Arabirimi ayıkla...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.tr.xlf
@@ -718,7 +718,7 @@ AM ve PM arasındaki farkın korunmasının gerekli olduğu diller için "tt" be
       <trans-unit id="Extract_base_record">
         <source>Extract base record...</source>
         <target state="new">Extract base record...</target>
-        <note>"record" is a language construct and should be left the same</note>
+        <note>{Locked="record"} "record" is a language construct for C# and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -715,6 +715,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">提取基类...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_base_record">
+        <source>Extract base record...</source>
+        <target state="new">Extract base record...</target>
+        <note>"record" is a language construct and should be left the same</note>
+      </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>
         <target state="translated">提取接口...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hans.xlf
@@ -718,7 +718,7 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Extract_base_record">
         <source>Extract base record...</source>
         <target state="new">Extract base record...</target>
-        <note>"record" is a language construct and should be left the same</note>
+        <note>{Locked="record"} "record" is a language construct for C# and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -715,6 +715,11 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
         <target state="translated">擷取基底類別...</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_base_record">
+        <source>Extract base record...</source>
+        <target state="new">Extract base record...</target>
+        <note>"record" is a language construct and should be left the same</note>
+      </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>
         <target state="translated">擷取介面...</target>

--- a/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
+++ b/src/Features/Core/Portable/xlf/FeaturesResources.zh-Hant.xlf
@@ -718,7 +718,7 @@ Make sure to use the "tt" specifier for languages for which it's necessary to ma
       <trans-unit id="Extract_base_record">
         <source>Extract base record...</source>
         <target state="new">Extract base record...</target>
-        <note>"record" is a language construct and should be left the same</note>
+        <note>{Locked="record"} "record" is a language construct for C# and should not be localized.</note>
       </trans-unit>
       <trans-unit id="Extract_interface">
         <source>Extract interface...</source>

--- a/src/VisualStudio/Core/Def/ExtractClass/ExtractClassDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/ExtractClass/ExtractClassDialog.xaml.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ExtractClass
         public string OK => ServicesVSResources.OK;
         public string Cancel => ServicesVSResources.Cancel;
         public string SelectMembers => ServicesVSResources.Select_members_colon;
-        public string ExtractClassTitle => ServicesVSResources.Extract_Base_Class;
+        public string ExtractClassTitle => ViewModel.Title;
         public ExtractClassViewModel ViewModel { get; }
         public MemberSelection MemberSelectionControl { get; }
 

--- a/src/VisualStudio/Core/Def/ExtractClass/ExtractClassViewModel.cs
+++ b/src/VisualStudio/Core/Def/ExtractClass/ExtractClassViewModel.cs
@@ -16,10 +16,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ExtractClass
     internal class ExtractClassViewModel
     {
         private readonly INotificationService _notificationService;
+        private readonly INamedTypeSymbol _selectedType;
 
         public ExtractClassViewModel(
             IUIThreadOperationExecutor uiThreadOperationExecutor,
             INotificationService notificationService,
+            INamedTypeSymbol selectedType,
             ImmutableArray<MemberSymbolViewModel> memberViewModels,
             ImmutableDictionary<ISymbol, Task<ImmutableArray<ISymbol>>> memberToDependentsMap,
             string defaultTypeName,
@@ -30,6 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ExtractClass
             ISyntaxFactsService syntaxFactsService)
         {
             _notificationService = notificationService;
+            _selectedType = selectedType;
 
             MemberSelectionViewModel = new MemberSelectionViewModel(
                 uiThreadOperationExecutor,
@@ -62,5 +65,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ExtractClass
 
         public MemberSelectionViewModel MemberSelectionViewModel { get; }
         public NewTypeDestinationSelectionViewModel DestinationViewModel { get; }
+        public string Title => _selectedType.IsRecord
+            ? ServicesVSResources.Extract_Base_Record
+            : ServicesVSResources.Extract_Base_Class;
     }
 }

--- a/src/VisualStudio/Core/Def/ExtractClass/VisualStudioExtractClassOptionsService.cs
+++ b/src/VisualStudio/Core/Def/ExtractClass/VisualStudioExtractClassOptionsService.cs
@@ -83,6 +83,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ExtractClass
             var viewModel = new ExtractClassViewModel(
                 _uiThreadOperationExecutor,
                 notificationService,
+                selectedType,
                 memberViewModels,
                 memberToDependentsMap,
                 defaultTypeName,

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -2007,4 +2007,8 @@ Additional information: {1}</value>
   <data name="Enable_navigation_to_sourcelink_and_embedded_sources" xml:space="preserve">
     <value>Enable navigation to Source Link and Embedded sources</value>
   </data>
+  <data name="Extract_Base_Record" xml:space="preserve">
+    <value>Extract Base Record</value>
+    <comment>"Record" is a language construct for C#</comment>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -2009,6 +2009,6 @@ Additional information: {1}</value>
   </data>
   <data name="Extract_Base_Record" xml:space="preserve">
     <value>Extract Base Record</value>
-    <comment>"Record" is a language construct for C#</comment>
+    <comment>{Locked="Record"} "Record" is a language construct for C# and should not be localized</comment>
   </data>
 </root>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -500,7 +500,7 @@
       <trans-unit id="Extract_Base_Record">
         <source>Extract Base Record</source>
         <target state="new">Extract Base Record</target>
-        <note>"Record" is a language construct for C#</note>
+        <note>{Locked="Record"} "Record" is a language construct for C# and should not be localized</note>
       </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.cs.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Extrahovat základní třídu</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_Base_Record">
+        <source>Extract Base Record</source>
+        <target state="new">Extract Base Record</target>
+        <note>"Record" is a language construct for C#</note>
+      </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>
         <target state="translated">Dokončit</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -500,7 +500,7 @@
       <trans-unit id="Extract_Base_Record">
         <source>Extract Base Record</source>
         <target state="new">Extract Base Record</target>
-        <note>"Record" is a language construct for C#</note>
+        <note>{Locked="Record"} "Record" is a language construct for C# and should not be localized</note>
       </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.de.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Basisklasse extrahieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_Base_Record">
+        <source>Extract Base Record</source>
+        <target state="new">Extract Base Record</target>
+        <note>"Record" is a language construct for C#</note>
+      </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>
         <target state="translated">Beenden</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -500,7 +500,7 @@
       <trans-unit id="Extract_Base_Record">
         <source>Extract Base Record</source>
         <target state="new">Extract Base Record</target>
-        <note>"Record" is a language construct for C#</note>
+        <note>{Locked="Record"} "Record" is a language construct for C# and should not be localized</note>
       </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.es.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Extraer clase base</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_Base_Record">
+        <source>Extract Base Record</source>
+        <target state="new">Extract Base Record</target>
+        <note>"Record" is a language construct for C#</note>
+      </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>
         <target state="translated">Finalizar</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Extraire la classe de base</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_Base_Record">
+        <source>Extract Base Record</source>
+        <target state="new">Extract Base Record</target>
+        <note>"Record" is a language construct for C#</note>
+      </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>
         <target state="translated">Terminer</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.fr.xlf
@@ -500,7 +500,7 @@
       <trans-unit id="Extract_Base_Record">
         <source>Extract Base Record</source>
         <target state="new">Extract Base Record</target>
-        <note>"Record" is a language construct for C#</note>
+        <note>{Locked="Record"} "Record" is a language construct for C# and should not be localized</note>
       </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -500,7 +500,7 @@
       <trans-unit id="Extract_Base_Record">
         <source>Extract Base Record</source>
         <target state="new">Extract Base Record</target>
-        <note>"Record" is a language construct for C#</note>
+        <note>{Locked="Record"} "Record" is a language construct for C# and should not be localized</note>
       </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.it.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Estrai classe di base</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_Base_Record">
+        <source>Extract Base Record</source>
+        <target state="new">Extract Base Record</target>
+        <note>"Record" is a language construct for C#</note>
+      </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>
         <target state="translated">Fine</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -500,7 +500,7 @@
       <trans-unit id="Extract_Base_Record">
         <source>Extract Base Record</source>
         <target state="new">Extract Base Record</target>
-        <note>"Record" is a language construct for C#</note>
+        <note>{Locked="Record"} "Record" is a language construct for C# and should not be localized</note>
       </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ja.xlf
@@ -497,6 +497,11 @@
         <target state="translated">基底クラスの抽出</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_Base_Record">
+        <source>Extract Base Record</source>
+        <target state="new">Extract Base Record</target>
+        <note>"Record" is a language construct for C#</note>
+      </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>
         <target state="translated">終了</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -500,7 +500,7 @@
       <trans-unit id="Extract_Base_Record">
         <source>Extract Base Record</source>
         <target state="new">Extract Base Record</target>
-        <note>"Record" is a language construct for C#</note>
+        <note>{Locked="Record"} "Record" is a language construct for C# and should not be localized</note>
       </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ko.xlf
@@ -497,6 +497,11 @@
         <target state="translated">기본 클래스 추출</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_Base_Record">
+        <source>Extract Base Record</source>
+        <target state="new">Extract Base Record</target>
+        <note>"Record" is a language construct for C#</note>
+      </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>
         <target state="translated">마침</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -500,7 +500,7 @@
       <trans-unit id="Extract_Base_Record">
         <source>Extract Base Record</source>
         <target state="new">Extract Base Record</target>
-        <note>"Record" is a language construct for C#</note>
+        <note>{Locked="Record"} "Record" is a language construct for C# and should not be localized</note>
       </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pl.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Wyodrębnij klasę bazową</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_Base_Record">
+        <source>Extract Base Record</source>
+        <target state="new">Extract Base Record</target>
+        <note>"Record" is a language construct for C#</note>
+      </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>
         <target state="translated">Zakończ</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -500,7 +500,7 @@
       <trans-unit id="Extract_Base_Record">
         <source>Extract Base Record</source>
         <target state="new">Extract Base Record</target>
-        <note>"Record" is a language construct for C#</note>
+        <note>{Locked="Record"} "Record" is a language construct for C# and should not be localized</note>
       </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.pt-BR.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Extrair a Classe Base</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_Base_Record">
+        <source>Extract Base Record</source>
+        <target state="new">Extract Base Record</target>
+        <note>"Record" is a language construct for C#</note>
+      </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>
         <target state="translated">Concluir</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -500,7 +500,7 @@
       <trans-unit id="Extract_Base_Record">
         <source>Extract Base Record</source>
         <target state="new">Extract Base Record</target>
-        <note>"Record" is a language construct for C#</note>
+        <note>{Locked="Record"} "Record" is a language construct for C# and should not be localized</note>
       </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.ru.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Извлечь базовый класс</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_Base_Record">
+        <source>Extract Base Record</source>
+        <target state="new">Extract Base Record</target>
+        <note>"Record" is a language construct for C#</note>
+      </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>
         <target state="translated">Готово</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -500,7 +500,7 @@
       <trans-unit id="Extract_Base_Record">
         <source>Extract Base Record</source>
         <target state="new">Extract Base Record</target>
-        <note>"Record" is a language construct for C#</note>
+        <note>{Locked="Record"} "Record" is a language construct for C# and should not be localized</note>
       </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.tr.xlf
@@ -497,6 +497,11 @@
         <target state="translated">Temel Sınıfı Ayıkla</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_Base_Record">
+        <source>Extract Base Record</source>
+        <target state="new">Extract Base Record</target>
+        <note>"Record" is a language construct for C#</note>
+      </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>
         <target state="translated">Son</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -500,7 +500,7 @@
       <trans-unit id="Extract_Base_Record">
         <source>Extract Base Record</source>
         <target state="new">Extract Base Record</target>
-        <note>"Record" is a language construct for C#</note>
+        <note>{Locked="Record"} "Record" is a language construct for C# and should not be localized</note>
       </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hans.xlf
@@ -497,6 +497,11 @@
         <target state="translated">提取基类</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_Base_Record">
+        <source>Extract Base Record</source>
+        <target state="new">Extract Base Record</target>
+        <note>"Record" is a language construct for C#</note>
+      </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>
         <target state="translated">完成</target>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -500,7 +500,7 @@
       <trans-unit id="Extract_Base_Record">
         <source>Extract Base Record</source>
         <target state="new">Extract Base Record</target>
-        <note>"Record" is a language construct for C#</note>
+        <note>{Locked="Record"} "Record" is a language construct for C# and should not be localized</note>
       </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>

--- a/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/Core/Def/xlf/ServicesVSResources.zh-Hant.xlf
@@ -497,6 +497,11 @@
         <target state="translated">擷取基底類別</target>
         <note />
       </trans-unit>
+      <trans-unit id="Extract_Base_Record">
+        <source>Extract Base Record</source>
+        <target state="new">Extract Base Record</target>
+        <note>"Record" is a language construct for C#</note>
+      </trans-unit>
       <trans-unit id="Finish">
         <source>Finish</source>
         <target state="translated">完成</target>


### PR DESCRIPTION
Fixes #62415 

This gets the "extract base class" to not fall over for records entirely. It no longer allows the user to select compiler generated methods, and generates the right type. 

Still to do: 

1. Make so invocation on record works `record $$R(string $$S)`. Both `$$` locations don't currently work
2. Support properties declared with syntax `record R(string S)` 
