### PR TITLE
Update xcopy msbuild version for .net7p7

### DIFF
--- a/global.json
+++ b/global.json
@@ -14,7 +14,7 @@
     "vs": {
       "version": "17.0"
     },
-    "xcopy-msbuild": "17.1.0"
+    "xcopy-msbuild": "17.2.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22419.1",


### PR DESCRIPTION
Signed builds are failing with an error saying msbuild is too outdated for .net7p7
https://dev.azure.com/dnceng/internal/_build/results?buildId=1959441&view=results

Suggestion was to upgrade xcopy msbuild.   Verifying signed build