### PR TITLE
Avoid linq overhead and having to create secondary result

### DIFF
--- a/src/EditorFeatures/Core/KeywordHighlighting/HighlighterViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/KeywordHighlighting/HighlighterViewTaggerProvider.cs
@@ -102,8 +102,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
             // want to actually go recompute things.  Note: this only works for containment.  If the
             // user moves their caret to the end of a highlighted reference, we do want to recompute
             // as they may now be at the start of some other reference that should be highlighted instead.
-            var existingTags = context.GetExistingContainingTags(new SnapshotPoint(snapshot, position));
-            if (!existingTags.IsEmpty())
+            var onExistingTags = context.HasExistingContainingTags(new SnapshotPoint(snapshot, position));
+            if (onExistingTags)
             {
                 context.SetSpansTagged(ImmutableArray<SnapshotSpan>.Empty);
                 return;

--- a/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/ReferenceHighlighting/ReferenceHighlightingViewTaggerProvider.cs
@@ -125,8 +125,8 @@ namespace Microsoft.CodeAnalysis.Editor.ReferenceHighlighting
             // want to actually go recompute things.  Note: this only works for containment.  If the
             // user moves their caret to the end of a highlighted reference, we do want to recompute
             // as they may now be at the start of some other reference that should be highlighted instead.
-            var existingTags = context.GetExistingContainingTags(caretPosition);
-            if (!existingTags.IsEmpty())
+            var onExistingTags = context.HasExistingContainingTags(caretPosition);
+            if (onExistingTags)
             {
                 context.SetSpansTagged(ImmutableArray<SnapshotSpan>.Empty);
                 return Task.CompletedTask;

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/src/EditorFeatures/Core/Tagging/TaggerContext.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerContext.cs
@@ -86,16 +86,9 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         public void SetSpansTagged(ImmutableArray<SnapshotSpan> spansTagged)
             => _spansTagged = spansTagged;
 
-        public IEnumerable<ITagSpan<TTag>> GetExistingContainingTags(SnapshotPoint point)
-        {
-            if (_existingTags != null && _existingTags.TryGetValue(point.Snapshot.TextBuffer, out var tree))
-            {
-                return tree.GetIntersectingSpans(
-                    new SnapshotSpan(point.Snapshot, new Span(point, 0)),
-                    predicate: s => s.Span.Contains(point));
-            }
-
-            return SpecializedCollections.EmptyEnumerable<ITagSpan<TTag>>();
-        }
+        public bool HasExistingContainingTags(SnapshotPoint point)
+            => _existingTags != null &&
+               _existingTags.TryGetValue(point.Snapshot.TextBuffer, out var tree) &&
+               tree.HasSpanThatContains(point);
     }
 }

--- a/src/EditorFeatures/Core/Tagging/TaggerContext.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerContext.cs
@@ -90,8 +90,9 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         {
             if (_existingTags != null && _existingTags.TryGetValue(point.Snapshot.TextBuffer, out var tree))
             {
-                return tree.GetIntersectingSpans(new SnapshotSpan(point.Snapshot, new Span(point, 0)))
-                           .Where(s => s.Span.Contains(point));
+                return tree.GetIntersectingSpans(
+                    new SnapshotSpan(point.Snapshot, new Span(point, 0)),
+                    predicate: s => s.Span.Contains(point));
             }
 
             return SpecializedCollections.EmptyEnumerable<ITagSpan<TTag>>();


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_queries/edit/1548898

Avoid creating an entire list (and a linq-query/copy of it) just to determine if we have a single matching element within it.