### PR TITLE
make roslyn solution default on unix

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,7 @@
       "*.yml": "azure-pipelines"
     },
     // ms-dotnettools.csharp settings
-    "omnisharp.defaultLaunchSolution": "Compilers.sln",
+    "omnisharp.defaultLaunchSolution": "Roslyn.sln",
     "omnisharp.disableMSBuildDiagnosticWarning": true,
     "omnisharp.enableEditorConfigSupport": true,
     "omnisharp.enableImportCompletion": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,7 +22,7 @@
         "*.yml": "azure-pipelines"
     },
     // ms-dotnettools.csharp settings
-    "omnisharp.defaultLaunchSolution": "Compilers.sln",
+    "omnisharp.defaultLaunchSolution": "Roslyn.sln",
     "omnisharp.disableMSBuildDiagnosticWarning": true,
     "omnisharp.enableEditorConfigSupport": true,
     "omnisharp.enableImportCompletion": true,

--- a/build.sh
+++ b/build.sh
@@ -13,4 +13,4 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
-"$scriptroot/eng/build.sh" --build $@
+"$scriptroot/eng/build.sh" --build --solution  Roslyn.sln $@

--- a/restore.sh
+++ b/restore.sh
@@ -13,4 +13,4 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
-"$scriptroot/eng/build.sh" --restore $@
+"$scriptroot/eng/build.sh" --restore --solution  Roslyn.sln $@


### PR DESCRIPTION
I am opening this for discussion. @davidwengier had mentioned that he wanted building all of Roslyn.sln to be the default but I want @333fred and others from the compiler team to way in.