### PR TITLE
Don't offer 'use compound operator' if pp-directives are present

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseCompoundAssignment/CSharpUseCompoundCoalesceAssignmentDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseCompoundAssignment/CSharpUseCompoundCoalesceAssignmentDiagnosticAnalyzer.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
@@ -150,6 +151,19 @@ namespace Microsoft.CodeAnalysis.CSharp.UseCompoundAssignment
                     syntaxFacts, testedExpression, semanticModel, cancellationToken))
             {
                 return;
+            }
+
+            if (ifStatement.Statement is BlockSyntax block)
+            {
+                // Single is safe here as GetWhenTrueAssignment will return null if we have a block without a single
+                // statement in it.
+                var firstStatement = block.Statements.Single();
+
+                // Don't want to offer anything if our if-statement body has any conditional directives in it.  That
+                // means there's some other code that may run under some other conditions, that we do not want to now
+                // run conditionally outside of the 'if' statement itself.
+                if (firstStatement.GetLeadingTrivia().Any(t => t.HasStructure && t.GetStructure() is ConditionalDirectiveTriviaSyntax))
+                    return;
             }
 
             if (semanticModel.GetTypeInfo(testedExpression, cancellationToken).Type.IsPointerType())

--- a/src/Analyzers/CSharp/Tests/UseCompoundAssignment/UseCompoundCoalesceAssignmentTests.cs
+++ b/src/Analyzers/CSharp/Tests/UseCompoundAssignment/UseCompoundCoalesceAssignmentTests.cs
@@ -695,6 +695,135 @@ class C
 }");
         }
 
+        [WorkItem(63552, "https://github.com/dotnet/roslyn/issues/63552")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)]
+        public async Task TestIfStatementWithPreprocessorBlock1()
+        {
+            await TestMissingAsync(
+@"using System;
+class C
+{
+    static void Main(object o)
+    {
+        if (o is null)
+        {
+#if true
+            o = """";
+#endif
+        }
+    }
+}");
+        }
+
+        [WorkItem(63552, "https://github.com/dotnet/roslyn/issues/63552")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)]
+        public async Task TestIfStatementWithPreprocessorBlock2()
+        {
+            await TestMissingAsync(
+@"using System;
+class C
+{
+    static void Main(object o)
+    {
+        if (o is null)
+        {
+#if X
+            Console.WriteLine(""Only run if o is null"");
+#endif
+            o = """";
+        }
+    }
+}");
+        }
+
+        [WorkItem(63552, "https://github.com/dotnet/roslyn/issues/63552")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)]
+        public async Task TestIfStatementWithPreprocessorBlock3()
+        {
+            await TestMissingAsync(
+@"using System;
+class C
+{
+    static void Main(object o)
+    {
+        if (o is null)
+        {
+#if X
+            Console.WriteLine(""Only run if o is null"");
+#else
+            o = """";
+#endif
+        }
+    }
+}");
+        }
+
+        [WorkItem(63552, "https://github.com/dotnet/roslyn/issues/63552")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)]
+        public async Task TestIfStatementWithPreprocessorBlock4()
+        {
+            await TestMissingAsync(
+@"using System;
+class C
+{
+    static void Main(object o)
+    {
+        if (o is null)
+        {
+#if X
+            Console.WriteLine(""Only run if o is null"");
+#elif true
+            o = """";
+#endif
+        }
+    }
+}");
+        }
+
+        [WorkItem(63552, "https://github.com/dotnet/roslyn/issues/63552")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)]
+        public async Task TestIfStatementWithPreprocessorBlock5()
+        {
+            await TestMissingAsync(
+@"using System;
+class C
+{
+    static void Main(object o)
+    {
+        if (o is null)
+        {
+#if true
+            o = """";
+#else
+            Console.WriteLine(""Only run if o is null"");
+#endif
+        }
+    }
+}");
+        }
+
+        [WorkItem(63552, "https://github.com/dotnet/roslyn/issues/63552")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)]
+        public async Task TestIfStatementWithPreprocessorBlock6()
+        {
+            await TestMissingAsync(
+@"using System;
+class C
+{
+    static void Main(object o)
+    {
+        if (o is null)
+        {
+#if true
+            o = """";
+#elif X
+            Console.WriteLine(""Only run if o is null"");
+#endif
+        }
+    }
+}");
+        }
+
         [WorkItem(62473, "https://github.com/dotnet/roslyn/issues/62473")]
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseCompoundAssignment)]
         public async Task TestPointerCannotUseCoalesceAssignment()


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/63552