### PR TITLE
Disable targeting windows for source-build

### DIFF
--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -24,7 +24,7 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateFullPaths>true</GenerateFullPaths>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <EnableWindowsTargeting Condition="'$(DotNetBuildFromSource)' != 'true'">true</EnableWindowsTargeting>
 
     <!-- Set to non-existent file to prevent common targets from importing Microsoft.CodeAnalysis.targets -->
     <CodeAnalysisTargets>NON_EXISTENT_FILE</CodeAnalysisTargets>


### PR DESCRIPTION
This line is causing Microsoft.WindowsDesktop.App.Ref prebuilts to be restored by source-build. We can just turn it off for source-build because we don't need to target windows on unix.