### PR TITLE
Change cancel behavior for rename

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Timers;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Timers;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -26,14 +27,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _textView.LayoutChanged += TextView_LayoutChanged;
             _textView.ViewportHeightChanged += TextView_ViewPortChanged;
             _textView.ViewportWidthChanged += TextView_ViewPortChanged;
-            _textView.LostAggregateFocus += TextView_LostFocus;
-            _textView.Caret.PositionChanged += TextView_CursorChanged;
 
             // On load focus the first tab target
             Loaded += (s, e) =>
             {
                 IdentifierTextBox.Focus();
                 IdentifierTextBox.Select(_viewModel.StartingSelection.Start, _viewModel.StartingSelection.Length);
+
+                // Don't hook up our close events until we're done loading and have focused withing the textbox
+                _textView.LostAggregateFocus += TextView_LostFocus;
+                LostFocus += RenameFlyout_LostFocus;
             };
 
             InitializeComponent();
@@ -50,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public string SubmitText => EditorFeaturesWpfResources.Enter_to_rename_shift_enter_to_preview;
 #pragma warning restore CA1822 // Mark members as static
 
-        private void TextView_CursorChanged(object sender, CaretPositionChangedEventArgs e)
+        private void RenameFlyout_LostFocus(object sender, RoutedEventArgs e)
             => _viewModel.Cancel();
 
         private void TextView_LostFocus(object sender, EventArgs e)
@@ -79,7 +82,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _textView.ViewportHeightChanged -= TextView_ViewPortChanged;
             _textView.ViewportWidthChanged -= TextView_ViewPortChanged;
             _textView.LostAggregateFocus -= TextView_LostFocus;
-            _textView.Caret.PositionChanged -= TextView_CursorChanged;
         }
 
         private void Submit_Click(object sender, RoutedEventArgs e)

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 IdentifierTextBox.Focus();
                 IdentifierTextBox.Select(_viewModel.StartingSelection.Start, _viewModel.StartingSelection.Length);
 
-                // Don't hook up our close events until we're done loading and have focused withing the textbox
+                // Don't hook up our close events until we're done loading and have focused within the textbox
                 _textView.LostAggregateFocus += TextView_LostFocus;
                 LostFocus += RenameFlyout_LostFocus;
             };

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
@@ -24,7 +24,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         private OleComponent? _oleComponent;
         private bool _disposedValue;
         private bool _isReplacementTextValid = true;
-        private bool _canceled;
         public event PropertyChangedEventHandler? PropertyChanged;
 
         public RenameFlyoutViewModel(InlineRenameSession session, TextSpan selectionSpan, bool registerOleComponent)
@@ -142,25 +141,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public TextSpan StartingSelection { get; }
 
         public void Submit()
-        {
-            _session.Commit();
-        }
+            => _session.Commit();
 
         public void Cancel()
-        {
-            // Cancel for RenameSession will throw if we try to cancel multiple times. 
-            // We could make sure this doesn't get called multiple times, but that gets difficult
-            // in managing state between why the cancel happened (Press Esc resulting in focus lost
-            // can trigger twice, for example). Rather than relying on correctly handling all the event handlers
-            // from the UI and TextView, just make sure we always only cancel once. 
-            if (_canceled)
-            {
-                return;
-            }
-
-            _canceled = true;
-            _session.Cancel();
-        }
+            => _session.Cancel();
 
         public void Dispose()
         {

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         private OleComponent? _oleComponent;
         private bool _disposedValue;
         private bool _isReplacementTextValid = true;
+        private bool _canceled;
         public event PropertyChangedEventHandler? PropertyChanged;
 
         public RenameFlyoutViewModel(InlineRenameSession session, TextSpan selectionSpan, bool registerOleComponent)
@@ -147,6 +148,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         public void Cancel()
         {
+            // Cancel for RenameSession will throw if we try to cancel multiple times. 
+            // We could make sure this doesn't get called multiple times, but that gets difficult
+            // in managing state between why the cancel happened (Press Esc resulting in focus lost
+            // can trigger twice, for example). Rather than relying on correctly handling all the event handlers
+            // from the UI and TextView, just make sure we always only cancel once. 
+            if (_canceled)
+            {
+                return;
+            }
+
+            _canceled = true;
             _session.Cancel();
         }
 

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -144,10 +144,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 var view = sender as ITextView;
                 view.Closed -= OnTextViewClosed;
                 _textViews.Remove(view);
-                if (!_session._dismissed)
-                {
-                    _session.Cancel();
-                }
+                _session.Cancel();
             }
 
             internal void ConnectToView(ITextView textView)

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -636,10 +636,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public void Cancel()
         {
             _threadingContext.ThrowIfNotOnUIThread();
-            if (_dismissed)
-            {
-                return;
-            }
 
             // This wait is safe.  We are not passing the async callback to DismissUIAndRollbackEditsAndEndRenameSessionAsync.
             // So everything in that method will happen synchronously.
@@ -652,6 +648,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             bool previewChanges,
             Func<Task> finalCommitAction = null)
         {
+            if (_dismissed)
+            {
+                return;
+            }
+
+            _dismissed = true;
+
             // Note: this entire sequence of steps is not cancellable.  We must perform it all to get back to a correct
             // state for all the editors the user is interacting with.
             var cancellationToken = CancellationToken.None;
@@ -687,7 +690,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             void DismissUIAndRollbackEdits()
             {
-                _dismissed = true;
                 _workspace.WorkspaceChanged -= OnWorkspaceChanged;
                 _textBufferAssociatedViewService.SubjectBuffersConnected -= OnSubjectBuffersConnected;
 

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -384,10 +384,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         {
             if (args.Kind != WorkspaceChangeKind.DocumentChanged)
             {
-                if (!_dismissed)
-                {
-                    this.Cancel();
-                }
+                Cancel();
             }
         }
 
@@ -639,7 +636,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public void Cancel()
         {
             _threadingContext.ThrowIfNotOnUIThread();
-            VerifyNotDismissed();
+            if (_dismissed)
+            {
+                return;
+            }
 
             // This wait is safe.  We are not passing the async callback to DismissUIAndRollbackEditsAndEndRenameSessionAsync.
             // So everything in that method will happen synchronously.


### PR DESCRIPTION
Rename cancel behavior depending on caret position change in the editor is fragile. Instead, it's better to just depend on focus events for the UI and dismiss as needed. This does introduce some complexity in handling events where we intentionally dismiss, or if the session is canceled without the UI calling it. Adding a guard in the viewmodel fixes this, and makes sure we're never trying to cancel the session more than once. 

This fixes the new rename behavior in vsvim 