### PR TITLE
Switch our statistics mean to be a double

### DIFF
--- a/src/Workspaces/Core/Portable/Log/StatisticLogAggregator.cs
+++ b/src/Workspaces/Core/Portable/Log/StatisticLogAggregator.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
                 }
                 else
                 {
-                    return new StatisticResult(_maximum, _mininum, mean: _total / _count, range: _maximum - _mininum, mode: null, count: _count);
+                    return new StatisticResult(_maximum, _mininum, mean: (double)_total / _count, range: _maximum - _mininum, mode: null, count: _count);
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/Log/StatisticResult.cs
+++ b/src/Workspaces/Core/Portable/Log/StatisticResult.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
                 total += current;
             }
 
-            var mean = total / values.Count;
+            var mean = (double)total / values.Count;
 
             var range = max - min;
             var mode = values.GroupBy(i => i).OrderByDescending(g => g.Count()).FirstOrDefault().Key;
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         /// <summary>
         /// average value of the total data set
         /// </summary>
-        public readonly int Mean;
+        public readonly double Mean;
 
         /// <summary>
         /// most frequent value in the total data set
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         /// </summary>
         public readonly int Count;
 
-        public StatisticResult(int max, int min, int mean, int range, int? mode, int count)
+        public StatisticResult(int max, int min, double mean, int range, int? mode, int count)
         {
             this.Maximum = max;
             this.Minimum = min;


### PR DESCRIPTION
Since we're using this to report the number of generated files from a source generator, the numbers being averaged are likely to be either 0 or 1; an integer average won't be useful there.