### PR TITLE
Add stages to the Roslyn CI

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -30,9 +30,27 @@ pr:
       - README.md
       - src/Compilers/*
 
-jobs:
-- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-  - job: VS_Integration_Debug_32
+stages:
+- stage: Debug_Integration
+  dependsOn: []
+  jobs:
+  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    - job: VS_Integration_Debug_32
+      pool:
+        name: $(poolName)
+        demands: ImageOverride -equals $(queueName)
+      timeoutInMinutes: 150
+      variables:
+        - name: XUNIT_LOGS
+          value: $(Build.SourcesDirectory)\artifacts\log\Debug
+      steps:
+        - template: eng/pipelines/test-integration-job.yml
+          parameters:
+            configuration: Debug
+            oop64bit: false
+            lspEditor: false
+
+  - job: VS_Integration_Debug_64
     pool:
       name: $(poolName)
       demands: ImageOverride -equals $(queueName)
@@ -44,41 +62,13 @@ jobs:
       - template: eng/pipelines/test-integration-job.yml
         parameters:
           configuration: Debug
-          oop64bit: false
+          oop64bit: true
           lspEditor: false
 
-- job: VS_Integration_Debug_64
-  pool:
-    name: $(poolName)
-    demands: ImageOverride -equals $(queueName)
-  timeoutInMinutes: 150
-  variables:
-    - name: XUNIT_LOGS
-      value: $(Build.SourcesDirectory)\artifacts\log\Debug
-  steps:
-    - template: eng/pipelines/test-integration-job.yml
-      parameters:
-        configuration: Debug
-        oop64bit: true
-        lspEditor: false
-
-- job: VS_Integration_Release_32
-  pool:
-    name: $(poolName)
-    demands: ImageOverride -equals $(queueName)
-  timeoutInMinutes: 150
-  variables:
-    - name: XUNIT_LOGS
-      value: $(Build.SourcesDirectory)\artifacts\log\Release
-  steps:
-    - template: eng/pipelines/test-integration-job.yml
-      parameters:
-        configuration: Release
-        oop64bit: false
-        lspEditor: false
-
-- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-  - job: VS_Integration_Release_64
+- stage: Release_Integration
+  dependsOn: []
+  jobs:
+  - job: VS_Integration_Release_32
     pool:
       name: $(poolName)
       demands: ImageOverride -equals $(queueName)
@@ -90,5 +80,21 @@ jobs:
       - template: eng/pipelines/test-integration-job.yml
         parameters:
           configuration: Release
-          oop64bit: true
+          oop64bit: false
           lspEditor: false
+
+  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    - job: VS_Integration_Release_64
+      pool:
+        name: $(poolName)
+        demands: ImageOverride -equals $(queueName)
+      timeoutInMinutes: 150
+      variables:
+        - name: XUNIT_LOGS
+          value: $(Build.SourcesDirectory)\artifacts\log\Release
+      steps:
+        - template: eng/pipelines/test-integration-job.yml
+          parameters:
+            configuration: Release
+            oop64bit: true
+            lspEditor: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ stages:
 
   - template: eng/common/templates/jobs/source-build.yml
 
--stage: Test_Desktop
+- stage: Test_Desktop
   # Test Windows Desktop
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - template: eng/pipelines/test-windows-job.yml
@@ -108,7 +108,7 @@ stages:
       configuration: Release
       testArguments: -testDesktop -testArch x64 -helixQueueName Windows.10.Amd64.Server2022.ES.Open
 
--stage: Test_CoreClr
+- stage: Test_CoreClr
   # Test Windows, Linux, MacOS CoreCLR
   - template: eng/pipelines/test-windows-job.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,7 @@ stages:
 
 - stage: Unix_Build
   dependsOn: []
+  jobs:
   - template: eng/pipelines/build-unix-job.yml
     parameters:
       jobName: Build_Unix_Debug
@@ -62,11 +63,13 @@ stages:
 
 - stage: Source_Build
   dependsOn: []
+  jobs:
   - template: eng/common/templates/jobs/source-build.yml
 
 - stage: Test_Desktop
   dependsOn: Windows_Build
   # Test Windows Desktop
+  jobs:
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - template: eng/pipelines/test-windows-job.yml
       parameters:
@@ -117,6 +120,7 @@ stages:
 - stage: Test_Windows_CoreClr
   dependsOn: Windows_Build
   # Test Windows CoreCLR
+  jobs:
   - template: eng/pipelines/test-windows-job.yml
     parameters:
       testRunName: 'Test Windows CoreClr Debug'
@@ -167,6 +171,7 @@ stages:
 
 - stage: Test_Linux_CoreClr
   dependsOn: Unix_Build
+  jobs:
   - template: eng/pipelines/test-unix-job.yml
     parameters:
       testRunName: 'Test Linux Debug'
@@ -199,6 +204,7 @@ stages:
 - stage: Correctness
   dependsOn: []
   # Build Correctness Jobs
+  jobs:
   - template: eng/pipelines/evaluate-changed-files.yml
     parameters:
       jobName: Determine_Changes

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,314 +28,319 @@ pr:
       - CONTRIBUTING.md
       - README.md
 
-# Windows Build and Test Jobs
-jobs:
-- template: eng/pipelines/build-windows-job.yml
-  parameters:
-    jobName: Build_Windows_Debug
-    testArtifactName: Transport_Artifacts_Windows_Debug
-    configuration: Debug
-    queueName: Build.Windows.Amd64.VS2022.Pre.Open
-    restoreArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
-    buildArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+stages:
+- stage: Build 
+  # Windows and Linux Builds
+  jobs:
+  - template: eng/pipelines/build-windows-job.yml
+    parameters:
+      jobName: Build_Windows_Debug
+      testArtifactName: Transport_Artifacts_Windows_Debug
+      configuration: Debug
+      queueName: Build.Windows.Amd64.VS2022.Pre.Open
+      restoreArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+      buildArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
-- template: eng/pipelines/build-windows-job.yml
-  parameters:
-    jobName: Build_Windows_Release
-    testArtifactName: Transport_Artifacts_Windows_Release
-    configuration: Release
-    queueName: Build.Windows.Amd64.VS2022.Pre.Open
-    restoreArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
-    buildArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+  - template: eng/pipelines/build-windows-job.yml
+    parameters:
+      jobName: Build_Windows_Release
+      testArtifactName: Transport_Artifacts_Windows_Release
+      configuration: Release
+      queueName: Build.Windows.Amd64.VS2022.Pre.Open
+      restoreArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+      buildArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
-- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - template: eng/pipelines/build-unix-job.yml
+    parameters:
+      jobName: Build_Unix_Debug
+      testArtifactName: Transport_Artifacts_Unix_Debug
+      configuration: Debug
+      queueName: Build.Ubuntu.1804.Amd64.Open
+
+  - template: eng/common/templates/jobs/source-build.yml
+
+-stage: Test_Desktop
+  # Test Windows Desktop
+  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    - template: eng/pipelines/test-windows-job.yml
+      parameters:
+        testRunName: 'Test Windows Desktop Debug 32'
+        jobName: Test_Windows_Desktop_Debug_32
+        buildJobName: Build_Windows_Debug
+        testArtifactName: Transport_Artifacts_Windows_Debug
+        configuration: Debug
+        testArguments: -testDesktop -testArch x86
+
   - template: eng/pipelines/test-windows-job.yml
     parameters:
-      testRunName: 'Test Windows Desktop Debug 32'
-      jobName: Test_Windows_Desktop_Debug_32
+      testRunName: 'Test Windows Desktop Debug 64'
+      jobName: Test_Windows_Desktop_Debug_64
       buildJobName: Build_Windows_Debug
       testArtifactName: Transport_Artifacts_Windows_Debug
       configuration: Debug
+      testArguments: -testDesktop -testArch x64
+
+  - template: eng/pipelines/test-windows-job.yml
+    parameters:
+      testRunName: 'Test Windows Desktop Release 32'
+      jobName: Test_Windows_Desktop_Release_32
+      buildJobName: Build_Windows_Release
+      testArtifactName: Transport_Artifacts_Windows_Release
+      configuration: Release
       testArguments: -testDesktop -testArch x86
 
-- template: eng/pipelines/test-windows-job.yml
-  parameters:
-    testRunName: 'Test Windows Desktop Debug 64'
-    jobName: Test_Windows_Desktop_Debug_64
-    buildJobName: Build_Windows_Debug
-    testArtifactName: Transport_Artifacts_Windows_Debug
-    configuration: Debug
-    testArguments: -testDesktop -testArch x64
+  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    - template: eng/pipelines/test-windows-job.yml
+      parameters:
+        testRunName: 'Test Windows Desktop Release 64'
+        jobName: Test_Windows_Desktop_Release_64
+        buildJobName: Build_Windows_Release
+        testArtifactName: Transport_Artifacts_Windows_Release
+        configuration: Release
+        testArguments: -testDesktop -testArch x64
 
-- template: eng/pipelines/test-windows-job.yml
-  parameters:
-    testRunName: 'Test Windows CoreClr Debug'
-    jobName: Test_Windows_CoreClr_Debug
-    buildJobName: Build_Windows_Debug
-    testArtifactName: Transport_Artifacts_Windows_Debug
-    configuration: Debug
-    testArguments: -testCoreClr
-
-- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-  - template: eng/pipelines/test-windows-job-single-machine.yml
+  - template: eng/pipelines/test-windows-job.yml
     parameters:
-      testRunName: 'Test Windows CoreClr Debug Single Machine'
-      jobName: Test_Windows_CoreClr_Debug_Single_Machine
+      testRunName: 'Test Windows Desktop Spanish Release 64'
+      jobName: Test_Windows_Desktop_Spanish_Release_64
+      buildJobName: Build_Windows_Release
+      testArtifactName: Transport_Artifacts_Windows_Release
+      configuration: Release
+      testArguments: -testDesktop -testArch x64 -helixQueueName Windows.10.Amd64.Server2022.ES.Open
+
+-stage: Test_CoreClr
+  # Test Windows, Linux, MacOS CoreCLR
+  - template: eng/pipelines/test-windows-job.yml
+    parameters:
+      testRunName: 'Test Windows CoreClr Debug'
+      jobName: Test_Windows_CoreClr_Debug
       buildJobName: Build_Windows_Debug
       testArtifactName: Transport_Artifacts_Windows_Debug
       configuration: Debug
       testArguments: -testCoreClr
 
-- template: eng/pipelines/test-windows-job.yml
-  parameters:
-    testRunName: 'Test Windows Desktop Release 32'
-    jobName: Test_Windows_Desktop_Release_32
-    buildJobName: Build_Windows_Release
-    testArtifactName: Transport_Artifacts_Windows_Release
-    configuration: Release
-    testArguments: -testDesktop -testArch x86
+  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    - template: eng/pipelines/test-windows-job-single-machine.yml
+      parameters:
+        testRunName: 'Test Windows CoreClr Debug Single Machine'
+        jobName: Test_Windows_CoreClr_Debug_Single_Machine
+        buildJobName: Build_Windows_Debug
+        testArtifactName: Transport_Artifacts_Windows_Debug
+        configuration: Debug
+        testArguments: -testCoreClr
 
-- template: eng/pipelines/test-windows-job.yml
-  parameters:
-    testRunName: 'Test Windows Desktop Spanish Release 64'
-    jobName: Test_Windows_Desktop_Spanish_Release_64
-    buildJobName: Build_Windows_Release
-    testArtifactName: Transport_Artifacts_Windows_Release
-    configuration: Release
-    testArguments: -testDesktop -testArch x64 -helixQueueName Windows.10.Amd64.Server2022.ES.Open
-
-- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
   - template: eng/pipelines/test-windows-job.yml
     parameters:
-      testRunName: 'Test Windows Desktop Release 64'
-      jobName: Test_Windows_Desktop_Release_64
+      testRunName: 'Test Windows CoreClr Release'
+      jobName: Test_Windows_CoreClr_Release
       buildJobName: Build_Windows_Release
       testArtifactName: Transport_Artifacts_Windows_Release
       configuration: Release
-      testArguments: -testDesktop -testArch x64
+      testArguments: -testCoreClr
 
-- template: eng/pipelines/test-windows-job.yml
-  parameters:
-    testRunName: 'Test Windows CoreClr Release'
-    jobName: Test_Windows_CoreClr_Release
-    buildJobName: Build_Windows_Release
-    testArtifactName: Transport_Artifacts_Windows_Release
-    configuration: Release
-    testArguments: -testCoreClr
-
-- template: eng/pipelines/test-windows-job.yml
-  parameters:
-    testRunName: 'Test Windows CoreCLR IOperation Debug'
-    jobName: Test_Windows_CoreClr_IOperation_Debug
-    buildJobName: Build_Windows_Debug
-    testArtifactName: Transport_Artifacts_Windows_Debug
-    configuration: Debug
-    testArguments: -testCoreClr -testIOperation -testCompilerOnly
-
-# This leg runs almost all the compiler tests supported on CoreCLR, but
-#  with additional validation for used assemblies and GetEmitDiagnostics
-- template: eng/pipelines/test-windows-job.yml
-  parameters:
-    testRunName: 'Test Windows CoreCLR UsedAssemblies Debug'
-    jobName: Test_Windows_CoreClr_UsedAssemblies_Debug
-    buildJobName: Build_Windows_Debug
-    testArtifactName: Transport_Artifacts_Windows_Debug
-    configuration: Debug
-    testArguments: -testCoreClr -testUsedAssemblies -testCompilerOnly
-
-# Unix Build and Test Jobs
-- template: eng/pipelines/build-unix-job.yml
-  parameters:
-    jobName: Build_Unix_Debug
-    testArtifactName: Transport_Artifacts_Unix_Debug
-    configuration: Debug
-    queueName: Build.Ubuntu.1804.Amd64.Open
-
-- template: eng/pipelines/test-unix-job.yml
-  parameters:
-    testRunName: 'Test Linux Debug'
-    jobName: Test_Linux_Debug
-    buildJobName: Build_Unix_Debug
-    testArtifactName: Transport_Artifacts_Unix_Debug
-    configuration: Debug
-    testArguments: --testCoreClr --helixQueueName Ubuntu.1804.Amd64.Open
-
-- ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-  - template: eng/pipelines/test-unix-job-single-machine.yml
+  - template: eng/pipelines/test-windows-job.yml
     parameters:
-      testRunName: 'Test Linux Debug Single Machine'
-      jobName: Test_Linux_Debug_Single_Machine
+      testRunName: 'Test Windows CoreCLR IOperation Debug'
+      jobName: Test_Windows_CoreClr_IOperation_Debug
+      buildJobName: Build_Windows_Debug
+      testArtifactName: Transport_Artifacts_Windows_Debug
+      configuration: Debug
+      testArguments: -testCoreClr -testIOperation -testCompilerOnly
+
+  # This leg runs almost all the compiler tests supported on CoreCLR, but
+  #  with additional validation for used assemblies and GetEmitDiagnostics
+  - template: eng/pipelines/test-windows-job.yml
+    parameters:
+      testRunName: 'Test Windows CoreCLR UsedAssemblies Debug'
+      jobName: Test_Windows_CoreClr_UsedAssemblies_Debug
+      buildJobName: Build_Windows_Debug
+      testArtifactName: Transport_Artifacts_Windows_Debug
+      configuration: Debug
+      testArguments: -testCoreClr -testUsedAssemblies -testCompilerOnly
+
+  - template: eng/pipelines/test-unix-job.yml
+    parameters:
+      testRunName: 'Test Linux Debug'
+      jobName: Test_Linux_Debug
       buildJobName: Build_Unix_Debug
       testArtifactName: Transport_Artifacts_Unix_Debug
       configuration: Debug
-      testArguments: --testCoreClr
-      queueName: Build.Ubuntu.1804.Amd64.Open
+      testArguments: --testCoreClr --helixQueueName Ubuntu.1804.Amd64.Open
 
-- template: eng/pipelines/test-unix-job.yml
-  parameters:
-    testRunName: 'Test macOS Debug'
-    jobName: Test_macOS_Debug
-    buildJobName: Build_Unix_Debug
-    testArtifactName: Transport_Artifacts_Unix_Debug
-    configuration: Debug
-    testArguments: --testCoreClr --helixQueueName OSX.1015.Amd64.Open
-
-- template: eng/common/templates/jobs/source-build.yml
-
-# Build Correctness Jobs
-
-- template: eng/pipelines/evaluate-changed-files.yml
-  parameters:
-    jobName: Determine_Changes
-    vmImageName: ubuntu-latest
-    paths:
-      - subset: compilers
-        include:
-        - src/Compilers/*
-        - src/Dependencies/*
-
-- job: Correctness_Build_Artifacts
-  dependsOn: Determine_Changes
-  pool:
-    name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
-  timeoutInMinutes: 90
-  variables:
-    compilerChange: $[dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange']]
-  steps:
-    - template: eng/pipelines/checkout-windows-task.yml
-
-    - task: PowerShell@2
-      displayName: Restore
-      inputs:
-        filePath: eng/build.ps1
-        arguments: -configuration Release -prepareMachine -ci -restore -binaryLog
-
-    - task: PowerShell@2
-      displayName: Build
-      inputs:
-        filePath: eng/build.ps1
-        arguments: -configuration Release -prepareMachine -ci -build -pack -publish -sign -binaryLog
-
-    - script: $(Build.SourcesDirectory)\artifacts\bin\BuildBoss\Release\net472\BuildBoss.exe  -r "$(Build.SourcesDirectory)/" -c Release -p Roslyn.sln
-      displayName: Validate Build Artifacts
-
-    - task: PowerShell@2
-      displayName: Generate Syntax Files
-      inputs:
-        filePath: eng/generate-compiler-code.ps1
-        arguments: -test -configuration Release
-      condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['compilerChange'], 'true'))
-      
-    - script: $(Build.SourcesDirectory)\.dotnet\dotnet.exe tool run dotnet-format whitespace  $(Build.SourcesDirectory)\src --folder --include-generated --include $(Build.SourcesDirectory)\src\Compilers\CSharp\Portable\Generated\ $(Build.SourcesDirectory)\src\Compilers\VisualBasic\Portable\Generated\ $(Build.SourcesDirectory)\src\ExpressionEvaluator\VisualBasic\Source\ResultProvider\Generated\ --verify-no-changes
-      displayName: Validate Generated Syntax Files
-      condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['compilerChange'], 'true'))
-      
-    - template: eng/pipelines/publish-logs.yml
+  - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    - template: eng/pipelines/test-unix-job-single-machine.yml
       parameters:
-        jobName: Correctness_Build_Artifacts
-        configuration: Release
-    
-- job: Correctness_Determinism
-  dependsOn: Determine_Changes
-  condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true'))
-  pool:
-    name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
-  timeoutInMinutes: 90
-  steps:
-    - template: eng/pipelines/checkout-windows-task.yml
-    
-    - script: eng/test-determinism.cmd -configuration Debug
-      displayName: Build - Validate determinism
-
-    - template: eng/pipelines/publish-logs.yml
-      parameters:
-        jobName: Correctness_Determinism
+        testRunName: 'Test Linux Debug Single Machine'
+        jobName: Test_Linux_Debug_Single_Machine
+        buildJobName: Build_Unix_Debug
+        testArtifactName: Transport_Artifacts_Unix_Debug
         configuration: Debug
+        testArguments: --testCoreClr
+        queueName: Build.Ubuntu.1804.Amd64.Open
 
-- job: Correctness_Bootstrap_Build
-  dependsOn: Determine_Changes
-  condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true'))
-  pool:
-    name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
-  timeoutInMinutes: 90
-  steps:
-    - template: eng/pipelines/checkout-windows-task.yml
+  - template: eng/pipelines/test-unix-job.yml
+    parameters:
+      testRunName: 'Test macOS Debug'
+      jobName: Test_macOS_Debug
+      buildJobName: Build_Unix_Debug
+      testArtifactName: Transport_Artifacts_Unix_Debug
+      configuration: Debug
+      testArguments: --testCoreClr --helixQueueName OSX.1015.Amd64.Open
 
-    - script: eng/test-build-correctness.cmd -configuration Release -enableDumps
-      displayName: Build - Validate correctness
+- stage: Correctness
+  # Build Correctness Jobs
+  - template: eng/pipelines/evaluate-changed-files.yml
+    parameters:
+      jobName: Determine_Changes
+      vmImageName: ubuntu-latest
+      paths:
+        - subset: compilers
+          include:
+          - src/Compilers/*
+          - src/Dependencies/*
 
-    - template: eng/pipelines/publish-logs.yml
-      parameters:
-        jobName: Correctness_Bootstrap_Build
-        configuration: Release
+  - job: Correctness_Build_Artifacts
+    dependsOn: Determine_Changes
+    pool:
+      name: NetCore1ESPool-Public
+      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+    timeoutInMinutes: 90
+    variables:
+      compilerChange: $[dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange']]
+    steps:
+      - template: eng/pipelines/checkout-windows-task.yml
 
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Artifact Packages
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\Release\PreRelease'
-        ArtifactName: 'Bootstrap Packages - PreRelease'
-        publishLocation: Container
+      - task: PowerShell@2
+        displayName: Restore
+        inputs:
+          filePath: eng/build.ps1
+          arguments: -configuration Release -prepareMachine -ci -restore -binaryLog
 
-    - task: PublishBuildArtifacts@1
-      displayName: Publish VSIX Packages
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\Release\Installer'
-        ArtifactName: 'Bootstrap VSIX - PreRelease'
-        publishLocation: Container
+      - task: PowerShell@2
+        displayName: Build
+        inputs:
+          filePath: eng/build.ps1
+          arguments: -configuration Release -prepareMachine -ci -build -pack -publish -sign -binaryLog
 
-- job: Correctness_TodoCheck
-  pool:
-    vmImage: ubuntu-20.04
-  timeoutInMinutes: 10
-  steps:
-    - template: eng/pipelines/checkout-unix-task.yml
+      - script: $(Build.SourcesDirectory)\artifacts\bin\BuildBoss\Release\net472\BuildBoss.exe  -r "$(Build.SourcesDirectory)/" -c Release -p Roslyn.sln
+        displayName: Validate Build Artifacts
 
-    - pwsh: eng/todo-check.ps1
-      displayName: Validate TODO/PROTOTYPE comments are not present
-
-- job: Correctness_Rebuild
-  dependsOn: Determine_Changes
-  condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true'))
-  pool:
-    name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
-  timeoutInMinutes: 90
-  steps:
-    - template: eng/pipelines/checkout-windows-task.yml
-
-    - task: PowerShell@2
-      displayName: Restore
-      inputs:
-        filePath: eng/build.ps1
-        arguments: -configuration Debug -prepareMachine -ci -restore -binaryLog
-
-    - powershell: .\eng\test-rebuild.ps1 -ci -configuration Release
-      displayName: Run BuildValidator
-
-    - task: PublishBuildArtifacts@1
-      displayName: Publish BuildValidator debug outputs
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/BuildValidator'
-        ArtifactName: 'BuildValidator_DebugOut'
-        publishLocation: Container
-      continueOnError: true
-      condition: failed()
-
-    - template: eng/pipelines/publish-logs.yml
-      parameters:
-        jobName: Correctness_Rebuild
-        configuration: Release
-
-- job: Correctness_Analyzers
-  pool:
-    name: NetCore1ESPool-Public
-    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
-  timeoutInMinutes: 35
-  steps:
-    - template: eng/pipelines/checkout-unix-task.yml
+      - task: PowerShell@2
+        displayName: Generate Syntax Files
+        inputs:
+          filePath: eng/generate-compiler-code.ps1
+          arguments: -test -configuration Release
+        condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['compilerChange'], 'true'))
+        
+      - script: $(Build.SourcesDirectory)\.dotnet\dotnet.exe tool run dotnet-format whitespace  $(Build.SourcesDirectory)\src --folder --include-generated --include $(Build.SourcesDirectory)\src\Compilers\CSharp\Portable\Generated\ $(Build.SourcesDirectory)\src\Compilers\VisualBasic\Portable\Generated\ $(Build.SourcesDirectory)\src\ExpressionEvaluator\VisualBasic\Source\ResultProvider\Generated\ --verify-no-changes
+        displayName: Validate Generated Syntax Files
+        condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['compilerChange'], 'true'))
+        
+      - template: eng/pipelines/publish-logs.yml
+        parameters:
+          jobName: Correctness_Build_Artifacts
+          configuration: Release
       
-    - script: ./eng/build.sh --solution Roslyn.sln --restore --build --configuration Debug --prepareMachine --ci --binaryLog --runanalyzers --warnaserror /p:RoslynEnforceCodeStyle=true
-      displayName: Build with analyzers
+  - job: Correctness_Determinism
+    dependsOn: Determine_Changes
+    condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true'))
+    pool:
+      name: NetCore1ESPool-Public
+      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+    timeoutInMinutes: 90
+    steps:
+      - template: eng/pipelines/checkout-windows-task.yml
+      
+      - script: eng/test-determinism.cmd -configuration Debug
+        displayName: Build - Validate determinism
+
+      - template: eng/pipelines/publish-logs.yml
+        parameters:
+          jobName: Correctness_Determinism
+          configuration: Debug
+
+  - job: Correctness_Bootstrap_Build
+    dependsOn: Determine_Changes
+    condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true'))
+    pool:
+      name: NetCore1ESPool-Public
+      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+    timeoutInMinutes: 90
+    steps:
+      - template: eng/pipelines/checkout-windows-task.yml
+
+      - script: eng/test-build-correctness.cmd -configuration Release -enableDumps
+        displayName: Build - Validate correctness
+
+      - template: eng/pipelines/publish-logs.yml
+        parameters:
+          jobName: Correctness_Bootstrap_Build
+          configuration: Release
+
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Artifact Packages
+        inputs:
+          PathtoPublish: '$(Build.SourcesDirectory)\artifacts\packages\Release\PreRelease'
+          ArtifactName: 'Bootstrap Packages - PreRelease'
+          publishLocation: Container
+
+      - task: PublishBuildArtifacts@1
+        displayName: Publish VSIX Packages
+        inputs:
+          PathtoPublish: '$(Build.SourcesDirectory)\artifacts\VSSetup\Release\Installer'
+          ArtifactName: 'Bootstrap VSIX - PreRelease'
+          publishLocation: Container
+
+  - job: Correctness_TodoCheck
+    pool:
+      vmImage: ubuntu-20.04
+    timeoutInMinutes: 10
+    steps:
+      - template: eng/pipelines/checkout-unix-task.yml
+
+      - pwsh: eng/todo-check.ps1
+        displayName: Validate TODO/PROTOTYPE comments are not present
+
+  - job: Correctness_Rebuild
+    dependsOn: Determine_Changes
+    condition: or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.Determine_Changes.outputs['SetPathVars_compilers.containsChange'], 'true'))
+    pool:
+      name: NetCore1ESPool-Public
+      demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+    timeoutInMinutes: 90
+    steps:
+      - template: eng/pipelines/checkout-windows-task.yml
+
+      - task: PowerShell@2
+        displayName: Restore
+        inputs:
+          filePath: eng/build.ps1
+          arguments: -configuration Debug -prepareMachine -ci -restore -binaryLog
+
+      - powershell: .\eng\test-rebuild.ps1 -ci -configuration Release
+        displayName: Run BuildValidator
+
+      - task: PublishBuildArtifacts@1
+        displayName: Publish BuildValidator debug outputs
+        inputs:
+          PathtoPublish: '$(Build.SourcesDirectory)/artifacts/BuildValidator'
+          ArtifactName: 'BuildValidator_DebugOut'
+          publishLocation: Container
+        continueOnError: true
+        condition: failed()
+
+      - template: eng/pipelines/publish-logs.yml
+        parameters:
+          jobName: Correctness_Rebuild
+          configuration: Release
+
+  - job: Correctness_Analyzers
+    pool:
+      name: NetCore1ESPool-Public
+      demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+    timeoutInMinutes: 35
+    steps:
+      - template: eng/pipelines/checkout-unix-task.yml
+        
+      - script: ./eng/build.sh --solution Roslyn.sln --restore --build --configuration Debug --prepareMachine --ci --binaryLog --runanalyzers --warnaserror /p:RoslynEnforceCodeStyle=true
+        displayName: Build with analyzers

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,8 +29,9 @@ pr:
       - README.md
 
 stages:
-- stage: Build 
-  # Windows and Linux Builds
+- stage: Windows_Build
+  dependsOn: []
+  # Windows Builds
   jobs:
   - template: eng/pipelines/build-windows-job.yml
     parameters:
@@ -50,6 +51,8 @@ stages:
       restoreArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
       buildArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
+- stage: Unix_Build
+  dependsOn: []
   - template: eng/pipelines/build-unix-job.yml
     parameters:
       jobName: Build_Unix_Debug
@@ -57,9 +60,12 @@ stages:
       configuration: Debug
       queueName: Build.Ubuntu.1804.Amd64.Open
 
+- stage: Source_Build
+  dependsOn: []
   - template: eng/common/templates/jobs/source-build.yml
 
 - stage: Test_Desktop
+  dependsOn: Windows_Build
   # Test Windows Desktop
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - template: eng/pipelines/test-windows-job.yml
@@ -108,8 +114,9 @@ stages:
       configuration: Release
       testArguments: -testDesktop -testArch x64 -helixQueueName Windows.10.Amd64.Server2022.ES.Open
 
-- stage: Test_CoreClr
-  # Test Windows, Linux, MacOS CoreCLR
+- stage: Test_Windows_CoreClr
+  dependsOn: Windows_Build
+  # Test Windows CoreCLR
   - template: eng/pipelines/test-windows-job.yml
     parameters:
       testRunName: 'Test Windows CoreClr Debug'
@@ -158,6 +165,8 @@ stages:
       configuration: Debug
       testArguments: -testCoreClr -testUsedAssemblies -testCompilerOnly
 
+- stage: Test_Linux_CoreClr
+  dependsOn: Unix_Build
   - template: eng/pipelines/test-unix-job.yml
     parameters:
       testRunName: 'Test Linux Debug'
@@ -188,6 +197,7 @@ stages:
       testArguments: --testCoreClr --helixQueueName OSX.1015.Amd64.Open
 
 - stage: Correctness
+  dependsOn: []
   # Build Correctness Jobs
   - template: eng/pipelines/evaluate-changed-files.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,7 @@ stages:
 
 - stage: Windows_Release_Build
   dependsOn: []
+  jobs:
   - template: eng/pipelines/build-windows-job.yml
     parameters:
       jobName: Build_Windows_Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ stages:
 - stage: Windows_Release_Desktop
   dependsOn: Windows_Release_Build
   jobs:
-    - template: eng/pipelines/test-windows-job.yml
+  - template: eng/pipelines/test-windows-job.yml
     parameters:
       testRunName: 'Test Windows Desktop Release 32'
       jobName: Test_Windows_Desktop_Release_32

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,7 +75,6 @@ stages:
       parameters:
         testRunName: 'Test Windows Desktop Debug 32'
         jobName: Test_Windows_Desktop_Debug_32
-        buildJobName: Build_Windows_Debug
         testArtifactName: Transport_Artifacts_Windows_Debug
         configuration: Debug
         testArguments: -testDesktop -testArch x86
@@ -84,7 +83,6 @@ stages:
     parameters:
       testRunName: 'Test Windows Desktop Debug 64'
       jobName: Test_Windows_Desktop_Debug_64
-      buildJobName: Build_Windows_Debug
       testArtifactName: Transport_Artifacts_Windows_Debug
       configuration: Debug
       testArguments: -testDesktop -testArch x64
@@ -93,7 +91,6 @@ stages:
     parameters:
       testRunName: 'Test Windows Desktop Release 32'
       jobName: Test_Windows_Desktop_Release_32
-      buildJobName: Build_Windows_Release
       testArtifactName: Transport_Artifacts_Windows_Release
       configuration: Release
       testArguments: -testDesktop -testArch x86
@@ -103,7 +100,6 @@ stages:
       parameters:
         testRunName: 'Test Windows Desktop Release 64'
         jobName: Test_Windows_Desktop_Release_64
-        buildJobName: Build_Windows_Release
         testArtifactName: Transport_Artifacts_Windows_Release
         configuration: Release
         testArguments: -testDesktop -testArch x64
@@ -112,7 +108,6 @@ stages:
     parameters:
       testRunName: 'Test Windows Desktop Spanish Release 64'
       jobName: Test_Windows_Desktop_Spanish_Release_64
-      buildJobName: Build_Windows_Release
       testArtifactName: Transport_Artifacts_Windows_Release
       configuration: Release
       testArguments: -testDesktop -testArch x64 -helixQueueName Windows.10.Amd64.Server2022.ES.Open
@@ -125,7 +120,6 @@ stages:
     parameters:
       testRunName: 'Test Windows CoreClr Debug'
       jobName: Test_Windows_CoreClr_Debug
-      buildJobName: Build_Windows_Debug
       testArtifactName: Transport_Artifacts_Windows_Debug
       configuration: Debug
       testArguments: -testCoreClr
@@ -135,7 +129,6 @@ stages:
       parameters:
         testRunName: 'Test Windows CoreClr Debug Single Machine'
         jobName: Test_Windows_CoreClr_Debug_Single_Machine
-        buildJobName: Build_Windows_Debug
         testArtifactName: Transport_Artifacts_Windows_Debug
         configuration: Debug
         testArguments: -testCoreClr
@@ -144,7 +137,6 @@ stages:
     parameters:
       testRunName: 'Test Windows CoreClr Release'
       jobName: Test_Windows_CoreClr_Release
-      buildJobName: Build_Windows_Release
       testArtifactName: Transport_Artifacts_Windows_Release
       configuration: Release
       testArguments: -testCoreClr
@@ -153,7 +145,6 @@ stages:
     parameters:
       testRunName: 'Test Windows CoreCLR IOperation Debug'
       jobName: Test_Windows_CoreClr_IOperation_Debug
-      buildJobName: Build_Windows_Debug
       testArtifactName: Transport_Artifacts_Windows_Debug
       configuration: Debug
       testArguments: -testCoreClr -testIOperation -testCompilerOnly
@@ -164,7 +155,6 @@ stages:
     parameters:
       testRunName: 'Test Windows CoreCLR UsedAssemblies Debug'
       jobName: Test_Windows_CoreClr_UsedAssemblies_Debug
-      buildJobName: Build_Windows_Debug
       testArtifactName: Transport_Artifacts_Windows_Debug
       configuration: Debug
       testArguments: -testCoreClr -testUsedAssemblies -testCompilerOnly
@@ -176,7 +166,6 @@ stages:
     parameters:
       testRunName: 'Test Linux Debug'
       jobName: Test_Linux_Debug
-      buildJobName: Build_Unix_Debug
       testArtifactName: Transport_Artifacts_Unix_Debug
       configuration: Debug
       testArguments: --testCoreClr --helixQueueName Ubuntu.1804.Amd64.Open
@@ -186,7 +175,6 @@ stages:
       parameters:
         testRunName: 'Test Linux Debug Single Machine'
         jobName: Test_Linux_Debug_Single_Machine
-        buildJobName: Build_Unix_Debug
         testArtifactName: Transport_Artifacts_Unix_Debug
         configuration: Debug
         testArguments: --testCoreClr
@@ -196,7 +184,6 @@ stages:
     parameters:
       testRunName: 'Test macOS Debug'
       jobName: Test_macOS_Debug
-      buildJobName: Build_Unix_Debug
       testArtifactName: Transport_Artifacts_Unix_Debug
       configuration: Debug
       testArguments: --testCoreClr --helixQueueName OSX.1015.Amd64.Open

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,9 +29,8 @@ pr:
       - README.md
 
 stages:
-- stage: Windows_Build
+- stage: Windows_Debug_Build
   dependsOn: []
-  # Windows Builds
   jobs:
   - template: eng/pipelines/build-windows-job.yml
     parameters:
@@ -42,6 +41,8 @@ stages:
       restoreArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
       buildArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
+- stage: Windows_Release_Build
+  dependsOn: []
   - template: eng/pipelines/build-windows-job.yml
     parameters:
       jobName: Build_Windows_Release
@@ -66,9 +67,8 @@ stages:
   jobs:
   - template: eng/common/templates/jobs/source-build.yml
 
-- stage: Test_Desktop
-  dependsOn: Windows_Build
-  # Test Windows Desktop
+- stage: Windows_Debug_Desktop
+  dependsOn: Windows_Debug_Build
   jobs:
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - template: eng/pipelines/test-windows-job.yml
@@ -87,14 +87,17 @@ stages:
       configuration: Debug
       testArguments: -testDesktop -testArch x64
 
-  - template: eng/pipelines/test-windows-job.yml
+- stage: Windows_Release_Desktop
+  dependsOn: Windows_Release_Build
+  jobs:
+    - template: eng/pipelines/test-windows-job.yml
     parameters:
       testRunName: 'Test Windows Desktop Release 32'
       jobName: Test_Windows_Desktop_Release_32
       testArtifactName: Transport_Artifacts_Windows_Release
       configuration: Release
       testArguments: -testDesktop -testArch x86
-
+      
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - template: eng/pipelines/test-windows-job.yml
       parameters:
@@ -112,9 +115,8 @@ stages:
       configuration: Release
       testArguments: -testDesktop -testArch x64 -helixQueueName Windows.10.Amd64.Server2022.ES.Open
 
-- stage: Test_Windows_CoreClr
-  dependsOn: Windows_Build
-  # Test Windows CoreCLR
+- stage: Windows_Debug_CoreClr
+  dependsOn: Windows_Debug_Build
   jobs:
   - template: eng/pipelines/test-windows-job.yml
     parameters:
@@ -135,14 +137,6 @@ stages:
 
   - template: eng/pipelines/test-windows-job.yml
     parameters:
-      testRunName: 'Test Windows CoreClr Release'
-      jobName: Test_Windows_CoreClr_Release
-      testArtifactName: Transport_Artifacts_Windows_Release
-      configuration: Release
-      testArguments: -testCoreClr
-
-  - template: eng/pipelines/test-windows-job.yml
-    parameters:
       testRunName: 'Test Windows CoreCLR IOperation Debug'
       jobName: Test_Windows_CoreClr_IOperation_Debug
       testArtifactName: Transport_Artifacts_Windows_Debug
@@ -159,7 +153,18 @@ stages:
       configuration: Debug
       testArguments: -testCoreClr -testUsedAssemblies -testCompilerOnly
 
-- stage: Test_Linux_CoreClr
+- stage: Windows_Release_CoreClr
+  dependsOn: Windows_Release_Build
+  jobs:
+  - template: eng/pipelines/test-windows-job.yml
+    parameters:
+      testRunName: 'Test Windows CoreClr Release'
+      jobName: Test_Windows_CoreClr_Release
+      testArtifactName: Transport_Artifacts_Windows_Release
+      configuration: Release
+      testArguments: -testCoreClr
+
+- stage: Unix_Debug_CoreClr
   dependsOn: Unix_Build
   jobs:
   - template: eng/pipelines/test-unix-job.yml
@@ -190,7 +195,6 @@ stages:
 
 - stage: Correctness
   dependsOn: []
-  # Build Correctness Jobs
   jobs:
   - template: eng/pipelines/evaluate-changed-files.yml
     parameters:

--- a/eng/pipelines/test-unix-job-single-machine.yml
+++ b/eng/pipelines/test-unix-job-single-machine.yml
@@ -6,9 +6,6 @@ parameters:
 - name: jobName
   type: string
   default: ''
-- name: buildJobName
-  type: string
-  default: ''
 - name: testArtifactName
   type: string
   default: ''
@@ -27,7 +24,6 @@ parameters:
 
 jobs:
 - job: ${{ parameters.jobName }}
-  dependsOn: ${{ parameters.buildJobName }}
   pool:
     ${{ if ne(parameters.queueName, '') }}:
       name: NetCore1ESPool-Public

--- a/eng/pipelines/test-unix-job.yml
+++ b/eng/pipelines/test-unix-job.yml
@@ -6,9 +6,6 @@ parameters:
 - name: jobName
   type: string
   default: ''
-- name: buildJobName
-  type: string
-  default: ''
 - name: testArtifactName
   type: string
   default: ''
@@ -21,7 +18,6 @@ parameters:
 
 jobs:
 - job: ${{ parameters.jobName }}
-  dependsOn: ${{ parameters.buildJobName }}
   pool:
     # Note that when helix is enabled, the agent running this job is essentially
     # a thin client that kicks off a helix job and waits for it to complete.

--- a/eng/pipelines/test-windows-job-single-machine.yml
+++ b/eng/pipelines/test-windows-job-single-machine.yml
@@ -6,9 +6,6 @@ parameters:
 - name: jobName
   type: string
   default: ''
-- name: buildJobName
-  type: string
-  default: ''
 - name: testArtifactName
   type: string
   default: ''
@@ -24,7 +21,6 @@ parameters:
 
 jobs:
 - job: ${{ parameters.jobName }}
-  dependsOn: ${{ parameters.buildJobName }}
   pool:
     name: NetCore1ESPool-Public
     demands: ImageOverride -equals ${{ parameters.queueName }}

--- a/eng/pipelines/test-windows-job.yml
+++ b/eng/pipelines/test-windows-job.yml
@@ -6,9 +6,6 @@ parameters:
 - name: jobName
   type: string
   default: ''
-- name: buildJobName
-  type: string
-  default: ''
 - name: testArtifactName
   type: string
   default: ''
@@ -21,7 +18,6 @@ parameters:
 
 jobs:
 - job: ${{ parameters.jobName }}
-  dependsOn: ${{ parameters.buildJobName }}
   pool:
     # Note that when helix is enabled, the agent running this job is essentially
     # a thin client that kicks off a helix job and waits for it to complete.


### PR DESCRIPTION
Since jobs can be retried when all jobs in their stage have completed, this PR tries to group similar jobs into stages. This may allow failed shorter jobs to be retried without waiting for the entire pipeline to complete.

roslyn-CI:
<img width="535" alt="image" src="https://user-images.githubusercontent.com/611219/186989499-c29651f6-c38e-4202-803d-9cc24bcb6785.png">

roslyn-integration-CI:
<img width="342" alt="image" src="https://user-images.githubusercontent.com/611219/186989590-d44e7707-2894-4bdb-a361-2edd992d4f0e.png">
