### PR TITLE
Don't include expanded items if there are exclusive items in the list

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
@@ -1230,7 +1230,7 @@ class Program
 
             if (!completionList.IsEmpty)
             {
-                Assert.True(exclusive == completionList.GetTestAccessor().IsExclusive, "group.IsExclusive == " + completionList.GetTestAccessor().IsExclusive);
+                Assert.True(exclusive == completionList.IsExclusive, "group.IsExclusive == " + completionList.IsExclusive);
             }
         }
     }

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSessionData.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSessionData.cs
@@ -26,6 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         public TextSpan? CompletionListSpan { get; set; }
         public CompletionList<CompletionItem>? CombinedSortedList { get; set; }
         public Task<(CompletionContext, RoslynCompletionList)>? ExpandedItemsTask { get; set; }
+        public bool IsExclusive { get; set; }
 
         private CompletionSessionData()
         {

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -19,7 +19,6 @@ using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
@@ -54,6 +53,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         // Use CWT to cache data needed to create VSCompletionItem, so the table would be cleared when Roslyn completion item cache is cleared.
         private static readonly ConditionalWeakTable<RoslynCompletionItem, StrongBox<VSCompletionItemData>> s_roslynItemToVsItemData =
             new();
+
+        // Cancellation series we use to stop background task for expanded items when exclusive items are returned by core providers.
+        private readonly CancellationSeries _expandeditemsTaskCancellationSeries = new();
 
         private readonly ITextView _textView;
         private readonly bool _isDebuggerTextView;
@@ -296,10 +298,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     // OK, expand item is enabled but we shouldn't block completion on its results.
                     // Kick off expand item calculation first in background.
                     Stopwatch stopwatch = new();
+
+                    var expandeditemsTaskCancellationToken = _expandeditemsTaskCancellationSeries.CreateNext(cancellationToken);
                     var expandedItemsTask = Task.Run(async () =>
                     {
                         var result = await GetCompletionContextWorkerAsync(session, document, trigger, triggerLocation,
-                          options with { ExpandedCompletionBehavior = ExpandedCompletionMode.ExpandedItemsOnly }, cancellationToken).ConfigureAwait(false);
+                          options with { ExpandedCompletionBehavior = ExpandedCompletionMode.ExpandedItemsOnly }, expandeditemsTaskCancellationToken).ConfigureAwait(false);
 
                         // Record how long it takes for the background task to complete *after* core providers returned.
                         // If telemetry shows that a short wait is all it takes for ExpandedItemsTask to complete in
@@ -310,12 +314,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                         AsyncCompletionLogger.LogAdditionalTicksToCompleteDelayedImportCompletionDataPoint(stopwatch.Elapsed);
 
                         return result;
-                    }, cancellationToken);
+                    }, expandeditemsTaskCancellationToken);
 
                     // Now trigger and wait for core providers to return;
                     var (nonExpandedContext, nonExpandedCompletionList) = await GetCompletionContextWorkerAsync(session, document, trigger, triggerLocation,
                             options with { ExpandedCompletionBehavior = ExpandedCompletionMode.NonExpandedItemsOnly }, cancellationToken).ConfigureAwait(false);
                     UpdateSessionData(session, sessionData, nonExpandedCompletionList, triggerLocation);
+
+                    // If the core items are exclusive, we don't include expanded items.
+                    if (sessionData.IsExclusive)
+                    {
+                        // This would cancel expandedItemsTask.
+                        _ = _expandeditemsTaskCancellationSeries.CreateNext(CancellationToken.None);
+                        return nonExpandedContext;
+                    }
 
                     if (expandedItemsTask.IsCompleted)
                     {
@@ -372,8 +384,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         {
             var sessionData = CompletionSessionData.GetOrCreateSessionData(session);
 
-            // We only want to provide expanded items for Roslyn's expander.
-            if (expander == FilterSet.Expander && sessionData.ExpandedItemTriggerLocation.HasValue)
+            // We only want to provide expanded items for Roslyn's expander
+            if (!sessionData.IsExclusive && expander == FilterSet.Expander && sessionData.ExpandedItemTriggerLocation.HasValue)
             {
                 var initialTriggerLocation = sessionData.ExpandedItemTriggerLocation.Value;
                 AsyncCompletionLogger.LogExpanderUsage();
@@ -458,6 +470,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
         private static void UpdateSessionData(IAsyncCompletionSession session, CompletionSessionData sessionData, CompletionList completionList, SnapshotPoint triggerLocation)
         {
+            sessionData.IsExclusive |= completionList.IsExclusive;
+
             // Store around the span this completion list applies to.  We'll use this later
             // to pass this value in when we're committing a completion list item.
             // It's OK to overwrite this value when expanded items are requested.

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.vb
@@ -462,7 +462,7 @@ End Program</Document>
                 Dim document = workspace.CurrentSolution.GetDocument(hostDocument.Id)
                 Dim service = GetCompletionService(document.Project)
                 Dim completionList = Await GetCompletionListAsync(service, document, caretPosition, RoslynCompletion.CompletionTrigger.Invoke)
-                Assert.True(completionList.IsEmpty OrElse completionList.GetTestAccessor().IsExclusive, "Expected always exclusive")
+                Assert.True(completionList.IsEmpty OrElse completionList.IsExclusive, "Expected always exclusive")
             End Using
         End Function
 

--- a/src/Features/Core/Portable/Completion/CompletionList.cs
+++ b/src/Features/Core/Portable/Completion/CompletionList.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis.Completion
     /// </summary>
     public sealed class CompletionList
     {
-        private readonly bool _isExclusive;
         private readonly Lazy<ImmutableArray<CompletionItem>> _lazyItems;
 
         /// <summary>
@@ -64,6 +63,11 @@ namespace Microsoft.CodeAnalysis.Completion
         /// </summary>
         public CompletionItem? SuggestionModeItem { get; }
 
+        /// <summary>
+        /// Whether the items in this list should be the only items presented to the user.
+        /// </summary>
+        internal bool IsExclusive { get; }
+
         private CompletionList(
             TextSpan defaultSpan,
             IReadOnlyList<CompletionItem> itemsList,
@@ -77,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Completion
 
             Rules = rules ?? CompletionRules.Default;
             SuggestionModeItem = suggestionModeItem;
-            _isExclusive = isExclusive;
+            IsExclusive = isExclusive;
 
             foreach (var item in ItemsList)
             {
@@ -132,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Completion
             }
             else
             {
-                return Create(newSpan, newItemsList, newRules, newSuggestionModeItem, isExclusive: false);
+                return Create(newSpan, newItemsList, newRules, newSuggestionModeItem, IsExclusive);
             }
         }
 
@@ -180,18 +184,5 @@ namespace Microsoft.CodeAnalysis.Completion
             suggestionModeItem: null, isExclusive: false);
 
         internal bool IsEmpty => ItemsList.Count == 0 && SuggestionModeItem is null;
-
-        internal TestAccessor GetTestAccessor()
-            => new(this);
-
-        internal readonly struct TestAccessor
-        {
-            private readonly CompletionList _completionList;
-
-            public TestAccessor(CompletionList completionList)
-                => _completionList = completionList;
-
-            internal bool IsExclusive => _completionList._isExclusive;
-        }
     }
 }


### PR DESCRIPTION
This was regressed when we introduced two-phase completion. Here's an example of the regression, when in the context of property name, we mistakenly included unimported items as well.

![completion_props](https://user-images.githubusercontent.com/788783/186986244-73de95f2-e41e-4961-ac5d-953505ab1e1f.gif)
