### PR TITLE
Revert - Don't allow parameter type changes on properties

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -15548,15 +15548,19 @@ class C
 
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifySemantics(
-                new[]
-                {
-                    SemanticEdit(SemanticEditKind.Delete, c => c.GetMembers("C.get_Item").FirstOrDefault(m => m.GetParameterTypes()[0].SpecialType == SpecialType.System_Int32)?.ISymbol, deletedSymbolContainerProvider: c => c.GetMember("C")),
-                    SemanticEdit(SemanticEditKind.Delete, c => c.GetMembers("C.set_Item").FirstOrDefault(m => m.GetParameterTypes()[0].SpecialType == SpecialType.System_Int32)?.ISymbol, deletedSymbolContainerProvider: c => c.GetMember("C")),
-                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMembers("C.get_Item").FirstOrDefault(m => m.GetParameterTypes()[0].SpecialType == SpecialType.System_String)?.ISymbol),
-                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMembers("C.set_Item").FirstOrDefault(m => m.GetParameterTypes()[0].SpecialType == SpecialType.System_String)?.ISymbol)
-                },
-                capabilities: EditAndContinueCapabilities.AddMethodToExistingType);
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.TypeUpdate, "string a", FeaturesResources.parameter));
+
+            // TODO:
+            // edits.VerifySemantics(
+            //     new[]
+            //     {
+            //         SemanticEdit(SemanticEditKind.Delete, c => c.GetMembers("C.get_Item").FirstOrDefault(m => m.GetParameterTypes()[0].SpecialType == SpecialType.System_Int32)?.ISymbol, deletedSymbolContainerProvider: c => c.GetMember("C")),
+            //         SemanticEdit(SemanticEditKind.Delete, c => c.GetMembers("C.set_Item").FirstOrDefault(m => m.GetParameterTypes()[0].SpecialType == SpecialType.System_Int32)?.ISymbol, deletedSymbolContainerProvider: c => c.GetMember("C")),
+            //         SemanticEdit(SemanticEditKind.Insert, c => c.GetMembers("C.get_Item").FirstOrDefault(m => m.GetParameterTypes()[0].SpecialType == SpecialType.System_String)?.ISymbol),
+            //         SemanticEdit(SemanticEditKind.Insert, c => c.GetMembers("C.set_Item").FirstOrDefault(m => m.GetParameterTypes()[0].SpecialType == SpecialType.System_String)?.ISymbol)
+            //     },
+            //     capabilities: EditAndContinueCapabilities.AddMethodToExistingType);
         }
 
         [Fact]
@@ -15567,15 +15571,19 @@ class C
 
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifySemantics(
-                new[]
-                {
-                    SemanticEdit(SemanticEditKind.Delete, c => c.GetMembers("C.get_Item").FirstOrDefault(m => m.GetParameterCount() == 1)?.ISymbol, deletedSymbolContainerProvider: c => c.GetMember("C")),
-                    SemanticEdit(SemanticEditKind.Delete, c => c.GetMembers("C.set_Item").FirstOrDefault(m => m.GetParameterCount() == 2)?.ISymbol, deletedSymbolContainerProvider: c => c.GetMember("C")),
-                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMembers("C.get_Item").FirstOrDefault(m => m.GetParameterCount() == 2)?.ISymbol),
-                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMembers("C.set_Item").FirstOrDefault(m => m.GetParameterCount() == 3)?.ISymbol)
-                },
-                capabilities: EditAndContinueCapabilities.AddMethodToExistingType);
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "string b", FeaturesResources.parameter));
+
+            // TODO:
+            // edits.VerifySemantics(
+            //     new[]
+            //     {
+            //         SemanticEdit(SemanticEditKind.Delete, c => c.GetMembers("C.get_Item").FirstOrDefault(m => m.GetParameterCount() == 1)?.ISymbol, deletedSymbolContainerProvider: c => c.GetMember("C")),
+            //         SemanticEdit(SemanticEditKind.Delete, c => c.GetMembers("C.set_Item").FirstOrDefault(m => m.GetParameterCount() == 2)?.ISymbol, deletedSymbolContainerProvider: c => c.GetMember("C")),
+            //         SemanticEdit(SemanticEditKind.Insert, c => c.GetMembers("C.get_Item").FirstOrDefault(m => m.GetParameterCount() == 2)?.ISymbol),
+            //         SemanticEdit(SemanticEditKind.Insert, c => c.GetMembers("C.set_Item").FirstOrDefault(m => m.GetParameterCount() == 3)?.ISymbol)
+            //     },
+            //     capabilities: EditAndContinueCapabilities.AddMethodToExistingType);
         }
 
         [Fact]
@@ -15586,15 +15594,19 @@ class C
 
             var edits = GetTopEdits(src1, src2);
 
-            edits.VerifySemantics(
-                new[]
-                {
-                    SemanticEdit(SemanticEditKind.Delete, c => c.GetMembers("C.get_Item").FirstOrDefault(m => m.GetParameterCount() == 2)?.ISymbol, deletedSymbolContainerProvider: c => c.GetMember("C")),
-                    SemanticEdit(SemanticEditKind.Delete, c => c.GetMembers("C.set_Item").FirstOrDefault(m => m.GetParameterCount() == 3)?.ISymbol, deletedSymbolContainerProvider: c => c.GetMember("C")),
-                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMembers("C.get_Item").FirstOrDefault(m => m.GetParameterCount() == 1)?.ISymbol),
-                    SemanticEdit(SemanticEditKind.Insert, c => c.GetMembers("C.set_Item").FirstOrDefault(m => m.GetParameterCount() == 2)?.ISymbol)
-                },
-                capabilities: EditAndContinueCapabilities.AddMethodToExistingType);
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "int this[int a]", DeletedSymbolDisplay(FeaturesResources.parameter, "string b")));
+
+            // TODO:
+            // edits.VerifySemantics(
+            //     new[]
+            //     {
+            //         SemanticEdit(SemanticEditKind.Delete, c => c.GetMembers("C.get_Item").FirstOrDefault(m => m.GetParameterCount() == 2)?.ISymbol, deletedSymbolContainerProvider: c => c.GetMember("C")),
+            //         SemanticEdit(SemanticEditKind.Delete, c => c.GetMembers("C.set_Item").FirstOrDefault(m => m.GetParameterCount() == 3)?.ISymbol, deletedSymbolContainerProvider: c => c.GetMember("C")),
+            //         SemanticEdit(SemanticEditKind.Insert, c => c.GetMembers("C.get_Item").FirstOrDefault(m => m.GetParameterCount() == 1)?.ISymbol),
+            //         SemanticEdit(SemanticEditKind.Insert, c => c.GetMembers("C.set_Item").FirstOrDefault(m => m.GetParameterCount() == 2)?.ISymbol)
+            //     },
+            //     capabilities: EditAndContinueCapabilities.AddMethodToExistingType);
         }
 
         [Fact]

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/TopLevelEditingTests.vb
@@ -10537,18 +10537,22 @@ End Class
             edits.VerifyEdits(
                 "Update [a As Integer]@38 -> [a As Object]@38")
 
-            edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                semanticEdits:=
-                {
-                    SemanticEdit(SemanticEditKind.Delete, Function(c) c.GetMembers("C.get_P").FirstOrDefault(Function(m) m.GetParameters().Any(Function(p) p.Type.SpecialType = SpecialType.System_Int32)), deletedSymbolContainerProvider:=Function(c) c.GetMember("C")),
-                    SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMembers("C.get_P").FirstOrDefault(Function(m) m.GetParameters().Any(Function(p) p.Type.SpecialType = SpecialType.System_Object)))
-                },
-                capabilities:=EditAndContinueCapabilities.AddMethodToExistingType)
-
             edits.VerifySemanticDiagnostics(
-                {Diagnostic(RudeEditKind.ChangingTypeNotSupportedByRuntime, "a As Object", FeaturesResources.parameter)},
-                capabilities:=EditAndContinueCapabilities.Baseline)
+                Diagnostic(RudeEditKind.TypeUpdate, "a As Object", FeaturesResources.parameter))
+
+            ' TODO:
+            ' edits.VerifySemantics(
+            '     ActiveStatementsDescription.Empty,
+            '     semanticEdits:=
+            '     {
+            '         SemanticEdit(SemanticEditKind.Delete, Function(c) c.GetMembers("C.get_P").FirstOrDefault(Function(m) m.GetParameters().Any(Function(p) p.Type.SpecialType = SpecialType.System_Int32)), deletedSymbolContainerProvider:=Function(c) c.GetMember("C")),
+            '         SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMembers("C.get_P").FirstOrDefault(Function(m) m.GetParameters().Any(Function(p) p.Type.SpecialType = SpecialType.System_Object)))
+            '     },
+            '     capabilities:=EditAndContinueCapabilities.AddMethodToExistingType)
+
+            ' edits.VerifySemanticDiagnostics(
+            '     {Diagnostic(RudeEditKind.ChangingTypeNotSupportedByRuntime, "a As Object", FeaturesResources.parameter)},
+            '     capabilities:=EditAndContinueCapabilities.Baseline)
         End Sub
 
         <Fact>
@@ -10560,18 +10564,22 @@ End Class
             edits.VerifyEdits(
                 "Update [a As Integer]@38 -> [a]@38")
 
-            edits.VerifySemantics(
-                ActiveStatementsDescription.Empty,
-                semanticEdits:=
-                {
-                    SemanticEdit(SemanticEditKind.Delete, Function(c) c.GetMembers("C.get_P").FirstOrDefault(Function(m) m.GetParameters().Any(Function(p) p.Type.SpecialType = SpecialType.System_Int32)), deletedSymbolContainerProvider:=Function(c) c.GetMember("C")),
-                    SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMembers("C.get_P").FirstOrDefault(Function(m) m.GetParameters().Any(Function(p) p.Type.SpecialType = SpecialType.System_Object)))
-                },
-                capabilities:=EditAndContinueCapabilities.AddMethodToExistingType)
-
             edits.VerifySemanticDiagnostics(
-                {Diagnostic(RudeEditKind.ChangingTypeNotSupportedByRuntime, "a", FeaturesResources.parameter)},
-                capabilities:=EditAndContinueCapabilities.Baseline)
+                Diagnostic(RudeEditKind.TypeUpdate, "a", FeaturesResources.parameter))
+
+            ' TODO:
+            ' edits.VerifySemantics(
+            '     ActiveStatementsDescription.Empty,
+            '     semanticEdits:=
+            '     {
+            '         SemanticEdit(SemanticEditKind.Delete, Function(c) c.GetMembers("C.get_P").FirstOrDefault(Function(m) m.GetParameters().Any(Function(p) p.Type.SpecialType = SpecialType.System_Int32)), deletedSymbolContainerProvider:=Function(c) c.GetMember("C")),
+            '         SemanticEdit(SemanticEditKind.Insert, Function(c) c.GetMembers("C.get_P").FirstOrDefault(Function(m) m.GetParameters().Any(Function(p) p.Type.SpecialType = SpecialType.System_Object)))
+            '     },
+            '     capabilities:=EditAndContinueCapabilities.AddMethodToExistingType)
+
+            ' edits.VerifySemanticDiagnostics(
+            '     {Diagnostic(RudeEditKind.ChangingTypeNotSupportedByRuntime, "a", FeaturesResources.parameter)},
+            '     capabilities:=EditAndContinueCapabilities.Baseline)
         End Sub
 
         <Fact>

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -3289,6 +3289,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 return false;
             }
 
+            // We don't (for now) support parameter inserts/deletes on properties or indexers
+            if (containingSymbol is not IMethodSymbol)
+            {
+                return false;
+            }
+
             // Find the node that matches this declaration
             SyntaxNode otherContainingNode;
             var containingNode = containingSymbol.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken);
@@ -3888,9 +3894,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 {
                     hasGeneratedAttributeChange = true;
                 }
-                else if (newParameter.ContainingType.IsDelegateType())
+                else if (newParameter.ContainingType.IsDelegateType() || newParameter.ContainingSymbol is not IMethodSymbol)
                 {
-                    // We don't allow changing parameter types in delegates
+                    // We don't allow changing parameter types in delegates, or in properties or indexers
                     rudeEdit = RudeEditKind.TypeUpdate;
                 }
                 else if (AllowsDeletion(newParameter.ContainingSymbol))


### PR DESCRIPTION
Reverts part of https://github.com/dotnet/roslyn/pull/62897 because I did a bad.

This revert is temporary, and I'll return the commented out portions in https://github.com/dotnet/roslyn/pull/63486, but wanted to get this in before the snap, before the badness ships anywhere outside the company.