### PR TITLE
Delete publishing steps that are no longer needed

### DIFF
--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -46,21 +46,3 @@ steps:
       publishLocation: Container
     continueOnError: true
     condition: not(succeeded())
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Test Attachments
-    inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\bin\Microsoft.VisualStudio.LanguageServices.New.IntegrationTests\${{ parameters.configuration }}\net472\TestResults'
-      ArtifactName: '$(System.JobAttempt)-Blame ${{ parameters.configuration }} OOP64_${{ parameters.oop64bit }} OOPCoreClr_${{ parameters.oopCoreClr }} LspEditor_${{ parameters.lspEditor }} $(Build.BuildNumber)'
-      publishLocation: Container
-    continueOnError: true
-    condition: not(succeeded())
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Screenshots and Test Attachments (Old Tests)
-    inputs:
-      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\bin\Microsoft.VisualStudio.LanguageServices.IntegrationTests\${{ parameters.configuration }}\net472\TestResults'
-      ArtifactName: '$(System.JobAttempt)-Screenshots ${{ parameters.configuration }} OOP64_${{ parameters.oop64bit }} OOPCoreClr_${{ parameters.oopCoreClr }} LspEditor_${{ parameters.lspEditor }} $(Build.BuildNumber)'
-      publishLocation: Container
-    continueOnError: true
-    condition: not(succeeded())

--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -46,3 +46,12 @@ steps:
       publishLocation: Container
     continueOnError: true
     condition: not(succeeded())
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Screenshots and Test Attachments (Old Tests)
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\bin\Microsoft.VisualStudio.LanguageServices.IntegrationTests\${{ parameters.configuration }}\net472\TestResults'
+      ArtifactName: '$(System.JobAttempt)-Screenshots ${{ parameters.configuration }} OOP64_${{ parameters.oop64bit }} OOPCoreClr_${{ parameters.oopCoreClr }} LspEditor_${{ parameters.lspEditor }} $(Build.BuildNumber)'
+      publishLocation: Container
+    continueOnError: true
+    condition: not(succeeded())


### PR DESCRIPTION
Screenshots, dumps, servicehub logs and misc results are all saved to the artifacts/log folder.

Example of dumps + logs + screenshots successfully published as an artifact even with these tasks failing - https://dev.azure.com/dnceng/public/_build/results?buildId=1970194&view=artifacts&pathAsName=false&type=publishedArtifacts
