### PR TITLE
Account for using declarations in nested switch statement gotos

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
@@ -10,12 +10,13 @@ using System.Linq;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
     internal class ControlFlowPass : AbstractFlowPass<ControlFlowPass.LocalState, ControlFlowPass.LocalFunctionState>
     {
-        private readonly PooledDictionary<LabelSymbol, BoundBlock> _labelsDefined = PooledDictionary<LabelSymbol, BoundBlock>.GetInstance();
+        private readonly PooledDictionary<LabelSymbol, BoundNode> _labelsDefined = PooledDictionary<LabelSymbol, BoundNode>.GetInstance();
         private readonly PooledHashSet<LabelSymbol> _labelsUsed = PooledHashSet<LabelSymbol>.GetInstance();
         protected bool _convertInsufficientExecutionStackExceptionToCancelledByStackGuardException = false; // By default, just let the original exception to bubble up.
 
@@ -133,8 +134,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             this.Diagnostics.Clear();  // clear reported diagnostics
             var result = base.Scan(ref badRegion);
-            foreach (var label in _labelsDefined.Keys)
+            foreach (var (label, node) in _labelsDefined)
             {
+                if (node is BoundSwitchStatement) continue;
+
                 if (!_labelsUsed.Contains(label))
                 {
                     Diagnostics.Add(ErrorCode.WRN_UnreferencedLabel, label.Locations[0]);
@@ -353,10 +356,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Backwards jump, so we must have already seen the label, or it must be a switch case label. If it is a switch case label, we know
                     // that either the user received an error for having a using declaration at the top level in a switch statement, or the label is a valid
                     // target to branch to.
-                    Debug.Assert(_labelsDefined.ContainsKey(node.Label) || node.Label is SourceLabelSymbol { SwitchCaseLabelConstant: not null });
+                    Debug.Assert(_labelsDefined.ContainsKey(node.Label));
 
                     // Error if label and using are part of the same block
-                    if (_labelsDefined.TryGetValue(node.Label, out var labeledBlock) && labeledBlock == usingDecl.block)
+                    if (_labelsDefined[node.Label] == usingDecl.block)
                     {
                         Diagnostics.Add(ErrorCode.ERR_GoToBackwardJumpOverUsingVar, sourceLocation);
                         break;
@@ -378,6 +381,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Diagnostics.Add(isLastSection ? ErrorCode.ERR_SwitchFallOut : ErrorCode.ERR_SwitchFallThrough,
                                 new SourceLocation(syntax), syntax.ToString());
             }
+        }
+
+        public override BoundNode VisitSwitchStatement(BoundSwitchStatement node)
+        {
+            foreach (var section in node.SwitchSections)
+            {
+                foreach (var label in section.SwitchLabels)
+                {
+                    _labelsDefined[label.Label] = node;
+                }
+            }
+
+            return base.VisitSwitchStatement(node);
         }
 
         public override BoundNode VisitBlock(BoundBlock node)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
@@ -350,11 +350,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else if (sourceStart > usingStart && targetStart < usingStart)
                 {
-                    // Backwards jump, so we must have already seen the label
-                    Debug.Assert(_labelsDefined.ContainsKey(node.Label));
+                    // Backwards jump, so we must have already seen the label, or it must be a switch case label. If it is a switch case label, we know
+                    // that either the user received an error for having a using declaration at the top level in a switch statement, or the label is a valid
+                    // target to branch to.
+                    Debug.Assert(_labelsDefined.ContainsKey(node.Label) || node.Label is SourceLabelSymbol { SwitchCaseLabelConstant: not null });
 
                     // Error if label and using are part of the same block
-                    if (_labelsDefined[node.Label] == usingDecl.block)
+                    if (_labelsDefined.TryGetValue(node.Label, out var labeledBlock) && labeledBlock == usingDecl.block)
                     {
                         Diagnostics.Add(ErrorCode.ERR_GoToBackwardJumpOverUsingVar, sourceLocation);
                         break;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingDeclarationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingDeclarationTests.cs
@@ -564,7 +564,7 @@ class C
         }
 
         [Fact]
-        public void UsingVariableInSwitchCase()
+        public void UsingVariableInSwitchCase_01()
         {
             var source = @"
 using System;
@@ -590,6 +590,110 @@ class C2
                 //                     using C1 o1 = new C1();
                 Diagnostic(ErrorCode.ERR_UsingVarInSwitchCase, "using C1 o1 = new C1();").WithLocation(15, 17)
             );
+        }
+
+        [Fact, WorkItem(63570, "https://github.com/dotnet/roslyn/issues/63570")]
+        public void UsingVariableInSwitchCase_02()
+        {
+            var source = """
+                using System;
+                StringSplitOptions temp = StringSplitOptions.RemoveEmptyEntries;
+                switch (temp)
+                {
+                    case StringSplitOptions.None:
+                        Console.WriteLine("None");
+                        break;
+                
+                    case StringSplitOptions.RemoveEmptyEntries:
+                    {
+                        using var streamReader = new C1();
+                        goto case StringSplitOptions.None;
+                    }
+                
+                    default:
+                        break;
+                }
+                
+                class C1 : IDisposable
+                {
+                    public void Dispose()
+                    {
+                        Console.WriteLine("Disposed");
+                    }
+                }
+                """;
+
+            var verifier = CompileAndVerify(source, expectedOutput: """
+                Disposed
+                None
+                """);
+
+            verifier.VerifyDiagnostics();
+
+            verifier.VerifyIL("<top-level-statements-entry-point>", """
+                {
+                  // Code size       39 (0x27)
+                  .maxstack  2
+                  .locals init (System.StringSplitOptions V_0, //temp
+                                C1 V_1) //streamReader
+                  IL_0000:  ldc.i4.1
+                  IL_0001:  stloc.0
+                  IL_0002:  ldloc.0
+                  IL_0003:  brfalse.s  IL_000a
+                  IL_0005:  ldloc.0
+                  IL_0006:  ldc.i4.1
+                  IL_0007:  beq.s      IL_0015
+                  IL_0009:  ret
+                  IL_000a:  ldstr      "None"
+                  IL_000f:  call       "void System.Console.WriteLine(string)"
+                  IL_0014:  ret
+                  IL_0015:  newobj     "C1..ctor()"
+                  IL_001a:  stloc.1
+                  .try
+                  {
+                    IL_001b:  leave.s    IL_000a
+                  }
+                  finally
+                  {
+                    IL_001d:  ldloc.1
+                    IL_001e:  brfalse.s  IL_0026
+                    IL_0020:  ldloc.1
+                    IL_0021:  callvirt   "void System.IDisposable.Dispose()"
+                    IL_0026:  endfinally
+                  }
+                }
+                """);
+        }
+
+        [Fact, WorkItem(63570, "https://github.com/dotnet/roslyn/issues/63570")]
+        public void UsingVariableInSwitchCase_03()
+        {
+            var source = """
+                using System;
+                StringSplitOptions temp = StringSplitOptions.RemoveEmptyEntries;
+                switch (temp)
+                {
+                    case StringSplitOptions.None:
+                        goto case StringSplitOptions.RemoveEmptyEntries;
+                
+                    case StringSplitOptions.RemoveEmptyEntries:
+                    {
+                        using var streamReader = new C1();
+                        goto case StringSplitOptions.None;
+                    }
+                }
+                
+                class C1 : IDisposable
+                {
+                    public void Dispose()
+                    {
+                        Console.WriteLine("Disposed");
+                    }
+                }
+                """;
+
+            var verifier = CompileAndVerify(source);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingDeclarationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingDeclarationTests.cs
@@ -731,6 +731,41 @@ class C2
             verifier.VerifyDiagnostics();
         }
 
+        [Fact, WorkItem(63570, "https://github.com/dotnet/roslyn/issues/63570")]
+        public void UsingVariableInSwitchCase_05()
+        {
+            var source = """
+                using System;
+                StringSplitOptions temp = StringSplitOptions.RemoveEmptyEntries;
+                switch (temp)
+                {
+                    default:
+                        Console.WriteLine("Default");
+                        break;
+
+                    case StringSplitOptions.RemoveEmptyEntries:
+                    {
+                        using var streamReader = new C1();
+                        goto default;
+                    }
+                }
+                
+                class C1 : IDisposable
+                {
+                    public void Dispose()
+                    {
+                        Console.WriteLine("Disposed");
+                    }
+                }
+                """;
+
+            var verifier = CompileAndVerify(source, expectedOutput: """
+                Disposed
+                Default
+                """);
+            verifier.VerifyDiagnostics();
+        }
+
         [Fact]
         public void UsingVariableDiagnosticsInDeclarationAreOnlyEmittedOnce()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UsingDeclarationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UsingDeclarationTests.cs
@@ -696,6 +696,41 @@ class C2
             verifier.VerifyDiagnostics();
         }
 
+        [Fact, WorkItem(63570, "https://github.com/dotnet/roslyn/issues/63570")]
+        public void UsingVariableInSwitchCase_04()
+        {
+            var source = """
+                using System;
+                StringSplitOptions temp = StringSplitOptions.RemoveEmptyEntries;
+                switch (temp)
+                {
+                    case StringSplitOptions.RemoveEmptyEntries:
+                    {
+                        using var streamReader = new C1();
+                        goto default;
+                    }
+
+                    default:
+                        Console.WriteLine("Default");
+                        break;
+                }
+                
+                class C1 : IDisposable
+                {
+                    public void Dispose()
+                    {
+                        Console.WriteLine("Disposed");
+                    }
+                }
+                """;
+
+            var verifier = CompileAndVerify(source, expectedOutput: """
+                Disposed
+                Default
+                """);
+            verifier.VerifyDiagnostics();
+        }
+
         [Fact]
         public void UsingVariableDiagnosticsInDeclarationAreOnlyEmittedOnce()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/63570. We were assuming that the label in a `goto` would always be present in our list, which wasn't true if the target was a different switch case.
