### PR TITLE
Fix race condition in analyzer driver for computing nodes to analyze …

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.CompilationData.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.CompilationData.cs
@@ -11,10 +11,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal abstract partial class AnalyzerDriver : IDisposable
     {
+        /// <summary>
+        /// Stores <see cref="DeclarationAnalysisData"/> for symbols declared in the compilation.
+        /// This allows us to avoid recomputing this data across analyzer execution for different analyzers
+        /// on the same symbols. This cached compilation data is strongly held by the associated
+        /// <see cref="CompilationWithAnalyzers"/> object.
+        /// </summary>
         internal class CompilationData
         {
-            private readonly record struct SyntaxReferenceAndSymbol(SyntaxReference Declaration, ISymbol Symbol);
-            private readonly Dictionary<(ISymbol, int), DeclarationAnalysisData> _declarationAnalysisDataMap;
+            private readonly Dictionary<(ISymbol symbol, int declarationIndex), DeclarationAnalysisData> _declarationAnalysisDataMap;
 
             public CompilationData(Compilation compilation)
             {
@@ -22,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 SemanticModelProvider = (CachingSemanticModelProvider)compilation.SemanticModelProvider;
                 this.SuppressMessageAttributeState = new SuppressMessageAttributeState(compilation);
-                _declarationAnalysisDataMap = new Dictionary<(ISymbol, int), DeclarationAnalysisData>();
+                _declarationAnalysisDataMap = new Dictionary<(ISymbol symbol, int declarationIndex), DeclarationAnalysisData>();
             }
 
             public CachingSemanticModelProvider SemanticModelProvider { get; }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -2504,15 +2504,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var declaringReferences = symbolEvent.DeclaringSyntaxReferences;
                 for (var i = 0; i < declaringReferences.Length; i++)
                 {
-                    var decl = declaringReferences[i];
-                    ClearCachedAnalysisDataIfAnalyzed(decl, symbol, i, analysisState);
+                    ClearCachedAnalysisDataIfAnalyzed(symbol, i, analysisState);
                 }
             }
 
             return success;
         }
 
-        private void ClearCachedAnalysisDataIfAnalyzed(SyntaxReference declaration, ISymbol symbol, int declarationIndex, AnalysisState analysisState)
+        private void ClearCachedAnalysisDataIfAnalyzed(ISymbol symbol, int declarationIndex, AnalysisState analysisState)
         {
             Debug.Assert(analysisState != null);
 
@@ -2521,7 +2520,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return;
             }
 
-            CurrentCompilationData.ClearDeclarationAnalysisData(declaration);
+            CurrentCompilationData.ClearDeclarationAnalysisData(symbol, declarationIndex);
         }
 
         private DeclarationAnalysisData ComputeDeclarationAnalysisData(
@@ -2586,7 +2585,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 (!analysisScope.FilterSpanOpt.HasValue || analysisScope.FilterSpanOpt.Value.Length >= decl.SyntaxTree.GetRoot(cancellationToken).Span.Length);
 
             var declarationAnalysisData = CurrentCompilationData.GetOrComputeDeclarationAnalysisData(
-                decl,
+                symbol,
+                declarationIndex,
                 computeDeclarationAnalysisData: () => ComputeDeclarationAnalysisData(symbol, decl, semanticModel, analysisScope, cancellationToken),
                 cacheAnalysisData: cacheAnalysisData);
 
@@ -2618,7 +2618,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 if (cacheAnalysisData)
                 {
-                    ClearCachedAnalysisDataIfAnalyzed(decl, symbol, declarationIndex, analysisState);
+                    ClearCachedAnalysisDataIfAnalyzed(symbol, declarationIndex, analysisState);
                 }
             }
 


### PR DESCRIPTION
…for top-level statements

Fixes #63225

We cache the syntax nodes to analyze within a given symbol's declaration in the analyzer driver for partial analysis case (when the analyzer host requests diagnostics for a file with an optional span). The key for this cache was the declaring syntax reference, which works fine in all cases except for top-level statements where the implicitly generated entry point method symbol and the entry point type symbol share the same declaration node and hence end up sharing the same key. This change fixes this issue by instead using the symbol and the declaration index as the key for the cache.

Verified that repro scenario in #63225 is consistently working fine after this fix. The missing/duplicate diagnostics in the repro was reproducing pretty consistently prior to the fix.