### PR TITLE
Install 3.1 runtime during official builds

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -135,6 +135,14 @@ stages:
       inputs:
         nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/engineering, devdiv/dotnet-core-internal-tooling
 
+    # Needed for SBOM tool
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core 3.1 runtime'
+      inputs:
+        packageType: runtime
+        version: 3.1.28
+        installationPath: '$(Build.SourcesDirectory)\.dotnet'
+
     # Needed because the build fails the NuGet Tools restore without it
     - task: UseDotNet@2
       displayName: 'Use .NET Core sdk'

--- a/global.json
+++ b/global.json
@@ -6,11 +6,6 @@
   },
   "tools": {
     "dotnet": "7.0.100-preview.7.22377.5",
-    "runtimes": {
-      "dotnet": [
-        "3.1.0"
-      ]
-    },
     "vs": {
       "version": "17.0"
     },


### PR DESCRIPTION
The 3.1 runtime was added to the global.json to support running the SBOM during official builds (https://github.com/dotnet/roslyn/pull/62447). This creates problems with restore on platforms that do not have a 3.1 runtime such as MacOS Arm64 (https://github.com/dotnet/arcade/issues/10423). This PR removes the 3.1 runtime from our global.json in favor of installing it during our official build with the UseDotNet task.