### PR TITLE
Run 'make struct readonly' on IDE code

### DIFF
--- a/src/Analyzers/Core/Analyzers/UseSystemHashCode/Analyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseSystemHashCode/Analyzer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.UseSystemHashCode
     /// Helper code to support both "UseSystemHashCodeCodeFixProvider" and
     /// <see cref="UseSystemHashCodeDiagnosticAnalyzer"/>.
     /// </summary>
-    internal partial struct Analyzer
+    internal readonly partial struct Analyzer
     {
         private readonly Compilation _compilation;
         private readonly IMethodSymbol _objectGetHashCodeMethod;

--- a/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller.Session_UpdateModel.cs
+++ b/src/EditorFeatures/Core.Wpf/SignatureHelp/Controller.Session_UpdateModel.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
     {
         internal partial class Session
         {
-            internal struct SignatureHelpSelection
+            internal readonly struct SignatureHelpSelection
             {
                 private readonly SignatureHelpItem _selectedItem;
                 private readonly bool _userSelected;

--- a/src/EditorFeatures/Core.Wpf/Workspaces/WpfTextBufferVisibilityTracker.cs
+++ b/src/EditorFeatures/Core.Wpf/Workspaces/WpfTextBufferVisibilityTracker.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Workspaces
         public TestAccessor GetTestAccessor()
             => new TestAccessor(this);
 
-        public struct TestAccessor
+        public readonly struct TestAccessor
         {
             private readonly WpfTextBufferVisibilityTracker _visibilityTracker;
 

--- a/src/EditorFeatures/Core/InlineRename/IEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/InlineRename/IEditorInlineRenameService.cs
@@ -18,7 +18,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor
 {
-    internal struct InlineRenameLocation
+    internal readonly struct InlineRenameLocation
     {
         public Document Document { get; }
         public TextSpan TextSpan { get; }
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor
         Allowed
     }
 
-    internal struct InlineRenameReplacement
+    internal readonly struct InlineRenameReplacement
     {
         public InlineRenameReplacementKind Kind { get; }
         public TextSpan OriginalSpan { get; }

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -651,7 +651,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 }
             }
 
-            private struct SelectionTracking : IDisposable
+            private readonly struct SelectionTracking : IDisposable
             {
                 private readonly int? _anchor;
                 private readonly int? _active;

--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -945,7 +945,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         internal TestAccessor GetTestAccessor()
             => new TestAccessor(this);
 
-        public struct TestAccessor
+        public readonly struct TestAccessor
         {
             private readonly InlineRenameSession _inlineRenameSession;
 

--- a/src/EditorFeatures/Core/InlineRename/RenameTrackingSpan.cs
+++ b/src/EditorFeatures/Core/InlineRename/RenameTrackingSpan.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 {
-    internal struct RenameTrackingSpan
+    internal readonly struct RenameTrackingSpan
     {
         public readonly ITrackingSpan TrackingSpan;
         public readonly RenameSpanKind Type;

--- a/src/EditorFeatures/Core/IntelliSense/ViewTextSpan.cs
+++ b/src/EditorFeatures/Core/IntelliSense/ViewTextSpan.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
     /// which need to be mapped to ViewTextSpans before comparing to view positions
     /// such as the current caret location.
     /// </summary>
-    internal struct ViewTextSpan
+    internal readonly struct ViewTextSpan
     {
         public readonly TextSpan TextSpan;
 
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
             => this.TextSpan = textSpan;
     }
 
-    internal struct DisconnectedBufferGraph
+    internal readonly struct DisconnectedBufferGraph
     {
         // The subject buffer's snapshot at the point of the initial model's creation
         public readonly ITextSnapshot SubjectBufferSnapshot;

--- a/src/EditorFeatures/Core/NavigationBar/NavigationBarController.cs
+++ b/src/EditorFeatures/Core/NavigationBar/NavigationBarController.cs
@@ -305,7 +305,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigationBar
             StartModelUpdateAndSelectedItemUpdateTasks();
         }
 
-        public struct TestAccessor
+        public readonly struct TestAccessor
         {
             private readonly NavigationBarController _navigationBarController;
 

--- a/src/EditorFeatures/Core/Shared/Utilities/VirtualTreePoint.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/VirtualTreePoint.cs
@@ -9,7 +9,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
 {
-    internal struct VirtualTreePoint : IComparable<VirtualTreePoint>, IEquatable<VirtualTreePoint>
+    internal readonly struct VirtualTreePoint : IComparable<VirtualTreePoint>, IEquatable<VirtualTreePoint>
     {
         private readonly SyntaxTree _tree;
         private readonly SourceText _text;

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/RudeEditDiagnosticDescription.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/RudeEditDiagnosticDescription.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 {
-    internal struct RudeEditDiagnosticDescription : IEquatable<RudeEditDiagnosticDescription>
+    internal readonly struct RudeEditDiagnosticDescription : IEquatable<RudeEditDiagnosticDescription>
     {
         private readonly RudeEditKind _rudeEditKind;
         private readonly string _firstLine;

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.InitializationOptions.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.InitializationOptions.cs
@@ -11,7 +11,7 @@ namespace Roslyn.Test.Utilities
 {
     public abstract partial class AbstractLanguageServerProtocolTests
     {
-        internal record struct InitializationOptions()
+        internal readonly record struct InitializationOptions()
         {
             internal string[] SourceGeneratedMarkups { get; init; } = Array.Empty<string>();
             internal LSP.ClientCapabilities ClientCapabilities { get; init; } = new LSP.ClientCapabilities();

--- a/src/EditorFeatures/TestUtilities/SignatureHelp/SignatureHelpTestItem.cs
+++ b/src/EditorFeatures/TestUtilities/SignatureHelp/SignatureHelpTestItem.cs
@@ -7,7 +7,7 @@ using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
 {
-    public struct SignatureHelpTestItem
+    public readonly struct SignatureHelpTestItem
     {
         /// <summary>
         /// Includes prefix, signature, suffix.

--- a/src/Features/CSharp/Portable/ChangeSignature/UnifiedArgumentSyntax.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/UnifiedArgumentSyntax.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
 {
-    internal struct UnifiedArgumentSyntax : IUnifiedArgumentSyntax
+    internal readonly struct UnifiedArgumentSyntax : IUnifiedArgumentSyntax
     {
         private readonly SyntaxNode _argument;
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationNameCompletionProvider.DeclarationInfo.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 {
     internal partial class DeclarationNameCompletionProvider
     {
-        internal struct NameDeclarationInfo
+        internal readonly struct NameDeclarationInfo
         {
             private static readonly ImmutableArray<SymbolKindOrTypeKind> s_parameterSyntaxKind =
                 ImmutableArray.Create(new SymbolKindOrTypeKind(SymbolKind.Parameter));

--- a/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.AddConstructorParameterResult.cs
+++ b/src/Features/Core/Portable/AddConstructorParametersFromMembers/AddConstructorParametersFromMembersCodeRefactoringProvider.AddConstructorParameterResult.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.AddConstructorParametersFromMembers
 {
     internal partial class AddConstructorParametersFromMembersCodeRefactoringProvider
     {
-        private struct AddConstructorParameterResult
+        private readonly struct AddConstructorParameterResult
         {
             internal readonly ImmutableArray<AddConstructorParametersCodeAction> RequiredParameterActions;
             internal readonly ImmutableArray<AddConstructorParametersCodeAction> OptionalParameterActions;

--- a/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractEmbeddedLanguageClassificationService.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractEmbeddedLanguageClassificationService.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Classification
             worker.Recurse(root);
         }
 
-        private ref struct Worker
+        private readonly ref struct Worker
         {
             private readonly AbstractEmbeddedLanguageClassificationService _owner;
             private readonly Project _project;

--- a/src/Features/Core/Portable/EmbeddedLanguages/Classification/EmbeddedLanguageClassifierContext.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Classification/EmbeddedLanguageClassifierContext.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Classification
 {
-    internal struct EmbeddedLanguageClassificationContext
+    internal readonly struct EmbeddedLanguageClassificationContext
     {
         private readonly ArrayBuilder<ClassifiedSpan> _result;
 

--- a/src/Features/Core/Portable/Intents/IntentResult.cs
+++ b/src/Features/Core/Portable/Intents/IntentResult.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Features.Intents
     /// <summary>
     /// Defines the text changes needed to apply an intent.
     /// </summary>
-    internal struct IntentProcessorResult
+    internal readonly struct IntentProcessorResult
     {
         /// <summary>
         /// The changed solution for this intent result.

--- a/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.TokenInfo.cs
+++ b/src/Features/Core/Portable/QuickInfo/CommonSemanticQuickInfoProvider.TokenInfo.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.QuickInfo
 {
     internal abstract partial class CommonSemanticQuickInfoProvider
     {
-        public struct TokenInformation
+        public readonly struct TokenInformation
         {
             public readonly ImmutableArray<ISymbol> Symbols;
 

--- a/src/Features/Core/Portable/Snippets/SnippetData.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetData.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Snippets
     /// Avoids using the Snippet and creating a TextChange/finding cursor
     /// position before we know it was the selected CompletionItem.
     /// </summary>
-    internal struct SnippetData
+    internal readonly struct SnippetData
     {
         public readonly string Description;
         public readonly string SnippetIdentifier;

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerProgressReporter.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerProgressReporter.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             private void OnProgressChanged(ProgressData progressData)
                 => ProgressChanged?.Invoke(this, progressData);
 
-            private struct ProgressStatusRAII : IDisposable
+            private readonly struct ProgressStatusRAII : IDisposable
             {
                 private readonly SolutionCrawlerProgressReporter _owner;
 

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckSpanService.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckSpanService.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.SpellCheck
             return spans.ToImmutable();
         }
 
-        private ref struct Worker
+        private readonly ref struct Worker
         {
             private readonly ISyntaxFactsService _syntaxFacts;
             private readonly ISyntaxKinds _syntaxKinds;

--- a/src/Features/LanguageServer/Protocol/Handler/BufferedProgress.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/BufferedProgress.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
     /// expected to be.  Namely, multiple client can be calling <see cref="IProgress{T}.Report(T)"/> on it at the same
     /// time.  This is safe, though the order that the items are reported in when called concurrently is not specified.
     /// </summary>
-    internal struct BufferedProgress<T> : IProgress<T[]>, IProgress<T>, IDisposable
+    internal readonly struct BufferedProgress<T> : IProgress<T[]>, IProgress<T>, IDisposable
     {
         /// <summary>
         /// The progress stream to report results to.  May be <see langword="null"/> for clients that do not support streaming.

--- a/src/Features/Lsif/Generator/Graph/Id.cs
+++ b/src/Features/Lsif/Generator/Graph/Id.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph
     /// </summary>
     /// <typeparam name="T">Used to distinguish what type of object this ID applies to. This is dropped in serialization, but simply helps
     /// to ensure type safety in the code so we don't cross IDs of different types.</typeparam>
-    internal struct Id<T> : IEquatable<Id<T>>, ISerializableId where T : Element
+    internal readonly struct Id<T> : IEquatable<Id<T>>, ISerializableId where T : Element
     {
         public Id(int id)
         {

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/HACK_VariantStructure.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/HACK_VariantStructure.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
     /// it to null instead of true.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    internal struct HACK_VariantStructure
+    internal readonly struct HACK_VariantStructure
     {
         private readonly short _type;
 

--- a/src/VisualStudio/Core/Def/Diagnostics/VisualStudioVenusSpanMappingService.cs
+++ b/src/VisualStudio/Core/Def/Diagnostics/VisualStudioVenusSpanMappingService.cs
@@ -263,7 +263,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             return false;
         }
 
-        private struct MappedSpan
+        private readonly struct MappedSpan
         {
             private readonly int _originalLine;
             private readonly int _originalColumn;

--- a/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/VSTypeScriptContainedDocumentWrapper.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/VSTypeScriptContainedDocumentWrapper.cs
@@ -13,7 +13,7 @@ using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Api
 {
-    internal struct VSTypeScriptContainedDocumentWrapper
+    internal readonly struct VSTypeScriptContainedDocumentWrapper
     {
         private readonly ContainedDocument _underlyingObject;
 

--- a/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/VSTypeScriptContainedLanguageWrapper.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/VSTypeScriptContainedLanguageWrapper.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.TextManager.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Api
 {
-    internal struct VSTypeScriptContainedLanguageWrapper
+    internal readonly struct VSTypeScriptContainedLanguageWrapper
     {
         private readonly ContainedLanguage _underlyingObject;
 

--- a/src/VisualStudio/Core/Def/Interop/ComHandle.cs
+++ b/src/VisualStudio/Core/Def/Interop/ComHandle.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interop
     /// </summary>
     /// <typeparam name="THandle">The COM interface type to keep a reference to</typeparam>
     /// <typeparam name="TObject">The managed object type to keep a reference to</typeparam>
-    internal struct ComHandle<THandle, TObject>
+    internal readonly struct ComHandle<THandle, TObject>
         where THandle : class
         where TObject : class, THandle
     {

--- a/src/VisualStudio/Core/Def/Interop/WeakComHandle.cs
+++ b/src/VisualStudio/Core/Def/Interop/WeakComHandle.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interop
 {
-    internal struct WeakComHandle<THandle, TObject>
+    internal readonly struct WeakComHandle<THandle, TObject>
         where THandle : class
         where TObject : class, THandle
     {

--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerService.ProjectState.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerService.ProjectState.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
 {
     internal partial class PackageInstallerService
     {
-        private struct ProjectState
+        private readonly struct ProjectState
         {
             public static readonly ProjectState Disabled = new(isEnabled: false, ImmutableDictionary<string, string>.Empty);
 

--- a/src/VisualStudio/Core/Def/Shared/VisualStudioImageIdService.cs
+++ b/src/VisualStudio/Core/Def/Shared/VisualStudioImageIdService.cs
@@ -24,7 +24,7 @@ using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Shared
 {
-    internal struct CompositeImage
+    internal readonly struct CompositeImage
     {
         public readonly ImmutableArray<ImageCompositionLayer> Layers;
         public readonly IImageHandle ImageHandle;

--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.CacheEntry.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.CacheEntry.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 {
     internal sealed partial class CodeModelProjectCache
     {
-        private struct CacheEntry
+        private readonly struct CacheEntry
         {
             // NOTE: The logic here is a little bit tricky.  We can't just keep a WeakReference to
             // something like a ComHandle, since it's not something that our clients keep alive.

--- a/src/VisualStudio/Core/Impl/CodeModel/GlobalNodeKey.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/GlobalNodeKey.cs
@@ -8,7 +8,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 {
-    internal struct GlobalNodeKey
+    internal readonly struct GlobalNodeKey
     {
         public readonly SyntaxNodeKey NodeKey;
         public readonly SyntaxPath Path;

--- a/src/VisualStudio/Core/Impl/CodeModel/MethodXml/AbstractMethodXmlBuilder.AttributeInfo.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/MethodXml/AbstractMethodXmlBuilder.AttributeInfo.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Metho
 {
     internal abstract partial class AbstractMethodXmlBuilder
     {
-        private struct AttributeInfo
+        private readonly struct AttributeInfo
         {
             public static readonly AttributeInfo Empty = new AttributeInfo();
 

--- a/src/VisualStudio/Core/Impl/CodeModel/ParentHandle.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ParentHandle.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 {
-    internal struct ParentHandle<T>
+    internal readonly struct ParentHandle<T>
     {
         private readonly ComHandle<object, object> _comHandle;
 

--- a/src/VisualStudio/Core/Impl/CodeModel/SyntaxNodeKey.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/SyntaxNodeKey.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
     /// ordinal value. The ordinal value is used to distinguish nodes which have the same
     /// qualified name -- for example, across partial classes within the same tree.
     /// </summary>
-    internal struct SyntaxNodeKey : IEquatable<SyntaxNodeKey>
+    internal readonly struct SyntaxNodeKey : IEquatable<SyntaxNodeKey>
     {
         private readonly string _name;
         private readonly int _ordinal;

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InputKey.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InputKey.cs
@@ -8,7 +8,7 @@ using WindowsInput.Native;
 
 namespace Roslyn.VisualStudio.IntegrationTests.InProcess
 {
-    internal struct InputKey
+    internal readonly struct InputKey
     {
         public readonly ImmutableArray<VirtualKeyCode> Modifiers;
         public readonly VirtualKeyCode VirtualKeyCode;

--- a/src/VisualStudio/Xaml/Impl/Features/Completion/XamlCompletionContext.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/Completion/XamlCompletionContext.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml.Features.Completion
     /// <summary>
     /// Contextual information needed for processing completion requests.
     /// </summary>
-    internal struct XamlCompletionContext
+    internal readonly struct XamlCompletionContext
     {
         public XamlCompletionContext(TextDocument document, int offset, char triggerChar = '\0')
         {

--- a/src/VisualStudio/Xaml/Impl/Features/DocumentSpan.cs
+++ b/src/VisualStudio/Xaml/Impl/Features/DocumentSpan.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.Editor.Xaml.Features
 {
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
-    internal struct DocumentSpan
+    internal readonly struct DocumentSpan
     {
         public Document Document { get; }
         public TextSpan TextSpan { get; }

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
     /// artifacts T T is normally either ClassificationSpan or a Tuple (for testing purposes) 
     /// and constructed via provided factory.
     /// </summary>
-    internal ref partial struct Worker
+    internal readonly ref partial struct Worker
     {
         private readonly TextSpan _textSpan;
         private readonly ArrayBuilder<ClassifiedSpan> _result;

--- a/src/Workspaces/Core/Desktop/Workspace/Host/Mef/MefV1HostServices.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/Host/Mef/MefV1HostServices.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
         internal TestAccessor GetTestAccessor()
             => new TestAccessor(this);
 
-        private struct ExportKey : IEquatable<ExportKey>
+        private readonly struct ExportKey : IEquatable<ExportKey>
         {
             internal readonly string ExtensionTypeName;
             internal readonly string MetadataTypeName;

--- a/src/Workspaces/Core/MSBuild/MSBuild/ProjectLoadProgress.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/ProjectLoadProgress.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
     /// <summary>
     /// Provides details as a project is loaded.
     /// </summary>
-    public struct ProjectLoadProgress
+    public readonly struct ProjectLoadProgress
     {
         /// <summary>
         /// The project for which progress is being reported.

--- a/src/Workspaces/Core/Portable/Classification/ClassifiedSpan.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassifiedSpan.cs
@@ -8,7 +8,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Classification
 {
-    public struct ClassifiedSpan : IEquatable<ClassifiedSpan>
+    public readonly struct ClassifiedSpan : IEquatable<ClassifiedSpan>
     {
         public string ClassificationType { get; }
         public TextSpan TextSpan { get; }

--- a/src/Workspaces/Core/Portable/Classification/ClassifiedText.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassifiedText.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CodeAnalysis.Classification
 {
-    internal struct ClassifiedText
+    internal readonly struct ClassifiedText
     {
         public string ClassificationType { get; }
         public string Text { get; }

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResult.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResult.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
     /// This holds onto diagnostics for a specific version of project snapshot
     /// in a way each kind of diagnostics can be queried fast.
     /// </summary>
-    internal struct DiagnosticAnalysisResult
+    internal readonly struct DiagnosticAnalysisResult
     {
         public readonly bool FromBuild;
         public readonly ProjectId ProjectId;

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultMap.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticAnalysisResultMap.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.Diagnostics
         }
     }
 
-    internal struct DiagnosticAnalysisResultMap<TKey, TValue>
+    internal readonly struct DiagnosticAnalysisResultMap<TKey, TValue>
         where TKey : notnull
     {
         public static readonly DiagnosticAnalysisResultMap<TKey, TValue> Empty = new(

--- a/src/Workspaces/Core/Portable/Differencing/Edit.cs
+++ b/src/Workspaces/Core/Portable/Differencing/Edit.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Differencing
     /// </summary>
     /// <typeparam name="TNode">Tree node.</typeparam>
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
-    public struct Edit<TNode> : IEquatable<Edit<TNode>>
+    public readonly struct Edit<TNode> : IEquatable<Edit<TNode>>
     {
         private readonly TreeComparer<TNode> _comparer;
         private readonly EditKind _kind;

--- a/src/Workspaces/Core/Portable/Differencing/SequenceEdit.cs
+++ b/src/Workspaces/Core/Portable/Differencing/SequenceEdit.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Differencing
     /// Represents an edit operation on a sequence of values.
     /// </summary>
     [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
-    internal struct SequenceEdit : IEquatable<SequenceEdit>
+    internal readonly struct SequenceEdit : IEquatable<SequenceEdit>
     {
         private readonly int _oldIndex;
         private readonly int _newIndex;

--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Internal.Editing
 namespace Microsoft.CodeAnalysis.Editing
 #endif
 {
-    public struct DeclarationModifiers : IEquatable<DeclarationModifiers>
+    public readonly struct DeclarationModifiers : IEquatable<DeclarationModifiers>
     {
         private readonly Modifiers _modifiers;
 

--- a/src/Workspaces/Core/Portable/ErrorReporting/InfoBarUI.cs
+++ b/src/Workspaces/Core/Portable/ErrorReporting/InfoBarUI.cs
@@ -8,7 +8,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ErrorReporting
 {
-    internal struct InfoBarUI
+    internal readonly struct InfoBarUI
     {
         public readonly string? Title;
         public readonly UIKind Kind;

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         /// these to <see cref="Node"/>s.
         /// </summary>
         [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
-        private struct BuilderNode
+        private readonly struct BuilderNode
         {
             public static readonly BuilderNode RootNode = new("", RootNodeParentIndex, default);
 
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         }
 
         [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
-        private struct Node
+        private readonly struct Node
         {
             /// <summary>
             /// The Name of this Node.

--- a/src/Workspaces/Core/Portable/Log/StatisticResult.cs
+++ b/src/Workspaces/Core/Portable/Log/StatisticResult.cs
@@ -9,7 +9,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Internal.Log
 {
-    internal struct StatisticResult
+    internal readonly struct StatisticResult
     {
         public static StatisticResult FromList(List<int> values)
         {

--- a/src/Workspaces/Core/Portable/PatternMatching/CamelCaseResult.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/CamelCaseResult.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.PatternMatching
 {
     internal partial class PatternMatcher
     {
-        private struct CamelCaseResult
+        private readonly struct CamelCaseResult
         {
             public readonly bool FromStart;
             public readonly bool Contiguous;

--- a/src/Workspaces/Core/Portable/PatternMatching/PatternMatch.cs
+++ b/src/Workspaces/Core/Portable/PatternMatching/PatternMatch.cs
@@ -9,7 +9,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.PatternMatching
 {
-    internal struct PatternMatch : IComparable<PatternMatch>
+    internal readonly struct PatternMatch : IComparable<PatternMatch>
     {
         /// <summary>
         /// True if this was a case sensitive match.

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
             private SymbolRenameOptions RenameOptions => _renameLocationSet.Options;
             private CodeCleanupOptionsProvider FallbackOptions => _renameLocationSet.FallbackOptions;
 
-            private struct ConflictLocationInfo
+            private readonly struct ConflictLocationInfo
             {
                 // The span of the Node that needs to be complexified 
                 public readonly TextSpan ComplexifiedSpan;

--- a/src/Workspaces/Core/Portable/Rename/RenameLocation.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocation.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Rename
 {
-    internal struct RenameLocation : IEquatable<RenameLocation>
+    internal readonly struct RenameLocation : IEquatable<RenameLocation>
     {
         public readonly Location Location;
         public readonly DocumentId DocumentId;

--- a/src/Workspaces/Core/Portable/Shared/Extensions/TokenSemanticInfo.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/TokenSemanticInfo.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions
 {
-    internal struct TokenSemanticInfo
+    internal readonly struct TokenSemanticInfo
     {
         public static readonly TokenSemanticInfo Empty = new(
             null, null, ImmutableArray<ISymbol>.Empty, null, null, default);

--- a/src/Workspaces/Core/Portable/Shared/Utilities/EditorBrowsableHelpers.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/EditorBrowsableHelpers.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 {
     internal static class EditorBrowsableHelpers
     {
-        public struct EditorBrowsableInfo
+        public readonly struct EditorBrowsableInfo
         {
             public Compilation Compilation { get; }
             public INamedTypeSymbol? HideModuleNameAttribute { get; }

--- a/src/Workspaces/Core/Portable/SolutionCrawler/InvocationReasons_Constants.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/InvocationReasons_Constants.cs
@@ -8,7 +8,7 @@ using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.SolutionCrawler
 {
-    internal partial struct InvocationReasons
+    internal readonly partial struct InvocationReasons
     {
         public static readonly InvocationReasons DocumentAdded =
             new(

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/Interop/ResettableSqlStatement.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/Interop/ResettableSqlStatement.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2.Interop
     /// as it will happen to all prepared statemnets when the <see cref="SqlStatement"/> is
     /// <see cref="SqlStatement.Close_OnlyForUseBySqlConnection"/>d.
     /// </summary>
-    internal struct ResettableSqlStatement : IDisposable
+    internal readonly struct ResettableSqlStatement : IDisposable
     {
         public readonly SqlStatement Statement;
 

--- a/src/Workspaces/Core/Portable/Utilities/FlowControlHelper.cs
+++ b/src/Workspaces/Core/Portable/Utilities/FlowControlHelper.cs
@@ -12,7 +12,7 @@ namespace Roslyn.Utilities
         public static AsyncFlowControlHelper TrySuppressFlow()
             => new(ExecutionContext.IsFlowSuppressed() ? default : ExecutionContext.SuppressFlow());
 
-        public struct AsyncFlowControlHelper : IDisposable
+        public readonly struct AsyncFlowControlHelper : IDisposable
         {
             private readonly AsyncFlowControl _asyncFlowControl;
 

--- a/src/Workspaces/Core/Portable/Utilities/ParameterName.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ParameterName.cs
@@ -11,7 +11,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Utilities
 {
-    internal struct ParameterName : IEquatable<ParameterName>
+    internal readonly struct ParameterName : IEquatable<ParameterName>
     {
         /// <summary>
         /// The name the underlying naming system came up with based on the argument itself.

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/IDocumentExcerptService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/IDocumentExcerptService.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Host
     /// <summary>
     /// Result of excerpt
     /// </summary>
-    internal struct ExcerptResult
+    internal readonly struct ExcerptResult
     {
         /// <summary>
         /// excerpt content

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/ISpanMappingService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/ISpanMappingService.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Host
     /// <summary>
     /// Result of span mapping
     /// </summary>
-    internal struct MappedSpanResult
+    internal readonly struct MappedSpanResult
     {
         /// <summary>
         /// Path to mapped file

--- a/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/NoOpPersistentStorage.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/PersistentStorage/NoOpPersistentStorage.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Host
         public Task<bool> WriteStreamAsync(DocumentKey documentKey, string name, Stream stream, Checksum checksum, CancellationToken cancellationToken)
             => SpecializedTasks.False;
 
-        public struct TestAccessor
+        public readonly struct TestAccessor
         {
             public static readonly IChecksummedPersistentStorage StorageInstance = Instance;
         }

--- a/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Host
 {
     internal abstract partial class AbstractSyntaxTreeFactoryService
     {
-        internal struct SyntaxTreeInfo
+        internal readonly struct SyntaxTreeInfo
         {
             public readonly string FilePath;
             public readonly ParseOptions Options;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectChanges.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectChanges.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis
 {
-    public struct ProjectChanges
+    public readonly struct ProjectChanges
     {
         private readonly Project _newProject;
         private readonly Project _oldProject;

--- a/src/Workspaces/Remote/Core/VisualStudioMefHostServices.cs
+++ b/src/Workspaces/Remote/Core/VisualStudioMefHostServices.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Host.Mef
             return (IEnumerable<Lazy<TExtension>>)exports;
         }
 
-        private struct ExportKey : IEquatable<ExportKey>
+        private readonly struct ExportKey : IEquatable<ExportKey>
         {
             internal readonly string ExtensionTypeName;
             internal readonly string MetadataTypeName;

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/IPerformanceTrackerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/IPerformanceTrackerService.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
         event EventHandler SnapshotAdded;
     }
 
-    internal struct ExpensiveAnalyzerInfo
+    internal readonly struct ExpensiveAnalyzerInfo
     {
         public readonly bool BuiltIn;
         public readonly string AnalyzerId;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/MemberDeclarationSyntaxExtensions.LocalDeclarationMap.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/MemberDeclarationSyntaxExtensions.LocalDeclarationMap.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 {
     internal partial class MemberDeclarationSyntaxExtensions
     {
-        public struct LocalDeclarationMap
+        public readonly struct LocalDeclarationMap
         {
             private readonly Dictionary<string, ImmutableArray<SyntaxToken>> _dictionary;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/TypeStyle/CSharpTypeStyleHelper.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/TypeStyle/CSharpTypeStyleHelper.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.CodeAnalysis.CSharp.Utilities
 {
-    internal struct TypeStyleResult
+    internal readonly struct TypeStyleResult
     {
         private readonly CSharpTypeStyleHelper _helper;
         private readonly TypeSyntax _typeName;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/Common/EmbeddedDiagnostic.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/Common/EmbeddedDiagnostic.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.Common
     /// for the range of characters for '\\p{0}' (even though the regex engine would only see the \\ 
     /// translated as a virtual char to the single \ character.
     /// </summary>
-    internal struct EmbeddedDiagnostic : IEquatable<EmbeddedDiagnostic>
+    internal readonly struct EmbeddedDiagnostic : IEquatable<EmbeddedDiagnostic>
     {
         public readonly string Message;
         public readonly TextSpan Span;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/Common/EmbeddedSyntaxNodeOrToken.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/Common/EmbeddedSyntaxNodeOrToken.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.EmbeddedLanguages.Common
 {
-    internal struct EmbeddedSyntaxNodeOrToken<TSyntaxKind, TSyntaxNode>
+    internal readonly struct EmbeddedSyntaxNodeOrToken<TSyntaxKind, TSyntaxNode>
         where TSyntaxKind : struct
         where TSyntaxNode : EmbeddedSyntaxNode<TSyntaxKind, TSyntaxNode>
     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/Common/EmbeddedSyntaxToken.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/Common/EmbeddedSyntaxToken.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.EmbeddedLanguages.Common
 {
-    internal struct EmbeddedSyntaxToken<TSyntaxKind> where TSyntaxKind : struct
+    internal readonly struct EmbeddedSyntaxToken<TSyntaxKind> where TSyntaxKind : struct
     {
         public readonly TSyntaxKind Kind;
         public readonly ImmutableArray<EmbeddedSyntaxTrivia<TSyntaxKind>> LeadingTrivia;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/Common/EmbeddedSyntaxTrivia.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/Common/EmbeddedSyntaxTrivia.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.Common
     /// <summary>
     /// Trivia on an <see cref="EmbeddedSyntaxToken{TSyntaxKind}"/>.
     /// </summary>
-    internal struct EmbeddedSyntaxTrivia<TSyntaxKind> where TSyntaxKind : struct
+    internal readonly struct EmbeddedSyntaxTrivia<TSyntaxKind> where TSyntaxKind : struct
     {
         public readonly TSyntaxKind Kind;
         public readonly VirtualCharSequence VirtualChars;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequence.Chunks.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/EmbeddedLanguages/VirtualChars/VirtualCharSequence.Chunks.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars
 {
-    internal partial struct VirtualCharSequence
+    internal readonly partial struct VirtualCharSequence
     {
         /// <summary>
         /// Abstraction over a contiguous chunk of <see cref="VirtualChar"/>s.  This

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SyntaxNodeExtensions.cs
@@ -834,7 +834,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static ValueAncestorsAndSelfEnumerable ValueAncestorsAndSelf(this SyntaxNode syntaxNode, bool ascendOutOfTrivia = true)
             => new(syntaxNode, ascendOutOfTrivia);
 
-        public struct ValueAncestorsAndSelfEnumerable
+        public readonly struct ValueAncestorsAndSelfEnumerable
         {
             private readonly SyntaxNode _syntaxNode;
             private readonly bool _ascendOutOfTrivia;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenPairWithOperations.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenPairWithOperations.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Formatting
     /// <summary>
     /// it holds onto space and wrapping operation need to run between two tokens.
     /// </summary>
-    internal struct TokenPairWithOperations
+    internal readonly struct TokenPairWithOperations
     {
         public TokenStream TokenStream { get; }
         public AdjustSpacesOperation? SpaceOperation { get; }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Indentation/AbstractIndentation.Indenter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Indentation/AbstractIndentation.Indenter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Indentation
 {
     internal abstract partial class AbstractIndentation<TSyntaxRoot>
     {
-        protected struct Indenter
+        protected readonly struct Indenter
         {
             private readonly AbstractIndentation<TSyntaxRoot> _service;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyle.WordSpanEnumerable.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/NamingStyles/NamingStyle.WordSpanEnumerable.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.NamingStyles
 {
     internal partial record struct NamingStyle
     {
-        private struct WordSpanEnumerable
+        private readonly struct WordSpanEnumerable
         {
             private readonly string _name;
             private readonly TextSpan _nameSpan;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SemanticFacts/ForEachSymbols.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SemanticFacts/ForEachSymbols.cs
@@ -6,7 +6,7 @@
 
 namespace Microsoft.CodeAnalysis.LanguageService
 {
-    internal struct ForEachSymbols
+    internal readonly struct ForEachSymbols
     {
         public readonly IMethodSymbol GetEnumeratorMethod;
         public readonly IMethodSymbol MoveNextMethod;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ExternalSourceInfo.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ExternalSourceInfo.cs
@@ -6,7 +6,7 @@
 
 namespace Microsoft.CodeAnalysis.LanguageService
 {
-    internal struct ExternalSourceInfo
+    internal readonly struct ExternalSourceInfo
     {
         public readonly int? StartLine;
         public readonly bool Ends;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ComparisonOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.ComparisonOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial struct SymbolKey
     {
-        private struct ComparisonOptions
+        private readonly struct ComparisonOptions
         {
             [Flags]
             private enum Option : byte

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.PooledArrayBuilder.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.PooledArrayBuilder.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial struct SymbolKey
     {
-        private ref struct PooledArrayBuilder<T>
+        private readonly ref struct PooledArrayBuilder<T>
         {
             public readonly ArrayBuilder<T> Builder;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKeyResolution.Enumeration.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKeyResolution.Enumeration.cs
@@ -4,9 +4,9 @@
 
 namespace Microsoft.CodeAnalysis
 {
-    internal partial struct SymbolKeyResolution
+    internal readonly partial struct SymbolKeyResolution
     {
-        public struct Enumerable<TSymbol> where TSymbol : ISymbol
+        public readonly struct Enumerable<TSymbol> where TSymbol : ISymbol
         {
             private readonly SymbolKeyResolution _resolution;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKeyResolution.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKeyResolution.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis
     /// If no symbol can be found <see cref="Symbol"/> will be <c>null</c> and <see cref="CandidateSymbols"/>
     /// will be empty.
     /// </summary>
-    internal partial struct SymbolKeyResolution
+    internal readonly partial struct SymbolKeyResolution
     {
         private readonly ImmutableArray<ISymbol> _candidateSymbols;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/AsyncLazy`1.cs
@@ -129,7 +129,7 @@ namespace Roslyn.Utilities
             return new WaitThatValidatesInvariants(this);
         }
 
-        private struct WaitThatValidatesInvariants : IDisposable
+        private readonly struct WaitThatValidatesInvariants : IDisposable
         {
             private readonly AsyncLazy<T> _asyncLazy;
 
@@ -366,7 +366,7 @@ namespace Roslyn.Utilities
             return new AsynchronousComputationToStart(_asynchronousComputeFunction, _asynchronousComputationCancellationSource);
         }
 
-        private struct AsynchronousComputationToStart
+        private readonly struct AsynchronousComputationToStart
         {
             public readonly Func<CancellationToken, Task<T>> AsynchronousComputeFunction;
             public readonly CancellationTokenSource CancellationTokenSource;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.Edge.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.Edge.cs
@@ -6,7 +6,7 @@ namespace Roslyn.Utilities
 {
     internal partial class BKTree
     {
-        private struct Edge
+        private readonly struct Edge
         {
             // The edit distance between the child and parent connected by this edge.
             // The child can be found in _nodes at ChildNodeIndex. 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.Node.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/BKTree.Node.cs
@@ -8,7 +8,7 @@ namespace Roslyn.Utilities
 {
     internal partial class BKTree
     {
-        private struct Node
+        private readonly struct Node
         {
             /// <summary>
             /// The string this node corresponds to.  Specifically, this span is the range of

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/NonReentrantLock.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/NonReentrantLock.cs
@@ -240,7 +240,7 @@ namespace Roslyn.Utilities
         /// <summary>
         /// Since we want to avoid boxing the return from <see cref="NonReentrantLock.DisposableWait"/>, this type must be public.
         /// </summary>
-        public struct SemaphoreDisposer : IDisposable
+        public readonly struct SemaphoreDisposer : IDisposable
         {
             private readonly NonReentrantLock _semaphore;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SyntaxPath.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SyntaxPath.cs
@@ -26,7 +26,7 @@ namespace Roslyn.Utilities
         // segment contains the index of the node in its parent, as well as the kind of the node.
         // The latter is not strictly necessary.  However, it ensures that resolving the path against
         // a different tree will either return the same type of node as the original, or will fail.  
-        protected struct PathSegment
+        protected readonly struct PathSegment
         {
             public int Ordinal { get; }
             public int Kind { get; }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/WordSimilarityChecker.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/WordSimilarityChecker.cs
@@ -10,7 +10,7 @@ namespace Roslyn.Utilities
 {
     internal class WordSimilarityChecker
     {
-        private struct CacheResult
+        private readonly struct CacheResult
         {
             public readonly string CandidateText;
             public readonly bool AreSimilar;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/ITypeInferenceService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/LanguageServices/TypeInferenceService/ITypeInferenceService.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.LanguageService
         ImmutableArray<TypeInferenceInfo> GetTypeInferenceInfo(SemanticModel semanticModel, SyntaxNode expression, string nameOpt, CancellationToken cancellationToken);
     }
 
-    internal struct TypeInferenceInfo
+    internal readonly struct TypeInferenceInfo
     {
         public TypeInferenceInfo(ITypeSymbol type)
         {


### PR DESCRIPTION
From @jaredpar , there shoudl be no downsides here. But this does allow the compiler to prevent unnecessary copies now in places it previously couldn't.