### PR TITLE
Build only test projects and split out building TFMs into separate queues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,8 +38,8 @@ stages:
       testArtifactName: Transport_Artifacts_Windows_Debug_net472
       configuration: Debug
       queueName: Build.Ubuntu.1804.Amd64.Open
-      restoreArguments: --solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
-      buildArguments: --solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+      restoreArguments: --solution src/Test/TestDependencies/TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+      buildArguments: --solution src/Test/TestDependencies/TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
 - stage: Windows_Release_Build_net472
   dependsOn: []
@@ -50,8 +50,8 @@ stages:
       testArtifactName: Transport_Artifacts_Windows_Release_net472
       configuration: Release
       queueName: Build.Ubuntu.1804.Amd64.Open
-      restoreArguments: --solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
-      buildArguments: --solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+      restoreArguments: --solution src/Test/TestDependencies/TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+      buildArguments: --solution src/Test/TestDependencies/TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
 - stage: Windows_Debug_Build_net60_windows
   dependsOn: []
@@ -62,8 +62,8 @@ stages:
       testArtifactName: Transport_Artifacts_Windows_Debug_net60_windows
       configuration: Debug
       queueName: Build.Ubuntu.1804.Amd64.Open
-      restoreArguments: --solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
-      buildArguments: --solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+      restoreArguments: --solution src/Test/TestDependencies/TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+      buildArguments: --solution src/Test/TestDependencies/TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
     
 - stage: Windows_Release_Build_net60_windows
   dependsOn: []
@@ -74,8 +74,8 @@ stages:
       testArtifactName: Transport_Artifacts_Windows_Release_net60_windows
       configuration: Release
       queueName: Build.Ubuntu.1804.Amd64.Open
-      restoreArguments: --solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
-      buildArguments: --solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+      restoreArguments: --solution src/Test/TestDependencies/TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+      buildArguments: --solution src/Test/TestDependencies/TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
       
 - stage: Unix_Build
   dependsOn: []

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ stages:
 - stage: Windows_Debug_Build_net472
   dependsOn: []
   jobs:
-  - template: eng/pipelines/build-windows-on-unix-job
+  - template: eng/pipelines/build-windows-on-unix-job.yml
     parameters:
       jobName: Windows_Debug_Build_net472
       testArtifactName: Transport_Artifacts_Windows_Debug_net472
@@ -44,7 +44,7 @@ stages:
 - stage: Windows_Release_Build_net472
   dependsOn: []
   jobs:
-  - template: eng/pipelines/build-windows-on-unix-job
+  - template: eng/pipelines/build-windows-on-unix-job.yml
     parameters:
       jobName: Windows_Release_Build_net472
       testArtifactName: Transport_Artifacts_Windows_Release_net472
@@ -56,7 +56,7 @@ stages:
 - stage: Windows_Debug_Build_net60_windows
   dependsOn: []
   jobs:
-  - template: eng/pipelines/build-windows-on-unix-job
+  - template: eng/pipelines/build-windows-on-unix-job.yml
     parameters:
       jobName: Windows_Debug_Build_net60_windows
       testArtifactName: Transport_Artifacts_Windows_Debug_net60_windows
@@ -68,7 +68,7 @@ stages:
 - stage: Windows_Release_Build_net60_windows
   dependsOn: []
   jobs:
-  - template: eng/pipelines/build-windows-on-unix-job
+  - template: eng/pipelines/build-windows-on-unix-job.yml
     parameters:
       jobName: Windows_Release_Build_net60_windows
       testArtifactName: Transport_Artifacts_Windows_Release_net60_windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,30 +29,54 @@ pr:
       - README.md
 
 stages:
-- stage: Windows_Debug_Build
+- stage: Windows_Debug_Build_net472
   dependsOn: []
   jobs:
   - template: eng/pipelines/build-windows-job.yml
     parameters:
-      jobName: Build_Windows_Debug
-      testArtifactName: Transport_Artifacts_Windows_Debug
+      jobName: Windows_Debug_Build_net472
+      testArtifactName: Transport_Artifacts_Windows_Debug_net472
       configuration: Debug
       queueName: windows.vs2022preview.amd64.open
-      restoreArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
-      buildArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+      restoreArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+      buildArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
-- stage: Windows_Release_Build
+- stage: Windows_Release_Build_net472
   dependsOn: []
   jobs:
   - template: eng/pipelines/build-windows-job.yml
     parameters:
-      jobName: Build_Windows_Release
-      testArtifactName: Transport_Artifacts_Windows_Release
+      jobName: Windows_Release_Build_net472
+      testArtifactName: Transport_Artifacts_Windows_Release_net472
       configuration: Release
       queueName: windows.vs2022preview.amd64.open
-      restoreArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
-      buildArguments: -msbuildEngine dotnet /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+      restoreArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+      buildArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
+- stage: Windows_Debug_Build_net60_windows
+  dependsOn: []
+  jobs:
+  - template: eng/pipelines/build-windows-job.yml
+    parameters:
+      jobName: Windows_Debug_Build_net60_windows
+      testArtifactName: Transport_Artifacts_Windows_Debug_net60_windows
+      configuration: Debug
+      queueName: Build.Windows.Amd64.VS2022.Pre.Open
+      restoreArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+      buildArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+    
+- stage: Windows_Release_Build_net60_windows
+  dependsOn: []
+  jobs:
+  - template: eng/pipelines/build-windows-job.yml
+    parameters:
+      jobName: Windows_Release_Build_net60_windows
+      testArtifactName: Transport_Artifacts_Windows_Release_net60_windows
+      configuration: Release
+      queueName: Build.Windows.Amd64.VS2022.Pre.Open
+      restoreArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+      buildArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+      
 - stage: Unix_Build
   dependsOn: []
   jobs:
@@ -62,6 +86,8 @@ stages:
       testArtifactName: Transport_Artifacts_Unix_Debug
       configuration: Debug
       queueName: Build.Ubuntu.1804.Amd64.Open
+      restoreArguments: --solution src/Test/TestDependencies/TestDependencies-Compiler.csproj
+      buildArguments: --solution src/Test/TestDependencies/TestDependencies-Compiler.csproj
 
 - stage: Source_Build
   dependsOn: []
@@ -69,14 +95,14 @@ stages:
   - template: eng/common/templates/jobs/source-build.yml
 
 - stage: Windows_Debug_Desktop
-  dependsOn: Windows_Debug_Build
+  dependsOn: Windows_Debug_Build_net472
   jobs:
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - template: eng/pipelines/test-windows-job.yml
       parameters:
         testRunName: 'Test Windows Desktop Debug 32'
         jobName: Test_Windows_Desktop_Debug_32
-        testArtifactName: Transport_Artifacts_Windows_Debug
+        testArtifactName: Transport_Artifacts_Windows_Debug_net472
         configuration: Debug
         testArguments: -testDesktop -testArch x86
 
@@ -84,18 +110,18 @@ stages:
     parameters:
       testRunName: 'Test Windows Desktop Debug 64'
       jobName: Test_Windows_Desktop_Debug_64
-      testArtifactName: Transport_Artifacts_Windows_Debug
+      testArtifactName: Transport_Artifacts_Windows_Debug_net472
       configuration: Debug
       testArguments: -testDesktop -testArch x64
 
 - stage: Windows_Release_Desktop
-  dependsOn: Windows_Release_Build
+  dependsOn: Windows_Release_Build_net472
   jobs:
   - template: eng/pipelines/test-windows-job.yml
     parameters:
       testRunName: 'Test Windows Desktop Release 32'
       jobName: Test_Windows_Desktop_Release_32
-      testArtifactName: Transport_Artifacts_Windows_Release
+      testArtifactName: Transport_Artifacts_Windows_Release_net472
       configuration: Release
       testArguments: -testDesktop -testArch x86
       
@@ -104,7 +130,7 @@ stages:
       parameters:
         testRunName: 'Test Windows Desktop Release 64'
         jobName: Test_Windows_Desktop_Release_64
-        testArtifactName: Transport_Artifacts_Windows_Release
+        testArtifactName: Transport_Artifacts_Windows_Release_net472
         configuration: Release
         testArguments: -testDesktop -testArch x64
 
@@ -112,18 +138,18 @@ stages:
     parameters:
       testRunName: 'Test Windows Desktop Spanish Release 64'
       jobName: Test_Windows_Desktop_Spanish_Release_64
-      testArtifactName: Transport_Artifacts_Windows_Release
+      testArtifactName: Transport_Artifacts_Windows_Release_net472
       configuration: Release
       testArguments: -testDesktop -testArch x64 -helixQueueName Windows.10.Amd64.Server2022.ES.Open
 
 - stage: Windows_Debug_CoreClr
-  dependsOn: Windows_Debug_Build
+  dependsOn: Windows_Debug_Build_net60_windows
   jobs:
   - template: eng/pipelines/test-windows-job.yml
     parameters:
       testRunName: 'Test Windows CoreClr Debug'
       jobName: Test_Windows_CoreClr_Debug
-      testArtifactName: Transport_Artifacts_Windows_Debug
+      testArtifactName: Transport_Artifacts_Windows_Debug_net60_windows
       configuration: Debug
       testArguments: -testCoreClr
 
@@ -132,7 +158,7 @@ stages:
       parameters:
         testRunName: 'Test Windows CoreClr Debug Single Machine'
         jobName: Test_Windows_CoreClr_Debug_Single_Machine
-        testArtifactName: Transport_Artifacts_Windows_Debug
+        testArtifactName: Transport_Artifacts_Windows_Debug_net60_windows
         configuration: Debug
         testArguments: -testCoreClr
 
@@ -140,7 +166,7 @@ stages:
     parameters:
       testRunName: 'Test Windows CoreCLR IOperation Debug'
       jobName: Test_Windows_CoreClr_IOperation_Debug
-      testArtifactName: Transport_Artifacts_Windows_Debug
+      testArtifactName: Transport_Artifacts_Windows_Debug_net60_windows
       configuration: Debug
       testArguments: -testCoreClr -testIOperation -testCompilerOnly
 
@@ -150,18 +176,18 @@ stages:
     parameters:
       testRunName: 'Test Windows CoreCLR UsedAssemblies Debug'
       jobName: Test_Windows_CoreClr_UsedAssemblies_Debug
-      testArtifactName: Transport_Artifacts_Windows_Debug
+      testArtifactName: Transport_Artifacts_Windows_Debug_net60_windows
       configuration: Debug
       testArguments: -testCoreClr -testUsedAssemblies -testCompilerOnly
 
 - stage: Windows_Release_CoreClr
-  dependsOn: Windows_Release_Build
+  dependsOn: Windows_Release_Build_net60_windows
   jobs:
   - template: eng/pipelines/test-windows-job.yml
     parameters:
       testRunName: 'Test Windows CoreClr Release'
       jobName: Test_Windows_CoreClr_Release
-      testArtifactName: Transport_Artifacts_Windows_Release
+      testArtifactName: Transport_Artifacts_Windows_Release_net60_windows
       configuration: Release
       testArguments: -testCoreClr
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,50 +32,50 @@ stages:
 - stage: Windows_Debug_Build_net472
   dependsOn: []
   jobs:
-  - template: eng/pipelines/build-windows-job.yml
+  - template: eng/pipelines/build-windows-on-unix-job
     parameters:
       jobName: Windows_Debug_Build_net472
       testArtifactName: Transport_Artifacts_Windows_Debug_net472
       configuration: Debug
-      queueName: windows.vs2022preview.amd64.open
-      restoreArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
-      buildArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+      queueName: Build.Ubuntu.1804.Amd64.Open
+      restoreArguments: --solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+      buildArguments: --solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
 - stage: Windows_Release_Build_net472
   dependsOn: []
   jobs:
-  - template: eng/pipelines/build-windows-job.yml
+  - template: eng/pipelines/build-windows-on-unix-job
     parameters:
       jobName: Windows_Release_Build_net472
       testArtifactName: Transport_Artifacts_Windows_Release_net472
       configuration: Release
-      queueName: windows.vs2022preview.amd64.open
-      restoreArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
-      buildArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+      queueName: Build.Ubuntu.1804.Amd64.Open
+      restoreArguments: --solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+      buildArguments: --solution src\Test\TestDependencies\TestDependencies-net472.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
 
 - stage: Windows_Debug_Build_net60_windows
   dependsOn: []
   jobs:
-  - template: eng/pipelines/build-windows-job.yml
+  - template: eng/pipelines/build-windows-on-unix-job
     parameters:
       jobName: Windows_Debug_Build_net60_windows
       testArtifactName: Transport_Artifacts_Windows_Debug_net60_windows
       configuration: Debug
-      queueName: Build.Windows.Amd64.VS2022.Pre.Open
-      restoreArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
-      buildArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+      queueName: Build.Ubuntu.1804.Amd64.Open
+      restoreArguments: --solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+      buildArguments: --solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
     
 - stage: Windows_Release_Build_net60_windows
   dependsOn: []
   jobs:
-  - template: eng/pipelines/build-windows-job.yml
+  - template: eng/pipelines/build-windows-on-unix-job
     parameters:
       jobName: Windows_Release_Build_net60_windows
       testArtifactName: Transport_Artifacts_Windows_Release_net60_windows
       configuration: Release
-      queueName: Build.Windows.Amd64.VS2022.Pre.Open
-      restoreArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
-      buildArguments: -msbuildEngine dotnet -solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
+      queueName: Build.Ubuntu.1804.Amd64.Open
+      restoreArguments: --solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false
+      buildArguments: --solution src\Test\TestDependencies\TestDependencies-net6.csproj /p:UsingToolPdbConverter=false /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false
       
 - stage: Unix_Build
   dependsOn: []

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -47,6 +47,7 @@ param (
   [switch]$oop64bit = $true,
   [switch]$oopCoreClr = $false,
   [switch]$lspEditor = $false,
+  [string]$solution = "Roslyn.sln",
 
   # official build settings
   [string]$officialBuildId = "",
@@ -209,7 +210,6 @@ function Process-Arguments() {
 }
 
 function BuildSolution() {
-  $solution = "Roslyn.sln"
 
   Write-Host "$($solution):"
 

--- a/eng/pipelines/build-unix-job.yml
+++ b/eng/pipelines/build-unix-job.yml
@@ -15,6 +15,13 @@ parameters:
 - name: vmImageName
   type: string
   default: ''
+- name: restoreArguments
+  type: string
+  default: ''
+- name: buildArguments
+  type: string
+  default: ''
+  
 
 jobs:
 - job: ${{ parameters.jobName }}
@@ -30,10 +37,10 @@ jobs:
   steps:
     - template: checkout-unix-task.yml
 
-    - script: ./eng/build.sh --ci --restore --prepareMachine --binaryLog --configuration ${{ parameters.configuration }}
+    - script: ./eng/build.sh --ci --restore --prepareMachine --binaryLog --configuration ${{ parameters.configuration }} ${{ parameters.restoreArguments }}
       displayName: Restore
 
-    - script: ./eng/build.sh --ci --build --publish --pack --prepareMachine --binaryLog --skipDocumentation --configuration ${{ parameters.configuration }}
+    - script: ./eng/build.sh --ci --build --prepareMachine --binaryLog --skipDocumentation --configuration ${{ parameters.configuration }} ${{ parameters.buildArguments }}
       displayName: Build
 
     - script: ./eng/prepare-tests.sh

--- a/eng/pipelines/build-windows-on-unix-job.yml
+++ b/eng/pipelines/build-windows-on-unix-job.yml
@@ -43,15 +43,17 @@ jobs:
     - script: ./eng/build.sh --ci --build --prepareMachine --binaryLog --skipDocumentation --configuration ${{ parameters.configuration }} ${{ parameters.buildArguments }}
       displayName: Build
 
-    - script: ./eng/prepare-tests.sh --unix
+    - script: ./eng/prepare-tests.sh -configuration ${{ parameters.configuration }}
       displayName: Prepare Test Payload
-
+      condition: and(ne(variables['artifactName'], ''), succeeded())
+      
     - task: PublishPipelineArtifact@1
       displayName: Publish Test Payload
       inputs:
         targetPath: '$(Build.SourcesDirectory)/artifacts/testPayload'
         artifactName: ${{ parameters.testArtifactName }}
-
+      condition: and(ne(variables['artifactName'], ''), succeeded())
+      
     - template: publish-logs.yml
       parameters:
         configuration: ${{ parameters.configuration }}

--- a/eng/pipelines/build-windows-on-unix-job.yml
+++ b/eng/pipelines/build-windows-on-unix-job.yml
@@ -45,7 +45,7 @@ jobs:
     - script: ./eng/build.sh --ci --build --prepareMachine --binaryLog --skipDocumentation --configuration ${{ parameters.configuration }} ${{ parameters.buildArguments }}
       displayName: Build
 
-    - script: ./eng/prepare-tests.sh -configuration ${{ parameters.configuration }}
+    - script: ./eng/prepare-tests.sh --configuration ${{ parameters.configuration }}
       displayName: Prepare Test Payload
       condition: and(ne(variables['artifactName'], ''), succeeded())
       

--- a/eng/pipelines/build-windows-on-unix-job.yml
+++ b/eng/pipelines/build-windows-on-unix-job.yml
@@ -33,6 +33,8 @@ jobs:
     ${{ if ne(parameters.vmImageName, '') }}:
       vmImage: ${{ parameters.vmImageName }}
   timeoutInMinutes: 40
+  variables:
+    artifactName: ${{ parameters.testArtifactName }}
 
   steps:
     - template: checkout-unix-task.yml

--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -24,10 +24,22 @@ steps:
     - template: checkout-windows-task.yml
 
   - task: PowerShell@2
-    displayName: Build and Test
+    displayName: Restore
     inputs:
       filePath: eng/build.ps1
-      arguments: -ci -restore -build -pack -sign -publish -binaryLog -configuration ${{ parameters.configuration }} -prepareMachine -testVsi -oop64bit:$${{ parameters.oop64bit }} -oopCoreClr:$${{ parameters.oopCoreClr }} -collectDumps -lspEditor:$${{ parameters.lspEditor }}
+      arguments: -ci -binaryLog -prepareMachine -configuration ${{ parameters.configuration }} -solution src/VisualStudio/IntegrationTest/IntegrationTestDependencies/IntegrationTestDependencies.csproj -restore
+    
+  - task: PowerShell@2
+    displayName: Build
+    inputs:
+      filePath: eng/build.ps1
+      arguments: -ci -binaryLog -prepareMachine -configuration ${{ parameters.configuration }} -solution src/VisualStudio/IntegrationTest/IntegrationTestDependencies/IntegrationTestDependencies.csproj -build
+
+  - task: PowerShell@2
+    displayName: Test
+    inputs:
+      filePath: eng/build.ps1
+      arguments: -ci -binaryLog -prepareMachine -configuration ${{ parameters.configuration }} -oop64bit:$${{ parameters.oop64bit }} -oopCoreClr:$${{ parameters.oopCoreClr }} -collectDumps -lspEditor:$${{ parameters.lspEditor }} -testVsi 
 
   - task: PublishTestResults@2
     displayName: Publish xUnit Test Results

--- a/eng/prepare-tests.sh
+++ b/eng/prepare-tests.sh
@@ -10,6 +10,28 @@ set -e
 
 source="${BASH_SOURCE[0]}"
 
+configuration="Debug"
+is_unix=false
+
+while [[ $# > 0 ]]; do
+  opt="$(echo "$1" | awk '{print tolower($0)}')"
+  case "$opt" in
+    --configuration|-c)
+      configuration=$2
+      shift
+      ;;
+    --unix)
+      is_unix=true
+      ;;
+    *)
+      echo "Invalid argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
 # resolve $source until the file is no longer a symlink
 while [[ -h "$source" ]]; do
   scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
@@ -28,4 +50,10 @@ InitializeDotNetCli true
 # permissions issues make this a pain to do in PrepareTests itself.
 rm -rf "$repo_root/artifacts/testPayload"
 
-dotnet "$repo_root/artifacts/bin/PrepareTests/Debug/net6.0/PrepareTests.dll" --source "$repo_root" --destination "$repo_root/artifacts/testPayload" --unix --dotnetPath ${_InitializeDotNetCli}/dotnet
+if [[ "$is_unix" == true ]]; then
+  dotnet "$repo_root/artifacts/bin/PrepareTests/$configuration/net6.0/PrepareTests.dll" --source "$repo_root" --destination "$repo_root/artifacts/testPayload" --unix --dotnetPath ${_InitializeDotNetCli}/dotnet
+fi
+
+if [[ "$is_unix" == false ]]; then
+  dotnet "$repo_root/artifacts/bin/PrepareTests/$configuration/net6.0/PrepareTests.dll" --source "$repo_root" --destination "$repo_root/artifacts/testPayload" --dotnetPath ${_InitializeDotNetCli}/dotnet
+fi

--- a/src/Test/TestDependencies/TestDependencies-Compiler.csproj
+++ b/src/Test/TestDependencies/TestDependencies-Compiler.csproj
@@ -24,6 +24,9 @@
     <ProjectReference Include="..\..\Compilers\Server\VBCSCompilerTests\VBCSCompiler.UnitTests.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\Scripting\CoreTest\Microsoft.CodeAnalysis.Scripting.UnitTests.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\Scripting\CSharpTest\Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\Emit\Microsoft.CodeAnalysis.VisualBasic.Emit.UnitTests.vbproj" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\IOperation\Roslyn.Compilers.VisualBasic.IOperation.UnitTests.vbproj" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\Semantic\Microsoft.CodeAnalysis.VisualBasic.Semantic.UnitTests.vbproj" />
   </ItemGroup>
   
 </Project>

--- a/src/Test/TestDependencies/TestDependencies-Compiler.csproj
+++ b/src/Test/TestDependencies/TestDependencies-Compiler.csproj
@@ -24,9 +24,9 @@
     <ProjectReference Include="..\..\Compilers\Server\VBCSCompilerTests\VBCSCompiler.UnitTests.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\Scripting\CoreTest\Microsoft.CodeAnalysis.Scripting.UnitTests.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\Scripting\CSharpTest\Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests.csproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\Emit\Microsoft.CodeAnalysis.VisualBasic.Emit.UnitTests.vbproj" />
-    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\IOperation\Roslyn.Compilers.VisualBasic.IOperation.UnitTests.vbproj" />
-    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\Semantic\Microsoft.CodeAnalysis.VisualBasic.Semantic.UnitTests.vbproj" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\Emit\Microsoft.CodeAnalysis.VisualBasic.Emit.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\IOperation\Roslyn.Compilers.VisualBasic.IOperation.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\Semantic\Microsoft.CodeAnalysis.VisualBasic.Semantic.UnitTests.vbproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
   
 </Project>

--- a/src/Test/TestDependencies/TestDependencies-Compiler.csproj
+++ b/src/Test/TestDependencies/TestDependencies-Compiler.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- This is a helper project to reference all the test projects that are included in Compilers.sln -->
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <SignAssembly>false</SignAssembly>
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Tools\Source\RunTests\RunTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Tools\PrepareTests\PrepareTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\Core\CodeAnalysisTest\Microsoft.CodeAnalysis.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\Core\MSBuildTaskTests\Microsoft.Build.Tasks.CodeAnalysis.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\Core\RebuildTest\Microsoft.CodeAnalysis.Rebuild.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\CommandLine\Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\Emit\Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\Emit2\Microsoft.CodeAnalysis.CSharp.Emit2.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\EndToEnd\Microsoft.CodeAnalysis.CSharp.EndToEnd.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\IOperation\Microsoft.CodeAnalysis.CSharp.IOperation.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\Semantic\Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\Symbol\Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\Syntax\Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\Server\VBCSCompilerTests\VBCSCompiler.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Scripting\CoreTest\Microsoft.CodeAnalysis.Scripting.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Scripting\CSharpTest\Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+  
+</Project>

--- a/src/Test/TestDependencies/TestDependencies-net472.csproj
+++ b/src/Test/TestDependencies/TestDependencies-net472.csproj
@@ -43,6 +43,22 @@
     <ProjectReference Include="..\..\VisualStudio\LiveShare\Test\Microsoft.VisualStudio.LanguageServices.LiveShare.UnitTests.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\Workspaces\CoreTest\Microsoft.CodeAnalysis.Workspaces.UnitTests.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\Workspaces\CSharpTest\Microsoft.CodeAnalysis.CSharp.Workspaces.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\CodeStyle\VisualBasic\Tests\Microsoft.CodeAnalysis.VisualBasic.CodeStyle.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\CommandLine\Microsoft.CodeAnalysis.VisualBasic.CommandLine.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\Emit\Microsoft.CodeAnalysis.VisualBasic.Emit.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\IOperation\Roslyn.Compilers.VisualBasic.IOperation.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\Semantic\Microsoft.CodeAnalysis.VisualBasic.Semantic.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\Symbol\Microsoft.CodeAnalysis.VisualBasic.Symbol.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\Syntax\Microsoft.CodeAnalysis.VisualBasic.Syntax.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\EditorFeatures\Test2\Microsoft.CodeAnalysis.EditorFeatures2.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\EditorFeatures\VisualBasicTest\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\ExpressionEvaluator\VisualBasic\Test\ExpressionCompiler\Microsoft.CodeAnalysis.VisualBasic.ExpressionCompiler.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\ExpressionEvaluator\VisualBasic\Test\ResultProvider\Microsoft.CodeAnalysis.VisualBasic.ResultProvider.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Features\Lsif\GeneratorTest\Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Scripting\VisualBasicTest\Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Scripting\VisualBasicTest.Desktop\Microsoft.CodeAnalysis.VisualBasic.Scripting.Desktop.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\VisualStudio\Core\Test\Microsoft.VisualStudio.LanguageServices.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Workspaces\VisualBasicTest\Microsoft.CodeAnalysis.VisualBasic.Workspaces.UnitTests.vbproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/src/Test/TestDependencies/TestDependencies-net472.csproj
+++ b/src/Test/TestDependencies/TestDependencies-net472.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- This is a helper project to reference all the unit test projects that are included in Roslyn.sln when building the net472 target framework -->
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <SignAssembly>false</SignAssembly>
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Tools\Source\RunTests\RunTests.csproj" SetTargetFramework="TargetFramework=net6.0" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Tools\PrepareTests\PrepareTests.csproj" SetTargetFramework="TargetFramework=net6.0" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\CodeStyle\CSharp\Tests\Microsoft.CodeAnalysis.CSharp.CodeStyle.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\Core\CodeAnalysisTest\Microsoft.CodeAnalysis.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\Core\MSBuildTaskTests\Microsoft.Build.Tasks.CodeAnalysis.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\Core\RebuildTest\Microsoft.CodeAnalysis.Rebuild.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\CommandLine\Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\Emit\Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\Emit2\Microsoft.CodeAnalysis.CSharp.Emit2.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\EndToEnd\Microsoft.CodeAnalysis.CSharp.EndToEnd.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\IOperation\Microsoft.CodeAnalysis.CSharp.IOperation.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\Semantic\Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\Symbol\Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\Syntax\Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\WinRT\Microsoft.CodeAnalysis.CSharp.WinRT.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\Server\VBCSCompilerTests\VBCSCompiler.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\EditorFeatures\CSharpTest\Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\EditorFeatures\CSharpTest2\Microsoft.CodeAnalysis.CSharp.EditorFeatures2.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\EditorFeatures\Test\Microsoft.CodeAnalysis.EditorFeatures.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\ExpressionEvaluator\Core\Test\FunctionResolver\Microsoft.CodeAnalysis.FunctionResolver.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\ExpressionEvaluator\CSharp\Test\ExpressionCompiler\Microsoft.CodeAnalysis.CSharp.ExpressionCompiler.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\ExpressionEvaluator\CSharp\Test\ResultProvider\Microsoft.CodeAnalysis.CSharp.ResultProvider.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Features\LanguageServer\ProtocolUnitTests\Microsoft.CodeAnalysis.LanguageServer.Protocol.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Scripting\CoreTest.Desktop\Microsoft.CodeAnalysis.Scripting.Desktop.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Scripting\CoreTest\Microsoft.CodeAnalysis.Scripting.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Scripting\CSharpTest.Desktop\Microsoft.CodeAnalysis.CSharp.Scripting.Desktop.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Scripting\CSharpTest\Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Tools\ExternalAccess\FSharpTest\Microsoft.CodeAnalysis.ExternalAccess.FSharp.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Tools\ExternalAccess\OmniSharpTest\Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Tools\ExternalAccess\RazorTest\Microsoft.CodeAnalysis.ExternalAccess.Razor.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\VisualStudio\Core\Test.Next\Roslyn.VisualStudio.Next.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\VisualStudio\CSharp\Test\Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\VisualStudio\LiveShare\Test\Microsoft.VisualStudio.LanguageServices.LiveShare.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Workspaces\CoreTest\Microsoft.CodeAnalysis.Workspaces.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Workspaces\CSharpTest\Microsoft.CodeAnalysis.CSharp.Workspaces.UnitTests.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/Test/TestDependencies/TestDependencies-net6.csproj
+++ b/src/Test/TestDependencies/TestDependencies-net6.csproj
@@ -33,6 +33,12 @@
     <ProjectReference Include="..\..\Workspaces\CSharpTest\Microsoft.CodeAnalysis.CSharp.Workspaces.UnitTests.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\Workspaces\MSBuildTest\Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\Workspaces\Remote\ServiceHubTest\Microsoft.CodeAnalysis.Remote.ServiceHub.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\Emit\Microsoft.CodeAnalysis.VisualBasic.Emit.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\IOperation\Roslyn.Compilers.VisualBasic.IOperation.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\Semantic\Microsoft.CodeAnalysis.VisualBasic.Semantic.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\Symbol\Microsoft.CodeAnalysis.VisualBasic.Symbol.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\VisualBasic\Test\Syntax\Microsoft.CodeAnalysis.VisualBasic.Syntax.UnitTests.vbproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Workspaces\VisualBasicTest\Microsoft.CodeAnalysis.VisualBasic.Workspaces.UnitTests.vbproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/Test/TestDependencies/TestDependencies-net6.csproj
+++ b/src/Test/TestDependencies/TestDependencies-net6.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-windows'">
-    <ProjectReference Include="..\..\Tools\Source\RunTests\RunTests.csproj" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\..\Tools\PrepareTests\PrepareTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Tools\Source\RunTests\RunTests.csproj" SetTargetFramework="TargetFramework=net6.0" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Tools\PrepareTests\PrepareTests.csproj" SetTargetFramework="TargetFramework=net6.0" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\Compilers\Core\CodeAnalysisTest\Microsoft.CodeAnalysis.UnitTests.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\Compilers\Core\MSBuildTaskTests\Microsoft.Build.Tasks.CodeAnalysis.UnitTests.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\Compilers\Core\RebuildTest\Microsoft.CodeAnalysis.Rebuild.UnitTests.csproj" ReferenceOutputAssembly="false" />

--- a/src/Test/TestDependencies/TestDependencies-net6.csproj
+++ b/src/Test/TestDependencies/TestDependencies-net6.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- This is a helper project to reference all the unit test projects that are included in Roslyn.sln when building the net6.0 target framework -->
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
+    <SignAssembly>false</SignAssembly>
+    <IsShipping>false</IsShipping>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Interactive\HostProcess\InteractiveHost64.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-windows'">
+    <ProjectReference Include="..\..\Tools\Source\RunTests\RunTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Tools\PrepareTests\PrepareTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\Core\CodeAnalysisTest\Microsoft.CodeAnalysis.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\Core\MSBuildTaskTests\Microsoft.Build.Tasks.CodeAnalysis.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\Core\RebuildTest\Microsoft.CodeAnalysis.Rebuild.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\CommandLine\Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\Emit\Microsoft.CodeAnalysis.CSharp.Emit.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\Emit2\Microsoft.CodeAnalysis.CSharp.Emit2.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\EndToEnd\Microsoft.CodeAnalysis.CSharp.EndToEnd.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\IOperation\Microsoft.CodeAnalysis.CSharp.IOperation.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\Semantic\Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\Symbol\Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\CSharp\Test\Syntax\Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Compilers\Server\VBCSCompilerTests\VBCSCompiler.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Interactive\HostTest\InteractiveHost.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Scripting\CoreTest\Microsoft.CodeAnalysis.Scripting.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Scripting\CSharpTest\Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Workspaces\CoreTest\Microsoft.CodeAnalysis.Workspaces.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Workspaces\CSharpTest\Microsoft.CodeAnalysis.CSharp.Workspaces.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Workspaces\MSBuildTest\Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\Workspaces\Remote\ServiceHubTest\Microsoft.CodeAnalysis.Remote.ServiceHub.UnitTests.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <ProjectReference Include="..\..\Interactive\HostProcess\InteractiveHost32.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/VisualStudio/IntegrationTest/IntegrationTestDependencies/IntegrationTestDependencies.csproj
+++ b/src/VisualStudio/IntegrationTest/IntegrationTestDependencies/IntegrationTestDependencies.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- This is a helper project to reference all the integration test projects and required VSIXs so that we only build the relevant projects in integration test CI -->
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <IsShipping>false</IsShipping>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="RoslynTools.VSIXExpInstaller" Version="$(RoslynToolsVSIXExpInstallerVersion)" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Tools\Source\RunTests\RunTests.csproj" SetTargetFramework="TargetFramework=net6.0" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\Compilers\Extension\Roslyn.Compilers.Extension.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\ExpressionEvaluator\Package\ExpressionEvaluatorPackage.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\Setup\DevDivVsix\CompilersPackage\arm64\Microsoft.CodeAnalysis.Compilers.Setup.arm64.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\Setup\DevDivVsix\CompilersPackage\x64\Microsoft.CodeAnalysis.Compilers.Setup.x64.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\Setup\DevDivVsix\CompilersPackage\x86\Microsoft.CodeAnalysis.Compilers.Setup.x86.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\VisualStudio\Setup\Roslyn.VisualStudio.Setup.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\VisualStudio\Setup.Dependencies\Roslyn.VisualStudio.Setup.Dependencies.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\VisualStudio\VisualStudioDiagnosticsToolWindow\Roslyn.VisualStudio.DiagnosticsWindow.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\VisualStudio\IntegrationTest\IntegrationTests\Microsoft.VisualStudio.LanguageServices.IntegrationTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\VisualStudio\IntegrationTest\New.IntegrationTests\Microsoft.VisualStudio.LanguageServices.New.IntegrationTests.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\..\VisualStudio\IntegrationTest\TestSetup\Microsoft.VisualStudio.IntegrationTest.Setup.csproj" ReferenceOutputAssembly="false" />
+  <ProjectReference Include="..\..\..\Workspaces\MSBuildTest\Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
As part of @dibarbet's work on running integration tests on helix he also changed things so we only build the root projects that were actually deployed: https://github.com/dotnet/roslyn/pull/63067

This resulted in a significant speedup that I wanted to investigate. After looking at a lot of binlogs most of the speedup is due to the happy accident of us only building the net472 tfm. After experimenting with different approaches, building a TFM per-machine cuts the build time by 10 minutes for integration tests, 5 minutes for windows builds, and halves it in unix builds.

| Definition | Current Time | Time With TFM Split |
|------------|--------------|:---------------------:|
| | <img width="241" alt="image" src="https://user-images.githubusercontent.com/9797472/187611447-666ba62a-6ce6-4388-878e-d355f6e1bdec.png"> | <img width="236" alt="image" src="https://user-images.githubusercontent.com/9797472/187612522-460ee8db-bb8f-4fdc-a543-bbf39a1250fd.png"> <img width="237" alt="image" src="https://user-images.githubusercontent.com/9797472/187613873-5f5d66e3-6890-4031-a601-f0c8e63a858f.png"> |
| | <img width="236" alt="image" src="https://user-images.githubusercontent.com/9797472/187611582-1ee5bed3-a3c8-446e-a446-8ef1b11dd8fb.png"> | <img width="236" alt="image" src="https://user-images.githubusercontent.com/9797472/187612648-c9a446bf-bab2-4ee6-ae2b-fedd41ce626f.png"> <img width="232" alt="image" src="https://user-images.githubusercontent.com/9797472/187614047-6217e3d8-3e1c-45d0-87e3-47eb1cadb777.png"> | 
| | <img width="236" alt="image" src="https://user-images.githubusercontent.com/9797472/187611645-baf3d9ce-5b92-44bc-9035-0b1f1ef891f3.png"> | <img width="244" alt="image" src="https://user-images.githubusercontent.com/9797472/187612796-7e0abbdd-f956-46fd-b636-8a44139fd675.png"> |
| | <img width="248" alt="image" src="https://user-images.githubusercontent.com/9797472/187612333-2c793621-f7a2-4362-a3c2-9dc4e5f6afe1.png"> | ![image](https://user-images.githubusercontent.com/9797472/187741616-5daa88c4-8952-4a8e-bd0a-ab85a5da87bf.png) |
| | <img width="253" alt="image" src="https://user-images.githubusercontent.com/9797472/187612394-15e4f16a-8cca-41cb-a7f6-57758ec5816e.png"> | <!-- in progress --> |
| | <img width="251" alt="image" src="https://user-images.githubusercontent.com/9797472/187612193-e385afd9-b052-4b16-971c-301fe09492e7.png"> | <img width="208" alt="image" src="https://user-images.githubusercontent.com/9797472/187741739-b1cadd4c-e471-4ae6-b896-27c1e8980d11.png">|




