### PR TITLE
Ensure we look for source-generated documents when making an OOP call

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Services/SymbolFinder/RemoteSymbolFinderService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SymbolFinder/RemoteSymbolFinderService.cs
@@ -185,7 +185,8 @@ namespace Microsoft.CodeAnalysis.Remote
                 async solution =>
                 {
                     var cacheService = solution.Services.GetRequiredService<SymbolTreeInfoCacheService>();
-                    await cacheService.AnalyzeDocumentAsync(solution.GetRequiredDocument(documentId), isMethodBodyEdit, cancellationToken).ConfigureAwait(false);
+                    var document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
+                    await cacheService.AnalyzeDocumentAsync(document, isMethodBodyEdit, cancellationToken).ConfigureAwait(false);
                 },
                 cancellationToken);
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/63682

Trying to figure out how to write a test for this now.