### PR TITLE
Update the DartLab Template branch to main

### DIFF
--- a/azure-pipelines-integration-dartlab.yml
+++ b/azure-pipelines-integration-dartlab.yml
@@ -15,7 +15,7 @@ resources:
   - repository: DartLabTemplates
     type: git
     name: DartLab.Templates
-    ref: refs/heads/dev/bradwhit/RemoveCheckoutNone
+    ref: main
   - repository: RoslynMirror
     endpoint: dnceng/internal dotnet-roslyn
     type: git


### PR DESCRIPTION
### Summary of the changes

- The `RemoveCheckoutNone` branch was deleted because it got merged into main, so lets use main.