### PR TITLE
Fail when brace matcher finds no matching spans

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter.cs
@@ -238,6 +238,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                                         var vsClosingSpans = textView.GetSpanInView(closingSpans.Value.ToSnapshotSpan(subjectBuffer.CurrentSnapshot)).ToList().First().ToVsTextSpan();
                                         pSpan[0].iEndIndex = vsClosingSpans.iStartIndex;
                                     }
+
+                                    return VSConstants.S_OK;
                                 }
                                 else if (matchingSpan.Value.End > position) // caret is at open parenthesis
                                 {
@@ -255,18 +257,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                                         var vsOpeningSpans = textView.GetSpanInView(openingSpans.Value.ToSnapshotSpan(subjectBuffer.CurrentSnapshot)).ToList().First().ToVsTextSpan();
                                         pSpan[0].iStartIndex = vsOpeningSpans.iStartIndex;
                                     }
+
+                                    return VSConstants.S_OK;
                                 }
                             }
-                        }
-                        else
-                        {
-                            return VSConstants.E_FAIL;
                         }
                     }
                 }
             }
 
-            return VSConstants.S_OK;
+            return VSConstants.S_FALSE;
         }
 
         int IVsTextViewFilter.GetWordExtent(int iLine, int iIndex, uint dwFlags, TextSpan[] pSpan)

--- a/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractVsTextViewFilter.cs
@@ -258,6 +258,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                                 }
                             }
                         }
+                        else
+                        {
+                            return VSConstants.E_FAIL;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This change allows the command handler for `Ctrl + ]` ("go to brace") to use `language-configuration.json` as a fallback: https://devdiv.visualstudio.com/DevDiv/_git/VS-Platform?path=/src/Editor/VisualStudio/Impl/ViewAdapter/IOleCommandTarget.cs&version=GBmain&line=3792&lineEnd=3835&lineStartColumn=1&lineEndColumn=40&lineStyle=plain&_a=contents