### PR TITLE
Fix numbering conflict in enum due to merge

### DIFF
--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2119,6 +2119,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         #endregion
 
         #region diagnostics introduced for C# 12.0
+        // PROTOTYPE: These enum values have temporarily been moved further out
+        // to prevent conflicts. Before merging to main, change them so that the
+        // numbering is consecutive with respect to the previous fields
         ERR_ImplicitlyTypedDefaultParameter = 9500,
         ERR_OptionalParamValueMismatch = 9501,
         #endregion

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2119,8 +2119,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         #endregion
 
         #region diagnostics introduced for C# 12.0
-        ERR_ImplicitlyTypedDefaultParameter = 9066,
-        ERR_OptionalParamValueMismatch = 9067,
+        ERR_ImplicitlyTypedDefaultParameter = 9500,
+        ERR_OptionalParamValueMismatch = 9501,
         #endregion
 
         // Note: you will need to do the following after adding warnings:

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -4614,7 +4614,7 @@ class Program
 }
 """;
             CreateCompilation(source).VerifyDiagnostics(
-                // (7,24): error CS9067: Parameter 1 has default value '2' in lambda and '1' in the target delegate type.
+                // (7,24): error CS9501: Parameter 1 has default value '2' in lambda and '1' in the target delegate type.
                 //         int y = F((int x = 2) => { });
                 Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "x").WithArguments("1", "2", "1").WithLocation(7, 24));
         }
@@ -11962,7 +11962,7 @@ class Program
 }
 """;
             CreateCompilation(source).VerifyDiagnostics(
-                // (8,20): error CS9067: Parameter 1 has default value '1000' in lambda and '1' in the target delegate type.
+                // (8,20): error CS9501: Parameter 1 has default value '1000' in lambda and '1' in the target delegate type.
                 //         D d = (int x = 1000) => x + x;
                 Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "x").WithArguments("1", "1000", "1").WithLocation(8, 20));
         }
@@ -12008,7 +12008,7 @@ class Program
 }
 """;
             CreateCompilation(source).VerifyDiagnostics(
-                // (8,20): error CS9067: Parameter 1 has default value '1000' in lambda and '<missing>' in the target delegate type.
+                // (8,20): error CS9501: Parameter 1 has default value '1000' in lambda and '<missing>' in the target delegate type.
                 //         D d = (int x = 1000) => x + x;
                 Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "x").WithArguments("1", "1000", "<missing>").WithLocation(8, 20));
         }
@@ -12414,7 +12414,7 @@ class Program
 }
 """;
             CreateCompilation(source).VerifyDiagnostics(
-                // (8,16): error CS9065: Implicitly typed lambda parameter 'x' cannot have a default value.
+                // (8,16): error CS9500: Implicitly typed lambda parameter 'x' cannot have a default value.
                 //         D d = (x = 3) => x;
                 Diagnostic(ErrorCode.ERR_ImplicitlyTypedDefaultParameter, "x").WithArguments("x").WithLocation(8, 16));
         }
@@ -12436,7 +12436,7 @@ class Program
 }
 """;
             CreateCompilation(source).VerifyDiagnostics(
-                // (8,27): error CS9067: Parameter 2 has default value '3' in lambda and '<missing>' in the target delegate type.
+                // (8,27): error CS9501: Parameter 2 has default value '3' in lambda and '<missing>' in the target delegate type.
                 //         D d = (int _, int _ = 3) => 10;
                 Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "_").WithArguments("2", "3", "<missing>").WithLocation(8, 27),
                 // (9,27): error CS7036: There is no argument given that corresponds to the required formal parameter 'y' of 'Program.D'
@@ -12461,7 +12461,7 @@ class Program
 }
 """;
             CreateCompilation(source).VerifyDiagnostics(
-                // (8,27): error CS9067: Parameter 2 has default value '3' in lambda and '7' in the target delegate type.
+                // (8,27): error CS9501: Parameter 2 has default value '3' in lambda and '7' in the target delegate type.
                 //         D d = (int _, int _ = 3) => 10;
                 Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "_").WithArguments("2", "3", "7").WithLocation(8, 27));
         }
@@ -12486,7 +12486,7 @@ class Program
 }
 """;
             CreateCompilation(source).VerifyDiagnostics(
-                // (8,27): error CS9067: Parameter 2 has default value '4' in lambda and '<missing>' in the target delegate type.
+                // (8,27): error CS9501: Parameter 2 has default value '4' in lambda and '<missing>' in the target delegate type.
                 //         D d = (int x, int y = 4) => {
                 Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "y").WithArguments("2", "4", "<missing>").WithLocation(8, 27),
                 // (12,27): error CS7036: There is no argument given that corresponds to the required formal parameter 'y' of 'Program.D'

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaDiscardParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaDiscardParametersTests.cs
@@ -344,7 +344,7 @@ public class C
                 // (6,51): error CS7014: Attributes are not valid in this context.
                 //         System.Func<int, int, long> f1 = delegate([System.Obsolete]int _, int _ = 0) { return 3L; };
                 Diagnostic(ErrorCode.ERR_AttributesNotAllowed, "[System.Obsolete]").WithLocation(6, 51),
-                // (6,79): error CS9067: Parameter 2 has default value 'default(int)' in lambda and '<missing>' in the target delegate type.
+                // (6,79): error CS9501: Parameter 2 has default value 'default(int)' in lambda and '<missing>' in the target delegate type.
                 //         System.Func<int, int, long> f1 = delegate([System.Obsolete]int _, int _ = 0) { return 3L; };
                 Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "_").WithArguments("2", "default(int)", "<missing>").WithLocation(6, 79));
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -4851,7 +4851,7 @@ class Program
 }";
             var comp = CreateCompilation(source, parseOptions: TestOptions.RegularPreview);
             comp.VerifyDiagnostics(
-                    // (7,68): error CS9067: Parameter 1 has default value '2' in lambda and '<missing>' in the target delegate type.
+                    // (7,68): error CS9501: Parameter 1 has default value '2' in lambda and '<missing>' in the target delegate type.
                     //         Action<int> a1 = ([Optional, DefaultParameterValue(2)] int i) => { };
                     Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "i").WithArguments("1", "2", "<missing>").WithLocation(7, 68));
 
@@ -7016,7 +7016,7 @@ class Program
                 // (5,20): error CS8917: The delegate type could not be inferred.
                 //         var lam1 = (x = 7) => x;
                 Diagnostic(ErrorCode.ERR_CannotInferDelegateType, "(x = 7) => x").WithLocation(5, 20),
-                // (5,21): error CS9063:  Default not allowed for implicitly typed lambda parameter 'x' 
+                // (5,21): error CS9500:  Default not allowed for implicitly typed lambda parameter 'x' 
                 //         var lam1 = (x = 7) => x;
                 Diagnostic(ErrorCode.ERR_ImplicitlyTypedDefaultParameter, "x").WithArguments("x").WithLocation(5, 21));
         }
@@ -7041,7 +7041,7 @@ class Program
                 // (5,37): error CS0748: Inconsistent lambda parameter usage; parameter types must be all explicit or all implicit
                 //         var lam = (string s = null, x = 7, double d = 3.14) => { };
                 Diagnostic(ErrorCode.ERR_InconsistentLambdaParameterUsage, "x").WithLocation(5, 37),
-                // (5,37): error CS9063:  Default not allowed for implicitly typed lambda parameter 'x' 
+                // (5,37): error CS9500:  Default not allowed for implicitly typed lambda parameter 'x' 
                 //         var lam = (string s = null, x = 7, double d = 3.14) => { };
                 Diagnostic(ErrorCode.ERR_ImplicitlyTypedDefaultParameter, "x").WithArguments("x").WithLocation(5, 37));
         }
@@ -7599,7 +7599,7 @@ class Program
 ";
 
             CreateCompilation(source).VerifyDiagnostics(
-                // (7,27): error CS9067: Parameter 1 has default value '"0123456..."' in lambda and '"abc"' in the target delegate type.
+                // (7,27): error CS9501: Parameter 1 has default value '"0123456..."' in lambda and '"abc"' in the target delegate type.
                 //         Del del = (string s = "0123456789101112131415161718192021222324252627282930313233343536373839404142434445464748495051525354555657585960616263646566676869707172737475767778798081828384858687888990919293949596979899") => { };
                 Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "s").WithArguments("1", @"""0123456...""", @"""abc""").WithLocation(7, 27));
         }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -5796,7 +5796,7 @@ class C {
             Assert.Equal(0, file.Errors().Length);
 
             CreateCompilation(text).VerifyDiagnostics(
-                // (5,26): error CS9067: Parameter 1 has default value 'default(int)' in lambda and '<missing>' in the target delegate type.
+                // (5,26): error CS9501: Parameter 1 has default value 'default(int)' in lambda and '<missing>' in the target delegate type.
                 //      F f = delegate (int x = 0) { };
                 Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "x").WithArguments("1", "default(int)", "<missing>").WithLocation(5, 26));
         }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -3246,7 +3246,7 @@ class A
 ";
 
             CreateCompilation(test).VerifyDiagnostics(
-                    // (5,25): error CS9067: Parameter 1 has default value '42' in lambda and '<missing>' in the target delegate type.
+                    // (5,25): error CS9501: Parameter 1 has default value '42' in lambda and '<missing>' in the target delegate type.
                     //     D d1 = delegate(int x = 42) { };
                     Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "x").WithArguments("1", "42", "<missing>").WithLocation(5, 25));
         }
@@ -3263,7 +3263,7 @@ class A
 ";
 
             CreateCompilation(test).VerifyDiagnostics(
-                    // (5,32): error CS9067: Parameter 2 has default value '42' in lambda and '<missing>' in the target delegate type.
+                    // (5,32): error CS9501: Parameter 2 has default value '42' in lambda and '<missing>' in the target delegate type.
                     //     D d1 = delegate(int x, int y = 42) { };
                     Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "y").WithArguments("2", "42", "<missing>").WithLocation(5, 32));
         }


### PR DESCRIPTION
Fixes a numbering conflict in the `ErrorCode` enum that came from the previous merge and is currently breaking the build in this feature branch.