### PR TITLE
Update public pool names

### DIFF
--- a/azure-pipelines-integration-corehost.yml
+++ b/azure-pipelines-integration-corehost.yml
@@ -36,7 +36,7 @@ pr:
 jobs:
 - job: VS_Integration_CoreHost_Debug
   pool:
-    name: NetCore1ESPool-Public
+    name: NetCore-Public
     demands: ImageOverride -equals $(queueName)
   timeoutInMinutes: 150
   variables:
@@ -52,7 +52,7 @@ jobs:
 - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
   - job: VS_Integration_CoreHost_Release
     pool:
-      name: NetCore1ESPool-Public
+      name: NetCore-Public
       demands: ImageOverride -equals $(queueName)
     timeoutInMinutes: 150
     variables:

--- a/azure-pipelines-integration-lsp.yml
+++ b/azure-pipelines-integration-lsp.yml
@@ -25,7 +25,7 @@ variables:
 jobs:
 - job: VS_Integration_LSP
   pool:
-    name: NetCore1ESPool-Public
+    name: NetCore-Public
     demands: ImageOverride -equals $(queueName)
   timeoutInMinutes: 150
 

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -19,7 +19,7 @@ pr: none
 jobs:
 - job: RichCodeNav_Indexing
   pool:
-    name: NetCore1ESPool-Public
+    name: NetCore-Public
     demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
   variables:
     EnableRichCodeNavigation: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,7 +182,7 @@ jobs:
 
 - job: Correctness_Determinism
   pool:
-    name: NetCore1ESPool-Public
+    name: NetCore-Public
     demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
   timeoutInMinutes: 90
   steps:

--- a/eng/common/templates/job/source-build.yml
+++ b/eng/common/templates/job/source-build.yml
@@ -46,7 +46,7 @@ jobs:
     # source-build builds run in Docker, including the default managed platform.
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Public
+        name: NetCore-Public
         demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: NetCore1ESPool-Internal

--- a/eng/common/templates/job/source-index-stage1.yml
+++ b/eng/common/templates/job/source-index-stage1.yml
@@ -28,7 +28,7 @@ jobs:
   ${{ if eq(parameters.pool, '') }}:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCore1ESPool-Public
+        name: NetCore-Public
         demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: NetCore1ESPool-Internal

--- a/eng/pipelines/build-unix-job.yml
+++ b/eng/pipelines/build-unix-job.yml
@@ -20,7 +20,7 @@ jobs:
 - job: ${{ parameters.jobName }}
   pool:
     ${{ if ne(parameters.queueName, '') }}:
-      name: NetCore1ESPool-Public
+      name: NetCore-Public
       demands: ImageOverride -equals ${{ parameters.queueName }}
 
     ${{ if ne(parameters.vmImageName, '') }}:

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -23,7 +23,7 @@ jobs:
 - job: ${{ parameters.jobName }}
   pool:
     ${{ if ne(parameters.queueName, '') }}:
-      name: NetCore1ESPool-Public
+      name: NetCore-Public
       demands: ImageOverride -equals ${{ parameters.queueName }}
 
     ${{ if ne(parameters.vmImageName, '') }}:

--- a/eng/pipelines/test-unix-job-single-machine.yml
+++ b/eng/pipelines/test-unix-job-single-machine.yml
@@ -30,7 +30,7 @@ jobs:
   dependsOn: ${{ parameters.buildJobName }}
   pool:
     ${{ if ne(parameters.queueName, '') }}:
-      name: NetCore1ESPool-Public
+      name: NetCore-Public
       demands: ImageOverride -equals ${{ parameters.queueName }}
 
     ${{ if ne(parameters.vmImageName, '') }}:

--- a/eng/pipelines/test-windows-job-single-machine.yml
+++ b/eng/pipelines/test-windows-job-single-machine.yml
@@ -26,7 +26,7 @@ jobs:
 - job: ${{ parameters.jobName }}
   dependsOn: ${{ parameters.buildJobName }}
   pool:
-    name: NetCore1ESPool-Public
+    name: NetCore-Public
     demands: ImageOverride -equals ${{ parameters.queueName }}
   timeoutInMinutes: 120
   variables:


### PR DESCRIPTION
This change is required to continue building PRs in the dotnet public repo.  The agents and images used in the new project / organization are identical and build regressions are not expected.  Updating files under eng/common is intentional to move as much as possible over to viable build agents (normally this is not done).

For questions / concerns, please stop by the .NET Core Engineering Services [First Responders Teams Channel](https://teams.microsoft.com/l/channel/19%3aafba3d1545dd45d7b79f34c1821f6055%40thread.skype/First%2520Responders?groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47).
