### PR TITLE
Capture dotnet test dumps and fix integration test timeout

### DIFF
--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -38,6 +38,7 @@ steps:
       testRunTitle: '$(System.JobAttempt)-Integration ${{ parameters.configuration }} OOP64_${{ parameters.oop64bit }} OOPCoreClr_${{ parameters.oopCoreClr }}'
     condition: always()
 
+  # Dumps from test timeouts or crashes get published to the test results directory by dotnet test, so make sure to publish any here.
   - task: PublishBuildArtifacts@1
     displayName: Publish Test Results Directory
     inputs:

--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -39,6 +39,15 @@ steps:
     condition: always()
 
   - task: PublishBuildArtifacts@1
+    displayName: Publish Test Results Directory
+    inputs:
+      PathtoPublish: '$(Build.SourcesDirectory)\artifacts\TestResults\${{ parameters.configuration }}'
+      ArtifactName: '$(System.JobAttempt)-Logs ${{ parameters.configuration }} OOP64_${{ parameters.oop64bit }} OOPCoreClr_${{ parameters.oopCoreClr }} LspEditor_${{ parameters.lspEditor }} $(Build.BuildNumber)'
+      publishLocation: Container
+    continueOnError: true
+    condition: not(succeeded())
+  
+  - task: PublishBuildArtifacts@1
     displayName: Publish Logs
     inputs:
       PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\${{ parameters.configuration }}'

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -54,7 +54,10 @@ namespace RunTests
             // Helix timeout is 15 minutes as helix jobs fully timeout in 30minutes.  So in order to capture dumps we need the timeout
             // to be 2x shorter than the expected test run time (15min) in case only the last test hangs.
             var timeout = options.UseHelix ? "15minutes" : "25minutes";
-            fileContentsBuilder.AppendLine($"/Blame:{blameOption};TestTimeout=15minutes;DumpType=full");
+            fileContentsBuilder.AppendLine($"/Blame:{blameOption};TestTimeout=1minutes;DumpType=full");
+
+            // Specifies the results directory - this is where dumps from the blame options will get published.
+            fileContentsBuilder.AppendLine($"/ResultsDirectory:{options.TestResultsDirectory}");
 
             // Build the filter string
             var filterStringBuilder = new StringBuilder();

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -54,7 +54,7 @@ namespace RunTests
             // Helix timeout is 15 minutes as helix jobs fully timeout in 30minutes.  So in order to capture dumps we need the timeout
             // to be 2x shorter than the expected test run time (15min) in case only the last test hangs.
             var timeout = options.UseHelix ? "15minutes" : "25minutes";
-            fileContentsBuilder.AppendLine($"/Blame:{blameOption};TestTimeout=1minutes;DumpType=full");
+            fileContentsBuilder.AppendLine($"/Blame:{blameOption};TestTimeout={timeout};DumpType=full");
 
             // Specifies the results directory - this is where dumps from the blame options will get published.
             fileContentsBuilder.AppendLine($"/ResultsDirectory:{options.TestResultsDirectory}");


### PR DESCRIPTION
Build with dumps created by dotnet test timeouts / crashes.

Related to https://github.com/dotnet/roslyn/issues/63773

This build has artifacts with dotnet test dumps for integration tests.
https://dev.azure.com/dnceng-public/public/_build/results?buildId=3292&view=artifacts&pathAsName=false&type=publishedArtifacts