### PR TITLE
Ensure we do not drop interfaces on partial type declarations when bases have oblivious differences

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -324,18 +324,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             {
                                 baseType = partBase;
                                 baseTypeLocation = decl.NameLocation;
-                                continue;
                             }
-                            else if (containsOnlyOblivious(partBase))
+                            else if (!containsOnlyOblivious(partBase))
                             {
-                                continue;
+                                reportBaseType();
                             }
                         }
+                        else
+                        {
+                            reportBaseType();
+                        }
 
-                        var info = diagnostics.Add(ErrorCode.ERR_PartialMultipleBases, Locations[0], this);
-                        baseType = new ExtendedErrorTypeSymbol(baseType, LookupResultKind.Ambiguous, info);
-                        baseTypeLocation = decl.NameLocation;
-                        reportedPartialConflict = true;
+                        void reportBaseType()
+                        {
+                            var info = diagnostics.Add(ErrorCode.ERR_PartialMultipleBases, Locations[0], this);
+                            baseType = new ExtendedErrorTypeSymbol(baseType, LookupResultKind.Ambiguous, info);
+                            baseTypeLocation = decl.NameLocation;
+                            reportedPartialConflict = true;
+                        }
 
                         static bool containsOnlyOblivious(TypeSymbol type)
                         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
@@ -9794,5 +9794,29 @@ class C2 : I
 ";
             var comp = CreateCompilation(source).VerifyDiagnostics();
         }
+
+        [Fact]
+        [WorkItem(63490, "https://github.com/dotnet/roslyn/issues/63490")]
+        public void MultipleBasesWithObliviousDifferencesAndInterfaces()
+        {
+            var source = @"
+#nullable enable
+interface ITest
+{
+    void Test();
+}
+
+class Generic<T> { }
+class Argument { }
+partial class Partial : Generic<Argument> { }
+
+#nullable disable
+partial class Partial : Generic<Argument>, ITest
+{
+    void ITest.Test() { }
+}
+";
+            CreateCompilation(source).VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
@@ -9799,7 +9799,7 @@ class C2 : I
         [WorkItem(63490, "https://github.com/dotnet/roslyn/issues/63490")]
         public void MultipleBasesWithObliviousDifferencesAndInterfaces()
         {
-            var source = @"
+            var source1 = @"
 #nullable enable
 interface ITest
 {
@@ -9809,14 +9809,17 @@ interface ITest
 class Generic<T> { }
 class Argument { }
 partial class Partial : Generic<Argument> { }
+";
 
+            var source2 = @"
 #nullable disable
 partial class Partial : Generic<Argument>, ITest
 {
     void ITest.Test() { }
 }
 ";
-            CreateCompilation(source).VerifyDiagnostics();
+            CreateCompilation(source1 + source2).VerifyDiagnostics();
+            CreateCompilation(source2 + source1).VerifyDiagnostics();
         }
     }
 }


### PR DESCRIPTION
Closes #63490

When we did #55861 we didn't realize that the `continue` would cause interfaces to be skipped.
