### PR TITLE
Get pipelineid from env vars

### DIFF
--- a/src/Tools/Source/RunTests/Options.cs
+++ b/src/Tools/Source/RunTests/Options.cs
@@ -106,6 +106,8 @@ namespace RunTests
 
         public string? AccessToken { get; set; }
 
+        public string? PipelineDefinitionId { get; set; }
+
         public string? PhaseName { get; set; }
 
         public string? TargetBranchName { get; set; }
@@ -148,6 +150,7 @@ namespace RunTests
             string? procDumpFilePath = null;
             string? artifactsPath = null;
             string? accessToken = null;
+            string? pipelineDefinitionId = null;
             string? phaseName = null;
             string? targetBranchName = null;
             var optionSet = new OptionSet()
@@ -172,6 +175,7 @@ namespace RunTests
                 { "collectdumps", "Whether or not to gather dumps on timeouts and crashes", o => collectDumps = o is object },
                 { "retry", "Retry failed test a few times", o => retry = o is object },
                 { "accessToken=", "Pipeline access token with permissions to view test history", (string s) => accessToken = s },
+                { "pipelineDefinitionId=", "Pipeline definition id", (string s) => pipelineDefinitionId = s },
                 { "phaseName=", "Pipeline phase name associated with this test run", (string s) => phaseName = s },
                 { "targetBranchName=", "Target branch of this pipeline run", (string s) => targetBranchName = s },
             };
@@ -251,6 +255,7 @@ namespace RunTests
                 Timeout = timeout is { } t ? TimeSpan.FromMinutes(t) : null,
                 Retry = retry,
                 AccessToken = accessToken,
+                PipelineDefinitionId = pipelineDefinitionId,
                 PhaseName = phaseName,
                 TargetBranchName = targetBranchName,
             };

--- a/src/Tools/Source/RunTests/Options.cs
+++ b/src/Tools/Source/RunTests/Options.cs
@@ -106,6 +106,8 @@ namespace RunTests
 
         public string? AccessToken { get; set; }
 
+        public string? ProjectUri { get; set; }
+
         public string? PipelineDefinitionId { get; set; }
 
         public string? PhaseName { get; set; }
@@ -150,6 +152,7 @@ namespace RunTests
             string? procDumpFilePath = null;
             string? artifactsPath = null;
             string? accessToken = null;
+            string? projectUri = null;
             string? pipelineDefinitionId = null;
             string? phaseName = null;
             string? targetBranchName = null;
@@ -175,6 +178,7 @@ namespace RunTests
                 { "collectdumps", "Whether or not to gather dumps on timeouts and crashes", o => collectDumps = o is object },
                 { "retry", "Retry failed test a few times", o => retry = o is object },
                 { "accessToken=", "Pipeline access token with permissions to view test history", (string s) => accessToken = s },
+                { "projectUri=", "ADO project containing the pipeline", (string s) => projectUri = s },
                 { "pipelineDefinitionId=", "Pipeline definition id", (string s) => pipelineDefinitionId = s },
                 { "phaseName=", "Pipeline phase name associated with this test run", (string s) => phaseName = s },
                 { "targetBranchName=", "Target branch of this pipeline run", (string s) => targetBranchName = s },
@@ -255,6 +259,7 @@ namespace RunTests
                 Timeout = timeout is { } t ? TimeSpan.FromMinutes(t) : null,
                 Retry = retry,
                 AccessToken = accessToken,
+                ProjectUri = projectUri,
                 PipelineDefinitionId = pipelineDefinitionId,
                 PhaseName = phaseName,
                 TargetBranchName = targetBranchName,

--- a/src/Tools/Source/RunTests/TestHistoryManager.cs
+++ b/src/Tools/Source/RunTests/TestHistoryManager.cs
@@ -26,7 +26,7 @@ internal class TestHistoryManager
     /// <summary>
     /// The Azure devops project that the build pipeline is located in.
     /// </summary>
-    private static readonly Uri s_projectUri = new(@"https://dev.azure.com/dnceng");
+    private static readonly Uri s_projectUri = new(@"https://dev.azure.com/dnceng-public");
 
     /// <summary>
     /// Looks up the last passing test run for the current build and stage to estimate execution times for each test.


### PR DESCRIPTION
The pipelineid changed in the dnceng migration.  Rather than hardcode it we pull from the pipeline env vars (will be needed for integration test partitioning as well).