### PR TITLE
Revert "Unify implementation of 'go to defintion' and 'go to definition on hover'"

### DIFF
--- a/src/EditorFeatures/CSharp/GoToDefinition/CSharpGoToSymbolService.cs
+++ b/src/EditorFeatures/CSharp/GoToDefinition/CSharpGoToSymbolService.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis.GoToDefinition;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.GoToDefinition
+{
+    [ExportLanguageService(typeof(IGoToSymbolService), LanguageNames.CSharp), Shared]
+    internal sealed class CSharpGoToSymbolService : AbstractGoToSymbolService
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpGoToSymbolService()
+        {
+        }
+    }
+}

--- a/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.NavigableSymbol.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.NavigableSymbol.cs
@@ -2,14 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.BackgroundWorkIndicator;
+using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
@@ -18,25 +23,31 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
     {
         private class NavigableSymbol : INavigableSymbol
         {
-            private readonly NavigableSymbolService _service;
-            private readonly ITextView _textView;
-            private readonly INavigableLocation _location;
-            private readonly IBackgroundWorkIndicatorFactory _indicatorFactory;
+            private readonly Workspace _workspace;
+            private readonly ImmutableArray<DefinitionItem> _definitions;
+            private readonly IThreadingContext _threadingContext;
+            private readonly IStreamingFindUsagesPresenter _presenter;
+            private readonly IUIThreadOperationExecutor _uiThreadOperationExecutor;
+            private readonly IAsynchronousOperationListener _listener;
 
             public NavigableSymbol(
-                NavigableSymbolService service,
-                ITextView textView,
-                INavigableLocation location,
+                Workspace workspace,
+                ImmutableArray<DefinitionItem> definitions,
                 SnapshotSpan symbolSpan,
-                IBackgroundWorkIndicatorFactory indicatorFactory)
+                IThreadingContext threadingContext,
+                IStreamingFindUsagesPresenter streamingPresenter,
+                IUIThreadOperationExecutor uiThreadOperationExecutor,
+                IAsynchronousOperationListenerProvider listenerProvider)
             {
-                Contract.ThrowIfNull(location);
+                Contract.ThrowIfFalse(definitions.Length > 0);
 
-                _service = service;
-                _textView = textView;
-                _location = location;
+                _workspace = workspace;
+                _definitions = definitions;
                 SymbolSpan = symbolSpan;
-                _indicatorFactory = indicatorFactory;
+                _threadingContext = threadingContext;
+                _presenter = streamingPresenter;
+                _uiThreadOperationExecutor = uiThreadOperationExecutor;
+                _listener = listenerProvider.GetListener(FeatureAttribute.NavigableSymbols);
             }
 
             public SnapshotSpan SymbolSpan { get; }
@@ -47,21 +58,25 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
             public void Navigate(INavigableRelationship relationship)
             {
                 // Fire and forget.
-                var token = _service._listener.BeginAsyncOperation(nameof(NavigateAsync));
+                var token = _listener.BeginAsyncOperation(nameof(NavigateAsync));
                 _ = NavigateAsync().ReportNonFatalErrorAsync().CompletesAsyncOperation(token);
             }
 
             private async Task NavigateAsync()
             {
-                // we're about to navigate.  so disable cancellation on focus-lost in our indicator so we don't end up
-                // causing ourselves to self-cancel.
-                using var backgroundIndicator = _indicatorFactory.Create(
-                    _textView, SymbolSpan,
-                    EditorFeaturesResources.Navigating_to_definition,
-                    cancelOnFocusLost: false);
+                using var context = _uiThreadOperationExecutor.BeginExecute(
+                    title: EditorFeaturesResources.Go_to_Definition,
+                    defaultDescription: EditorFeaturesResources.Navigating_to_definition,
+                    allowCancellation: true,
+                    showProgress: false);
 
-                await _location.TryNavigateToAsync(
-                    _service._threadingContext, new NavigationOptions(PreferProvisionalTab: true, ActivateTab: true), backgroundIndicator.UserCancellationToken).ConfigureAwait(false);
+                var cancellationToken = context.UserCancellationToken;
+                await _presenter.TryPresentLocationOrNavigateIfOneAsync(
+                    _threadingContext,
+                    _workspace,
+                    _definitions[0].NameDisplayParts.GetFullText(),
+                    _definitions,
+                    cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.NavigableSymbolSource.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.NavigableSymbolSource.cs
@@ -2,39 +2,51 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor.BackgroundWorkIndicator;
+using Microsoft.CodeAnalysis.Editor.Host;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.GoToDefinition;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
 {
     internal partial class NavigableSymbolService
     {
-        private sealed class NavigableSymbolSource : INavigableSymbolSource
+        private partial class NavigableSymbolSource : INavigableSymbolSource
         {
-            private readonly NavigableSymbolService _service;
-            private readonly ITextView _textView;
+            private readonly IThreadingContext _threadingContext;
+            private readonly IStreamingFindUsagesPresenter _presenter;
+            private readonly IUIThreadOperationExecutor _uiThreadOperationExecutor;
+            private readonly IAsynchronousOperationListenerProvider _listenerProvider;
 
             private bool _disposed;
 
             public NavigableSymbolSource(
-                NavigableSymbolService service,
-                ITextView textView)
+                IThreadingContext threadingContext,
+                IStreamingFindUsagesPresenter streamingPresenter,
+                IUIThreadOperationExecutor uiThreadOperationExecutor,
+                IAsynchronousOperationListenerProvider listenerProvider)
             {
-                _service = service;
-                _textView = textView;
+                _threadingContext = threadingContext;
+                _presenter = streamingPresenter;
+                _uiThreadOperationExecutor = uiThreadOperationExecutor;
+                _listenerProvider = listenerProvider;
             }
 
             public void Dispose()
                 => _disposed = true;
 
-            public async Task<INavigableSymbol?> GetNavigableSymbolAsync(SnapshotSpan triggerSpan, CancellationToken cancellationToken)
+            public async Task<INavigableSymbol> GetNavigableSymbolAsync(SnapshotSpan triggerSpan, CancellationToken cancellationToken)
             {
                 if (_disposed)
                     return null;
@@ -45,23 +57,26 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
                 if (document == null)
                     return null;
 
-                var service = document.GetLanguageService<IAsyncGoToDefinitionService>();
+                var service = document.GetLanguageService<IGoToSymbolService>();
                 if (service == null)
                     return null;
 
-                var (navigableLocation, symbolSpan) = await service.FindDefinitionLocationAsync(
-                    document, position, includeType: false, cancellationToken).ConfigureAwait(false);
-                if (navigableLocation == null)
+                var context = new GoToSymbolContext(document, position, cancellationToken);
+
+                await service.GetSymbolsAsync(context).ConfigureAwait(false);
+
+                if (!context.TryGetItems(WellKnownSymbolTypes.Definition, out var definitions))
                     return null;
 
-                var indicatorFactory = document.Project.Solution.Services.GetRequiredService<IBackgroundWorkIndicatorFactory>();
-
+                var snapshotSpan = new SnapshotSpan(snapshot, context.Span.ToSpan());
                 return new NavigableSymbol(
-                    _service,
-                    _textView,
-                    navigableLocation,
-                    snapshot.GetSpan(symbolSpan.ToSpan()),
-                    indicatorFactory);
+                    document.Project.Solution.Workspace,
+                    definitions.ToImmutableArray(),
+                    snapshotSpan,
+                    _threadingContext,
+                    _presenter,
+                    _uiThreadOperationExecutor,
+                    _listenerProvider);
             }
         }
     }

--- a/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.cs
+++ b/src/EditorFeatures/Core.Wpf/NavigableSymbols/NavigableSymbolService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Host;
@@ -18,27 +20,32 @@ namespace Microsoft.CodeAnalysis.Editor.NavigableSymbols
     [Export(typeof(INavigableSymbolSourceProvider))]
     [Name(nameof(NavigableSymbolService))]
     [ContentType(ContentTypeNames.RoslynContentType)]
-    internal sealed partial class NavigableSymbolService : INavigableSymbolSourceProvider
+    internal partial class NavigableSymbolService : INavigableSymbolSourceProvider
     {
         private static readonly object s_key = new();
-
         private readonly IUIThreadOperationExecutor _uiThreadOperationExecutor;
         private readonly IThreadingContext _threadingContext;
-        private readonly IAsynchronousOperationListener _listener;
+        private readonly IStreamingFindUsagesPresenter _streamingPresenter;
+        private readonly IAsynchronousOperationListenerProvider _listenerProvider;
 
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
         public NavigableSymbolService(
             IUIThreadOperationExecutor uiThreadOperationExecutor,
             IThreadingContext threadingContext,
+            IStreamingFindUsagesPresenter streamingPresenter,
             IAsynchronousOperationListenerProvider listenerProvider)
         {
             _uiThreadOperationExecutor = uiThreadOperationExecutor;
             _threadingContext = threadingContext;
-            _listener = listenerProvider.GetListener(FeatureAttribute.NavigableSymbols);
+            _streamingPresenter = streamingPresenter;
+            _listenerProvider = listenerProvider;
         }
 
         public INavigableSymbolSource TryCreateNavigableSymbolSource(ITextView textView, ITextBuffer buffer)
-            => textView.GetOrCreatePerSubjectBufferProperty(buffer, s_key, (view, _) => new NavigableSymbolSource(this, view));
+        {
+            return textView.GetOrCreatePerSubjectBufferProperty(buffer, s_key,
+                (v, b) => new NavigableSymbolSource(_threadingContext, _streamingPresenter, _uiThreadOperationExecutor, _listenerProvider));
+        }
     }
 }

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptGoToSymbolContext.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptGoToSymbolContext.cs
@@ -3,32 +3,29 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
-using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.GoToDefinition;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
 {
     internal sealed class VSTypeScriptGoToSymbolContext
     {
-        internal DefinitionItem? DefinitionItem;
+        internal readonly GoToSymbolContext UnderlyingObject;
 
-        internal VSTypeScriptGoToSymbolContext(Document document, int position, CancellationToken cancellationToken)
+        internal VSTypeScriptGoToSymbolContext(GoToSymbolContext underlyingObject)
+            => UnderlyingObject = underlyingObject;
+
+        public Document Document => UnderlyingObject.Document;
+        public int Position => UnderlyingObject.Position;
+        public CancellationToken CancellationToken => UnderlyingObject.CancellationToken;
+
+        public TextSpan Span
         {
-            Document = document;
-            Position = position;
-            CancellationToken = cancellationToken;
+            get => UnderlyingObject.Span;
+            set => UnderlyingObject.Span = value;
         }
-
-        public Document Document { get; }
-        public int Position { get; }
-        public CancellationToken CancellationToken { get; }
-
-        public TextSpan Span { get; }
 
         public void AddItem(string key, VSTypeScriptDefinitionItem item)
-        {
-            _ = key;
-            this.DefinitionItem = item.UnderlyingObject;
-        }
+            => UnderlyingObject.AddItem(key, item.UnderlyingObject);
     }
 }

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptWellKnownSymbolTypes.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/VSTypeScriptWellKnownSymbolTypes.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CodeAnalysis.GoToDefinition;
+
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
 {
     internal static class VSTypeScriptWellKnownSymbolTypes
     {
-        /// <summary>
-        /// Exists for binary compat.  Not actually used for any purpose.
-        /// </summary>
-        public const string Definition = nameof(Definition);
+        public const string Definition = WellKnownSymbolTypes.Definition;
     }
 }

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptGoToSymbolService.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptGoToSymbolService.cs
@@ -4,18 +4,15 @@
 
 using System;
 using System.Composition;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor;
-using Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
+using Microsoft.CodeAnalysis.GoToDefinition;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Navigation;
-using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
 {
-    [ExportLanguageService(typeof(IAsyncGoToDefinitionService), InternalLanguageNames.TypeScript), Shared]
-    internal sealed class VSTypeScriptGoToSymbolService : IAsyncGoToDefinitionService
+    [ExportLanguageService(typeof(IGoToSymbolService), InternalLanguageNames.TypeScript), Shared]
+    internal sealed class VSTypeScriptGoToSymbolService : IGoToSymbolService
     {
         private readonly IVSTypeScriptGoToSymbolServiceImplementation _impl;
 
@@ -24,22 +21,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
         public VSTypeScriptGoToSymbolService(IVSTypeScriptGoToSymbolServiceImplementation impl)
             => _impl = impl;
 
-        public async Task<(INavigableLocation? location, TextSpan symbolSpan)> FindDefinitionLocationAsync(
-            Document document,
-            int position,
-            bool includeType,
-            CancellationToken cancellationToken)
-        {
-            var context = new VSTypeScriptGoToSymbolContext(document, position, cancellationToken);
-            await _impl.GetSymbolsAsync(context).ConfigureAwait(false);
-
-            if (context.DefinitionItem == null)
-                return default;
-
-            var navigableLocation = await context.DefinitionItem.GetNavigableLocationAsync(
-                document.Project.Solution.Workspace, cancellationToken).ConfigureAwait(false);
-
-            return (navigableLocation, context.Span);
-        }
+        public Task GetSymbolsAsync(GoToSymbolContext context)
+            => _impl.GetSymbolsAsync(new VSTypeScriptGoToSymbolContext(context));
     }
 }

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToDefinitionService.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Navigation;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.GoToDefinition
 {
@@ -43,48 +42,40 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
                 workspace, document.Id, position, virtualSpace: 0, cancellationToken);
         }
 
-        public async Task<(INavigableLocation? location, TextSpan symbolSpan)> FindDefinitionLocationAsync(
-            Document document,
-            int position,
-            bool includeType,
-            CancellationToken cancellationToken)
+        public async Task<INavigableLocation?> FindDefinitionLocationAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var symbolService = document.GetRequiredLanguageService<IGoToDefinitionSymbolService>();
-            var (controlFlowTarget, controlFlowSpan) = await symbolService.GetTargetIfControlFlowAsync(
+            var targetPositionOfControlFlow = await symbolService.GetTargetIfControlFlowAsync(
                 document, position, cancellationToken).ConfigureAwait(false);
-            if (controlFlowTarget != null)
+            if (targetPositionOfControlFlow is not null)
             {
-                var location = await GetNavigableLocationAsync(
-                    document, controlFlowTarget.Value, cancellationToken).ConfigureAwait(false);
-                return (location, controlFlowSpan);
+                return await GetNavigableLocationAsync(
+                    document, targetPositionOfControlFlow.Value, cancellationToken).ConfigureAwait(false);
             }
-            else
-            {
-                // Try to compute the referenced symbol and attempt to go to definition for the symbol.
-                var (symbol, project, span) = await symbolService.GetSymbolProjectAndBoundSpanAsync(
-                    document, position, includeType, cancellationToken).ConfigureAwait(false);
-                if (symbol is null)
-                    return default;
 
-                // if the symbol only has a single source location, and we're already on it,
-                // try to see if there's a better symbol we could navigate to.
-                var remappedLocation = await GetAlternativeLocationIfAlreadyOnDefinitionAsync(
-                    project, position, symbol, originalDocument: document, cancellationToken).ConfigureAwait(false);
-                if (remappedLocation != null)
-                    return (remappedLocation, span);
+            // Try to compute the referenced symbol and attempt to go to definition for the symbol.
+            var (symbol, project, _) = await symbolService.GetSymbolProjectAndBoundSpanAsync(
+                document, position, includeType: true, cancellationToken).ConfigureAwait(false);
+            if (symbol is null)
+                return null;
 
-                var isThirdPartyNavigationAllowed = await IsThirdPartyNavigationAllowedAsync(
-                    symbol, position, document, cancellationToken).ConfigureAwait(false);
+            // if the symbol only has a single source location, and we're already on it,
+            // try to see if there's a better symbol we could navigate to.
+            var remappedLocation = await GetAlternativeLocationIfAlreadyOnDefinitionAsync(
+                project, position, symbol, originalDocument: document, cancellationToken).ConfigureAwait(false);
+            if (remappedLocation != null)
+                return remappedLocation;
 
-                var location = await GoToDefinitionHelpers.GetDefinitionLocationAsync(
-                    symbol,
-                    project.Solution,
-                    _threadingContext,
-                    _streamingPresenter,
-                    thirdPartyNavigationAllowed: isThirdPartyNavigationAllowed,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
-                return (location, span);
-            }
+            var isThirdPartyNavigationAllowed = await IsThirdPartyNavigationAllowedAsync(
+                symbol, position, document, cancellationToken).ConfigureAwait(false);
+
+            return await GoToDefinitionHelpers.GetDefinitionLocationAsync(
+                symbol,
+                project.Solution,
+                _threadingContext,
+                _streamingPresenter,
+                thirdPartyNavigationAllowed: isThirdPartyNavigationAllowed,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/EditorFeatures/Core/GoToDefinition/AbstractGoToSymbolService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/AbstractGoToSymbolService.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.GoToDefinition;
+
+namespace Microsoft.CodeAnalysis.GoToDefinition
+{
+    // Ctrl+Click (GoToSymbol)
+    internal abstract class AbstractGoToSymbolService : IGoToSymbolService
+    {
+        public async Task GetSymbolsAsync(GoToSymbolContext context)
+        {
+            var document = context.Document;
+            var position = context.Position;
+            var cancellationToken = context.CancellationToken;
+            var service = document.GetRequiredLanguageService<IGoToDefinitionSymbolService>();
+
+            // [includeType: false]
+            // Enable Ctrl+Click on tokens with aliased, referenced or declared symbol.
+            // If the token has none of those but does have a type (mostly literals), we're not interested
+            var (symbol, project, span) = await service.GetSymbolProjectAndBoundSpanAsync(document, position, includeType: false, cancellationToken).ConfigureAwait(false);
+
+            if (symbol == null)
+            {
+                return;
+            }
+
+            var solution = project.Solution;
+            var definitions = await GoToDefinitionHelpers.GetDefinitionsAsync(symbol, solution, thirdPartyNavigationAllowed: true, cancellationToken).ConfigureAwait(false);
+
+            foreach (var definition in definitions)
+            {
+                var location = await definition.GetNavigableLocationAsync(solution.Workspace, cancellationToken).ConfigureAwait(false);
+                if (location != null)
+                    context.AddItem(WellKnownSymbolTypes.Definition, definition);
+            }
+
+            context.Span = span;
+        }
+    }
+}

--- a/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionCommandHandler.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionCommandHandler.cs
@@ -126,8 +126,8 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
                     return _threadingContext.JoinableTaskFactory.Run(async () =>
                     {
                         // determine the location first.
-                        var (location, _) = await asyncService.FindDefinitionLocationAsync(
-                            document, position, includeType: true, cancellationToken).ConfigureAwait(false);
+                        var location = await asyncService.FindDefinitionLocationAsync(
+                            document, position, cancellationToken).ConfigureAwait(false);
                         return await location.TryNavigateToAsync(
                             _threadingContext, NavigationOptions.Default, cancellationToken).ConfigureAwait(false);
                     });
@@ -163,8 +163,7 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
                 var cancellationToken = backgroundIndicator.UserCancellationToken;
 
                 // determine the location first.
-                var (location, _) = await service.FindDefinitionLocationAsync(
-                    document, position, includeType: true, cancellationToken).ConfigureAwait(false);
+                var location = await service.FindDefinitionLocationAsync(document, position, cancellationToken).ConfigureAwait(false);
 
                 // make sure that if our background indicator got canceled, that we do not still perform the navigation.
                 if (backgroundIndicator.UserCancellationToken.IsCancellationRequested)

--- a/src/EditorFeatures/Core/GoToDefinition/GoToSymbolContext.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToSymbolContext.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.CodeAnalysis.FindUsages;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.GoToDefinition
+{
+    internal class GoToSymbolContext
+    {
+        private readonly object _gate = new();
+
+        private readonly MultiDictionary<string, DefinitionItem> _items = new();
+
+        public GoToSymbolContext(Document document, int position, CancellationToken cancellationToken)
+        {
+            Document = document;
+            Position = position;
+            CancellationToken = cancellationToken;
+        }
+
+        public Document Document { get; }
+        public int Position { get; }
+        public CancellationToken CancellationToken { get; }
+
+        public TextSpan Span { get; set; }
+
+        internal bool TryGetItems(string key, out IEnumerable<DefinitionItem> items)
+        {
+            if (_items.ContainsKey(key))
+            {
+                // Multidictionary valuesets are structs so we can't
+                // just check for null
+                items = _items[key];
+                return true;
+            }
+            else
+            {
+                items = null;
+                return false;
+            }
+        }
+
+        public void AddItem(string key, DefinitionItem item)
+        {
+            lock (_gate)
+            {
+                _items.Add(key, item);
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Core/GoToDefinition/IAsyncGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/IAsyncGoToDefinitionService.cs
@@ -6,19 +6,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Navigation;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Editor
 {
     internal interface IAsyncGoToDefinitionService : ILanguageService
     {
-        /// <summary>
-        /// If the supplied <paramref name="position"/> is on a code construct with a navigable location, then this
-        /// returns that <see cref="INavigableLocation"/>.  The <see cref="TextSpan"/> returned in the span of the
-        /// symbol in the code that references that navigable location.  e.g. the full identifier token that the
-        /// position is within.
-        /// </summary>
-        Task<(INavigableLocation? location, TextSpan symbolSpan)> FindDefinitionLocationAsync(
-            Document document, int position, bool includeType, CancellationToken cancellationToken);
+        Task<INavigableLocation?> FindDefinitionLocationAsync(Document document, int position, CancellationToken cancellationToken);
     }
 }

--- a/src/EditorFeatures/Core/GoToDefinition/IGoToSymbolService.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/IGoToSymbolService.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.GoToDefinition;
+
+internal interface IGoToSymbolService : ILanguageService
+{
+    Task GetSymbolsAsync(GoToSymbolContext context);
+}

--- a/src/EditorFeatures/Core/GoToDefinition/WellKnownSymbolTypes.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/WellKnownSymbolTypes.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.GoToDefinition;
+
+internal static class WellKnownSymbolTypes
+{
+    public const string Definition = nameof(Definition);
+}

--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTestsBase.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTestsBase.vb
@@ -45,10 +45,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.GoToDefinition
                     DirectCast(New CSharpAsyncGoToDefinitionService(threadingContext, presenter), IAsyncGoToDefinitionService),
                     New VisualBasicAsyncGoToDefinitionService(threadingContext, presenter))
 
-                Dim defLocationAndSpan = Await goToDefService.FindDefinitionLocationAsync(
-                    document, cursorPosition, includeType:=True, CancellationToken.None)
-                Dim defLocation = defLocationAndSpan.location
-
+                Dim defLocation = Await goToDefService.FindDefinitionLocationAsync(document, cursorPosition, CancellationToken.None)
                 Dim actualResult = defLocation IsNot Nothing AndAlso
                     Await defLocation.NavigateToAsync(NavigationOptions.Default, CancellationToken.None)
                 Assert.Equal(expectedResult, actualResult)

--- a/src/EditorFeatures/Test2/NavigableSymbols/NavigableSymbolsTest.vb
+++ b/src/EditorFeatures/Test2/NavigableSymbols/NavigableSymbolsTest.vb
@@ -117,8 +117,9 @@ End Class"
 
         Private Shared Function ExtractSymbol(workspace As TestWorkspace, position As Integer) As Task(Of INavigableSymbol)
             Dim threadingContext = workspace.ExportProvider.GetExportedValue(Of IThreadingContext)()
+            Dim presenter = New MockStreamingFindUsagesPresenter(workspace.GlobalOptions, Sub() Return)
             Dim listenerProvider = workspace.ExportProvider.GetExportedValue(Of IAsynchronousOperationListenerProvider)
-            Dim service = New NavigableSymbolService(workspace.ExportProvider.GetExportedValue(Of IUIThreadOperationExecutor)(), threadingContext, listenerProvider)
+            Dim service = New NavigableSymbolService(workspace.ExportProvider.GetExportedValue(Of IUIThreadOperationExecutor)(), threadingContext, presenter, listenerProvider)
             Dim view = workspace.Documents.First().GetTextView()
             Dim buffer = workspace.Documents.First().GetTextBuffer()
             Dim triggerSpan = New SnapshotSpan(buffer.CurrentSnapshot, New Span(position, 0))

--- a/src/EditorFeatures/VisualBasic/GoToDefinition/VisualBasicGoToSymbolService.vb
+++ b/src/EditorFeatures/VisualBasic/GoToDefinition/VisualBasicGoToSymbolService.vb
@@ -1,0 +1,19 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Composition
+Imports Microsoft.CodeAnalysis.GoToDefinition
+Imports Microsoft.CodeAnalysis.Host.Mef
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.GoToDefinition
+    <ExportLanguageService(GetType(IGoToSymbolService), LanguageNames.VisualBasic), [Shared]>
+    Friend NotInheritable Class VisualBasicGoToSymbolService
+        Inherits AbstractGoToSymbolService
+
+        <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+        Public Sub New()
+        End Sub
+    End Class
+End Namespace

--- a/src/Features/Core/Portable/GoToDefinition/AbstractGoToDefinitionSymbolService.cs
+++ b/src/Features/Core/Portable/GoToDefinition/AbstractGoToDefinitionSymbolService.cs
@@ -55,18 +55,20 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
             return (FindRelatedExplicitlyDeclaredSymbol(symbol, compilation), project, semanticInfo.Span);
         }
 
-        public async Task<(int? targetPosition, TextSpan tokenSpan)> GetTargetIfControlFlowAsync(Document document, int position, CancellationToken cancellationToken)
+        public async Task<int?> GetTargetIfControlFlowAsync(Document document, int position, CancellationToken cancellationToken)
         {
             var syntaxTree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
             var token = await syntaxTree.GetTouchingTokenAsync(position, syntaxFacts.IsBindableToken, cancellationToken, findInsideTrivia: true).ConfigureAwait(false);
 
             if (token == default)
-                return default;
+            {
+                return null;
+            }
 
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
-            return (GetTargetPositionIfControlFlow(semanticModel, token), token.Span);
+            return GetTargetPositionIfControlFlow(semanticModel, token);
         }
 
         private static ISymbol? GetSymbol(TokenSemanticInfo semanticInfo, bool includeType)

--- a/src/Features/Core/Portable/GoToDefinition/IGoToDefinitionSymbolService.cs
+++ b/src/Features/Core/Portable/GoToDefinition/IGoToDefinitionSymbolService.cs
@@ -17,6 +17,6 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
         /// If the position is on a control flow keyword (continue, break, yield, return , etc), returns the relevant position in the corresponding control flow statement.
         /// Otherwise, returns null.
         /// </summary>
-        Task<(int? targetPosition, TextSpan tokenSpan)> GetTargetIfControlFlowAsync(Document document, int position, CancellationToken cancellationToken);
+        Task<int?> GetTargetIfControlFlowAsync(Document document, int position, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
Reverts dotnet/roslyn#63703. TS was using the `VSTypeScriptGoToSymbolContext.set_Span(Microsoft.CodeAnalysis.Text.TextSpan)` API. This needs a coordinated insertion.