### PR TITLE
Propagate In/Out attributes on local functions

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
@@ -469,6 +469,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
             }
 
+            internal override bool IsMetadataIn => RefKind == RefKind.In;
+
+            internal override bool IsMetadataOut => RefKind == RefKind.Out;
+
             public override bool Equals(Symbol obj, TypeCompareKind compareKind)
             {
                 if (obj == (object)this)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -315,6 +315,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool IsMetadataOptional => _baseParameterForAttributes?.IsMetadataOptional == true;
 
+        internal override bool IsMetadataIn => base.IsMetadataIn || _baseParameterForAttributes?.IsMetadataIn == true;
+
+        internal override bool IsMetadataOut => base.IsMetadataOut || _baseParameterForAttributes?.IsMetadataOut == true;
+
         internal override ConstantValue? ExplicitDefaultConstantValue => _baseParameterForAttributes?.ExplicitDefaultConstantValue;
 
         internal override FlowAnalysisAnnotations FlowAnalysisAnnotations

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -48,10 +48,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public sealed override bool IsDiscard => false;
 
-        internal override bool IsMetadataIn => RefKind == RefKind.In;
-
-        internal override bool IsMetadataOut => RefKind == RefKind.Out;
-
         public override string Name
         {
             get { return _name; }
@@ -208,6 +204,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
         }
 
+        internal sealed override bool IsMetadataIn => RefKind == RefKind.In;
+
+        internal sealed override bool IsMetadataOut => RefKind == RefKind.Out;
+
         public static ParameterSymbol Create(
             MethodSymbol? container,
             TypeWithAnnotations type,
@@ -315,9 +315,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool IsMetadataOptional => _baseParameterForAttributes?.IsMetadataOptional == true;
 
-        internal override bool IsMetadataIn => base.IsMetadataIn || _baseParameterForAttributes?.IsMetadataIn == true;
+        internal override bool IsMetadataIn => RefKind == RefKind.In || _baseParameterForAttributes?.IsMetadataIn == true;
 
-        internal override bool IsMetadataOut => base.IsMetadataOut || _baseParameterForAttributes?.IsMetadataOut == true;
+        internal override bool IsMetadataOut => RefKind == RefKind.Out || _baseParameterForAttributes?.IsMetadataOut == true;
 
         internal override ConstantValue? ExplicitDefaultConstantValue => _baseParameterForAttributes?.ExplicitDefaultConstantValue;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -315,9 +315,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool IsMetadataOptional => _baseParameterForAttributes?.IsMetadataOptional == true;
 
-        internal override bool IsMetadataIn => RefKind == RefKind.In || _baseParameterForAttributes?.IsMetadataIn == true;
+        internal override bool IsMetadataIn => RefKind == RefKind.In || _baseParameterForAttributes?.GetDecodedWellKnownAttributeData()?.HasInAttribute == true;
 
-        internal override bool IsMetadataOut => RefKind == RefKind.Out || _baseParameterForAttributes?.IsMetadataOut == true;
+        internal override bool IsMetadataOut => RefKind == RefKind.Out || _baseParameterForAttributes?.GetDecodedWellKnownAttributeData()?.HasOutAttribute == true;
 
         internal override ConstantValue? ExplicitDefaultConstantValue => _baseParameterForAttributes?.ExplicitDefaultConstantValue;
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -6131,7 +6131,6 @@ class Program
         }
 
         [Fact]
-        [InlineData("")]
         [WorkItem(57325, "https://github.com/dotnet/roslyn/issues/57325")]
         public void BaseParameterWithDifferentRefKind()
         {


### PR DESCRIPTION
Fixes #57325.

I found that we didn't override the appropriate methods to propagate these pseudo-custom attributes.

I reviewed *II.21.2.1 Pseudo custom attributes* in ECMA-335 for any attributes which could be applied to local functions or their parameters. I found that we had tests for every case except In/Out attributes.
