### PR TITLE
Update tests to assert different behavior on .net core

### DIFF
--- a/src/Workspaces/CSharpTest/OrganizeImports/OrganizeUsingsTests.cs
+++ b/src/Workspaces/CSharpTest/OrganizeImports/OrganizeUsingsTests.cs
@@ -1040,9 +1040,54 @@ using cc;
 using cC;
 using CC;
 
-// If Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// In .Net Core あ always comes before ア. In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
 // If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.";
 
+#if NETCOREAPP
+            var final =
+@"using a;
+using A;
+using aa;
+using aA;
+using Aa;
+using AA;
+using b;
+using B;
+using bb;
+using bB;
+using Bb;
+using BB;
+using bbb;
+using bbB;
+using bBb;
+using bBB;
+using Bbb;
+using BbB;
+using BBb;
+using BBB;
+using c;
+using C;
+using cc;
+using cC;
+using cC;
+using Cc;
+using CC;
+using あ;
+using ｱ;
+using ああ;
+using あｱ;
+using ｱあ;
+using ｱｱ;
+using あア;
+using ｱア;
+using ア;
+using アあ;
+using アｱ;
+using アア;
+
+// In .Net Core あ always comes before ア. In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.";
+#else
             var final =
 @"using a;
 using A;
@@ -1084,8 +1129,10 @@ using あア;
 using あｱ;
 using ああ;
 
-// If Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
-// If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.";
+// In .Net Core あ always comes before ア. In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.";     
+#endif
+
             await CheckAsync(initial, final);
         }
 
@@ -1106,6 +1153,22 @@ using ｱあ;
 using ｱア;
 using ｱｱ;";
 
+#if NETCOREAPP
+            var final =
+@"using あ;
+using ｱ;
+using ああ;
+using あｱ;
+using ｱあ;
+using ｱｱ;
+using あア;
+using ｱア;
+using ア;
+using アあ;
+using アｱ;
+using アア;
+";
+#else
             var final =
 @"using ア;
 using ｱ;
@@ -1120,6 +1183,7 @@ using あア;
 using あｱ;
 using ああ;
 ";
+#endif
 
             await CheckAsync(initial, final);
         }

--- a/src/Workspaces/VisualBasicTest/OrganizeImports/OrganizeImportsTests.vb
+++ b/src/Workspaces/VisualBasicTest/OrganizeImports/OrganizeImportsTests.vb
@@ -674,9 +674,54 @@ Imports cc
 Imports cC
 Imports CC
 
-// If Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// In .Net Core あ always comes before ア.  In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
 // If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.</content>
 
+#If NETCOREAPP Then
+            Dim final =
+<content>Imports a
+Imports A
+Imports aa
+Imports aA
+Imports Aa
+Imports AA
+Imports b
+Imports B
+Imports bb
+Imports bB
+Imports Bb
+Imports BB
+Imports bbb
+Imports bbB
+Imports bBb
+Imports bBB
+Imports Bbb
+Imports BbB
+Imports BBb
+Imports BBB
+Imports c
+Imports C
+Imports cc
+Imports cC
+Imports cC
+Imports Cc
+Imports CC
+Imports あ
+Imports ｱ
+Imports ああ
+Imports あｱ
+Imports ｱあ
+Imports ｱｱ
+Imports あア
+Imports ｱア
+Imports ア
+Imports アあ
+Imports アｱ
+Imports アア
+
+// In .Net Core あ always comes before ア.  In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.</content>
+#Else
             Dim final =
 <content>Imports a
 Imports A
@@ -718,8 +763,9 @@ Imports あア
 Imports あｱ
 Imports ああ
 
-// If Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// In .Net Core あ always comes before ア.  In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
 // If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.</content>
+#End If
             Await CheckAsync(initial, final)
         End Function
 
@@ -739,6 +785,22 @@ Imports ｱあ
 Imports ｱア
 Imports ｱｱ</content>
 
+#If NETCOREAPP Then
+            Dim final =
+<content>Imports あ
+Imports ｱ
+Imports ああ
+Imports あｱ
+Imports ｱあ
+Imports ｱｱ
+Imports あア
+Imports ｱア
+Imports ア
+Imports アあ
+Imports アｱ
+Imports アア
+</content>
+#Else
             Dim final =
 <content>Imports ア
 Imports ｱ
@@ -753,6 +815,7 @@ Imports あア
 Imports あｱ
 Imports ああ
 </content>
+#End If
 
             Await CheckAsync(initial, final)
         End Function


### PR DESCRIPTION
.Net core has different ordering for these hiragana characters on the invariant culture as compared to .net framework.  This updates the test to assert the correct ordering on each platform.