### PR TITLE
Change test import ordering based on runtime globalization library

### DIFF
--- a/src/Workspaces/CSharpTest/OrganizeImports/OrganizeUsingsTests.cs
+++ b/src/Workspaces/CSharpTest/OrganizeImports/OrganizeUsingsTests.cs
@@ -1040,54 +1040,9 @@ using cc;
 using cC;
 using CC;
 
-// In .Net Core あ always comes before ア. In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// If Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
 // If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.";
 
-#if NETCOREAPP
-            var final =
-@"using a;
-using A;
-using aa;
-using aA;
-using Aa;
-using AA;
-using b;
-using B;
-using bb;
-using bB;
-using Bb;
-using BB;
-using bbb;
-using bbB;
-using bBb;
-using bBB;
-using Bbb;
-using BbB;
-using BBb;
-using BBB;
-using c;
-using C;
-using cc;
-using cC;
-using cC;
-using Cc;
-using CC;
-using あ;
-using ｱ;
-using ああ;
-using あｱ;
-using ｱあ;
-using ｱｱ;
-using あア;
-using ｱア;
-using ア;
-using アあ;
-using アｱ;
-using アア;
-
-// In .Net Core あ always comes before ア. In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
-// If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.";
-#else
             var final =
 @"using a;
 using A;
@@ -1129,10 +1084,8 @@ using あア;
 using あｱ;
 using ああ;
 
-// In .Net Core あ always comes before ア. In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
-// If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.";     
-#endif
-
+// If Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.";
             await CheckAsync(initial, final);
         }
 
@@ -1153,22 +1106,6 @@ using ｱあ;
 using ｱア;
 using ｱｱ;";
 
-#if NETCOREAPP
-            var final =
-@"using あ;
-using ｱ;
-using ああ;
-using あｱ;
-using ｱあ;
-using ｱｱ;
-using あア;
-using ｱア;
-using ア;
-using アあ;
-using アｱ;
-using アア;
-";
-#else
             var final =
 @"using ア;
 using ｱ;
@@ -1183,7 +1120,6 @@ using あア;
 using あｱ;
 using ああ;
 ";
-#endif
 
             await CheckAsync(initial, final);
         }

--- a/src/Workspaces/CSharpTest/OrganizeImports/OrganizeUsingsTests.cs
+++ b/src/Workspaces/CSharpTest/OrganizeImports/OrganizeUsingsTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Editing;
@@ -1122,6 +1123,39 @@ using ああ;
 ";
 
             await CheckAsync(initial, final);
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.Organizing)]
+        [InlineData(CompareOptions.IgnoreCase)]
+        [InlineData(CompareOptions.IgnoreWidth)]
+        [InlineData(CompareOptions.IgnoreCase | CompareOptions.IgnoreWidth)]
+        [InlineData(CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreWidth)]
+        [InlineData(CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreWidth)]
+        public void CaseSensitivity3(CompareOptions options)
+        {
+            Compare("ｱ", "ア", options);
+        }
+
+        [Theory, Trait(Traits.Feature, Traits.Features.Organizing)]
+        [InlineData(CompareOptions.IgnoreCase)]
+        [InlineData(CompareOptions.IgnoreWidth)]
+        [InlineData(CompareOptions.IgnoreCase | CompareOptions.IgnoreWidth)]
+        [InlineData(CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreWidth)]
+        [InlineData(CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreWidth)]
+        public void CaseSensitivity4(CompareOptions options)
+        {
+            Compare("あ", "ア", options);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Organizing)]
+        public void CaseSensitivity5()
+        {
+            Assert.Equal("", $"{Environment.Version},{Environment.OSVersion}");
+        }
+
+        private static void Compare(string one, string two, CompareOptions option = CompareOptions.None)
+        {
+            Assert.Equal("", $"({one}, {two}) = {CultureInfo.InvariantCulture.CompareInfo.Compare(one, two, option)}");
         }
 
         [WorkItem(20988, "https://github.com/dotnet/roslyn/issues/20988")]

--- a/src/Workspaces/CSharpTest/OrganizeImports/OrganizeUsingsTests.cs
+++ b/src/Workspaces/CSharpTest/OrganizeImports/OrganizeUsingsTests.cs
@@ -1040,9 +1040,54 @@ using cc;
 using cC;
 using CC;
 
-// If Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// In .Net Core あ always comes before ア. In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
 // If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.";
 
+#if NETCOREAPP
+            var final =
+@"using a;
+using A;
+using aa;
+using aA;
+using Aa;
+using AA;
+using b;
+using B;
+using bb;
+using bB;
+using Bb;
+using BB;
+using bbb;
+using bbB;
+using bBb;
+using bBB;
+using Bbb;
+using BbB;
+using BBb;
+using BBB;
+using c;
+using C;
+using cc;
+using cC;
+using cC;
+using Cc;
+using CC;
+using あ;
+using ｱ;
+using ああ;
+using あｱ;
+using ｱあ;
+using ｱｱ;
+using あア;
+using ｱア;
+using ア;
+using アあ;
+using アｱ;
+using アア;
+
+// In .Net Core あ always comes before ア. In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.";
+#else
             var final =
 @"using a;
 using A;
@@ -1084,8 +1129,10 @@ using あア;
 using あｱ;
 using ああ;
 
-// If Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
-// If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.";
+// In .Net Core あ always comes before ア. In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.";     
+#endif
+
             await CheckAsync(initial, final);
         }
 
@@ -1106,6 +1153,22 @@ using ｱあ;
 using ｱア;
 using ｱｱ;";
 
+#if NETCOREAPP
+            var final =
+@"using あ;
+using ｱ;
+using ああ;
+using あｱ;
+using ｱあ;
+using ｱｱ;
+using あア;
+using ｱア;
+using ア;
+using アあ;
+using アｱ;
+using アア;
+";
+#else
             var final =
 @"using ア;
 using ｱ;
@@ -1120,6 +1183,7 @@ using あア;
 using あｱ;
 using ああ;
 ";
+#endif
 
             await CheckAsync(initial, final);
         }

--- a/src/Workspaces/CoreTestUtilities/GlobalizationUtilities.cs
+++ b/src/Workspaces/CoreTestUtilities/GlobalizationUtilities.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+
+namespace Microsoft.CodeAnalysis.UnitTests;
+internal class GlobalizationUtilities
+{
+    /// <summary>
+    /// The final ordering of kana depends on what globalization mode is being used.
+    /// On .net framework it is NLS, but on .net core + newer versions of windows, it defers to ICU
+    /// See https://docs.microsoft.com/en-us/dotnet/core/extensions/globalization-icu
+    /// and https://github.com/dotnet/runtime/blob/78065413b2d1b4f0ed26343567379e992a3e26ee/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs#L100
+    /// 
+    /// This helper allows us to figure out at runtime which mode is being used so tests can behave accordingly.
+    /// </summary>
+    public static bool ICUMode()
+    {
+        // Copied from https://docs.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#determine-if-your-app-is-using-icu
+        var sortVersion = CultureInfo.InvariantCulture.CompareInfo.Version;
+        var bytes = sortVersion.SortId.ToByteArray();
+        var version = bytes[3] << 24 | bytes[2] << 16 | bytes[1] << 8 | bytes[0];
+        return version != 0 && version == sortVersion.FullVersion;
+    }
+}

--- a/src/Workspaces/VisualBasicTest/OrganizeImports/OrganizeImportsTests.vb
+++ b/src/Workspaces/VisualBasicTest/OrganizeImports/OrganizeImportsTests.vb
@@ -13,6 +13,7 @@ Imports Roslyn.Test.Utilities
 Imports Xunit
 Imports Microsoft.CodeAnalysis.[Shared].Extensions
 Imports Microsoft.CodeAnalysis.OrganizeImports
+Imports Microsoft.CodeAnalysis.UnitTests
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Workspaces.UnitTests.OrganizeImports
     <[UseExportProvider]>
@@ -673,11 +674,53 @@ Imports Bbb
 Imports cc
 Imports cC
 Imports CC
+</content>
 
-// If Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
-// If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.</content>
-
-            Dim final =
+            Dim final As XElement
+            If GlobalizationUtilities.ICUMode() Then
+                final =
+<content>Imports a
+Imports A
+Imports aa
+Imports aA
+Imports Aa
+Imports AA
+Imports b
+Imports B
+Imports bb
+Imports bB
+Imports Bb
+Imports BB
+Imports bbb
+Imports bbB
+Imports bBb
+Imports bBB
+Imports Bbb
+Imports BbB
+Imports BBb
+Imports BBB
+Imports c
+Imports C
+Imports cc
+Imports cC
+Imports cC
+Imports Cc
+Imports CC
+Imports あ
+Imports ｱ
+Imports ああ
+Imports あｱ
+Imports ｱあ
+Imports ｱｱ
+Imports あア
+Imports ｱア
+Imports ア
+Imports アあ
+Imports アｱ
+Imports アア
+</content>
+            Else
+                final =
 <content>Imports a
 Imports A
 Imports aa
@@ -717,9 +760,9 @@ Imports ｱあ
 Imports あア
 Imports あｱ
 Imports ああ
+</content>
+            End If
 
-// If Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
-// If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.</content>
             Await CheckAsync(initial, final)
         End Function
 
@@ -739,7 +782,24 @@ Imports ｱあ
 Imports ｱア
 Imports ｱｱ</content>
 
-            Dim final =
+            Dim final As XElement
+            If GlobalizationUtilities.ICUMode() Then
+                final =
+<content>Imports あ
+Imports ｱ
+Imports ああ
+Imports あｱ
+Imports ｱあ
+Imports ｱｱ
+Imports あア
+Imports ｱア
+Imports ア
+Imports アあ
+Imports アｱ
+Imports アア
+</content>
+            Else
+                final =
 <content>Imports ア
 Imports ｱ
 Imports あ
@@ -753,6 +813,7 @@ Imports あア
 Imports あｱ
 Imports ああ
 </content>
+            End If
 
             Await CheckAsync(initial, final)
         End Function

--- a/src/Workspaces/VisualBasicTest/OrganizeImports/OrganizeImportsTests.vb
+++ b/src/Workspaces/VisualBasicTest/OrganizeImports/OrganizeImportsTests.vb
@@ -674,54 +674,9 @@ Imports cc
 Imports cC
 Imports CC
 
-// In .Net Core あ always comes before ア.  In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// If Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
 // If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.</content>
 
-#If NETCOREAPP Then
-            Dim final =
-<content>Imports a
-Imports A
-Imports aa
-Imports aA
-Imports Aa
-Imports AA
-Imports b
-Imports B
-Imports bb
-Imports bB
-Imports Bb
-Imports BB
-Imports bbb
-Imports bbB
-Imports bBb
-Imports bBB
-Imports Bbb
-Imports BbB
-Imports BBb
-Imports BBB
-Imports c
-Imports C
-Imports cc
-Imports cC
-Imports cC
-Imports Cc
-Imports CC
-Imports あ
-Imports ｱ
-Imports ああ
-Imports あｱ
-Imports ｱあ
-Imports ｱｱ
-Imports あア
-Imports ｱア
-Imports ア
-Imports アあ
-Imports アｱ
-Imports アア
-
-// In .Net Core あ always comes before ア.  In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
-// If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.</content>
-#Else
             Dim final =
 <content>Imports a
 Imports A
@@ -763,9 +718,8 @@ Imports あア
 Imports あｱ
 Imports ああ
 
-// In .Net Core あ always comes before ア.  In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// If Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
 // If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.</content>
-#End If
             Await CheckAsync(initial, final)
         End Function
 
@@ -785,22 +739,6 @@ Imports ｱあ
 Imports ｱア
 Imports ｱｱ</content>
 
-#If NETCOREAPP Then
-            Dim final =
-<content>Imports あ
-Imports ｱ
-Imports ああ
-Imports あｱ
-Imports ｱあ
-Imports ｱｱ
-Imports あア
-Imports ｱア
-Imports ア
-Imports アあ
-Imports アｱ
-Imports アア
-</content>
-#Else
             Dim final =
 <content>Imports ア
 Imports ｱ
@@ -815,7 +753,6 @@ Imports あア
 Imports あｱ
 Imports ああ
 </content>
-#End If
 
             Await CheckAsync(initial, final)
         End Function

--- a/src/Workspaces/VisualBasicTest/OrganizeImports/OrganizeImportsTests.vb
+++ b/src/Workspaces/VisualBasicTest/OrganizeImports/OrganizeImportsTests.vb
@@ -674,9 +674,54 @@ Imports cc
 Imports cC
 Imports CC
 
-// If Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// In .Net Core あ always comes before ア.  In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
 // If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.</content>
 
+#If NETCOREAPP Then
+            Dim final =
+<content>Imports a
+Imports A
+Imports aa
+Imports aA
+Imports Aa
+Imports AA
+Imports b
+Imports B
+Imports bb
+Imports bB
+Imports Bb
+Imports BB
+Imports bbb
+Imports bbB
+Imports bBb
+Imports bBB
+Imports Bbb
+Imports BbB
+Imports BBb
+Imports BBB
+Imports c
+Imports C
+Imports cc
+Imports cC
+Imports cC
+Imports Cc
+Imports CC
+Imports あ
+Imports ｱ
+Imports ああ
+Imports あｱ
+Imports ｱあ
+Imports ｱｱ
+Imports あア
+Imports ｱア
+Imports ア
+Imports アあ
+Imports アｱ
+Imports アア
+
+// In .Net Core あ always comes before ア.  In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.</content>
+#Else
             Dim final =
 <content>Imports a
 Imports A
@@ -718,8 +763,9 @@ Imports あア
 Imports あｱ
 Imports ああ
 
-// If Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
+// In .Net Core あ always comes before ア.  In .NetFramework if Kana is sensitive あ != ア, if Kana is insensitive あ == ア.
 // If Width is sensitiveア != ｱ, if Width is insensitive ア == ｱ.</content>
+#End If
             Await CheckAsync(initial, final)
         End Function
 
@@ -739,6 +785,22 @@ Imports ｱあ
 Imports ｱア
 Imports ｱｱ</content>
 
+#If NETCOREAPP Then
+            Dim final =
+<content>Imports あ
+Imports ｱ
+Imports ああ
+Imports あｱ
+Imports ｱあ
+Imports ｱｱ
+Imports あア
+Imports ｱア
+Imports ア
+Imports アあ
+Imports アｱ
+Imports アア
+</content>
+#Else
             Dim final =
 <content>Imports ア
 Imports ｱ
@@ -753,6 +815,7 @@ Imports あア
 Imports あｱ
 Imports ああ
 </content>
+#End If
 
             Await CheckAsync(initial, final)
         End Function


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/core/extensions/globalization-icu#icu-on-windows
Windows 10 May 2019 update shipped a ICU for localization which dotnet core will use if present. This update corresponds to version 18362. Our helix machines are using a version prior to this update, so they are not using the windows ICU. The single machine runs are using a version after this windows update and so are using ICU.

The ordering for hiragana vs katakana is different in ICU vs the previous localization method (NLS). Additionally the ordering for half width characters is different. See https://github.com/dotnet/runtime/blob/main/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs#L100-L106

At some point last week the ADO ci machines updated to this new version of windows which uses ICU which caused the test run to fail. But helix is still on an older version of windows which does not include ICU, so it uses the old NLS method (with the reversed ordering).

The fix is to check the runtime globalization library and switch test behavior based on that.