### PR TITLE
Disable duplicate analyzer warning

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceTests.cs
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 """, writer.ToString());
         }
 
-        [ConditionalFact(typeof(IsEnglishLocal))]
+        [ConditionalFact(typeof(IsEnglishLocal), Reason = "https://github.com/dotnet/roslyn/issues/63856")]
         public void DuplicateAnalyzerReference()
         {
             var directory = Temp.CreateDirectory();

--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceTests.cs
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 """, writer.ToString());
         }
 
-        [ConditionalFact(typeof(IsEnglishLocal), Reason = "https://github.com/dotnet/roslyn/issues/63856")]
+        [ConditionalFact(typeof(IsEnglishLocal), AlwaysSkip = "https://github.com/dotnet/roslyn/issues/63856")]
         public void DuplicateAnalyzerReference()
         {
             var directory = Temp.CreateDirectory();

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
@@ -527,7 +527,8 @@ namespace Microsoft.CodeAnalysis
                     }
                     else
                     {
-                        diagnostics.Add(new DiagnosticInfo(messageProvider, messageProvider.WRN_DuplicateAnalyzerReference, reference.FilePath));
+                        // https://github.com/dotnet/roslyn/issues/63856
+                        //diagnostics.Add(new DiagnosticInfo(messageProvider, messageProvider.WRN_DuplicateAnalyzerReference, reference.FilePath));
                     }
                 }
                 else


### PR DESCRIPTION
Disabling as part of https://github.com/dotnet/roslyn/issues/63856 to unblock the VS insertion.
