### PR TITLE
Use frozen partial semantic for import completion in OOP

### DIFF
--- a/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
+++ b/src/Features/Core/Portable/Completion/Log/CompletionProvidersLogger.cs
@@ -26,6 +26,7 @@ namespace Microsoft.CodeAnalysis.Completion.Log
             ExtensionMethodCompletionMethodsProvided,
             ExtensionMethodCompletionGetSymbolsTicks,
             ExtensionMethodCompletionCreateItemsTicks,
+            ExtensionMethodCompletionRemoteAssetSyncTicks,
             ExtensionMethodCompletionRemoteTicks,
             CommitsOfExtensionMethodImportCompletionItem,
             ExtensionMethodCompletionPartialResultCount,
@@ -52,14 +53,15 @@ namespace Microsoft.CodeAnalysis.Completion.Log
         internal static void LogCommitOfTypeImportCompletionItem() =>
             s_countLogAggregator.IncreaseCount(ActionInfo.CommitsOfTypeImportCompletionItem);
 
-        internal static void LogExtensionMethodCompletionTicksDataPoint(TimeSpan total, TimeSpan getSymbols, TimeSpan createItems, bool isRemote)
+        internal static void LogExtensionMethodCompletionTicksDataPoint(TimeSpan total, TimeSpan getSymbols, TimeSpan createItems, TimeSpan? remoteAssetSync)
         {
             s_histogramLogAggregator.LogTime(ActionInfo.ExtensionMethodCompletionTicks, total);
             s_statisticLogAggregator.AddDataPoint(ActionInfo.ExtensionMethodCompletionTicks, total);
 
-            if (isRemote)
+            if (remoteAssetSync.HasValue)
             {
-                s_statisticLogAggregator.AddDataPoint(ActionInfo.ExtensionMethodCompletionRemoteTicks, total - getSymbols - createItems);
+                s_statisticLogAggregator.AddDataPoint(ActionInfo.ExtensionMethodCompletionRemoteAssetSyncTicks, remoteAssetSync.Value);
+                s_statisticLogAggregator.AddDataPoint(ActionInfo.ExtensionMethodCompletionRemoteTicks, total - remoteAssetSync.Value - getSymbols - createItems);
             }
 
             s_statisticLogAggregator.AddDataPoint(ActionInfo.ExtensionMethodCompletionGetSymbolsTicks, getSymbols);

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractExtensionMethodImportCompletionProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -14,7 +13,6 @@ using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Completion.Providers
 {
@@ -44,7 +42,6 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 var syntaxFacts = completionContext.Document.GetRequiredLanguageService<ISyntaxFactsService>();
                 if (TryGetReceiverTypeSymbol(syntaxContext, syntaxFacts, cancellationToken, out var receiverTypeSymbol))
                 {
-                    var totalTime = SharedStopwatch.StartNew();
 
                     var inferredTypes = completionContext.CompletionOptions.TargetTypedCompletionFilter
                         ? syntaxContext.InferredTypes
@@ -60,18 +57,11 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                         hideAdvancedMembers: completionContext.CompletionOptions.HideAdvancedMembers,
                         cancellationToken).ConfigureAwait(false);
 
-                    if (result is null)
-                        return;
-
-                    var receiverTypeKey = SymbolKey.CreateString(receiverTypeSymbol, cancellationToken);
-                    completionContext.AddItems(result.CompletionItems.Select(i => Convert(i, receiverTypeKey)));
-
-                    // report telemetry:
-                    CompletionProvidersLogger.LogExtensionMethodCompletionTicksDataPoint(
-                        totalTime.Elapsed, result.GetSymbolsTime, result.CreateItemsTime, result.IsRemote);
-
-                    if (result.IsPartialResult)
-                        CompletionProvidersLogger.LogExtensionMethodCompletionPartialResultCount();
+                    if (result is not null)
+                    {
+                        var receiverTypeKey = SymbolKey.CreateString(receiverTypeSymbol, cancellationToken);
+                        completionContext.AddItems(result.CompletionItems.Select(i => Convert(i, receiverTypeKey)));
+                    }
                 }
             }
         }

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/SerializableUnimportedExtensionMethods.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/SerializableUnimportedExtensionMethods.cs
@@ -18,26 +18,26 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         public readonly bool IsPartialResult;
 
         [DataMember(Order = 2)]
-        public readonly TimeSpan GetSymbolsTime;
+        public TimeSpan GetSymbolsTime { get; set; }
 
         [DataMember(Order = 3)]
         public readonly TimeSpan CreateItemsTime;
 
         [DataMember(Order = 4)]
-        public readonly bool IsRemote;
+        public readonly TimeSpan? RemoteAssetSyncTime;
 
         public SerializableUnimportedExtensionMethods(
             ImmutableArray<SerializableImportCompletionItem> completionItems,
             bool isPartialResult,
             TimeSpan getSymbolsTime,
             TimeSpan createItemsTime,
-            bool isRemote)
+            TimeSpan? remoteAssetSyncTime)
         {
             CompletionItems = completionItems;
             IsPartialResult = isPartialResult;
             GetSymbolsTime = getSymbolsTime;
             CreateItemsTime = createItemsTime;
-            IsRemote = isRemote;
+            RemoteAssetSyncTime = remoteAssetSyncTime;
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/ExtensionMethodImportCompletion/RemoteExtensionMethodImportCompletionService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ExtensionMethodImportCompletion/RemoteExtensionMethodImportCompletionService.cs
@@ -42,7 +42,8 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             return RunServiceAsync(solutionChecksum, async solution =>
             {
-                var document = solution.GetDocument(documentId)!;
+                // Completion always uses frozen-partial semantic in-proc, which is not automatically passed to OOP, so enable it explicitly
+                var document = solution.GetRequiredDocument(documentId).WithFrozenPartialSemantics(cancellationToken);
                 var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
                 var symbol = SymbolKey.ResolveString(receiverTypeSymbolKeyData, compilation, cancellationToken: cancellationToken).GetAnySymbol();
 

--- a/src/Workspaces/Remote/ServiceHub/Services/ExtensionMethodImportCompletion/RemoteExtensionMethodImportCompletionService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ExtensionMethodImportCompletion/RemoteExtensionMethodImportCompletionService.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -10,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -40,8 +38,11 @@ namespace Microsoft.CodeAnalysis.Remote
             bool hideAdvancedMembers,
             CancellationToken cancellationToken)
         {
+            var stopwatch = SharedStopwatch.StartNew();
             return RunServiceAsync(solutionChecksum, async solution =>
             {
+                var assetSyncTime = stopwatch.Elapsed;
+
                 // Completion always uses frozen-partial semantic in-proc, which is not automatically passed to OOP, so enable it explicitly
                 var document = solution.GetRequiredDocument(documentId).WithFrozenPartialSemantics(cancellationToken);
                 var compilation = await document.Project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
@@ -55,8 +56,13 @@ namespace Microsoft.CodeAnalysis.Remote
                             .Select(symbolKey => SymbolKey.ResolveString(symbolKey, compilation, cancellationToken: cancellationToken).GetAnySymbol() as ITypeSymbol)
                             .WhereNotNull().ToImmutableArray();
 
-                    return await ExtensionMethodImportCompletionHelper.GetUnimportedExtensionMethodsInCurrentProcessAsync(
-                        document, position, receiverTypeSymbol, namespaceInScopeSet, targetTypes, forceCacheCreation, hideAdvancedMembers, isRemote: true, cancellationToken).ConfigureAwait(false);
+                    var intialGetSymbolsTime = stopwatch.Elapsed - assetSyncTime;
+
+                    var result = await ExtensionMethodImportCompletionHelper.GetUnimportedExtensionMethodsInCurrentProcessAsync(
+                        document, position, receiverTypeSymbol, namespaceInScopeSet, targetTypes, forceCacheCreation, hideAdvancedMembers, assetSyncTime, cancellationToken).ConfigureAwait(false);
+
+                    result.GetSymbolsTime += intialGetSymbolsTime;
+                    return result;
                 }
 
                 return null;


### PR DESCRIPTION
I seeing some random delays occur for calls into import completion's remote service. So switched to frozen partial semantic in remote, and clean up the telemetry logging for more accurate measurements