### PR TITLE
Avoid a first-chance exception if the PE reference doesn't exist

### DIFF
--- a/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
+++ b/src/Workspaces/Core/Portable/Serialization/SerializerService_Reference.cs
@@ -553,13 +553,19 @@ namespace Microsoft.CodeAnalysis.Serialization
         {
             try
             {
+                // It's common for us to have references to paths that don't exist for things like project-to-project references;
+                // the project system gives us metadata references we convert, but if the user unloads projects we might have some
+                // places we do see them. Since we're going to swallow all failures, we can avoid throwing first-chance exceptions
+                // for this case.
+                if (!File.Exists(reference.FilePath))
+                    return null;
+
                 return reference.GetMetadata();
             }
             catch
             {
-                // we have a reference but the file the reference is pointing to
-                // might not actually exist on disk.
-                // in that case, rather than crashing, we will handle it gracefully.
+                // Something prevented our ability to read the metadata; in this case we'll count this as a failure when computing checksums
+                // or serializing.
                 return null;
             }
         }


### PR DESCRIPTION
When we serialize references across, we read the referenced DLL in a few different places. During solution load, especially for a solution not built, this could create some first chance exceptions which creates noise in our performance systems. This attempts to avoid the noise.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1601375