### PR TITLE
Compiler outputs

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -1130,7 +1130,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                             else
                             {
-                                touchedFilesPath = unquoted;
+                                touchedFilesPath = ParseGenericPathToFile(unquoted, diagnostics, baseDirectory); ;
                             }
 
                             continue;

--- a/src/Compilers/CSharp/Test/CommandLine/TouchedFileLoggingTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/TouchedFileLoggingTests.cs
@@ -232,11 +232,11 @@ public class C { }").Path;
             var touchedReadPath = touchedFilesBase + ".read";
             var touchedWritesPath = touchedFilesBase + ".write";
 
-            var expected = expectedReads.Select(s => s.ToUpperInvariant()).OrderBy(s => s);
+            var expected = expectedReads.OrderBy(s => s);
             Assert.Equal(string.Join("\r\n", expected),
                          File.ReadAllText(touchedReadPath).Trim());
 
-            expected = expectedWrites.Select(s => s.ToUpperInvariant()).OrderBy(s => s);
+            expected = expectedWrites.OrderBy(s => s);
             Assert.Equal(string.Join("\r\n", expected),
                          File.ReadAllText(touchedWritesPath).Trim());
         }

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -382,6 +382,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             get { return (string?)_store[nameof(TargetType)]; }
         }
 
+        public string? TouchedFilesOutputPath
+        {
+            set { _store[nameof(TouchedFilesOutputPath)] = value; }
+            get { return (string?)_store[nameof(TouchedFilesOutputPath)]; }
+        }
+
         public bool TreatWarningsAsErrors
         {
             set { _store[nameof(TreatWarningsAsErrors)] = value; }
@@ -918,6 +924,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             // If the strings "LogicalName" or "Access" ever change, make sure to search/replace everywhere in vsproject.
             commandLine.AppendSwitchIfNotNull("/resource:", Resources, new string[] { "LogicalName", "Access" });
             commandLine.AppendSwitchIfNotNull("/target:", TargetType);
+            commandLine.AppendSwitchIfNotNull("/touchedfiles:", TouchedFilesOutputPath);
             commandLine.AppendPlusOrMinusSwitch("/warnaserror", _store, nameof(TreatWarningsAsErrors));
             commandLine.AppendWhenTrue("/utf8output", _store, nameof(Utf8Output));
             commandLine.AppendSwitchIfNotNull("/win32icon:", Win32Icon);

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -143,6 +143,7 @@
          TargetType="$(OutputType)"
          ToolExe="$(CscToolExe)"
          ToolPath="$(CscToolPath)"
+         TouchedFilesOutputPath="$(TouchedFilesOutputPath)"
          TreatWarningsAsErrors="$(TreatWarningsAsErrors)"
          UseHostCompilerIfAvailable="$(UseHostCompilerIfAvailable)"
          UseSharedCompilation="$(UseSharedCompilation)"

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -350,4 +350,31 @@
     <ProjectCapability Include="RoslynComponent" Condition="'$(IsRoslynComponent)' == 'true'"/>
   </ItemGroup>
 
+  <!--
+    ========================
+    Read Compiler Written Files
+    ========================
+    
+    After compilation, read back the list of files the compiler wrote to disk
+    and add them to FileWrites so they are properly tracked by MSBuild
+    -->
+  <Target Name="ReadCompilerTouchedFilesBack" 
+          AfterTargets="CoreCompile"
+          Inputs="$(TouchedFilesOutputPath).write"
+          Outputs="$(TouchedFilesOutputPath).write"
+          Condition="'$(TouchedFilesOutputPath)' != ''">
+    
+    <ReadLinesFromFile File="$(TouchedFilesOutputPath).write">
+      <Output TaskParameter="Lines"
+              ItemName="_CompilerFilesWritten"/>
+    </ReadLinesFromFile>
+    
+    <ItemGroup>
+      <FileWrites Include="@(_CompilerFilesWritten)" />
+      <FileWrites Include="$(TouchedFilesOutputPath).read" />
+      <FileWrites Include="$(TouchedFilesOutputPath).write" />
+    </ItemGroup>
+    
+  </Target>
+  
 </Project>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -111,6 +111,7 @@
          TargetType="$(OutputType)"
          ToolExe="$(VbcToolExe)"
          ToolPath="$(VbcToolPath)"
+         TouchedFilesOutputPath="$(TouchedFilesOutputPath)"
          TreatWarningsAsErrors="$(TreatWarningsAsErrors)"
          UseHostCompilerIfAvailable="$(UseHostCompilerIfAvailable)"
          UseSharedCompilation="$(UseSharedCompilation)"

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
@@ -263,7 +263,7 @@ namespace Microsoft.CodeAnalysis
         public ImmutableArray<CommandLineSourceFile> SourceFiles { get; internal set; }
 
         /// <summary>
-        /// Full path of a log of file paths accessed by the compiler, or null if file logging should be suppressed.
+        /// Path of a log of file paths accessed by the compiler, or null if file logging should be suppressed.
         /// </summary>
         /// <remarks>
         /// Two log files will be created: 

--- a/src/Compilers/Core/Portable/CommandLine/TouchedFileLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/TouchedFileLogger.cs
@@ -60,41 +60,25 @@ namespace Microsoft.CodeAnalysis
         /// TextWriter in upper case. After calling this method the
         /// logger is in an undefined state.
         /// </summary>
-        public void WriteReadPaths(TextWriter s)
-        {
-            var temp = new string[_readFiles.Count];
-            int i = 0;
-            var readFiles = Interlocked.Exchange(
-                ref _readFiles,
-                null!);
-            foreach (var path in readFiles)
-            {
-                temp[i] = path.ToUpperInvariant();
-                i++;
-            }
-            Array.Sort<string>(temp);
-
-            foreach (var path in temp)
-            {
-                s.WriteLine(path);
-            }
-        }
+        public void WriteReadPaths(TextWriter s) => WritePathSet(s, ref _readFiles);
 
         /// <summary>
         /// Writes all of the paths the TouchedFileLogger to the given 
         /// TextWriter in upper case. After calling this method the
         /// logger is in an undefined state.
         /// </summary>
-        public void WriteWrittenPaths(TextWriter s)
+        public void WriteWrittenPaths(TextWriter s) => WritePathSet(s, ref _writtenFiles);
+
+        private void WritePathSet(TextWriter s, ref ConcurrentSet<string> pathSet)
         {
-            var temp = new string[_writtenFiles.Count];
+            var temp = new string[pathSet.Count];
             int i = 0;
-            var writtenFiles = Interlocked.Exchange(
-                ref _writtenFiles,
+            var paths = Interlocked.Exchange(
+                ref pathSet,
                 null!);
-            foreach (var path in writtenFiles)
+            foreach (var path in paths)
             {
-                temp[i] = path.ToUpperInvariant();
+                temp[i] = path;
                 i++;
             }
             Array.Sort<string>(temp);

--- a/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/TouchedFileLoggingTests.cs
@@ -181,11 +181,11 @@ End Class
             var touchedReadPath = touchedFilesBase + ".read";
             var touchedWritesPath = touchedFilesBase + ".write";
 
-            var expected = expectedReads.Select(s => s.ToUpperInvariant()).OrderBy(s => s);
+            var expected = expectedReads.OrderBy(s => s);
             Assert.Equal(string.Join("\r\n", expected),
                          File.ReadAllText(touchedReadPath).Trim());
 
-            expected = expectedWrites.Select(s => s.ToUpperInvariant()).OrderBy(s => s);
+            expected = expectedWrites.OrderBy(s => s);
             Assert.Equal(string.Join("\r\n", expected),
                          File.ReadAllText(touchedWritesPath).Trim());
         }

--- a/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
@@ -189,11 +189,11 @@ End Class
             Dim touchedReadPath = touchedFilesBase + ".read"
             Dim touchedWritesPath = touchedFilesBase + ".write"
 
-            Dim expected = expectedReads.Select(Function(s) s.ToUpperInvariant()).OrderBy(Function(s) s)
+            Dim expected = expectedReads.OrderBy(Function(s) s)
             Assert.Equal(String.Join(vbCrLf, expected),
                          File.ReadAllText(touchedReadPath).Trim())
 
-            expected = expectedWrites.Select(Function(s) s.ToUpperInvariant()).OrderBy(Function(s) s)
+            expected = expectedWrites.OrderBy(Function(s) s)
             Assert.Equal(String.Join(vbCrLf, expected),
                          File.ReadAllText(touchedWritesPath).Trim())
         End Sub


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/48649 

This repurposes the touched file logger so that we can correctly record which files were emitted to disk by the compiler. An msbuild task then reads the file back and adds them to file wites so that they are correctly tracked.