### PR TITLE
Colorize langword inside doc comments

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -1140,7 +1140,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             for (int i = (int)SyntaxKind.YieldKeyword; i <= (int)SyntaxKind.FileKeyword; i++)
             {
-                yield return (SyntaxKind)i;
+                // 8441 corresponds to a deleted kind (DataKeyword) that was previously shipped.
+                if (i != 8441)
+                {
+                    yield return (SyntaxKind)i;
+                }
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
@@ -1770,6 +1772,68 @@ class Bar { }";
                 Class("Bar"),
                 Punctuation.OpenCurly,
                 Punctuation.CloseCurly);
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task XmlDocComment_Langword_NormalKeywords(TestHost testHost)
+        {
+            var keywords = SyntaxFacts.GetKeywordKinds().Select(SyntaxFacts.GetText);
+
+            foreach (var keyword in keywords)
+            {
+                var code = @$"
+///   <see langword=""{keyword}"" />
+class Bar {{ }}";
+                await TestAsync(code,
+                    testHost,
+                    XmlDoc.Delimiter("///"),
+                    XmlDoc.Text("   "),
+                    XmlDoc.Delimiter("<"),
+                    XmlDoc.Name("see"),
+                    XmlDoc.AttributeName("langword"),
+                    XmlDoc.Delimiter("="),
+                    XmlDoc.AttributeQuotes(@""""),
+                    Keyword(keyword),
+                    XmlDoc.AttributeQuotes(@""""),
+                    XmlDoc.Delimiter("/>"),
+                    Keyword("class"),
+                    Class("Bar"),
+                    Punctuation.OpenCurly,
+                    Punctuation.CloseCurly);
+            }
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task XmlDocComment_Langword_PreprocessorKeywords(TestHost testHost)
+        {
+            var keywords = SyntaxFacts.GetPreprocessorKeywordKinds()
+                                      .Where(k => !SyntaxFacts.GetKeywordKinds().Contains(k))
+                                      .Select(SyntaxFacts.GetText);
+
+            foreach (var keyword in keywords)
+            {
+                var code = @$"
+///   <see langword=""{keyword}"" />
+class Bar {{ }}";
+                await TestAsync(code,
+                    testHost,
+                    XmlDoc.Delimiter("///"),
+                    XmlDoc.Text("   "),
+                    XmlDoc.Delimiter("<"),
+                    XmlDoc.Name("see"),
+                    XmlDoc.AttributeName("langword"),
+                    XmlDoc.Delimiter("="),
+                    XmlDoc.AttributeQuotes(@""""),
+                    PPKeyword(keyword),
+                    XmlDoc.AttributeQuotes(@""""),
+                    XmlDoc.Delimiter("/>"),
+                    Keyword("class"),
+                    Class("Bar"),
+                    Punctuation.OpenCurly,
+                    Punctuation.CloseCurly);
+            }
         }
 
         [Theory]

--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Workspaces/CSharp/Portable/Classification/Worker_DocumentationComments.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker_DocumentationComments.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                 if (token.HasLeadingTrivia)
                     ClassifyXmlTrivia(token.LeadingTrivia);
 
-                if (token.Parent is XmlTextAttributeSyntax { Name.LocalName.Text: "langword" })
+                if (token.Parent is XmlTextAttributeSyntax { Name.LocalName.Text: DocumentationCommentXmlNames.LangwordAttributeName })
                 {
                     ClassifyXmlLangwordAttributeValue(token);
                 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/63885

Looks like this:
![fLtVSE0SeU](https://user-images.githubusercontent.com/70431552/189424424-38dfc028-dd5d-4c16-bd9d-004897559fdb.png)