### PR TITLE
Do not serialize extern aliases to synthesized method

### DIFF
--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Cci
             bool emitEncInfo = compilationOptions.EnableEditAndContinue && _metadataWriter.IsFullMetadata && !suppressNewCustomDebugInfo;
 
             byte[] blob = customDebugInfoWriter.SerializeMethodDebugInfo(Context, methodBody, methodHandle, emitStateMachineInfo: emitAllDebugInfo, emitEncInfo, emitDynamicAndTupleInfo, out bool emitExternNamespaces);
+            Debug.Assert(emitAllDebugInfo || !emitExternNamespaces);
 
             if (!emitAllDebugInfo && blob.Length == 0)
             {

--- a/src/Compilers/Core/Portable/PEWriter/CustomDebugInfoWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/CustomDebugInfoWriter.cs
@@ -72,26 +72,6 @@ namespace Microsoft.Cci
             bool emitDynamicAndTupleInfo,
             out bool emitExternNamespaces)
         {
-            emitExternNamespaces = false;
-
-            // CONSIDER: this may not be the same "first" method as in Dev10, but
-            // it shouldn't matter since all methods will still forward to a method
-            // containing the appropriate information.
-            if (_methodBodyWithModuleInfo == null)
-            {
-                // This module level information could go on every method (and does in
-                // the edit-and-continue case), but - as an optimization - we'll just
-                // put it on the first method we happen to encounter and then put a
-                // reference to the first method's token in every other method (so they
-                // can find the information).
-                if (context.Module.GetAssemblyReferenceAliases(context).Any())
-                {
-                    _methodWithModuleInfo = methodHandle;
-                    _methodBodyWithModuleInfo = methodBody;
-                    emitExternNamespaces = true;
-                }
-            }
-
             var pooledBuilder = PooledBlobBuilder.GetInstance();
             var encoder = new CustomDebugInfoEncoder(pooledBuilder);
 
@@ -123,6 +103,27 @@ namespace Microsoft.Cci
 
             byte[] result = encoder.ToArray() ?? Array.Empty<byte>();
             pooledBuilder.Free();
+
+            emitExternNamespaces = false;
+
+            // CONSIDER: this may not be the same "first" method as in Dev10, but
+            // it shouldn't matter since all methods will still forward to a method
+            // containing the appropriate information.
+            if (_methodBodyWithModuleInfo == null && result.Length > 0)
+            {
+                // This module level information could go on every method (and does in
+                // the edit-and-continue case), but - as an optimization - we'll just
+                // put it on the first method we happen to encounter and then put a
+                // reference to the first method's token in every other method (so they
+                // can find the information).
+                if (context.Module.GetAssemblyReferenceAliases(context).Any())
+                {
+                    _methodWithModuleInfo = methodHandle;
+                    _methodBodyWithModuleInfo = methodBody;
+                    emitExternNamespaces = true;
+                }
+            }
+
             return result;
         }
 


### PR DESCRIPTION
`PdbWriter.SerializeDebugInfo()` drops extern aliases from the native PDB if the first method has no other debug info.

Fixes #63927.