### PR TITLE
Fix Equals override for CompilerDiagnostic reported by CompilerDiagnosticAnalyzer

### DIFF
--- a/src/Compilers/CSharp/Test/Emit2/Diagnostics/GetDiagnosticsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Diagnostics/GetDiagnosticsTests.cs
@@ -800,13 +800,19 @@ internal class TestAttribute : Attribute
                 Diagnostic(ErrorCode.WRN_AttributeLocationOnBadDeclaration, "property").WithArguments("property", "field").WithLocation(5, 6));
             var compilationDiagnostic = compilationDiagnostics.Single();
 
-            // Verify equality for the compiler diagnostic fetched from Compilation and diagnostic reported from 'CSharpCompilerDiagnosticAnalyzer'.
             var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new CSharpCompilerDiagnosticAnalyzer());
             var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers);
             var analyzerDiagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
             var analyzerDiagnostic = analyzerDiagnostics.Single();
-            Assert.Equal(analyzerDiagnostic, compilationDiagnostic);
+
+            // Verify equality for the compiler diagnostic reported from 'CSharpCompilerDiagnosticAnalyzer' with itself.
             Assert.Equal(analyzerDiagnostic, analyzerDiagnostic);
+
+            // Verify that diagnostic equality check fails when compared with the same compiler diagnostic
+            // fetched from 'compilation.GetDiagnostics()'. Hosts that want to compare compiler diagnostics from
+            // different sources should use custom equality comparer.
+            Assert.NotEqual(analyzerDiagnostic, compilationDiagnostic);
+            Assert.NotEqual(compilationDiagnostic, analyzerDiagnostic);
         }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 }
             }
 
-            private class CompilerDiagnostic : Diagnostic
+            private sealed class CompilerDiagnostic : Diagnostic
             {
                 private readonly Diagnostic _original;
                 private readonly ImmutableDictionary<string, string?> _properties;
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     // We only support equality check with another instance of "CompilerDiagnostic".
                     // Hosts that want to compare compiler diagnostics from different sources,
-                    // such as with diagnostic reported from comilation.GetDiagnostics(), should
+                    // such as with diagnostic reported from compilation.GetDiagnostics(), should
                     // use a custom equality comparer.
                     return obj is CompilerDiagnostic other &&
                         _original.Equals(other._original);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
@@ -111,10 +111,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 public override bool Equals(Diagnostic? obj)
                 {
-                    if (obj is CompilerDiagnostic other)
-                        return _original.Equals(other._original);
-
-                    return _original.Equals(obj);
+                    // We only support equality check with another instance of "CompilerDiagnostic".
+                    // Hosts that want to compare compiler diagnostics from different sources,
+                    // such as with diagnostic reported from comilation.GetDiagnostics(), should
+                    // use a custom equality comparer.
+                    return obj is CompilerDiagnostic other &&
+                        _original.Equals(other._original);
                 }
 
                 internal override Diagnostic WithLocation(Location location)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs
@@ -111,6 +111,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
                 public override bool Equals(Diagnostic? obj)
                 {
+                    if (obj is CompilerDiagnostic other)
+                        return _original.Equals(other._original);
+
                     return _original.Equals(obj);
                 }
 


### PR DESCRIPTION
Fixes #63923
For compiler diagnostics which have a non-null property bag attached to it, the `CompilerDiagnosticAnalyzer` reports a wrapping `CompilerDiagnostic`: https://github.com/dotnet/roslyn/blob/c71fa5419aa035a8d76c8a82387353e3892180a7/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilerDiagnosticAnalyzer.CompilationAnalyzer.cs#L70-L71 Equality check for this wrapping diagnostic always compared the other diagnostic with the underlying original diagnostic, but did not account for comparison with itself. I have added a unit test that fails prior to the fix and also verified the original repro case in the bug works fine after this fix.

**NOTE:** I do not have historical context on why we report this wrapping `CompilerDiagnostic` in presence of a non-null property bag on the diagnostic. We may want to consider experimenting removing this type and verify what, if anything, breaks. At the minimum, we should document the reason behind this wrapping diagnostic.
~~I'll file a tracking issue for this work~~ - Filed #63938