### PR TITLE
Delegate to base constructor when generating from members

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
@@ -1832,5 +1832,53 @@ using System.Collections.Generic;
     </Project>
 </Workspace>");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
+        [WorkItem(63273, "https://github.com/dotnet/roslyn/issues/63273")]
+        public async Task TestBaseClass()
+        {
+            await TestWithPickMembersDialogAsync(
+@"
+class Person
+{
+    public string Name { get; }
+    public string Age { get; }
+
+    public Person(string name, string age)
+    {
+        Name = name;
+        Age = age;
+    }
+}
+class [||]Employee : Person
+{
+    public string Salary { get; }
+    public string Role { get; }
+}",
+@"
+class Person
+{
+    public string Name { get; }
+    public string Age { get; }
+
+    public Person(string name, string age)
+    {
+        Name = name;
+        Age = age;
+    }
+}
+class Employee : Person
+{
+    public Employee(string name, string age, string salary, string role{|Navigation:)|} : base(name, age)
+    {
+        Salary = salary;
+        Role = role;
+    }
+
+    public string Salary { get; }
+    public string Role { get; }
+}",
+chosenSymbols: null);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
@@ -2012,5 +2012,66 @@ class B : A
 }",
 chosenSymbols: null);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
+        [WorkItem(63273, "https://github.com/dotnet/roslyn/issues/63273")]
+        public async Task TestBaseClass_NonintersectingConstructors()
+        {
+            await TestWithPickMembersDialogAsync(
+@"
+class A
+{
+    public int A1 { get; }
+    public int A2 { get; }
+    public int A3 { get; }
+    public int A4 { get; }
+
+    public A(int a1, int a2)
+    {
+        A1 = a1;
+        A2 = a2;
+    }
+
+    public A(int a2, int a3)
+    {
+        A2 = a2;
+        A3 = a3;
+    }
+}
+class [||]B : A
+{
+    public int B1 { get; set; }
+}",
+@"
+class A
+{
+    public int A1 { get; }
+    public int A2 { get; }
+    public int A3 { get; }
+    public int A4 { get; }
+
+    public A(int a1, int a2)
+    {
+        A1 = a1;
+        A2 = a2;
+    }
+
+    public A(int a2, int a3)
+    {
+        A2 = a2;
+        A3 = a3;
+    }
+}
+class B : A
+{
+    public B(int a1, int a2, int b1{|Navigation:)|} : base(a1, a2)
+    {
+        B1 = b1;
+    }
+
+    public int B1 { get; set; }
+}",
+chosenSymbols: null);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
@@ -1880,5 +1880,137 @@ class Employee : Person
 }",
 chosenSymbols: null);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
+        [WorkItem(63273, "https://github.com/dotnet/roslyn/issues/63273")]
+        public async Task TestBaseClass_PrivateBaseCtor()
+        {
+            await TestWithPickMembersDialogAsync(
+@"
+class A
+{
+    public int A1 { get; }
+
+    private A(int a1)
+    {
+        A1 = a1;
+    }
+}
+class [||]B : A
+{
+    public int B1 { get; set; }
+}",
+@"
+class A
+{
+    public int A1 { get; }
+
+    private A(int a1)
+    {
+        A1 = a1;
+    }
+}
+class B : A
+{
+    public B(int b1{|Navigation:)|}
+    {
+        B1 = b1;
+    }
+
+    public int B1 { get; set; }
+}",
+chosenSymbols: null);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
+        [WorkItem(63273, "https://github.com/dotnet/roslyn/issues/63273")]
+        public async Task TestBaseClass_MoreBaseMembers()
+        {
+            await TestWithPickMembersDialogAsync(
+@"
+class A
+{
+    public int A1 { get; set; }
+    public int A2 { get; set; }
+
+    public A(int a1)
+    {
+        A1 = a1;
+    }
+}
+class [||]B : A
+{
+    public int B1 { get; set; }
+}",
+@"
+class A
+{
+    public int A1 { get; set; }
+    public int A2 { get; set; }
+
+    public A(int a1)
+    {
+        A1 = a1;
+    }
+}
+class B : A
+{
+    public B(int a1, int a2, int b1{|Navigation:)|} : base(a1)
+    {
+        A2 = a2;
+        B1 = b1;
+    }
+
+    public int B1 { get; set; }
+}",
+chosenSymbols: null);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
+        [WorkItem(63273, "https://github.com/dotnet/roslyn/issues/63273")]
+        public async Task TestBaseClass_UnaccessibleBaseMembers()
+        {
+            await TestWithPickMembersDialogAsync(
+@"
+class A
+{
+    public int A1 { get; set; }
+    public int A2 { get; }
+    private int A3 { get; set; }
+    public int A4 { get; private set; }
+
+    public A(int a1)
+    {
+        A1 = a1;
+    }
+}
+class [||]B : A
+{
+    public int B1 { get; set; }
+}",
+@"
+class A
+{
+    public int A1 { get; set; }
+    public int A2 { get; }
+    private int A3 { get; set; }
+    public int A4 { get; private set; }
+
+    public A(int a1)
+    {
+        A1 = a1;
+    }
+}
+class B : A
+{
+    public B(int a1, int b1{|Navigation:)|} : base(a1)
+    {
+        B1 = b1;
+    }
+
+    public int B1 { get; set; }
+}",
+chosenSymbols: null);
+        }
     }
 }

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.ConstructorDelegatingCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.ConstructorDelegatingCodeAction.cs
@@ -56,7 +56,8 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 var codeGenerationService = languageServices.GetRequiredService<ICodeGenerationService>();
 
                 Contract.ThrowIfNull(_state.DelegatedConstructor);
-                var thisConstructorArguments = factory.CreateArguments(
+                var thisConstructor = _state.DelegatedConstructor.ContainingType == _state.ContainingType;
+                var delegatedConstructorArguments = factory.CreateArguments(
                     _state.Parameters.Take(_state.DelegatedConstructor.Parameters.Length).ToImmutableArray());
 
                 using var _1 = ArrayBuilder<SyntaxNode>.GetInstance(out var nullCheckStatements);
@@ -105,7 +106,8 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                         typeName: _state.ContainingType.Name,
                         parameters: _state.Parameters,
                         statements: statements,
-                        thisConstructorArguments: thisConstructorArguments),
+                        baseConstructorArguments: thisConstructor ? default : delegatedConstructorArguments,
+                        thisConstructorArguments: thisConstructor ? delegatedConstructorArguments : default),
                     cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 return await AddNavigationAnnotationAsync(result, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.State.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.State.cs
@@ -80,6 +80,10 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 // We are going to create a new contructor and pass part of the parameters into DelegatedConstructor,
                 // so parameters should be compared based on types since we don't want get a type mismatch error after the new constructor is genreated.
                 DelegatedConstructor = GetDelegatedConstructorBasedOnParameterTypes(ContainingType, Parameters);
+                if (DelegatedConstructor is null && ContainingType.BaseType is not null)
+                {
+                    DelegatedConstructor = GetDelegatedConstructorBasedOnParameterTypes(ContainingType.BaseType, Parameters);
+                }
                 return true;
             }
 

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.State.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.State.cs
@@ -79,20 +79,22 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
                 MatchingConstructor = GetMatchingConstructorBasedOnParameterTypes(ContainingType, Parameters);
                 // We are going to create a new contructor and pass part of the parameters into DelegatedConstructor,
                 // so parameters should be compared based on types since we don't want get a type mismatch error after the new constructor is genreated.
-                DelegatedConstructor = GetDelegatedConstructorBasedOnParameterTypes(ContainingType, Parameters);
+                DelegatedConstructor = GetDelegatedConstructorBasedOnParameterTypes(ContainingType, Parameters, ContainingType);
                 if (DelegatedConstructor is null && ContainingType.BaseType is not null)
                 {
-                    DelegatedConstructor = GetDelegatedConstructorBasedOnParameterTypes(ContainingType.BaseType, Parameters);
+                    DelegatedConstructor = GetDelegatedConstructorBasedOnParameterTypes(ContainingType.BaseType, Parameters, ContainingType);
                 }
                 return true;
             }
 
             private static IMethodSymbol? GetDelegatedConstructorBasedOnParameterTypes(
                 INamedTypeSymbol containingType,
-                ImmutableArray<IParameterSymbol> parameters)
+                ImmutableArray<IParameterSymbol> parameters,
+                INamedTypeSymbol accessibleWithin)
             {
                 var q =
                     from c in containingType.InstanceConstructors
+                    where c.IsAccessibleWithin(accessibleWithin)
                     orderby c.Parameters.Length descending
                     where c.Parameters.Length > 0 && c.Parameters.Length < parameters.Length
                     where c.Parameters.All(p => p.RefKind == RefKind.None) && !c.Parameters.Any(static p => p.IsParams)

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
@@ -202,7 +202,11 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
             // Find all the possible writable instance fields/properties.  If there are any, then
             // show a dialog to the user to select the ones they want.  Otherwise, if there are none
             // don't offer to generate anything.
-            var viableMembers = containingType.GetAccessibleMembersInThisAndBaseTypes<ISymbol>(containingType).WhereAsArray(IsWritableInstanceFieldOrProperty);
+            // First suggest `base` members, then `this` members.
+            var viableMembers = containingType.GetAccessibleMembersInBaseTypes<ISymbol>(containingType)
+                .Concat(containingType.GetMembers())
+                .Where(IsWritableInstanceFieldOrProperty)
+                .ToImmutableArray();
             if (viableMembers.Length == 0)
             {
                 return null;

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
@@ -203,9 +203,9 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
             // show a dialog to the user to select the ones they want.  Otherwise, if there are none
             // don't offer to generate anything.
             // First suggest `base` members, then `this` members.
-            var viableMembers = containingType.GetAccessibleMembersInBaseTypes<ISymbol>(containingType)
-                .Concat(containingType.GetMembers())
-                .Where(IsWritableInstanceFieldOrProperty)
+            // Even inaccessible members are considered because they could be delegated to a base constructor.
+            var viableMembers = containingType.GetBaseTypesAndThis().Reverse()
+                .SelectMany(t => t.GetMembers().Where(IsWritableInstanceFieldOrProperty))
                 .ToImmutableArray();
             if (viableMembers.Length == 0)
             {

--- a/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateConstructorFromMembers/AbstractGenerateConstructorFromMembersCodeRefactoringProvider.cs
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.GenerateConstructorFromMembers
             // Find all the possible writable instance fields/properties.  If there are any, then
             // show a dialog to the user to select the ones they want.  Otherwise, if there are none
             // don't offer to generate anything.
-            var viableMembers = containingType.GetMembers().WhereAsArray(IsWritableInstanceFieldOrProperty);
+            var viableMembers = containingType.GetAccessibleMembersInThisAndBaseTypes<ISymbol>(containingType).WhereAsArray(IsWritableInstanceFieldOrProperty);
             if (viableMembers.Length == 0)
             {
                 return null;

--- a/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersCodeRefactoringProvider.cs
@@ -55,7 +55,10 @@ namespace Microsoft.CodeAnalysis.GenerateFromMembers
             => !symbol.IsStatic && IsReadableFieldOrProperty(symbol);
 
         protected static bool IsWritableInstanceFieldOrProperty(ISymbol symbol)
-            => !symbol.IsStatic && IsWritableFieldOrProperty(symbol);
+            => IsWritableInstanceFieldOrProperty(symbol, within: null);
+
+        protected static bool IsWritableInstanceFieldOrProperty(ISymbol symbol, ISymbol? within)
+            => !symbol.IsStatic && IsWritableFieldOrProperty(symbol, within);
 
         private static bool IsReadableFieldOrProperty(ISymbol symbol)
             => symbol switch
@@ -65,12 +68,12 @@ namespace Microsoft.CodeAnalysis.GenerateFromMembers
                 _ => false,
             };
 
-        private static bool IsWritableFieldOrProperty(ISymbol symbol)
+        private static bool IsWritableFieldOrProperty(ISymbol symbol, ISymbol? within = null)
             => symbol switch
             {
                 // Can use non const fields and properties with setters in them.
-                IFieldSymbol field => IsViableField(field) && !field.IsConst,
-                IPropertySymbol property => IsViableProperty(property) && property.IsWritableInConstructor(),
+                IFieldSymbol field => IsViableField(field) && !field.IsConst && (within == null || field.IsAccessibleWithin(within)),
+                IPropertySymbol property => IsViableProperty(property) && property.IsWritableInConstructor(within),
                 _ => false,
             };
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IPropertySymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IPropertySymbolExtensions.cs
@@ -73,15 +73,16 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 a.AttributeClass?.IsAccessibleWithin(arg.accessibleWithin) == false;
         }
 
-        public static bool IsWritableInConstructor(this IPropertySymbol property)
-            => (property.SetMethod != null || ContainsBackingField(property));
+        public static bool IsWritableInConstructor(this IPropertySymbol property, ISymbol? within = null)
+            => (property.SetMethod != null && (within == null || property.SetMethod.IsAccessibleWithin(within)))
+                || ContainsBackingField(property, within);
 
         public static IFieldSymbol? GetBackingFieldIfAny(this IPropertySymbol property)
             => property.ContainingType.GetMembers()
                 .OfType<IFieldSymbol>()
                 .FirstOrDefault(f => property.Equals(f.AssociatedSymbol));
 
-        private static bool ContainsBackingField(IPropertySymbol property)
-            => property.GetBackingFieldIfAny() != null;
+        private static bool ContainsBackingField(IPropertySymbol property, ISymbol? accessibleWithin = null)
+            => property.GetBackingFieldIfAny() is { } f && (accessibleWithin == null || f.IsAccessibleWithin(accessibleWithin));
     }
 }


### PR DESCRIPTION
Fixes #63273.

Changes the `GenerateConstructorFromMembers` (i.e., "Generate constructor...") code action to
- include members from base classes in the "select members" dialog,
- call the `base` constructor.