### PR TITLE
Skip a flaky test

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicErrorListCommon.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicErrorListCommon.cs
@@ -60,7 +60,7 @@ End Module
                 string.Join(Environment.NewLine, actualContents));
         }
 
-        [IdeFact]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/63981 and https://github.com/dotnet/roslyn/issues/63982")]
         public virtual async Task ErrorsDuringMethodBodyEditing()
         {
             await TestServices.Editor.SetTextAsync(@"


### PR DESCRIPTION
This test is failed with of two different stack traces.
https://github.com/dotnet/roslyn/issues/63981
https://github.com/dotnet/roslyn/issues/63982
And it failed 55 times last day
![image](https://user-images.githubusercontent.com/24360909/189990532-12126a6b-5549-48c3-9dfc-3d23c7fd7be8.png)
