### PR TITLE
Don't request frozen partial document for semantic tokens in proc

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRangeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensRangeHandler.cs
@@ -155,10 +155,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             Contract.ThrowIfNull(request.TextDocument, "TextDocument is null.");
             Contract.ThrowIfNull(context.Document, "Document is null.");
 
-            // If the full compilation is not yet available, we'll try getting a partial one. It may contain inaccurate
-            // results but will speed up how quickly we can respond to the client's request.
-            var document = context.Document.WithFrozenPartialSemantics(cancellationToken);
+            var document = context.Document;
             var project = document.Project;
+
+            // Currently this does nothing as OOP does not support frozen partial.  However we set this flag as an indicator that we do
+            // want to support it here eventually (tracked by https://github.com/dotnet/roslyn/issues/63968).
             var options = _globalOptions.GetClassificationOptions(project.Language) with { ForceFrozenPartialSemanticsForCrossProcessOperations = true };
 
             // The results from the range handler should not be cached since we don't want to cache


### PR DESCRIPTION
Semantic tokens currently requests the frozen partial document in-proc.  This was showing up in a trace causing bind. While that should be fast, it seems completely unnecessary to even hit this code path in-proc since all the semantic calculation happens OOP.

![image](https://user-images.githubusercontent.com/5749229/189995878-dbb9d601-ba6d-4a42-a132-b4d5790f556f.png)
