### PR TITLE
Add theming service and VS implementation

### DIFF
--- a/src/EditorFeatures/Core.Wpf/IWpfThemeService.cs
+++ b/src/EditorFeatures/Core.Wpf/IWpfThemeService.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Media;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal interface IWpfThemeService
+    {
+        void ApplyThemeToElement(FrameworkElement element);
+        Color GetThemeColor(ThemeResourceKey resourceKey);
+    }
+}

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
@@ -16,39 +16,17 @@
              GotKeyboardFocus="Adornment_GotKeyboardFocus"
              Focusable="False"
              UseLayoutRounding="True"
-             x:Name="control"
-             Background="{DynamicResource {x:Static rename:InlineRenameColors.BackgroundBrushKey}}">
+             x:Name="control">
 
     <UserControl.Resources>
         <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../InlineRenameColors.xaml"/>
-            </ResourceDictionary.MergedDictionaries>
-
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
-
-            <Style TargetType="CheckBox">
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static rename:InlineRenameColors.CheckBoxTextBrushKey}}"/>
-            </Style>
-
-            <Style TargetType="TextBlock">
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static rename:InlineRenameColors.CheckBoxTextBrushKey}}"/>
-            </Style>
-
-            <Style TargetType="TextBox">
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static rename:InlineRenameColors.TextBoxTextBrushKey}}" />
-                <Setter Property="Background" Value="{DynamicResource {x:Static rename:InlineRenameColors.TextBoxBackgroundBrushKey}}" />
-                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static rename:InlineRenameColors.TextBoxBorderBrushKey}}" />
-                <Setter Property="BorderThickness" Value="1" />
-                <Setter Property="Padding" Value="5" />
-            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
 
     <Border 
-        Background="{DynamicResource {x:Static rename:InlineRenameColors.BackgroundBrushKey}}" 
-        BorderThickness="1" 
-        BorderBrush="{DynamicResource {x:Static rename:InlineRenameColors.ButtonBorderBrush}}" >
+        BorderThickness="1"
+        x:Name="Outline">
         <StackPanel Orientation="Vertical" Margin="5" >
             <Grid Margin="0 0 0 10">
                 <Grid.ColumnDefinitions>
@@ -73,15 +51,9 @@
                                     <ControlTemplate TargetType="Button">
                                         <Border Name="border" 
                                         BorderThickness="1"
-                                        BorderBrush="{DynamicResource {x:Static rename:InlineRenameColors.BackgroundBrushKey}}"
                                         Background="{TemplateBinding Background}">
                                             <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
                                         </Border>
-                                        <ControlTemplate.Triggers>
-                                            <Trigger Property="IsMouseOver" Value="True">
-                                                <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource {x:Static rename:InlineRenameColors.ButtonBorderBrush}}" />
-                                            </Trigger>
-                                        </ControlTemplate.Triggers>
                                     </ControlTemplate>
                                 </Setter.Value>
                             </Setter>
@@ -119,10 +91,10 @@
             </StackPanel>
 
             <TextBlock 
+                x:Name="SubmitTextBlock"
                 Text="{Binding ElementName=control, Path=SubmitText}" 
                 Margin="5, 5, 0, 0" 
                 FontStyle="Italic"
-                Foreground="{DynamicResource {x:Static rename:InlineRenameColors.GrayTextKey}}"
                 />
     </StackPanel>
     </Border>

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
@@ -7,6 +7,8 @@
              xmlns:rename="clr-namespace:Microsoft.CodeAnalysis.Editor.Implementation.InlineRename"
              xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
              xmlns:imagecatalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
+             xmlns:imageutils="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
+             xmlns:utils="clr-namespace:Microsoft.CodeAnalysis.Utilities"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
              MinWidth="200"
@@ -21,6 +23,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+            <utils:BrushToColorConverter x:Key="BrushToColorConverter"/>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -43,7 +46,12 @@
                     HorizontalAlignment="Stretch" />
 
                 <!-- Expand/Collapse button and glyph -->
-                <Button x:Name="ToggleExpandButton" Grid.Column="1" Click="ToggleExpand" Background="Transparent">
+                <Button 
+                    x:Name="ToggleExpandButton" 
+                    Grid.Column="1" 
+                    Click="ToggleExpand" 
+                    Background="Transparent"
+                    imageutils:ImageThemingUtilities.ImageBackgroundColor="{Binding Background, RelativeSource={RelativeSource Self}, Converter={StaticResource BrushToColorConverter}}">
                     <Button.Style>
                         <Style TargetType="Button">
                             <Setter Property="Template">

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml
@@ -51,7 +51,7 @@
                     Grid.Column="1" 
                     Click="ToggleExpand" 
                     Background="Transparent"
-                    imageutils:ImageThemingUtilities.ImageBackgroundColor="{Binding Background, RelativeSource={RelativeSource Self}, Converter={StaticResource BrushToColorConverter}}">
+                    imageutils:ImageThemingUtilities.ImageBackgroundColor="{Binding Path=Parent.Background, RelativeSource={RelativeSource Self}, Converter={StaticResource BrushToColorConverter}}">
                     <Button.Style>
                         <Style TargetType="Button">
                             <Setter Property="Template">

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -48,9 +48,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             if (themeService is not null)
             {
                 Outline.BorderBrush = new SolidColorBrush(themeService.GetThemeColor(EnvironmentColors.AccentBorderColorKey));
-                ToggleExpandButton.Foreground = new SolidColorBrush(themeService.GetThemeColor(EnvironmentColors.ButtonTextColorKey));
                 Background = new SolidColorBrush(themeService.GetThemeColor(EnvironmentColors.ToolWindowBackgroundColorKey));
-                ImageThemingUtilities.SetImageBackgroundColor(ToggleExpandButton, themeService.GetThemeColor(EnvironmentColors.ToolWindowBackgroundColorKey));
             }
         }
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -6,6 +6,10 @@ using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.Editor;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
@@ -18,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         private readonly RenameFlyoutViewModel _viewModel;
         private readonly IWpfTextView _textView;
 
-        public RenameFlyout(RenameFlyoutViewModel viewModel, IWpfTextView textView)
+        public RenameFlyout(RenameFlyoutViewModel viewModel, IWpfTextView textView, IWpfThemeService? themeService)
         {
             DataContext = _viewModel = viewModel;
             _textView = textView;
@@ -40,6 +44,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
             InitializeComponent();
             PositionAdornment();
+
+            if (themeService is not null)
+            {
+                Outline.BorderBrush = new SolidColorBrush(themeService.GetThemeColor(EnvironmentColors.AccentBorderColorKey));
+                ToggleExpandButton.Foreground = new SolidColorBrush(themeService.GetThemeColor(EnvironmentColors.ButtonTextColorKey));
+                SubmitTextBlock.Foreground = new SolidColorBrush(themeService.GetThemeColor(EnvironmentColors.ScreenTipTextColorKey));
+                Background = new SolidColorBrush(themeService.GetThemeColor(EnvironmentColors.ToolWindowBackgroundColorKey));
+                ImageThemingUtilities.SetImageBackgroundColor(ToggleExpandButton, themeService.GetThemeColor(EnvironmentColors.ToolWindowBackgroundColorKey));
+            }
         }
 
 #pragma warning disable CA1822 // Mark members as static - used in xaml

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -49,7 +49,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             {
                 Outline.BorderBrush = new SolidColorBrush(themeService.GetThemeColor(EnvironmentColors.AccentBorderColorKey));
                 ToggleExpandButton.Foreground = new SolidColorBrush(themeService.GetThemeColor(EnvironmentColors.ButtonTextColorKey));
-                SubmitTextBlock.Foreground = new SolidColorBrush(themeService.GetThemeColor(EnvironmentColors.ScreenTipTextColorKey));
                 Background = new SolidColorBrush(themeService.GetThemeColor(EnvironmentColors.ToolWindowBackgroundColorKey));
                 ImageThemingUtilities.SetImageBackgroundColor(ToggleExpandButton, themeService.GetThemeColor(EnvironmentColors.ToolWindowBackgroundColorKey));
             }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.ComponentModel.Composition;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
@@ -18,6 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
     {
         private readonly IWpfTextView _textView;
         private readonly IGlobalOptionService _globalOptionService;
+        private readonly IWpfThemeService? _themeingService;
         private readonly InlineRenameService _renameService;
         private readonly IEditorFormatMapService _editorFormatMapService;
         private readonly IInlineRenameColorUpdater? _dashboardColorUpdater;
@@ -32,13 +34,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             IEditorFormatMapService editorFormatMapService,
             IInlineRenameColorUpdater? dashboardColorUpdater,
             IWpfTextView textView,
-            IGlobalOptionService globalOptionService)
+            IGlobalOptionService globalOptionService,
+            IWpfThemeService? themeingService)
         {
             _renameService = renameService;
             _editorFormatMapService = editorFormatMapService;
             _dashboardColorUpdater = dashboardColorUpdater;
             _textView = textView;
             _globalOptionService = globalOptionService;
+            _themeingService = themeingService;
             _adornmentLayer = textView.GetAdornmentLayer(InlineRenameAdornmentProvider.AdornmentLayerName);
 
             _renameService.ActiveSessionChanged += OnActiveSessionChanged;
@@ -68,51 +72,70 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             {
                 _dashboardColorUpdater?.UpdateColors();
 
-                var useInlineAdornment = _globalOptionService.GetOption(InlineRenameUIOptions.UseInlineAdornment);
-                if (useInlineAdornment)
+                var adornment = GetAdornment();
+
+                if (adornment is null)
                 {
-                    if (!_textView.HasAggregateFocus)
-                    {
-                        // For the rename flyout, the adornment is dismissed on focus lost. There's
-                        // no need to keep an adornment on every textview for show/hide behaviors
-                        return;
-                    }
-
-                    // Get the active selection to make sure the rename text is selected in the same way
-                    var originalSpan = _renameService.ActiveSession.TriggerSpan;
-                    var selectionSpan = _textView.Selection.SelectedSpans.First();
-
-                    var start = selectionSpan.IsEmpty
-                        ? 0
-                        : selectionSpan.Start - originalSpan.Start; // The length from the identifier to the start of selection
-
-                    var length = selectionSpan.IsEmpty
-                        ? originalSpan.Length
-                        : selectionSpan.Length;
-
-                    var identifierSelection = new TextSpan(start, length);
-
-                    var adornment = new RenameFlyout(
-                        (RenameFlyoutViewModel)s_createdViewModels.GetValue(_renameService.ActiveSession, session => new RenameFlyoutViewModel(session, identifierSelection, registerOleComponent: true, _globalOptionService)),
-                        _textView);
-
-                    _adornmentLayer.AddAdornment(
-                        AdornmentPositioningBehavior.ViewportRelative,
-                        null, // Set no visual span because we don't want the editor to automatically remove the adornment if the overlapping span changes
-                        tag: null,
-                        adornment,
-                        (tag, adornment) => ((InlineRenameAdornment)adornment).Dispose());
+                    return;
                 }
-                else
+
+                _themeingService?.ApplyThemeToElement(adornment);
+
+                _adornmentLayer.AddAdornment(
+                    AdornmentPositioningBehavior.ViewportRelative,
+                    null, // Set no visual span because we don't want the editor to automatically remove the adornment if the overlapping span changes
+                    tag: null,
+                    adornment,
+                    (tag, adornment) => ((InlineRenameAdornment)adornment).Dispose());
+            }
+        }
+
+        private InlineRenameAdornment? GetAdornment()
+        {
+            if (_renameService.ActiveSession is null)
+            {
+                return null;
+            }
+
+            var useInlineAdornment = _globalOptionService.GetOption(InlineRenameUIOptions.UseInlineAdornment);
+            if (useInlineAdornment)
+            {
+                if (!_textView.HasAggregateFocus)
                 {
-                    var newAdornment = new RenameDashboard(
-                        (RenameDashboardViewModel)s_createdViewModels.GetValue(_renameService.ActiveSession, session => new RenameDashboardViewModel(session)),
-                        _editorFormatMapService,
-                        _textView);
-
-                    _adornmentLayer.AddAdornment(AdornmentPositioningBehavior.ViewportRelative, null, null, newAdornment,
-                        (tag, adornment) => ((RenameDashboard)adornment).Dispose());
+                    // For the rename flyout, the adornment is dismissed on focus lost. There's
+                    // no need to keep an adornment on every textview for show/hide behaviors
+                    return null;
                 }
+
+                // Get the active selection to make sure the rename text is selected in the same way
+                var originalSpan = _renameService.ActiveSession.TriggerSpan;
+                var selectionSpan = _textView.Selection.SelectedSpans.First();
+
+                var start = selectionSpan.IsEmpty
+                    ? 0
+                    : selectionSpan.Start - originalSpan.Start; // The length from the identifier to the start of selection
+
+                var length = selectionSpan.IsEmpty
+                    ? originalSpan.Length
+                    : selectionSpan.Length;
+
+                var identifierSelection = new TextSpan(start, length);
+
+                var adornment = new RenameFlyout(
+                    (RenameFlyoutViewModel)s_createdViewModels.GetValue(_renameService.ActiveSession, session => new RenameFlyoutViewModel(session, identifierSelection, registerOleComponent: true, _globalOptionService)),
+                    _textView,
+                    _themeingService);
+
+                return adornment;
+            }
+            else
+            {
+                var newAdornment = new RenameDashboard(
+                    (RenameDashboardViewModel)s_createdViewModels.GetValue(_renameService.ActiveSession, session => new RenameDashboardViewModel(session)),
+                    _editorFormatMapService,
+                    _textView);
+
+                return newAdornment;
             }
         }
 

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentManager.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
     {
         private readonly IWpfTextView _textView;
         private readonly IGlobalOptionService _globalOptionService;
-        private readonly IWpfThemeService? _themeingService;
+        private readonly IWpfThemeService? _themeService;
         private readonly InlineRenameService _renameService;
         private readonly IEditorFormatMapService _editorFormatMapService;
         private readonly IInlineRenameColorUpdater? _dashboardColorUpdater;
@@ -35,14 +35,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             IInlineRenameColorUpdater? dashboardColorUpdater,
             IWpfTextView textView,
             IGlobalOptionService globalOptionService,
-            IWpfThemeService? themeingService)
+            IWpfThemeService? themeService)
         {
             _renameService = renameService;
             _editorFormatMapService = editorFormatMapService;
             _dashboardColorUpdater = dashboardColorUpdater;
             _textView = textView;
             _globalOptionService = globalOptionService;
-            _themeingService = themeingService;
+            _themeService = themeService;
             _adornmentLayer = textView.GetAdornmentLayer(InlineRenameAdornmentProvider.AdornmentLayerName);
 
             _renameService.ActiveSessionChanged += OnActiveSessionChanged;
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     return;
                 }
 
-                _themeingService?.ApplyThemeToElement(adornment);
+                _themeService?.ApplyThemeToElement(adornment);
 
                 _adornmentLayer.AddAdornment(
                     AdornmentPositioningBehavior.ViewportRelative,
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 var adornment = new RenameFlyout(
                     (RenameFlyoutViewModel)s_createdViewModels.GetValue(_renameService.ActiveSession, session => new RenameFlyoutViewModel(session, identifierSelection, registerOleComponent: true, _globalOptionService)),
                     _textView,
-                    _themeingService);
+                    _themeService);
 
                 return adornment;
             }

--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentProvider.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/InlineRenameAdornmentProvider.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         private readonly InlineRenameService _renameService;
         private readonly IEditorFormatMapService _editorFormatMapService;
         private readonly IInlineRenameColorUpdater? _dashboardColorUpdater;
+        private readonly IWpfThemeService? _themeingService;
         private readonly IGlobalOptionService _globalOptionService;
         public const string AdornmentLayerName = "RoslynRenameDashboard";
 
@@ -45,18 +46,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             InlineRenameService renameService,
             IEditorFormatMapService editorFormatMapService,
             [Import(AllowDefault = true)] IInlineRenameColorUpdater? dashboardColorUpdater,
+            [Import(AllowDefault = true)] IWpfThemeService? themeingService,
             IGlobalOptionService globalOptionService)
         {
             _renameService = renameService;
             _editorFormatMapService = editorFormatMapService;
             _dashboardColorUpdater = dashboardColorUpdater;
+            _themeingService = themeingService;
             _globalOptionService = globalOptionService;
         }
 
         public void SubjectBuffersConnected(IWpfTextView textView, ConnectionReason reason, Collection<ITextBuffer> subjectBuffers)
         {
             // Create it for the view if we don't already have one
-            textView.GetOrCreateAutoClosingProperty(v => new InlineRenameAdornmentManager(_renameService, _editorFormatMapService, _dashboardColorUpdater, v, _globalOptionService));
+            textView.GetOrCreateAutoClosingProperty(v => new InlineRenameAdornmentManager(_renameService, _editorFormatMapService, _dashboardColorUpdater, v, _globalOptionService, _themeingService));
         }
 
         public void SubjectBuffersDisconnected(IWpfTextView textView, ConnectionReason reason, Collection<ITextBuffer> subjectBuffers)

--- a/src/EditorFeatures/Core.Wpf/Utilities/BrushToColorConverter.cs
+++ b/src/EditorFeatures/Core.Wpf/Utilities/BrushToColorConverter.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Media;
+using Microsoft.VisualStudio.PlatformUI;
+
+namespace Microsoft.CodeAnalysis.Utilities
+{
+    internal class BrushToColorConverter : ValueConverter<Brush, Color>
+    {
+        protected override Color Convert(Brush brush, object parameter, CultureInfo culture)
+            => brush switch
+            {
+                SolidColorBrush solidColorBrush => solidColorBrush.Color,
+                GradientBrush gradientBrush => gradientBrush.GradientStops.FirstOrDefault()?.Color ?? Colors.Transparent,
+                _ => Colors.Transparent
+            };
+    }
+}

--- a/src/EditorFeatures/Test2/Rename/RenameViewModelTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameViewModelTests.vb
@@ -616,7 +616,8 @@ class D : B
 
                 Using flyout = New RenameFlyout(
                     New RenameFlyoutViewModel(DirectCast(sessionInfo.Session, InlineRenameSession), selectionSpan:=Nothing, registerOleComponent:=False, globalOptions), ' Don't registerOleComponent in tests, it requires OleComponentManagers that don't exist in our host
-                    textView:=cursorDocument.GetTextView())
+                    textView:=cursorDocument.GetTextView(),
+                    themeService:=Nothing)
 
                     Await WaitForRename(workspace)
 

--- a/src/VisualStudio/Core/Def/VSWpfThemeService.cs
+++ b/src/VisualStudio/Core/Def/VSWpfThemeService.cs
@@ -34,7 +34,6 @@ namespace Microsoft.VisualStudio.LanguageServices
         public void ApplyThemeToElement(FrameworkElement frameworkElement)
         {
             frameworkElement.Resources.MergedDictionaries.Add(_themeDictionary);
-            ImageThemingUtilities.SetImageBackgroundColor(frameworkElement, GetThemeColor(EnvironmentColors.EnvironmentBackgroundColorKey));
         }
 
         public Color GetThemeColor(ThemeResourceKey themeResourceKey)

--- a/src/VisualStudio/Core/Def/VSWpfThemeService.cs
+++ b/src/VisualStudio/Core/Def/VSWpfThemeService.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.LanguageServices
+{
+    [Export(typeof(IWpfThemeService)), Shared]
+    internal class VSWpfThemeService : IWpfThemeService
+    {
+        private readonly ResourceDictionary _themeDictionary = new();
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public VSWpfThemeService()
+        {
+            _themeDictionary.Source = new Uri("/Microsoft.VisualStudio.LanguageServices;component/VSThemeDictionary.xaml", UriKind.Relative);
+        }
+
+        public void ApplyThemeToElement(FrameworkElement frameworkElement)
+        {
+            frameworkElement.Resources.MergedDictionaries.Add(_themeDictionary);
+            ImageThemingUtilities.SetImageBackgroundColor(frameworkElement, GetThemeColor(EnvironmentColors.EnvironmentBackgroundColorKey));
+        }
+
+        public Color GetThemeColor(ThemeResourceKey themeResourceKey)
+        {
+            var color = VSColorTheme.GetThemedColor(themeResourceKey);
+            return Color.FromArgb(color.A, color.R, color.G, color.B);
+        }
+    }
+}


### PR DESCRIPTION
This adds an IWpfThemeService that we implement to add VS theme dictionaries to WPF elements, as well as manually apply some colors. It would also allow any WPF host to implement their own theming service if desired. 

In the future we could move all of our WPF items into the WPF layer. 

This also makes the rename dialog much closer to actual VS theme

### Dark Theme

![image](https://user-images.githubusercontent.com/475144/190017195-4b5fe7dd-710a-4094-a673-81460701331f.png)



### Blue Theme

![image](https://user-images.githubusercontent.com/475144/190016291-577f41f7-7cfa-44bd-aa39-fd983a04078a.png)
