### PR TITLE
Change the container of Inheritance margin

### DIFF
--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginViewMarginProvider.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginViewMarginProvider.cs
@@ -24,8 +24,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
     [ContentType(ContentTypeNames.CSharpContentType)]
     [ContentType(ContentTypeNames.VisualBasicContentType)]
     [Name(nameof(InheritanceMarginViewMarginProvider))]
-    [MarginContainer(PredefinedMarginNames.Left)]
-    [Order(After = PredefinedMarginNames.Glyph)]
+    // Place our margin inside Left Selection Margin Container. And keep it to the left-most location.
+    [MarginContainer(PredefinedMarginNames.LeftSelection)]
+    [Order(After = DefaultOrderings.Lowest)]
     [TextViewRole(PredefinedTextViewRoles.Document)]
     internal class InheritanceMarginViewMarginProvider : IWpfTextViewMarginProvider
     {


### PR DESCRIPTION
Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1614764?src=WorkItemMention&src-action=artifact_link
As suggested by @olegtk, we should place the inheritance margin inside PredefinedMarginNames.LeftSelection.

Before:
![image](https://user-images.githubusercontent.com/24360909/190020925-183cea35-18dc-4911-ab60-5b6734cd5b46.png)
Note: The red rectangle is 'Left Margin'

After:
![image](https://user-images.githubusercontent.com/24360909/190021771-630d5f0b-0df1-4e6d-8b13-24f5c4488d55.png)
Note: The red rectangle is 'Left Selection Margin'

