### PR TITLE
Fix feedback reply template text

### DIFF
--- a/docs/wiki/Responding-to-customers-encountering-crashes-or-performance-issues.md
+++ b/docs/wiki/Responding-to-customers-encountering-crashes-or-performance-issues.md
@@ -16,16 +16,19 @@ Thank you for letting us know you are experiencing a similar situation. Due to t
 
 Thank you for providing feedback, and we're sorry to hear it's not behaving as you expect. Based on your description so far, it sounds like you are experiencing a problem which is historically hard to diagnose and resolve using the normal "steps to reproduce". We created a set of instructions for providing additional information which will help us track down the true source of the problems.
 
-Based on the information provided so far, the most likely scenario to follow is for "Crashes". To provide the feedback most relevant for the problems you would like to see fixed, see [Crashes](https://docs.microsoft.com/visualstudio/ide/how-to-increase-chances-of-performance-issue-being-fixed#crashes).
+Based on the information provided so far, the most likely scenario to follow is for "Crashes". Please take a look at the following document to provide the feedback most relevant for the problems you would like to see fixed:
+https://docs.microsoft.com/en-us/visualstudio/ide/how-to-increase-chances-of-performance-issue-being-fixed?view=vs-2019#crashes
 
 ### Slowness and High CPU Issues
 
 Thank you for providing feedback, and we're sorry to hear it's not behaving as you expect. Based on your description so far, it sounds like you are experiencing a problem which is historically hard to diagnose and resolve using the normal "steps to reproduce". We created a set of instructions for providing additional information which will help us track down the true source of the problems.
 
-Based on the information provided so far, the most likely scenario to follow is for "Slowness and High CPU Issues". To provide the feedback most relevant for the problems you would like to see fixed, see [Slowness and High CPU Issues](https://docs.microsoft.com/visualstudio/ide/how-to-increase-chances-of-performance-issue-being-fixed#slowness-and-high-cpu-issues).
+Based on the information provided so far, the most likely scenario to follow is for "Slowness and High CPU Issues". Please look at the following document to provide the feedback most relevant for the problems you would like to see fixed:
+https://docs.microsoft.com/en-us/visualstudio/ide/how-to-increase-chances-of-performance-issue-being-fixed?view=vs-2019#slowness-and-high-cpu-issues
 
 ### Out-Of-Process Issues
 
 Thank you for providing feedback, and we're sorry to hear it's not behaving as you expect. Based on your description so far, it sounds like you are experiencing a problem which is historically hard to diagnose and resolve using the normal "steps to reproduce". We created a set of instructions for providing additional information which will help us track down the true source of the problems.
 
-Based on the information provided so far, the most likely scenario to follow is for "Out-Of-Process Issues". To provide the feedback most relevant for the problems you would like to see fixed, see [Out-of-process issues](https://docs.microsoft.com/visualstudio/ide/how-to-increase-chances-of-performance-issue-being-fixed#out-of-process-issues).
+Based on the information provided so far, the most likely scenario to follow is for "Out-Of-Process Issues". Please look at the following document to provide the feedback most relevant for the problems you would like to see fixed:
+https://docs.microsoft.com/en-us/visualstudio/ide/how-to-increase-chances-of-performance-issue-being-fixed?view=vs-2019#out-of-process-issues


### PR DESCRIPTION
This change reverts #63791 as it applies to the VS feedback ticket reply templates, since these templates have specific formatting requirements to work with copy/paste.