### PR TITLE
Add EA extensibility point to allow go-to-def to navigate to F# source symbols.

### DIFF
--- a/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
+++ b/src/EditorFeatures/Core/GoToDefinition/GoToDefinitionHelpers.cs
@@ -2,19 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.FindUsages;
 using Microsoft.CodeAnalysis.Navigation;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
@@ -64,7 +61,7 @@ namespace Microsoft.CodeAnalysis.GoToDefinition
                 symbol = method.PartialImplementationPart ?? symbol;
             }
 
-            using var definitionsDisposer = ArrayBuilder<DefinitionItem>.GetInstance(out var definitions);
+            using var _ = ArrayBuilder<DefinitionItem>.GetInstance(out var definitions);
 
             // Going to a symbol may end up actually showing the symbol in the Find-Usages window.
             // This happens when there is more than one location for the symbol (i.e. for partial

--- a/src/Features/Core/Portable/FindUsages/DefinitionItem.cs
+++ b/src/Features/Core/Portable/FindUsages/DefinitionItem.cs
@@ -249,9 +249,10 @@ namespace Microsoft.CodeAnalysis.FindUsages
             var projectId = solution.GetOriginatingProjectId(symbol);
             Contract.ThrowIfNull(projectId);
 
-            properties = properties.Add(MetadataSymbolKey, symbolKey)
-                                   .Add(MetadataSymbolOriginatingProjectIdGuid, projectId.Id.ToString())
-                                   .Add(MetadataSymbolOriginatingProjectIdDebugName, projectId.DebugName ?? "");
+            properties = properties
+                .Add(MetadataSymbolKey, symbolKey)
+                .Add(MetadataSymbolOriginatingProjectIdGuid, projectId.Id.ToString())
+                .Add(MetadataSymbolOriginatingProjectIdDebugName, projectId.DebugName ?? "");
 
             // Find the highest level containing type to show as the "file name". For metadata locations
             // that come from embedded source or SourceLink this could be wrong, as there is no reason

--- a/src/Features/Core/Portable/Navigation/ICrossLanguageSymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/ICrossLanguageSymbolNavigationService.cs
@@ -7,8 +7,17 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CodeAnalysis.Navigation
 {
+    /// <summary>
+    /// Service to allow 3rd party languages to handle navigating to some metadata symbol.  For example, this can allow
+    /// a language like F# to navigate to its source definition of a symbol that roslyn views as a metadata symbol.
+    /// </summary>
     internal interface ICrossLanguageSymbolNavigationService
     {
+        /// <summary>
+        /// Attempts to get location that can be navigated to for a particular symbol id.  The symbol id format is
+        /// defined at: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/#id-strings.  Should
+        /// return <see langword="null"/> if the 3rd party language cannot navigate to this particular symbol.
+        /// </summary>
         Task<INavigableLocation?> TryGetNavigableLocationAsync(string documentationCommentId, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/Navigation/ICrossLanguageSymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/ICrossLanguageSymbolNavigationService.cs
@@ -4,12 +4,11 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.FindUsages;
 
 namespace Microsoft.CodeAnalysis.Navigation
 {
     internal interface ICrossLanguageSymbolNavigationService
     {
-        Task<DefinitionItem?> TryGetDefinitionItemAsync(string documentationCommentId, CancellationToken cancellationToken);
+        Task<INavigableLocation?> TryGetNavigableLocationAsync(string documentationCommentId, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/Navigation/ICrossLanguageSymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/ICrossLanguageSymbolNavigationService.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.FindUsages;
+
+namespace Microsoft.CodeAnalysis.Navigation
+{
+    internal interface ICrossLanguageSymbolNavigationService
+    {
+        Task<DefinitionItem?> TryGetDefinitionItemAsync(string documentationCommentId, CancellationToken cancellationToken);
+    }
+}

--- a/src/Tools/ExternalAccess/FSharp/Internal/Navigation/FSharpCrossLanguageSymbolNavigationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Navigation/FSharpCrossLanguageSymbolNavigationService.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Navigation;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Navigation
+{
+    /// <summary>
+    /// Internal F# implementation of the <see cref="ICrossLanguageSymbolNavigationService"/>.  Will defer to the EA
+    /// layer api (<see cref="IFSharpCrossLanguageSymbolNavigationService"/>) that they will actually export to do the
+    /// work here.
+    /// </summary>
+    [Export(typeof(ICrossLanguageSymbolNavigationService)), Shared]
+    internal sealed class FSharpCrossLanguageSymbolNavigationService : ICrossLanguageSymbolNavigationService
+    {
+        private readonly IFSharpCrossLanguageSymbolNavigationService _underlyingService;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public FSharpCrossLanguageSymbolNavigationService(
+            [Import(AllowDefault = true)] IFSharpCrossLanguageSymbolNavigationService underlyingService)
+        {
+            _underlyingService = underlyingService;
+        }
+
+        public async Task<INavigableLocation?> TryGetNavigableLocationAsync(string documentationCommentId, CancellationToken cancellationToken)
+        {
+            // Only defer to actual F# service if it exists.
+            if (_underlyingService is null)
+                return null;
+
+            var location = await _underlyingService.TryGetNavigableLocationAsync(documentationCommentId, cancellationToken).ConfigureAwait(false);
+            if (location == null)
+                return null;
+
+            return new NavigableLocation((options, cancellationToken) =>
+                location.NavigateToAsync(new FSharpNavigationOptions2(options.PreferProvisionalTab, options.ActivateTab), cancellationToken));
+        }
+    }
+}

--- a/src/Tools/ExternalAccess/FSharp/Navigation/IFSharpCrossLanguageSymbolNavigationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Navigation/IFSharpCrossLanguageSymbolNavigationService.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Navigation;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
+{
+    /// <inheritdoc cref="ICrossLanguageSymbolNavigationService"/>
+    internal interface IFSharpCrossLanguageSymbolNavigationService
+    {
+        /// <inheritdoc cref="ICrossLanguageSymbolNavigationService.TryGetNavigableLocationAsync"/>
+        Task<IFSharpNavigableLocation?> TryGetNavigableLocationAsync(string documentationCommentId, CancellationToken cancellationToken);
+    }
+
+    /// <inheritdoc cref="NavigationOptions"/>
+    internal sealed record class FSharpNavigationOptions2(
+        bool PreferProvisionalTab,
+        bool ActivateTab);
+
+    /// <inheritdoc cref="INavigableLocation"/>
+    internal interface IFSharpNavigableLocation
+    {
+        Task<bool> NavigateToAsync(FSharpNavigationOptions2 options, CancellationToken cancellationToken);
+    }
+}

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioSymbolNavigationService.cs
@@ -60,10 +60,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             ISymbol symbol, Project project, CancellationToken cancellationToken)
         {
             if (project == null || symbol == null)
-            {
                 return null;
-            }
 
+            var solution = project.Solution;
             symbol = symbol.OriginalDefinition;
 
             // Prefer visible source locations if possible.
@@ -73,13 +72,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             if (sourceLocation != null)
             {
-                var targetDocument = project.Solution.GetDocument(sourceLocation.SourceTree);
+                var targetDocument = solution.GetDocument(sourceLocation.SourceTree);
                 if (targetDocument != null)
                 {
-                    var editorWorkspace = targetDocument.Project.Solution.Workspace;
-                    var navigationService = editorWorkspace.Services.GetRequiredService<IDocumentNavigationService>();
+                    var navigationService = solution.Services.GetRequiredService<IDocumentNavigationService>();
                     return await navigationService.GetLocationForSpanAsync(
-                        editorWorkspace, targetDocument.Id, sourceLocation.SourceSpan,
+                        solution.Workspace, targetDocument.Id, sourceLocation.SourceSpan,
                         allowInvalidSpan: false, cancellationToken).ConfigureAwait(false);
                 }
             }
@@ -89,6 +87,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             if (!_metadataAsSourceFileService.IsNavigableMetadataSymbol(symbol))
             {
                 return null;
+            }
+
+            // See if there's another .Net language service that can handle navigating to this metadata symbol (for example, F#).
+            var docCommentId = symbol.GetDocumentationCommentId();
+            if (docCommentId != null)
+            {
+                foreach (var lazyService in solution.Services.ExportProvider.GetExports<ICrossLanguageSymbolNavigationService>())
+                {
+                    var crossLanguageService = lazyService.Value;
+                    var crossLanguageLocation = await crossLanguageService.TryGetNavigableLocationAsync(docCommentId, cancellationToken).ConfigureAwait(false);
+                    if (crossLanguageLocation != null)
+                        return crossLanguageLocation;
+                }
             }
 
             // Should we prefer navigating to the Object Browser over metadata-as-source?


### PR DESCRIPTION
Note: this will not work for 'peek definition' currently due to that system needing complex information about the actual file/span to present. 

if peek is important, we'll need to come up with some additional approaches to make that work.