### PR TITLE
Support collapsing multi-line comments in any context

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/AccessorDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/AccessorDeclarationStructureTests.cs
@@ -59,28 +59,6 @@ class C
         }
 
         [Fact]
-        public async Task TestPropertyGetterWithMultiLineComments1()
-        {
-            const string code = @"
-class C
-{
-    public string Text
-    {
-        {|span1:/* My
-           Getter */|}
-        $${|hint2:get{|textspan2:
-        {
-        }|}|}
-    }
-}
-";
-
-            await VerifyBlockSpansAsync(code,
-                Region("span1", "/* My ...", autoCollapse: true),
-                Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
-        }
-
-        [Fact]
         public async Task TestPropertyGetter2()
         {
             const string code = @"
@@ -123,31 +101,6 @@ class C
 
             await VerifyBlockSpansAsync(code,
                 Region("span1", "// My ...", autoCollapse: true),
-                Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
-        }
-
-        [Fact]
-        public async Task TestPropertyGetterWithMultiLineComments2()
-        {
-            const string code = @"
-class C
-{
-    public string Text
-    {
-        {|span1:/* My
-           Getter */|}
-        $${|hint2:get{|textspan2:
-        {
-        }|}|}
-        set
-        {
-        }
-    }
-}
-";
-
-            await VerifyBlockSpansAsync(code,
-                Region("span1", "/* My ...", autoCollapse: true),
                 Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
 
@@ -200,32 +153,6 @@ class C
         }
 
         [Fact]
-        public async Task TestPropertyGetterWithMultiLineComments3()
-        {
-            const string code = @"
-class C
-{
-    public string Text
-    {
-        {|span1:/* My
-           Getter */|}
-        $${|hint2:get{|textspan2:
-        {
-        }|}|}
-
-        set
-        {
-        }
-    }
-}
-";
-
-            await VerifyBlockSpansAsync(code,
-                Region("span1", "/* My ...", autoCollapse: true),
-                Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
-        }
-
-        [Fact]
         public async Task TestPropertySetter1()
         {
             const string code = @"
@@ -261,27 +188,6 @@ class C
 
             await VerifyBlockSpansAsync(code,
                 Region("span1", "// My ...", autoCollapse: true),
-                Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
-        }
-
-        [Fact]
-        public async Task TestPropertySetterWithMultiLineComments1()
-        {
-            const string code = @"
-class C
-{
-    public string Text
-    {
-        {|span1:/* My
-           Setter */|}
-        $${|hint2:set{|textspan2:
-        {
-        }|}|}
-    }
-}";
-
-            await VerifyBlockSpansAsync(code,
-                Region("span1", "/* My ...", autoCollapse: true),
                 Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
 
@@ -331,30 +237,6 @@ class C
         }
 
         [Fact]
-        public async Task TestPropertySetterWithMultiLineComments2()
-        {
-            const string code = @"
-class C
-{
-    public string Text
-    {
-        get
-        {
-        }
-        {|span1:/* My
-           Setter */|}
-        $${|hint2:set{|textspan2:
-        {
-        }|}|}
-    }
-}";
-
-            await VerifyBlockSpansAsync(code,
-                Region("span1", "/* My ...", autoCollapse: true),
-                Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
-        }
-
-        [Fact]
         public async Task TestPropertySetter3()
         {
             const string code = @"
@@ -398,31 +280,6 @@ class C
 
             await VerifyBlockSpansAsync(code,
                 Region("span1", "// My ...", autoCollapse: true),
-                Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
-        }
-
-        [Fact]
-        public async Task TestPropertySetterWithMultiLineComments3()
-        {
-            const string code = @"
-class C
-{
-    public string Text
-    {
-        get
-        {
-        }
-
-        {|span1:/* My
-           Setter */|}
-        $${|hint2:set{|textspan2:
-        {
-        }|}|}
-    }
-}";
-
-            await VerifyBlockSpansAsync(code,
-                Region("span1", "/* My ...", autoCollapse: true),
                 Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
     }

--- a/src/EditorFeatures/CSharpTest/Structure/CommentStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/CommentStructureTests.cs
@@ -104,56 +104,5 @@ class C
             await VerifyBlockSpansAsync(code,
                 Region("span", "// Hello ...", autoCollapse: true));
         }
-
-        [Fact]
-        public async Task TestMultilineComment1()
-        {
-            const string code = @"
-{|span:/* Hello
-$$C# */|}
-class C
-{
-}
-";
-
-            await VerifyBlockSpansAsync(code,
-                Region("span", "/* Hello ...", autoCollapse: true));
-        }
-
-        [Fact]
-        public async Task TestMultilineCommentOnOneLine()
-        {
-            const string code = @"
-{|span:/* Hello $$C# */|}
-class C
-{
-}
-";
-
-            await VerifyBlockSpansAsync(code,
-                Region("span", "/* Hello C# ...", autoCollapse: true));
-        }
-
-        [Fact, WorkItem(1108049, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1108049")]
-        [WorkItem(791, "https://github.com/dotnet/roslyn/issues/791")]
-        public async Task TestIncompleteMultilineCommentZeroSpace()
-        {
-            const string code = @"
-{|span:$$/*|}";
-
-            await VerifyBlockSpansAsync(code,
-                Region("span", "/*  ...", autoCollapse: true));
-        }
-
-        [Fact, WorkItem(1108049, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1108049")]
-        [WorkItem(791, "https://github.com/dotnet/roslyn/issues/791")]
-        public async Task TestIncompleteMultilineCommentSingleSpace()
-        {
-            const string code = @"
-{|span:$$/* |}";
-
-            await VerifyBlockSpansAsync(code,
-                Region("span", "/*  ...", autoCollapse: true));
-        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Structure/CompilationUnitStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/CompilationUnitStructureTests.cs
@@ -150,15 +150,6 @@ $${|hint:using|} {|textspan:|}";
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
 
-        [Fact, WorkItem(16186, "https://github.com/dotnet/roslyn/issues/16186")]
-        public async Task TestInvalidComment()
-        {
-            const string code = @"$${|span:/*/|}";
-
-            await VerifyBlockSpansAsync(code,
-                Region("span", "/* / ...", autoCollapse: true));
-        }
-
         [Theory, CombinatorialData]
         public async Task TestUsingsShouldBeCollapsedByDefault(bool collapseUsingsByDefault)
         {

--- a/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/AccessorDeclarationStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/AccessorDeclarationStructureTests.cs
@@ -75,9 +75,9 @@ class C
 {
     public string Text
     {
-        {|span1:/* My
-           Getter */|}
-        $${|#0:get{|textspan2:
+        /* My
+           Getter */
+        $${|#0:get{|textspan1:
         {
         }|#0}
 |}
@@ -89,8 +89,7 @@ class C
 ";
 
             await VerifyBlockSpansAsync(code,
-                Region("span1", "/* My ...", autoCollapse: true),
-                Region("textspan2", "#0", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
+                Region("textspan1", "#0", CSharpStructureHelpers.Ellipsis, autoCollapse: true));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/InvalidIdentifierStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MetadataAsSource/InvalidIdentifierStructureTests.cs
@@ -65,12 +65,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure.MetadataAsSou
             const string code = @"
 {|hint1:$$class C{|textspan1:
 {
-    public void }|}|} } {|hint2:public class CodeInjection{|textspan2:{ }|}|} /* now everything is commented ();
-}";
+    public void }|}|} } {|hint2:public class CodeInjection{|textspan2:{ }|}|} {|textspan3:/* now everything is commented ();
+}|}";
 
             await VerifyBlockSpansAsync(code,
                 Region("textspan1", "hint1", CSharpStructureHelpers.Ellipsis, autoCollapse: false),
-                Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+                Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: false),
+                Region("textspan3", "/* now everything is commented (); ...", autoCollapse: true));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Structure/MultilineCommentStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/MultilineCommentStructureTests.cs
@@ -1,0 +1,339 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Structure;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Structure;
+using Microsoft.CodeAnalysis.Structure;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Structure;
+
+[Trait(Traits.Feature, Traits.Features.Outlining)]
+public class MultilineCommentStructureTests : AbstractCSharpSyntaxTriviaStructureTests
+{
+    internal override AbstractSyntaxStructureProvider CreateProvider() => new MultilineCommentBlockStructureProvider();
+
+    [Fact]
+    public async Task TestMultilineComment1()
+    {
+        const string code = @"
+{|span:/* Hello
+$$C# */|}
+class C
+{
+}
+";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span", "/* Hello ...", autoCollapse: true));
+    }
+
+    [Fact]
+    public async Task TestMultilineCommentOnOneLine()
+    {
+        const string code = @"
+{|span:/* Hello $$C# */|}
+class C
+{
+}
+";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span", "/* Hello C# ...", autoCollapse: true));
+    }
+
+    [Fact, WorkItem(1108049, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1108049")]
+    [WorkItem(791, "https://github.com/dotnet/roslyn/issues/791")]
+    public async Task TestIncompleteMultilineCommentZeroSpace()
+    {
+        const string code = @"
+{|span:$$/*|}";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span", "/*  ...", autoCollapse: true));
+    }
+
+    [Fact, WorkItem(1108049, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1108049")]
+    [WorkItem(791, "https://github.com/dotnet/roslyn/issues/791")]
+    public async Task TestIncompleteMultilineCommentSingleSpace()
+    {
+        const string code = @"
+{|span:$$/* |}";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span", "/*  ...", autoCollapse: true));
+    }
+
+    [Fact]
+    public async Task TestPropertyGetterWithMultiLineComments1()
+    {
+        const string code = @"
+class C
+{
+    public string Text
+    {
+        $${|span1:/* My
+           Getter */|}
+        get
+        {
+        }
+    }
+}
+";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span1", "/* My ...", autoCollapse: true));
+    }
+
+    [Fact]
+    public async Task TestPropertyGetterWithMultiLineComments2()
+    {
+        const string code = @"
+class C
+{
+    public string Text
+    {
+        $${|span1:/* My
+           Getter */|}
+        get
+        {
+        }
+        set
+        {
+        }
+    }
+}
+";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span1", "/* My ...", autoCollapse: true));
+    }
+
+    [Fact]
+    public async Task TestPropertyGetterWithMultiLineComments3()
+    {
+        const string code = @"
+class C
+{
+    public string Text
+    {
+        $${|span1:/* My
+           Getter */|}
+        get
+        {
+        }
+
+        set
+        {
+        }
+    }
+}
+";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span1", "/* My ...", autoCollapse: true));
+    }
+
+    [Fact]
+    public async Task TestPropertySetterWithMultiLineComments1()
+    {
+        const string code = @"
+class C
+{
+    public string Text
+    {
+        $${|span1:/* My
+           Setter */|}
+        set
+        {
+        }
+    }
+}";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span1", "/* My ...", autoCollapse: true));
+    }
+
+    [Fact]
+    public async Task TestPropertySetterWithMultiLineComments2()
+    {
+        const string code = @"
+class C
+{
+    public string Text
+    {
+        get
+        {
+        }
+        $${|span1:/* My
+           Setter */|}
+        set
+        {
+        }
+    }
+}";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span1", "/* My ...", autoCollapse: true));
+    }
+
+    [Fact]
+    public async Task TestPropertySetterWithMultiLineComments3()
+    {
+        const string code = @"
+class C
+{
+    public string Text
+    {
+        get
+        {
+        }
+
+        $${|span1:/* My
+           Setter */|}
+        set
+        {
+        }
+    }
+}";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span1", "/* My ...", autoCollapse: true));
+    }
+
+    [Fact]
+    public async Task TestMultilineCommentInFile()
+    {
+        const string code = @"
+$${|span1:/* Comment in file
+ */|}
+namespace M
+{
+}
+";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span1", "/* Comment in file ...", autoCollapse: true));
+    }
+
+    [Fact]
+    public async Task TestMultilineCommentInNamespace()
+    {
+        const string code = @"
+namespace M
+{
+    $${|span1:/* Comment in namespace
+     */|}
+}
+";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span1", "/* Comment in namespace ...", autoCollapse: true));
+    }
+
+    [Fact]
+    public async Task TestMultilineCommentInClass()
+    {
+        const string code = @"
+namespace M
+{
+    class C
+    {
+        $${|span1:/* Comment in class
+         */|}
+    }
+    
+}
+";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span1", "/* Comment in class ...", autoCollapse: true));
+    }
+
+    [Fact, WorkItem(64001, "https://github.com/dotnet/roslyn/issues/64001")]
+    public async Task TestMultilineCommentInMethod()
+    {
+        const string code = @"
+namespace M
+{
+    class C
+    {
+        void M()
+        {
+            $${|span1:/* Comment in method
+             */|}
+        }
+    }
+    
+}
+";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span1", "/* Comment in method ...", autoCollapse: true));
+    }
+
+    [Fact, WorkItem(64001, "https://github.com/dotnet/roslyn/issues/64001")]
+    public async Task TestMultilineCommentInLocalFunction()
+    {
+        const string code = @"
+namespace M
+{
+    class C
+    {
+        void M()
+        {
+            void LocalFunc()
+            {
+                $${|span1:/* Comment in local function
+                 */|}
+            }
+        }
+    }
+    
+}
+";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span1", "/* Comment in local function ...", autoCollapse: true));
+    }
+
+    [Fact, WorkItem(64001, "https://github.com/dotnet/roslyn/issues/64001")]
+    public async Task TestMultilineCommentInConstructor()
+    {
+        const string code = @"
+namespace M
+{
+    class C
+    {
+        C()
+        {
+            $${|span1:/* Comment in constructor
+             */|}
+        }
+    }
+    
+}
+";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span1", "/* Comment in constructor ...", autoCollapse: true));
+    }
+
+    [Fact, WorkItem(16186, "https://github.com/dotnet/roslyn/issues/16186")]
+    public async Task TestInvalidComment()
+    {
+        const string code = @"$${|span:/*/|}";
+
+        await VerifyBlockSpansAsync(code,
+            Region("span", "/* / ...", autoCollapse: true));
+    }
+}

--- a/src/Features/CSharp/Portable/Structure/CSharpBlockStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/CSharpBlockStructureProvider.cs
@@ -58,6 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             var builder = ImmutableDictionary.CreateBuilder<int, ImmutableArray<AbstractSyntaxStructureProvider>>();
 
             builder.Add((int)SyntaxKind.DisabledTextTrivia, ImmutableArray.Create<AbstractSyntaxStructureProvider>(new DisabledTextTriviaStructureProvider()));
+            builder.Add((int)SyntaxKind.MultiLineCommentTrivia, ImmutableArray.Create<AbstractSyntaxStructureProvider>(new MultilineCommentBlockStructureProvider()));
 
             return builder.ToImmutable();
         }

--- a/src/Features/CSharp/Portable/Structure/CSharpStructureHelpers.cs
+++ b/src/Features/CSharp/Portable/Structure/CSharpStructureHelpers.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             return prefix + " " + text.Substring(prefixLength).Trim() + " " + Ellipsis;
         }
 
-        private static string GetCommentBannerText(SyntaxTrivia comment)
+        internal static string GetCommentBannerText(SyntaxTrivia comment)
         {
             Contract.ThrowIfFalse(comment.IsSingleLineComment() || comment.IsMultiLineComment());
 
@@ -224,10 +224,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                     }
                     else if (trivia.IsMultiLineComment())
                     {
-                        completeSingleLineCommentGroup(ref spans);
-
-                        var multilineCommentRegion = CreateCommentBlockSpan(trivia, trivia);
-                        spans.Add(multilineCommentRegion);
+                        // Multiline comments are handled by the MultilineCommentBlockStructureProvider.
+                        continue;
                     }
                     else if (trivia is not SyntaxTrivia(
                         SyntaxKind.WhitespaceTrivia or SyntaxKind.EndOfLineTrivia or SyntaxKind.EndOfFileToken))

--- a/src/Features/CSharp/Portable/Structure/CSharpStructureHelpers.cs
+++ b/src/Features/CSharp/Portable/Structure/CSharpStructureHelpers.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             return prefix + " " + text.Substring(prefixLength).Trim() + " " + Ellipsis;
         }
 
-        internal static string GetCommentBannerText(SyntaxTrivia comment)
+        public static string GetCommentBannerText(SyntaxTrivia comment)
         {
             Contract.ThrowIfFalse(comment.IsSingleLineComment() || comment.IsMultiLineComment());
 

--- a/src/Features/CSharp/Portable/Structure/Providers/MultilineCommentBlockStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/MultilineCommentBlockStructureProvider.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using Microsoft.CodeAnalysis.Shared.Collections;
+using Microsoft.CodeAnalysis.Structure;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.Structure
+{
+    internal class MultilineCommentBlockStructureProvider : AbstractSyntaxTriviaStructureProvider
+    {
+        public override void CollectBlockSpans(
+            SyntaxTrivia trivia,
+            ref TemporaryArray<BlockSpan> spans,
+            BlockStructureOptions options,
+            CancellationToken cancellationToken)
+        {
+            var span = new BlockSpan(
+                isCollapsible: true,
+                textSpan: trivia.Span,
+                hintSpan: trivia.Span,
+                type: BlockTypes.Comment,
+                bannerText: CSharpStructureHelpers.GetCommentBannerText(trivia),
+                autoCollapse: true);
+            spans.Add(span);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/64001

Looks like
![image](https://user-images.githubusercontent.com/5749229/190273427-9b09c0c4-3686-45ce-9dce-bedca203bb8f.png)
