### PR TITLE
Rename SymbolCompletionProvider to RecommendationServiceBasedCompletionProvider

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CompletionProviderOrderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CompletionProviderOrderTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
                 typeof(KeywordCompletionProvider),
                 typeof(AwaitCompletionProvider),
                 typeof(SpeculativeTCompletionProvider),
-                typeof(SymbolCompletionProvider),
+                typeof(RecommendationServiceBasedCompletionProvider),
                 typeof(UnnamedSymbolCompletionProvider),
                 typeof(ExplicitInterfaceMemberCompletionProvider),
                 typeof(ExplicitInterfaceTypeCompletionProvider),

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/RecommendationServiceBasedCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/RecommendationServiceBasedCompletionProviderTests.cs
@@ -21,10 +21,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionSe
 {
     [UseExportProvider]
     [Trait(Traits.Feature, Traits.Features.Completion)]
-    public partial class SymbolCompletionProviderTests : AbstractCSharpCompletionProviderTests
+    public partial class RecommendationServiceBasedCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
         internal override Type GetCompletionProviderType()
-            => typeof(SymbolCompletionProvider);
+            => typeof(RecommendationServiceBasedCompletionProvider);
 
         [Theory]
         [InlineData(SourceCodeKind.Regular)]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/RecommendationServiceBasedCompletionProviderTests_NoInteractive.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/RecommendationServiceBasedCompletionProviderTests_NoInteractive.cs
@@ -23,10 +23,10 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionSetSources
 {
     [Trait(Traits.Feature, Traits.Features.Completion)]
-    public class SymbolCompletionProviderTests_NoInteractive : AbstractCSharpCompletionProviderTests
+    public class RecommendationServiceBasedCompletionProviderTests_NoInteractive : AbstractCSharpCompletionProviderTests
     {
         internal override Type GetCompletionProviderType()
-            => typeof(SymbolCompletionProvider);
+            => typeof(RecommendationServiceBasedCompletionProvider);
 
         private protected override Task VerifyWorkerAsync(
             string code, int position, string expectedItemOrNull, string expectedDescriptionOrNull,

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -1033,7 +1033,7 @@ class c { $$
             End Using
         End Function
 
-        ' NOTE(cyrusn): This should just be a unit test for SymbolCompletionProvider.  However, I'm
+        ' NOTE(cyrusn): This should just be a unit test for RecommendationServiceBasedCompletionProvider.  However, I'm
         ' just porting the integration tests to here for now.
         <WpfTheory, CombinatorialData>
         <Trait(Traits.Feature, Traits.Features.Completion)>

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviderOrderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviderOrderTests.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion
                 GetType(FirstBuiltInCompletionProvider),
                 GetType(KeywordCompletionProvider),
                 GetType(AwaitCompletionProvider),
-                GetType(SymbolCompletionProvider),
+                GetType(RecommendationServiceBasedCompletionProvider),
                 GetType(PreprocessorCompletionProvider),
                 GetType(ObjectInitializerCompletionProvider),
                 GetType(ObjectCreationCompletionProvider),

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/RecommendationServiceBasedCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/RecommendationServiceBasedCompletionProviderTests.vb
@@ -10,13 +10,13 @@ Imports Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.CompletionProviders
     <UseExportProvider>
     <Trait(Traits.Feature, Traits.Features.Completion)>
-    Public Class SymbolCompletionProviderTests
+    Public Class RecommendationServiceBasedCompletionProviderTests
         Inherits AbstractVisualBasicCompletionProviderTests
 
         Private Const s_unicodeEllipsis = ChrW(&H2026)
 
         Friend Overrides Function GetCompletionProviderType() As Type
-            Return GetType(SymbolCompletionProvider)
+            Return GetType(RecommendationServiceBasedCompletionProvider)
         End Function
 
 #Region "StandaloneNamespaceAndTypeSourceTests"

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 // Don't show up within member access
                 // This previously worked because the type inferrer didn't work
                 // in member access expressions.
-                // The regular SymbolCompletionProvider will handle completion after .
+                // The regular RecommendationServiceBasedCompletionProvider will handle completion after .
                 if (token.IsKind(SyntaxKind.DotToken))
                     return;
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/OperatorsAndIndexer/UnnamedSymbolCompletionProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
     /// dotted off of.
     /// </summary>
     [ExportCompletionProvider(nameof(UnnamedSymbolCompletionProvider), LanguageNames.CSharp), Shared]
-    [ExtensionOrder(After = nameof(SymbolCompletionProvider))]
+    [ExtensionOrder(After = nameof(RecommendationServiceBasedCompletionProvider))]
     internal partial class UnnamedSymbolCompletionProvider : LSPCompletionProvider
     {
         /// <summary>

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/RecommendationServiceBasedCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/RecommendationServiceBasedCompletionProvider.cs
@@ -23,14 +23,14 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 {
-    [ExportCompletionProvider(nameof(SymbolCompletionProvider), LanguageNames.CSharp)]
+    [ExportCompletionProvider(nameof(RecommendationServiceBasedCompletionProvider), LanguageNames.CSharp)]
     [ExtensionOrder(After = nameof(SpeculativeTCompletionProvider))]
     [Shared]
-    internal sealed class SymbolCompletionProvider : AbstractRecommendationServiceBasedCompletionProvider<CSharpSyntaxContext>
+    internal sealed class RecommendationServiceBasedCompletionProvider : AbstractRecommendationServiceBasedCompletionProvider<CSharpSyntaxContext>
     {
         private static readonly Dictionary<(bool importDirective, bool preselect, bool tupleLiteral), CompletionItemRules> s_cachedRules = new();
 
-        static SymbolCompletionProvider()
+        static RecommendationServiceBasedCompletionProvider()
         {
             for (var importDirective = 0; importDirective < 2; importDirective++)
             {
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public SymbolCompletionProvider()
+        public RecommendationServiceBasedCompletionProvider()
         {
         }
 

--- a/src/Features/Core/Portable/Completion/Providers/CompletionLinkedFilesSymbolEquivalenceComparer.cs
+++ b/src/Features/Core/Portable/Completion/Providers/CompletionLinkedFilesSymbolEquivalenceComparer.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 
 namespace Microsoft.CodeAnalysis.Completion.Providers

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             End If
 
             ' This providers provides fully qualified names, eg "DayOfWeek.Monday"
-            ' Don't run after dot because SymbolCompletionProvider will provide
+            ' Don't run after dot because RecommendationServiceBasedCompletionProvider will provide
             ' members in situations like Dim x = DayOfWeek.$$
             If context.TargetToken.IsKind(SyntaxKind.DotToken) Then
                 Return SpecializedTasks.EmptyImmutableArray(Of ISymbol)()

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/PreprocessorCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/PreprocessorCompletionProvider.vb
@@ -12,7 +12,7 @@ Imports Microsoft.CodeAnalysis.Text
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
     <ExportCompletionProvider(NameOf(PreprocessorCompletionProvider), LanguageNames.VisualBasic)>
-    <ExtensionOrder(After:=NameOf(SymbolCompletionProvider))>
+    <ExtensionOrder(After:=NameOf(RecommendationServiceBasedCompletionProvider))>
     <[Shared]>
     Friend Class PreprocessorCompletionProvider
         Inherits AbstractPreprocessorCompletionProvider

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/RecommendationServiceBasedCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/RecommendationServiceBasedCompletionProvider.vb
@@ -15,10 +15,10 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
-    <ExportCompletionProvider(NameOf(SymbolCompletionProvider), LanguageNames.VisualBasic)>
+    <ExportCompletionProvider(NameOf(RecommendationServiceBasedCompletionProvider), LanguageNames.VisualBasic)>
     <ExtensionOrder(After:=NameOf(AwaitCompletionProvider))>
     <[Shared]>
-    Friend NotInheritable Class SymbolCompletionProvider
+    Friend NotInheritable Class RecommendationServiceBasedCompletionProvider
         Inherits AbstractRecommendationServiceBasedCompletionProvider(Of VisualBasicSyntaxContext)
 
         Private Shared ReadOnly s_cachedRules As New Dictionary(Of (importDirective As Boolean, preselect As Boolean, tuple As Boolean), CompletionItemRules)


### PR DESCRIPTION
I always find the name of `SymbolCompletionProvider` slightly confusing when navigate through the inheritance graph of `AbstractSymbolCompletionProvider` (which is derived by 7 subclasses atm) , so I renamed it to `RecommendationServiceBasedCompletionProvider`. Let me know if you folks are OK with this.


```
AbstractSymbolCompletionProvider
             ↑
AbstractRecommendationServiceBasedCompletionProvider
             ↑
SymbolCompletionProvider
```

FYI @dotnet/roslyn-ide 