### PR TITLE
Add some additional data for bug investigation

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -174,14 +174,27 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
+            /// <summary>
+            /// A class to help simplify the investigation of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1467404 when we
+            /// see a crash dump with the failure. The goal is just to make it easy to find the state that we operated on in memory,
+            /// when sometimes local have been optimized away.
+            /// </summary>
+            private class OldStateHolderForBug1467404Investigation
+            {
+                public CompilationTrackerState? State;
+            }
+
             public ICompilationTracker FreezePartialStateWithTree(SolutionState solution, DocumentState docState, SyntaxTree tree, CancellationToken cancellationToken)
             {
+                var stateHolder = new OldStateHolderForBug1467404Investigation();
+
                 GetPartialCompilationState(
                     solution, docState.Id,
                     out var inProgressProject,
                     out var compilationPair,
                     out var generatorInfo,
                     out var metadataReferenceToProjectId,
+                    out stateHolder.State,
                     cancellationToken);
 
                 // Ensure we actually have the tree we need in there
@@ -213,6 +226,8 @@ namespace Microsoft.CodeAnalysis
                     this.ProjectState.Id,
                     metadataReferenceToProjectId);
 
+                GC.KeepAlive(stateHolder);
+
                 return new CompilationTracker(inProgressProject, finalState, this.SkeletonReferenceCache.Clone());
             }
 
@@ -232,9 +247,11 @@ namespace Microsoft.CodeAnalysis
                 out CompilationPair compilations,
                 out CompilationTrackerGeneratorInfo generatorInfo,
                 out Dictionary<MetadataReference, ProjectId>? metadataReferenceToProjectId,
+                out CompilationTrackerState oldStateForBugInvestigation,
                 CancellationToken cancellationToken)
             {
                 var state = ReadState();
+                oldStateForBugInvestigation = state;
                 var compilationWithoutGeneratedDocuments = state.CompilationWithoutGeneratedDocuments;
 
                 // check whether we can bail out quickly for typing case


### PR DESCRIPTION
I'm investigating https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1467404 and unfortunately it's difficult to figure what was the state of the compilation tracker when we originally did the production of our partial compilation state that's out of sync. This adds some tracking for that.