### PR TITLE
Remove unused parameter

### DIFF
--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDiagnosticData.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDiagnosticData.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
@@ -33,11 +34,15 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
         /// <summary>
         /// Note: the <paramref name="useMapped"/> parameter is ignored.
         /// </summary>
+        [Obsolete("Use overload that only takes a SourceText")]
         public LinePositionSpan GetLinePositionSpan(SourceText sourceText, bool useMapped)
         {
             // TypeScript has no concept of mapped spans, so this should never be passed 'true'.
             Contract.ThrowIfTrue(useMapped);
             return DiagnosticData.GetUnmappedLinePositionSpan(_data.DataLocation, sourceText);
         }
+
+        public LinePositionSpan GetLinePositionSpan(SourceText sourceText)
+            => DiagnosticData.GetUnmappedLinePositionSpan(_data.DataLocation, sourceText);
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDiagnosticData.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDiagnosticData.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
 {
@@ -30,6 +31,10 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
             => _data.CustomTags;
 
         public LinePositionSpan GetLinePositionSpan(SourceText sourceText, bool useMapped)
-            => DiagnosticData.GetLinePositionSpan(_data.DataLocation, sourceText, useMapped);
+        {
+            // TypeScript has no concept of mapped spans, so this should never be passed 'true'.
+            Contract.ThrowIfTrue(useMapped);
+            return DiagnosticData.GetUnmappedLinePositionSpan(_data.DataLocation, sourceText);
+        }
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDiagnosticData.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/Api/VSTypeScriptDiagnosticData.cs
@@ -30,6 +30,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
         public ImmutableArray<string> CustomTags
             => _data.CustomTags;
 
+        /// <summary>
+        /// Note: the <paramref name="useMapped"/> parameter is ignored.
+        /// </summary>
         public LinePositionSpan GetLinePositionSpan(SourceText sourceText, bool useMapped)
         {
             // TypeScript has no concept of mapped spans, so this should never be passed 'true'.

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
@@ -246,13 +246,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 location, additionalLocations, customTags: CustomTags, properties: Properties);
         }
 
-        public static LinePositionSpan GetLinePositionSpan(DiagnosticDataLocation dataLocation, SourceText text, bool useMapped)
+        /// <summary>
+        /// Gets the <see cref="LinePositionSpan"/> of <see cref="DiagnosticDataLocation.UnmappedFileSpan"/> clamped so
+        /// that it is entirely contained within the bounds of <paramref name="text"/>.
+        /// </summary>
+        public static LinePositionSpan GetUnmappedLinePositionSpan(DiagnosticDataLocation dataLocation, SourceText text)
         {
             var lines = text.Lines;
             if (lines.Count == 0)
                 return default;
 
-            var fileSpan = useMapped ? dataLocation.MappedFileSpan : dataLocation.UnmappedFileSpan;
+            var fileSpan = dataLocation.UnmappedFileSpan;
 
             var startLine = fileSpan.StartLinePosition.Line;
             var endLine = fileSpan.EndLinePosition.Line;
@@ -303,7 +307,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public static TextSpan GetTextSpan(DiagnosticDataLocation dataLocation, SourceText text)
         {
-            var linePositionSpan = GetLinePositionSpan(dataLocation, text, useMapped: false);
+            var linePositionSpan = GetUnmappedLinePositionSpan(dataLocation, text);
 
             var span = text.Lines.GetTextSpan(linePositionSpan);
             return EnsureInBounds(TextSpan.FromBounds(Math.Max(span.Start, 0), Math.Max(span.End, 0)), text);

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
@@ -305,6 +305,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return new LinePositionSpan(start, end);
         }
 
+        /// <summary>
+        /// Gets the <see cref="TextSpan"/> of <see cref="DiagnosticDataLocation.UnmappedFileSpan"/> clamped so that it
+        /// is entirely contained within the bounds of <paramref name="text"/>.
+        /// </summary>
         public static TextSpan GetTextSpan(DiagnosticDataLocation dataLocation, SourceText text)
         {
             var linePositionSpan = GetUnmappedLinePositionSpan(dataLocation, text);


### PR DESCRIPTION
All callers pass in 'false' here, so there's no need for an actual parameter.