### PR TITLE
Use LoadFrom instead of Load for analyzer dependencies

### DIFF
--- a/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.Loader.cs
+++ b/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerProvider.Loader.cs
@@ -31,8 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 try
                 {
                     // We want to load the analyzer assembly assets in default context.
-                    // Use Assembly.Load instead of Assembly.LoadFrom to ensure that if the assembly is ngen'ed, then the native image gets loaded.
-                    return Assembly.Load(AssemblyName.GetAssemblyName(fullPath));
+                    return Assembly.LoadFrom(fullPath);
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
What we were doing is effectively reimplementing the behavior of LoadFrom, instead of using it directly.
