### PR TITLE
Deprecate public constructors of various diagnostic analysis context types

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
@@ -542,6 +542,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public CancellationToken CancellationToken { get { return _cancellationToken; } }
 
+        [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public CompilationAnalysisContext(Compilation compilation, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
             : this(compilation, options, reportDiagnostic, isSupportedDiagnostic, null, cancellationToken)
         {
@@ -658,7 +659,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public bool IsGeneratedCode { get; }
 
-        // TODO: Mark obsolete, tracked with https://github.com/dotnet/roslyn/issues/63440
+        [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public SemanticModelAnalysisContext(SemanticModel semanticModel, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
             : this(semanticModel, options, reportDiagnostic, isSupportedDiagnostic, filterSpan: null, isGeneratedCode: false, cancellationToken)
         {
@@ -736,7 +737,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public bool IsGeneratedCode { get; }
 
-        // TODO: Mark obsolete, tracked with https://github.com/dotnet/roslyn/issues/63440
+        [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public SymbolAnalysisContext(ISymbol symbol, Compilation compilation, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
             : this(symbol, compilation, options, reportDiagnostic, isSupportedDiagnostic, isGeneratedCode: false, cancellationToken)
         {
@@ -805,7 +806,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public CancellationToken CancellationToken { get; }
 
-        // TODO: Mark obsolete, tracked with https://github.com/dotnet/roslyn/issues/63440
+        [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public SymbolStartAnalysisContext(ISymbol symbol, Compilation compilation, AnalyzerOptions options, CancellationToken cancellationToken)
             : this(symbol, compilation, options, isGeneratedCode: false, cancellationToken)
         {
@@ -954,7 +955,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public CancellationToken CancellationToken { get { return _cancellationToken; } }
 
-        // TODO: Mark obsolete, tracked with https://github.com/dotnet/roslyn/issues/63440
+        [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         protected CodeBlockStartAnalysisContext(SyntaxNode codeBlock, ISymbol owningSymbol, SemanticModel semanticModel, AnalyzerOptions options, CancellationToken cancellationToken)
             : this(codeBlock, owningSymbol, semanticModel, options, isGeneratedCode: false, cancellationToken)
         {
@@ -1049,7 +1050,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public CancellationToken CancellationToken { get { return _cancellationToken; } }
 
-        // TODO: Mark obsolete, tracked with https://github.com/dotnet/roslyn/issues/63440
+        [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public CodeBlockAnalysisContext(SyntaxNode codeBlock, ISymbol owningSymbol, SemanticModel semanticModel, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
             : this(codeBlock, owningSymbol, semanticModel, options, reportDiagnostic, isSupportedDiagnostic, isGeneratedCode: false, cancellationToken)
         {
@@ -1144,7 +1145,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public CancellationToken CancellationToken => _cancellationToken;
 
-        // TODO: Mark obsolete, tracked with https://github.com/dotnet/roslyn/issues/63440
+        [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         protected OperationBlockStartAnalysisContext(
             ImmutableArray<IOperation> operationBlocks,
             ISymbol owningSymbol,
@@ -1269,7 +1270,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public CancellationToken CancellationToken => _cancellationToken;
 
-        // TODO: Mark obsolete, tracked with https://github.com/dotnet/roslyn/issues/63440
+        [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public OperationBlockAnalysisContext(
             ImmutableArray<IOperation> operationBlocks,
             ISymbol owningSymbol,
@@ -1372,7 +1373,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         internal Compilation? Compilation => _compilationOpt;
 
-        // TODO: Mark obsolete, tracked with https://github.com/dotnet/roslyn/issues/63440
+        [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public SyntaxTreeAnalysisContext(SyntaxTree tree, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
             : this(tree, options, reportDiagnostic, isSupportedDiagnostic, compilation: null, isGeneratedCode: false, cancellationToken)
         {
@@ -1519,13 +1520,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public CancellationToken CancellationToken => _cancellationToken;
 
-        // TODO: Mark obsolete, tracked with https://github.com/dotnet/roslyn/issues/63440
+        [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public SyntaxNodeAnalysisContext(SyntaxNode node, ISymbol? containingSymbol, SemanticModel semanticModel, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
             : this(node, containingSymbol, semanticModel, options, reportDiagnostic, isSupportedDiagnostic, isGeneratedCode: false, cancellationToken)
         {
         }
 
-        // TODO: Mark obsolete, tracked with https://github.com/dotnet/roslyn/issues/63440
+        [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public SyntaxNodeAnalysisContext(SyntaxNode node, SemanticModel semanticModel, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
            : this(node, null, semanticModel, options, reportDiagnostic, isSupportedDiagnostic, isGeneratedCode: false, cancellationToken)
         {
@@ -1610,7 +1611,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public CancellationToken CancellationToken => _cancellationToken;
 
-        // TODO: Mark obsolete, tracked with https://github.com/dotnet/roslyn/issues/63440
+        [Obsolete("Use CompilationWithAnalyzers instead. See https://github.com/dotnet/roslyn/issues/63440 for more details.")]
         public OperationAnalysisContext(
             IOperation operation,
             ISymbol containingSymbol,


### PR DESCRIPTION
Fixes #63440

NOTE: This PR is built on top of #63447 to avoid merge conflicts. The only relevant commit for this PR is https://github.com/dotnet/roslyn/commit/a101a16e7ee770a4f706770f296ffc70b19300f5