### PR TITLE
Set output encoding properly in LSIF gen scenarios.

### DIFF
--- a/src/Features/Lsif/Generator/Program.cs
+++ b/src/Features/Lsif/Generator/Program.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing;
@@ -43,7 +44,19 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
         {
             // If we have an output file, we'll write to that, else we'll use Console.Out
             using var outputFile = output != null ? new StreamWriter(output) : null;
-            var outputWriter = outputFile ?? Console.Out;
+            TextWriter? outputWriter = null;
+
+            if (outputFile is null)
+            {
+                Console.Out.Encoding = UTF8Encoding.UTF8;
+                Console.OutputEncoding = UTF8Encoding.UTF8;
+                Console.Error.Encoding = UTF8Encoding.UTF8;
+                outputWriter = Console.Out;
+            }
+            else
+            {
+                outputWriter = outputFile;
+            }
 
             using var logFile = log != null ? new StreamWriter(log) : TextWriter.Null;
             ILsifJsonWriter lsifWriter = outputFormat switch

--- a/src/Features/Lsif/Generator/Program.cs
+++ b/src/Features/Lsif/Generator/Program.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
         {
             // If we have an output file, we'll write to that, else we'll use Console.Out
             using var outputFile = output != null ? new StreamWriter(output, append: false, Encoding.UTF8) : null;
-            TextWriter? outputWriter;
+            TextWriter outputWriter;
 
             if (outputFile is null)
             {

--- a/src/Features/Lsif/Generator/Program.cs
+++ b/src/Features/Lsif/Generator/Program.cs
@@ -43,14 +43,12 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
         private static async Task GenerateAsync(FileInfo? solution, FileInfo? project, FileInfo? compilerInvocation, FileInfo? binLog, string? output, LsifFormat outputFormat, string? log)
         {
             // If we have an output file, we'll write to that, else we'll use Console.Out
-            using var outputFile = output != null ? new StreamWriter(output) : null;
-            TextWriter? outputWriter = null;
+            using var outputFile = output != null ? new StreamWriter(output, append: false, Encoding.UTF8) : null;
+            TextWriter? outputWriter;
 
             if (outputFile is null)
             {
-                Console.Out.Encoding = UTF8Encoding.UTF8;
-                Console.OutputEncoding = UTF8Encoding.UTF8;
-                Console.Error.Encoding = UTF8Encoding.UTF8;
+                Console.OutputEncoding = Encoding.UTF8;
                 outputWriter = Console.Out;
             }
             else


### PR DESCRIPTION
- When we were writing to the console the console was translating characters characters away from their originating type. This resulted in a lot of unexpected JSON failures when deserializing. For instance if you were to have "fancy" Microsoft word quotes in a doc comment the hover results from LSIF generation would contain malformed values because the fancy quote would be translated to a regular quote (breaking the value).

Fixes #64050