### PR TITLE
`scoped` should set ref escape scope to current block

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly RefKind _refKind;
         private readonly LocalDeclarationKind _declarationKind;
         private readonly DeclarationScope _scope;
+        private readonly uint _localScopeDepth;
 
         private TypeWithAnnotations.Boxed _type;
 
@@ -89,6 +90,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // create this eagerly as it will always be needed for the EnsureSingleDefinition
             _locations = ImmutableArray.Create<Location>(identifierToken.GetLocation());
 
+            _localScopeDepth = scopeBinder.LocalScopeDepth;
+
             _refEscapeScope = this._refKind == RefKind.None ?
                                         scopeBinder.LocalScopeDepth :
                                         Binder.ExternalScope; // default to returnable, unless there is initializer
@@ -129,7 +132,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     return _refEscapeScope;
                 }
-                return Binder.TopLevelScope;
+                return _scope == DeclarationScope.RefScoped ?
+                    _localScopeDepth :
+                    Binder.TopLevelScope;
             }
         }
 
@@ -143,7 +148,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return _valEscapeScope;
                 }
                 return _scope == DeclarationScope.ValueScoped ?
-                    Binder.TopLevelScope :
+                    _localScopeDepth :
                     Binder.ExternalScope;
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -32,7 +32,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly RefKind _refKind;
         private readonly LocalDeclarationKind _declarationKind;
         private readonly DeclarationScope _scope;
-        private readonly uint _localScopeDepth;
 
         private TypeWithAnnotations.Boxed _type;
 
@@ -90,8 +89,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // create this eagerly as it will always be needed for the EnsureSingleDefinition
             _locations = ImmutableArray.Create<Location>(identifierToken.GetLocation());
 
-            _localScopeDepth = scopeBinder.LocalScopeDepth;
-
             _refEscapeScope = this._refKind == RefKind.None ?
                                         scopeBinder.LocalScopeDepth :
                                         Binder.ExternalScope; // default to returnable, unless there is initializer
@@ -133,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return _refEscapeScope;
                 }
                 return _scope == DeclarationScope.RefScoped ?
-                    _localScopeDepth :
+                    _scopeBinder.LocalScopeDepth :
                     Binder.TopLevelScope;
             }
         }
@@ -148,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return _valEscapeScope;
                 }
                 return _scope == DeclarationScope.ValueScoped ?
-                    _localScopeDepth :
+                    _scopeBinder.LocalScopeDepth :
                     Binder.ExternalScope;
             }
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -9163,8 +9163,16 @@ ref struct S
             r0 = ref r1; // 1
         }
         {
+            ref S r2 = ref s0;
+            r0 = ref r2;
+        }
+        {
             scoped ref S r2 = ref r0;
             r0 = ref r2; // 2
+        }
+        {
+            ref S r4 = ref r0;
+            r0 = ref r4;
         }
     }
 }
@@ -9175,9 +9183,9 @@ ref struct S { }
                 // (9,13): error CS8374: Cannot ref-assign 'r1' to 'r0' because 'r1' has a narrower escape scope than 'r0'.
                 //             r0 = ref r1; // 1
                 Diagnostic(ErrorCode.ERR_RefAssignNarrower, "r0 = ref r1").WithArguments("r0", "r1").WithLocation(9, 13),
-                // (13,13): error CS8374: Cannot ref-assign 'r2' to 'r0' because 'r2' has a narrower escape scope than 'r0'.
+                // (17,13): error CS8374: Cannot ref-assign 'r2' to 'r0' because 'r2' has a narrower escape scope than 'r0'.
                 //             r0 = ref r2; // 2
-                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "r0 = ref r2").WithArguments("r0", "r2").WithLocation(13, 13));
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "r0 = ref r2").WithArguments("r0", "r2").WithLocation(17, 13));
         }
 
         [Fact]
@@ -9198,6 +9206,10 @@ ref struct S { }
         {
             scoped S s2 = s0;
             s0 = s2; // 2
+        }
+        {
+            S s2 = s0;
+            s0 = s2;
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -9163,12 +9163,12 @@ ref struct S
             r0 = ref r1; // 1
         }
         {
-            ref S r2 = ref s0;
-            r0 = ref r2;
-        }
-        {
             scoped ref S r2 = ref r0;
             r0 = ref r2; // 2
+        }
+        {
+            ref S r3 = ref s0;
+            r0 = ref r3;
         }
         {
             ref S r4 = ref r0;
@@ -9183,9 +9183,9 @@ ref struct S { }
                 // (9,13): error CS8374: Cannot ref-assign 'r1' to 'r0' because 'r1' has a narrower escape scope than 'r0'.
                 //             r0 = ref r1; // 1
                 Diagnostic(ErrorCode.ERR_RefAssignNarrower, "r0 = ref r1").WithArguments("r0", "r1").WithLocation(9, 13),
-                // (17,13): error CS8374: Cannot ref-assign 'r2' to 'r0' because 'r2' has a narrower escape scope than 'r0'.
+                // (13,13): error CS8374: Cannot ref-assign 'r2' to 'r0' because 'r2' has a narrower escape scope than 'r0'.
                 //             r0 = ref r2; // 2
-                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "r0 = ref r2").WithArguments("r0", "r2").WithLocation(17, 13));
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "r0 = ref r2").WithArguments("r0", "r2").WithLocation(13, 13));
         }
 
         [Fact]
@@ -9208,8 +9208,8 @@ ref struct S { }
             s0 = s2; // 2
         }
         {
-            S s2 = s0;
-            s0 = s2;
+            S s3 = s0;
+            s0 = s3;
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -9115,6 +9115,40 @@ class Program
                 );
         }
 
+        [WorkItem(64009, "https://github.com/dotnet/roslyn/issues/64009")]
+        [Fact]
+        public void LocalScope_09()
+        {
+            var source =
+@"{
+    scoped s1 = default;
+    scoped ref @scoped s2 = ref s1;
+}
+ref struct @scoped { }
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+        }
+
+        [WorkItem(64009, "https://github.com/dotnet/roslyn/issues/64009")]
+        [Fact]
+        public void LocalScope_10()
+        {
+            var source =
+@"{
+    int i = 0;
+    S s1 = new S(ref i);
+    scoped S s2 = s1;
+}
+ref struct S
+{
+    public S(ref int i) { }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+        }
+
         [Fact]
         public void LocalScopeAndInitializer_01()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -9130,7 +9130,6 @@ ref struct @scoped { }
             comp.VerifyDiagnostics();
         }
 
-        [WorkItem(64009, "https://github.com/dotnet/roslyn/issues/64009")]
         [Fact]
         public void LocalScope_10()
         {
@@ -9147,6 +9146,74 @@ ref struct S
 ";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void LocalScope_11()
+        {
+            var source =
+@"class Program
+{
+    static void Main()
+    {
+        S s0 = default;
+        scoped ref S r0 = ref s0;
+        {
+            scoped ref S r1 = ref s0;
+            r0 = ref r1; // 1
+        }
+        {
+            scoped ref S r2 = ref r0;
+            r0 = ref r2; // 2
+        }
+    }
+}
+ref struct S { }
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (9,13): error CS8374: Cannot ref-assign 'r1' to 'r0' because 'r1' has a narrower escape scope than 'r0'.
+                //             r0 = ref r1; // 1
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "r0 = ref r1").WithArguments("r0", "r1").WithLocation(9, 13),
+                // (13,13): error CS8374: Cannot ref-assign 'r2' to 'r0' because 'r2' has a narrower escape scope than 'r0'.
+                //             r0 = ref r2; // 2
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "r0 = ref r2").WithArguments("r0", "r2").WithLocation(13, 13));
+        }
+
+        [Fact]
+        public void LocalScope_12()
+        {
+            var source =
+@"class Program
+{
+    static void Main()
+    {
+        int i0 = 0;
+        S s0 = new S(ref i0);
+        {
+            int i1 = 1;
+            S s1 = new S(ref i1);
+            s0 = s1; // 1
+        }
+        {
+            scoped S s2 = s0;
+            s0 = s2; // 2
+        }
+    }
+}
+ref struct S
+{
+    public S(ref int i) { }
+}
+";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (10,18): error CS8352: Cannot use variable 's1' in this context because it may expose referenced variables outside of their declaration scope
+                //             s0 = s1; // 1
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "s1").WithArguments("s1").WithLocation(10, 18),
+                // (14,18): error CS8352: Cannot use variable 's2' in this context because it may expose referenced variables outside of their declaration scope
+                //             s0 = s2; // 2
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "s2").WithArguments("s2").WithLocation(14, 18));
         }
 
         [Fact]


### PR DESCRIPTION
`scoped` should set ref escape scope to the current block rather than the current method.

Fixes #64009.