### PR TITLE
Improve SymbolDisplay to handle operator symbols that are not valid operators for the target language.

### DIFF
--- a/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
+++ b/src/Compilers/Test/Core/Compilation/OperationTreeVerifier.cs
@@ -50,6 +50,13 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             var walker = new OperationTreeVerifier(compilation, operation, initialIndent);
             walker.Visit(operation);
+
+            var visitor = TestOperationVisitor.Singleton;
+            foreach (var op in operation.DescendantsAndSelf())
+            {
+                visitor.Visit(op);
+            }
+
             return walker._builder.ToString();
         }
 

--- a/src/Compilers/Test/Core/Compilation/TestOperationVisitor.cs
+++ b/src/Compilers/Test/Core/Compilation/TestOperationVisitor.cs
@@ -736,9 +736,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             AssertConstrainedToType(operatorMethod, operation.ConstrainedToType);
             Assert.Same(operation.Operand, operation.ChildOperations.Single());
 
-            // Directly get the symbol for this operator from the semantic model.  This allows us to exercise
-            // potentially creating synthesized intrinsic operators.
-            CheckBuiltInOperators(operation.SemanticModel, operation.Syntax);
+            CheckOperators(operation.SemanticModel, operation.Syntax);
         }
 
         public override void VisitBinaryOperator(IBinaryOperation operation)
@@ -773,29 +771,38 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             AssertEx.Equal(new[] { operation.LeftOperand, operation.RightOperand }, operation.ChildOperations);
 
-            // Directly get the symbol for this operator from the semantic model.  This allows us to exercise
-            // potentially creating synthesized intrinsic operators.
-            CheckBuiltInOperators(operation.SemanticModel, operation.Syntax);
+            CheckOperators(operation.SemanticModel, operation.Syntax);
         }
 
-        private static void CheckBuiltInOperators(SemanticModel semanticModel, SyntaxNode syntax)
+        private static void CheckOperators(SemanticModel semanticModel, SyntaxNode syntax)
         {
+            // Directly get the symbol for this operator from the semantic model.  This allows us to exercise
+            // potentially creating synthesized intrinsic operators.
             var symbolInfo = semanticModel?.GetSymbolInfo(syntax) ?? default;
+
             foreach (var symbol in symbolInfo.GetAllSymbols())
             {
-                if (symbol is IMethodSymbol { MethodKind: MethodKind.BuiltinOperator } method)
+                if (symbol is IMethodSymbol method)
                 {
-                    switch (method.Parameters.Length)
+                    VisualBasic.SymbolDisplay.ToDisplayString(method, SymbolDisplayFormat.TestFormat);
+                    VisualBasic.SymbolDisplay.ToDisplayString(method);
+                    CSharp.SymbolDisplay.ToDisplayString(method, SymbolDisplayFormat.TestFormat);
+                    CSharp.SymbolDisplay.ToDisplayString(method);
+
+                    if (method.MethodKind == MethodKind.BuiltinOperator)
                     {
-                        case 1:
-                            semanticModel.Compilation.CreateBuiltinOperator(symbol.Name, method.ReturnType, method.Parameters[0].Type);
-                            break;
-                        case 2:
-                            semanticModel.Compilation.CreateBuiltinOperator(symbol.Name, method.ReturnType, method.Parameters[0].Type, method.Parameters[1].Type);
-                            break;
-                        default:
-                            AssertEx.Fail($"Unexpected parameter count for built in method: {method.ToDisplayString()}");
-                            break;
+                        switch (method.Parameters.Length)
+                        {
+                            case 1:
+                                semanticModel.Compilation.CreateBuiltinOperator(symbol.Name, method.ReturnType, method.Parameters[0].Type);
+                                break;
+                            case 2:
+                                semanticModel.Compilation.CreateBuiltinOperator(symbol.Name, method.ReturnType, method.Parameters[0].Type, method.Parameters[1].Type);
+                                break;
+                            default:
+                                AssertEx.Fail($"Unexpected parameter count for built in method: {method.ToDisplayString()}");
+                                break;
+                        }
                     }
                 }
             }
@@ -836,6 +843,14 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
 
             Assert.Same(operation.Operand, operation.ChildOperations.Single());
+
+            if (operatorMethod != null)
+            {
+                VisualBasic.SymbolDisplay.ToDisplayString(operatorMethod, SymbolDisplayFormat.TestFormat);
+                VisualBasic.SymbolDisplay.ToDisplayString(operatorMethod);
+                CSharp.SymbolDisplay.ToDisplayString(operatorMethod, SymbolDisplayFormat.TestFormat);
+                CSharp.SymbolDisplay.ToDisplayString(operatorMethod);
+            }
         }
 
         private static void AssertConstrainedToType(ISymbol member, ITypeSymbol constrainedToType)

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
@@ -1208,6 +1208,21 @@ End Class
                                        returnName),
                          symbol1.ToTestDisplayString())
 
+            Assert.Equal(String.Format("Public Shared Operator {0}(left As {1}, right As {2}) As {3}",
+                                       SyntaxFacts.GetText(OverloadResolution.GetOperatorTokenKind(
+                                           If(op = BinaryOperatorKind.Add AndAlso resultType = SpecialType.System_String,
+                                              BinaryOperatorKind.Concatenate,
+                                              op))),
+                                       symbol1.Parameters(0).Type.ToDisplayString(),
+                                       symbol1.Parameters(1).Type.ToDisplayString(),
+                                       symbol1.ReturnType.ToDisplayString()),
+                         symbol1.ToDisplayString())
+
+            If op = BinaryOperatorKind.Add AndAlso resultType = SpecialType.System_String Then
+                Assert.Equal("System.String System.String.op_Concatenate(System.String left, System.String right)", CSharp.SymbolDisplay.ToDisplayString(symbol1, SymbolDisplayFormat.TestFormat))
+                Assert.Equal("string.op_Concatenate(string, string)", CSharp.SymbolDisplay.ToDisplayString(symbol1))
+            End If
+
             Assert.Equal(MethodKind.BuiltinOperator, symbol1.MethodKind)
             Assert.True(symbol1.IsImplicitlyDeclared)
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/UnaryOperators.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/UnaryOperators.vb
@@ -755,6 +755,12 @@ End Class
                                        returnName),
                          symbol1.ToTestDisplayString())
 
+            Assert.Equal(String.Format("Public Shared Operator {0}(value As {1}) As {2}",
+                                       SyntaxFacts.GetText(OverloadResolution.GetOperatorTokenKind(op)),
+                                       symbol1.Parameters(0).Type.ToDisplayString(),
+                                       symbol1.ReturnType.ToDisplayString()),
+                         symbol1.ToDisplayString())
+
             Assert.Equal(MethodKind.BuiltinOperator, symbol1.MethodKind)
             Assert.True(symbol1.IsImplicitlyDeclared)
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CheckedUserDefinedOperatorsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/CheckedUserDefinedOperatorsTests.vb
@@ -186,12 +186,21 @@ End Class
 
             Dim c0_3 = comp3.GetTypeByMetadataName("C0")
 
-            For Each m In c0_3.GetMembers().OfType(Of IMethodSymbol)()
-                If m.MethodKind <> MethodKind.Constructor Then
-                    Assert.Equal(MethodKind.UserDefinedOperator, m.MethodKind)
-                End If
+            Dim operators = c0_3.GetMembers().OfType(Of IMethodSymbol)().Where(Function(m) m.MethodKind <> MethodKind.Constructor).ToArray()
+
+            Assert.Equal(3, operators.Length)
+
+            For Each m In operators
+                Assert.Equal(MethodKind.UserDefinedOperator, m.MethodKind)
             Next
 
+            Assert.Equal("Function C0.op_CheckedUnaryNegation(x As C0) As C0", SymbolDisplay.ToDisplayString(operators(0), SymbolDisplayFormat.TestFormat))
+            Assert.Equal("Function C0.op_CheckedDecrement(x As C0) As C0", SymbolDisplay.ToDisplayString(operators(1), SymbolDisplayFormat.TestFormat))
+            Assert.Equal("Function C0.op_CheckedIncrement(x As C0) As C0", SymbolDisplay.ToDisplayString(operators(2), SymbolDisplayFormat.TestFormat))
+
+            Assert.Equal("Public Shared Function op_CheckedUnaryNegation(x As C0) As C0", SymbolDisplay.ToDisplayString(operators(0)))
+            Assert.Equal("Public Shared Function op_CheckedDecrement(x As C0) As C0", SymbolDisplay.ToDisplayString(operators(1)))
+            Assert.Equal("Public Shared Function op_CheckedIncrement(x As C0) As C0", SymbolDisplay.ToDisplayString(operators(2)))
         End Sub
 
         <Theory>
@@ -364,12 +373,13 @@ End Class
 
             Dim c0_3 = comp3.GetTypeByMetadataName("C0")
 
-            For Each m In c0_3.GetMembers().OfType(Of IMethodSymbol)()
-                If m.MethodKind <> MethodKind.Constructor Then
-                    Assert.Equal(MethodKind.UserDefinedOperator, m.MethodKind)
-                End If
-            Next
+            Dim operators = c0_3.GetMembers().OfType(Of IMethodSymbol)().Where(Function(m) m.MethodKind <> MethodKind.Constructor).ToArray()
 
+            Assert.Equal(1, operators.Length)
+
+            Assert.Equal(MethodKind.UserDefinedOperator, operators(0).MethodKind)
+            Assert.Equal("Function C0." + metadataName + "(x As C0, y As C0) As C0", SymbolDisplay.ToDisplayString(operators(0), SymbolDisplayFormat.TestFormat))
+            Assert.Equal("Public Shared Function " + metadataName + "(x As C0, y As C0) As C0", SymbolDisplay.ToDisplayString(operators(0)))
         End Sub
 
         <Theory>
@@ -543,15 +553,14 @@ End Class
 
             Dim c0_3 = comp3.GetTypeByMetadataName("C0")
 
-            For Each m In c0_3.GetMembers().OfType(Of IMethodSymbol)()
-                If m.MethodKind <> MethodKind.Constructor Then
-                    Assert.Equal(MethodKind.Conversion, m.MethodKind)
-                End If
-            Next
+            Dim operators = c0_3.GetMembers().OfType(Of IMethodSymbol)().Where(Function(m) m.MethodKind <> MethodKind.Constructor).ToArray()
 
+            Assert.Equal(1, operators.Length)
+
+            Assert.Equal(MethodKind.Conversion, operators(0).MethodKind)
+            Assert.Equal("Function C0.op_CheckedExplicit(x As C0) As System.Int64", SymbolDisplay.ToDisplayString(operators(0), SymbolDisplayFormat.TestFormat))
+            Assert.Equal("Public Shared Function op_CheckedExplicit(x As C0) As Long", SymbolDisplay.ToDisplayString(operators(0)))
         End Sub
-
-        'Public shared Narrowing Operator CType 
 
         <Theory>
         <CombinatorialData>


### PR DESCRIPTION
Also ensure SymbolDisplay for VB can handle symbols for VB checked built-in operators after the recent change in https://github.com/dotnet/roslyn/pull/63604. This fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1615080.