### PR TITLE
Move test RSP to artifacts directory

### DIFF
--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -134,7 +134,7 @@ namespace RunTests
             try
             {
                 var rspFileContents = BuildRspFileContents(workItemInfo, options);
-                var rspFilePath = Path.Combine(Directory.GetCurrentDirectory(), $"vstest_{workItemInfo.PartitionIndex}.rsp");
+                var rspFilePath = Path.Combine(getRspDirectory(), $"vstest_{workItemInfo.PartitionIndex}.rsp");
                 File.WriteAllText(rspFilePath, rspFileContents);
 
                 var vsTestConsolePath = GetVsTestConsolePath(options.DotnetFilePath);
@@ -241,6 +241,19 @@ namespace RunTests
                     testResultInfo,
                     commandLineArguments,
                     processResults: ImmutableArray.CreateRange(processResultList));
+
+                string getRspDirectory()
+                {
+                    // There is no artifacts directory on Helix, just use the current directory
+                    if (options.UseHelix)
+                    {
+                        return Directory.GetCurrentDirectory();
+                    }
+
+                    var dirPath = Path.Combine(options.ArtifactsDirectory, "tmp", options.Configuration, "vstest-rsp");
+                    Directory.CreateDirectory(dirPath);
+                    return dirPath;
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This moves our generated vstest RSP files into the tmp folder under artifacts. Previously they were being dropped into the root which was causing them to show up in `git status` calls.

closes #63779