### PR TITLE
Remove the usage of grid in Inheritance margin

### DIFF
--- a/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginViewMargin.cs
+++ b/src/VisualStudio/Core/Def/InheritanceMargin/InheritanceMarginViewMargin.cs
@@ -32,7 +32,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
         private readonly IGlobalOptionService _globalOptions;
         private readonly InheritanceGlyphManager _glyphManager;
         private readonly string _languageName;
-        private readonly Grid _grid;
         private readonly Canvas _mainCanvas;
 
         /// <summary>
@@ -61,8 +60,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             _globalOptions = globalOptions;
             _languageName = languageName;
             _mainCanvas = new Canvas { ClipToBounds = true, Width = HeightAndWidthOfMargin };
-            _grid = new Grid();
-            _grid.Children.Add(_mainCanvas);
             _glyphManager = new InheritanceGlyphManager(
                 workspace,
                 textView,
@@ -83,10 +80,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             _textView.ZoomLevelChanged += OnZoomLevelChanged;
             _globalOptions.OptionChanged += OnGlobalOptionChanged;
 
-            _grid.LayoutTransform = new ScaleTransform(
-                scaleX: _textView.ZoomLevel / 100,
-                scaleY: _textView.ZoomLevel / 100);
-            _grid.LayoutTransform.Freeze();
             UpdateMarginVisibility();
         }
 
@@ -107,7 +100,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
 
         private void OnZoomLevelChanged(object sender, ZoomLevelChangedEventArgs e)
         {
-            _grid.LayoutTransform = e.ZoomTransform;
             _refreshAllGlyphs = true;
         }
 
@@ -212,7 +204,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             get
             {
                 ThrowIfDisposed();
-                return _grid;
+                return _mainCanvas;
             }
         }
 
@@ -221,7 +213,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.InheritanceMarg
             get
             {
                 ThrowIfDisposed();
-                return _grid.ActualWidth;
+                return _mainCanvas.ActualWidth;
             }
         }
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InheritanceMarginInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InheritanceMarginInProcess.cs
@@ -68,7 +68,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
         private async Task EnsureGlyphsAppearAsync(Func<CancellationToken, Task> makeChangeFunc, int expectedGlyphsNumberInMargin, CancellationToken cancellationToken)
         {
             var margin = await GetTextViewMarginAsync(cancellationToken);
-            var marginCanvas = (Canvas)((Grid)margin.VisualElement).Children[0];
+            var marginCanvas = (Canvas)margin.VisualElement;
             var taskCompletionSource = new TaskCompletionSource<bool>();
             using var _ = cancellationToken.Register(() => taskCompletionSource.TrySetCanceled());
 
@@ -116,11 +116,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
             var wpfTextViewLine = activeView.TextViewLines[lineNumber - 1];
             var midOfTheLine = wpfTextViewLine.TextTop + wpfTextViewLine.Height / 2;
             var margin = await GetTextViewMarginAsync(cancellationToken);
-
-            var grid = (Grid)margin.VisualElement;
-            // There will be only one Canvas element.
-            Assert.True(grid.Children.Count == 1);
-            var containingCanvas = (Canvas)((Grid)margin.VisualElement).Children[0];
+            var containingCanvas = (Canvas)margin.VisualElement;
 
             var glyphsOnLine = new List<InheritanceMarginGlyph>();
             foreach (var glyph in containingCanvas.Children)


### PR DESCRIPTION
After the inheritance margin is moved into the left selection margin https://github.com/dotnet/roslyn/pull/63992
It would become like
![image](https://user-images.githubusercontent.com/24360909/191154391-3afc3078-d8d9-47b1-86a9-dc4aebc860a7.png)

This is because in left selection margin http://index/?leftProject=Microsoft.VisualStudio.Platform.VSEditor&leftSymbol=gsp1xdezk7ju 
It has already set the LayoutTransform.

And before that, Left margin, doesn't do that for us (so we have a grid and set it by ourselves)

Because left selection margin already change the layout, if we still do that, we will scale the glyph twice.
Remove the grid would fix the issue.

- [x] (waiting to see if Integration test pass)