### PR TITLE
Pass cancellationToken to input processor

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpArgumentProvider.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpArgumentProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Roslyn.Test.Utilities;
 using Roslyn.VisualStudio.IntegrationTests;
+using Roslyn.VisualStudio.IntegrationTests.InProcess;
 using WindowsInput.Native;
 using Xunit;
 
@@ -46,17 +47,17 @@ public class Test
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
-            await TestServices.Input.SendAsync("f.ToSt");
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
+            await TestServices.Input.SendAsync("f.ToSt", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString($$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString()$$", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
@@ -73,19 +74,19 @@ public class Test
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync("object.Equ");
+            await TestServices.Input.SendAsync("object.Equ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        object.Equals$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        object.Equals(null$$, null)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        object.Equals(null, null$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        object.Equals(null, null)$$", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
@@ -102,16 +103,16 @@ public class Test
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync("new obje");
+            await TestServices.Input.SendAsync("new obje", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        var value = new object$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        var value = new object($$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        var value = new object()$$", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
@@ -130,16 +131,16 @@ public class Test
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync("f.ToSt");
+            await TestServices.Input.SendAsync("f.ToSt", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString$$;", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString($$);", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString()$$;", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
@@ -158,38 +159,38 @@ public class Test
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
-            await TestServices.Input.SendAsync("f.ToSt");
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
+            await TestServices.Input.SendAsync("f.ToSt", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString($$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(provider$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(null$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(null$$, provider)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync("\"format\"");
+            await TestServices.Input.SendAsync("\"format\"", HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(\"format\"$$, provider)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(\"format\", provider$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.UP);
+            await TestServices.Input.SendAsync(VirtualKeyCode.UP, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(\"format\"$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.UP);
+            await TestServices.Input.SendAsync(VirtualKeyCode.UP, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(provider$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(\"format\"$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
@@ -210,29 +211,29 @@ public class TestClass
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
-            await TestServices.Input.SendAsync("Test");
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
+            await TestServices.Input.SendAsync("Test", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test($$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$, 0)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test($$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$, 0)", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
@@ -253,20 +254,20 @@ public class TestClass
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
-            await TestServices.Input.SendAsync("Tes");
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
+            await TestServices.Input.SendAsync("Tes", HangMitigatingCancellationToken);
 
             // Trigger the session and type '0' without waiting for the session to finish initializing
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, VirtualKeyCode.TAB, '0');
+            await TestServices.Input.SendAsync(new InputKey[] { VirtualKeyCode.TAB, VirtualKeyCode.TAB, '0' }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$, 0)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.UP);
+            await TestServices.Input.SendAsync(VirtualKeyCode.UP, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
@@ -287,17 +288,17 @@ public class Test
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
-            await TestServices.Input.SendAsync("f.ToSt");
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
+            await TestServices.Input.SendAsync("f.ToSt", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString($$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(';');
+            await TestServices.Input.SendAsync(';', HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString();$$", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
@@ -318,20 +319,20 @@ public class Test
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
-            await TestServices.Input.SendAsync("object.Equ");
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
+            await TestServices.Input.SendAsync("object.Equ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        object.Equals$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        object.Equals(null$$, null)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        object.Equals(null, null$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(';');
+            await TestServices.Input.SendAsync(';', HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        object.Equals(null, null);$$", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
@@ -356,17 +357,17 @@ public class Test
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
-            await TestServices.Input.SendAsync("this.M2");
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
+            await TestServices.Input.SendAsync("this.M2", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        this.Method2$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        this.Method2(value$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(';');
+            await TestServices.Input.SendAsync(';', HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        this.Method2(value);$$", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
@@ -384,17 +385,17 @@ public class Test
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
-            await TestServices.Input.SendAsync("f.ToSt");
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
+            await TestServices.Input.SendAsync("f.ToSt", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString($$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync((VirtualKeyCode.RETURN, VirtualKeyCode.SHIFT));
+            await TestServices.Input.SendAsync((VirtualKeyCode.RETURN, VirtualKeyCode.SHIFT), HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.TextContainsAsync(@"
 public class Test
 {
@@ -423,20 +424,20 @@ public class Test
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
-            await TestServices.Input.SendAsync("object.Equ");
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
+            await TestServices.Input.SendAsync("object.Equ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        object.Equals$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        object.Equals(null$$, null)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        object.Equals(null, null$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync((VirtualKeyCode.RETURN, VirtualKeyCode.SHIFT));
+            await TestServices.Input.SendAsync((VirtualKeyCode.RETURN, VirtualKeyCode.SHIFT), HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.TextContainsAsync(@"
 public class Test
 {
@@ -477,20 +478,20 @@ public class Test
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
-            await TestServices.Input.SendAsync("M");
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
+            await TestServices.Input.SendAsync("M", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        M$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        M(null, 0)", cancellationToken: HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(parameterText);
+            await TestServices.Input.SendAsync(parameterText, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        M(" + parameterText + ", 0)", cancellationToken: HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        M(" + parameterText + ", 0, 0)", cancellationToken: HangMitigatingCancellationToken);
         }
 
@@ -506,12 +507,12 @@ $$
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync("#i");
+            await TestServices.Input.SendAsync("#i", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("#if$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("#if true$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
             var expected = @"

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Extensibility.Testing;
 using Roslyn.Test.Utilities;
 using Roslyn.VisualStudio.IntegrationTests;
+using Roslyn.VisualStudio.IntegrationTests.InProcess;
 using WindowsInput.Native;
 using Xunit;
 
@@ -492,7 +493,7 @@ public class Program
 
 public class P2 { }", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.BACK, VirtualKeyCode.BACK, "Stream");
+            await TestServices.Input.SendAsync(new InputKey[] { VirtualKeyCode.BACK, VirtualKeyCode.BACK, "Stream" }, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
                 new[]
                 {
@@ -557,8 +558,7 @@ namespace NS
         }
     }
 }", HangMitigatingCancellationToken);
-            await TestServices.Input.SendAsync(VirtualKeyCode.BACK, VirtualKeyCode.BACK,
-                "Foober");
+            await TestServices.Input.SendAsync(new InputKey[] { VirtualKeyCode.BACK, VirtualKeyCode.BACK, "Foober" }, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
                 new[]
                 {
@@ -865,7 +865,7 @@ class C
             await TestServices.SolutionExplorer.AddFileAsync(ProjectName, ".editorconfig", open: true, cancellationToken: HangMitigatingCancellationToken);
             await TestServices.Input.SendAsync(@"
 [*.cs]
-dotnet_diagnostic.CS0168.severity = ");
+dotnet_diagnostic.CS0168.severity = ", HangMitigatingCancellationToken);
 
             // NOTE: Below wait is a critical step in repro-ing the original regression.
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
@@ -878,7 +878,7 @@ dotnet_diagnostic.CS0168.severity = ");
                 },
                 HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync("error");
+            await TestServices.Input.SendAsync("error", HangMitigatingCancellationToken);
 
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(
                 new[]

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpErrorListCommon.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpErrorListCommon.cs
@@ -107,7 +107,7 @@ class Program2
 
             await TestServices.Editor.ActivateAsync(HangMitigatingCancellationToken);
             await TestServices.Editor.PlaceCaretAsync("a = aa", charsOffset: -1, HangMitigatingCancellationToken);
-            await TestServices.Input.SendAsync("a");
+            await TestServices.Input.SendAsync("a", HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SolutionCrawler, FeatureAttribute.DiagnosticService, FeatureAttribute.ErrorSquiggles, FeatureAttribute.ErrorList }, HangMitigatingCancellationToken);
             await TestServices.ErrorList.ShowErrorListAsync(HangMitigatingCancellationToken);
             expectedContents =
@@ -123,7 +123,7 @@ class Program2
 
             await TestServices.Editor.ActivateAsync(HangMitigatingCancellationToken);
             await TestServices.Editor.PlaceCaretAsync("aa = aa", charsOffset: -1, HangMitigatingCancellationToken);
-            await TestServices.Input.SendAsync(VirtualKeyCode.DELETE);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DELETE, HangMitigatingCancellationToken);
             await TestServices.ErrorList.ShowErrorListAsync(HangMitigatingCancellationToken);
             expectedContents = new string[] { };
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SolutionCrawler, FeatureAttribute.DiagnosticService, FeatureAttribute.ErrorSquiggles, FeatureAttribute.ErrorList }, HangMitigatingCancellationToken);
@@ -156,7 +156,7 @@ class Program2
 
             await TestServices.Editor.ActivateAsync(HangMitigatingCancellationToken);
             await TestServices.Editor.PlaceCaretAsync("a = aa", charsOffset: -1, HangMitigatingCancellationToken);
-            await TestServices.Input.SendAsync("a");
+            await TestServices.Input.SendAsync("a", HangMitigatingCancellationToken);
             await TestServices.ErrorList.ShowErrorListAsync(HangMitigatingCancellationToken);
             expectedContents = new[] {
                 "(Compiler) Class1.cs(7, 13): error CS0128: A local variable or function named 'aa' is already defined in this scope",
@@ -174,7 +174,7 @@ class Program2
             // Assert the window title is Class1.cs, which also means the file has no unsaved changes
             Assert.Equal("Class1.cs", await TestServices.Shell.GetActiveWindowCaptionAsync(HangMitigatingCancellationToken));
 
-            await TestServices.Input.SendAsync((VirtualKeyCode.F4, VirtualKeyCode.CONTROL));
+            await TestServices.Input.SendAsync((VirtualKeyCode.F4, VirtualKeyCode.CONTROL), HangMitigatingCancellationToken);
             await TestServices.ErrorList.ShowErrorListAsync(HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SolutionCrawler, FeatureAttribute.DiagnosticService, FeatureAttribute.ErrorSquiggles, FeatureAttribute.ErrorList }, HangMitigatingCancellationToken);
             actualContents = await TestServices.ErrorList.GetErrorsAsync(HangMitigatingCancellationToken);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpFindReferences.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpFindReferences.cs
@@ -50,7 +50,7 @@ class SomeOtherClass
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync((VirtualKeyCode.F12, VirtualKeyCode.SHIFT));
+            await TestServices.Input.SendAsync((VirtualKeyCode.F12, VirtualKeyCode.SHIFT), HangMitigatingCancellationToken);
 
             var results = await TestServices.FindReferencesWindow.GetContentsAsync(HangMitigatingCancellationToken);
 
@@ -96,7 +96,7 @@ class Program
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync((VirtualKeyCode.F12, VirtualKeyCode.SHIFT));
+            await TestServices.Input.SendAsync((VirtualKeyCode.F12, VirtualKeyCode.SHIFT), HangMitigatingCancellationToken);
 
             var results = await TestServices.FindReferencesWindow.GetContentsAsync(HangMitigatingCancellationToken);
 
@@ -134,7 +134,7 @@ class Program
 }
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync((VirtualKeyCode.F12, VirtualKeyCode.SHIFT));
+            await TestServices.Input.SendAsync((VirtualKeyCode.F12, VirtualKeyCode.SHIFT), HangMitigatingCancellationToken);
 
             var results = await TestServices.FindReferencesWindow.GetContentsAsync(HangMitigatingCancellationToken);
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToGlobalImportsTests.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpGoToGlobalImportsTests.cs
@@ -37,9 +37,9 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp
             await TestServices.InheritanceMargin.ClickTheGlyphOnLine(1, HangMitigatingCancellationToken);
 
             // Move focus to menu item 'System'
-            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             // Navigate to 'System'
-            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.RETURN);
+            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.InheritanceMargin }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.TextContainsAsync(@"global using global::System;$$", assertCaretPosition: true);
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpInheritanceMarginTests.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpInheritanceMarginTests.cs
@@ -46,9 +46,9 @@ class Implementation : IBar
             await TestServices.InheritanceMargin.ClickTheGlyphOnLine(2, HangMitigatingCancellationToken);
 
             // Move focus to menu item of 'IBar', the destination is targeting 'class Implementation'
-            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             // Navigate to the destination
-            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.RETURN);
+            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.InheritanceMargin }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.TextContainsAsync(@"class Implementation$$", assertCaretPosition: true);
         }
@@ -78,11 +78,11 @@ class Implementation : IBar
 
             // The context menu contains two members, e1 and e2.
             // Move focus to menu item of 'event e1'
-            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             // Expand the submenu
-            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.RETURN);
+            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
             // Navigate to the implemention
-            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.RETURN);
+            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.InheritanceMargin }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.TextContainsAsync(@"public event EventHandler e1$$, e2;", assertCaretPosition: true);
         }
@@ -110,9 +110,9 @@ class Implementation : IEnumerable
             await TestServices.InheritanceMargin.ClickTheGlyphOnLine(4, HangMitigatingCancellationToken);
 
             // Move focus to menu item of 'class Implementation'
-            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             // Navigate to 'IEnumerable'
-            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.RETURN);
+            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.InheritanceMargin }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.TextContainsAsync(@"public interface IEnumerable$$", assertCaretPosition: true);
 
@@ -152,9 +152,9 @@ class Implementation : IBar
             await TestServices.InheritanceMargin.ClickTheGlyphOnLine(4, HangMitigatingCancellationToken);
 
             // Move focus to menu item of 'class Implementation'
-            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             // Navigate to 'IBar'
-            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.RETURN);
+            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.InheritanceMargin }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.TextContainsAsync(@"Public Interface IBar$$", assertCaretPosition: true);
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpSourceGenerators.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpSourceGenerators.cs
@@ -92,7 +92,7 @@ internal static class Program
                 Assert.Equal($"{HelloWorldGenerator.GeneratedEnglishClassName}.cs {ServicesVSResources.generated_suffix}", await TestServices.Shell.GetActiveWindowCaptionAsync(HangMitigatingCancellationToken));
             }
 
-            await TestServices.Input.SendAsync((VirtualKeyCode.F12, VirtualKeyCode.SHIFT));
+            await TestServices.Input.SendAsync((VirtualKeyCode.F12, VirtualKeyCode.SHIFT), HangMitigatingCancellationToken);
 
             var results = (await TestServices.FindReferencesWindow.GetContentsAsync(HangMitigatingCancellationToken)).OrderBy(r => r.GetLine()).ToArray();
 
@@ -134,7 +134,7 @@ internal static class Program
 }", HangMitigatingCancellationToken);
 
             await TestServices.Editor.PlaceCaretAsync(HelloWorldGenerator.GeneratedEnglishClassName, charsOffset: 0, HangMitigatingCancellationToken);
-            await TestServices.Input.SendAsync((VirtualKeyCode.F12, VirtualKeyCode.SHIFT));
+            await TestServices.Input.SendAsync((VirtualKeyCode.F12, VirtualKeyCode.SHIFT), HangMitigatingCancellationToken);
 
             var results = await TestServices.FindReferencesWindow.GetContentsAsync(HangMitigatingCancellationToken);
             var referenceInGeneratedFile = results.Single(r => r.GetText()?.Contains("<summary>") ?? false);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/DocumentationCommentTests.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/DocumentationCommentTests.cs
@@ -37,7 +37,7 @@ class C2 { }
 class C3 { }
 ";
             await SetUpEditorAsync(code, HangMitigatingCancellationToken);
-            await TestServices.Input.SendAsync('/');
+            await TestServices.Input.SendAsync('/', HangMitigatingCancellationToken);
             var expected =
 @"
 /// <summary>

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EditorInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EditorInProcess.cs
@@ -520,13 +520,13 @@ namespace Microsoft.VisualStudio.Extensibility.Testing
             }
 
             await ExpandNavigationBarAsync(index, cancellationToken);
-            await TestServices.Input.SendAsync(VirtualKeyCode.HOME);
+            await TestServices.Input.SendAsync(VirtualKeyCode.HOME, cancellationToken);
             for (var i = 0; i < itemIndex; i++)
             {
-                await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+                await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, cancellationToken);
             }
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, cancellationToken);
 
             // Navigation and/or code generation following selection is tracked under FeatureAttribute.NavigationBar
             await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.NavigationBar, cancellationToken);
@@ -704,7 +704,7 @@ namespace Microsoft.VisualStudio.Extensibility.Testing
             {
                 // Workaround for extremely unstable async lightbulb (can dismiss itself when SuggestedActionsChanged
                 // fires while expanding the light bulb).
-                await TestServices.Input.SendAsync((VirtualKeyCode.OEM_PERIOD, VirtualKeyCode.CONTROL));
+                await TestServices.Input.SendAsync((VirtualKeyCode.OEM_PERIOD, VirtualKeyCode.CONTROL), cancellationToken);
                 await Task.Delay(5000, cancellationToken);
 
                 await TestServices.Editor.DismissLightBulbSessionAsync(cancellationToken);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EncapsulateFieldInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/EncapsulateFieldInProcess.cs
@@ -19,7 +19,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
             // Cancellation is not currently supported by SendAsync
             _ = cancellationToken;
 
-            return TestServices.Input.SendAsync((VirtualKeyCode.VK_R, VirtualKeyCode.CONTROL), (VirtualKeyCode.VK_E, VirtualKeyCode.CONTROL));
+            return TestServices.Input.SendAsync(new InputKey[] { (VirtualKeyCode.VK_R, VirtualKeyCode.CONTROL), (VirtualKeyCode.VK_E, VirtualKeyCode.CONTROL) }, cancellationToken);
         }
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InheritanceMarginInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InheritanceMarginInProcess.cs
@@ -104,9 +104,9 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.InProcess
             var glyph = await GetTheGlyphOnLineAsync(lineNumber, cancellationToken);
 
             var point = await GetCenterOfGlyphOnScreenAsync(glyph, cancellationToken);
-            await TestServices.Input.MoveMouseAsync(point);
+            await TestServices.Input.MoveMouseAsync(point, cancellationToken);
             await TestServices.Input.SendWithoutActivateAsync(
-                simulator => simulator.Mouse.LeftButtonClick());
+                simulator => simulator.Mouse.LeftButtonClick(), cancellationToken);
         }
 
         public async Task<InheritanceMarginGlyph> GetTheGlyphOnLineAsync(int lineNumber, CancellationToken cancellationToken)

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InputInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InputInProcess.cs
@@ -50,7 +50,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
             });
         }
 
-        internal Task SendWithoutActivateAsync(params InputKey[] keys)
+        internal Task SendWithoutActivateAsync(CancellationToken cancellationToken, params InputKey[] keys)
         {
             return SendWithoutActivateAsync(
                 simulator =>
@@ -59,10 +59,10 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
                     {
                         key.Apply(simulator);
                     }
-                });
+                }, cancellationToken);
         }
 
-        internal async Task SendWithoutActivateAsync(Action<IInputSimulator> callback)
+        internal async Task SendWithoutActivateAsync(Action<IInputSimulator> callback, CancellationToken cancellationToken)
         {
             // AbstractSendKeys runs synchronously, so switch to a background thread before the call
             await TaskScheduler.Default;
@@ -71,7 +71,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
 
             TestServices.JoinableTaskFactory.Run(async () =>
             {
-                await WaitForApplicationIdleAsync(CancellationToken.None);
+                await WaitForApplicationIdleAsync(cancellationToken);
             });
         }
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InputInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InputInProcess.cs
@@ -20,7 +20,10 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
     [TestService]
     internal partial class InputInProcess
     {
-        internal Task SendAsync(params InputKey[] keys)
+        internal Task SendAsync(InputKey key, CancellationToken cancellationToken)
+            => SendAsync(new InputKey[] { key }, cancellationToken);
+
+        internal Task SendAsync(InputKey[] keys, CancellationToken cancellationToken)
         {
             return SendAsync(
                 simulator =>
@@ -29,28 +32,31 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
                     {
                         key.Apply(simulator);
                     }
-                });
+                }, cancellationToken);
         }
 
-        internal async Task SendAsync(Action<IInputSimulator> callback)
+        internal async Task SendAsync(Action<IInputSimulator> callback, CancellationToken cancellationToken)
         {
             // AbstractSendKeys runs synchronously, so switch to a background thread before the call
             await TaskScheduler.Default;
 
             TestServices.JoinableTaskFactory.Run(async () =>
             {
-                await TestServices.Editor.ActivateAsync(CancellationToken.None);
+                await TestServices.Editor.ActivateAsync(cancellationToken);
             });
 
             callback(new InputSimulator());
 
             TestServices.JoinableTaskFactory.Run(async () =>
             {
-                await WaitForApplicationIdleAsync(CancellationToken.None);
+                await WaitForApplicationIdleAsync(cancellationToken);
             });
         }
 
-        internal Task SendWithoutActivateAsync(CancellationToken cancellationToken, params InputKey[] keys)
+        internal Task SendWithoutActivateAsync(InputKey key, CancellationToken cancellationToken)
+            => SendWithoutActivateAsync(new[] { key }, cancellationToken);
+
+        internal Task SendWithoutActivateAsync(InputKey[] keys, CancellationToken cancellationToken)
         {
             return SendWithoutActivateAsync(
                 simulator =>
@@ -108,13 +114,13 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
             });
         }
 
-        internal async Task MoveMouseAsync(Point point)
+        internal async Task MoveMouseAsync(Point point, CancellationToken cancellationToken)
         {
             var horizontalResolution = NativeMethods.GetSystemMetrics(NativeMethods.SM_CXSCREEN);
             var verticalResolution = NativeMethods.GetSystemMetrics(NativeMethods.SM_CYSCREEN);
             var virtualPoint = new ScaleTransform(65535.0 / horizontalResolution, 65535.0 / verticalResolution).Transform(point);
 
-            await SendAsync(simulator => simulator.Mouse.MoveMouseTo(virtualPoint.X, virtualPoint.Y));
+            await SendAsync(simulator => simulator.Mouse.MoveMouseTo(virtualPoint.X, virtualPoint.Y), cancellationToken);
 
             // ⚠ The call to GetCursorPos is required for correct behavior.
             var actualPoint = NativeMethods.GetCursorPos();

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/StateResetInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/StateResetInProcess.cs
@@ -94,7 +94,7 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
                     break;
                 }
 
-                await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.ESCAPE);
+                await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.ESCAPE, cancellationToken);
                 var nextModalWindow = IntegrationHelper.GetModalWindowFromParentWindow(mainWindow);
                 if (nextModalWindow == modalWindow)
                 {

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InfrastructureTests.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InfrastructureTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Roslyn.Utilities;
 using Roslyn.VisualStudio.IntegrationTests;
+using Roslyn.VisualStudio.IntegrationTests.InProcess;
 using WindowsInput.Native;
 using Xunit;
 
@@ -34,14 +35,14 @@ $$
                 HangMitigatingCancellationToken);
 
             // Trigger a call to File.Close to ensure we can recover from it
-            await TestServices.Input.SendAsync((VirtualKeyCode.VK_F, VirtualKeyCode.MENU), VirtualKeyCode.VK_C);
+            await TestServices.Input.SendAsync(new InputKey[] { (VirtualKeyCode.VK_F, VirtualKeyCode.MENU), VirtualKeyCode.VK_C }, HangMitigatingCancellationToken);
 
             var modalWindow = IntegrationHelper.GetModalWindowFromParentWindow(await TestServices.Shell.GetMainWindowAsync(HangMitigatingCancellationToken));
             Assert.NotEqual(IntPtr.Zero, modalWindow);
 
             Assert.Equal("Microsoft Visual Studio", IntegrationHelper.GetTitleForWindow(modalWindow));
 
-            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.ESCAPE);
+            await TestServices.Input.SendWithoutActivateAsync(VirtualKeyCode.ESCAPE, HangMitigatingCancellationToken);
 
             modalWindow = IntegrationHelper.GetModalWindowFromParentWindow(await TestServices.Shell.GetMainWindowAsync(HangMitigatingCancellationToken));
             if (modalWindow != IntPtr.Zero)

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicArgumentProvider.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicArgumentProvider.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Roslyn.VisualStudio.IntegrationTests;
+using Roslyn.VisualStudio.IntegrationTests.InProcess;
 using WindowsInput.Native;
 using Xunit;
 
@@ -43,17 +44,17 @@ Public Class Test
 End Class
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
-            await TestServices.Input.SendAsync("f.ToSt");
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
+            await TestServices.Input.SendAsync("f.ToSt", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString($$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString()$$", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
@@ -68,12 +69,12 @@ Public Class Test
 End Class
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync("Object.Equ");
+            await TestServices.Input.SendAsync("Object.Equ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Object.Equals$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Object.Equals(Nothing$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
@@ -89,16 +90,16 @@ Public Class Test
 End Class
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync("New Obje");
+            await TestServices.Input.SendAsync("New Obje", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Dim value = New Object$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Dim value = New Object($$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Dim value = New Object()$$", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
@@ -115,38 +116,38 @@ Public Class Test
 End Class
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
-            await TestServices.Input.SendAsync("f.ToSt");
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
+            await TestServices.Input.SendAsync("f.ToSt", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString($$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(provider$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(Nothing$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(Nothing$$, provider)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync("\"format\"");
+            await TestServices.Input.SendAsync("\"format\"", HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(\"format\"$$, provider)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(\"format\", provider$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.UP);
+            await TestServices.Input.SendAsync(VirtualKeyCode.UP, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(\"format\"$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.UP);
+            await TestServices.Input.SendAsync(VirtualKeyCode.UP, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(provider$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString(\"format\"$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
@@ -170,29 +171,29 @@ Public Class TestClass
 End Class
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
-            await TestServices.Input.SendAsync("Tes");
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
+            await TestServices.Input.SendAsync("Tes", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test($$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$, 0)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test($$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$, 0)", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
@@ -216,20 +217,20 @@ Public Class TestClass
 End Class
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
-            await TestServices.Input.SendAsync("Tes");
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
+            await TestServices.Input.SendAsync("Tes", HangMitigatingCancellationToken);
 
             // Trigger the session and type '0' without waiting for the session to finish initializing
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, VirtualKeyCode.TAB, '0');
+            await TestServices.Input.SendAsync(new InputKey[] { VirtualKeyCode.TAB, VirtualKeyCode.TAB, '0' }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$, 0)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.UP);
+            await TestServices.Input.SendAsync(VirtualKeyCode.UP, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        Test(0$$)", assertCaretPosition: true, HangMitigatingCancellationToken);
         }
 
@@ -245,17 +246,17 @@ Public Class Test
 End Class
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
-            await TestServices.Input.SendAsync("f.ToSt");
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
+            await TestServices.Input.SendAsync("f.ToSt", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString$$", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync(VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(VirtualKeyCode.TAB, HangMitigatingCancellationToken);
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SignatureHelp }, HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentLineTextAsync("        f.ToString($$)", assertCaretPosition: true, HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync((VirtualKeyCode.RETURN, VirtualKeyCode.SHIFT));
+            await TestServices.Input.SendAsync((VirtualKeyCode.RETURN, VirtualKeyCode.SHIFT), HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.TextContainsAsync(@"
 Public Class Test
     Private f As Object

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicErrorListCommon.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicErrorListCommon.cs
@@ -74,7 +74,7 @@ Namespace N
 End Namespace
 ", HangMitigatingCancellationToken);
             await TestServices.Editor.PlaceCaretAsync(" Comment", charsOffset: -2, HangMitigatingCancellationToken);
-            await TestServices.Input.SendAsync("F = 0");
+            await TestServices.Input.SendAsync("F = 0", HangMitigatingCancellationToken);
             await TestServices.ErrorList.ShowErrorListAsync(HangMitigatingCancellationToken);
             var expectedContents = Array.Empty<string>();
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SolutionCrawler, FeatureAttribute.DiagnosticService, FeatureAttribute.ErrorSquiggles, FeatureAttribute.ErrorList }, HangMitigatingCancellationToken);
@@ -85,7 +85,7 @@ End Namespace
 
             await TestServices.Editor.ActivateAsync(HangMitigatingCancellationToken);
             await TestServices.Editor.PlaceCaretAsync("F = 0 ' Comment", charsOffset: -1, HangMitigatingCancellationToken);
-            await TestServices.Input.SendAsync("F");
+            await TestServices.Input.SendAsync("F", HangMitigatingCancellationToken);
             await TestServices.ErrorList.ShowErrorListAsync(HangMitigatingCancellationToken);
             expectedContents = new[] {
                 "(Compiler) Class1.vb(6, 13): error BC30451: 'FF' is not declared. It may be inaccessible due to its protection level.",
@@ -98,7 +98,7 @@ End Namespace
 
             await TestServices.Editor.ActivateAsync(HangMitigatingCancellationToken);
             await TestServices.Editor.PlaceCaretAsync("FF = 0 ' Comment", charsOffset: -1, HangMitigatingCancellationToken);
-            await TestServices.Input.SendAsync(VirtualKeyCode.DELETE);
+            await TestServices.Input.SendAsync(VirtualKeyCode.DELETE, HangMitigatingCancellationToken);
             await TestServices.ErrorList.ShowErrorListAsync(HangMitigatingCancellationToken);
             expectedContents = Array.Empty<string>();
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace, FeatureAttribute.SolutionCrawler, FeatureAttribute.DiagnosticService, FeatureAttribute.ErrorSquiggles, FeatureAttribute.ErrorList }, HangMitigatingCancellationToken);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicFindReferences.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicFindReferences.cs
@@ -36,7 +36,7 @@ Class Program
 End Class
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync((VirtualKeyCode.F12, VirtualKeyCode.SHIFT));
+            await TestServices.Input.SendAsync((VirtualKeyCode.F12, VirtualKeyCode.SHIFT), HangMitigatingCancellationToken);
 
             var results = await TestServices.FindReferencesWindow.GetContentsAsync(HangMitigatingCancellationToken);
 
@@ -79,7 +79,7 @@ Class SomeOtherClass
 End Class
 ", HangMitigatingCancellationToken);
 
-            await TestServices.Input.SendAsync((VirtualKeyCode.F12, VirtualKeyCode.SHIFT));
+            await TestServices.Input.SendAsync((VirtualKeyCode.F12, VirtualKeyCode.SHIFT), HangMitigatingCancellationToken);
 
             var results = await TestServices.FindReferencesWindow.GetContentsAsync(HangMitigatingCancellationToken);
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicLineCommit.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicLineCommit.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio;
 using Roslyn.Test.Utilities;
 using Roslyn.VisualStudio.IntegrationTests;
+using Roslyn.VisualStudio.IntegrationTests.InProcess;
 using WindowsInput.Native;
 using Xunit;
 
@@ -36,7 +37,7 @@ Dim x = Sub()
 End Module", HangMitigatingCancellationToken);
 
             await TestServices.Editor.PlaceCaretAsync("Sub()", charsOffset: 1, HangMitigatingCancellationToken);
-            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN);
+            await TestServices.Input.SendAsync(VirtualKeyCode.RETURN, HangMitigatingCancellationToken);
             Assert.Equal(48, await TestServices.Editor.GetCaretPositionAsync(HangMitigatingCancellationToken));
         }
 
@@ -50,7 +51,7 @@ End Module", HangMitigatingCancellationToken);
 End Module", HangMitigatingCancellationToken);
 
             await TestServices.Editor.PlaceCaretAsync("    REM", charsOffset: 0, HangMitigatingCancellationToken);
-            await TestServices.Input.SendAsync("sub", VirtualKeyCode.ESCAPE, " goo()", VirtualKeyCode.RETURN);
+            await TestServices.Input.SendAsync(new InputKey[] { "sub", VirtualKeyCode.ESCAPE, " goo()", VirtualKeyCode.RETURN }, HangMitigatingCancellationToken);
             AssertEx.EqualOrDiff(@"Module Module1
     Sub Main()
     End Sub
@@ -73,7 +74,7 @@ End Module", await TestServices.Editor.GetTextAsync(HangMitigatingCancellationTo
 End Module", HangMitigatingCancellationToken);
 
             await TestServices.Editor.PlaceCaretAsync("Module1", charsOffset: 0, HangMitigatingCancellationToken);
-            await TestServices.Input.SendAsync(VirtualKeyCode.DOWN, VirtualKeyCode.RETURN);
+            await TestServices.Input.SendAsync(new InputKey[] { VirtualKeyCode.DOWN, VirtualKeyCode.RETURN }, HangMitigatingCancellationToken);
             AssertEx.EqualOrDiff(@"Module Module1
 
 
@@ -96,10 +97,10 @@ End Module
 ", HangMitigatingCancellationToken);
 
             await TestServices.Editor.PlaceCaretAsync("(", charsOffset: 1, HangMitigatingCancellationToken);
-            await TestServices.Input.SendAsync("x   As   integer", VirtualKeyCode.TAB);
+            await TestServices.Input.SendAsync(new InputKey[] { "x   As   integer", VirtualKeyCode.TAB }, HangMitigatingCancellationToken);
 
             Assert.False(await TestServices.Editor.IsSavedAsync(HangMitigatingCancellationToken));
-            await TestServices.Input.SendAsync((VirtualKeyCode.VK_S, VirtualKeyCode.CONTROL));
+            await TestServices.Input.SendAsync((VirtualKeyCode.VK_S, VirtualKeyCode.CONTROL), HangMitigatingCancellationToken);
 
             // Wait for async save operations to complete before proceeding
             await TestServices.Workspace.WaitForAllAsyncOperationsAsync(new[] { FeatureAttribute.Workspace }, HangMitigatingCancellationToken);
@@ -130,10 +131,10 @@ End Module
 End Module", HangMitigatingCancellationToken);
 
             await TestServices.Editor.PlaceCaretAsync("End Sub", charsOffset: -1, HangMitigatingCancellationToken);
-            await TestServices.Input.SendAsync(" ");
+            await TestServices.Input.SendAsync(" ", HangMitigatingCancellationToken);
             await TestServices.SolutionExplorer.AddFileAsync(ProjectName, "TestZ.vb", open: true, cancellationToken: HangMitigatingCancellationToken); // Cause focus lost
             await TestServices.SolutionExplorer.OpenFileAsync(ProjectName, "TestZ.vb", HangMitigatingCancellationToken); // Work around https://github.com/dotnet/roslyn/issues/18488
-            await TestServices.Input.SendAsync("                  ");
+            await TestServices.Input.SendAsync("                  ", HangMitigatingCancellationToken);
             await TestServices.SolutionExplorer.CloseCodeFileAsync(ProjectName, "TestZ.vb", saveFile: false, cancellationToken: HangMitigatingCancellationToken);
             AssertEx.EqualOrDiff(@"Module M
     Sub M()
@@ -153,10 +154,10 @@ End Module", await TestServices.Editor.GetTextAsync(HangMitigatingCancellationTo
 End Module", HangMitigatingCancellationToken);
 
             await TestServices.Editor.PlaceCaretAsync("End Sub", charsOffset: -1, HangMitigatingCancellationToken);
-            await TestServices.Input.SendAsync(" ");
+            await TestServices.Input.SendAsync(" ", HangMitigatingCancellationToken);
             await TestServices.SolutionExplorer.AddFileAsync(ProjectName, "TestZ.vb", open: true, cancellationToken: HangMitigatingCancellationToken); // Cause focus lost
             await TestServices.SolutionExplorer.OpenFileAsync(ProjectName, "TestZ.vb", HangMitigatingCancellationToken); // Work around https://github.com/dotnet/roslyn/issues/18488
-            await TestServices.Input.SendAsync("                  ");
+            await TestServices.Input.SendAsync("                  ", HangMitigatingCancellationToken);
             await TestServices.SolutionExplorer.CloseCodeFileAsync(ProjectName, "TestZ.vb", saveFile: false, HangMitigatingCancellationToken);
             AssertEx.EqualOrDiff(@"Module M
     Sub M()


### PR DESCRIPTION
As suggested by @sharwell , forward all the cancellationToken in order to get a screenshot when timeout