### PR TITLE
use xunit apis for test discovery

### DIFF
--- a/Compilers.sln
+++ b/Compilers.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32228.430
@@ -161,6 +162,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "vbc-arm64", "src\Compilers\VisualBasic\vbc\arm64\vbc-arm64.csproj", "{48C93F90-8776-4847-96D8-127B896D6C80}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.CSharp.EndToEnd.UnitTests", "src\Compilers\CSharp\Test\EndToEnd\Microsoft.CodeAnalysis.CSharp.EndToEnd.UnitTests.csproj", "{F3D9264A-7CAE-4265-AF48-0C863301F51E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestDiscoveryWorker", "src\Tools\TestDiscoveryWorker\TestDiscoveryWorker.csproj", "{FB617466-C4A1-4289-A512-A06182FC779F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -416,6 +419,10 @@ Global
 		{F3D9264A-7CAE-4265-AF48-0C863301F51E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F3D9264A-7CAE-4265-AF48-0C863301F51E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F3D9264A-7CAE-4265-AF48-0C863301F51E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB617466-C4A1-4289-A512-A06182FC779F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB617466-C4A1-4289-A512-A06182FC779F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB617466-C4A1-4289-A512-A06182FC779F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB617466-C4A1-4289-A512-A06182FC779F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -491,6 +498,7 @@ Global
 		{810B02AD-2EA5-4422-88AC-B71B8AB0DF0B} = {C65C6143-BED3-46E6-869E-9F0BE6E84C37}
 		{48C93F90-8776-4847-96D8-127B896D6C80} = {C65C6143-BED3-46E6-869E-9F0BE6E84C37}
 		{F3D9264A-7CAE-4265-AF48-0C863301F51E} = {32A48625-F0AD-419D-828B-A50BDABA38EA}
+		{FB617466-C4A1-4289-A512-A06182FC779F} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6F599E08-A9EA-4FAA-897F-5D824B0210E6}

--- a/Roslyn.sln
+++ b/Roslyn.sln
@@ -521,6 +521,8 @@ Project("{9a19103f-16f7-4668-be54-9a1e7a4f7556}") = "Microsoft.CodeAnalysis.CSha
 EndProject
 Project("{778dae3c-4631-46ea-aa77-85c1314464d9}") = "Microsoft.CodeAnalysis.VisualBasic.LanguageServer.Protocol", "src\Features\LanguageServer\Microsoft.CodeAnalysis.VisualBasic.LanguageServer.Protocol\Microsoft.CodeAnalysis.VisualBasic.LanguageServer.Protocol.vbproj", "{F836BDB1-4EC7-4F4C-B2E9-BCD721C9E650}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestDiscoveryWorker", "src\Tools\TestDiscoveryWorker\TestDiscoveryWorker.csproj", "{8BC50AFF-1EBF-4E9A-AEBB-04F387AA800F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1271,6 +1273,10 @@ Global
 		{F836BDB1-4EC7-4F4C-B2E9-BCD721C9E650}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F836BDB1-4EC7-4F4C-B2E9-BCD721C9E650}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F836BDB1-4EC7-4F4C-B2E9-BCD721C9E650}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BC50AFF-1EBF-4E9A-AEBB-04F387AA800F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BC50AFF-1EBF-4E9A-AEBB-04F387AA800F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BC50AFF-1EBF-4E9A-AEBB-04F387AA800F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BC50AFF-1EBF-4E9A-AEBB-04F387AA800F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1508,6 +1514,7 @@ Global
 		{8A29449D-411E-49E4-B99E-E8428076BB21} = {55A62CFA-1155-46F1-ADF3-BEEE51B58AB5}
 		{4C1B26EE-465B-4B30-9E50-0285EF7AB035} = {3E5FE3DB-45F7-4D83-9097-8F05D3B3AEC6}
 		{F836BDB1-4EC7-4F4C-B2E9-BCD721C9E650} = {3E5FE3DB-45F7-4D83-9097-8F05D3B3AEC6}
+		{8BC50AFF-1EBF-4E9A-AEBB-04F387AA800F} = {FD0FAF5F-1DED-485C-99FA-84B97F3A8EEC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {604E6B91-7BC0-4126-AE07-D4D2FEFC3D29}

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -250,6 +250,7 @@
     <SystemSecurityPrincipalVersion>4.3.0</SystemSecurityPrincipalVersion>
     <SystemTextEncodingCodePagesVersion>6.0.0</SystemTextEncodingCodePagesVersion>
     <SystemTextEncodingExtensionsVersion>4.3.0</SystemTextEncodingExtensionsVersion>
+    <SystemThreadingChannelsVersion>6.0.0</SystemThreadingChannelsVersion>
     <!-- Note: When updating SystemTextJsonVersion ensure that the version is no higher than what is used by MSBuild. -->
     <SystemTextJsonVersion>6.0.0</SystemTextJsonVersion>
     <SystemThreadingChannelsVersion>6.0.0</SystemThreadingChannelsVersion>
@@ -274,6 +275,9 @@
     <xunitrunnerconsoleVersion>2.4.5</xunitrunnerconsoleVersion>
     <xunitrunnerwpfVersion>1.0.51</xunitrunnerwpfVersion>
     <xunitrunnervisualstudioVersion>2.4.5</xunitrunnervisualstudioVersion>
+    <xunitrunnerutilityVersion>$(xunitVersion)</xunitrunnerutilityVersion>
+    <xunitextensibilityexecutionVersion>$(xunitVersion)</xunitextensibilityexecutionVersion>
+    <xunitabstractionsVersion>2.0.3</xunitabstractionsVersion>
     <xunitextensibilityexecutionVersion>$(xunitVersion)</xunitextensibilityexecutionVersion>
     <runtimeWinX64MicrosoftNETCoreILAsmPackageVersion>$(ILAsmPackageVersion)</runtimeWinX64MicrosoftNETCoreILAsmPackageVersion>
     <runtimeLinuxX64MicrosoftNETCoreILAsmPackageVersion>$(ILAsmPackageVersion)</runtimeLinuxX64MicrosoftNETCoreILAsmPackageVersion>

--- a/src/Tools/PrepareTests/PrepareTests.csproj
+++ b/src/Tools/PrepareTests/PrepareTests.csproj
@@ -10,8 +10,5 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="$(MonoOptionsVersion)" />
-    <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftTestPlatformTranslationLayerVersion)" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftTestPlatformObjectModelVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Tools/PrepareTests/Program.cs
+++ b/src/Tools/PrepareTests/Program.cs
@@ -46,7 +46,11 @@ internal static class Program
             return ExitFailure;
         }
 
-        TestDiscovery.RunDiscovery(source, dotnetPath, isUnix);
+        var success = TestDiscovery.RunDiscovery(source, dotnetPath, isUnix);
+        if (!success)
+        {
+            return ExitFailure;
+        }
 
         MinimizeUtil.Run(source, destination, isUnix);
         return ExitSuccess;

--- a/src/Tools/PrepareTests/TestDiscovery.cs
+++ b/src/Tools/PrepareTests/TestDiscovery.cs
@@ -44,7 +44,7 @@ internal class TestDiscovery
     {
         var testDiscoveryWorkerFolder = Path.Combine(binDirectory, "TestDiscoveryWorker");
         var configuration = Directory.Exists(Path.Combine(testDiscoveryWorkerFolder, "Debug")) ? "Debug" : "Release";
-        return (Path.Combine(testDiscoveryWorkerFolder, configuration, "net6.0", "TestDiscoveryWorker.dll"),
+        return (Path.Combine(testDiscoveryWorkerFolder, configuration, "net7.0", "TestDiscoveryWorker.dll"),
                 Path.Combine(testDiscoveryWorkerFolder, configuration, "net472", "TestDiscoveryWorker.exe"));
     }
 

--- a/src/Tools/PrepareTests/TestDiscovery.cs
+++ b/src/Tools/PrepareTests/TestDiscovery.cs
@@ -3,18 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
-using Microsoft.TestPlatform.VsTestConsole.TranslationLayer;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using System.IO.Pipes;
+using System.Threading.Tasks;
 
 namespace PrepareTests;
 internal class TestDiscovery
@@ -23,88 +17,78 @@ internal class TestDiscovery
     {
         var binDirectory = Path.Combine(repoRootDirectory, "artifacts", "bin");
         var assemblies = GetAssemblies(binDirectory, isUnix);
+        var testDiscoveryWorkerFolder = Path.Combine(binDirectory, "TestDiscoveryWorker");
+        var (dotnetCoreWorker, dotnetFrameworkWorker) = GetWorkers(binDirectory);
 
         Console.WriteLine($"Found {assemblies.Count} test assemblies");
 
-        var vsTestConsole = Directory.EnumerateFiles(Path.Combine(Path.GetDirectoryName(dotnetPath)!, "sdk"), "vstest.console.dll", SearchOption.AllDirectories).OrderBy(s => s).Last();
-
-        var vstestConsoleWrapper = new VsTestConsoleWrapper(vsTestConsole, new ConsoleParameters
-        {
-            LogFilePath = Path.Combine(repoRootDirectory, "logs", "test_discovery_logs.txt"),
-            TraceLevel = TraceLevel.Error,
-        });
-
-        var discoveryHandler = new DiscoveryHandler();
-
         var stopwatch = new Stopwatch();
         stopwatch.Start();
-        vstestConsoleWrapper.DiscoverTests(assemblies, @"<RunSettings><RunConfiguration><MaxCpuCount>0</MaxCpuCount></RunConfiguration></RunSettings>", discoveryHandler);
-        stopwatch.Stop();
-
-        var tests = discoveryHandler.GetTests();
-
-        Console.WriteLine($"Discovered {tests.Length} tests in {stopwatch.Elapsed}");
-
-        stopwatch.Restart();
-        var testGroupedByAssembly = tests.GroupBy(test => test.Source);
-        foreach (var assemblyGroup in testGroupedByAssembly)
+        Parallel.ForEach(assemblies, assembly =>
         {
-            var directory = Path.GetDirectoryName(assemblyGroup.Key);
+            var workerPath = assembly.Contains("net472")
+                ? dotnetFrameworkWorker
+                : dotnetCoreWorker;
 
-            // Tests with combinatorial data are output multiple times with the same fully qualified test name.
-            // We only need to include it once as run all combinations under the same filter.
-            var testToWrite = assemblyGroup.Select(test => test.FullyQualifiedName).Distinct().ToList();
-
-            using var fileStream = File.Create(Path.Combine(directory!, "testlist.json"));
-            JsonSerializer.Serialize(fileStream, testToWrite);
-        }
+            RunWorker(dotnetPath, workerPath, assembly);
+        });
         stopwatch.Stop();
-        Console.WriteLine($"Serialized tests in {stopwatch.Elapsed}");
+
+        Console.WriteLine($"Discovered tests in {stopwatch.Elapsed}");
     }
 
-    private class DiscoveryHandler : ITestDiscoveryEventsHandler
+    static (string dotnetCoreWorker, string dotnetFrameworkWorker) GetWorkers(string binDirectory)
     {
-        private readonly ConcurrentBag<TestCase> _tests = new();
-        private bool _isComplete = false;
+        var testDiscoveryWorkerFolder = Path.Combine(binDirectory, "TestDiscoveryWorker");
+        var configuration = Directory.Exists(Path.Combine(testDiscoveryWorkerFolder, "Debug")) ? "Debug" : "Release";
+        return (Path.Combine(testDiscoveryWorkerFolder, configuration, "net6.0", "TestDiscoveryWorker.dll"),
+                Path.Combine(testDiscoveryWorkerFolder, configuration, "net472", "TestDiscoveryWorker.exe"));
+    }
 
-        public void HandleDiscoveredTests(IEnumerable<TestCase>? discoveredTestCases)
+    static void RunWorker(string dotnetPath, string pathToWorker, string pathToAssembly)
+    {
+        var pipeClient = new Process();
+        var arguments = new List<string>();
+        if (pathToWorker.EndsWith("dll"))
         {
-            if (discoveredTestCases != null)
+            arguments.Add(pathToWorker);
+            pipeClient.StartInfo.FileName = dotnetPath;
+        }
+        else
+        {
+            pipeClient.StartInfo.FileName = pathToWorker;
+        }
+
+        using (var pipeServer = new AnonymousPipeServerStream(PipeDirection.Out, HandleInheritability.Inheritable))
+        {
+            // Pass the client process a handle to the server.
+            arguments.Add(pipeServer.GetClientHandleAsString());
+            pipeClient.StartInfo.Arguments = string.Join(" ", arguments);
+            pipeClient.StartInfo.UseShellExecute = false;
+            pipeClient.Start();
+
+            pipeServer.DisposeLocalCopyOfClientHandle();
+
+            try
             {
-                foreach (var test in discoveredTestCases)
-                {
-                    _tests.Add(test);
-                }
+                // Read user input and send that to the client process.
+                using var sw = new StreamWriter(pipeServer);
+                sw.AutoFlush = true;
+                // Send a 'sync message' and wait for client to receive it.
+                sw.WriteLine("ASSEMBLY");
+                // Send the console input to the client process.
+                sw.WriteLine(pathToAssembly);
+            }
+            // Catch the IOException that is raised if the pipe is broken
+            // or disconnected.
+            catch (IOException e)
+            {
+                Console.WriteLine("Error: {0}", e.Message);
             }
         }
 
-        public void HandleDiscoveryComplete(long totalTests, IEnumerable<TestCase>? lastChunk, bool isAborted)
-        {
-            if (lastChunk != null)
-            {
-                foreach (var test in lastChunk)
-                {
-                    _tests.Add(test);
-                }
-            }
-
-            _isComplete = true;
-        }
-
-        public void HandleLogMessage(TestMessageLevel level, string? message)
-        {
-            Console.WriteLine(message);
-        }
-
-        public void HandleRawMessage(string rawMessage)
-        {
-        }
-
-        public ImmutableArray<TestCase> GetTests()
-        {
-            Contract.Assert(_isComplete);
-            return _tests.ToImmutableArray();
-        }
+        pipeClient.WaitForExit();
+        pipeClient.Close();
     }
 
     private static List<string> GetAssemblies(string binDirectory, bool isUnix)

--- a/src/Tools/TestDiscoveryWorker/Program.cs
+++ b/src/Tools/TestDiscoveryWorker/Program.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading.Channels;
+
+using Xunit;
+using Xunit.Abstractions;
+
+if (args.Length <= 0)
+{
+    return;
+}
+
+using var pipeClient = new AnonymousPipeClientStream(PipeDirection.In, args[0]);
+using var sr = new StreamReader(pipeClient);
+// Display the read text to the console
+string? output;
+
+// Wait for 'sync message' from the server.
+do
+{
+    output = sr.ReadLine();
+}
+while (!(output?.StartsWith("ASSEMBLY") == true));
+
+if ((output = sr.ReadLine()) is not null)
+{
+    var assemblyFileName = output;
+
+#if NET6_0_OR_GREATER   
+    var resolver = new System.Runtime.Loader.AssemblyDependencyResolver(assemblyFileName);
+    System.Runtime.Loader.AssemblyLoadContext.Default.Resolving += (context, assemblyName) =>
+    {
+        var assemblyPath = resolver.ResolveAssemblyToPath(assemblyName);
+        if (assemblyPath != null)
+        {
+            return Assembly.LoadFrom(assemblyPath);
+        }
+
+        return null;
+    };
+#endif
+
+
+    using var xunit = new XunitFrontController(AppDomainSupport.IfAvailable, assemblyFileName, shadowCopy: false);
+    var configuration = ConfigReader.Load(assemblyFileName);
+    var sink = new Sink();
+    xunit.Find(includeSourceInformation: false, messageSink: sink,
+                discoveryOptions: TestFrameworkOptions.ForDiscovery(configuration));
+
+    var builder = ImmutableArray.CreateBuilder<string>();
+    await foreach (var fullyQualifiedName in sink.GetTestCaseNamesAsync())
+    {
+        builder.Add(fullyQualifiedName);
+    }
+
+    var testsToWrite = builder.Distinct().ToArray();
+#if NET6_0_OR_GREATER
+    Console.WriteLine($"Discovered {testsToWrite.Length} tests in {Path.GetFileName(assemblyFileName)} (.NET Core)");
+#else
+    Console.WriteLine($"Discovered {testsToWrite.Length} tests in {Path.GetFileName(assemblyFileName)} (.NET Framework)");
+#endif
+
+    var directory = Path.GetDirectoryName(assemblyFileName);
+    using var fileStream = File.Create(Path.Combine(directory!, "testlist.json"));
+    JsonSerializer.Serialize(fileStream, testsToWrite);
+}
+
+internal class Sink : IMessageSink
+{
+    public Sink()
+    {
+        _channel = Channel.CreateUnbounded<string>();
+    }
+
+    private readonly Channel<string> _channel;
+
+    public async IAsyncEnumerable<string> GetTestCaseNamesAsync()
+    {
+        while (await _channel.Reader.WaitToReadAsync(default).ConfigureAwait(false))
+        {
+            while (_channel.Reader.TryRead(out var item))
+            {
+                yield return item;
+            }
+        }
+    }
+
+    public bool OnMessage(IMessageSinkMessage message)
+    {
+        if (message is ITestCaseDiscoveryMessage discoveryMessage)
+        {
+            OnTestDiscovered(discoveryMessage);
+        }
+
+        if (message is IDiscoveryCompleteMessage)
+        {
+            _channel.Writer.Complete();
+        }
+
+        return true;
+    }
+
+    private void OnTestDiscovered(ITestCaseDiscoveryMessage testCaseDiscovered)
+    {
+        var fullName = $"{testCaseDiscovered.TestCase.TestMethod.TestClass.Class.Name}.{testCaseDiscovered.TestCase.TestMethod.Method.Name}";
+        _ = _channel.Writer.TryWrite(fullName);
+    }
+}

--- a/src/Tools/TestDiscoveryWorker/Program.cs
+++ b/src/Tools/TestDiscoveryWorker/Program.cs
@@ -75,7 +75,7 @@ if ((output = sr.ReadLine()) is not null)
     JsonSerializer.Serialize(fileStream, testsToWrite);
 }
 
-internal class Sink : IMessageSink
+internal sealed class Sink : IMessageSink
 {
     public Sink()
     {

--- a/src/Tools/TestDiscoveryWorker/Program.cs
+++ b/src/Tools/TestDiscoveryWorker/Program.cs
@@ -43,7 +43,7 @@ if ((output = sr.ReadLine()) is not null)
         var assemblyPath = resolver.ResolveAssemblyToPath(assemblyName);
         if (assemblyPath != null)
         {
-            return Assembly.LoadFrom(assemblyPath);
+            return context.LoadFromAssemblyPath(assemblyPath);
         }
 
         return null;

--- a/src/Tools/TestDiscoveryWorker/Program.cs
+++ b/src/Tools/TestDiscoveryWorker/Program.cs
@@ -49,8 +49,6 @@ if ((output = sr.ReadLine()) is not null)
         return null;
     };
 #endif
-
-
     using var xunit = new XunitFrontController(AppDomainSupport.IfAvailable, assemblyFileName, shadowCopy: false);
     var configuration = ConfigReader.Load(assemblyFileName);
     var sink = new Sink();

--- a/src/Tools/TestDiscoveryWorker/TestDiscoveryWorker.csproj
+++ b/src/Tools/TestDiscoveryWorker/TestDiscoveryWorker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net7.0;net472</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   

--- a/src/Tools/TestDiscoveryWorker/TestDiscoveryWorker.csproj
+++ b/src/Tools/TestDiscoveryWorker/TestDiscoveryWorker.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="xunit.abstractions" Version="$(xunitabstractionsVersion)" />
+    <PackageReference Include="xunit.runner.utility" Version="$(xunitrunnerutilityVersion)" />
+    <PackageReference Include="xunit.extensibility.execution" Version="$(xunitextensibilityexecutionVersion)" />
+  </ItemGroup>
+    
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
+    <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVersion)" />
+    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This change uses xUnit directly to discover tests instead of using the TestPlatform apis

| Build | Current | With Change |
|-------|---------|-------------|
| Build_Windows_Debug | <img width="174" alt="current Build_Windows_Debug" src="https://user-images.githubusercontent.com/9797472/191381142-3d6b752b-6166-436e-9b20-2f7e1c2b0ad0.png"> | <img width="175" alt="Build_Windows_Debug with changes" src="https://user-images.githubusercontent.com/9797472/191381223-ad1a6f65-561c-49b0-87e6-24fe41c94928.png"> |
| Build_Windows_Release | <img width="175" alt="current Build_Windows_Release" src="https://user-images.githubusercontent.com/9797472/191381309-39f6bcf7-7dda-43ec-9cc2-91d4ac21a5b1.png"> | <img width="180" alt="Build_Windows_Release with changes" src="https://user-images.githubusercontent.com/9797472/191381343-63cae05f-f14a-49c8-bc7e-b2edad139424.png"> |
| Build_Unix_Debug | <img width="179" alt="image" src="https://user-images.githubusercontent.com/9797472/191381449-89ac1302-7c52-4e41-b4ce-8f4f89922d57.png"> | <img width="179" alt="image" src="https://user-images.githubusercontent.com/9797472/191381473-b623ec34-499b-4b76-a5fa-30ab98b0acc1.png"> |
