### PR TITLE
Cherrypick for 17.3: Fix potential deadlock if we are previewing a rename change

### DIFF
--- a/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/InlineRename/InlineRenameSession.cs
@@ -804,6 +804,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 {
                     var previewService = _workspace.Services.GetService<IPreviewDialogService>();
 
+                    // The preview service needs to be called from the UI thread, since it's doing COM calls underneath.
+                    await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
                     newSolution = previewService.PreviewChanges(
                         string.Format(EditorFeaturesResources.Preview_Changes_0, EditorFeaturesResources.Rename),
                         "vs.csharp.refactoring.rename",


### PR DESCRIPTION
Cherrypick from https://github.com/dotnet/roslyn/pull/63652