### PR TITLE
Reduce GetTypeByMetadataName allocations for fail-path

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -323,9 +323,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Take forwarded types into account.
         /// </param>
         /// <remarks></remarks>
-        internal NamedTypeSymbol LookupTopLevelMetadataType(ref MetadataTypeName emittedName, bool digThroughForwardedTypes)
+        internal NamedTypeSymbol LookupTopLevelMetadataType(ref MetadataTypeName emittedName, bool digThroughForwardedTypes, bool returnNullForMissing = false)
         {
-            return LookupTopLevelMetadataTypeWithCycleDetection(ref emittedName, visitedAssemblies: null, digThroughForwardedTypes: digThroughForwardedTypes);
+            return LookupTopLevelMetadataTypeWithCycleDetection(ref emittedName, visitedAssemblies: null, digThroughForwardedTypes: digThroughForwardedTypes, returnNullForMissing: returnNullForMissing);
         }
 
         /// <summary>
@@ -341,7 +341,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <param name="digThroughForwardedTypes">
         /// Take forwarded types into account.
         /// </param>
-        internal abstract NamedTypeSymbol LookupTopLevelMetadataTypeWithCycleDetection(ref MetadataTypeName emittedName, ConsList<AssemblySymbol> visitedAssemblies, bool digThroughForwardedTypes);
+        internal abstract NamedTypeSymbol LookupTopLevelMetadataTypeWithCycleDetection(ref MetadataTypeName emittedName, ConsList<AssemblySymbol> visitedAssemblies, bool digThroughForwardedTypes, bool returnNullForMissing = false);
 
         /// <summary>
         /// Returns the type symbol for a forwarded type based its canonical CLR metadata name.
@@ -974,12 +974,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private static NamedTypeSymbol? GetTopLevelTypeByMetadataName(AssemblySymbol assembly, ref MetadataTypeName metadataName, AssemblyIdentity? assemblyOpt)
         {
-            var result = assembly.LookupTopLevelMetadataType(ref metadataName, digThroughForwardedTypes: false);
-            if (!IsAcceptableMatchForGetTypeByMetadataName(result))
+            var result = assembly.LookupTopLevelMetadataType(ref metadataName, digThroughForwardedTypes: false, returnNullForMissing: true);
+            if (result is null)
             {
                 return null;
             }
 
+            Debug.Assert(IsAcceptableMatchForGetTypeByMetadataName(result));
             if (assemblyOpt != null && !assemblyOpt.Equals(assembly.Identity))
             {
                 return null;

--- a/src/Compilers/CSharp/Portable/Symbols/MissingAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingAssemblySymbol.cs
@@ -161,10 +161,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override NamedTypeSymbol LookupTopLevelMetadataTypeWithCycleDetection(ref MetadataTypeName emittedName, ConsList<AssemblySymbol> visitedAssemblies, bool digThroughForwardedTypes)
+        internal override NamedTypeSymbol LookupTopLevelMetadataTypeWithCycleDetection(ref MetadataTypeName emittedName, ConsList<AssemblySymbol> visitedAssemblies, bool digThroughForwardedTypes, bool returnNullForMissing = false)
         {
-            var result = this.moduleSymbol.LookupTopLevelMetadataType(ref emittedName);
-            Debug.Assert(result is MissingMetadataTypeSymbol);
+            var result = this.moduleSymbol.LookupTopLevelMetadataType(ref emittedName, returnNullForMissing: returnNullForMissing);
+            Debug.Assert(result is MissingMetadataTypeSymbol || (result is null && returnNullForMissing));
             return result;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
@@ -143,8 +143,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override NamedTypeSymbol LookupTopLevelMetadataType(ref MetadataTypeName emittedName)
+        internal override NamedTypeSymbol LookupTopLevelMetadataType(ref MetadataTypeName emittedName, bool returnNullForMissing = false)
         {
+            if (returnNullForMissing)
+            {
+                return null;
+            }
+
             return new MissingMetadataTypeSymbol.TopLevel(this, ref emittedName);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
@@ -306,10 +307,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Full type name, possibly with generic name mangling.
         /// </param>
         /// <returns>
-        /// Symbol for the type, or MissingMetadataSymbol if the type isn't found.
+        /// Symbol for the type.
+        /// If the type isn't found and <paramref name="returnNullForMissing"/> is <see langword="true"/>, <see langword="null"/> is returned.
+        /// If the type isn't found and <paramref name="returnNullForMissing"/> is <see langword="false"/>, MissingMetadataSymbol is returned.
         /// </returns>
         /// <remarks></remarks>
-        internal abstract NamedTypeSymbol LookupTopLevelMetadataType(ref MetadataTypeName emittedName);
+        internal abstract NamedTypeSymbol LookupTopLevelMetadataType(ref MetadataTypeName emittedName, bool returnNullForMissing = false);
 
         internal abstract ICollection<string> TypeNames { get; }
 

--- a/src/Compilers/CSharp/Portable/Symbols/NonMissingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NonMissingModuleSymbol.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Symbol for the type, or MissingMetadataSymbol if the type isn't found.
         /// </returns>
         /// <remarks></remarks>
-        internal sealed override NamedTypeSymbol LookupTopLevelMetadataType(ref MetadataTypeName emittedName)
+        internal sealed override NamedTypeSymbol LookupTopLevelMetadataType(ref MetadataTypeName emittedName, bool returnNullForMissing = false)
         {
             NamedTypeSymbol result;
             NamespaceSymbol scope = this.GlobalNamespace.LookupNestedNamespace(emittedName.NamespaceSegments);
@@ -191,6 +191,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if ((object)scope == null)
             {
                 // We failed to locate the namespace
+                if (returnNullForMissing)
+                {
+                    return null;
+                }
+
                 result = new MissingMetadataTypeSymbol.TopLevel(this, ref emittedName);
             }
             else


### PR DESCRIPTION
Fixes #64142

Per my understanding, this is the root cause of https://github.com/unoplatform/uno/issues/7506