### PR TITLE
Fix regression in error list updates

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -75,6 +75,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             private readonly Func<string, bool>? _shouldIncludeDiagnostic;
             private readonly bool _includeCompilerDiagnostics;
             private readonly Func<string, IDisposable?>? _addOperationScope;
+            private readonly bool _cacheFullDocumentDiagnostics;
 
             private delegate Task<IEnumerable<DiagnosticData>> DiagnosticsGetterAsync(DiagnosticAnalyzer analyzer, DocumentAnalysisExecutor executor, CancellationToken cancellationToken);
 
@@ -96,11 +97,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 var ideOptions = owner.AnalyzerService.GlobalOptions.GetIdeAnalyzerOptions(document.Project);
 
+                // We want to cache computed full document diagnostics in LatestDiagnosticsForSpanGetter
+                // only in LSP pull diagnostics mode. In LSP push diagnostics mode,
+                // the background analysis from solution crawler handles caching these diagnostics and
+                // updating the error list simultaneously.
+                var cacheFullDocumentDiagnostics = owner.AnalyzerService.GlobalOptions.IsPullDiagnostics(InternalDiagnosticsOptions.NormalDiagnosticMode);
+
                 var compilationWithAnalyzers = await GetOrCreateCompilationWithAnalyzersAsync(document.Project, ideOptions, stateSets, includeSuppressedDiagnostics, cancellationToken).ConfigureAwait(false);
 
                 return new LatestDiagnosticsForSpanGetter(
                     owner, compilationWithAnalyzers, document, text, stateSets, shouldIncludeDiagnostic, includeCompilerDiagnostics,
-                    range, blockForData, addOperationScope, includeSuppressedDiagnostics, priority);
+                    range, blockForData, addOperationScope, includeSuppressedDiagnostics, priority, cacheFullDocumentDiagnostics);
             }
 
             private static async Task<CompilationWithAnalyzers?> GetOrCreateCompilationWithAnalyzersAsync(
@@ -141,7 +148,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 bool blockForData,
                 Func<string, IDisposable?>? addOperationScope,
                 bool includeSuppressedDiagnostics,
-                CodeActionRequestPriority priority)
+                CodeActionRequestPriority priority,
+                bool cacheFullDocumentDiagnostics)
             {
                 _owner = owner;
                 _compilationWithAnalyzers = compilationWithAnalyzers;
@@ -155,6 +163,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 _addOperationScope = addOperationScope;
                 _includeSuppressedDiagnostics = includeSuppressedDiagnostics;
                 _priority = priority;
+                _cacheFullDocumentDiagnostics = cacheFullDocumentDiagnostics;
             }
 
             public async Task<bool> TryGetAsync(ArrayBuilder<DiagnosticData> list, CancellationToken cancellationToken)
@@ -320,8 +329,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     var diagnostics = diagnosticsMap[stateSet.Analyzer];
                     builder.AddRange(diagnostics.Where(ShouldInclude));
 
-                    // Cache the computed diagnostics if they were computed for the entire document.
-                    if (!span.HasValue)
+                    // Save the computed diagnostics if caching is enabled and diagnostics were computed for the entire document.
+                    if (_cacheFullDocumentDiagnostics && !span.HasValue)
                     {
                         var state = stateSet.GetOrCreateActiveFileState(_document.Id);
                         var data = new DocumentAnalysisData(version, diagnostics);


### PR DESCRIPTION
Fixes [AB#1618061](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1618061)

This was introduced by me with #63130. Earlier we used to cache full document diagnostics computed only from background analysis, which also handles updating the error list simulataneously. With the above PR, we also do this caching from other code paths if we are computing full document diagnostics (diagnostic tagger, LSP pull diags, etc.), but we don't raise events to update the error list from these code paths - basically the code added here: https://github.com/mavasani/roslyn/blob/cd5e6895d3dc8dfad270505b37d28be70077a645/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs#L323-L329. So when background analysis gets to refreshing the document diagnostics, it founds cached items and ends up not updating the error list.

With this PR, we now cache the computed full document diagnostics in the new code paths only in LSP pull diagnostics mode. Verified that the repro in the above bug is fixed after this change.