### PR TITLE
Skip some tests that are currently failing on debug 32-bit

### DIFF
--- a/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
+++ b/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
@@ -52,6 +52,8 @@ namespace Roslyn.Test.Utilities
         /// Mono issues around Default Interface Methods
         /// </summary>
         public const string MonoDefaultInterfaceMethods = "Mono can't execute this default interface method test yet";
+
+        public const string TestIsTriggeringMessagePackIssue = "https://github.com/dotnet/roslyn/issues/64195";
     }
 
     public class ConditionalFactAttribute : FactAttribute

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing
         {
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestTypeFromMultipleNamespaces1(TestHost testHost)
         {
@@ -51,7 +51,7 @@ class Class
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestTypeFromMultipleNamespaces1_FileScopedNamespace_Outer(TestHost testHost)
         {
@@ -80,7 +80,7 @@ class Class
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestTypeFromMultipleNamespaces1_FileScopedNamespace_Inner(TestHost testHost)
         {
@@ -112,7 +112,7 @@ class Class
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(11241, "https://github.com/dotnet/roslyn/issues/11241")]
         public async Task TestAddImportWithCaseChange(TestHost testHost)
@@ -142,7 +142,7 @@ class Class1 : TextBox
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestTypeFromMultipleNamespaces2(TestHost testHost)
         {
@@ -166,7 +166,7 @@ class Class
 testHost, index: 1);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestGenericWithNoArgs(TestHost testHost)
         {
@@ -189,7 +189,7 @@ class Class
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestGenericWithCorrectArgs(TestHost testHost)
         {
@@ -212,7 +212,7 @@ class Class
 }", testHost);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestGenericWithWrongArgs1()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -225,7 +225,7 @@ class Class
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestGenericWithWrongArgs2()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -238,7 +238,7 @@ class Class
 }");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestGenericInLocalDeclaration(TestHost testHost)
         {
@@ -261,7 +261,7 @@ class Class
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestGenericItemType(TestHost testHost)
         {
@@ -281,7 +281,7 @@ class Class
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestGenerateWithExistingUsings(TestHost testHost)
         {
@@ -307,7 +307,7 @@ class Class
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestGenerateInNamespace(TestHost testHost)
         {
@@ -336,7 +336,7 @@ namespace N
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestGenerateInNamespaceWithUsings(TestHost testHost)
         {
@@ -368,7 +368,7 @@ namespace N
 }", testHost);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestExistingUsing_ActionCount()
         {
             await TestActionCountAsync(
@@ -384,7 +384,7 @@ class Class
 count: 1);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestExistingUsing(TestHost testHost)
         {
@@ -410,7 +410,7 @@ class Class
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(541730, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541730")]
         public async Task TestAddUsingForGenericExtensionMethod(TestHost testHost)
@@ -435,7 +435,7 @@ class Class
 }", testHost);
         }
 
-        [Fact, WorkItem(541730, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541730")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(541730, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541730")]
         public async Task TestAddUsingForNormalExtensionMethod()
         {
             await TestAsync(
@@ -476,7 +476,7 @@ namespace N
 parseOptions: Options.Regular);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestOnEnum(TestHost testHost)
         {
@@ -519,7 +519,7 @@ namespace A
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestOnClassInheritance(TestHost testHost)
         {
@@ -548,7 +548,7 @@ namespace A
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestOnImplementedInterface(TestHost testHost)
         {
@@ -577,7 +577,7 @@ namespace A
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAllInBaseList(TestHost testHost)
         {
@@ -661,7 +661,7 @@ namespace B
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAttributeUnexpanded(TestHost testHost)
         {
@@ -678,7 +678,7 @@ class Class
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAttributeExpanded(TestHost testHost)
         {
@@ -695,7 +695,7 @@ class Class
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(538018, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538018")]
         public async Task TestAfterNew(TestHost testHost)
@@ -721,7 +721,7 @@ class Class
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestArgumentsInMethodCall(TestHost testHost)
         {
@@ -744,7 +744,7 @@ class Class
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestCallSiteArgs(TestHost testHost)
         {
@@ -765,7 +765,7 @@ class Class
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestUsePartialClass(TestHost testHost)
         {
@@ -802,7 +802,7 @@ namespace B
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestGenericClassInNestedNamespace(TestHost testHost)
         {
@@ -845,7 +845,7 @@ namespace C
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(541730, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541730")]
         public async Task TestExtensionMethods(TestHost testHost)
@@ -874,7 +874,7 @@ class Goo
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(541730, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541730")]
         public async Task TestQueryPatterns(TestHost testHost)
@@ -908,7 +908,7 @@ class Goo
         }
 
         // Tests for Insertion Order
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestSimplePresortedUsings1(TestHost testHost)
         {
@@ -956,7 +956,7 @@ namespace D
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestSimplePresortedUsings2(TestHost testHost)
         {
@@ -1004,7 +1004,7 @@ namespace A
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestSimpleUnsortedUsings1(TestHost testHost)
         {
@@ -1052,7 +1052,7 @@ namespace A
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestSimpleUnsortedUsings2(TestHost testHost)
         {
@@ -1100,7 +1100,7 @@ namespace C
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestMultiplePresortedUsings1(TestHost testHost)
         {
@@ -1148,7 +1148,7 @@ namespace B
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestMultiplePresortedUsings2(TestHost testHost)
         {
@@ -1196,7 +1196,7 @@ namespace B.A
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestMultiplePresortedUsings3(TestHost testHost)
         {
@@ -1250,7 +1250,7 @@ namespace B
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestMultipleUnsortedUsings1(TestHost testHost)
         {
@@ -1304,7 +1304,7 @@ namespace B
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestMultipleUnsortedUsings2(TestHost testHost)
         {
@@ -1353,7 +1353,7 @@ namespace B
         }
 
         // System on top cases
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestSimpleSystemSortedUsings1(TestHost testHost)
         {
@@ -1402,7 +1402,7 @@ namespace A
 testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestSimpleSystemSortedUsings2(TestHost testHost)
         {
@@ -1453,7 +1453,7 @@ namespace A
 testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestSimpleSystemSortedUsings3(TestHost testHost)
         {
@@ -1482,7 +1482,7 @@ class Class
 testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestSimpleSystemUnsortedUsings1(TestHost testHost)
         {
@@ -1535,7 +1535,7 @@ namespace A
 testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestSimpleSystemUnsortedUsings2(TestHost testHost)
         {
@@ -1586,7 +1586,7 @@ namespace A
 testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestSimpleSystemUnsortedUsings3(TestHost testHost)
         {
@@ -1615,7 +1615,7 @@ class Class
 testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestSimpleBogusSystemUsings1(TestHost testHost)
         {
@@ -1642,7 +1642,7 @@ class Class
 testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestSimpleBogusSystemUsings2(TestHost testHost)
         {
@@ -1669,7 +1669,7 @@ class Class
 testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestUsingsWithComments(TestHost testHost)
         {
@@ -1697,7 +1697,7 @@ testHost);
         }
 
         // System Not on top cases
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestSimpleSystemUnsortedUsings4(TestHost testHost)
         {
@@ -1750,7 +1750,7 @@ namespace A
 testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestSimpleSystemSortedUsings5(TestHost testHost)
         {
@@ -1799,7 +1799,7 @@ namespace A
 testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestSimpleSystemSortedUsings4(TestHost testHost)
         {
@@ -1828,7 +1828,7 @@ class Class
 testHost, options: Option(GenerationOptions.PlaceSystemNamespaceFirst, false));
         }
 
-        [Fact, WorkItem(538136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538136")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(538136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538136")]
         [WorkItem(538763, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538763")]
         public async Task TestAddUsingForNamespace()
         {
@@ -1852,7 +1852,7 @@ namespace B
 }");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(538220, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538220")]
         public async Task TestAddUsingForFieldWithFormatting(TestHost testHost)
@@ -1864,7 +1864,7 @@ namespace B
 class C { DateTime t; }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(539657, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539657")]
         public async Task BugFix5688(TestHost testHost)
@@ -1876,7 +1876,7 @@ class C { DateTime t; }", testHost);
 class Program { static void Main ( string [ ] args ) { Console . Out . NewLine = ""\r\n\r\n"" ; } } ", testHost);
         }
 
-        [Fact, WorkItem(539853, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539853")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(539853, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539853")]
         public async Task BugFix5950()
         {
             await TestAsync(
@@ -1888,7 +1888,7 @@ WriteLine(Expression.Constant(123));",
 parseOptions: GetScriptOptions());
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(540339, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540339")]
         public async Task TestAddAfterDefineDirective1(TestHost testHost)
@@ -1921,7 +1921,7 @@ class Program
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(540339, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540339")]
         public async Task TestAddAfterDefineDirective2(TestHost testHost)
@@ -1949,7 +1949,7 @@ class Program
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddAfterDefineDirective3(TestHost testHost)
         {
@@ -1977,7 +1977,7 @@ class Program
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddAfterDefineDirective4(TestHost testHost)
         {
@@ -2006,7 +2006,7 @@ class Program
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddAfterExistingBanner(TestHost testHost)
         {
@@ -2035,7 +2035,7 @@ class Program
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddAfterExternAlias1(TestHost testHost)
         {
@@ -2066,7 +2066,7 @@ class Program
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddAfterExternAlias2(TestHost testHost)
         {
@@ -2100,7 +2100,7 @@ class Program
 }", testHost);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestWithReferenceDirective()
         {
             var resolver = new TestMetadataReferenceResolver(assemblyNames: new Dictionary<string, PortableExecutableReference>()
@@ -2119,7 +2119,7 @@ GetScriptOptions(),
 TestOptions.ReleaseDll.WithMetadataReferenceResolver(resolver));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(542643, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542643")]
         public async Task TestAssemblyAttribute(TestHost testHost)
@@ -2131,7 +2131,7 @@ TestOptions.ReleaseDll.WithMetadataReferenceResolver(resolver));
 [assembly: InternalsVisibleTo(""Project"")]", testHost);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestDoNotAddIntoHiddenRegion()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -2148,7 +2148,7 @@ class Program
 }");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddToVisibleRegion(TestHost testHost)
         {
@@ -2184,7 +2184,7 @@ class Program
 #line default", testHost);
         }
 
-        [Fact, WorkItem(545248, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545248")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(545248, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545248")]
         public async Task TestVenusGeneration1()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -2201,14 +2201,14 @@ class Program
     }");
         }
 
-        [Fact, WorkItem(545774, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545774")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(545774, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545774")]
         public async Task TestAttribute_ActionCount()
         {
             var input = @"[ assembly : [|Guid|] ( ""9ed54f84-a89d-4fcd-a854-44251e925f09"" ) ] ";
             await TestActionCountAsync(input, 2);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(545774, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545774")]
         public async Task TestAttribute(TestHost testHost)
@@ -2222,7 +2222,7 @@ input,
 [ assembly : Guid ( ""9ed54f84-a89d-4fcd-a854-44251e925f09"" ) ] ", testHost);
         }
 
-        [Fact, WorkItem(546833, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546833")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(546833, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546833")]
         public async Task TestNotOnOverloadResolutionError()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -2242,7 +2242,7 @@ input,
 }");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(17020, "DevDiv_Projects/Roslyn")]
         public async Task TestAddUsingForGenericArgument(TestHost testHost)
@@ -2286,7 +2286,7 @@ namespace ConsoleApplication10
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(775448, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/775448")]
         public async Task ShouldTriggerOnCS0308(TestHost testHost)
@@ -2314,7 +2314,7 @@ class Test
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(838253, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/838253")]
         public async Task TestConflictedInaccessibleType(TestHost testHost)
@@ -2354,7 +2354,7 @@ class C
 testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(858085, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/858085")]
         public async Task TestConflictedAttributeName(TestHost testHost)
@@ -2372,7 +2372,7 @@ class Description
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(872908, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/872908")]
         public async Task TestConflictedGenericName(TestHost testHost)
@@ -2393,7 +2393,7 @@ class X
 }", testHost);
         }
 
-        [Fact, WorkItem(913300, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/913300")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(913300, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/913300")]
         public async Task TestNoDuplicateReport_ActionCount()
         {
             await TestActionCountInAllFixesAsync(
@@ -2410,7 +2410,7 @@ class X
 }", count: 1);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(913300, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/913300")]
         public async Task TestNoDuplicateReport(TestHost testHost)
@@ -2440,7 +2440,7 @@ class C
 }", testHost);
         }
 
-        [Fact, WorkItem(938296, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/938296")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(938296, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/938296")]
         public async Task TestNullParentInNode()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -2455,7 +2455,7 @@ class MultiDictionary<K, V> : Dictionary<K, HashSet<V>>
 }");
         }
 
-        [Fact, WorkItem(968303, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/968303")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(968303, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/968303")]
         public async Task TestMalformedUsingSection()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -2464,7 +2464,7 @@ class MultiDictionary<K, V> : Dictionary<K, HashSet<V>>
     [|List<|] }");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(875899, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/875899")]
         public async Task TestAddUsingsWithExternAlias(TestHost testHost)
@@ -2516,7 +2516,7 @@ namespace ExternAliases
             await TestAsync(InitialWorkspace, ExpectedDocumentText, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(875899, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/875899")]
         public async Task TestAddUsingsWithPreExistingExternAlias(TestHost testHost)
@@ -2580,7 +2580,7 @@ namespace ExternAliases
             await TestAsync(InitialWorkspace, ExpectedDocumentText, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(875899, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/875899")]
         public async Task TestAddUsingsWithPreExistingExternAlias_FileScopedNamespace(TestHost testHost)
@@ -2642,7 +2642,7 @@ class Program
             await TestAsync(InitialWorkspace, ExpectedDocumentText, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(875899, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/875899")]
         public async Task TestAddUsingsNoExtern(TestHost testHost)
@@ -2694,7 +2694,7 @@ namespace ExternAliases
             await TestAsync(InitialWorkspace, ExpectedDocumentText, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(875899, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/875899")]
         public async Task TestAddUsingsNoExtern_FileScopedNamespace(TestHost testHost)
@@ -2743,7 +2743,7 @@ class Program
             await TestAsync(InitialWorkspace, ExpectedDocumentText, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(875899, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/875899")]
         public async Task TestAddUsingsNoExternFilterGlobalAlias(TestHost testHost)
@@ -2767,7 +2767,7 @@ class Program
 }", testHost);
         }
 
-        [Fact, WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")]
         public async Task TestAddUsingForCref()
         {
             var initialText =
@@ -2788,7 +2788,7 @@ interface MyNotifyPropertyChanged { }";
             await TestAsync(initialText, expectedText, parseOptions: options);
         }
 
-        [Fact, WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")]
         public async Task TestAddUsingForCref2()
         {
             var initialText =
@@ -2809,7 +2809,7 @@ interface MyNotifyPropertyChanged { }";
             await TestAsync(initialText, expectedText, parseOptions: options);
         }
 
-        [Fact, WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")]
         public async Task TestAddUsingForCref3()
         {
             var initialText =
@@ -2857,7 +2857,7 @@ public class MyClass2
             await TestAsync(initialText, expectedText, parseOptions: options);
         }
 
-        [Fact, WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")]
         public async Task TestAddUsingForCref4()
         {
             var initialText =
@@ -2895,7 +2895,7 @@ public class MyClass
             await TestAsync(initialText, expectedText, parseOptions: options);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(773614, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773614")]
         public async Task TestAddStaticType(TestHost testHost)
@@ -2936,7 +2936,7 @@ class Test
             await TestAsync(initialText, expectedText, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(773614, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773614")]
         public async Task TestAddStaticType2(TestHost testHost)
@@ -2981,7 +2981,7 @@ class Test
             await TestAsync(initialText, expectedText, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(773614, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773614")]
         public async Task TestAddStaticType3(TestHost testHost)
@@ -3024,7 +3024,7 @@ class Test
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(773614, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773614")]
         public async Task TestAddStaticType4(TestHost testHost)
@@ -3071,7 +3071,7 @@ class Test
             await TestAsync(initialText, expectedText, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(991463, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/991463")]
         public async Task TestAddInsideUsingDirective1(TestHost testHost)
@@ -3089,7 +3089,7 @@ namespace ns
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(991463, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/991463")]
         public async Task TestAddInsideUsingDirective2(TestHost testHost)
@@ -3110,7 +3110,7 @@ namespace ns
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(991463, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/991463")]
         public async Task TestAddInsideUsingDirective3(TestHost testHost)
@@ -3148,7 +3148,7 @@ namespace ns2
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(991463, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/991463")]
         public async Task TestAddInsideUsingDirective4(TestHost testHost)
@@ -3183,7 +3183,7 @@ namespace ns2
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(991463, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/991463")]
         public async Task TestAddInsideUsingDirective5(TestHost testHost)
@@ -3224,14 +3224,14 @@ namespace ns2
 }", testHost);
         }
 
-        [Fact, WorkItem(991463, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/991463")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(991463, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/991463")]
         public async Task TestAddInsideUsingDirective6()
         {
             await TestMissingInRegularAndScriptAsync(
 @"using B = [|Byte|];");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(1064748, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064748")]
         public async Task TestAddConditionalAccessExpression(TestHost testHost)
@@ -3275,7 +3275,7 @@ public class C
             await TestAsync(initialText, expectedText, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(1064748, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064748")]
         public async Task TestAddConditionalAccessExpression2(TestHost testHost)
@@ -3331,7 +3331,7 @@ public class C
             await TestAsync(initialText, expectedText, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(1089138, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1089138")]
         public async Task TestAmbiguousUsingName(TestHost testHost)
@@ -3394,7 +3394,7 @@ namespace ClassLibrary1.SubNamespaceName
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddUsingInDirective(TestHost testHost)
         {
@@ -3432,7 +3432,7 @@ class Program
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddUsingInDirective2(TestHost testHost)
         {
@@ -3458,7 +3458,7 @@ using System.Text;
 class Program { static void Main ( string [ ] args ) { var a = File . OpenRead ( """" ) ; } } ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddUsingInDirective3(TestHost testHost)
         {
@@ -3485,7 +3485,7 @@ using System.IO;
 class Program { static void Main ( string [ ] args ) { var a = File . OpenRead ( """" ) ; } } ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddUsingInDirective4(TestHost testHost)
         {
@@ -3512,7 +3512,7 @@ using System.IO;
 class Program { static void Main ( string [ ] args ) { var a = File . OpenRead ( """" ) ; } } ", testHost);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestInaccessibleExtensionMethod()
         {
             const string initial = @"
@@ -3540,7 +3540,7 @@ namespace N2
             await TestMissingInRegularAndScriptAsync(initial);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(1116011, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1116011")]
         public async Task TestAddUsingForProperty(TestHost testHost)
@@ -3579,7 +3579,7 @@ class Program
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(1116011, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1116011")]
         public async Task TestAddUsingForField(TestHost testHost)
@@ -3634,7 +3634,7 @@ namespace A
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(1893, "https://github.com/dotnet/roslyn/issues/1893")]
         public async Task TestNameSimplification(TestHost testHost)
@@ -3684,7 +3684,7 @@ namespace A.C
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(935, "https://github.com/dotnet/roslyn/issues/935")]
         public async Task TestAddUsingWithOtherExtensionsInScope(TestHost testHost)
@@ -3757,7 +3757,7 @@ public class B
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(935, "https://github.com/dotnet/roslyn/issues/935")]
         public async Task TestAddUsingWithOtherExtensionsInScope2(TestHost testHost)
@@ -3830,7 +3830,7 @@ public class B
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(562, "https://github.com/dotnet/roslyn/issues/562")]
         public async Task TestAddUsingWithOtherExtensionsInScope3(TestHost testHost)
@@ -3867,7 +3867,7 @@ namespace X
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(562, "https://github.com/dotnet/roslyn/issues/562")]
         public async Task TestAddUsingWithOtherExtensionsInScope4(TestHost testHost)
@@ -3912,7 +3912,7 @@ namespace X
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(3080, "https://github.com/dotnet/roslyn/issues/3080")]
         public async Task TestNestedNamespaceSimplified(TestHost testHost)
@@ -3945,7 +3945,7 @@ namespace X
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(3080, "https://github.com/dotnet/roslyn/issues/3080")]
         public async Task TestNestedNamespaceSimplified2(TestHost testHost)
@@ -3978,7 +3978,7 @@ namespace X
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(3080, "https://github.com/dotnet/roslyn/issues/3080")]
         public async Task TestNestedNamespaceSimplified3(TestHost testHost)
@@ -4013,7 +4013,7 @@ namespace X
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(3080, "https://github.com/dotnet/roslyn/issues/3080")]
         public async Task TestNestedNamespaceSimplified4(TestHost testHost)
@@ -4048,7 +4048,7 @@ namespace X
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(3080, "https://github.com/dotnet/roslyn/issues/3080")]
         public async Task TestNestedNamespaceSimplified5(TestHost testHost)
@@ -4087,7 +4087,7 @@ namespace X
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(3080, "https://github.com/dotnet/roslyn/issues/3080")]
         public async Task TestNestedNamespaceSimplified6(TestHost testHost)
@@ -4128,7 +4128,7 @@ namespace X
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddUsingOrdinalUppercase(TestHost testHost)
         {
@@ -4185,7 +4185,7 @@ namespace Uppercase
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddUsingOrdinalLowercase(TestHost testHost)
         {
@@ -4242,7 +4242,7 @@ namespace Uppercase
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(7443, "https://github.com/dotnet/roslyn/issues/7443")]
         public async Task TestWithExistingIncompatibleExtension(TestHost testHost)
@@ -4291,7 +4291,7 @@ namespace N
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(1744, @"https://github.com/dotnet/roslyn/issues/1744")]
         public async Task TestIncompleteCatchBlockInLambda(TestHost testHost)
@@ -4315,7 +4315,7 @@ class A
     catch (Exception", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(1033612, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1033612")]
         public async Task TestAddInsideLambda(TestHost testHost)
@@ -4339,7 +4339,7 @@ static void Main(string[] args)
             await TestAsync(initialText, expectedText, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(1033612, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1033612")]
         public async Task TestAddInsideLambda2(TestHost testHost)
@@ -4363,7 +4363,7 @@ static void Main(string[] args)
             await TestAsync(initialText, expectedText, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(1033612, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1033612")]
         public async Task TestAddInsideLambda3(TestHost testHost)
@@ -4395,7 +4395,7 @@ static void Main(string[] args)
             await TestAsync(initialText, expectedText, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(1033612, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1033612")]
         public async Task TestAddInsideLambda4(TestHost testHost)
@@ -4458,7 +4458,7 @@ class Test
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(7461, "https://github.com/dotnet/roslyn/issues/7461")]
         public async Task TestExtensionWithIncompatibleInstance(TestHost testHost)
@@ -4513,7 +4513,7 @@ namespace Namespace2
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(5499, "https://github.com/dotnet/roslyn/issues/5499")]
         public async Task TestFormattingForNamespaceUsings(TestHost testHost)
@@ -4552,7 +4552,7 @@ namespace Namespace2
 }", testHost);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestGenericAmbiguityInSameNamespace()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -4567,7 +4567,7 @@ namespace Namespace2
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestNotOnVar1()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -4586,7 +4586,7 @@ class C
 ");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestNotOnVar2()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -4605,7 +4605,7 @@ class C
 ");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(226826, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=226826")]
         public async Task TestAddUsingWithLeadingDocCommentInFrontOfUsing1(TestHost testHost)
@@ -4634,7 +4634,7 @@ class C : IEnumerable<int>
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(226826, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=226826")]
         public async Task TestAddUsingWithLeadingDocCommentInFrontOfUsing2(TestHost testHost)
@@ -4665,7 +4665,7 @@ class C
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(226826, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=226826")]
         public async Task TestAddUsingWithLeadingDocCommentInFrontOfClass1(TestHost testHost)
@@ -4690,7 +4690,7 @@ class C
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestPlaceUsingWithUsings_NotWithAliases(TestHost testHost)
         {
@@ -4728,7 +4728,7 @@ namespace N
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(15025, "https://github.com/dotnet/roslyn/issues/15025")]
         public async Task TestPreferSystemNamespaceFirst(TestHost testHost)
@@ -4774,7 +4774,7 @@ namespace N
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(15025, "https://github.com/dotnet/roslyn/issues/15025")]
         public async Task TestPreferSystemNamespaceFirst2(TestHost testHost)
@@ -4820,7 +4820,7 @@ namespace N
 }", testHost, index: 1);
         }
 
-        [Fact, WorkItem(18275, "https://github.com/dotnet/roslyn/issues/18275")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(18275, "https://github.com/dotnet/roslyn/issues/18275")]
         public async Task TestContextualKeyword1()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -4841,7 +4841,7 @@ class C
 }");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(19218, "https://github.com/dotnet/roslyn/issues/19218")]
         public async Task TestChangeCaseWithUsingsInNestedNamespace(TestHost testHost)
@@ -4892,7 +4892,7 @@ namespace Outer
 ", testHost);
         }
 
-        [Fact, WorkItem(19575, "https://github.com/dotnet/roslyn/issues/19575")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(19575, "https://github.com/dotnet/roslyn/issues/19575")]
         public async Task TestNoNonGenericsWithGenericCodeParsedAsExpression()
         {
             var code = @"
@@ -4921,7 +4921,7 @@ class C
 }");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(19796, "https://github.com/dotnet/roslyn/issues/19796")]
         public async Task TestWhenInRome1(TestHost testHost)
@@ -4975,7 +4975,7 @@ namespace A
 testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(19796, "https://github.com/dotnet/roslyn/issues/19796")]
         public async Task TestWhenInRome2(TestHost testHost)
@@ -5028,7 +5028,7 @@ namespace A
 }", testHost);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestExactMatchNoGlyph()
         {
             await TestSmartTagGlyphTagsAsync(
@@ -5049,7 +5049,7 @@ class C
 ", ImmutableArray<string>.Empty);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestFuzzyMatchGlyph()
         {
             await TestSmartTagGlyphTagsAsync(
@@ -5070,7 +5070,7 @@ class C
 ", WellKnownTagArrays.Namespace);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(29313, "https://github.com/dotnet/roslyn/issues/29313")]
         public async Task TestGetAwaiterExtensionMethod1(TestHost testHost)
@@ -5151,7 +5151,7 @@ namespace B
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(29313, "https://github.com/dotnet/roslyn/issues/29313")]
         public async Task TestGetAwaiterExtensionMethod2(TestHost testHost)
@@ -5232,7 +5232,7 @@ namespace B
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(745490, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/745490")]
         public async Task TestAddUsingForAwaitableReturningExtensionMethod(TestHost testHost)
@@ -5291,7 +5291,7 @@ namespace B
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddUsingForExtensionGetEnumeratorReturningIEnumerator(TestHost testHost)
         {
@@ -5342,7 +5342,7 @@ namespace B
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddUsingForExtensionGetEnumeratorReturningPatternEnumerator(TestHost testHost)
         {
@@ -5403,7 +5403,7 @@ namespace B
 }", testHost);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestMissingForExtensionInvalidGetEnumerator()
         {
             await TestMissingAsync(
@@ -5429,7 +5429,7 @@ namespace B
 }");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddUsingForExtensionGetEnumeratorReturningPatternEnumeratorWrongAsync(TestHost testHost)
         {
@@ -5510,7 +5510,7 @@ namespace B
 }", testHost);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestMissingForExtensionGetAsyncEnumeratorOnForeach()
         {
             await TestMissingAsync(
@@ -5537,7 +5537,7 @@ namespace B
 }" + IAsyncEnumerable);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddUsingForExtensionGetAsyncEnumeratorReturningIAsyncEnumerator(TestHost testHost)
         {
@@ -5590,7 +5590,7 @@ namespace B
 }" + IAsyncEnumerable, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddUsingForExtensionGetAsyncEnumeratorReturningPatternEnumerator(TestHost testHost)
         {
@@ -5653,7 +5653,7 @@ namespace B
 }", testHost);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestMissingForExtensionInvalidGetAsyncEnumerator()
         {
             await TestMissingAsync(
@@ -5681,7 +5681,7 @@ namespace B
 }");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         public async Task TestAddUsingForExtensionGetAsyncEnumeratorReturningPatternEnumeratorWrongAsync(TestHost testHost)
         {
@@ -5766,7 +5766,7 @@ namespace B
 }", testHost);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestMissingForExtensionGetEnumeratorOnAsyncForeach()
         {
             await TestMissingAsync(
@@ -5795,7 +5795,7 @@ namespace B
 }");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(30734, "https://github.com/dotnet/roslyn/issues/30734")]
         public async Task UsingPlacedWithStaticUsingInNamespace_WhenNoExistingUsings(TestHost testHost)
@@ -5826,7 +5826,7 @@ namespace N
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(30734, "https://github.com/dotnet/roslyn/issues/30734")]
         public async Task UsingPlacedWithStaticUsingInInnerNestedNamespace_WhenNoExistingUsings(TestHost testHost)
@@ -5863,7 +5863,7 @@ namespace N
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(30734, "https://github.com/dotnet/roslyn/issues/30734")]
         public async Task UsingPlacedWithStaticUsingInOuterNestedNamespace_WhenNoExistingUsings(TestHost testHost)
@@ -5900,7 +5900,7 @@ namespace N
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(30734, "https://github.com/dotnet/roslyn/issues/30734")]
         public async Task UsingPlacedWithExistingUsingInCompilationUnit_WhenStaticUsingInNamespace(TestHost testHost)
@@ -5935,7 +5935,7 @@ namespace N
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(30734, "https://github.com/dotnet/roslyn/issues/30734")]
         public async Task UsingPlacedWithExistingUsing_WhenStaticUsingInInnerNestedNamespace(TestHost testHost)
@@ -5976,7 +5976,7 @@ namespace N
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(30734, "https://github.com/dotnet/roslyn/issues/30734")]
         public async Task UsingPlacedWithExistingUsing_WhenStaticUsingInOuterNestedNamespace(TestHost testHost)
@@ -6017,7 +6017,7 @@ namespace N
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(30734, "https://github.com/dotnet/roslyn/issues/30734")]
         public async Task UsingPlacedWithUsingAliasInNamespace_WhenNoExistingUsing(TestHost testHost)
@@ -6048,7 +6048,7 @@ namespace N
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(30734, "https://github.com/dotnet/roslyn/issues/30734")]
         public async Task UsingPlacedWithUsingAliasInInnerNestedNamespace_WhenNoExistingUsing(TestHost testHost)
@@ -6085,7 +6085,7 @@ namespace N
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(30734, "https://github.com/dotnet/roslyn/issues/30734")]
         public async Task UsingPlacedWithUsingAliasInOuterNestedNamespace_WhenNoExistingUsing(TestHost testHost)
@@ -6122,7 +6122,7 @@ namespace N
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(30734, "https://github.com/dotnet/roslyn/issues/30734")]
         public async Task UsingPlacedWithExistingUsingInCompilationUnit_WhenUsingAliasInNamespace(TestHost testHost)
@@ -6157,7 +6157,7 @@ namespace N
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(30734, "https://github.com/dotnet/roslyn/issues/30734")]
         public async Task UsingPlacedWithExistingUsing_WhenUsingAliasInInnerNestedNamespace(TestHost testHost)
@@ -6198,7 +6198,7 @@ namespace N
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(30734, "https://github.com/dotnet/roslyn/issues/30734")]
         public async Task UsingPlacedWithExistingUsing_WhenUsingAliasInOuterNestedNamespace(TestHost testHost)
@@ -6239,7 +6239,7 @@ namespace N
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(25003, "https://github.com/dotnet/roslyn/issues/25003")]
         public async Task KeepUsingsGrouped1(TestHost testHost)
@@ -6282,7 +6282,7 @@ namespace Microsoft
 }", testHost);
         }
 
-        [Fact, WorkItem(1239, @"https://github.com/dotnet/roslyn/issues/1239")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(1239, @"https://github.com/dotnet/roslyn/issues/1239")]
         public async Task TestIncompleteLambda1()
         {
             await TestInRegularAndScriptAsync(
@@ -6305,7 +6305,7 @@ class C
         new Byte");
         }
 
-        [Fact, WorkItem(1239, @"https://github.com/dotnet/roslyn/issues/1239")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(1239, @"https://github.com/dotnet/roslyn/issues/1239")]
         public async Task TestIncompleteLambda2()
         {
             await TestInRegularAndScriptAsync(
@@ -6328,7 +6328,7 @@ class C
             new Byte() }");
         }
 
-        [Fact, WorkItem(902014, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/902014")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(902014, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/902014")]
         [WorkItem(860648, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/860648")]
         public async Task TestIncompleteSimpleLambdaExpression()
         {
@@ -6356,7 +6356,7 @@ class Program
 }");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(1266354, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1266354")]
         public async Task TestAddUsingsEditorBrowsableNeverSameProject(TestHost testHost)
@@ -6401,7 +6401,7 @@ class Program
             await TestAsync(InitialWorkspace, ExpectedDocumentText, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(1266354, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1266354")]
         public async Task TestAddUsingsEditorBrowsableNeverDifferentProject(TestHost testHost)
@@ -6434,7 +6434,7 @@ class Program
             await TestMissingAsync(InitialWorkspace, new TestParameters(testHost: testHost));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(1266354, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1266354")]
         public async Task TestAddUsingsEditorBrowsableAdvancedDifferentProjectOptionOn(TestHost testHost)
@@ -6479,7 +6479,7 @@ class Program
             await TestAsync(InitialWorkspace, ExpectedDocumentText, testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(1266354, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1266354")]
         public async Task TestAddUsingsEditorBrowsableAdvancedDifferentProjectOptionOff(TestHost testHost)

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_ExtensionMethods.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_ExtensionMethods.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing
 {
     public partial class AddUsingTests
     {
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestWhereExtension()
         {
             await TestInRegularAndScriptAsync(
@@ -39,7 +39,7 @@ class Program
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestSelectExtension()
         {
             await TestInRegularAndScriptAsync(
@@ -64,7 +64,7 @@ class Program
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestGroupByExtension()
         {
             await TestInRegularAndScriptAsync(
@@ -89,7 +89,7 @@ class Program
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestJoinExtension()
         {
             await TestInRegularAndScriptAsync(
@@ -114,7 +114,7 @@ class Program
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task RegressionFor8455()
         {
             await TestMissingInRegularAndScriptAsync(
@@ -127,7 +127,7 @@ class Program
 }");
         }
 
-        [Fact, WorkItem(772321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/772321")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(772321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/772321")]
         public async Task TestExtensionWithThePresenceOfTheSameNameNonExtensionMethod()
         {
             await TestInRegularAndScriptAsync(
@@ -189,7 +189,7 @@ namespace NS2
 }");
         }
 
-        [Fact, WorkItem(920398, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/920398")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(920398, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/920398")]
         [WorkItem(772321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/772321")]
         public async Task TestExtensionWithThePresenceOfTheSameNameNonExtensionPrivateMethod()
         {
@@ -252,7 +252,7 @@ namespace NS2
 }");
         }
 
-        [Fact, WorkItem(920398, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/920398")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(920398, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/920398")]
         [WorkItem(772321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/772321")]
         public async Task TestExtensionWithThePresenceOfTheSameNameExtensionPrivateMethod()
         {
@@ -332,7 +332,7 @@ namespace NS3
 }");
         }
 
-        [Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
         public async Task TestAddUsingForAddExtentionMethod()
         {
             await TestAsync(
@@ -382,7 +382,7 @@ namespace Ext
 parseOptions: null);
         }
 
-        [Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
         public async Task TestAddUsingForAddExtentionMethod2()
         {
             await TestAsync(
@@ -432,7 +432,7 @@ namespace Ext
 parseOptions: null);
         }
 
-        [Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
         public async Task TestAddUsingForAddExtentionMethod3()
         {
             await TestAsync(
@@ -482,7 +482,7 @@ namespace Ext
 parseOptions: null);
         }
 
-        [Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
         public async Task TestAddUsingForAddExtentionMethod4()
         {
             await TestAsync(
@@ -532,7 +532,7 @@ namespace Ext
 parseOptions: null);
         }
 
-        [Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
         public async Task TestAddUsingForAddExtentionMethod5()
         {
             await TestAsync(
@@ -582,7 +582,7 @@ namespace Ext
 parseOptions: null);
         }
 
-        [Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
         public async Task TestAddUsingForAddExtentionMethod6()
         {
             await TestAsync(
@@ -632,7 +632,7 @@ namespace Ext
 parseOptions: null);
         }
 
-        [Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
         public async Task TestAddUsingForAddExtentionMethod7()
         {
             await TestAsync(
@@ -682,7 +682,7 @@ namespace Ext
 parseOptions: null);
         }
 
-        [Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
         public async Task TestAddUsingForAddExtentionMethod8()
         {
             await TestAsync(
@@ -732,7 +732,7 @@ namespace Ext
 parseOptions: null);
         }
 
-        [Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
         public async Task TestAddUsingForAddExtentionMethod9()
         {
             await TestAsync(
@@ -782,7 +782,7 @@ namespace Ext
 parseOptions: null);
         }
 
-        [Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
         public async Task TestAddUsingForAddExtentionMethod10()
         {
             await TestAsync(
@@ -852,7 +852,7 @@ namespace Ext2
 parseOptions: null);
         }
 
-        [Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")]
         public async Task TestAddUsingForAddExtentionMethod11()
         {
             await TestAsync(
@@ -923,7 +923,7 @@ index: 1,
 parseOptions: null);
         }
 
-        [Fact, WorkItem(3818, "https://github.com/dotnet/roslyn/issues/3818")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(3818, "https://github.com/dotnet/roslyn/issues/3818")]
         public async Task InExtensionMethodUnderConditionalAccessExpression()
         {
             var initialText =
@@ -976,7 +976,7 @@ namespace Sample
             await TestInRegularAndScriptAsync(initialText, expectedText);
         }
 
-        [Fact, WorkItem(3818, "https://github.com/dotnet/roslyn/issues/3818")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(3818, "https://github.com/dotnet/roslyn/issues/3818")]
         public async Task InExtensionMethodUnderMultipleConditionalAccessExpressions()
         {
             var initialText =
@@ -1021,7 +1021,7 @@ public class C
             await TestInRegularAndScriptAsync(initialText, expectedText);
         }
 
-        [Fact, WorkItem(3818, "https://github.com/dotnet/roslyn/issues/3818")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(3818, "https://github.com/dotnet/roslyn/issues/3818")]
         public async Task InExtensionMethodUnderMultipleConditionalAccessExpressions2()
         {
             var initialText =
@@ -1066,7 +1066,7 @@ public class C
             await TestInRegularAndScriptAsync(initialText, expectedText);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestDeconstructExtension()
         {
             await TestAsync(
@@ -1327,7 +1327,7 @@ namespace A.Extension
 ", testHost);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestExtensionDeconstructOverload()
         {
             await TestAsync(
@@ -1391,7 +1391,7 @@ namespace A.Extension
 parseOptions: null);
         }
 
-        [Fact, WorkItem(55117, "https://github.com/dotnet/roslyn/issues/55117")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(55117, "https://github.com/dotnet/roslyn/issues/55117")]
         public async Task TestMethodConflictWithGenericExtension()
         {
             await TestInRegularAndScriptAsync(
@@ -1449,7 +1449,7 @@ namespace A.Extensions
 }");
         }
 
-        [Fact, WorkItem(55117, "https://github.com/dotnet/roslyn/issues/55117")]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(55117, "https://github.com/dotnet/roslyn/issues/55117")]
         public async Task TestMethodConflictWithConditionalGenericExtension()
         {
             await TestInRegularAndScriptAsync(

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_Queries.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_Queries.cs
@@ -6,6 +6,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing
@@ -13,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing
     [Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
     public partial class AddUsingTests
     {
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestSimpleQuery()
         {
             await TestInRegularAndScriptAsync(
@@ -40,7 +41,7 @@ class Program
 }");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestSimpleWhere()
         {
             await TestInRegularAndScriptAsync(

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_Razor.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_Razor.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Remote.Testing;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing
@@ -13,7 +14,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.AddUsing
     [Trait(Traits.Feature, Traits.Features.CodeActionsAddImport)]
     public partial class AddUsingTests_Razor : AbstractAddUsingTests
     {
-        [Theory, CombinatorialData]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
+        [CombinatorialData]
         public async Task TestAddIntoHiddenRegionWithModernSpanMapper(TestHost host)
         {
             await TestAsync(

--- a/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/RemoteEditAndContinueServiceTests.cs
@@ -38,7 +38,8 @@ namespace Roslyn.VisualStudio.Next.UnitTests.EditAndContinue
                 (!string.IsNullOrWhiteSpace(d.DataLocation.UnmappedFileSpan.Path) ? $" {d.DataLocation.UnmappedFileSpan.Path}({d.DataLocation.UnmappedFileSpan.StartLinePosition.Line}, {d.DataLocation.UnmappedFileSpan.StartLinePosition.Character}, {d.DataLocation.UnmappedFileSpan.EndLinePosition.Line}, {d.DataLocation.UnmappedFileSpan.EndLinePosition.Character}):" : "") +
                 $" {d.Message}";
 
-        [Theory, CombinatorialData]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
+        [CombinatorialData]
         public async Task Proxy(TestHost testHost)
         {
             var localComposition = EditorTestCompositions.EditorFeatures.WithTestHostParts(testHost)

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/AddImport/AddImportTests.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeActions.AddImp
             Return (Nothing, New VisualBasicAddImportCodeFixProvider())
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestSimpleImportFromSameFile(testHost As TestHost) As Task
             Await TestAsync(
@@ -67,7 +67,7 @@ Class Class1
 End Class", testHost, priority:=CodeActionPriority.Medium)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestSimpleImportFromReference(testHost As TestHost) As Task
             Await TestAsync(
@@ -81,7 +81,7 @@ Class Class1
 End Class", testHost)
         End Function
 
-        <Fact>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         Public Async Function TestSmartTagDisplay() As Task
             Await TestSmartTagTextAsync(
 "Class Class1
@@ -90,7 +90,7 @@ End Class",
 "Imports System.Threading")
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestGenericClassDefinitionAsClause(testHost As TestHost) As Task
             Await TestAsync(
@@ -110,7 +110,7 @@ Class SomeClass(Of x As Base)
 End Class", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestGenericClassInstantiationOfClause(testHost As TestHost) As Task
             Await TestAsync(
@@ -140,7 +140,7 @@ Class Goo
 End Class", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestGenericMethodDefinitionAsClause(testHost As TestHost) As Task
             Await TestAsync(
@@ -164,7 +164,7 @@ Class Goo
 End Class", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestGenericMethodInvocationOfClause(testHost As TestHost) As Task
             Await TestAsync(
@@ -194,7 +194,7 @@ Class Goo
 End Class", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestAttributeApplication(testHost As TestHost) As Task
             Await TestAsync(
@@ -218,7 +218,7 @@ Namespace SomeNamespace
 End Namespace", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestMultipleAttributeApplicationBelow(testHost As TestHost) As Task
             Await TestAsync(
@@ -250,7 +250,7 @@ Namespace SomeNamespace
 End Namespace", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestMultipleAttributeApplicationAbove(testHost As TestHost) As Task
             Await TestAsync(
@@ -282,7 +282,7 @@ Namespace SomeNamespace
 End Namespace", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestImportsIsEscapedWhenNamespaceMatchesKeyword(testHost As TestHost) As Task
             Await TestAsync(
@@ -304,7 +304,7 @@ Namespace [Namespace]
 End Namespace", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestImportsIsNOTEscapedWhenNamespaceMatchesKeywordButIsNested(testHost As TestHost) As Task
             Await TestAsync(
@@ -330,7 +330,7 @@ Namespace Outer
 End Namespace", testHost)
         End Function
 
-        <Fact>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         Public Async Function TestAddImportsNotSuggestedForImportsStatement() As Task
             Await TestMissingInRegularAndScriptAsync(
 "Imports [|InnerNamespace|]
@@ -342,7 +342,7 @@ Namespace SomeNamespace
 End Namespace")
         End Function
 
-        <Fact>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         Public Async Function TestAddImportsNotSuggestedForGenericTypeParametersOfClause() As Task
             Await TestMissingInRegularAndScriptAsync(
 "Class SomeClass
@@ -355,7 +355,7 @@ Namespace SomeNamespace
 End Namespace")
         End Function
 
-        <Fact>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         Public Async Function TestAddImportsNotSuggestedForGenericTypeParametersAsClause() As Task
             Await TestMissingInRegularAndScriptAsync(
 "Class SomeClass
@@ -368,7 +368,7 @@ Namespace SomeNamespace
 End Namespace")
         End Function
 
-        <Theory, WorkItem(540543, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540543")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(540543, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540543")>
         <CombinatorialData>
         Public Async Function TestCaseSensitivity1(testHost As TestHost) As Task
             Await TestAsync(
@@ -390,7 +390,7 @@ Namespace SomeNamespace
 End Namespace", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestTypeFromMultipleNamespaces1(testHost As TestHost) As Task
             Await TestAsync(
@@ -406,7 +406,7 @@ Class Goo
 End Class", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestTypeFromMultipleNamespaces2(testHost As TestHost) As Task
             Await TestAsync(
@@ -423,7 +423,7 @@ End Class",
                 testHost, index:=1)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestGenericWithNoArgs(testHost As TestHost) As Task
             Await TestAsync(
@@ -439,7 +439,7 @@ Class Goo
 End Class", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestGenericWithCorrectArgs(testHost As TestHost) As Task
             Await TestAsync(
@@ -455,7 +455,7 @@ Class Goo
 End Class", testHost)
         End Function
 
-        <Fact>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         Public Async Function TestGenericWithWrongArgs1() As Task
             Await TestMissingInRegularAndScriptAsync(
 "Class Goo
@@ -464,7 +464,7 @@ End Class", testHost)
 End Class")
         End Function
 
-        <Fact>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         Public Async Function TestGenericWithWrongArgs2() As Task
             Await TestMissingInRegularAndScriptAsync(
 "Class Goo
@@ -473,7 +473,7 @@ End Class")
 End Class")
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestGenericInLocalDeclaration(testHost As TestHost) As Task
             Await TestAsync(
@@ -491,7 +491,7 @@ Class Goo
 End Class", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestGenericItemType(testHost As TestHost) As Task
             Await TestAsync(
@@ -509,7 +509,7 @@ Class Goo
 End Class", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestGenerateWithExistingUsings(testHost As TestHost) As Task
             Await TestAsync(
@@ -529,7 +529,7 @@ Class Goo
 End Class", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestGenerateInNamespace(testHost As TestHost) As Task
             Await TestAsync(
@@ -553,7 +553,7 @@ Namespace NS
 End Namespace", testHost)
         End Function
 
-        <Fact, WorkItem(540519, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540519")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(540519, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540519")>
         Public Async Function TestCodeIssueCountInExistingUsing() As Task
             Await TestActionCountAsync(
 "Imports System.Collections.Generic
@@ -566,7 +566,7 @@ End Namespace",
 count:=1)
         End Function
 
-        <Theory, WorkItem(540519, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540519")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(540519, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540519")>
         <CombinatorialData>
         Public Async Function TestFixInExistingUsing(testHost As TestHost) As Task
             Await TestAsync(
@@ -587,7 +587,7 @@ Namespace NS
 End Namespace", testHost)
         End Function
 
-        <Theory, WorkItem(541731, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541731")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(541731, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541731")>
         <CombinatorialData>
         Public Async Function TestGenericExtensionMethod(testHost As TestHost) As Task
             Await TestAsync(
@@ -607,7 +607,7 @@ Class Test
 End Class", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestParameterType(testHost As TestHost) As Task
             Await TestAsync(
@@ -628,7 +628,7 @@ Module Program
 End Module", testHost)
         End Function
 
-        <Theory, WorkItem(540519, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540519")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(540519, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540519")>
         <CombinatorialData>
         Public Async Function TestAddWithExistingConflictWithDifferentArity(testHost As TestHost) As Task
             Await TestAsync(
@@ -649,7 +649,7 @@ Namespace NS
 End Namespace", testHost)
         End Function
 
-        <Theory, WorkItem(540673, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540673")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(540673, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540673")>
         <CombinatorialData>
         Public Async Function TestImportNamespace(testHost As TestHost) As Task
             Await TestAsync(
@@ -679,7 +679,7 @@ Namespace SomeNamespace
 End Namespace", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestCaseSensitivity2(testHost As TestHost) As Task
             Await TestAsync(
@@ -709,7 +709,7 @@ Namespace SomeNamespace
 End Namespace", testHost)
         End Function
 
-        <Theory, WorkItem(540745, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540745")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(540745, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540745")>
         <CombinatorialData>
         Public Async Function TestCaseSensitivity3(testHost As TestHost) As Task
             Await TestAsync(
@@ -739,7 +739,7 @@ Namespace OUTER
 End Namespace", testHost)
         End Function
 
-        <Theory, WorkItem(541746, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541746")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(541746, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541746")>
         <CombinatorialData>
         Public Async Function TestAddBlankLineAfterLastImports(testHost As TestHost) As Task
             Await TestAsync(
@@ -780,7 +780,7 @@ Namespace SomeNamespace
 End Namespace</Text>.Value.Replace(vbLf, vbCrLf), testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestSimpleWhereClause(testHost As TestHost) As Task
             Await TestAsync(
@@ -804,7 +804,7 @@ Class Program
 End Class", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestAggregateClause(testHost As TestHost) As Task
             Await TestAsync(
@@ -828,7 +828,7 @@ Class Program
 End Class", testHost)
         End Function
 
-        <Fact, WorkItem(543107, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543107")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(543107, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543107")>
         Public Async Function TestNoCrashOnMissingLeftSide() As Task
             Await TestMissingInRegularAndScriptAsync(
 "Imports System
@@ -839,7 +839,7 @@ Class C1
 End Class")
         End Function
 
-        <Theory, WorkItem(544335, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544335")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(544335, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544335")>
         <CombinatorialData>
         Public Async Function TestOnCallWithoutArgumentList(testHost As TestHost) As Task
             Await TestAsync(
@@ -857,7 +857,7 @@ Module Program
 End Module", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestAddToVisibleRegion(testHost As TestHost) As Task
             Await TestAsync(
@@ -884,7 +884,7 @@ Class C
 End Class", testHost)
         End Function
 
-        <Fact>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         Public Async Function TestDoNotAddIntoHiddenRegion() As Task
             Await TestMissingInRegularAndScriptAsync(
 "Imports System
@@ -897,7 +897,7 @@ Class C
 End Class")
         End Function
 
-        <Theory, WorkItem(546369, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546369")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(546369, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546369")>
         <CombinatorialData>
         Public Async Function TestFormattingAfterImports(testHost As TestHost) As Task
             Await TestAsync(
@@ -921,7 +921,7 @@ End Module
 </Text>.Value.Replace(vbLf, vbCrLf), testHost)
         End Function
 
-        <Theory, WorkItem(775448, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/775448")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(775448, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/775448")>
         <CombinatorialData>
         Public Async Function TestShouldTriggerOnBC32045(testHost As TestHost) As Task
             ' BC32045: 'A' has no type parameters and so cannot have type arguments.
@@ -943,7 +943,7 @@ Module Program
 End Module</Text>.Value.Replace(vbLf, vbCrLf), testHost)
         End Function
 
-        <Theory, WorkItem(867425, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/867425")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(867425, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/867425")>
         <CombinatorialData>
         Public Async Function TestUnknownIdentifierInModule(testHost As TestHost) As Task
             Await TestAsync(
@@ -963,7 +963,7 @@ Module Goo
 End Module", testHost)
         End Function
 
-        <Theory, WorkItem(872908, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/872908")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(872908, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/872908")>
         <CombinatorialData>
         Public Async Function TestConflictedGenericName(testHost As TestHost) As Task
             Await TestAsync(
@@ -983,7 +983,7 @@ Module Goo
 End Module", testHost)
         End Function
 
-        <Theory, WorkItem(838253, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/838253")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(838253, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/838253")>
         <CombinatorialData>
         Public Async Function TestConflictedInaccessibleType(testHost As TestHost) As Task
             Await TestAsync(
@@ -1011,7 +1011,7 @@ Class C
 End Class", testHost, index:=1)
         End Function
 
-        <Theory, WorkItem(858085, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/858085")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(858085, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/858085")>
         <CombinatorialData>
         Public Async Function TestConflictedAttributeName(testHost As TestHost) As Task
             Await TestAsync(
@@ -1023,7 +1023,7 @@ End Class",
 End Class", testHost)
         End Function
 
-        <Theory, WorkItem(772321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/772321")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(772321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/772321")>
         <CombinatorialData>
         Public Async Function TestExtensionWithThePresenceOfTheSameNameNonExtensionMethod(testHost As TestHost) As Task
             Await TestAsync(
@@ -1073,7 +1073,7 @@ Namespace NS2
 End Namespace", testHost)
         End Function
 
-        <Theory, WorkItem(772321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/772321")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(772321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/772321")>
         <WorkItem(920398, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/920398")>
         <CombinatorialData>
         Public Async Function TestExtensionWithThePresenceOfTheSameNameNonExtensionPrivateMethod(testHost As TestHost) As Task
@@ -1124,7 +1124,7 @@ Namespace NS2
 End Namespace", testHost)
         End Function
 
-        <Theory, WorkItem(772321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/772321")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(772321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/772321")>
         <WorkItem(920398, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/920398")>
         <CombinatorialData>
         Public Async Function TestExtensionWithThePresenceOfTheSameNameExtensionPrivateMethod(testHost As TestHost) As Task
@@ -1193,7 +1193,7 @@ Namespace NS3
 End Namespace", testHost)
         End Function
 
-        <Fact, WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")>
         Public Async Function TestAddImportForCref() As Task
             Dim initialText As String = "''' <summary>
 ''' This is just like <see cref=[|""INotifyPropertyChanged""|]/>, but this one is mine.
@@ -1213,7 +1213,7 @@ End Interface"
                 parseOptions:=options)
         End Function
 
-        <Fact, WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")>
         Public Async Function TestAddImportForCref2() As Task
             Dim initialText As String = "''' <summary>
 ''' This is just like <see cref=[|""INotifyPropertyChanged.PropertyChanged""|]/>, but this one is mine.
@@ -1233,7 +1233,7 @@ End Interface"
                 parseOptions:=options)
         End Function
 
-        <Fact, WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")>
         Public Async Function TestAddImportForCref3() As Task
             Dim initialText =
 "
@@ -1288,7 +1288,7 @@ End Module
                 parseOptions:=options)
         End Function
 
-        <Fact, WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")>
         Public Async Function TestAddImportForCref4() As Task
             Dim initialText =
 "
@@ -1346,7 +1346,7 @@ End Module
                 parseOptions:=options)
         End Function
 
-        <Fact, WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(916368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916368")>
         Public Async Function TestAddImportForCref5() As Task
             Dim initialText =
 "
@@ -1383,7 +1383,7 @@ End Class
                 parseOptions:=options)
         End Function
 
-        <Theory, WorkItem(772321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/772321")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(772321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/772321")>
         <CombinatorialData>
         Public Async Function TestExtensionMethodNoMemberAccessOverload(testHost As TestHost) As Task
             Await TestAsync(
@@ -1427,7 +1427,7 @@ Namespace NS2
 End Namespace", testHost, )
         End Function
 
-        <Theory, WorkItem(772321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/772321")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(772321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/772321")>
         <CombinatorialData>
         Public Async Function TestExtensionMethodNoMemberAccess(testHost As TestHost) As Task
             Await TestAsync(
@@ -1467,7 +1467,7 @@ Namespace NS2
 End Namespace", testHost, )
         End Function
 
-        <Theory, WorkItem(1003618, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1003618")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(1003618, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1003618")>
         <CombinatorialData>
         Public Async Function TestAddImportsTypeParsedAsNamespace(testHost As TestHost) As Task
             Await TestAsync(
@@ -1506,7 +1506,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.AutomaticCompletion
 End Namespace", testHost)
         End Function
 
-        <Theory, WorkItem(773614, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773614")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(773614, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773614")>
         <CombinatorialData>
         Public Async Function TestAddImportsForTypeAttribute(testHost As TestHost) As Task
             Await TestAsync(
@@ -1537,7 +1537,7 @@ Namespace N
 End Namespace", testHost)
         End Function
 
-        <Theory, WorkItem(773614, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773614")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(773614, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773614")>
         <CombinatorialData>
         Public Async Function TestAddImportsForTypeAttributeMultipleNestedClasses(testHost As TestHost) As Task
             Await TestAsync(
@@ -1572,7 +1572,7 @@ Namespace N
 End Namespace", testHost)
         End Function
 
-        <Theory, WorkItem(773614, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773614")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(773614, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773614")>
         <CombinatorialData>
         Public Async Function TestAddImportsForTypeAttributePartiallyQualified(testHost As TestHost) As Task
             Await TestAsync(
@@ -1607,7 +1607,7 @@ Namespace N
 End Namespace", testHost)
         End Function
 
-        <Theory, WorkItem(1064815, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064815")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(1064815, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064815")>
         <CombinatorialData>
         Public Async Function TestConditionalAccessExtensionMethod(testHost As TestHost) As Task
             Dim initial = <Workspace>
@@ -1644,7 +1644,7 @@ End Class
             Await TestAsync(initial, expected, testHost)
         End Function
 
-        <Theory, WorkItem(1064815, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064815")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(1064815, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1064815")>
         <CombinatorialData>
         Public Async Function TestConditionalAccessExtensionMethod2(testHost As TestHost) As Task
             Dim initial = <Workspace>
@@ -1697,7 +1697,7 @@ End Class
             Await TestAsync(initial, expected, testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestAddUsingInDirective(testHost As TestHost) As Task
             Await TestAsync(
@@ -1726,7 +1726,7 @@ Module Program
 End Module", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestAddUsingInDirective2(testHost As TestHost) As Task
             Await TestAsync(
@@ -1755,7 +1755,7 @@ Module Program
 End Module", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestAddUsingInDirective3(testHost As TestHost) As Task
             Await TestAsync(
@@ -1784,7 +1784,7 @@ Module Program
 End Module", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestInaccessibleExtensionMethod(testHost As TestHost) As Task
             Dim initial = <Workspace>
@@ -1830,7 +1830,7 @@ End Module
             Await TestAsync(initial, expected, testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         Public Async Function TestInaccessibleExtensionMethod2(testHost As TestHost) As Task
             Dim initial = <Workspace>
@@ -1865,7 +1865,7 @@ End Module
             Await TestMissingInRegularAndScriptAsync(initial)
         End Function
 
-        <Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")>
         Public Async Function TestAddImportForAddExtensionMethod() As Task
             Await TestAsync(
 "Imports System
@@ -1907,7 +1907,7 @@ End Namespace",
 parseOptions:=Nothing)
         End Function
 
-        <Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")>
         Public Async Function TestAddImportForAddExtensionMethod2() As Task
             Await TestAsync(
 "Imports System
@@ -1949,7 +1949,7 @@ End Namespace",
 parseOptions:=Nothing)
         End Function
 
-        <Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")>
         Public Async Function TestAddImportForAddExtensionMethod3() As Task
             Await TestAsync(
 "Imports System
@@ -1991,7 +1991,7 @@ End Namespace",
 parseOptions:=Nothing)
         End Function
 
-        <Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")>
         Public Async Function TestAddImportForAddExtensionMethod4() As Task
             Await TestAsync(
 "Imports System
@@ -2033,7 +2033,7 @@ End Namespace",
 parseOptions:=Nothing)
         End Function
 
-        <Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")>
         Public Async Function TestAddImportForAddExtensionMethod5() As Task
             Await TestAsync(
 "Imports System
@@ -2075,7 +2075,7 @@ End Namespace",
 parseOptions:=Nothing)
         End Function
 
-        <Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")>
         Public Async Function TestAddImportForAddExtensionMethod6() As Task
             Await TestAsync(
 "Imports System
@@ -2131,7 +2131,7 @@ End Namespace",
 parseOptions:=Nothing)
         End Function
 
-        <Fact, WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(269, "https://github.com/dotnet/roslyn/issues/269")>
         Public Async Function TestAddImportForAddExtensionMethod7() As Task
             Await TestAsync(
 "Imports System
@@ -2188,7 +2188,7 @@ index:=1,
 parseOptions:=Nothing)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         <WorkItem(935, "https://github.com/dotnet/roslyn/issues/935")>
         Public Async Function TestAddUsingWithOtherExtensionsInScope(testHost As TestHost) As Task
@@ -2227,7 +2227,7 @@ Namespace X
 End Namespace", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         <WorkItem(935, "https://github.com/dotnet/roslyn/issues/935")>
         Public Async Function TestAddUsingWithOtherExtensionsInScope2(testHost As TestHost) As Task
@@ -2268,7 +2268,7 @@ Namespace X
 End Namespace", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         <WorkItem(562, "https://github.com/dotnet/roslyn/issues/562")>
         Public Async Function TestAddUsingWithOtherExtensionsInScope3(testHost As TestHost) As Task
@@ -2325,7 +2325,7 @@ Namespace Y
 End Namespace", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         <WorkItem(562, "https://github.com/dotnet/roslyn/issues/562")>
         Public Async Function TestAddUsingWithOtherExtensionsInScope4(testHost As TestHost) As Task
@@ -2382,7 +2382,7 @@ Namespace Y
 End Namespace", testHost)
         End Function
 
-        <Theory>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue)>
         <CombinatorialData>
         <WorkItem(19796, "https://github.com/dotnet/roslyn/issues/19796")>
         Public Async Function TestWhenInRome1(testHost As TestHost) As Task
@@ -2412,7 +2412,7 @@ Namespace A
 End Namespace", testHost, placeSystemFirst:=False)
         End Function
 
-        <Theory, WorkItem(19796, "https://github.com/dotnet/roslyn/issues/19796")>
+        <ConditionalTheory(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(19796, "https://github.com/dotnet/roslyn/issues/19796")>
         <CombinatorialData>
         Public Async Function TestWhenInRome2(testHost As TestHost) As Task
             Await TestAsync(
@@ -2441,7 +2441,7 @@ Namespace A
 End Namespace", testHost, placeSystemFirst:=True)
         End Function
 
-        <Fact, WorkItem(1744, "https://github.com/dotnet/roslyn/issues/1744")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(1744, "https://github.com/dotnet/roslyn/issues/1744")>
         Public Async Function TestImportIncompleteSub() As Task
             Await TestAsync(
 "Imports System
@@ -2473,7 +2473,7 @@ Namespace T
 End Namespace", TestHost.InProcess)
         End Function
 
-        <Fact, WorkItem(1239, "https://github.com/dotnet/roslyn/issues/1239")>
+        <ConditionalFact(GetType(IsRelease), Reason:=ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(1239, "https://github.com/dotnet/roslyn/issues/1239")>
         Public Async Function TestImportIncompleteSub2() As Task
             Await TestAsync(
 "Imports System

--- a/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
@@ -43,7 +43,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
     [Trait(Traits.Feature, Traits.Features.RemoteHost)]
     public class VisualStudioDiagnosticAnalyzerExecutorTests
     {
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestCSharpAnalyzerOptions()
         {
             var code = @"class Test
@@ -82,7 +82,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             Assert.Equal(DiagnosticSeverity.Info, diagnostics[0].Severity);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestVisualBasicAnalyzerOptions()
         {
             var code = @"Class Test
@@ -126,7 +126,7 @@ End Class";
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestCancellation()
         {
             var code = @"class Test { void Method() { } }";
@@ -162,7 +162,7 @@ End Class";
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestHostAnalyzers_OutOfProc()
         {
             var code = @"class Test
@@ -202,7 +202,7 @@ End Class";
             Assert.Equal(IDEDiagnosticIds.UseExplicitTypeDiagnosticId, diagnostics[0].Id);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         public async Task TestDuplicatedAnalyzers()
         {
             var code = @"class Test


### PR DESCRIPTION
We have some unit tests that are failing on debug 32-bit only due to https://github.com/dotnet/roslyn/issues/64195, this skips them on debug so they aren't impacting CI.