### PR TITLE
Add multiple language support to stack trace explorer

### DIFF
--- a/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameParserTests.cs
+++ b/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameParserTests.cs
@@ -468,9 +468,18 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EmbeddedLanguages.StackFrame
                 );
 
         [Theory]
-        [InlineData("at", "in", "line")]        // en
-        [InlineData("bei", "in", "Zeile")]      // de
-        [InlineData("à", "dans", "ligne")]      // fr
+        [InlineData("v", "v", "řádek")] // Czech
+        [InlineData("bei", "in", "Zeile")] // German
+        [InlineData("en", "en", "línea")] // Spanish
+        [InlineData("à", "dans", "ligne")] // French
+        [InlineData("in", "in", "riga")] // Italian
+        [InlineData("場所", "場所", "行")] // Japanese
+        [InlineData("위치:", "파일", "줄")] // Korean
+        [InlineData("w", "w", "wiersz")] // Polish
+        [InlineData("em", "na", "linha")] // Portuguese (Brazil)
+        [InlineData("в", "в", "строка")] // Russian
+        [InlineData("在", "位置", "行号")] // Chinese (Simplified)
+        [InlineData("於", "於", " 行")] // Chinese (Traditional)
         public void TestLanguages(string at, string @in, string line)
             => Verify(@$"{at} Program.Main() {@in} C:\repos\languages\Program.cs:{line} 16",
                 methodDeclaration: MethodDeclaration(

--- a/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameParserTests.cs
+++ b/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameParserTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 using System.Collections.Immutable;
 using static Microsoft.CodeAnalysis.Editor.UnitTests.EmbeddedLanguages.StackFrame.StackFrameSyntaxFactory;
 using static Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame.StackFrameExtensions;
+using Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.EmbeddedLanguages.StackFrame
 {
@@ -465,5 +466,22 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EmbeddedLanguages.StackFrame
                             "0_0"))
                     )
                 );
+
+        [Theory]
+        [InlineData("at", "in", "line")]        // en
+        [InlineData("bei", "in", "Zeile")]      // de
+        [InlineData("à", "dans", "ligne")]      // fr
+        public void TestLanguages(string at, string @in, string line)
+            => Verify(@$"{at} Program.Main() {@in} C:\repos\languages\Program.cs:{line} 16",
+                methodDeclaration: MethodDeclaration(
+                    QualifiedName("Program.Main",
+                        leadingTrivia: CreateTrivia(StackFrameKind.AtTrivia, $"{at} "))),
+
+                fileInformation: FileInformation(
+                    Path(@"C:\repos\languages\Program.cs"),
+                    ColonToken,
+                    line: CreateToken(StackFrameKind.NumberToken, "16", leadingTrivia: ImmutableArray.Create(CreateTrivia(StackFrameKind.LineTrivia, $"{line} "))),
+                    inTrivia: CreateTrivia(StackFrameKind.InTrivia, $" {@in} "))
+                    );
     }
 }

--- a/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameSyntaxFactory.cs
+++ b/src/EditorFeatures/Test/EmbeddedLanguages/StackFrame/StackFrameSyntaxFactory.cs
@@ -196,8 +196,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.EmbeddedLanguages.StackFrame
         public static StackFrameIdentifierNameNode TypeArgument(StackFrameToken identifier)
             => new(identifier);
 
-        public static StackFrameFileInformationNode FileInformation(StackFrameToken path, StackFrameToken colon, StackFrameToken line)
-            => new(path.With(leadingTrivia: ImmutableArray.Create(InTrivia)), colon, line);
+        public static StackFrameFileInformationNode FileInformation(StackFrameToken path, StackFrameToken colon, StackFrameToken line, StackFrameTrivia? inTrivia = null)
+            => new(path.With(leadingTrivia: ImmutableArray.Create(inTrivia.HasValue ? inTrivia.Value : InTrivia)), colon, line);
 
         public static StackFrameToken Path(string path)
             => CreateToken(StackFrameKind.PathToken, path);

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
@@ -182,16 +182,46 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
         }
 
         public StackFrameTrivia? TryScanAtTrivia()
-            // TODO: Handle multiple languages? Right now we're going to only parse english
-            => TryScanStringTrivia("at ", StackFrameKind.AtTrivia);
+        {
+            foreach (var language in s_languages)
+            {
+                var result = TryScanStringTrivia(language.At, StackFrameKind.AtTrivia);
+                if (result.HasValue)
+                {
+                    return result.Value;
+                }
+            }
+
+            return null;
+        }
 
         public StackFrameTrivia? TryScanInTrivia()
-            // TODO: Handle multiple languages? Right now we're going to only parse english
-            => TryScanStringTrivia(" in ", StackFrameKind.InTrivia);
+        {
+            foreach (var language in s_languages)
+            {
+                var result = TryScanStringTrivia(language.In, StackFrameKind.InTrivia);
+                if (result.HasValue)
+                {
+                    return result.Value;
+                }
+            }
+
+            return null;
+        }
 
         public StackFrameTrivia? TryScanLineTrivia()
-            // TODO: Handle multiple languages? Right now we're going to only parse english
-            => TryScanStringTrivia("line ", StackFrameKind.LineTrivia);
+        {
+            foreach (var language in s_languages)
+            {
+                var result = TryScanStringTrivia(language.Line, StackFrameKind.LineTrivia);
+                if (result.HasValue)
+                {
+                    return result.Value;
+                }
+            }
+
+            return null;
+        }
 
         /// <summary>
         /// Attempts to parse <see cref="StackFrameKind.InTrivia"/> and a path following https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#file-and-directory-names
@@ -479,5 +509,12 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
 
         private static bool IsNumber(VirtualChar ch)
             => ch.Value is >= '0' and <= '9';
+
+        private readonly record struct Language(string At, string In, string Line);
+        private static readonly ImmutableArray<Language> s_languages = ImmutableArray.Create(
+            new Language("at ", " in ", "line "),    // en
+            new Language("bei ", " in ", "Zeile "),  // de
+            new Language("à ", " dans ", "ligne ")   // fr
+            );
     }
 }

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
@@ -512,7 +512,7 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
 
         private readonly record struct Language(string At, string In, string Line);
         private static readonly ImmutableArray<Language> s_languages = ImmutableArray.Create(
-            new Language("in ", " in ", "line "), // en
+            new Language("at ", " in ", "line "), // en
             new Language("v ", " v ", "řádek "), // cs
             new Language("bei ", " in ", "Zeile "), // de
             new Language("en ", " en ", "línea "), // es

--- a/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/StackFrame/StackFrameLexer.cs
@@ -512,9 +512,19 @@ namespace Microsoft.CodeAnalysis.EmbeddedLanguages.StackFrame
 
         private readonly record struct Language(string At, string In, string Line);
         private static readonly ImmutableArray<Language> s_languages = ImmutableArray.Create(
-            new Language("at ", " in ", "line "),    // en
-            new Language("bei ", " in ", "Zeile "),  // de
-            new Language("à ", " dans ", "ligne ")   // fr
+            new Language("in ", " in ", "line "), // en
+            new Language("v ", " v ", "řádek "), // cs
+            new Language("bei ", " in ", "Zeile "), // de
+            new Language("en ", " en ", "línea "), // es
+            new Language("à ", " dans ", "ligne "), // fr
+            new Language("in ", " in ", "riga "), // it
+            new Language("場所 ", " 場所 ", "行 "), // ja
+            new Language("위치: ", " 파일 ", "줄 "), // ko
+            new Language("w ", " w ", "wiersz "), // pl
+            new Language("em ", " na ", "linha "), // pt-BR
+            new Language("в ", " в ", "строка "), // ru
+            new Language("在 ", " 位置 ", "行号 "), // zh-Hans
+            new Language("於 ", " 於 ", " 行 ") // zh-Hant
             );
     }
 }


### PR DESCRIPTION
Fixes #62436 

We now support 

English
Czech
German
Spanish
French
Italian
Japanese
Korean
Polish
Portuguese (Brazil)
Russian
Chinese (Simplified)
Chinese (Traditional)

If more languages need to be added later they should be fairly straightforward 