### PR TITLE
Skip some more tests that are currently failing on debug 32-bit

### DIFF
--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests.cs
@@ -4427,7 +4427,7 @@ static void Main(string[] args)
             await TestAsync(initialText, expectedText, testHost);
         }
 
-        [Theory, WorkItem(860648, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/860648")]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue), WorkItem(860648, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/860648")]
         [CombinatorialData]
         [WorkItem(902014, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/902014")]
         public async Task TestIncompleteParenthesizedLambdaExpression(TestHost testHost)

--- a/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_ExtensionMethods.cs
+++ b/src/EditorFeatures/CSharpTest/AddUsing/AddUsingTests_ExtensionMethods.cs
@@ -1107,7 +1107,7 @@ namespace N
 parseOptions: null);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(16547, "https://github.com/dotnet/roslyn/issues/16547")]
         public async Task TestAddUsingForAddExtentionMethodWithSameNameAsProperty(TestHost testHost)
@@ -1171,7 +1171,7 @@ namespace A.Extensions
 }", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(39155, "https://github.com/dotnet/roslyn/issues/39155")]
         public async Task TestExtensionGetAwaiterOverload(TestHost testHost)
@@ -1262,7 +1262,7 @@ namespace A.Extension
 ", testHost);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(IsRelease), Reason = ConditionalSkipReason.TestIsTriggeringMessagePackIssue)]
         [CombinatorialData]
         [WorkItem(39155, "https://github.com/dotnet/roslyn/issues/39155")]
         public async Task TestExtensionSelectOverload(TestHost testHost)


### PR DESCRIPTION
We have some unit tests that are failing on debug 32-bit only due to https://github.com/dotnet/roslyn/issues/64195, this skips them on debug so they aren't impacting CI.