### PR TITLE
Remove exportProvider parameter from TestWorkspace ctor

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 </Workspace>";
 
         protected override TestWorkspace CreateWorkspace(string fileContents)
-            => TestWorkspace.CreateCSharp(fileContents, exportProvider: ExportProvider);
+            => TestWorkspace.CreateCSharp(fileContents, composition: GetComposition());
 
         internal override CompletionService GetCompletionService(Project project)
             => Assert.IsType<CSharpCompletionService>(base.GetCompletionService(project));

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractInteractiveCSharpCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractInteractiveCSharpCompletionProviderTests.cs
@@ -11,6 +11,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     public abstract class AbstractInteractiveCSharpCompletionProviderTests : AbstractCSharpCompletionProviderTests<InteractiveCSharpTestWorkspaceFixture>
     {
         protected override TestWorkspace CreateWorkspace(string fileContents)
-            => InteractiveCSharpTestWorkspaceFixture.CreateInteractiveWorkspace(fileContents, exportProvider: ExportProvider);
+            => InteractiveCSharpTestWorkspaceFixture.CreateInteractiveWorkspace(fileContents, composition: GetComposition());
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
@@ -427,7 +427,7 @@ class C
 class C
 {
 }";
-            using var workspace = TestWorkspace.Create(LanguageNames.CSharp, new CSharpCompilationOptions(OutputKind.ConsoleApplication), new CSharpParseOptions(), new[] { text }, exportProvider: ExportProvider);
+            using var workspace = TestWorkspace.Create(LanguageNames.CSharp, new CSharpCompilationOptions(OutputKind.ConsoleApplication), new CSharpParseOptions(), new[] { text }, composition: GetComposition());
             var called = false;
 
             var hostDocument = workspace.DocumentWithCursor;

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -690,7 +690,7 @@ public class C
         {
             using var workspaceFixture = GetOrCreateWorkspaceFixture();
 
-            var workspace = workspaceFixture.Target.GetWorkspace(ExportProvider);
+            var workspace = workspaceFixture.Target.GetWorkspace(GetComposition());
 
             var options = new CompletionOptions()
             {
@@ -2340,7 +2340,7 @@ public class Class1
         {
             using var workspaceFixture = GetOrCreateWorkspaceFixture();
 
-            var workspace = workspaceFixture.Target.GetWorkspace(ExportProvider);
+            var workspace = workspaceFixture.Target.GetWorkspace(GetComposition());
 
             var options = new CompletionOptions()
             {
@@ -2368,7 +2368,7 @@ class Configuration
         {
             using var workspaceFixture = GetOrCreateWorkspaceFixture();
 
-            var workspace = workspaceFixture.Target.GetWorkspace(ExportProvider);
+            var workspace = workspaceFixture.Target.GetWorkspace(GetComposition());
 
             var options = new CompletionOptions()
             {
@@ -2784,7 +2784,7 @@ class C
         {
             using var workspaceFixture = GetOrCreateWorkspaceFixture();
 
-            var workspace = workspaceFixture.Target.GetWorkspace(ExportProvider);
+            var workspace = workspaceFixture.Target.GetWorkspace(GetComposition());
 
             var options = new CompletionOptions()
             {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
@@ -615,7 +615,7 @@ class D
     }
 }";
 
-            using var workspace = TestWorkspace.CreateCSharp(markup, exportProvider: ExportProvider);
+            using var workspace = TestWorkspace.CreateCSharp(markup, composition: GetComposition());
             var hostDocument = workspace.Documents.Single();
             var position = hostDocument.CursorPosition.Value;
             var document = workspace.CurrentSolution.GetDocument(hostDocument.Id);
@@ -1187,7 +1187,7 @@ class Program
 
         private async Task VerifyExclusiveAsync(string markup, bool exclusive)
         {
-            using var workspace = TestWorkspace.CreateCSharp(markup, exportProvider: ExportProvider);
+            using var workspace = TestWorkspace.CreateCSharp(markup, composition: GetComposition());
             var hostDocument = workspace.Documents.Single();
             var position = hostDocument.CursorPosition.Value;
             var document = workspace.CurrentSolution.GetDocument(hostDocument.Id);

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -2363,7 +2363,7 @@ End Class
     
 </Workspace>", LanguageNames.CSharp, csharpFile, LanguageNames.VisualBasic, vbFile);
 
-            using var testWorkspace = TestWorkspace.Create(xmlString, exportProvider: ExportProvider);
+            using var testWorkspace = TestWorkspace.Create(xmlString, composition: GetComposition());
             var testDocument = testWorkspace.Documents.Single(d => d.Name == "CSharpDocument");
 
             Contract.ThrowIfNull(testDocument.CursorPosition);
@@ -2620,7 +2620,7 @@ int bar;
     </Project>
 </Workspace>", LanguageNames.CSharp, file1, file2);
 
-            using var testWorkspace = TestWorkspace.Create(xmlString, exportProvider: ExportProvider);
+            using var testWorkspace = TestWorkspace.Create(xmlString, composition: GetComposition());
             var testDocument = testWorkspace.Documents.Single(d => d.Name == "CSharpDocument2");
 
             Contract.ThrowIfNull(testDocument.CursorPosition);
@@ -2676,7 +2676,7 @@ int bar;
     </Project>
 </Workspace>", LanguageNames.CSharp, file2, file1);
 
-            using var testWorkspace = TestWorkspace.Create(xmlString, exportProvider: ExportProvider);
+            using var testWorkspace = TestWorkspace.Create(xmlString, composition: GetComposition());
             var testDocument = testWorkspace.Documents.Single(d => d.Name == "CSharpDocument");
 
             Contract.ThrowIfNull(testDocument.CursorPosition);
@@ -2963,7 +2963,7 @@ namespace ConsoleApplication46
         override $$
     }
 }";
-            using var workspace = TestWorkspace.Create(LanguageNames.CSharp, new CSharpCompilationOptions(OutputKind.ConsoleApplication), new CSharpParseOptions(), new[] { text }, exportProvider: ExportProvider);
+            using var workspace = TestWorkspace.Create(LanguageNames.CSharp, new CSharpCompilationOptions(OutputKind.ConsoleApplication), new CSharpParseOptions(), new[] { text }, composition: GetComposition());
             var provider = new OverrideCompletionProvider();
             var testDocument = workspace.Documents.Single();
             var document = workspace.CurrentSolution.GetRequiredDocument(testDocument.Id);
@@ -3091,7 +3091,7 @@ namespace ClassLibrary7
             // P1 has a metadata reference to P3 and therefore doesn't get the transitive
             // reference to P2. If we try to override Goo, the missing "Missing" type will
             // prevent round tripping the symbolkey.
-            using var workspace = TestWorkspace.Create(text, exportProvider: ExportProvider);
+            using var workspace = TestWorkspace.Create(text, composition: GetComposition());
             var compilation = await workspace.CurrentSolution.Projects.First(p => p.Name == "P3").GetCompilationAsync();
 
             // CompilationExtensions is in the Microsoft.CodeAnalysis.Test.Utilities namespace 
@@ -3129,7 +3129,7 @@ public class SomeClass : Base
     </Project>
 </Workspace>");
 
-            using var workspace = TestWorkspace.Create(source, exportProvider: ExportProvider);
+            using var workspace = TestWorkspace.Create(source, composition: GetComposition());
             var before = @"
 public abstract class Base
 {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PartialMethodCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PartialMethodCompletionProviderTests.cs
@@ -779,7 +779,7 @@ partial class Bar
         {
             using var workspaceFixture = GetOrCreateWorkspaceFixture();
 
-            var workspace = workspaceFixture.Target.GetWorkspace(ExportProvider);
+            var workspace = workspaceFixture.Target.GetWorkspace(GetComposition());
             workspace.GlobalOptions.SetGlobalOption(
                 new OptionKey(CSharpCodeStyleOptions.PreferExpressionBodiedMethods),
                 new CodeStyleOption2<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption2.Silent));
@@ -810,7 +810,7 @@ partial class Bar
         {
             using var workspaceFixture = GetOrCreateWorkspaceFixture();
 
-            var workspace = workspaceFixture.Target.GetWorkspace(ExportProvider);
+            var workspace = workspaceFixture.Target.GetWorkspace(GetComposition());
             workspace.GlobalOptions.SetGlobalOption(
                 new OptionKey(CSharpCodeStyleOptions.PreferExpressionBodiedMethods),
                 new CodeStyleOption2<ExpressionBodyPreference>(ExpressionBodyPreference.WhenPossible, NotificationOption2.Silent));

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
@@ -1393,7 +1393,7 @@ class P
 
             using (var workspaceFixture = new CSharpTestWorkspaceFixture())
             {
-                workspaceFixture.GetWorkspace(ExportProvider);
+                workspaceFixture.GetWorkspace(GetComposition());
                 var document1 = workspaceFixture.UpdateDocument(code, SourceCodeKind.Regular);
                 await CheckResultsAsync(document1, position, isBuilder);
 

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/CSharpEditAndContinueAnalyzerTests.cs
@@ -507,7 +507,7 @@ class C
                 var experimental = TestOptions.Regular.WithFeatures(featuresToEnable);
 
                 using var workspace = TestWorkspace.CreateCSharp(
-                    source1, parseOptions: experimental, compilationOptions: null, exportProvider: null);
+                    source1, parseOptions: experimental, compilationOptions: null);
 
                 var oldSolution = workspace.CurrentSolution;
                 var oldProject = oldSolution.Projects.Single();

--- a/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/Interactive/NavigateTo/InteractiveNavigateToTests.cs
@@ -24,8 +24,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
     {
         protected override string Language => "csharp";
 
-        protected override TestWorkspace CreateWorkspace(string content, ExportProvider exportProvider)
-            => TestWorkspace.CreateCSharp(content, parseOptions: Options.Script, exportProvider: exportProvider);
+        protected override TestWorkspace CreateWorkspace(string content, TestComposition composition)
+            => TestWorkspace.CreateCSharp(content, parseOptions: Options.Script, composition: composition);
 
         [WpfTheory]
         [CombinatorialData]

--- a/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
+++ b/src/EditorFeatures/CSharpTest/NavigateTo/NavigateToTests.cs
@@ -28,8 +28,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.NavigateTo
     {
         protected override string Language => "csharp";
 
-        protected override TestWorkspace CreateWorkspace(string content, ExportProvider exportProvider)
-            => TestWorkspace.CreateCSharp(content, exportProvider: exportProvider);
+        protected override TestWorkspace CreateWorkspace(string content, TestComposition composition)
+            => TestWorkspace.CreateCSharp(content, composition: composition);
 
         [Theory]
         [CombinatorialData]

--- a/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests_EditorFeatures.cs
+++ b/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests_EditorFeatures.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Workspaces
             TestComposition composition = null)
         {
             composition ??= EditorTestCompositions.EditorFeatures;
-            return new TestWorkspace(exportProvider: null, composition, workspaceKind, disablePartialSolutions: disablePartialSolutions);
+            return new TestWorkspace(composition, workspaceKind, disablePartialSolutions: disablePartialSolutions);
         }
 
         private static async Task WaitForWorkspaceOperationsToComplete(TestWorkspace workspace)

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -596,7 +596,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             if (TestWorkspace.IsWorkspaceElement(expectedText))
             {
                 var newSolutionWithLinkedFiles = await newSolution.WithMergedLinkedFileChangesAsync(oldSolution);
-                await VerifyAgainstWorkspaceDefinitionAsync(expectedText, newSolutionWithLinkedFiles, workspace.ExportProvider);
+                await VerifyAgainstWorkspaceDefinitionAsync(expectedText, newSolutionWithLinkedFiles, workspace.Composition);
                 return Tuple.Create(oldSolution, newSolution);
             }
 
@@ -661,9 +661,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             return document;
         }
 
-        private static async Task VerifyAgainstWorkspaceDefinitionAsync(string expectedText, Solution newSolution, ExportProvider exportProvider)
+        private static async Task VerifyAgainstWorkspaceDefinitionAsync(string expectedText, Solution newSolution, TestComposition composition)
         {
-            using (var expectedWorkspace = TestWorkspace.Create(expectedText, exportProvider: exportProvider))
+            using (var expectedWorkspace = TestWorkspace.Create(expectedText, composition: composition))
             {
                 var expectedSolution = expectedWorkspace.CurrentSolution;
                 Assert.Equal(expectedSolution.Projects.Count(), newSolution.Projects.Count());

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -16,7 +16,9 @@ using Microsoft.CodeAnalysis.Diagnostics.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics.EngineV2;
 using Microsoft.CodeAnalysis.Editor.Test;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote.Diagnostics;
@@ -868,19 +870,21 @@ class A
                 sourceGeneratedFiles = Array.Empty<string>();
             }
 
-            using var workspace = TestWorkspace.CreateCSharp(files, sourceGeneratedFiles,
-                composition: s_editorFeaturesCompositionWithMockDiagnosticUpdateSourceRegistrationService.AddParts(
-                    typeof(TestDocumentTrackingService),
-                    typeof(TestWorkspaceConfigurationService)));
+            var composition = s_editorFeaturesCompositionWithMockDiagnosticUpdateSourceRegistrationService.AddParts(
+                typeof(TestDocumentTrackingService),
+                typeof(TestWorkspaceConfigurationService));
+
+            using var workspace = new TestWorkspace(composition);
 
             var workspaceConfigurationService = workspace.GetService<TestWorkspaceConfigurationService>();
-            workspaceConfigurationService.Options = new(EnableOpeningSourceGeneratedFiles: true);
+            workspaceConfigurationService.Options = new WorkspaceConfigurationOptions(EnableOpeningSourceGeneratedFiles: true);
 
             workspace.GlobalOptions.SetGlobalOption(new OptionKey(SolutionCrawlerOptionsStorage.BackgroundAnalysisScopeOption, LanguageNames.CSharp), analysisScope);
 
             var compilerDiagnosticsScope = analysisScope.ToEquivalentCompilerDiagnosticsScope();
             workspace.GlobalOptions.SetGlobalOption(new OptionKey(SolutionCrawlerOptionsStorage.CompilerDiagnosticsScopeOption, LanguageNames.CSharp), compilerDiagnosticsScope);
 
+            workspace.InitializeDocuments(TestWorkspace.CreateWorkspaceElement(LanguageNames.CSharp, files: files, sourceGeneratedFiles: sourceGeneratedFiles), openDocuments: false);
             workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences(new[] { analyzerReference }));
 
             var project = workspace.CurrentSolution.Projects.Single();

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -871,13 +871,9 @@ class A
             }
 
             var composition = s_editorFeaturesCompositionWithMockDiagnosticUpdateSourceRegistrationService.AddParts(
-                typeof(TestDocumentTrackingService),
-                typeof(TestWorkspaceConfigurationService));
+                typeof(TestDocumentTrackingService));
 
-            using var workspace = new TestWorkspace(composition);
-
-            var workspaceConfigurationService = workspace.GetService<TestWorkspaceConfigurationService>();
-            workspaceConfigurationService.Options = new WorkspaceConfigurationOptions(EnableOpeningSourceGeneratedFiles: true);
+            using var workspace = new TestWorkspace(composition, configurationOptions: new WorkspaceConfigurationOptions(EnableOpeningSourceGeneratedFiles: true));
 
             workspace.GlobalOptions.SetGlobalOption(new OptionKey(SolutionCrawlerOptionsStorage.BackgroundAnalysisScopeOption, LanguageNames.CSharp), analysisScope);
 

--- a/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/SignatureHelpControllerTests.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Sub InvokeSignatureHelpWithoutDocumentShouldNotStartNewSession()
             Dim emptyProvider = New Mock(Of IDocumentProvider)(MockBehavior.Strict)
             emptyProvider.Setup(Function(p) p.GetDocument(It.IsAny(Of ITextSnapshot), It.IsAny(Of CancellationToken))).Returns(DirectCast(Nothing, Document))
-            Dim controller As Controller = CreateController(documentProvider:=emptyProvider)
+            Dim controller As Controller = CreateController(CreateWorkspace(), documentProvider:=emptyProvider)
 
             GetMocks(controller).PresenterSession.Setup(Sub(p) p.Dismiss())
 
@@ -40,7 +40,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
         <WpfFact>
         Public Sub InvokeSignatureHelpWithDocumentShouldStartNewSession()
-            Dim controller = CreateController()
+            Dim controller = CreateController(CreateWorkspace())
 
             GetMocks(controller).Presenter.Verify(Function(p) p.CreateSession(It.IsAny(Of ITextView), It.IsAny(Of ITextBuffer), It.IsAny(Of ISignatureHelpSession)), Times.Once)
         End Sub
@@ -50,14 +50,14 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Dim presenterSession = New Mock(Of ISignatureHelpPresenterSession)(MockBehavior.Strict)
             presenterSession.Setup(Sub(p) p.Dismiss())
 
-            Dim controller = CreateController(presenterSession:=presenterSession, items:={}, waitForPresentation:=True)
+            Dim controller = CreateController(CreateWorkspace(), presenterSession:=presenterSession, items:={}, waitForPresentation:=True)
 
             GetMocks(controller).PresenterSession.Verify(Sub(p) p.Dismiss(), Times.Once)
         End Sub
 
         <WpfFact>
         Public Sub UpKeyShouldDismissWhenThereIsOnlyOneItem()
-            Dim controller = CreateController(items:=CreateItems(1), waitForPresentation:=True)
+            Dim controller = CreateController(CreateWorkspace(), items:=CreateItems(1), waitForPresentation:=True)
 
             GetMocks(controller).PresenterSession.Setup(Sub(p) p.Dismiss())
 
@@ -69,7 +69,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
         <WpfFact>
         Public Sub UpKeyShouldNavigateWhenThereAreMultipleItems()
-            Dim controller = CreateController(items:=CreateItems(2), waitForPresentation:=True)
+            Dim controller = CreateController(CreateWorkspace(), items:=CreateItems(2), waitForPresentation:=True)
 
             GetMocks(controller).PresenterSession.Setup(Sub(p) p.SelectPreviousItem())
 
@@ -89,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             slowProvider.Setup(Function(p) p.IsRetriggerCharacter(" "c)).Returns(True)
             slowProvider.Setup(Function(p) p.GetItemsAsync(It.IsAny(Of Document), It.IsAny(Of Integer), It.IsAny(Of SignatureHelpTriggerInfo), options, It.IsAny(Of CancellationToken))) _
                 .Returns(Task.FromResult(New SignatureHelpItems(CreateItems(2), TextSpan.FromBounds(0, 0), selectedItem:=0, argumentIndex:=0, argumentCount:=0, argumentName:=Nothing)))
-            Dim controller = CreateController(provider:=slowProvider.Object, waitForPresentation:=True)
+            Dim controller = CreateController(CreateWorkspace(), provider:=slowProvider.Object, waitForPresentation:=True)
 
             ' Now force an update to the model that will result in stopping the session
             slowProvider.Setup(Function(p) p.GetItemsAsync(It.IsAny(Of Document), It.IsAny(Of Integer), It.IsAny(Of SignatureHelpTriggerInfo), options, It.IsAny(Of CancellationToken))) _
@@ -111,7 +111,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Sub DownKeyShouldNotBlockOnModelComputation()
             Dim options = New SignatureHelpOptions()
             Dim mre = New ManualResetEvent(False)
-            Dim controller = CreateController(items:=CreateItems(2), waitForPresentation:=False)
+            Dim controller = CreateController(CreateWorkspace(), items:=CreateItems(2), waitForPresentation:=False)
             Dim slowProvider = New Mock(Of ISignatureHelpProvider)(MockBehavior.Strict)
             slowProvider.Setup(Function(p) p.GetItemsAsync(It.IsAny(Of Document), It.IsAny(Of Integer), It.IsAny(Of SignatureHelpTriggerInfo), Options, It.IsAny(Of CancellationToken))) _
                 .Returns(Function()
@@ -131,7 +131,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Sub UpKeyShouldNotBlockOnModelComputation()
             Dim options = New SignatureHelpOptions()
             Dim mre = New ManualResetEvent(False)
-            Dim controller = CreateController(items:=CreateItems(2), waitForPresentation:=False)
+            Dim controller = CreateController(CreateWorkspace(), items:=CreateItems(2), waitForPresentation:=False)
             Dim slowProvider = New Mock(Of ISignatureHelpProvider)(MockBehavior.Strict)
             slowProvider.Setup(Function(p) p.GetItemsAsync(It.IsAny(Of Document), It.IsAny(Of Integer), It.IsAny(Of SignatureHelpTriggerInfo), options, It.IsAny(Of CancellationToken))) _
                 .Returns(Function()
@@ -149,9 +149,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
         <WpfFact, WorkItem(179726, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workItems?id=179726&_a=edit")>
         Public Async Function UpKeyShouldBlockOnRecomputationAfterPresentation() As Task
-            Dim exportProvider = EditorTestCompositions.EditorFeatures.ExportProviderFactory.CreateExportProvider()
-            Dim threadingContext = exportProvider.GetExportedValue(Of IThreadingContext)()
             Dim options = New SignatureHelpOptions()
+            Dim workspace = CreateWorkspace()
+            Dim threadingContext = workspace.GetService(Of IThreadingContext)()
 
             Dim worker = Async Function()
                              Dim slowProvider = New Mock(Of ISignatureHelpProvider)(MockBehavior.Strict)
@@ -161,7 +161,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                  .Returns(Task.FromResult(New SignatureHelpItems(CreateItems(2), TextSpan.FromBounds(0, 0), selectedItem:=0, argumentIndex:=0, argumentCount:=0, argumentName:=Nothing)))
 
                              Await threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync()
-                             Dim controller = CreateController(provider:=slowProvider.Object, waitForPresentation:=True)
+                             Dim controller = CreateController(workspace, provider:=slowProvider.Object, waitForPresentation:=True)
 
                              ' Update session so that providers are requeried.
                              ' SlowProvider now blocks on the checkpoint's task.
@@ -199,7 +199,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
         <WpfFact>
         Public Sub DownKeyShouldNavigateWhenThereAreMultipleItems()
-            Dim controller = CreateController(items:=CreateItems(2), waitForPresentation:=True)
+            Dim controller = CreateController(CreateWorkspace(), items:=CreateItems(2), waitForPresentation:=True)
 
             GetMocks(controller).PresenterSession.Setup(Sub(p) p.SelectNextItem())
 
@@ -213,7 +213,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         <WpfFact>
         Public Sub UpAndDownKeysShouldStillNavigateWhenDuplicateItemsAreFiltered()
             Dim item = CreateItems(1).Single()
-            Dim controller = CreateController(items:={item, item}, waitForPresentation:=True)
+            Dim controller = CreateController(CreateWorkspace(), items:={item, item}, waitForPresentation:=True)
 
             GetMocks(controller).PresenterSession.Setup(Sub(p) p.Dismiss())
 
@@ -225,7 +225,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
         <WpfFact>
         Public Sub CaretMoveWithActiveSessionShouldRecomputeModel()
-            Dim controller = CreateController(waitForPresentation:=True)
+            Dim controller = CreateController(CreateWorkspace(), waitForPresentation:=True)
 
             Mock.Get(GetMocks(controller).View.Object.Caret).Raise(Sub(c) AddHandler c.PositionChanged, Nothing, New CaretPositionChangedEventArgs(Nothing, Nothing, Nothing))
             controller.WaitForController()
@@ -236,7 +236,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
         <WpfFact>
         Public Sub RetriggerActiveSessionOnClosingBrace()
-            Dim controller = CreateController(waitForPresentation:=True)
+            Dim controller = CreateController(CreateWorkspace(), waitForPresentation:=True)
 
             DirectCast(controller, IChainedCommandHandler(Of TypeCharCommandArgs)).ExecuteCommand(
                 New TypeCharCommandArgs(CreateMock(Of ITextView), CreateMock(Of ITextBuffer), ")"c),
@@ -249,7 +249,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
 
         <WpfFact, WorkItem(959116, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/959116")>
         Public Sub TypingNonTriggerCharacterShouldNotRequestDocument()
-            Dim controller = CreateController(triggerSession:=False)
+            Dim controller = CreateController(CreateWorkspace(), triggerSession:=False)
 
             DirectCast(controller, IChainedCommandHandler(Of TypeCharCommandArgs)).ExecuteCommand(
                 New TypeCharCommandArgs(CreateMock(Of ITextView), CreateMock(Of ITextBuffer), "a"c),
@@ -265,19 +265,23 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Return result
         End Function
 
-        Private Shared Function CreateController(Optional documentProvider As Mock(Of IDocumentProvider) = Nothing,
-                                                 Optional presenterSession As Mock(Of ISignatureHelpPresenterSession) = Nothing,
-                                                 Optional items As IList(Of SignatureHelpItem) = Nothing,
-                                                 Optional provider As ISignatureHelpProvider = Nothing,
-                                                 Optional waitForPresentation As Boolean = False,
-                                                 Optional triggerSession As Boolean = True) As Controller
-            Dim workspace = TestWorkspace.CreateWorkspace(
+        Private Shared Function CreateWorkspace() As TestWorkspace
+            Return TestWorkspace.CreateWorkspace(
                 <Workspace>
                     <Project Language="C#">
                         <Document>
                         </Document>
                     </Project>
-                </Workspace>)
+                </Workspace>, composition:=EditorTestCompositions.EditorFeatures)
+        End Function
+
+        Private Shared Function CreateController(workspace As TestWorkspace,
+                                                 Optional documentProvider As Mock(Of IDocumentProvider) = Nothing,
+                                                 Optional presenterSession As Mock(Of ISignatureHelpPresenterSession) = Nothing,
+                                                 Optional items As IList(Of SignatureHelpItem) = Nothing,
+                                                 Optional provider As ISignatureHelpProvider = Nothing,
+                                                 Optional waitForPresentation As Boolean = False,
+                                                 Optional triggerSession As Boolean = True) As Controller
             Dim document = workspace.CurrentSolution.GetDocument(workspace.Documents.Single().Id)
 
             Dim threadingContext = workspace.GetService(Of IThreadingContext)

--- a/src/EditorFeatures/Test2/PasteTracking/PasteTrackingTestState.vb
+++ b/src/EditorFeatures/Test2/PasteTracking/PasteTrackingTestState.vb
@@ -21,20 +21,12 @@ Namespace Microsoft.CodeAnalysis.PasteTracking
 
         Public ReadOnly Property Workspace As TestWorkspace
 
-        Public Sub New(workspaceElement As XElement, Optional exportProvider As ExportProvider = Nothing)
-            Workspace = TestWorkspace.CreateWorkspace(workspaceElement, exportProvider:=exportProvider)
-            PasteTrackingService = GetExportedValue(Of PasteTrackingService)()
-            PasteTrackingPasteCommandHandler = GetExportedValue(Of PasteTrackingPasteCommandHandler)()
-            FormatCommandHandler = GetExportedValue(Of FormatCommandHandler)()
+        Public Sub New(workspaceElement As XElement, Optional composition As TestComposition = Nothing)
+            Workspace = TestWorkspace.CreateWorkspace(workspaceElement, composition:=composition)
+            PasteTrackingService = Workspace.GetService(Of PasteTrackingService)()
+            PasteTrackingPasteCommandHandler = Workspace.GetService(Of PasteTrackingPasteCommandHandler)()
+            FormatCommandHandler = Workspace.GetService(Of FormatCommandHandler)()
         End Sub
-
-        Public Function GetService(Of T)() As T
-            Return Workspace.GetService(Of T)()
-        End Function
-
-        Public Function GetExportedValue(Of T)() As T
-            Return Workspace.ExportProvider.GetExportedValue(Of T)()
-        End Function
 
         Public Function OpenDocument(projectName As String, fileName As String) As TestHostDocument
             Dim hostDocument = Workspace.Documents.FirstOrDefault(Function(document) document.Project.Name = projectName AndAlso document.Name = fileName)
@@ -60,7 +52,7 @@ Namespace Microsoft.CodeAnalysis.PasteTracking
 
         Public Sub InsertText(hostDocument As TestHostDocument, insertedText As String)
             Dim textView = hostDocument.GetTextView()
-            Dim editorOperations = GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(textView)
+            Dim editorOperations = Workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(textView)
 
             editorOperations.InsertText(insertedText)
         End Sub
@@ -70,7 +62,7 @@ Namespace Microsoft.CodeAnalysis.PasteTracking
             Dim caretPosition = textView.Caret.Position.BufferPosition.Position
             Dim trackingSpan = textView.TextSnapshot.CreateTrackingSpan(caretPosition, 0, SpanTrackingMode.EdgeInclusive)
 
-            Dim editorOperations = GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(textView)
+            Dim editorOperations = Workspace.GetService(Of IEditorOperationsFactoryService)().GetEditorOperations(textView)
             Dim insertAction As Action = Sub() editorOperations.InsertText(pastedText)
 
             Dim pasteCommandArgs = New PasteCommandArgs(textView, textView.TextBuffer)

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractArgumentProviderTests`1.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractArgumentProviderTests`1.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.Completion
         {
             using var workspaceFixture = GetOrCreateWorkspaceFixture();
 
-            var workspace = workspaceFixture.Target.GetWorkspace(markup, ExportProvider);
+            var workspace = workspaceFixture.Target.GetWorkspace(markup, GetComposition());
             var code = workspaceFixture.Target.Code;
             var position = workspaceFixture.Target.Position;
 

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -45,7 +45,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         private readonly TestFixtureHelper<TWorkspaceFixture> _fixtureHelper = new();
 
         protected readonly Mock<ICompletionSession> MockCompletionSession;
-        private ExportProvider _lazyExportProvider;
 
         protected bool? ShowTargetTypedCompletionFilter { get; set; }
         protected bool? TypeImportCompletionFeatureFlag { get; set; }
@@ -90,9 +89,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
             return options;
         }
-
-        protected ExportProvider ExportProvider
-            => _lazyExportProvider ??= GetComposition().ExportProviderFactory.CreateExportProvider();
 
         protected virtual TestComposition GetComposition()
             => s_baseComposition.AddParts(GetCompletionProviderType());
@@ -254,7 +250,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             {
                 using var workspaceFixture = GetOrCreateWorkspaceFixture();
 
-                var workspace = workspaceFixture.Target.GetWorkspace(markup, ExportProvider);
+                var workspace = workspaceFixture.Target.GetWorkspace(markup, GetComposition());
                 var code = workspaceFixture.Target.Code;
                 var position = workspaceFixture.Target.Position;
 
@@ -273,7 +269,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         protected async Task<CompletionList> GetCompletionListAsync(string markup, string workspaceKind = null)
         {
             using var workspaceFixture = GetOrCreateWorkspaceFixture();
-            var workspace = workspaceFixture.Target.GetWorkspace(markup, ExportProvider, workspaceKind: workspaceKind);
+            var workspace = workspaceFixture.Target.GetWorkspace(markup, GetComposition(), workspaceKind: workspaceKind);
 
             // Set options that are not CompletionOptions
             NonCompletionOptions?.SetGlobalOptions(workspace.GlobalOptions);
@@ -288,7 +284,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         protected async Task VerifyCustomCommitProviderAsync(string markupBeforeCommit, string itemToCommit, string expectedCodeAfterCommit, SourceCodeKind? sourceCodeKind = null, char? commitChar = null)
         {
             using var workspaceFixture = GetOrCreateWorkspaceFixture();
-            using (workspaceFixture.Target.GetWorkspace(markupBeforeCommit, ExportProvider))
+            using (workspaceFixture.Target.GetWorkspace(markupBeforeCommit, GetComposition()))
             {
                 var code = workspaceFixture.Target.Code;
                 var position = workspaceFixture.Target.Position;
@@ -314,7 +310,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         {
             using var workspaceFixture = GetOrCreateWorkspaceFixture();
 
-            workspaceFixture.Target.GetWorkspace(markupBeforeCommit, ExportProvider);
+            workspaceFixture.Target.GetWorkspace(markupBeforeCommit, GetComposition());
 
             var code = workspaceFixture.Target.Code;
             var position = workspaceFixture.Target.Position;
@@ -420,7 +416,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         {
             using var workspaceFixture = GetOrCreateWorkspaceFixture();
 
-            workspaceFixture.Target.GetWorkspace(ExportProvider);
+            workspaceFixture.Target.GetWorkspace(GetComposition());
             var document1 = workspaceFixture.Target.UpdateDocument(code, sourceCodeKind);
 
             await CheckResultsAsync(
@@ -805,7 +801,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         private async Task VerifyItemWithReferenceWorkerAsync(
             string xmlString, string expectedItem, int expectedSymbols)
         {
-            using (var testWorkspace = TestWorkspace.Create(xmlString, exportProvider: ExportProvider))
+            using (var testWorkspace = TestWorkspace.Create(xmlString, composition: GetComposition()))
             {
                 var position = testWorkspace.Documents.Single(d => d.Name == "SourceDocument").CursorPosition.Value;
                 var solution = testWorkspace.CurrentSolution;
@@ -863,7 +859,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         private async Task VerifyItemWithMscorlib45WorkerAsync(
             string xmlString, string expectedItem, string expectedDescription)
         {
-            using (var testWorkspace = TestWorkspace.Create(xmlString, exportProvider: ExportProvider))
+            using (var testWorkspace = TestWorkspace.Create(xmlString, composition: GetComposition()))
             {
                 var position = testWorkspace.Documents.Single(d => d.Name == "SourceDocument").CursorPosition.Value;
                 var solution = testWorkspace.CurrentSolution;
@@ -894,7 +890,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         protected async Task VerifyItemInLinkedFilesAsync(string xmlString, string expectedItem, string expectedDescription)
         {
-            using (var testWorkspace = TestWorkspace.Create(xmlString, exportProvider: ExportProvider))
+            using (var testWorkspace = TestWorkspace.Create(xmlString, composition: GetComposition()))
             {
                 var position = testWorkspace.Documents.First().CursorPosition.Value;
                 var solution = testWorkspace.CurrentSolution;
@@ -1125,7 +1121,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         {
             using var workspaceFixture = GetOrCreateWorkspaceFixture();
 
-            workspaceFixture.Target.GetWorkspace(markup, ExportProvider);
+            workspaceFixture.Target.GetWorkspace(markup, GetComposition());
             var code = workspaceFixture.Target.Code;
             var position = workspaceFixture.Target.Position;
             var document = workspaceFixture.Target.UpdateDocument(code, sourceCodeKind);

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -365,6 +365,7 @@ namespace Roslyn.Test.Utilities
 
             workspace.GetService<LspWorkspaceRegistrationService>().Register(workspace);
 
+            // solution crawler is currently required in order to create incremental analyzer that provides diagnostics
             var solutionCrawlerRegistrationService = (SolutionCrawlerRegistrationService)workspace.Services.GetRequiredService<ISolutionCrawlerRegistrationService>();
             solutionCrawlerRegistrationService.Register(workspace);
 

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -303,15 +303,12 @@ namespace Roslyn.Test.Utilities
         {
             var lspOptions = initializationOptions ?? new InitializationOptions();
 
-            var workspace = languageName switch
-            {
-                LanguageNames.CSharp => TestWorkspace.CreateCSharp(markups, lspOptions.SourceGeneratedMarkups, composition: Composition),
-                LanguageNames.VisualBasic => TestWorkspace.CreateVisualBasic(markups, lspOptions.SourceGeneratedMarkups, composition: Composition),
-                _ => throw new ArgumentException($"language name {languageName} is not valid for a test workspace"),
-            };
+            var workspace = new TestWorkspace(Composition);
 
             var workspaceConfigurationService = workspace.GetService<TestWorkspaceConfigurationService>();
             workspaceConfigurationService.Options = new WorkspaceConfigurationOptions(EnableOpeningSourceGeneratedFiles: true);
+
+            workspace.InitializeDocuments(TestWorkspace.CreateWorkspaceElement(languageName, files: markups, sourceGeneratedFiles: lspOptions.SourceGeneratedMarkups), openDocuments: false);
 
             lspOptions.OptionUpdater?.Invoke(workspace.GetService<IGlobalOptionService>());
 

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -47,7 +47,6 @@ namespace Roslyn.Test.Utilities
         private static readonly TestComposition s_composition = EditorTestCompositions.LanguageServerProtocol
             .AddParts(typeof(TestDocumentTrackingService))
             .AddParts(typeof(TestWorkspaceRegistrationService))
-            .AddParts(typeof(TestWorkspaceConfigurationService))
             .RemoveParts(typeof(MockWorkspaceEventListenerProvider));
 
         private class TestSpanMapperProvider : IDocumentServiceProvider
@@ -303,10 +302,7 @@ namespace Roslyn.Test.Utilities
         {
             var lspOptions = initializationOptions ?? new InitializationOptions();
 
-            var workspace = new TestWorkspace(Composition);
-
-            var workspaceConfigurationService = workspace.GetService<TestWorkspaceConfigurationService>();
-            workspaceConfigurationService.Options = new WorkspaceConfigurationOptions(EnableOpeningSourceGeneratedFiles: true);
+            var workspace = new TestWorkspace(Composition, configurationOptions: new WorkspaceConfigurationOptions(EnableOpeningSourceGeneratedFiles: true));
 
             workspace.InitializeDocuments(TestWorkspace.CreateWorkspaceElement(languageName, files: markups, sourceGeneratedFiles: lspOptions.SourceGeneratedMarkups), openDocuments: false);
 
@@ -356,10 +352,7 @@ namespace Roslyn.Test.Utilities
 
             var workspace = TestWorkspace.Create(XElement.Parse(xmlContent), openDocuments: false, composition: Composition, workspaceKind: workspaceKind);
 
-            if (lspOptions.OptionUpdater != null)
-            {
-                lspOptions.OptionUpdater(workspace.GetService<IGlobalOptionService>());
-            }
+            lspOptions.OptionUpdater?.Invoke(workspace.GetService<IGlobalOptionService>());
 
             workspace.TryApplyChanges(workspace.CurrentSolution.WithAnalyzerReferences(new[] { TestAnalyzerReferences }));
 

--- a/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
+++ b/src/EditorFeatures/TestUtilities/NavigateTo/AbstractNavigateToTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo
         internal static readonly PatternMatch s_emptyCamelCaseNonContiguousSubstringPatternMatch_NotCaseSensitive = new PatternMatch(PatternMatchKind.CamelCaseNonContiguousSubstring, true, false, ImmutableArray<Span>.Empty);
         internal static readonly PatternMatch s_emptyFuzzyPatternMatch_NotCaseSensitive = new PatternMatch(PatternMatchKind.Fuzzy, true, false, ImmutableArray<Span>.Empty);
 
-        protected abstract TestWorkspace CreateWorkspace(string content, ExportProvider exportProvider);
+        protected abstract TestWorkspace CreateWorkspace(string content, TestComposition composition);
         protected abstract string Language { get; }
 
         public enum Composition
@@ -130,9 +130,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo
             TestHost testHost,
             TestComposition composition)
         {
-            var exportProvider = composition.WithTestHostParts(testHost).ExportProviderFactory.CreateExportProvider();
+            composition = composition.WithTestHostParts(testHost);
 
-            var workspace = TestWorkspace.Create(workspaceElement, exportProvider: exportProvider);
+            var workspace = TestWorkspace.Create(workspaceElement, composition: composition);
             InitializeWorkspace(workspace);
             return workspace;
         }
@@ -142,9 +142,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo
             TestHost testHost,
             TestComposition composition)
         {
-            var exportProvider = composition.WithTestHostParts(testHost).ExportProviderFactory.CreateExportProvider();
+            composition = composition.WithTestHostParts(testHost);
 
-            var workspace = CreateWorkspace(content, exportProvider);
+            var workspace = CreateWorkspace(content, composition);
             InitializeWorkspace(workspace);
             return workspace;
         }

--- a/src/EditorFeatures/TestUtilities/Workspaces/CSharpTestWorkspaceFixture.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/CSharpTestWorkspaceFixture.cs
@@ -6,18 +6,20 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Composition;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 {
     public class CSharpTestWorkspaceFixture : TestWorkspaceFixture
     {
-        protected override TestWorkspace CreateWorkspace(ExportProvider exportProvider = null)
+        protected override TestWorkspace CreateWorkspace(TestComposition composition = null)
         {
-            return TestWorkspace.CreateCSharp2(
-                new string[] { string.Empty, },
-                new CSharpParseOptions[] { new CSharpParseOptions(kind: SourceCodeKind.Regular), },
-                exportProvider: exportProvider);
+            return TestWorkspace.CreateWithSingleEmptySourceFile(
+                LanguageNames.CSharp,
+                compilationOptions: null,
+                parseOptions: new CSharpParseOptions(kind: SourceCodeKind.Regular),
+                composition: composition);
         }
     }
 }

--- a/src/EditorFeatures/TestUtilities/Workspaces/InteractiveCSharpTestWorkspaceFixture.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/InteractiveCSharpTestWorkspaceFixture.cs
@@ -5,25 +5,28 @@
 #nullable disable
 
 using System.Xml.Linq;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Composition;
+using static Microsoft.CodeAnalysis.Editor.UnitTests.NavigateTo.AbstractNavigateToTests;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 {
     public class InteractiveCSharpTestWorkspaceFixture : CSharpTestWorkspaceFixture
     {
-        internal static TestWorkspace CreateInteractiveWorkspace(string fileContent, ExportProvider exportProvider)
+        internal static TestWorkspace CreateInteractiveWorkspace(string fileContent, TestComposition composition)
         {
             var workspaceDefinition = $@"
 <Workspace>
     <Submission Language=""C#"" CommonReferences=""true"">
-<![CDATA[{fileContent}]]>
+<![CDATA[
+            {fileContent}]]>
     </Submission>
 </Workspace>
 ";
-            return TestWorkspace.Create(XElement.Parse(workspaceDefinition), exportProvider: exportProvider, workspaceKind: WorkspaceKind.Interactive);
+            return TestWorkspace.Create(XElement.Parse(workspaceDefinition), composition: composition, workspaceKind: WorkspaceKind.Interactive);
         }
 
-        protected override TestWorkspace CreateWorkspace(ExportProvider exportProvider = null)
-            => CreateInteractiveWorkspace(fileContent: "", exportProvider);
+        protected override TestWorkspace CreateWorkspace(TestComposition composition = null)
+            => CreateInteractiveWorkspace(fileContent: "", composition);
     }
 }

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -111,15 +111,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             _metadataAsSourceFileService = ExportProvider.GetExportedValues<IMetadataAsSourceFileService>().FirstOrDefault();
         }
 
-        private static HostServices GetHostServices([NotNull] ref TestComposition? composition, bool disablePartialSolutions)
+        private static HostServices GetHostServices([NotNull] ref TestComposition? composition)
         {
             composition ??= EditorTestCompositions.EditorFeatures;
-
-            if (disablePartialSolutions)
-            {
-                composition = composition.AddParts(typeof(WorkpacePartialSolutionsTestHook));
-            }
-
             return composition.GetHostServices();
         }
 

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             Guid solutionTelemetryId = default,
             bool disablePartialSolutions = true,
             bool ignoreUnchangeableDocumentsWhenApplyingChanges = true)
-            : base(GetHostServices(ref composition, disablePartialSolutions), workspaceKind ?? WorkspaceKind.Host)
+            : base(GetHostServices(ref composition), workspaceKind ?? WorkspaceKind.Host)
         {
             SetCurrentSolution(CreateSolution(SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Create()).WithTelemetryId(solutionTelemetryId)));
 

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspaceFixture.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspaceFixture.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Text;
 using Roslyn.Test.Utilities;
@@ -25,13 +26,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
         public TestHostDocument CurrentDocument => _currentDocument ?? _workspace.Documents.Single();
 
-        public TestWorkspace GetWorkspace(ExportProvider exportProvider = null)
+        public TestWorkspace GetWorkspace(TestComposition composition = null)
         {
-            _workspace = _workspace ?? CreateWorkspace(exportProvider);
+            _workspace ??= CreateWorkspace(composition);
             return _workspace;
         }
 
-        public TestWorkspace GetWorkspace(string markup, ExportProvider exportProvider = null, string workspaceKind = null)
+        public TestWorkspace GetWorkspace(string markup, TestComposition composition = null, string workspaceKind = null)
         {
             // If it looks like XML, we'll treat it as XML; any parse error would be rejected and will throw.
             // We'll do a case insensitive search here so if somebody has a lowercase W it'll be tried (and
@@ -41,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 CloseTextView();
                 _workspace?.Dispose();
 
-                _workspace = TestWorkspace.CreateWorkspace(XElement.Parse(markup), exportProvider: exportProvider, workspaceKind: workspaceKind);
+                _workspace = TestWorkspace.CreateWorkspace(XElement.Parse(markup), composition: composition, workspaceKind: workspaceKind);
                 _currentDocument = _workspace.Documents.First(d => d.CursorPosition.HasValue);
                 Position = _currentDocument.CursorPosition.Value;
                 Code = _currentDocument.GetTextBuffer().CurrentSnapshot.GetText();
@@ -50,13 +51,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             else
             {
                 MarkupTestFile.GetPosition(markup.NormalizeLineEndings(), out Code, out Position);
-                var workspace = GetWorkspace(exportProvider);
+                var workspace = GetWorkspace(composition);
                 _currentDocument = workspace.Documents.Single();
                 return workspace;
             }
         }
 
-        protected abstract TestWorkspace CreateWorkspace(ExportProvider exportProvider);
+        protected abstract TestWorkspace CreateWorkspace(TestComposition composition);
 
         public void Dispose()
         {

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
@@ -106,16 +106,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
         /// <param name="files">Can pass in multiple file contents: files will be named test1.cs, test2.cs, etc.</param>
         internal static TestWorkspace Create(
-            string language,
-            CompilationOptions compilationOptions,
-            ParseOptions parseOptions,
-            params string[] files)
-        {
-            return Create(language, compilationOptions, parseOptions, files);
-        }
-
-        /// <param name="files">Can pass in multiple file contents: files will be named test1.cs, test2.cs, etc.</param>
-        internal static TestWorkspace Create(
             string workspaceKind,
             string language,
             CompilationOptions compilationOptions,

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
@@ -13,6 +13,7 @@ using System.Xml.Linq;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.Composition;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 {
@@ -110,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             ParseOptions parseOptions,
             params string[] files)
         {
-            return Create(language, compilationOptions, parseOptions, files, exportProvider: null);
+            return Create(language, compilationOptions, parseOptions, files);
         }
 
         /// <param name="files">Can pass in multiple file contents: files will be named test1.cs, test2.cs, etc.</param>
@@ -121,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             ParseOptions parseOptions,
             params string[] files)
         {
-            return Create(language, compilationOptions, parseOptions, files, exportProvider: null, workspaceKind: workspaceKind);
+            return Create(language, compilationOptions, parseOptions, files, workspaceKind: workspaceKind);
         }
 
         internal static string GetDefaultTestSourceDocumentName(int index, string extension)
@@ -133,7 +134,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             ParseOptions parseOptions,
             string[] files,
             string[] sourceGeneratedFiles = null,
-            ExportProvider exportProvider = null,
             TestComposition composition = null,
             string[] metadataReferences = null,
             string workspaceKind = null,
@@ -144,48 +144,42 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             IDocumentServiceProvider documentServiceProvider = null)
         {
             var workspaceElement = CreateWorkspaceElement(language, compilationOptions, parseOptions, files, sourceGeneratedFiles, metadataReferences, extension, commonReferences, isMarkup);
-            return Create(workspaceElement, openDocuments, exportProvider, composition, workspaceKind, documentServiceProvider);
+            return Create(workspaceElement, openDocuments, composition, workspaceKind, documentServiceProvider);
         }
 
-        internal static TestWorkspace Create(
+        internal static TestWorkspace CreateWithSingleEmptySourceFile(
             string language,
             CompilationOptions compilationOptions,
-            ParseOptions[] parseOptions,
-            string[] files,
-            ExportProvider exportProvider)
+            ParseOptions parseOptions,
+            TestComposition composition)
         {
-            Debug.Assert(parseOptions == null || (files.Length == parseOptions.Length), "Please specify a parse option for each file.");
-
-            var documentElements = new List<XElement>();
-            var index = 0;
-            string extension;
-
-            for (var i = 0; i < files.Length; i++)
+            var documentElements = new[]
             {
-                if (language == LanguageNames.CSharp)
-                {
-                    extension = parseOptions[i].Kind == SourceCodeKind.Regular
-                        ? CSharpExtension
-                        : CSharpScriptExtension;
-                }
-                else if (language == LanguageNames.VisualBasic)
-                {
-                    extension = parseOptions[i].Kind == SourceCodeKind.Regular
-                        ? VisualBasicExtension
-                        : VisualBasicScriptExtension;
-                }
-                else
-                {
-                    extension = language;
-                }
-
-                documentElements.Add(CreateDocumentElement(files[i], GetDefaultTestSourceDocumentName(index++, extension), parseOptions?[i]));
-            }
+                CreateDocumentElement(code: "", filePath: GetDefaultTestSourceDocumentName(index: 0, GetSourceFileExtension(language, parseOptions)), parseOptions)
+            };
 
             var workspaceElement = CreateWorkspaceElement(
-                CreateProjectElement("Test", language, true, parseOptions.FirstOrDefault(), compilationOptions, documentElements));
+                CreateProjectElement("Test", language, commonReferences: true, parseOptions, compilationOptions, documentElements));
 
-            return Create(workspaceElement, exportProvider: exportProvider);
+            return Create(workspaceElement, composition: composition);
+        }
+
+        private static string GetSourceFileExtension(string language, ParseOptions parseOptions)
+        {
+            if (language == LanguageNames.CSharp)
+            {
+                return parseOptions.Kind == SourceCodeKind.Regular
+                    ? CSharpExtension
+                    : CSharpScriptExtension;
+            }
+            else if (language == LanguageNames.VisualBasic)
+            {
+                return parseOptions.Kind == SourceCodeKind.Regular
+                    ? VisualBasicExtension
+                    : VisualBasicScriptExtension;
+            }
+
+            throw ExceptionUtilities.UnexpectedValue(language);
         }
 
         #region C#
@@ -194,13 +188,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             string file,
             ParseOptions parseOptions = null,
             CompilationOptions compilationOptions = null,
-            ExportProvider exportProvider = null,
             TestComposition composition = null,
             string[] metadataReferences = null,
             bool isMarkup = true,
             bool openDocuments = false)
         {
-            return CreateCSharp(new[] { file }, Array.Empty<string>(), parseOptions, compilationOptions, exportProvider, composition, metadataReferences, isMarkup, openDocuments);
+            return CreateCSharp(new[] { file }, Array.Empty<string>(), parseOptions, compilationOptions, composition, metadataReferences, isMarkup, openDocuments);
         }
 
         public static TestWorkspace CreateCSharp(
@@ -208,22 +201,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             string[] sourceGeneratedFiles = null,
             ParseOptions parseOptions = null,
             CompilationOptions compilationOptions = null,
-            ExportProvider exportProvider = null,
             TestComposition composition = null,
             string[] metadataReferences = null,
             bool isMarkup = true,
             bool openDocuments = false)
         {
-            return Create(LanguageNames.CSharp, compilationOptions, parseOptions, files, sourceGeneratedFiles, exportProvider, composition, metadataReferences, isMarkup: isMarkup, openDocuments: openDocuments);
-        }
-
-        public static TestWorkspace CreateCSharp2(
-            string[] files,
-            ParseOptions[] parseOptions = null,
-            CompilationOptions compilationOptions = null,
-            ExportProvider exportProvider = null)
-        {
-            return Create(LanguageNames.CSharp, compilationOptions, parseOptions, files, exportProvider);
+            return Create(LanguageNames.CSharp, compilationOptions, parseOptions, files, sourceGeneratedFiles, composition, metadataReferences, isMarkup: isMarkup, openDocuments: openDocuments);
         }
 
         #endregion
@@ -234,12 +217,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             string file,
             ParseOptions parseOptions = null,
             CompilationOptions compilationOptions = null,
-            ExportProvider exportProvider = null,
             TestComposition composition = null,
             string[] metadataReferences = null,
             bool openDocuments = false)
         {
-            return CreateVisualBasic(new[] { file }, Array.Empty<string>(), parseOptions, compilationOptions, exportProvider, composition, metadataReferences, openDocuments);
+            return CreateVisualBasic(new[] { file }, Array.Empty<string>(), parseOptions, compilationOptions, composition, metadataReferences, openDocuments);
         }
 
         public static TestWorkspace CreateVisualBasic(
@@ -247,22 +229,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             string[] sourceGeneratedFiles = null,
             ParseOptions parseOptions = null,
             CompilationOptions compilationOptions = null,
-            ExportProvider exportProvider = null,
             TestComposition composition = null,
             string[] metadataReferences = null,
             bool openDocuments = false)
         {
-            return Create(LanguageNames.VisualBasic, compilationOptions, parseOptions, files, sourceGeneratedFiles, exportProvider, composition, metadataReferences, openDocuments: openDocuments);
-        }
-
-        /// <param name="files">Can pass in multiple file contents with individual source kind: files will be named test1.vb, test2.vbx, etc.</param>
-        public static TestWorkspace CreateVisualBasic(
-            string[] files,
-            ParseOptions[] parseOptions = null,
-            CompilationOptions compilationOptions = null,
-            ExportProvider exportProvider = null)
-        {
-            return Create(LanguageNames.VisualBasic, compilationOptions, parseOptions, files, exportProvider);
+            return Create(LanguageNames.VisualBasic, compilationOptions, parseOptions, files, sourceGeneratedFiles, composition, metadataReferences, openDocuments: openDocuments);
         }
 
         #endregion

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -58,29 +58,27 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 => RuntimeHelpers.GetHashCode(this);
         }
 
-        public static TestWorkspace Create(string xmlDefinition, bool openDocuments = false, ExportProvider exportProvider = null, TestComposition composition = null)
-            => Create(XElement.Parse(xmlDefinition), openDocuments, exportProvider, composition);
+        public static TestWorkspace Create(string xmlDefinition, bool openDocuments = false, TestComposition composition = null)
+            => Create(XElement.Parse(xmlDefinition), openDocuments, composition);
 
         public static TestWorkspace CreateWorkspace(
             XElement workspaceElement,
             bool openDocuments = true,
-            ExportProvider exportProvider = null,
             TestComposition composition = null,
             string workspaceKind = null)
         {
-            return Create(workspaceElement, openDocuments, exportProvider, composition, workspaceKind);
+            return Create(workspaceElement, openDocuments, composition, workspaceKind);
         }
 
         internal static TestWorkspace Create(
             XElement workspaceElement,
             bool openDocuments = true,
-            ExportProvider exportProvider = null,
             TestComposition composition = null,
             string workspaceKind = null,
             IDocumentServiceProvider documentServiceProvider = null,
             bool ignoreUnchangeableDocumentsWhenApplyingChanges = true)
         {
-            var workspace = new TestWorkspace(exportProvider, composition, workspaceKind, ignoreUnchangeableDocumentsWhenApplyingChanges: ignoreUnchangeableDocumentsWhenApplyingChanges);
+            var workspace = new TestWorkspace(composition, workspaceKind, ignoreUnchangeableDocumentsWhenApplyingChanges: ignoreUnchangeableDocumentsWhenApplyingChanges);
             workspace.InitializeDocuments(workspaceElement, openDocuments, documentServiceProvider);
             return workspace;
         }

--- a/src/EditorFeatures/TestUtilities/Workspaces/VisualBasicTestWorkspaceFixture.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/VisualBasicTestWorkspaceFixture.cs
@@ -8,6 +8,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.VisualStudio.Composition;
@@ -16,13 +17,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 {
     public class VisualBasicTestWorkspaceFixture : TestWorkspaceFixture
     {
-        protected override TestWorkspace CreateWorkspace(ExportProvider exportProvider = null)
+        protected override TestWorkspace CreateWorkspace(TestComposition composition = null)
         {
-            return TestWorkspace.CreateVisualBasic(
-                new string[] { string.Empty },
-                new VisualBasicParseOptions[] { new VisualBasicParseOptions(kind: SourceCodeKind.Regular) },
-                new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
-                exportProvider: exportProvider);
+            return TestWorkspace.CreateWithSingleEmptySourceFile(
+                LanguageNames.VisualBasic,
+                compilationOptions: new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+                parseOptions: new VisualBasicParseOptions(kind: SourceCodeKind.Regular),
+                composition: composition);
         }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
         Inherits AbstractCompletionProviderTests(Of VisualBasicTestWorkspaceFixture)
 
         Protected Overrides Function CreateWorkspace(fileContents As String) As TestWorkspace
-            Return TestWorkspace.CreateVisualBasic(fileContents, exportProvider:=ExportProvider)
+            Return TestWorkspace.CreateVisualBasic(fileContents, composition:=GetComposition())
         End Function
 
         Friend Overrides Function GetCompletionService(project As Project) As CompletionService
@@ -111,7 +111,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
 
         Protected Async Function VerifySendEnterThroughToEditorAsync(
                 initialMarkup As String, textTypedSoFar As String, expected As Boolean, Optional sourceCodeKind As SourceCodeKind = SourceCodeKind.Regular) As Task
-            Using workspace = TestWorkspace.CreateVisualBasic(initialMarkup, exportProvider:=ExportProvider)
+            Using workspace = TestWorkspace.CreateVisualBasic(initialMarkup, composition:=GetComposition())
                 Dim hostDocument = workspace.DocumentWithCursor
                 workspace.OnDocumentSourceCodeKindChanged(hostDocument.Id, sourceCodeKind)
                 Dim documentId = workspace.GetDocumentId(hostDocument)

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
@@ -415,7 +415,7 @@ Class C
     End Sub
 End Class]]></a>.Value.NormalizeLineEndings()
 
-            Using workspace = TestWorkspace.Create(LanguageNames.VisualBasic, New VisualBasicCompilationOptions(OutputKind.ConsoleApplication), New VisualBasicParseOptions(), {text}, exportProvider:=ExportProvider)
+            Using workspace = TestWorkspace.Create(LanguageNames.VisualBasic, New VisualBasicCompilationOptions(OutputKind.ConsoleApplication), New VisualBasicParseOptions(), {text}, composition:=GetComposition())
                 Dim called = False
 
                 Dim hostDocument = workspace.DocumentWithCursor

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ImplementsClauseCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ImplementsClauseCompletionProviderTests.vb
@@ -620,7 +620,7 @@ End Interface
                     </Project>
                 </Workspace>
 
-            Using workspace = TestWorkspace.Create(element, exportProvider:=ExportProvider)
+            Using workspace = TestWorkspace.Create(element, composition:=GetComposition())
                 Dim position = workspace.Documents.Single().CursorPosition.Value
                 Dim document = workspace.CurrentSolution.GetDocument(workspace.Documents.Single().Id)
                 Dim service = GetCompletionService(document.Project)

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.vb
@@ -446,7 +446,7 @@ End Program</Document>
                            </Project>
                        </Workspace>
 
-            Using workspace = TestWorkspace.Create(text, exportProvider:=ExportProvider)
+            Using workspace = TestWorkspace.Create(text, composition:=GetComposition())
                 Dim hostDocument = workspace.Documents.First()
                 Dim caretPosition = hostDocument.CursorPosition.Value
                 Dim document = workspace.CurrentSolution.GetDocument(hostDocument.Id)

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
@@ -1847,7 +1847,7 @@ public class C
                            </Project>
                        </Workspace>
 
-            Using workspace = TestWorkspace.Create(text, exportProvider:=ExportProvider)
+            Using workspace = TestWorkspace.Create(text, composition:=GetComposition())
                 Dim hostDocument = workspace.Documents.First()
                 Dim caretPosition = hostDocument.CursorPosition.Value
                 Dim document = workspace.CurrentSolution.GetDocument(hostDocument.Id)

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.vb
@@ -362,7 +362,7 @@ End Class</a>
             MarkupTestFile.GetPosition(markup.NormalizedValue, code, position)
 
             Using workspaceFixture = New VisualBasicTestWorkspaceFixture()
-                workspaceFixture.GetWorkspace(ExportProvider)
+                workspaceFixture.GetWorkspace(GetComposition())
                 Dim document1 = workspaceFixture.UpdateDocument(code, SourceCodeKind.Regular)
 
                 Dim options As CompletionOptions

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -7651,7 +7651,7 @@ End Namespace
                     </Project>
                 </Workspace>
 
-            Using workspace = TestWorkspace.Create(input, exportProvider:=ExportProvider)
+            Using workspace = TestWorkspace.Create(input, composition:=GetComposition())
                 Dim document = workspace.CurrentSolution.GetDocument(workspace.DocumentWithCursor.Id)
                 Dim position = workspace.DocumentWithCursor.CursorPosition.Value
                 Await CheckResultsAsync(document, position, "InstanceMethod", expectedDescriptionOrNull:=Nothing, usePreviousCharAsTrigger:=False, checkForAbsence:=False,

--- a/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/NavigateTo/NavigateToTests.vb
@@ -22,8 +22,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.NavigateTo
 
         Protected Overrides ReadOnly Property Language As String = "vb"
 
-        Protected Overrides Function CreateWorkspace(content As String, exportProvider As ExportProvider) As TestWorkspace
-            Return TestWorkspace.CreateVisualBasic(content, exportProvider:=exportProvider)
+        Protected Overrides Function CreateWorkspace(content As String, composition As TestComposition) As TestWorkspace
+            Return TestWorkspace.CreateVisualBasic(content, composition:=composition)
         End Function
 
         <Theory>

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
             bool useProgress = false,
             bool includeTaskListItems = false)
         {
-            var optionService = testLspServer.TestWorkspace.ExportProvider.GetExportedValue<IGlobalOptionService>();
+            var optionService = testLspServer.TestWorkspace.GetService<IGlobalOptionService>();
             optionService.SetGlobalOption(new OptionKey(TaskListOptionsStorage.ComputeTaskListItemsForClosedFiles), includeTaskListItems);
             await testLspServer.WaitForDiagnosticsAsync();
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
@@ -30,19 +30,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
 
     public abstract class AbstractPullDiagnosticTestsBase : AbstractLanguageServerProtocolTests
     {
-        private protected override TestAnalyzerReferenceByLanguage TestAnalyzerReferences
+        private protected override TestAnalyzerReferenceByLanguage CreateTestAnalyzersReference()
         {
-            get
-            {
-                var builder = ImmutableDictionary.CreateBuilder<string, ImmutableArray<DiagnosticAnalyzer>>();
-                builder.Add(LanguageNames.CSharp, ImmutableArray.Create(
-                    DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.CSharp),
-                    new CSharpRemoveUnnecessaryImportsDiagnosticAnalyzer(),
-                    new CSharpRemoveUnnecessaryExpressionParenthesesDiagnosticAnalyzer()));
-                builder.Add(LanguageNames.VisualBasic, ImmutableArray.Create(DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.VisualBasic)));
-                builder.Add(InternalLanguageNames.TypeScript, ImmutableArray.Create<DiagnosticAnalyzer>(new MockTypescriptDiagnosticAnalyzer()));
-                return new(builder.ToImmutableDictionary());
-            }
+            var builder = ImmutableDictionary.CreateBuilder<string, ImmutableArray<DiagnosticAnalyzer>>();
+            builder.Add(LanguageNames.CSharp, ImmutableArray.Create(
+                DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.CSharp),
+                new CSharpRemoveUnnecessaryImportsDiagnosticAnalyzer(),
+                new CSharpRemoveUnnecessaryExpressionParenthesesDiagnosticAnalyzer()));
+            builder.Add(LanguageNames.VisualBasic, ImmutableArray.Create(DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.VisualBasic)));
+            builder.Add(InternalLanguageNames.TypeScript, ImmutableArray.Create<DiagnosticAnalyzer>(new MockTypescriptDiagnosticAnalyzer()));
+            return new(builder.ToImmutableDictionary());
         }
 
         protected override TestComposition Composition => base.Composition.AddParts(typeof(MockTypescriptDiagnosticAnalyzer));

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
@@ -19,8 +19,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics;
 public class AdditionalFileDiagnosticsTests : AbstractPullDiagnosticTestsBase
 {
     [Theory, CombinatorialData]
-    public async Task TestWorkspaceDiagnosticsReportsAdditionalFileDiagnostic(bool useVSDiagnostics)
+    public async Task TestWorkspaceDiagnosticsReportsAdditionalFileDiagnostic(bool useVSDiagnostics, [CombinatorialRange(0, 1000)] int iteration)
     {
+        _ = iteration;
         var workspaceXml =
 @$"<Workspace>
     <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj1"" FilePath=""C:\CSProj1.csproj"">

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
@@ -122,8 +122,10 @@ public class AdditionalFileDiagnosticsTests : AbstractPullDiagnosticTestsBase
 
     protected override TestComposition Composition => base.Composition.AddParts(typeof(MockAdditionalFileDiagnosticAnalyzer));
 
-    private protected override TestAnalyzerReferenceByLanguage TestAnalyzerReferences => new(ImmutableDictionary.Create<string, ImmutableArray<DiagnosticAnalyzer>>()
-        .Add(LanguageNames.CSharp, ImmutableArray.Create(DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.CSharp), new MockAdditionalFileDiagnosticAnalyzer())));
+    private protected override TestAnalyzerReferenceByLanguage CreateTestAnalyzersReference()
+        => new(ImmutableDictionary<string, ImmutableArray<DiagnosticAnalyzer>>.Empty.Add(LanguageNames.CSharp, ImmutableArray.Create(
+                DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.CSharp),
+                new MockAdditionalFileDiagnosticAnalyzer())));
 
     [DiagnosticAnalyzer(LanguageNames.CSharp), PartNotDiscoverable]
     private class MockAdditionalFileDiagnosticAnalyzer : DiagnosticAnalyzer

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
@@ -19,9 +19,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics;
 public class AdditionalFileDiagnosticsTests : AbstractPullDiagnosticTestsBase
 {
     [Theory, CombinatorialData]
-    public async Task TestWorkspaceDiagnosticsReportsAdditionalFileDiagnostic(bool useVSDiagnostics, [CombinatorialRange(0, 1000)] int iteration)
+    public async Task TestWorkspaceDiagnosticsReportsAdditionalFileDiagnostic(bool useVSDiagnostics)
     {
-        _ = iteration;
         var workspaceXml =
 @$"<Workspace>
     <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj1"" FilePath=""C:\CSProj1.csproj"">

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -32,12 +33,12 @@ public class AdditionalFileDiagnosticsTests : AbstractPullDiagnosticTestsBase
         await using var testLspServer = await CreateTestWorkspaceFromXmlAsync(workspaceXml, BackgroundAnalysisScope.FullSolution, useVSDiagnostics);
 
         var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics);
-        Assert.Equal(3, results.Length);
-
-        Assert.Empty(results[0].Diagnostics);
-        Assert.Equal(MockAdditionalFileDiagnosticAnalyzer.Id, results[1].Diagnostics.Single().Code);
-        Assert.Equal(@"C:\Test.txt", results[1].Uri.LocalPath);
-        Assert.Empty(results[2].Diagnostics);
+        AssertEx.Equal(new[]
+        {
+            @"C:\C.cs: []",
+            @$"C:\Test.txt: [{MockAdditionalFileDiagnosticAnalyzer.Id}]",
+            @"C:\CSProj1.csproj: []"
+        }, results.Select(r => $"{r.Uri.LocalPath}: [{string.Join(", ", r.Diagnostics.Select(d => d.Code?.Value?.ToString()))}]"));
 
         // Asking again should give us back an unchanged diagnostic.
         var results2 = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics, previousResults: CreateDiagnosticParamsFromPreviousReports(results));

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/WorkspaceProjectDiagnosticsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/WorkspaceProjectDiagnosticsTests.cs
@@ -63,8 +63,10 @@ public class WorkspaceProjectDiagnosticsTests : AbstractPullDiagnosticTestsBase
 
     protected override TestComposition Composition => base.Composition.AddParts(typeof(MockProjectDiagnosticAnalyzer));
 
-    private protected override TestAnalyzerReferenceByLanguage TestAnalyzerReferences => new(ImmutableDictionary.Create<string, ImmutableArray<DiagnosticAnalyzer>>()
-        .Add(LanguageNames.CSharp, ImmutableArray.Create(DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.CSharp), new MockProjectDiagnosticAnalyzer())));
+    private protected override TestAnalyzerReferenceByLanguage CreateTestAnalyzersReference()
+        => new(ImmutableDictionary<string, ImmutableArray<DiagnosticAnalyzer>>.Empty.Add(LanguageNames.CSharp, ImmutableArray.Create(
+            DiagnosticExtensions.GetCompilerDiagnosticAnalyzer(LanguageNames.CSharp),
+            new MockProjectDiagnosticAnalyzer())));
 
     [DiagnosticAnalyzer(LanguageNames.CSharp), PartNotDiscoverable]
     private class MockProjectDiagnosticAnalyzer : DiagnosticAnalyzer

--- a/src/Features/LanguageServer/ProtocolUnitTests/Miscellaneous/LspMiscellaneousFilesWorkspaceTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Miscellaneous/LspMiscellaneousFilesWorkspaceTests.cs
@@ -53,6 +53,10 @@ public class LspMiscellaneousFilesWorkspaceTests : AbstractLanguageServerProtoco
 
         // Create a server that supports LSP misc files and verify no misc files present.
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
+
+        var miscWorkspace = testLspServer.GetRequiredLspService<LspMiscellaneousFilesWorkspace>();
+        testLspServer.TestWorkspace.GetService<LspWorkspaceRegistrationService>().Register(miscWorkspace);
+
         Assert.Null(GetMiscellaneousDocument(testLspServer));
 
         var looseFileUri = new Uri(@"C:\SomeFile.cs");

--- a/src/Features/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
@@ -252,7 +252,7 @@ public class LspWorkspaceManagerTests : AbstractLanguageServerProtocolTests
         using var testWorkspaceTwo = TestWorkspace.Create(
             XElement.Parse(secondWorkspaceXml),
             workspaceKind: "OtherWorkspaceKind",
-            composition: Composition);
+            composition: testLspServer.TestWorkspace.Composition);
 
         // Wait for workspace creation operations for the second workspace to complete.
         await WaitForWorkspaceOperationsAsync(testWorkspaceTwo);
@@ -314,10 +314,8 @@ public class LspWorkspaceManagerTests : AbstractLanguageServerProtocolTests
 
         await using var testLspServer = await CreateXmlTestLspServerAsync(firstWorkspaceXml);
 
-        using var testWorkspaceTwo = TestWorkspace.Create(
-            XElement.Parse(secondWorkspaceXml),
-            workspaceKind: WorkspaceKind.MSBuild,
-            composition: Composition);
+        using var testWorkspaceTwo = CreateWorkspace(options: null, WorkspaceKind.MSBuild);
+        testWorkspaceTwo.InitializeDocuments(XElement.Parse(secondWorkspaceXml));
 
         // Wait for workspace creation operations to complete for the second workspace.
         await WaitForWorkspaceOperationsAsync(testWorkspaceTwo);
@@ -375,10 +373,8 @@ public class LspWorkspaceManagerTests : AbstractLanguageServerProtocolTests
 
         await using var testLspServer = await CreateXmlTestLspServerAsync(firstWorkspaceXml);
 
-        using var testWorkspaceTwo = TestWorkspace.Create(
-            XElement.Parse(secondWorkspaceXml),
-            workspaceKind: WorkspaceKind.MSBuild,
-            composition: Composition);
+        using var testWorkspaceTwo = CreateWorkspace(options: null, workspaceKind: WorkspaceKind.MSBuild);
+        testWorkspaceTwo.InitializeDocuments(XElement.Parse(secondWorkspaceXml));
 
         // Wait for workspace operations to complete for the second workspace.
         await WaitForWorkspaceOperationsAsync(testWorkspaceTwo);
@@ -423,7 +419,8 @@ public class LspWorkspaceManagerTests : AbstractLanguageServerProtocolTests
     </Project>
 </Workspace>";
 
-        using var testWorkspace = TestWorkspace.Create(XElement.Parse(workspaceXml), composition: Composition);
+        using var testWorkspace = CreateWorkspace(options: null, workspaceKind: null);
+        testWorkspace.InitializeDocuments(XElement.Parse(workspaceXml));
 
         // Wait for workspace creation operations to complete.
         await WaitForWorkspaceOperationsAsync(testWorkspace);

--- a/src/Features/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
@@ -249,19 +249,17 @@ public class LspWorkspaceManagerTests : AbstractLanguageServerProtocolTests
         // Verify 1 workspace registered to start with.
         Assert.True(IsWorkspaceRegistered(testLspServer.TestWorkspace, testLspServer));
 
-        var exportProvider = testLspServer.TestWorkspace.ExportProvider;
-
         using var testWorkspaceTwo = TestWorkspace.Create(
             XElement.Parse(secondWorkspaceXml),
             workspaceKind: "OtherWorkspaceKind",
-            exportProvider: exportProvider);
+            composition: Composition);
 
         // Wait for workspace creation operations for the second workspace to complete.
         await WaitForWorkspaceOperationsAsync(testWorkspaceTwo);
 
         // Manually register the workspace since the workspace listener does not listen for this workspace kind.
-        var workspaceRegistrationService = exportProvider.GetExport<LspWorkspaceRegistrationService>();
-        workspaceRegistrationService.Value.Register(testWorkspaceTwo);
+        var workspaceRegistrationService = testLspServer.TestWorkspace.GetService<LspWorkspaceRegistrationService>();
+        workspaceRegistrationService.Register(testWorkspaceTwo);
 
         // Verify both workspaces registered.
         Assert.True(IsWorkspaceRegistered(testLspServer.TestWorkspace, testLspServer));
@@ -315,12 +313,11 @@ public class LspWorkspaceManagerTests : AbstractLanguageServerProtocolTests
 </Workspace>";
 
         await using var testLspServer = await CreateXmlTestLspServerAsync(firstWorkspaceXml);
-        var exportProvider = testLspServer.TestWorkspace.ExportProvider;
 
         using var testWorkspaceTwo = TestWorkspace.Create(
             XElement.Parse(secondWorkspaceXml),
             workspaceKind: WorkspaceKind.MSBuild,
-            exportProvider: exportProvider);
+            composition: Composition);
 
         // Wait for workspace creation operations to complete for the second workspace.
         await WaitForWorkspaceOperationsAsync(testWorkspaceTwo);
@@ -378,12 +375,10 @@ public class LspWorkspaceManagerTests : AbstractLanguageServerProtocolTests
 
         await using var testLspServer = await CreateXmlTestLspServerAsync(firstWorkspaceXml);
 
-        var exportProvider = testLspServer.TestWorkspace.ExportProvider;
-
         using var testWorkspaceTwo = TestWorkspace.Create(
             XElement.Parse(secondWorkspaceXml),
             workspaceKind: WorkspaceKind.MSBuild,
-            exportProvider: exportProvider);
+            composition: Composition);
 
         // Wait for workspace operations to complete for the second workspace.
         await WaitForWorkspaceOperationsAsync(testWorkspaceTwo);

--- a/src/VisualStudio/CSharp/Test/DocumentOutline/DocumentOutlineTestsBase.cs
+++ b/src/VisualStudio/CSharp/Test/DocumentOutline/DocumentOutlineTestsBase.cs
@@ -67,7 +67,6 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.DocumentOutline
         private static readonly TestComposition s_composition = EditorTestCompositions.LanguageServerProtocol
             .AddParts(typeof(TestDocumentTrackingService))
             .AddParts(typeof(TestWorkspaceRegistrationService))
-            .AddParts(typeof(TestWorkspaceConfigurationService))
             .RemoveParts(typeof(MockWorkspaceEventListenerProvider));
 
         protected async Task<DocumentOutlineTestMocks> CreateMocksAsync(string code)


### PR DESCRIPTION
Test should pass in `TestComposition` and then they can ask the `TestWorkspace` for exported services.