### PR TITLE
Remove TextDocumentState.sourceText

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalDocumentState.cs
@@ -17,10 +17,9 @@ namespace Microsoft.CodeAnalysis
             HostWorkspaceServices solutionServices,
             IDocumentServiceProvider documentServiceProvider,
             DocumentInfo.DocumentAttributes attributes,
-            SourceText? sourceText,
             ITextAndVersionSource textAndVersionSource,
             LoadTextOptions loadTextOptions)
-            : base(solutionServices, documentServiceProvider, attributes, sourceText, textAndVersionSource, loadTextOptions)
+            : base(solutionServices, documentServiceProvider, attributes, textAndVersionSource, loadTextOptions)
         {
             _additionalText = new AdditionalTextWithState(this);
         }
@@ -51,7 +50,6 @@ namespace Microsoft.CodeAnalysis
                 this.solutionServices,
                 this.Services,
                 this.Attributes,
-                this.sourceText,
                 newTextSource,
                 this.LoadTextOptions);
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocumentState.cs
@@ -20,10 +20,9 @@ namespace Microsoft.CodeAnalysis
             HostWorkspaceServices solutionServices,
             IDocumentServiceProvider documentServiceProvider,
             DocumentInfo.DocumentAttributes attributes,
-            SourceText sourceTextOpt,
             ITextAndVersionSource textAndVersionSource,
             LoadTextOptions loadTextOptions)
-            : base(solutionServices, documentServiceProvider, attributes, sourceTextOpt, textAndVersionSource, loadTextOptions)
+            : base(solutionServices, documentServiceProvider, attributes, textAndVersionSource, loadTextOptions)
         {
             _analyzerConfigValueSource = CreateAnalyzerConfigValueSource();
         }
@@ -63,7 +62,6 @@ namespace Microsoft.CodeAnalysis
                 this.solutionServices,
                 this.Services,
                 this.Attributes,
-                this.sourceText,
                 newTextSource,
                 this.LoadTextOptions);
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1597,12 +1597,7 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentOutOfRangeException(nameof(mode));
             }
 
-            return UpdateDocumentTextLoader(documentId, loader, text: null, mode: mode);
-        }
-
-        internal Solution UpdateDocumentTextLoader(DocumentId documentId, TextLoader loader, SourceText? text, PreservationMode mode)
-        {
-            var newState = _state.UpdateDocumentTextLoader(documentId, loader, text, mode);
+            var newState = _state.UpdateDocumentTextLoader(documentId, loader, mode);
 
             // Note: state is currently not reused.
             // If UpdateDocumentTextLoader is changed to reuse the state replace this assert with Solution instance reusal.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1389,13 +1389,13 @@ namespace Microsoft.CodeAnalysis
             return UpdateDocumentState(oldDocument.UpdateSourceCodeKind(sourceCodeKind), textChanged: true);
         }
 
-        public SolutionState UpdateDocumentTextLoader(DocumentId documentId, TextLoader loader, SourceText? text, PreservationMode mode)
+        public SolutionState UpdateDocumentTextLoader(DocumentId documentId, TextLoader loader, PreservationMode mode)
         {
             var oldDocument = GetRequiredDocumentState(documentId);
 
             // Assumes that text has changed. User could have closed a doc without saving and we are loading text from closed file with
             // old content. Also this should make sure we don't re-use latest doc version with data associated with opened document.
-            return UpdateDocumentState(oldDocument.UpdateText(loader, text, mode), textChanged: true, recalculateDependentVersions: true);
+            return UpdateDocumentState(oldDocument.UpdateText(loader, mode), textChanged: true, recalculateDependentVersions: true);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis
             ITextAndVersionSource textSource,
             LoadTextOptions loadTextOptions,
             ValueSource<TreeAndVersion> treeSource)
-            : base(languageServices, solutionServices, documentServiceProvider, attributes, options, sourceText: null, textSource, loadTextOptions, treeSource)
+            : base(languageServices, solutionServices, documentServiceProvider, attributes, options, textSource, loadTextOptions, treeSource)
         {
             Identity = documentIdentity;
         }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -383,16 +383,9 @@ namespace Microsoft.CodeAnalysis
                 }
                 else
                 {
-                    // We don't have the old text or version.  And we don't want to retrieve them
-                    // just yet (as that would cause blocking in this synchronous method).  So just
-                    // make a simple loader to do that for us later when requested.
-                    //
+                    // We don't have the old text or version.  Rather than trying to reuse a version that we still have, let's just assume the file has changed.
                     // keep open document text alive by using PreserveIdentity
-                    //
-                    // Note: we pass along the newText here so that clients can easily get the text
-                    // of an opened document just by calling TryGetText without any blocking.
-                    currentSolution = oldSolution.UpdateDocumentTextLoader(documentId,
-                        new ReuseVersionLoader((DocumentState)oldDocument.State, newText), newText, PreservationMode.PreserveIdentity);
+                    currentSolution = oldSolution.WithDocumentText(documentId, newText, PreservationMode.PreserveValue);
                 }
 
                 var newSolution = this.SetCurrentSolution(currentSolution);
@@ -459,38 +452,6 @@ namespace Microsoft.CodeAnalysis
                 _ = RaiseDocumentClosedEventAsync(document).CompletesAsyncOperation(token);
                 token = _taskQueue.Listener.BeginAsyncOperation(TextDocumentClosedEventName);
                 _ = RaiseTextDocumentClosedEventAsync(document).CompletesAsyncOperation(token);
-            }
-        }
-
-        private sealed class ReuseVersionLoader : TextLoader
-        {
-            // Capture DocumentState instead of Document so that we don't hold onto the old solution.
-            private readonly DocumentState _oldDocumentState;
-            private readonly SourceText _newText;
-
-            public ReuseVersionLoader(DocumentState oldDocumentState, SourceText newText)
-            {
-                _oldDocumentState = oldDocumentState;
-                _newText = newText;
-            }
-
-            internal override string? FilePath
-                => _oldDocumentState.FilePath;
-
-            internal override async Task<TextAndVersion> LoadTextAndVersionAsync(LoadTextOptions options, CancellationToken cancellationToken)
-            {
-                var oldText = await _oldDocumentState.GetTextAsync(cancellationToken).ConfigureAwait(false);
-                var version = await _oldDocumentState.GetTextVersionAsync(cancellationToken).ConfigureAwait(false);
-
-                return GetProperTextAndVersion(oldText, _newText, version, _oldDocumentState.FilePath);
-            }
-
-            internal override TextAndVersion LoadTextAndVersionSynchronously(LoadTextOptions options, CancellationToken cancellationToken)
-            {
-                var oldText = _oldDocumentState.GetTextSynchronously(cancellationToken);
-                var version = _oldDocumentState.GetTextVersionSynchronously(cancellationToken);
-
-                return GetProperTextAndVersion(oldText, _newText, version, _oldDocumentState.FilePath);
             }
         }
 


### PR DESCRIPTION
First, some background: if we are opening a document, and the document is unchanged from the copy on disk, we try to reuse the version stamp from the disk version to avoid invalidating caches. If the file being opened has already been read, we have a fast path where we quickly compare against the prior text. If it's not read, we would then create a deferred text loader which would read the file on disk and then compare when somebody later asks for the version.

This sourceText argument was to guarantee that if somebody were to synchronously ask for the text (and only the text) of a file that was just opened, and they didn't care about the version, we'd be able to get the text quickly without actually going through the TextLoader.

It's unclear to me what benefit this really brings: if a file has already been read in the background, we'll take the fast path and none of this gets used. If the file hasn't been read previously, we'll be persisting a version that hasn't yet been observed -- but since we hadn't read the file nobody could have that version number to compare to.