### PR TITLE
Remove code that thinks it needs to close a document before removing

### DIFF
--- a/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -305,11 +305,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             if (_monikersToProjectIdAndContainer.TryGetValue(moniker, out var projectIdAndContainer))
             {
-                var document = this.CurrentSolution.GetProject(projectIdAndContainer.projectId).Documents.Single();
-
-                // We must close the document prior to deleting the project
-                OnDocumentClosed(document.Id, new FileTextLoader(document.FilePath, defaultEncoding: null));
-                OnProjectRemoved(document.Project.Id);
+                OnProjectRemoved(projectIdAndContainer.projectId);
 
                 _monikersToProjectIdAndContainer.Remove(moniker);
 


### PR DESCRIPTION
This hasn't been needed for many many years: https://github.com/dotnet/roslyn/pull/12308