### PR TITLE
Add support to avoid showing F1 help for TS diagnostics

### DIFF
--- a/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptWellKnownDiagnosticCustomTags.cs
+++ b/src/Features/Core/Portable/ExternalAccess/VSTypeScript/VSTypeScriptWellKnownDiagnosticCustomTags.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
+{
+    internal static class VSTypeScriptWellKnownDiagnosticCustomTags
+    {
+        public const string DoesNotSupportF1Help = WellKnownDiagnosticCustomTags.DoesNotSupportF1Help;
+    }
+}

--- a/src/VisualStudio/Core/Def/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/TableDataSource/VisualStudioBaseDiagnosticListTable.LiveTableDataSource.cs
@@ -367,7 +367,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                             content = (data.GetValidHelpLinkUri() != null) ? string.Format(EditorFeaturesResources.Get_help_for_0, data.Id) : null;
                             return content != null;
                         case StandardTableKeyNames.HelpKeyword:
-                            content = data.Id;
+                            content = data.GetHelpKeyword();
                             return content != null;
                         case StandardTableKeyNames.HelpLink:
                             content = data.GetValidHelpLinkUri()?.AbsoluteUri;

--- a/src/VisualStudio/Core/Def/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
@@ -162,7 +162,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                                 content = (data.GetValidHelpLinkUri() != null) ? string.Format(EditorFeaturesResources.Get_help_for_0, data.Id) : null;
                                 return content != null;
                             case StandardTableKeyNames.HelpKeyword:
-                                content = data.Id;
+                                content = data.GetHelpKeyword();
                                 return content != null;
                             case StandardTableKeyNames.HelpLink:
                                 content = data.GetValidHelpLinkUri()?.AbsoluteUri;

--- a/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
@@ -474,7 +474,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Dim projectId = documentId.ProjectId
 
                 Dim item1 = CreateItem(workspace.CurrentSolution, projectId, documentId, DiagnosticSeverity.Error, "http://link/")
-                Dim provider = New TestDiagnosticService(item1)
+                Dim item2 = CreateItem(workspace.CurrentSolution, projectId, documentId, DiagnosticSeverity.Error, customTags:={WellKnownDiagnosticCustomTags.DoesNotSupportF1Help})
+                Dim provider = New TestDiagnosticService(item1, item2)
 
                 Dim tableManagerProvider = New TestTableManagerProvider()
 
@@ -487,12 +488,13 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
                 Dim sink = DirectCast(sinkAndSubscription.Key, TestTableManagerProvider.TestTableManager.TestSink)
                 Dim snapshot = sink.Entries.First().GetCurrentSnapshot()
-                Assert.Equal(1, snapshot.Count)
+                Assert.Equal(2, snapshot.Count)
 
                 Dim keyword As Object = Nothing
                 Assert.True(snapshot.TryGetValue(0, StandardTableKeyNames.HelpKeyword, keyword))
-
                 Assert.Equal(item1.Id, keyword.ToString())
+
+                Assert.False(snapshot.TryGetValue(1, StandardTableKeyNames.HelpKeyword, keyword))
             End Using
         End Sub
 
@@ -762,7 +764,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Return CreateItem(solution, documentId.ProjectId, documentId, severity)
         End Function
 
-        Private Shared Function CreateItem(solution As Solution, projectId As ProjectId, documentId As DocumentId, Optional severity As DiagnosticSeverity = DiagnosticSeverity.Error, Optional link As String = Nothing) As DiagnosticData
+        Private Shared Function CreateItem(solution As Solution, projectId As ProjectId, documentId As DocumentId, Optional severity As DiagnosticSeverity = DiagnosticSeverity.Error, Optional link As String = Nothing, Optional customTags As String() = Nothing) As DiagnosticData
             Dim location =
                 If(documentId Is Nothing,
                     If(projectId Is Nothing, New DiagnosticDataLocation(New FileLinePositionSpan("", Nothing)), New DiagnosticDataLocation(New FileLinePositionSpan(solution.GetProject(projectId).FilePath, Nothing))),
@@ -776,7 +778,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 defaultSeverity:=severity,
                 isEnabledByDefault:=True,
                 warningLevel:=0,
-                customTags:=ImmutableArray(Of String).Empty,
+                customTags:=If(customTags IsNot Nothing, customTags.ToImmutableArray(), ImmutableArray(Of String).Empty),
                 properties:=ImmutableDictionary(Of String, String).Empty,
                 projectId,
                 location:=location,

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
@@ -368,5 +368,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         // TODO: the value stored in HelpLink should already be valid URI (https://github.com/dotnet/roslyn/issues/59205)
         internal Uri? GetValidHelpLinkUri()
             => Uri.TryCreate(HelpLink, UriKind.Absolute, out var uri) ? uri : null;
+
+        // Return the diagnostic ID as the HelpKeyword, unless the diagnostic does support F1 help for keyword.
+        internal string? GetHelpKeyword()
+            => CustomTags.Contains(WellKnownDiagnosticCustomTags.DoesNotSupportF1Help) ? null : Id;
     }
 }

--- a/src/Workspaces/Core/Portable/Diagnostics/WellKnownDiagnosticCustomTags.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/WellKnownDiagnosticCustomTags.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.Diagnostics
+{
+    internal static class WellKnownDiagnosticCustomTags
+    {
+        public const string DoesNotSupportF1Help = nameof(DoesNotSupportF1Help);
+    }
+}


### PR DESCRIPTION
Fixes #64145

TS diagnostics do not help corresponding help links, so the default help navigation invokes F1 help for the diagnostic ID. F1 help returns 404 error code for all TS diagnostics, so they wish to avoid showing F1 help. This PR adds a special well-known custom tag to allow diagnostics to skip F1 help navigation.