### PR TITLE
Fix handling of duplicate analyzer references in CommandLineProject

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/CommandLineProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/CommandLineProject.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis
                 analyzerLoader.AddDependencyLocation(relativePathResolver.ResolvePath(path, baseFilePath: null));
             }
 
-            var boundAnalyzerReferences = commandLineArguments.ResolveAnalyzerReferences(analyzerLoader);
+            var boundAnalyzerReferences = commandLineArguments.ResolveAnalyzerReferences(analyzerLoader).Distinct().ToList();
             var unresolvedAnalyzerReferences = boundAnalyzerReferences.FirstOrDefault(r => r is UnresolvedAnalyzerReference);
             if (unresolvedAnalyzerReferences != null)
             {

--- a/src/Workspaces/CoreTest/CommandLineProject/CommandLineProjectTests.cs
+++ b/src/Workspaces/CoreTest/CommandLineProject/CommandLineProjectTests.cs
@@ -145,6 +145,19 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
+        public void TestDuplicateAnalyzerReferences()
+        {
+            var pathToAssembly = typeof(object).Assembly.Location;
+            var assemblyBaseDir = Path.GetDirectoryName(pathToAssembly);
+            var relativePath = Path.Combine(".", Path.GetFileName(pathToAssembly));
+            var commandLine = $@"goo.cs /a:{relativePath} /a:{relativePath}";
+            var info = CommandLineProject.CreateProjectInfo("TestProject", LanguageNames.CSharp, commandLine, assemblyBaseDir);
+
+            var analyzerRef = info.AnalyzerReferences.Single();
+            Assert.Equal(pathToAssembly, analyzerRef.FullPath);
+        }
+
+        [Fact]
         public void TestDuplicateReferenceInVisualBasic()
         {
             var pathToAssembly = typeof(object).Assembly.Location;

--- a/src/Workspaces/CoreTest/CommandLineProject/CommandLineProjectTests.cs
+++ b/src/Workspaces/CoreTest/CommandLineProject/CommandLineProjectTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var info = CommandLineProject.CreateProjectInfo("TestProject", LanguageNames.CSharp, commandLine, assemblyBaseDir);
 
             var firstDoc = info.Documents.Single();
-            var analyzerRef = info.AnalyzerReferences.First();
+            var analyzerRef = info.AnalyzerReferences.Single();
             Assert.Equal("goo.cs", firstDoc.Name);
             Assert.Equal(pathToAssembly, analyzerRef.FullPath);
         }


### PR DESCRIPTION
The compiler allows duplicate analyzer references, so we shouldn't throw here.

Fixes https://github.com/dotnet/roslyn/issues/59883