### PR TITLE
Fix miscellaneous LSIF indexing issues to better match the 0.6.0 spec

### DIFF
--- a/src/Features/Lsif/Generator/Generator.cs
+++ b/src/Features/Lsif/Generator/Generator.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -51,7 +52,12 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
 
         public async Task GenerateForCompilationAsync(Compilation compilation, string projectPath, LanguageServices languageServices, GeneratorOptions options)
         {
-            var projectVertex = new Graph.LsifProject(kind: GetLanguageKind(compilation.Language), new Uri(projectPath), _idFactory);
+            var projectVertex = new Graph.LsifProject(
+                kind: GetLanguageKind(compilation.Language),
+                new Uri(projectPath),
+                Path.GetFileNameWithoutExtension(projectPath),
+                _idFactory);
+
             _lsifJsonWriter.Write(projectVertex);
             _lsifJsonWriter.Write(new Event(Event.EventKind.Begin, projectVertex.GetId(), _idFactory));
 

--- a/src/Features/Lsif/Generator/Graph/Item.cs
+++ b/src/Features/Lsif/Generator/Graph/Item.cs
@@ -10,13 +10,13 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph
     /// </summary>
     internal sealed class Item : Edge
     {
-        public Id<LsifDocument> Document { get; }
+        public Id<LsifDocument> Shard { get; }
         public string? Property { get; }
 
         public Item(Id<Vertex> outVertex, Id<Range> range, Id<LsifDocument> document, IdFactory idFactory, string? property = null)
             : base(label: "item", outVertex, new[] { range.As<Range, Vertex>() }, idFactory)
         {
-            Document = document;
+            Shard = document;
             Property = property;
         }
     }

--- a/src/Features/Lsif/Generator/Graph/LsifProject.cs
+++ b/src/Features/Lsif/Generator/Graph/LsifProject.cs
@@ -13,12 +13,14 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph
     {
         public string Kind { get; }
         public Uri? Resource { get; }
+        public string Name { get; }
 
-        public LsifProject(string kind, Uri? resource, IdFactory idFactory)
+        public LsifProject(string kind, Uri? resource, string name, IdFactory idFactory)
             : base(label: "project", idFactory)
         {
             Kind = kind;
             Resource = resource;
+            Name = name;
         }
     }
 }

--- a/src/Features/Lsif/Generator/Graph/Moniker.cs
+++ b/src/Features/Lsif/Generator/Graph/Moniker.cs
@@ -10,12 +10,18 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph
         public string Identifier { get; }
         public string? Kind { get; }
 
-        public Moniker(string scheme, string identifier, string? kind, IdFactory idFactory)
+        /// <summary>
+        /// Corresponds to the uniqueness level of a moniker, per https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#uniquenessLevel.
+        /// </summary>
+        public string? Unique { get; }
+
+        public Moniker(string scheme, string identifier, string? kind, string? unique, IdFactory idFactory)
             : base(label: "moniker", idFactory)
         {
             Scheme = scheme;
             Identifier = identifier;
             Kind = kind;
+            Unique = unique;
         }
     }
 }

--- a/src/Features/Lsif/Generator/ResultSetTracking/SymbolHoldingResultSetTracker.cs
+++ b/src/Features/Lsif/Generator/ResultSetTracking/SymbolHoldingResultSetTracker.cs
@@ -112,7 +112,8 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.ResultSetTr
                 kind = "import";
             }
 
-            return new Moniker(moniker.Scheme, moniker.Identifier, kind, _idFactory);
+            // Since we fully qualify everything, all monitors are unique within the scheme
+            return new Moniker(moniker.Scheme, moniker.Identifier, kind, unique: "scheme", _idFactory);
         }
 
         public Id<ResultSet> GetResultSetIdForSymbol(ISymbol symbol)

--- a/src/Features/Lsif/GeneratorTest/OutputFormatTests.vb
+++ b/src/Features/Lsif/GeneratorTest/OutputFormatTests.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
 
             AssertEx.EqualOrDiff(
 "{""hoverProvider"":true,""declarationProvider"":false,""definitionProvider"":true,""referencesProvider"":true,""typeDefinitionProvider"":false,""documentSymbolProvider"":false,""foldingRangeProvider"":true,""diagnosticProvider"":false,""id"":1,""type"":""vertex"",""label"":""capabilities""}
-{""kind"":""csharp"",""resource"":""file:///Z:/TestProject.csproj"",""id"":2,""type"":""vertex"",""label"":""project""}
+{""kind"":""csharp"",""resource"":""file:///Z:/TestProject.csproj"",""name"":""TestProject"",""id"":2,""type"":""vertex"",""label"":""project""}
 {""kind"":""begin"",""scope"":""project"",""data"":2,""id"":3,""type"":""vertex"",""label"":""$event""}
 {""uri"":""file:///Z:/A.cs"",""languageId"":""csharp"",""id"":4,""type"":""vertex"",""label"":""document""}
 {""kind"":""begin"",""scope"":""document"",""data"":4,""id"":5,""type"":""vertex"",""label"":""$event""}
@@ -71,6 +71,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
   {
     ""kind"": ""csharp"",
     ""resource"": ""file:///Z:/TestProject.csproj"",
+    ""name"": ""TestProject"",
     ""id"": 2,
     ""type"": ""vertex"",
     ""label"": ""project""

--- a/src/Features/Lsif/GeneratorTest/RangeResultSetTests.vb
+++ b/src/Features/Lsif/GeneratorTest/RangeResultSetTests.vb
@@ -35,6 +35,10 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
 
             Assert.Equal(expectedMoniker, monikerVertex?.Identifier)
             Assert.Equal(expectedMonikerScheme, monikerVertex?.Scheme)
+
+            If monikerVertex IsNot Nothing Then
+                Assert.Equal("scheme", monikerVertex.Unique)
+            End If
         End Function
 
         <Theory>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/63840, with each bullet point in its own commit.