### PR TITLE
Fix preview changes not working for new inline rename

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -64,14 +64,36 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
         private void RenameFlyout_IsKeyboardFocusWithinChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
-            if (!IsKeyboardFocusWithin)
+            // When previewing changes, focus will be lost and put 
+            // into a preview changes window. If we're returning back
+            // to this UI, reset the flag to false. Otherwise, just ignore
+            // this focus change. No need to cancel in that case 
+            if (_viewModel.PreviewChangesFlag)
+            {
+                if (IsKeyboardFocused)
+                {
+                    _viewModel.PreviewChangesFlag = false;
+                }
+
+                return;
+            }
+
+            if (!IsKeyboardFocused)
             {
                 _viewModel.Cancel();
             }
         }
 
         private void TextView_LostFocus(object sender, EventArgs e)
-            => _viewModel.Cancel();
+        {
+            // Preview changes is happening, no need to act on focus changes.
+            if (_viewModel.PreviewChangesFlag)
+            {
+                return;
+            }
+
+            _viewModel.Cancel();
+        }
 
         private void TextView_ViewPortChanged(object sender, EventArgs e)
             => PositionAdornment();


### PR DESCRIPTION
Since focus changes a lot while preview changes are happening, and the UI thread isn't blocked by previewing changes, we would cancel the rename session when the preview window popped up due to lost focus on the textview and/or the flyout. 

This changes so we don't cancel if preview changes is going. We still need to reset the flag if focus is restored. Otherwise a user would always preview the changes whether they intended to or not. 

Fixes [AB#1619520](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1619520) and [AB#1631159](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1631159)