### PR TITLE
Update NuGet version to fix rolling CI

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -217,7 +217,7 @@
       is expected by the NET SDK used in the Workspace.MSBuild UnitTests. In order to test against the same verion of NuGet
       as our configured SDK, we must set the version to be the same.
      -->
-    <NuGetCommonVersion>6.3.0-rc.128</NuGetCommonVersion>
+    <NuGetCommonVersion>6.4.0-preview.1.54</NuGetCommonVersion>
     <NuGetConfigurationVersion>$(NuGetCommonVersion)</NuGetConfigurationVersion>
     <NuGetFrameworksVersion>$(NuGetCommonVersion)</NuGetFrameworksVersion>
     <NuGetPackagingVersion>$(NuGetCommonVersion)</NuGetPackagingVersion>


### PR DESCRIPTION
This PR should have been blocked by fabric-bot for changing the global.json SDK version - https://github.com/dotnet/roslyn/pull/64082

NuGet package version needs to be updated for any SDK change so that we do not break MSBuildWorkspace tests.