### PR TITLE
Rename Binder.*Scope constants

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2811,7 +2811,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert(isVar != declType.HasType);
 
                         // ValEscape is the same as for an uninitialized local
-                        return new BoundDiscardExpression(declarationExpression, Binder.ExternalScope, declType.Type);
+                        return new BoundDiscardExpression(declarationExpression, Binder.CallingMethodScope, declType.Type);
                     }
                 case SyntaxKind.SingleVariableDesignation:
                     return BindOutVariableDeclarationArgument(declarationExpression, diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     var field = boundInitializer.Field;
                                     if (field.Type.IsRefLikeType)
                                     {
-                                        BoundExpression value = parentBinder.ValidateEscape(boundInitializer.Value, ExternalScope, isByRef: false, diagnostics);
+                                        BoundExpression value = parentBinder.ValidateEscape(boundInitializer.Value, CallingMethodScope, isByRef: false, diagnostics);
                                         boundInitializer = boundInitializer.Update(field, boundInitializer.Locals, value);
                                     }
                                 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -1016,13 +1016,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert(receiver != null);
                         valSafeToEscapeScope = requiresInstanceReceiver
                             ? receiver.GetRefKind().IsWritableReference() == true ? GetRefEscape(receiver, LocalScopeDepth) : GetValEscape(receiver, LocalScopeDepth)
-                            : Binder.ExternalScope;
+                            : Binder.CallingMethodScope;
                         isSuppressed = receiver.IsSuppressed;
                         placeholderSyntax = receiver.Syntax;
                         break;
                     case BoundInterpolatedStringArgumentPlaceholder.UnspecifiedParameter:
                         placeholderSyntax = unconvertedString.Syntax;
-                        valSafeToEscapeScope = Binder.ExternalScope;
+                        valSafeToEscapeScope = Binder.CallingMethodScope;
                         isSuppressed = false;
                         break;
                     case >= 0:

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private bool IsCountableAndIndexable(SyntaxNode node, TypeSymbol inputType, out PropertySymbol? lengthProperty)
         {
-            var success = BindLengthAndIndexerForListPattern(node, inputType, inputValEscape: ExternalScope, BindingDiagnosticBag.Discarded,
+            var success = BindLengthAndIndexerForListPattern(node, inputType, inputValEscape: CallingMethodScope, BindingDiagnosticBag.Discarded,
                 indexerAccess: out _, out var lengthAccess, receiverPlaceholder: out _, argumentPlaceholder: out _);
             lengthProperty = success ? GetPropertySymbol(lengthAccess, out _, out _) : null;
             return success;
@@ -908,11 +908,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Compute the val escape of an expression of the given <paramref name="type"/>, which is known to be derived
         /// from an expression whose escape scope is <paramref name="possibleValEscape"/>. By the language rules, the
-        /// result is either that same scope (if the type is a ref struct type) or <see cref="Binder.ExternalScope"/>.
+        /// result is either that same scope (if the type is a ref struct type) or <see cref="Binder.CallingMethodScope"/>.
         /// </summary>
         private static uint GetValEscape(TypeSymbol type, uint possibleValEscape)
         {
-            return type.IsRefLikeType ? possibleValEscape : Binder.ExternalScope;
+            return type.IsRefLikeType ? possibleValEscape : Binder.CallingMethodScope;
         }
 
         private TypeWithAnnotations BindRecursivePatternType(
@@ -1099,7 +1099,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BindingDiagnosticBag diagnostics)
         {
             // Since the input has been cast to ITuple, it must be escapable.
-            const uint valEscape = Binder.ExternalScope;
+            const uint valEscape = Binder.CallingMethodScope;
             var objectType = Compilation.GetSpecialType(SpecialType.System_Object);
             foreach (var subpatternSyntax in node.Subpatterns)
             {
@@ -1128,7 +1128,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BindingDiagnosticBag diagnostics)
         {
             // Since the input has been cast to ITuple, it must be escapable.
-            const uint valEscape = Binder.ExternalScope;
+            const uint valEscape = Binder.CallingMethodScope;
             var objectType = Compilation.GetSpecialType(SpecialType.System_Object);
             foreach (var variable in node.Variables)
             {

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        internal override uint LocalScopeDepth => Binder.ExternalScope;
+        internal override uint LocalScopeDepth => Binder.CallingMethodScope;
 
         protected override bool InExecutableBinder => false;
         protected override SyntaxNode? EnclosingNameofArgument => null;

--- a/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InContainerBinder.cs
@@ -143,6 +143,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        internal override uint LocalScopeDepth => Binder.ExternalScope;
+        internal override uint LocalScopeDepth => Binder.CallingMethodScope;
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        internal override uint LocalScopeDepth => Binder.TopLevelScope;
+        internal override uint LocalScopeDepth => Binder.CurrentMethodScope;
 
         protected override bool InExecutableBinder => true;
 

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var parentDepth = next.LocalScopeDepth;
 
-            if (parentDepth != Binder.TopLevelScope)
+            if (parentDepth != Binder.CurrentMethodScope)
             {
                 _localScopeDepth = parentDepth + 1;
             }
@@ -45,13 +45,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (parentScope is InMethodBinder || parentScope is WithLambdaParametersBinder)
                     {
-                        _localScopeDepth = Binder.TopLevelScope;
+                        _localScopeDepth = Binder.CurrentMethodScope;
                         break;
                     }
 
                     if (parentScope is LocalScopeBinder)
                     {
-                        _localScopeDepth = Binder.TopLevelScope + 1;
+                        _localScopeDepth = Binder.CurrentMethodScope + 1;
                         break;
                     }
 

--- a/src/Compilers/CSharp/Portable/Binder/WithExternAliasesBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithExternAliasesBinder.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        internal sealed override uint LocalScopeDepth => Binder.ExternalScope;
+        internal sealed override uint LocalScopeDepth => Binder.CallingMethodScope;
 
         internal static WithExternAliasesBinder Create(SourceNamespaceSymbol declaringSymbol, CSharpSyntaxNode declarationSyntax, Binder next)
         {

--- a/src/Compilers/CSharp/Portable/Binder/WithLambdaParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithLambdaParametersBinder.cs
@@ -177,6 +177,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             throw ExceptionUtilities.Unreachable;
         }
 
-        internal override uint LocalScopeDepth => Binder.TopLevelScope;
+        internal override uint LocalScopeDepth => Binder.CurrentMethodScope;
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/WithUsingNamespacesAndTypesBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithUsingNamespacesAndTypesBinder.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        internal override uint LocalScopeDepth => Binder.ExternalScope;
+        internal override uint LocalScopeDepth => Binder.CallingMethodScope;
 
 
         internal override ImportChain? ImportChain

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -91,11 +91,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             _refEscapeScope = this._refKind == RefKind.None ?
                                         scopeBinder.LocalScopeDepth :
-                                        Binder.ExternalScope; // default to returnable, unless there is initializer
+                                        Binder.CallingMethodScope; // default to returnable, unless there is initializer
 
             // we do not know the type yet. 
             // assume this is returnable in case we never get to know our type.
-            _valEscapeScope = Binder.ExternalScope;
+            _valEscapeScope = Binder.CallingMethodScope;
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 return _scope == DeclarationScope.RefScoped ?
                     _scopeBinder.LocalScopeDepth :
-                    Binder.TopLevelScope;
+                    Binder.CurrentMethodScope;
             }
         }
 
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
                 return _scope == DeclarationScope.ValueScoped ?
                     _scopeBinder.LocalScopeDepth :
-                    Binder.ExternalScope;
+                    Binder.CallingMethodScope;
             }
         }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbolBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbolBase.cs
@@ -88,13 +88,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         /// EE Symbols have no source symbols associated with them.
         /// They should be safe to escape for evaluation purposes.
         /// </summary>
-        internal override uint ValEscapeScope => Binder.TopLevelScope;
+        internal override uint ValEscapeScope => Binder.CurrentMethodScope;
 
         /// <summary>
         /// EE Symbols have no source symbols associated with them.
         /// They should be safe to escape for evaluation purposes.
         /// </summary>
-        internal override uint RefEscapeScope => Binder.TopLevelScope;
+        internal override uint RefEscapeScope => Binder.CurrentMethodScope;
 
         internal override DeclarationScope Scope => DeclarationScope.Unscoped;
     }


### PR DESCRIPTION
Rename Binder.*Scope constants to match spec terms.

From a suggestion by @jaredpar.