### PR TITLE
[LSP] Fix additional file diagnostics when in a multi-targeting project

### DIFF
--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -660,6 +660,26 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 debugName: projectContext.Id.Substring(delimiter + 1));
         }
 
+        public static LSP.VSProjectContext ProjectToProjectContext(Project project)
+        {
+            var projectContext = new LSP.VSProjectContext
+            {
+                Id = ProjectIdToProjectContextId(project.Id),
+                Label = project.Name
+            };
+
+            if (project.Language == LanguageNames.CSharp)
+            {
+                projectContext.Kind = LSP.VSProjectKind.CSharp;
+            }
+            else if (project.Language == LanguageNames.VisualBasic)
+            {
+                projectContext.Kind = LSP.VSProjectKind.VisualBasic;
+            }
+
+            return projectContext;
+        }
+
         public static async Task<SyntaxFormattingOptions> GetFormattingOptionsAsync(
             LSP.FormattingOptions? options,
             Document document,

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
                 }
                 else
                 {
-                    context.TraceInformation($"Diagnostics were unchanged for document: {diagnosticSource.GetUri()}");
+                    context.TraceInformation($"Diagnostics were unchanged for {diagnosticSource.GetDocumentIdentifier().Uri} in {diagnosticSource.GetProject().Name}");
 
                     // Nothing changed between the last request and this one.  Report a (null-diagnostics,
                     // same-result-id) response to the client as that means they should just preserve the current
@@ -251,12 +251,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
         {
             using var _ = ArrayBuilder<LSP.Diagnostic>.GetInstance(out var result);
             var diagnostics = await diagnosticSource.GetDiagnosticsAsync(DiagnosticAnalyzerService, context, cancellationToken).ConfigureAwait(false);
-            context.TraceInformation($"Found {diagnostics.Length} diagnostics for {diagnosticSource.GetUri()}");
+            context.TraceInformation($"Found {diagnostics.Length} diagnostics for {diagnosticSource.GetDocumentIdentifier().Uri} in {diagnosticSource.GetProject().Name}");
 
             foreach (var diagnostic in diagnostics)
                 result.AddRange(ConvertDiagnostic(diagnosticSource, diagnostic, clientCapabilities));
 
-            return CreateReport(new LSP.TextDocumentIdentifier { Uri = diagnosticSource.GetUri() }, result.ToArray(), resultId);
+            return CreateReport(diagnosticSource.GetDocumentIdentifier(), result.ToArray(), resultId);
         }
 
         private void HandleRemovedDocuments(RequestContext context, ImmutableArray<PreviousPullResult> removedPreviousResults, BufferedProgress<TReport> progress)

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractDocumentDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractDocumentDiagnosticSource.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.TaskList;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 
@@ -30,7 +31,8 @@ internal abstract class AbstractDocumentDiagnosticSource<TDocument> : IDiagnosti
 
     public ProjectOrDocumentId GetId() => new(Document.Id);
     public Project GetProject() => Document.Project;
-    public Uri GetUri() => Document.GetURI();
+    public TextDocumentIdentifier GetDocumentIdentifier()
+        => new VSTextDocumentIdentifier { ProjectContext = ProtocolConversions.ProjectToProjectContext(Document.Project), Uri = Document.GetURI() };
 
     protected abstract bool IncludeTaskListItems { get; }
     protected abstract bool IncludeStandardDiagnostics { get; }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/IDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/IDiagnosticSource.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 
@@ -18,7 +19,7 @@ internal interface IDiagnosticSource
 {
     Project GetProject();
     ProjectOrDocumentId GetId();
-    Uri GetUri();
+    TextDocumentIdentifier GetDocumentIdentifier();
 
     Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
         IDiagnosticAnalyzerService diagnosticAnalyzerService,

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/ProjectDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/ProjectDiagnosticSource.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
@@ -15,11 +16,10 @@ internal sealed record class ProjectDiagnosticSource(Project Project) : IDiagnos
 {
     public ProjectOrDocumentId GetId() => new(Project.Id);
     public Project GetProject() => Project;
-
-    public Uri GetUri()
+    public TextDocumentIdentifier GetDocumentIdentifier()
     {
         Contract.ThrowIfNull(Project.FilePath);
-        return ProtocolConversions.GetUriFromFilePath(Project.FilePath);
+        return new VSTextDocumentIdentifier { ProjectContext = ProtocolConversions.ProjectToProjectContext(Project), Uri = ProtocolConversions.GetUriFromFilePath(Project.FilePath) };
     }
 
     public async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(

--- a/src/Features/LanguageServer/Protocol/Handler/ProjectContext/GetTextDocumentWithContextHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/ProjectContext/GetTextDocumentWithContextHandler.cs
@@ -48,21 +48,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             foreach (var document in documents)
             {
                 var project = document.Project;
-                var projectContext = new VSProjectContext
-                {
-                    Id = ProtocolConversions.ProjectIdToProjectContextId(project.Id),
-                    Label = project.Name
-                };
-
-                if (project.Language == LanguageNames.CSharp)
-                {
-                    projectContext.Kind = VSProjectKind.CSharp;
-                }
-                else if (project.Language == LanguageNames.VisualBasic)
-                {
-                    projectContext.Kind = VSProjectKind.VisualBasic;
-                }
-
+                var projectContext = ProtocolConversions.ProjectToProjectContext(project);
                 contexts.Add(projectContext);
             }
 

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -183,7 +183,7 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, ILspService
             var documents = lspSolution.GetDocuments(uri);
             if (documents.Any())
             {
-                var document = documents.FindDocumentInProjectContext(textDocumentIdentifier);
+                var document = documents.FindDocumentInProjectContext(textDocumentIdentifier, (sln, id) => sln.GetRequiredDocument(id));
 
                 // Record metadata on how we got this document.
                 var workspaceKind = document.Project.Solution.WorkspaceKind;

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AbstractPullDiagnosticTestsBase.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
         private protected static async Task<ImmutableArray<TestDiagnosticResult>> RunGetWorkspacePullDiagnosticsAsync(
             TestLspServer testLspServer,
             bool useVSDiagnostics,
-            ImmutableArray<(string resultId, Uri uri)>? previousResults = null,
+            ImmutableArray<(string resultId, TextDocumentIdentifier identifier)>? previousResults = null,
             bool useProgress = false,
             bool includeTaskListItems = false)
         {
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
                 }
 
                 AssertEx.NotNull(diagnostics);
-                return diagnostics.Select(d => new TestDiagnosticResult(d.TextDocument!.Uri, d.ResultId!, d.Diagnostics)).ToImmutableArray();
+                return diagnostics.Select(d => new TestDiagnosticResult(d.TextDocument!, d.ResultId!, d.Diagnostics)).ToImmutableArray();
             }
             else
             {
@@ -97,10 +97,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
             }
 
             static WorkspaceDiagnosticParams CreateProposedWorkspaceDiagnosticParams(
-                ImmutableArray<(string resultId, Uri uri)>? previousResults = null,
+                ImmutableArray<(string resultId, TextDocumentIdentifier identifier)>? previousResults = null,
                 IProgress<WorkspaceDiagnosticReport[]>? progress = null)
             {
-                var previousResultsLsp = previousResults?.Select(r => new PreviousResultId(r.uri, r.resultId)).ToArray() ?? Array.Empty<PreviousResultId>();
+                var previousResultsLsp = previousResults?.Select(r => new PreviousResultId(r.identifier.Uri, r.resultId)).ToArray() ?? Array.Empty<PreviousResultId>();
                 return new WorkspaceDiagnosticParams(identifier: null, previousResultsLsp, workDoneToken: null, partialResultToken: progress);
             }
 
@@ -108,21 +108,22 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
             {
                 if (workspaceReport.Value is WorkspaceFullDocumentDiagnosticReport fullReport)
                 {
-                    return new TestDiagnosticResult(fullReport.Uri, fullReport.ResultId!, fullReport.Items);
+                    return new TestDiagnosticResult(new TextDocumentIdentifier { Uri = fullReport.Uri }, fullReport.ResultId!, fullReport.Items);
                 }
                 else
                 {
                     var unchangedReport = (WorkspaceUnchangedDocumentDiagnosticReport)workspaceReport.Value!;
-                    return new TestDiagnosticResult(unchangedReport.Uri, unchangedReport.ResultId!, null);
+                    return new TestDiagnosticResult(new TextDocumentIdentifier { Uri = unchangedReport.Uri }, unchangedReport.ResultId!, null);
                 }
             }
         }
 
         private protected static Task CloseDocumentAsync(TestLspServer testLspServer, Document document) => testLspServer.CloseDocumentAsync(document.GetURI());
 
-        private protected static ImmutableArray<(string resultId, Uri uri)> CreateDiagnosticParamsFromPreviousReports(ImmutableArray<TestDiagnosticResult> results)
+        private protected static ImmutableArray<(string resultId, TextDocumentIdentifier identifier)> CreateDiagnosticParamsFromPreviousReports(ImmutableArray<TestDiagnosticResult> results)
         {
-            return results.Select(r => (r.ResultId, r.Uri)).ToImmutableArray();
+
+            return results.Select(r => (r.ResultId, r.TextDocument)).ToImmutableArray();
         }
 
         private protected static VSInternalDocumentDiagnosticsParams CreateDocumentDiagnosticParams(
@@ -139,12 +140,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
         }
 
         private protected static VSInternalWorkspaceDiagnosticsParams CreateWorkspaceDiagnosticParams(
-            ImmutableArray<(string resultId, Uri uri)>? previousResults = null,
+            ImmutableArray<(string resultId, TextDocumentIdentifier identifier)>? previousResults = null,
             IProgress<VSInternalWorkspaceDiagnosticReport[]>? progress = null)
         {
             return new VSInternalWorkspaceDiagnosticsParams
             {
-                PreviousResults = previousResults?.Select(r => new VSInternalDiagnosticParams { PreviousResultId = r.resultId, TextDocument = new TextDocumentIdentifier { Uri = r.uri } }).ToArray(),
+                PreviousResults = previousResults?.Select(r => new VSInternalDiagnosticParams { PreviousResultId = r.resultId, TextDocument = r.identifier }).ToArray(),
                 PartialResultToken = progress,
             };
         }
@@ -197,7 +198,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
                 }
 
                 AssertEx.NotNull(diagnostics);
-                return diagnostics.Select(d => new TestDiagnosticResult(vsTextDocumentIdentifier.Uri, d.ResultId!, d.Diagnostics)).ToImmutableArray();
+                return diagnostics.Select(d => new TestDiagnosticResult(vsTextDocumentIdentifier, d.ResultId!, d.Diagnostics)).ToImmutableArray();
             }
             else
             {
@@ -220,11 +221,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
                 else if (diagnostics.Value.Value is UnchangedDocumentDiagnosticReport)
                 {
                     // The public LSP spec returns different types when unchanged in contrast to VS which just returns null diagnostic array.
-                    return ImmutableArray.Create(new TestDiagnosticResult(vsTextDocumentIdentifier.Uri, diagnostics.Value.Second.ResultId!, null));
+                    return ImmutableArray.Create(new TestDiagnosticResult(vsTextDocumentIdentifier, diagnostics.Value.Second.ResultId!, null));
                 }
                 else
                 {
-                    return ImmutableArray.Create(new TestDiagnosticResult(vsTextDocumentIdentifier.Uri, diagnostics.Value.First.ResultId!, diagnostics.Value.First.Items));
+                    return ImmutableArray.Create(new TestDiagnosticResult(vsTextDocumentIdentifier, diagnostics.Value.First.ResultId!, diagnostics.Value.First.Items));
                 }
             }
 
@@ -272,9 +273,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Diagnostics
         /// Helper type to store unified LSP diagnostic results.
         /// Diagnostics are null when unchanged.
         /// </summary>
-        private protected record TestDiagnosticResult(Uri Uri, string ResultId, LSP.Diagnostic[]? Diagnostics)
+        private protected record TestDiagnosticResult(TextDocumentIdentifier TextDocument, string ResultId, LSP.Diagnostic[]? Diagnostics)
         {
-            public TextDocumentIdentifier TextDocument { get; } = new TextDocumentIdentifier { Uri = Uri };
+            public Uri Uri { get; } = TextDocument.Uri;
         }
 
         [DiagnosticAnalyzer(InternalLanguageNames.TypeScript), PartNotDiscoverable]

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
@@ -86,6 +86,39 @@ public class AdditionalFileDiagnosticsTests : AbstractPullDiagnosticTestsBase
         Assert.NotNull(results2[2].ResultId);
     }
 
+    [Fact]
+    public async Task TestWorkspaceDiagnosticsWithAdditionalFileInMultipleProjects()
+    {
+        var workspaceXml =
+@$"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj1"" FilePath=""C:\CSProj1.csproj"">
+        <Document FilePath=""C:\A.cs""></Document>
+        <AdditionalDocument FilePath=""C:\Test.txt""></AdditionalDocument>
+    </Project>
+    <Project Language=""C#"" CommonReferences=""true"" AssemblyName=""CSProj2"" FilePath=""C:\CSProj1.csproj"">
+        <Document FilePath=""C:\B.cs""></Document>
+        <AdditionalDocument FilePath=""C:\Test.txt""></AdditionalDocument>
+    </Project>
+</Workspace>";
+
+        using var testLspServer = await CreateTestWorkspaceFromXmlAsync(workspaceXml, BackgroundAnalysisScope.FullSolution, useVSDiagnostics: true);
+
+        var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics: true);
+        Assert.Equal(6, results.Length);
+
+        Assert.Equal(MockAdditionalFileDiagnosticAnalyzer.Id, results[1].Diagnostics.Single().Code);
+        Assert.Equal(@"C:\Test.txt", results[1].Uri.LocalPath);
+        Assert.Equal("CSProj1", ((LSP.VSDiagnostic)results[1].Diagnostics.Single()).Projects.First().ProjectName);
+        Assert.Equal(MockAdditionalFileDiagnosticAnalyzer.Id, results[4].Diagnostics.Single().Code);
+        Assert.Equal(@"C:\Test.txt", results[4].Uri.LocalPath);
+        Assert.Equal("CSProj2", ((LSP.VSDiagnostic)results[4].Diagnostics.Single()).Projects.First().ProjectName);
+
+        // Asking again should give us back an unchanged diagnostic.
+        var results2 = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics: true, previousResults: CreateDiagnosticParamsFromPreviousReports(results));
+        Assert.Equal(results[1].ResultId, results2[1].ResultId);
+        Assert.Equal(results[4].ResultId, results2[4].ResultId);
+    }
+
     protected override TestComposition Composition => base.Composition.AddParts(typeof(MockAdditionalFileDiagnosticAnalyzer));
 
     private protected override TestAnalyzerReferenceByLanguage TestAnalyzerReferences => new(ImmutableDictionary.Create<string, ImmutableArray<DiagnosticAnalyzer>>()


### PR DESCRIPTION
Found this when looking into diagnostics logs.

Previously we would throw when querying workspace diagnostics for a solution containing a multi-targeted project with an additional file because we would do `SingleOrDefault` on the ids that we found for additional documents when looking up the previous diagnostics results.

```
Exception: System.InvalidOperationException: Sequence contains more than one element
   at System.Linq.Enumerable.SingleOrDefault[TSource](IEnumerable`1 source)
   at Microsoft.CodeAnalysis.LanguageServer.Extensions.GetAdditionalDocument(Solution solution, TextDocumentIdentifier documentIdentifier)
   at Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics.AbstractPullDiagnosticHandler`3.<GetIdToPreviousDiagnosticParams>g__GetIdForPreviousResult|22_0(TextDocumentIdentifier textDocumentIdentifier, Solution solution)
   at Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics.AbstractPullDiagnosticHandler`3.GetIdToPreviousDiagnosticParams(RequestContext context, ImmutableArray`1 previousResults, ImmutableArray`1& removedDocuments)
   at Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics.AbstractPullDiagnosticHandler`3.<HandleRequestAsync>d__21.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.LanguageServer.Handler.RequestExecutionQueue.QueueItem`2.<CallbackAsync>d__27.MoveNext()
```

This changes the code so that we lookup the additional document (or project diagnostic) with project context information (same as what we do for regular documents).  It also fixes up a place where we were not including the project context on the diagnostic report we sent back to the client (needed so they send us back the project context information in the previous results field).