### PR TITLE
Update our test sdk version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,7 +22,7 @@
     <RoslynDiagnosticsNugetPackageVersion>3.3.4-beta1.22204.1</RoslynDiagnosticsNugetPackageVersion>
     <MicrosoftCodeAnalysisNetAnalyzersVersion>7.0.0-preview1.22218.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.22462.1</MicrosoftCodeAnalysisTestingVersion>
-    <MicrosoftVisualStudioExtensibilityTestingVersion>0.1.145-beta</MicrosoftVisualStudioExtensibilityTestingVersion>
+    <MicrosoftVisualStudioExtensibilityTestingVersion>0.1.149-beta</MicrosoftVisualStudioExtensibilityTestingVersion>
     <!-- CodeStyleAnalyzerVersion should we updated together with version of dotnet-format in dotnet-tools.json -->
     <CodeStyleAnalyzerVersion>4.3.0-1.final</CodeStyleAnalyzerVersion>
     <VisualStudioEditorPackagesVersion>17.3.174</VisualStudioEditorPackagesVersion>


### PR DESCRIPTION
Update the build to https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6745355&view=results

It would contain this change https://github.com/microsoft/vs-extension-testing/pull/130
So that we can get the snapshot when devenv is poping something during settings reset