### PR TITLE
Skip the stackoverflow test because it's not stable enough

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpStackOverFlowTests.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpStackOverFlowTests.cs
@@ -29,7 +29,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp
         {
         }
 
-        [IdeFact]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/63349")]
         public async Task TestDevenvDoNotCrash()
         {
             var sampleCode = await GetSampleCodeAsync();
@@ -43,7 +43,7 @@ namespace Roslyn.VisualStudio.NewIntegrationTests.CSharp
             await TestServices.Editor.ShowLightBulbAsync(HangMitigatingCancellationToken);
         }
 
-        [IdeFact]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/63349")]
         public async Task TestSyntaxIndex()
         {
             var sampleCode = await GetSampleCodeAsync();


### PR DESCRIPTION
Need to make these two tests more stable before we can finally make it run in the CI.
The original checked-in PR doesn't have any production code changes.
https://github.com/dotnet/roslyn/pull/64290
So it's fine to get in 17.4