### PR TITLE
Avoid dropping Razor SDK source generator when not included in VSIX

### DIFF
--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProject.cs
@@ -991,14 +991,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             if (fullPath.LastIndexOf(s_razorSourceGeneratorSdkDirectory, StringComparison.OrdinalIgnoreCase) + s_razorSourceGeneratorSdkDirectory.Length - 1 ==
                 fullPath.LastIndexOf(Path.DirectorySeparatorChar))
             {
-                if (fullPath.EndsWith(s_razorSourceGeneratorMainAssemblyRootedFileName, StringComparison.OrdinalIgnoreCase))
+                var vsixRazorAnalyzers = _vsixAnalyzerProvider.GetAnalyzerReferencesInExtensions();
+                if (!vsixRazorAnalyzers.IsEmpty)
                 {
-                    return OneOrMany.Create(_vsixAnalyzerProvider.GetAnalyzerReferencesInExtensions().SelectAsArray(
-                        predicate: item => item.extensionId == RazorVsixExtensionId,
-                        selector: item => item.reference.FullPath));
-                }
+                    if (fullPath.EndsWith(s_razorSourceGeneratorMainAssemblyRootedFileName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return OneOrMany.Create(vsixRazorAnalyzers.SelectAsArray(
+                            predicate: item => item.extensionId == RazorVsixExtensionId,
+                            selector: item => item.reference.FullPath));
+                    }
 
-                return OneOrMany.Create(ImmutableArray<string>.Empty);
+                    return OneOrMany.Create(ImmutableArray<string>.Empty);
+                }
             }
 
             return OneOrMany.Create(fullPath);

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProject.cs
@@ -991,14 +991,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             if (fullPath.LastIndexOf(s_razorSourceGeneratorSdkDirectory, StringComparison.OrdinalIgnoreCase) + s_razorSourceGeneratorSdkDirectory.Length - 1 ==
                 fullPath.LastIndexOf(Path.DirectorySeparatorChar))
             {
-                var vsixRazorAnalyzers = _vsixAnalyzerProvider.GetAnalyzerReferencesInExtensions();
+                var vsixRazorAnalyzers = _vsixAnalyzerProvider.GetAnalyzerReferencesInExtensions().SelectAsArray(
+                    predicate: item => item.extensionId == RazorVsixExtensionId,
+                    selector: item => item.reference.FullPath);
+
                 if (!vsixRazorAnalyzers.IsEmpty)
                 {
                     if (fullPath.EndsWith(s_razorSourceGeneratorMainAssemblyRootedFileName, StringComparison.OrdinalIgnoreCase))
                     {
-                        return OneOrMany.Create(vsixRazorAnalyzers.SelectAsArray(
-                            predicate: item => item.extensionId == RazorVsixExtensionId,
-                            selector: item => item.reference.FullPath));
+                        return OneOrMany.Create(vsixRazorAnalyzers);
                     }
 
                     return OneOrMany.Create(ImmutableArray<string>.Empty);

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
@@ -112,7 +112,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
         End Function
 
         <WpfFact>
-        Public Async Function RazorSourceGenerator() As Task
+        Public Async Function RazorSourceGenerator_FromVsix() As Task
             Using environment = New TestEnvironment()
                 Dim providerFactory = DirectCast(environment.ExportProvider.GetExportedValue(Of IVisualStudioDiagnosticAnalyzerProviderFactory), MockVisualStudioDiagnosticAnalyzerProviderFactory)
                 providerFactory.Extensions =
@@ -142,7 +142,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
 
                 Assert.Empty(environment.Workspace.CurrentSolution.Projects.Single().AnalyzerReferences)
 
-                ' add Razor source generator and a couple more other analyzer filess:
+                ' add Razor source generator and a couple more other analyzer files:
                 project.AddAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "SdkDependency1.dll"))
                 project.AddAnalyzerReference(Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "Microsoft.NET.Sdk.Razor.SourceGenerators.dll"))
                 project.AddAnalyzerReference(Path.Combine(TempRoot.Root, "Some other directory", "Microsoft.NET.Sdk.Razor.SourceGenerators.dll"))
@@ -190,6 +190,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 {
                     Path.Combine(TempRoot.Root, "Dir", "File.dll")
                 }, environment.Workspace.CurrentSolution.Projects.Single().AnalyzerReferences.Select(Function(r) r.FullPath))
+            End Using
+        End Function
+
+        <WpfFact>
+        Public Async Function RazorSourceGenerator_FromSdk() As Task
+            Using environment = New TestEnvironment()
+                Dim project = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
+                    "Project", LanguageNames.CSharp, CancellationToken.None)
+
+                ' add Razor source generator and a couple more other analyzer filess:
+                Dim path1 = Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "Microsoft.NET.Sdk.Razor.SourceGenerators.dll")
+                Dim path2 = Path.Combine(TempRoot.Root, "Sdks", "Microsoft.NET.Sdk.Razor", "source-generators", "SdkDependency1.dll")
+                project.AddAnalyzerReference(path1)
+                project.AddAnalyzerReference(path2)
+
+                AssertEx.Equal({path1, path2}, environment.Workspace.CurrentSolution.Projects.Single().AnalyzerReferences.Select(Function(r) r.FullPath))
+
             End Using
         End Function
 

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioProjectTests/AnalyzerReferenceTests.vb
@@ -196,6 +196,15 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
         <WpfFact>
         Public Async Function RazorSourceGenerator_FromSdk() As Task
             Using environment = New TestEnvironment()
+                Dim providerFactory = DirectCast(environment.ExportProvider.GetExportedValue(Of IVisualStudioDiagnosticAnalyzerProviderFactory), MockVisualStudioDiagnosticAnalyzerProviderFactory)
+                providerFactory.Extensions =
+                {
+                     ({
+                        Path.Combine(TempRoot.Root, "File.dll")
+                     },
+                     "AnotherExtension")
+                }
+
                 Dim project = Await environment.ProjectFactory.CreateAndAddToWorkspaceAsync(
                     "Project", LanguageNames.CSharp, CancellationToken.None)
 


### PR DESCRIPTION
https://github.com/dotnet/roslyn/pull/63912 replaced Razor SDK source generator with one from VSIX. If the generator is not included in the VSIX though it was dropped. This resulted in Hot Reload not working at all for Razor.

When testing the previous PR I did not realize that my local VS testing hive is still "polluted" with the Razor VSIX from previous testing, so I was in fact not testing the real VS install.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1632487/