### PR TITLE
Fix test to use await using after clasp merge

### DIFF
--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/AdditionalFileDiagnosticsTests.cs
@@ -101,7 +101,7 @@ public class AdditionalFileDiagnosticsTests : AbstractPullDiagnosticTestsBase
     </Project>
 </Workspace>";
 
-        using var testLspServer = await CreateTestWorkspaceFromXmlAsync(workspaceXml, BackgroundAnalysisScope.FullSolution, useVSDiagnostics: true);
+        await using var testLspServer = await CreateTestWorkspaceFromXmlAsync(workspaceXml, BackgroundAnalysisScope.FullSolution, useVSDiagnostics: true);
 
         var results = await RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics: true);
         Assert.Equal(6, results.Length);


### PR DESCRIPTION
broken in main, e.g. https://dev.azure.com/dnceng-public/public/_build/results?buildId=33571&view=logs&s=3d57594e-d27c-511d-5e9c-b8ce2f916915&j=86868256-cb82-53ae-480d-0cc498d0e893

My pr to add a test and clasp merged without re-running CI and they conflicted