### PR TITLE
Miscellaneous improvements to the ETW logging code

### DIFF
--- a/src/EditorFeatures/Core/Logging/FunctionIdOptions.cs
+++ b/src/EditorFeatures/Core/Logging/FunctionIdOptions.cs
@@ -22,6 +22,17 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         {
             var name = id.ToString();
 
+            // This local storage location can be set via vsregedit. Which is available on any VS Command Prompt.
+            //
+            // To enable logging:
+            //
+            //     vsregedit set local [hive name] HKCU Roslyn\Internal\Performance\FunctionId [function name] dword 1
+            //
+            // To disable logging
+            //
+            //     vsregedit delete local [hive name] HKCU Roslyn\Internal\Performance\FunctionId [function name]
+            //
+            // If you want to set it for the default hive, use "" as the hive name (i.e. an empty argument)
             return new(nameof(FunctionIdOptions), name, defaultValue: false,
                 storageLocation: new LocalUserProfileStorageLocation(@"Roslyn\Internal\Performance\FunctionId\" + name));
         }

--- a/src/EditorFeatures/Core/Logging/FunctionIdOptions.cs
+++ b/src/EditorFeatures/Core/Logging/FunctionIdOptions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         private static Option2<bool> CreateOption(FunctionId id)
         {
-            var name = Enum.GetName(typeof(FunctionId), id) ?? throw ExceptionUtilities.UnexpectedValue(id);
+            var name = id.ToString();
 
             return new(nameof(FunctionIdOptions), name, defaultValue: false,
                 storageLocation: new LocalUserProfileStorageLocation(@"Roslyn\Internal\Performance\FunctionId\" + name));

--- a/src/Workspaces/Core/Portable/Log/EtwLogger.cs
+++ b/src/Workspaces/Core/Portable/Log/EtwLogger.cs
@@ -16,17 +16,17 @@ namespace Microsoft.CodeAnalysis.Internal.Log
     /// </summary>
     internal sealed class EtwLogger : ILogger
     {
-        private readonly Lazy<Func<FunctionId, bool>> _isEnabledPredicate;
+        private readonly Func<FunctionId, bool> _isEnabledPredicate;
 
         // Due to ETW specifics, RoslynEventSource.Instance needs to be initialized during EtwLogger construction 
         // so that we can enable the listeners synchronously before any events are logged.
         private readonly RoslynEventSource _source = RoslynEventSource.Instance;
 
         public EtwLogger(Func<FunctionId, bool> isEnabledPredicate)
-            => _isEnabledPredicate = new Lazy<Func<FunctionId, bool>>(() => isEnabledPredicate);
+            => _isEnabledPredicate = isEnabledPredicate;
 
         public bool IsEnabled(FunctionId functionId)
-            => _source.IsEnabled() && _isEnabledPredicate.Value(functionId);
+            => _source.IsEnabled() && _isEnabledPredicate(functionId);
 
         public void Log(FunctionId functionId, LogMessage logMessage)
             => _source.Log(GetMessage(logMessage), functionId);

--- a/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.Host
             {
                 Contract.ThrowIfNull(_storage);
 
-                using (RoslynEventSource.LogInformationalBlock(FunctionId.Workspace_Recoverable_RecoverRootAsync, _containingTree.FilePath, cancellationToken))
+                using (Logger.LogBlock(FunctionId.Workspace_Recoverable_RecoverRootAsync, _containingTree.FilePath, cancellationToken, LogLevel.Information))
                 {
                     using var stream = await _storage.ReadStreamAsync(cancellationToken).ConfigureAwait(false);
                     return RecoverRoot(stream, cancellationToken);
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.Host
             {
                 Contract.ThrowIfNull(_storage);
 
-                using (RoslynEventSource.LogInformationalBlock(FunctionId.Workspace_Recoverable_RecoverRoot, _containingTree.FilePath, cancellationToken))
+                using (Logger.LogBlock(FunctionId.Workspace_Recoverable_RecoverRoot, _containingTree.FilePath, cancellationToken, LogLevel.Information))
                 {
                     using var stream = _storage.ReadStream(cancellationToken);
                     return RecoverRoot(stream, cancellationToken);


### PR DESCRIPTION
Mostly small changes I noticed while looking at how this all works again. However one potentially impactful change is the change to move the tree recovery from explicitly calling our ETW logging code to going through the same filtering as everything else; if we have some automation that expects this to be enabled, it'll need an update.