### PR TITLE
Remove special case in PEModuleSymbol.UseUpdatedEscapeRules for module referencing System.Runtime 7.0

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -811,48 +811,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         private bool CalculateUseUpdatedRules()
         {
             // [RefSafetyRules(version)], regardless of version.
-            if (_module.HasRefSafetyRulesAttribute(Token, out _))
-            {
-                return true;
-            }
-
-            // System.Runtime { ver: 7.0 }
-            if (IsOrReferencesSystemRuntimeCorLibrary(_module, out var corlibVersion) && corlibVersion is { Major: 7, Minor: 0 })
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        private static bool IsOrReferencesSystemRuntimeCorLibrary(PEModule module, out Version? version)
-        {
-            const string corlibName = "System.Runtime";
-
-            AssemblyIdentity? identity;
-            try
-            {
-                identity = module.ReadAssemblyIdentityOrThrow();
-            }
-            catch (BadImageFormatException)
-            {
-                identity = null;
-            }
-            if (identity?.Name == corlibName)
-            {
-                version = identity.Version;
-                return true;
-            }
-
-            var assemblyHandle = module.GetAssemblyRef(corlibName);
-            if (!assemblyHandle.IsNil)
-            {
-                version = module.GetAssemblyRef(assemblyHandle).Version;
-                return true;
-            }
-
-            version = null;
-            return false;
+            return _module.HasRefSafetyRulesAttribute(Token, out _);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -20102,6 +20102,7 @@ $@".assembly extern mscorlib {{ .ver 4:0:0:0 .publickeytoken = (B7 7A 5C 56 19 3
             Assert.True(method.ContainingModule.UseUpdatedEscapeRules);
         }
 
+        [WorkItem(63691, "https://github.com/dotnet/roslyn/issues/63691")]
         [Theory]
         [CombinatorialData]
         public void DetectUpdatedEscapeRulesFromCorlib(
@@ -20152,12 +20153,13 @@ $@".assembly extern mscorlib {{ .ver 4:0:0:0 .publickeytoken = (B7 7A 5C 56 19 3
             Assert.Equal(assemblyIdentity, module.ReferencedAssemblies.Single());
             Assert.Equal(assemblyIdentity, module.ContainingAssembly.CorLibrary.Identity);
 
-            Assert.Equal(languageVersion == LanguageVersion.CSharp11 || majorVersion == 7, module.UseUpdatedEscapeRules);
+            Assert.Equal(languageVersion == LanguageVersion.CSharp11, module.UseUpdatedEscapeRules);
 
             module = comp.GetMember<NamedTypeSymbol>("System.Object").ContainingModule;
-            Assert.Equal(majorVersion == 7, module.UseUpdatedEscapeRules);
+            Assert.False(module.UseUpdatedEscapeRules);
         }
 
+        [WorkItem(63691, "https://github.com/dotnet/roslyn/issues/63691")]
         [Theory]
         [CombinatorialData]
         public void DetectUpdatedEscapeRulesFromCorlib_Retargeting(
@@ -20220,11 +20222,12 @@ $@".assembly extern mscorlib {{ .ver 4:0:0:0 .publickeytoken = (B7 7A 5C 56 19 3
             Assert.Equal(languageVersion == LanguageVersion.CSharp11, module.UseUpdatedEscapeRules);
 
             module = module.ContainingAssembly.CorLibrary.Modules[0];
-            Assert.Equal(higherVersion == 7, module.UseUpdatedEscapeRules);
+            Assert.False(module.UseUpdatedEscapeRules);
         }
 
+        [WorkItem(63691, "https://github.com/dotnet/roslyn/issues/63691")]
         [Theory]
-        [InlineData("System.Runtime", 7, 0, true)]
+        [InlineData("System.Runtime", 7, 0, false)]
         [InlineData("System.Runtime", 7, 1, false)]
         [InlineData("System.Runtime", 8, 0, false)]
         [InlineData("mscorlib", 7, 0, false)]


### PR DESCRIPTION
Fixes #63691.