### PR TITLE
Bitness specific test conditions

### DIFF
--- a/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
+++ b/src/Compilers/CSharp/Test/EndToEnd/EndToEndTests.cs
@@ -101,13 +101,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EndToEnd
         [ConditionalFact(typeof(WindowsOrLinuxOnly)), WorkItem(34880, "https://github.com/dotnet/roslyn/issues/34880")]
         public void OverflowOnFluentCall()
         {
-            int numberFluentCalls = (ExecutionConditionUtil.Architecture, ExecutionConditionUtil.Configuration) switch
+            int numberFluentCalls = (IntPtr.Size, ExecutionConditionUtil.Configuration) switch
             {
-                (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 520, // 510
-                (ExecutionArchitecture.x86, ExecutionConfiguration.Release) => 1400, // 1310
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) => 250, // 225,
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 700, // 620
-                _ => throw new Exception($"Unexpected configuration {ExecutionConditionUtil.Architecture} {ExecutionConditionUtil.Configuration}")
+                (4, ExecutionConfiguration.Debug) => 520, // 510
+                (4, ExecutionConfiguration.Release) => 1400, // 1310
+                (8, ExecutionConfiguration.Debug) => 250, // 225,
+                (8, ExecutionConfiguration.Release) => 700, // 620
+                _ => throw new Exception($"Unexpected configuration {IntPtr.Size * 8}-bit {ExecutionConditionUtil.Configuration}")
             };
 
             // <path>\xunit.console.exe "<path>\CSharpCompilerEmitTest\Roslyn.Compilers.CSharp.Emit.UnitTests.dll"  -noshadow -verbose -class "Microsoft.CodeAnalysis.CSharp.UnitTests.Emit.EndToEndTests"
@@ -156,14 +156,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.EndToEnd
         [WorkItem(53361, "https://github.com/dotnet/roslyn/issues/53361")]
         public void DeeplyNestedGeneric()
         {
-            int nestingLevel = (ExecutionConditionUtil.Architecture, ExecutionConditionUtil.Configuration) switch
+            int nestingLevel = (IntPtr.Size, ExecutionConditionUtil.Configuration) switch
             {
                 // Legacy baselines are indicated by comments
-                (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 370, // 270
-                (ExecutionArchitecture.x86, ExecutionConfiguration.Release) => 1290, // 1290
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) => 270, // 170
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 730, // 730
-                _ => throw new Exception($"Unexpected configuration {ExecutionConditionUtil.Architecture} {ExecutionConditionUtil.Configuration}")
+                (4, ExecutionConfiguration.Debug) => 370, // 270
+                (4, ExecutionConfiguration.Release) => 1290, // 1290
+                (8, ExecutionConfiguration.Debug) => 270, // 170
+                (8, ExecutionConfiguration.Release) => 730, // 730
+                _ => throw new Exception($"Unexpected configuration {IntPtr.Size * 8}-bit {ExecutionConditionUtil.Configuration}")
             };
 
             // Un-comment loop below and use above commands to figure out the new limits
@@ -231,13 +231,13 @@ public class Test
         [ConditionalFact(typeof(WindowsOrLinuxOnly), typeof(NoIOperationValidation))]
         public void NestedIfStatements()
         {
-            int nestingLevel = (ExecutionConditionUtil.Architecture, ExecutionConditionUtil.Configuration) switch
+            int nestingLevel = (IntPtr.Size, ExecutionConditionUtil.Configuration) switch
             {
-                (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 310,
-                (ExecutionArchitecture.x86, ExecutionConfiguration.Release) => 1650,
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) => 200,
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 780,
-                _ => throw new Exception($"Unexpected configuration {ExecutionConditionUtil.Architecture} {ExecutionConditionUtil.Configuration}")
+                (4, ExecutionConfiguration.Debug) => 310,
+                (4, ExecutionConfiguration.Release) => 1650,
+                (8, ExecutionConfiguration.Debug) => 200,
+                (8, ExecutionConfiguration.Release) => 780,
+                _ => throw new Exception($"Unexpected configuration {IntPtr.Size * 8}-bit {ExecutionConditionUtil.Configuration}")
             };
 
             RunTest(nestingLevel, runTest);
@@ -277,13 +277,13 @@ $@"        if (F({i}))
         [ConditionalFact(typeof(WindowsOrLinuxOnly))]
         public void Constraints()
         {
-            int n = (ExecutionConditionUtil.Architecture, ExecutionConditionUtil.Configuration) switch
+            int n = (IntPtr.Size, ExecutionConditionUtil.Configuration) switch
             {
-                (ExecutionArchitecture.x86, ExecutionConfiguration.Debug) => 420,
-                (ExecutionArchitecture.x86, ExecutionConfiguration.Release) => 1100,
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Debug) => 180,
-                (ExecutionArchitecture.x64, ExecutionConfiguration.Release) => 400,
-                _ => throw new Exception($"Unexpected configuration {ExecutionConditionUtil.Architecture} {ExecutionConditionUtil.Configuration}")
+                (4, ExecutionConfiguration.Debug) => 420,
+                (4, ExecutionConfiguration.Release) => 1100,
+                (8, ExecutionConfiguration.Debug) => 180,
+                (8, ExecutionConfiguration.Release) => 400,
+                _ => throw new Exception($"Unexpected configuration {IntPtr.Size * 8}-bit {ExecutionConditionUtil.Configuration}")
             };
 
             RunTest(n, runTest);

--- a/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/ModuleMetadataTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/MetadataReferences/ModuleMetadataTests.cs
@@ -352,7 +352,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
         }
 
-        [Fact]
+        /// <summary>
+        /// Only test in 64-bit process. <see cref="UnmanagedMemoryStream"/> throws if the given length is greater than the size of the available address space.
+        /// </summary>
+        [ConditionalFact(typeof(Bitness64))]
         public unsafe void CreateFromUnmanagedMemoryStream_LargeIntSize()
         {
             var assembly = TestResources.Basic.Members;

--- a/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
+++ b/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
@@ -190,7 +190,7 @@ namespace Roslyn.Test.Utilities
     {
         public override bool ShouldSkip => IntPtr.Size != 4;
 
-        public override string SkipReason => "Target platform is not 32-bit";
+        public override string SkipReason => "Target bitness is not 32-bit";
     }
 
     public class Bitness64 : ExecutionCondition

--- a/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
+++ b/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
@@ -144,12 +144,6 @@ namespace Roslyn.Test.Utilities
 
     public static class ExecutionConditionUtil
     {
-        public static ExecutionArchitecture Architecture => (IntPtr.Size) switch
-        {
-            4 => ExecutionArchitecture.x86,
-            8 => ExecutionArchitecture.x64,
-            _ => throw new InvalidOperationException($"Unrecognized pointer size {IntPtr.Size}")
-        };
         public static ExecutionConfiguration Configuration =>
 #if DEBUG
             ExecutionConfiguration.Debug;
@@ -186,23 +180,24 @@ namespace Roslyn.Test.Utilities
         public static bool OperatingSystemRestrictsFileNames => s_operatingSystemRestrictsFileNames.Value;
     }
 
-    public enum ExecutionArchitecture
-    {
-        x86,
-        x64,
-    }
-
     public enum ExecutionConfiguration
     {
         Debug,
         Release,
     }
 
-    public class x86 : ExecutionCondition
+    public class Bitness32 : ExecutionCondition
     {
-        public override bool ShouldSkip => ExecutionConditionUtil.Architecture != ExecutionArchitecture.x86;
+        public override bool ShouldSkip => IntPtr.Size != 4;
 
-        public override string SkipReason => "Target platform is not x86";
+        public override string SkipReason => "Target platform is not 32-bit";
+    }
+
+    public class Bitness64 : ExecutionCondition
+    {
+        public override bool ShouldSkip => IntPtr.Size != 8;
+
+        public override string SkipReason => "Target bitness is not 64-bit";
     }
 
     public class HasShiftJisDefaultEncoding : ExecutionCondition

--- a/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
+++ b/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
@@ -248,7 +248,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
         }
 
         [WorkItem(28639, "https://github.com/dotnet/roslyn/issues/28639")]
-        [ConditionalFact(typeof(x86))]
+        [ConditionalFact(typeof(Bitness32))]
         public void TestPreviewWorkspaceDoesNotLeakSolution()
         {
             // Verify that analyzer execution doesn't leak solution instances from the preview workspace.

--- a/src/EditorFeatures/Test/Workspaces/ProjectCacheHostServiceFactoryTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/ProjectCacheHostServiceFactoryTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         }
 
         [WorkItem(28639, "https://github.com/dotnet/roslyn/issues/28639")]
-        [ConditionalFact(typeof(x86))]
+        [ConditionalFact(typeof(Bitness32))]
         public void TestCacheKeepsObjectAlive1()
         {
             Test((cacheService, projectId, owner, instance) =>
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         }
 
         [WorkItem(28639, "https://github.com/dotnet/roslyn/issues/28639")]
-        [ConditionalFact(typeof(x86))]
+        [ConditionalFact(typeof(Bitness32))]
         public void TestCacheKeepsObjectAlive2()
         {
             Test((cacheService, projectId, owner, instance) =>
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         }
 
         [WorkItem(28639, "https://github.com/dotnet/roslyn/issues/28639")]
-        [ConditionalFact(typeof(x86))]
+        [ConditionalFact(typeof(Bitness32))]
         public void TestCacheDoesNotKeepObjectsAliveAfterOwnerIsCollected1()
         {
             Test((cacheService, projectId, owner, instance) =>
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         }
 
         [WorkItem(28639, "https://github.com/dotnet/roslyn/issues/28639")]
-        [ConditionalFact(typeof(x86))]
+        [ConditionalFact(typeof(Bitness32))]
         public void TestCacheDoesNotKeepObjectsAliveAfterOwnerIsCollected2()
         {
             Test((cacheService, projectId, owner, instance) =>
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         }
 
         [WorkItem(28639, "https://github.com/dotnet/roslyn/issues/28639")]
-        [ConditionalFact(typeof(x86))]
+        [ConditionalFact(typeof(Bitness32))]
         public void TestImplicitCacheKeepsObjectAlive1()
         {
             var workspace = new AdhocWorkspace(MockHostServices.Instance, workspaceKind: WorkspaceKind.Host);
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         }
 
         [WorkItem(28639, "https://github.com/dotnet/roslyn/issues/28639")]
-        [ConditionalFact(typeof(x86))]
+        [ConditionalFact(typeof(Bitness32))]
         public void TestP2PReference()
         {
             var workspace = new AdhocWorkspace();
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         }
 
         [WorkItem(28639, "https://github.com/dotnet/roslyn/issues/28639")]
-        [ConditionalFact(typeof(x86))]
+        [ConditionalFact(typeof(Bitness32))]
         public void TestEjectFromImplicitCache()
         {
             var compilations = new List<Compilation>();
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         }
 
         [WorkItem(28639, "https://github.com/dotnet/roslyn/issues/28639")]
-        [ConditionalFact(typeof(x86))]
+        [ConditionalFact(typeof(Bitness32))]
         public void TestCacheCompilationTwice()
         {
             var comp1 = CSharpCompilation.Create("1");


### PR DESCRIPTION
Removes `ExecutionConditionUtil.Architecture` enum as the naming of its fields is confusing and having the enum doesn't add clarity over checking `IntPtr.Size` directly. The enum was used to check bitness but the field names are architecture specific (`x86` and `x64`).

Replace `x86` test conditional with `Bitness32` and add `Bitness64`. 

Disable test `CreateFromUnmanagedMemoryStream_LargeIntSize` when running in 32-bit process.