### PR TITLE
Add non-strict search flag for legacy unit test providers

### DIFF
--- a/src/EditorFeatures/Test2/UnitTesting/UnitTestingSearchHelpersTests_CSharp.vb
+++ b/src/EditorFeatures/Test2/UnitTesting/UnitTestingSearchHelpersTests_CSharp.vb
@@ -41,11 +41,27 @@ class Outer<T>
         End Function
 
         <Theory, CombinatorialData>
+        Public Async Function CS_TestGenericType2_NonStrict(host As TestHost) As Task
+            Await TestCSharp("
+class [|Outer|]<T>
+{
+}", UnitTestingSearchQuery.ForType("Outer", strict:=False), host)
+        End Function
+
+        <Theory, CombinatorialData>
         Public Async Function CS_TestGenericType3(host As TestHost) As Task
             Await TestCSharp("
 class Outer<T>
 {
 }", UnitTestingSearchQuery.ForType("Outer`2"), host)
+        End Function
+
+        <Theory, CombinatorialData>
+        Public Async Function CS_TestGenericType3_NonStrict(host As TestHost) As Task
+            Await TestCSharp("
+class [|Outer|]<T>
+{
+}", UnitTestingSearchQuery.ForType("Outer`2", strict:=False), host)
         End Function
 
         <Theory, CombinatorialData>
@@ -169,12 +185,30 @@ class Outer
         End Function
 
         <Theory, CombinatorialData>
+        Public Async Function CS_TestMethod2_NonStrict(host As TestHost) As Task
+            Await TestCSharp("
+class Outer
+{
+    void [|Goo|]() { }
+}", UnitTestingSearchQuery.ForMethod("Outer", "Goo", methodArity:=1, methodParameterCount:=0, strict:=False), host)
+        End Function
+
+        <Theory, CombinatorialData>
         Public Async Function CS_TestMethod3(host As TestHost) As Task
             Await TestCSharp("
 class Outer
 {
     void Goo() { }
 }", UnitTestingSearchQuery.ForMethod("Outer", "Goo", methodArity:=0, methodParameterCount:=1), host)
+        End Function
+
+        <Theory, CombinatorialData>
+        Public Async Function CS_TestMethod3_NonStrict(host As TestHost) As Task
+            Await TestCSharp("
+class Outer
+{
+    void [|Goo|]() { }
+}", UnitTestingSearchQuery.ForMethod("Outer", "Goo", methodArity:=0, methodParameterCount:=1, strict:=False), host)
         End Function
 
         <Theory, CombinatorialData>

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingSearchHelpers.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingSearchHelpers.cs
@@ -139,7 +139,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
             var index = await TopLevelSyntaxTreeIndex.GetRequiredIndexAsync(document, cancellationToken).ConfigureAwait(false);
             foreach (var info in index.DeclaredSymbolInfos)
             {
-                // Fast check to see if this looks like a candidate.
+                // Fast checks to see if this looks like a candidate.
+
+                // In non-strict mode, allow the type-parameter count to be mismatched.
                 if (query.Strict && info.TypeParameterCount != symbolArity)
                     continue;
 
@@ -152,6 +154,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
                     if (info.Kind is not (DeclaredSymbolInfoKind.Method or DeclaredSymbolInfoKind.ExtensionMethod))
                         continue;
 
+                    // In non-strict mode, allow the parameter count to be mismatched.
                     if (query.Strict && info.ParameterCount != query.MethodParameterCount)
                         continue;
                 }

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingSearchQuery.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingSearchQuery.cs
@@ -35,18 +35,28 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
         [DataMember(Order = 3)]
         public readonly int MethodParameterCount;
 
-        public static UnitTestingSearchQuery ForType(string fullyQualifiedTypeName)
-            => new(fullyQualifiedTypeName, methodName: null, methodArity: 0, methodParameterCount: 0);
+        /// <summary>
+        /// Whether or not this is a strict search or not.  Strict searches require matching arity and parameter counts,
+        /// while non-strict searches do not.  Non-strict searches are useful in cases where the initial searching data
+        /// may not be produced in a well formed fashion (for example, some legacy test providers that do not follow:
+        /// https://github.com/microsoft/vstest-docs/blob/main/RFCs/0017-Managed-TestCase-Properties.md).
+        /// </summary>
+        [DataMember(Order = 4)]
+        public readonly bool Strict;
 
-        public static UnitTestingSearchQuery ForMethod(string fullyQualifiedTypeName, string methodName, int methodArity, int methodParameterCount)
-            => new(fullyQualifiedTypeName, methodName, methodArity, methodParameterCount);
+        public static UnitTestingSearchQuery ForType(string fullyQualifiedTypeName, bool strict = true)
+            => new(fullyQualifiedTypeName, methodName: null, methodArity: 0, methodParameterCount: 0, strict);
 
-        private UnitTestingSearchQuery(string fullyQualifiedTypeName, string? methodName, int methodArity, int methodParameterCount)
+        public static UnitTestingSearchQuery ForMethod(string fullyQualifiedTypeName, string methodName, int methodArity, int methodParameterCount, bool strict = true)
+            => new(fullyQualifiedTypeName, methodName, methodArity, methodParameterCount, strict);
+
+        private UnitTestingSearchQuery(string fullyQualifiedTypeName, string? methodName, int methodArity, int methodParameterCount, bool strict)
         {
             FullyQualifiedTypeName = fullyQualifiedTypeName;
             MethodName = methodName;
             MethodArity = methodArity;
             MethodParameterCount = methodParameterCount;
+            Strict = strict;
         }
     }
 }


### PR DESCRIPTION
This is useful as not all test providers are written with a high degree of quality wrt to the data they produce.  This allows our search service to first be called in strict mode to look for precise matches, but then be called in a more relaxed mode of none are found.