### PR TITLE
Wait until an analyzer is registered before streaming workspace events over to OOP

### DIFF
--- a/src/EditorFeatures/Core/SolutionEvents/HostLegacySolutionEventsWorkspaceEventListener.cs
+++ b/src/EditorFeatures/Core/SolutionEvents/HostLegacySolutionEventsWorkspaceEventListener.cs
@@ -79,6 +79,11 @@ namespace Microsoft.CodeAnalysis.LegacySolutionEvents
             }
             else
             {
+                // Notifying OOP of workspace events can be expensive (there may be a lot of them, and they involve
+                // syncing over entire solution snapshots).  As such, do not bother to do this if the remote side says
+                // that it's not interested in the events.  This will happen, for example, when the unitTtesting
+                // Test-Explorer window has not been shown yet, and so the unit testing system will not have registered
+                // an incremental analyzer with us.
                 var shouldReport = await client.TryInvokeAsync<IRemoteLegacySolutionEventsAggregationService, bool>(
                     (service, cancellationToken) => service.ShouldReportChangesAsync(cancellationToken),
                     cancellationToken).ConfigureAwait(false);

--- a/src/EditorFeatures/Core/SolutionEvents/HostLegacySolutionEventsWorkspaceEventListener.cs
+++ b/src/EditorFeatures/Core/SolutionEvents/HostLegacySolutionEventsWorkspaceEventListener.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.LegacySolutionEvents
             {
                 // Notifying OOP of workspace events can be expensive (there may be a lot of them, and they involve
                 // syncing over entire solution snapshots).  As such, do not bother to do this if the remote side says
-                // that it's not interested in the events.  This will happen, for example, when the unitTtesting
+                // that it's not interested in the events.  This will happen, for example, when the unittesting
                 // Test-Explorer window has not been shown yet, and so the unit testing system will not have registered
                 // an incremental analyzer with us.
                 var shouldReport = await client.TryInvokeAsync<IRemoteLegacySolutionEventsAggregationService, bool>(

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/LegacySolutionEvents/UnitTestingLegacySolutionEventsListener.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/LegacySolutionEvents/UnitTestingLegacySolutionEventsListener.cs
@@ -7,6 +7,7 @@ using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LegacySolutionEvents;
 using Roslyn.Utilities;
@@ -33,6 +34,15 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.LegacySolutionEvents
                 return null;
 
             return service.Register(solution);
+        }
+
+        public bool ShouldReportChanges(SolutionServices services)
+        {
+            var service = services.GetService<IUnitTestingSolutionCrawlerRegistrationService>();
+            if (service == null)
+                return false;
+
+            return service.HasRegisteredAnalyzerProviders;
         }
 
         public ValueTask OnWorkspaceChangedAsync(WorkspaceChangeEventArgs args, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/IUnitTestingSolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/IUnitTestingSolutionCrawlerRegistrationService.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.LegacySolutionEvents;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
 {
@@ -20,5 +18,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
 #endif
 
         void AddAnalyzerProvider(IUnitTestingIncrementalAnalyzerProvider provider, UnitTestingIncrementalAnalyzerProviderMetadata metadata);
+
+        bool HasRegisteredAnalyzerProviders { get; }
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingSolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingSolutionCrawlerRegistrationService.cs
@@ -104,6 +104,17 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
         }
 #endif
 
+        public bool HasRegisteredAnalyzerProviders
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _analyzerProviders.Count > 0;
+                }
+            }
+        }
+
         public void AddAnalyzerProvider(IUnitTestingIncrementalAnalyzerProvider provider, UnitTestingIncrementalAnalyzerProviderMetadata metadata)
         {
             // now update all existing work coordinator

--- a/src/Features/Core/Portable/LegacySolutionEvents/ILegacySolutionEventsListener.cs
+++ b/src/Features/Core/Portable/LegacySolutionEvents/ILegacySolutionEventsListener.cs
@@ -4,6 +4,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.LegacySolutionEvents
 {
@@ -14,7 +15,9 @@ namespace Microsoft.CodeAnalysis.LegacySolutionEvents
     /// </summary>
     internal interface ILegacySolutionEventsListener
     {
+        bool ShouldReportChanges(SolutionServices services);
         ValueTask OnWorkspaceChangedAsync(WorkspaceChangeEventArgs args, CancellationToken cancellationToken);
+
 #if false // Not used in unit testing crawling
         ValueTask OnTextDocumentOpenedAsync(TextDocumentEventArgs args, CancellationToken cancellationToken);
         ValueTask OnTextDocumentClosedAsync(TextDocumentEventArgs args, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/LegacySolutionEvents/IRemoteLegacySolutionEventsAggregationService.cs
+++ b/src/Features/Core/Portable/LegacySolutionEvents/IRemoteLegacySolutionEventsAggregationService.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis.LegacySolutionEvents
     /// </summary>
     internal interface IRemoteLegacySolutionEventsAggregationService
     {
+        ValueTask<bool> ShouldReportChangesAsync(CancellationToken cancellationToken);
+
         /// <param name="oldSolutionChecksum"><inheritdoc cref="WorkspaceChangeEventArgs.OldSolution"/></param>
         /// <param name="newSolutionChecksum"><inheritdoc cref="WorkspaceChangeEventArgs.NewSolution"/></param>
         /// <param name="kind"><inheritdoc cref="WorkspaceChangeEventArgs.Kind"/></param>

--- a/src/Workspaces/Remote/ServiceHub/Services/LegacySolutionEvents/RemoteLegacySolutionEventsAggregationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/LegacySolutionEvents/RemoteLegacySolutionEventsAggregationService.cs
@@ -25,6 +25,18 @@ namespace Microsoft.CodeAnalysis.Remote
         {
         }
 
+        public ValueTask<bool> ShouldReportChangesAsync(CancellationToken cancellationToken)
+        {
+            return RunServiceImplAsync(
+                cancellationToken =>
+                {
+                    var services = this.GetWorkspaceServices();
+                    var service = this.GetWorkspaceServices().GetRequiredService<ILegacySolutionEventsAggregationService>();
+                    return new ValueTask<bool>(service.ShouldReportChanges(services));
+                },
+                cancellationToken);
+        }
+
         public ValueTask OnWorkspaceChangedAsync(
             Checksum oldSolutionChecksum,
             Checksum newSolutionChecksum,

--- a/src/Workspaces/Remote/ServiceHub/Services/LegacySolutionEvents/RemoteLegacySolutionEventsAggregationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/LegacySolutionEvents/RemoteLegacySolutionEventsAggregationService.cs
@@ -31,8 +31,8 @@ namespace Microsoft.CodeAnalysis.Remote
                 cancellationToken =>
                 {
                     var services = this.GetWorkspaceServices();
-                    var service = services.GetRequiredService<ILegacySolutionEventsAggregationService>();
-                    return new ValueTask<bool>(service.ShouldReportChanges(services));
+                    var aggregationService = services.GetRequiredService<ILegacySolutionEventsAggregationService>();
+                    return new ValueTask<bool>(aggregationService.ShouldReportChanges(services));
                 },
                 cancellationToken);
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/LegacySolutionEvents/RemoteLegacySolutionEventsAggregationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/LegacySolutionEvents/RemoteLegacySolutionEventsAggregationService.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 cancellationToken =>
                 {
                     var services = this.GetWorkspaceServices();
-                    var service = this.GetWorkspaceServices().GetRequiredService<ILegacySolutionEventsAggregationService>();
+                    var service = services.GetRequiredService<ILegacySolutionEventsAggregationService>();
                     return new ValueTask<bool>(service.ShouldReportChanges(services));
                 },
                 cancellationToken);


### PR DESCRIPTION
This ensures we're not wasting tons of cpu/memory syncing data to oop that isn't even needed when TestExplorer isn't even visible.