### PR TITLE
Semantic Snippets - don't show in razor documents

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return ImmutableArray<CompletionItem>.Empty;
 
             var snippets = service.GetSnippetsIfAvailable();
-            if (context.CompletionOptions.ShouldShowNewSnippetExperience())
+            if (context.CompletionOptions.ShouldShowNewSnippetExperience() && !context.Document.IsRazorDocument())
             {
                 snippets = snippets.Where(snippet => !s_builtInSnippets.Contains(snippet.Shortcut));
             }

--- a/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ConvertToInterpolatedString;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Snippets;
@@ -66,6 +67,11 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
 
         public override async Task ProvideCompletionsAsync(CompletionContext context)
         {
+            if (context.Document.IsRazorDocument())
+            {
+                return;
+            }
+
             if (!context.CompletionOptions.ShouldShowNewSnippetExperience())
             {
                 return;


### PR DESCRIPTION
Reverts back to the original behavior 
<img width="488" alt="image" src="https://user-images.githubusercontent.com/40616383/193151600-a5dff8bc-18d6-4b30-84b8-48266bcdd2a8.png">
