### PR TITLE
Semantic snippets - don't show in razor documents

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Interactive/InteractiveSupportsFeatureService.cs
+++ b/src/EditorFeatures/Core.Wpf/Interactive/InteractiveSupportsFeatureService.cs
@@ -75,6 +75,9 @@ namespace Microsoft.CodeAnalysis.Interactive
 
             public bool SupportsNavigationToAnyPosition(Document document)
                 => true;
+
+            public bool SupportsSemanticSnippets(Document document)
+                => false;
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return ImmutableArray<CompletionItem>.Empty;
 
             var snippets = service.GetSnippetsIfAvailable();
-            if (context.CompletionOptions.ShouldShowNewSnippetExperience())
+            if (context.CompletionOptions.ShouldShowNewSnippetExperience(context.Document))
             {
                 snippets = snippets.Where(snippet => !s_builtInSnippets.Contains(snippet.Shortcut));
             }

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Recommendations;
 
 namespace Microsoft.CodeAnalysis.Completion
@@ -55,8 +56,14 @@ namespace Microsoft.CodeAnalysis.Completion
         /// This takes into consideration the experiment we are running in addition to the value
         /// from user facing options.
         /// </summary>
-        public bool ShouldShowNewSnippetExperience()
+        public bool ShouldShowNewSnippetExperience(Document document)
         {
+            // Will be removed once semantic snippets will be added to razor.
+            if (document.IsRazorDocument())
+            {
+                return false;
+            }
+
             // Don't trigger snippet completion if the option value is "default" and the experiment is disabled for the user. 
             return ShowNewSnippetExperience ?? SnippetCompletion;
         }

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -5,6 +5,7 @@
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Recommendations;
+using Microsoft.CodeAnalysis.Shared;
 
 namespace Microsoft.CodeAnalysis.Completion
 {
@@ -59,7 +60,9 @@ namespace Microsoft.CodeAnalysis.Completion
         public bool ShouldShowNewSnippetExperience(Document document)
         {
             // Will be removed once semantic snippets will be added to razor.
-            if (document.IsRazorDocument())
+            var solution = document.Project.Solution;
+            var documentSupportsFeatureService = solution.Services.GetRequiredService<IDocumentSupportsFeatureService>();
+            if (!documentSupportsFeatureService.SupportsSemanticSnippets(document))
             {
                 return false;
             }

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -67,6 +67,11 @@ namespace Microsoft.CodeAnalysis.Completion
                 return false;
             }
 
+            if (document.IsRazorDocument())
+            {
+                return false;
+            }
+
             // Don't trigger snippet completion if the option value is "default" and the experiment is disabled for the user. 
             return ShowNewSnippetExperience ?? SnippetCompletion;
         }

--- a/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ConvertToInterpolatedString;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Snippets;
@@ -66,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
 
         public override async Task ProvideCompletionsAsync(CompletionContext context)
         {
-            if (!context.CompletionOptions.ShouldShowNewSnippetExperience())
+            if (!context.CompletionOptions.ShouldShowNewSnippetExperience(context.Document))
             {
                 return;
             }

--- a/src/Features/Core/Portable/Shared/IDocumentSupportsFeatureService.cs
+++ b/src/Features/Core/Portable/Shared/IDocumentSupportsFeatureService.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.Shared
         bool SupportsRefactorings(Document document);
         bool SupportsRename(Document document);
         bool SupportsNavigationToAnyPosition(Document document);
+        bool SupportsSemanticSnippets(Document document);
     }
 
     [ExportWorkspaceService(typeof(IDocumentSupportsFeatureService), ServiceLayer.Default), Shared]
@@ -38,6 +39,9 @@ namespace Microsoft.CodeAnalysis.Shared
             => true;
 
         public bool SupportsRename(Document document)
+            => true;
+
+        public bool SupportsSemanticSnippets(Document document)
             => true;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/VisualStudioSupportsFeatureService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/VisualStudioSupportsFeatureService.cs
@@ -119,7 +119,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SuggestionServi
         }
 
         private static bool SupportsSemanticSnippetsWorker(DocumentId id)
-            => ContainedDocument.TryGetContainedDocument(id).SupportsSemanticSnippets;
+        {
+            var containedDocument = ContainedDocument.TryGetContainedDocument(id);
+            return containedDocument == null || containedDocument.SupportsSemanticSnippets;
+        }
 
         private static bool SupportsNavigationToAnyPositionWorker(DocumentId id)
             => ContainedDocument.TryGetContainedDocument(id) == null;

--- a/src/VisualStudio/Core/Def/Implementation/VisualStudioSupportsFeatureService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/VisualStudioSupportsFeatureService.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SuggestionServi
             => ContainedDocument.TryGetContainedDocument(id) == null;
 
         private static bool SupportsRefactoringsWorker(DocumentId id)
-            => ContainedDocument.TryGetContainedDocument(id).SupportsRename;
+            => ContainedDocument.TryGetContainedDocument(id) == null;
 
         private static bool SupportsRenameWorker(ImmutableArray<DocumentId> ids)
         {

--- a/src/VisualStudio/Core/Def/Implementation/VisualStudioSupportsFeatureService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/VisualStudioSupportsFeatureService.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Configuration;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared;
@@ -98,6 +99,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SuggestionServi
             public bool SupportsRename(Document document)
                 => SupportsRenameWorker(document.Project.Solution.GetRelatedDocumentIds(document.Id));
 
+            public bool SupportsSemanticSnippets(Document document)
+                => SupportsSemanticSnippetsWorker(document.Id);
+
             public bool SupportsNavigationToAnyPosition(Document document)
                 => SupportsNavigationToAnyPositionWorker(document.Id);
         }
@@ -106,13 +110,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SuggestionServi
             => ContainedDocument.TryGetContainedDocument(id) == null;
 
         private static bool SupportsRefactoringsWorker(DocumentId id)
-            => ContainedDocument.TryGetContainedDocument(id) == null;
+            => ContainedDocument.TryGetContainedDocument(id).SupportsRename;
 
         private static bool SupportsRenameWorker(ImmutableArray<DocumentId> ids)
         {
             return ids.Select(id => ContainedDocument.TryGetContainedDocument(id))
                     .All(cd => cd == null || cd.SupportsRename);
         }
+
+        private static bool SupportsSemanticSnippetsWorker(DocumentId id)
+            => ContainedDocument.TryGetContainedDocument(id).SupportsSemanticSnippets;
 
         private static bool SupportsNavigationToAnyPositionWorker(DocumentId id)
             => ContainedDocument.TryGetContainedDocument(id) == null;

--- a/src/VisualStudio/Core/Def/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedDocument.cs
@@ -90,6 +90,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         private readonly VisualStudioProject _project;
 
         public bool SupportsRename { get { return _hostType == HostType.Razor; } }
+        public bool SupportsSemanticSnippets { get { return _hostType == HostType.Razor; } }
 
         public DocumentId Id { get; }
         public ITextBuffer SubjectBuffer { get; }

--- a/src/VisualStudio/Core/Def/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedDocument.cs
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         private readonly VisualStudioProject _project;
 
         public bool SupportsRename { get { return _hostType == HostType.Razor; } }
-        public bool SupportsSemanticSnippets { get { return _hostType == HostType.Razor; } }
+        public bool SupportsSemanticSnippets { get { return false; } }
 
         public DocumentId Id { get; }
         public ITextBuffer SubjectBuffer { get; }


### PR DESCRIPTION
#64377
https://github.com/dotnet/razor-tooling/issues/6927

based off of main instead of dev17.4 and it's easier to redo than rebase 