### PR TITLE
Add instrumentation to investigate flakiness in `ConstantFolding_01`

### DIFF
--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -9006,7 +9006,8 @@ $@"public class Library
                 var refA = comp.EmitToImageReference();
                 comp = CreateEmptyCompilation(sourceB, references: new[] { refA, mscorlibRefWithoutSharing }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
 
-                CompileAndVerify(comp, expectedOutput: expectedResult);
+                // Investigating flaky IL verification issue. Tracked by https://github.com/dotnet/roslyn/issues/63782
+                CompileAndVerify(comp, expectedOutput: expectedResult, verify: Verification.PassesOrFailFast);
                 Assert.NotNull(expectedResult);
             }
 
@@ -9040,7 +9041,8 @@ class Program
                     return;
                 }
 
-                CompileAndVerify(comp, expectedOutput: expectedResult).VerifyDiagnostics(expectedDiagnostics);
+                // Investigating flaky IL verification issue. Tracked by https://github.com/dotnet/roslyn/issues/63782
+                CompileAndVerify(comp, expectedOutput: expectedResult, verify: Verification.PassesOrFailFast).VerifyDiagnostics(expectedDiagnostics);
                 Assert.NotNull(expectedResult);
             }
         }

--- a/src/Compilers/Test/Core/CommonTestBase.cs
+++ b/src/Compilers/Test/Core/CommonTestBase.cs
@@ -32,6 +32,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         FailsPEVerify = 1 << 2,
         FailsILVerify = 1 << 3,
         Fails = FailsPEVerify | FailsILVerify,
+
+        PassesOrFailFast = 1 << 4,
     }
 
     /// <summary>

--- a/src/Compilers/Test/Core/CompilationVerifier.cs
+++ b/src/Compilers/Test/Core/CompilationVerifier.cs
@@ -160,6 +160,18 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
         }
 
+        public string DumpIL()
+        {
+            var output = new ICSharpCode.Decompiler.PlainTextOutput();
+            using var testEnvironment = RuntimeEnvironmentFactory.Create(_dependencies);
+            string mainModuleFullName = Emit(testEnvironment, manifestResources: null, EmitOptions.Default);
+            using var moduleMetadata = ModuleMetadata.CreateFromImage(testEnvironment.GetMainImage());
+            var peFile = new PEFile(mainModuleFullName, moduleMetadata.Module.PEReaderOpt);
+            var disassembler = new ICSharpCode.Decompiler.Disassembler.ReflectionDisassembler(output, default);
+            disassembler.WriteModuleContents(peFile);
+            return output.ToString();
+        }
+
         /// <summary>
 		/// Asserts that the emitted IL for a type is the same as the expected IL.
 		/// Many core library types are in different assemblies on .Net Framework, and .Net Core.
@@ -214,10 +226,21 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             string mainModuleName = Emit(testEnvironment, manifestResources, emitOptions);
             _allModuleData = testEnvironment.GetAllModuleData();
-            testEnvironment.Verify(peVerify);
+
+            try
+            {
+                testEnvironment.Verify(peVerify);
 #if NETCOREAPP
-            ILVerify(peVerify);
+                ILVerify(peVerify);
 #endif
+            }
+            catch (Exception) when (peVerify is Verification.PassesOrFailFast)
+            {
+                var il = DumpIL();
+                Console.WriteLine(il);
+
+                Environment.FailFast("Investigating flaky IL verification issue. Tracked by https://github.com/dotnet/roslyn/issues/63782");
+            }
 
             if (expectedSignatures != null)
             {


### PR DESCRIPTION
Trying to troubleshoot https://github.com/dotnet/roslyn/issues/63782

I'm trying to figure out whether the flakiness is in the production of IL or in the verification of IL.
The additional instrumentation should output the IL (as text) in case of failure and capture a crash dump.