### PR TITLE
Use required members for option types

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
       Keep the setting conditional. The toolset sets the assembly version to 42.42.42.42 if not set explicitly.
     -->
     <AssemblyVersion Condition="'$(OfficialBuild)' == 'true' or '$(DotNetUseShippingVersions)' == 'true'">$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
-    <MicrosoftNetCompilersToolsetVersion>4.3.0-1.final</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.3.1</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Versions used by several individual references below -->

--- a/src/Compilers/Core/Portable/InternalUtilities/CompilerFeatureRequiredAttribute.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/CompilerFeatureRequiredAttribute.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Copied from:
+// https://github.com/dotnet/runtime/blob/fdd104ec5e1d0d2aa24a6723995a98d0124f724b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CompilerFeatureRequiredAttribute.cs
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Indicates that compiler support for a particular feature is required for the location where this attribute is applied.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+    internal sealed class CompilerFeatureRequiredAttribute : Attribute
+    {
+        public CompilerFeatureRequiredAttribute(string featureName)
+        {
+            FeatureName = featureName;
+        }
+ 
+        /// <summary>
+        /// The name of the compiler feature.
+        /// </summary>
+        public string FeatureName { get; }
+ 
+        /// <summary>
+        /// If true, the compiler can choose to allow access to the location where this attribute is applied if it does not understand <see cref="FeatureName"/>.
+        /// </summary>
+        public bool IsOptional { get; init; }
+ 
+        /// <summary>
+        /// The <see cref="FeatureName"/> used for the ref structs C# feature.
+        /// </summary>
+        public const string RefStructs = nameof(RefStructs);
+ 
+        /// <summary>
+        /// The <see cref="FeatureName"/> used for the required members C# feature.
+        /// </summary>
+        public const string RequiredMembers = nameof(RequiredMembers);
+    }
+}

--- a/src/Compilers/Core/Portable/InternalUtilities/CompilerFeatureRequiredAttribute.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/CompilerFeatureRequiredAttribute.cs
@@ -17,22 +17,22 @@ namespace System.Runtime.CompilerServices
         {
             FeatureName = featureName;
         }
- 
+
         /// <summary>
         /// The name of the compiler feature.
         /// </summary>
         public string FeatureName { get; }
- 
+
         /// <summary>
         /// If true, the compiler can choose to allow access to the location where this attribute is applied if it does not understand <see cref="FeatureName"/>.
         /// </summary>
         public bool IsOptional { get; init; }
- 
+
         /// <summary>
         /// The <see cref="FeatureName"/> used for the ref structs C# feature.
         /// </summary>
         public const string RefStructs = nameof(RefStructs);
- 
+
         /// <summary>
         /// The <see cref="FeatureName"/> used for the required members C# feature.
         /// </summary>

--- a/src/Compilers/Core/Portable/InternalUtilities/RequiredMemberAttribute.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/RequiredMemberAttribute.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Copied from:
+// https://github.com/dotnet/runtime/blob/fdd104ec5e1d0d2aa24a6723995a98d0124f724b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RequiredMemberAttribute.cs
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>Specifies that a type has required members or that a member is required.</summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    internal sealed class RequiredMemberAttribute : Attribute
+    {
+    }
+}

--- a/src/Compilers/Core/Portable/InternalUtilities/SetsRequiredMembersAttribute.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SetsRequiredMembersAttribute.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Copied from:
+// https://github.com/dotnet/runtime/blob/fdd104ec5e1d0d2aa24a6723995a98d0124f724b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/SetsRequiredMembersAttribute.cs
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Specifies that this constructor sets all required members for the current type, and callers
+    /// do not need to set any required members themselves.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    internal sealed class SetsRequiredMembersAttribute : Attribute
+    {
+    }
+}

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
@@ -131,8 +131,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             var document = workspace.CurrentSolution.GetDocument(testDocument.Id);
             Assert.NotNull(document);
 
-            var options = new ExtractMethodGenerationOptions(CodeGenerationOptions.GetDefault(document.Project.Services))
+            var options = new ExtractMethodGenerationOptions()
             {
+                CodeGenerationOptions = CodeGenerationOptions.GetDefault(document.Project.Services),
                 ExtractOptions = new() { DontPutOutOrRefOnStruct = dontPutOutOrRefOnStruct }
             };
 

--- a/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/Microsoft.CodeAnalysis.EditorFeatures.csproj
@@ -18,6 +18,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\IsExternalInit.cs" Link="IsExternalInit.cs" />
+    <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\CompilerFeatureRequiredAttribute.cs" Link="CompilerFeatureRequiredAttribute.cs" />
+    <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\RequiredMemberAttribute.cs" Link="RequiredMemberAttribute.cs" />
+    <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\SetsRequiredMembersAttribute.cs" Link="SetsRequiredMembersAttribute.cs" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\Microsoft.CodeAnalysis.csproj" />

--- a/src/EditorFeatures/TestUtilities/Utilities/CSharpCodeActionOptions.cs
+++ b/src/EditorFeatures/TestUtilities/Utilities/CSharpCodeActionOptions.cs
@@ -20,10 +20,14 @@ namespace Microsoft.CodeAnalysis.Test.Utilities;
 
 internal static class CSharpCodeActionOptions
 {
-    public static CodeActionOptions Default = new(
-        new CodeCleanupOptions(
-            CSharpSyntaxFormattingOptions.Default,
-            CSharpSimplifierOptions.Default),
-        CSharpCodeGenerationOptions.Default,
-        CSharpIdeCodeStyleOptions.Default);
+    public static CodeActionOptions Default = new()
+    {
+        CleanupOptions = new()
+        {
+            FormattingOptions = CSharpSyntaxFormattingOptions.Default,
+            SimplifierOptions = CSharpSimplifierOptions.Default
+        },
+        CodeGenerationOptions = CSharpCodeGenerationOptions.Default,
+        CodeStyleOptions = CSharpIdeCodeStyleOptions.Default
+    };
 }

--- a/src/EditorFeatures/TestUtilities/Utilities/VisualBasicCodeActionOptions.cs
+++ b/src/EditorFeatures/TestUtilities/Utilities/VisualBasicCodeActionOptions.cs
@@ -21,12 +21,16 @@ namespace Microsoft.CodeAnalysis.Test.Utilities;
 
 internal static class VisualBasicCodeActionOptions
 {
-    public static CodeActionOptions Default = new(
-        new CodeCleanupOptions(
-            VisualBasicSyntaxFormattingOptions.Default,
-            VisualBasicSimplifierOptions.Default),
-        VisualBasicCodeGenerationOptions.Default,
-        VisualBasicIdeCodeStyleOptions.Default);
+    public static CodeActionOptions Default = new()
+    {
+        CleanupOptions = new()
+        {
+            FormattingOptions = VisualBasicSyntaxFormattingOptions.Default,
+            SimplifierOptions = VisualBasicSimplifierOptions.Default,
+        },
+        CodeGenerationOptions = VisualBasicCodeGenerationOptions.Default,
+        CodeStyleOptions = VisualBasicIdeCodeStyleOptions.Default
+    };
 
     public static CodeActionOptions WithWrappingColumn(this CodeActionOptions options, int value)
         => options with { WrappingColumn = value };

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
@@ -15,6 +15,7 @@ Imports Microsoft.CodeAnalysis.ExtractMethod
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
+Imports Microsoft.CodeAnalysis.UnitTests
 Imports Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.VisualStudio.Text
@@ -115,10 +116,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
             Assert.True(selectedCode.ContainsValidContext)
 
             ' extract method
-            Dim extractGenerationOptions = New ExtractMethodGenerationOptions(CodeGenerationOptions.GetDefault(document.Project.Services)) With
-            {
-                .ExtractOptions = extractOptions
-            }
+            Dim extractGenerationOptions = VBOptionsFactory.CreateExtractMethodGenerationOptions(
+                CodeGenerationOptions.GetDefault(document.Project.Services),
+                extractOptions)
 
             Dim extractor = New VisualBasicMethodExtractor(CType(selectedCode, VisualBasicSelectionResult), extractGenerationOptions)
             Dim result = Await extractor.ExtractMethodAsync(CancellationToken.None)

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.cs
@@ -48,7 +48,11 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                     generateDocumentationComments: true,
                     mergeAttributes: false,
                     autoInsertionLocation: false),
-                new CodeAndImportGenerationOptions(options.GenerationOptions, options.CleanupOptions.AddImportOptions).CreateProvider());
+                new CodeAndImportGenerationOptions()
+                {
+                    GenerationOptions = options.GenerationOptions,
+                    AddImportOptions = options.CleanupOptions.AddImportOptions
+                }.CreateProvider());
 
             // Add the interface of the symbol to the top of the root namespace
             document = await CodeGenerator.AddNamespaceOrTypeDeclarationAsync(

--- a/src/Features/LanguageServer/Protocol/Features/Options/CodeActionOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/CodeActionOptionsStorage.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Xml.Serialization;
 using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.CodeStyle;
@@ -21,11 +22,11 @@ namespace Microsoft.CodeAnalysis.CodeActions
             new("FormattingOptions", "WrappingColumn", CodeActionOptions.DefaultWrappingColumn);
 
         public static CodeActionOptions GetCodeActionOptions(this IGlobalOptionService globalOptions, LanguageServices languageServices)
-            => new(
-                cleanupOptions: globalOptions.GetCodeCleanupOptions(languageServices),
-                codeGenerationOptions: globalOptions.GetCodeGenerationOptions(languageServices),
-                codeStyleOptions: globalOptions.GetCodeStyleOptions(languageServices))
+            => new()
             {
+                CleanupOptions = globalOptions.GetCodeCleanupOptions(languageServices),
+                CodeGenerationOptions = globalOptions.GetCodeGenerationOptions(languageServices),
+                CodeStyleOptions = globalOptions.GetCodeStyleOptions(languageServices),
                 SearchOptions = globalOptions.GetSymbolSearchOptions(languageServices.Language),
                 ImplementTypeOptions = globalOptions.GetImplementTypeOptions(languageServices.Language),
                 ExtractMethodOptions = globalOptions.GetExtractMethodOptions(languageServices.Language),

--- a/src/Features/LanguageServer/Protocol/Features/Options/CodeCleanupOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/CodeCleanupOptionsStorage.cs
@@ -19,10 +19,10 @@ internal static class CodeCleanupOptionsStorage
         => document.GetCodeCleanupOptionsAsync(globalOptions.GetCodeCleanupOptions(document.Project.Services), cancellationToken);
 
     public static CodeCleanupOptions GetCodeCleanupOptions(this IGlobalOptionService globalOptions, LanguageServices languageServices)
-        => new(
-            globalOptions.GetSyntaxFormattingOptions(languageServices),
-            globalOptions.GetSimplifierOptions(languageServices))
+        => new()
         {
+            FormattingOptions = globalOptions.GetSyntaxFormattingOptions(languageServices),
+            SimplifierOptions = globalOptions.GetSimplifierOptions(languageServices),
             AddImportOptions = globalOptions.GetAddImportPlacementOptions(languageServices),
             DocumentFormattingOptions = globalOptions.GetDocumentFormattingOptions(languageServices.Language)
         };

--- a/src/Features/LanguageServer/Protocol/Features/Options/CodeGenerationOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/CodeGenerationOptionsStorage.cs
@@ -36,8 +36,16 @@ internal static class CodeGenerationOptionsStorage
         => languageServices.GetRequiredService<ICodeGenerationOptionsStorage>().GetOptions(globalOptions);
 
     public static CodeAndImportGenerationOptions GetCodeAndImportGenerationOptions(this IGlobalOptionService globalOptions, LanguageServices languageServices)
-        => new(globalOptions.GetCodeGenerationOptions(languageServices), globalOptions.GetAddImportPlacementOptions(languageServices));
+        => new()
+        {
+            GenerationOptions = globalOptions.GetCodeGenerationOptions(languageServices),
+            AddImportOptions = globalOptions.GetAddImportPlacementOptions(languageServices)
+        };
 
     public static CleanCodeGenerationOptions GetCleanCodeGenerationOptions(this IGlobalOptionService globalOptions, LanguageServices languageServices)
-        => new(globalOptions.GetCodeGenerationOptions(languageServices), globalOptions.GetCodeCleanupOptions(languageServices));
+        => new()
+        {
+            GenerationOptions = globalOptions.GetCodeGenerationOptions(languageServices),
+            CleanupOptions = globalOptions.GetCodeCleanupOptions(languageServices)
+        };
 }

--- a/src/Features/LanguageServer/Protocol/Features/Options/ExtractMethodOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/ExtractMethodOptionsStorage.cs
@@ -22,8 +22,9 @@ internal static class ExtractMethodOptionsStorage
         };
 
     public static ExtractMethodGenerationOptions GetExtractMethodGenerationOptions(this IGlobalOptionService globalOptions, LanguageServices languageServices)
-        => new(globalOptions.GetCodeGenerationOptions(languageServices))
+        => new()
         {
+            CodeGenerationOptions = globalOptions.GetCodeGenerationOptions(languageServices),
             ExtractOptions = globalOptions.GetExtractMethodOptions(languageServices.Language),
             AddImportOptions = globalOptions.GetAddImportPlacementOptions(languageServices),
             LineFormattingOptions = globalOptions.GetLineFormattingOptions(languageServices.Language)

--- a/src/Tools/ExternalAccess/OmniSharp.CSharp/Formatting/OmniSharpSyntaxFormattingOptionsFactory.cs
+++ b/src/Tools/ExternalAccess/OmniSharp.CSharp/Formatting/OmniSharpSyntaxFormattingOptionsFactory.cs
@@ -78,12 +78,13 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp.Formatting
             bool newLineForMembersInObjectInit,
             bool newLineForMembersInAnonymousTypes,
             bool newLineForClausesInQuery)
-            => new(new(
-                FormattingOptions: new CSharpSyntaxFormattingOptions()
+            => new(new()
+            {
+                FormattingOptions = new CSharpSyntaxFormattingOptions()
                 {
-                    Common = new SyntaxFormattingOptions.CommonOptions()
+                    Common = new()
                     {
-                        LineFormatting = new LineFormattingOptions()
+                        LineFormatting = new()
                         {
                             UseTabs = useTabs,
                             TabSize = tabSize,
@@ -142,6 +143,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp.Formatting
                     WrappingKeepStatementsOnSingleLine = wrappingKeepStatementsOnSingleLine,
                     WrappingPreserveSingleLine = wrappingPreserveSingleLine
                 },
-                SimplifierOptions: CSharpSimplifierOptions.Default));
+                SimplifierOptions = CSharpSimplifierOptions.Default
+            });
     }
 }

--- a/src/Tools/ExternalAccess/OmniSharp/MetadataAsSource/OmniSharpMetadataAsSourceService.cs
+++ b/src/Tools/ExternalAccess/OmniSharp/MetadataAsSource/OmniSharpMetadataAsSourceService.cs
@@ -36,9 +36,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.MetadataAsSource
 
             var cleanupOptions = await document.GetCodeCleanupOptionsAsync(CodeActionOptions.DefaultProvider, cancellationToken).ConfigureAwait(false);
 
-            var options = new CleanCodeGenerationOptions(
-                GenerationOptions: CodeGenerationOptions.GetDefault(document.Project.Services),
-                CleanupOptions: cleanupOptions);
+            var options = new CleanCodeGenerationOptions()
+            {
+                GenerationOptions = CodeGenerationOptions.GetDefault(document.Project.Services),
+                CleanupOptions = cleanupOptions
+            };
 
             return await service.AddSourceToAsync(document, symbolCompilation, symbol, options, cancellationToken).ConfigureAwait(false);
         }
@@ -58,9 +60,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.MetadataAsSource
         {
             var service = document.GetRequiredLanguageService<IMetadataAsSourceService>();
 
-            var options = new CleanCodeGenerationOptions(
-                GenerationOptions: CodeGenerationOptions.GetDefault(document.Project.Services),
-                CleanupOptions: formattingOptions.CleanupOptions);
+            var options = new CleanCodeGenerationOptions()
+            {
+                GenerationOptions = CodeGenerationOptions.GetDefault(document.Project.Services),
+                CleanupOptions = formattingOptions.CleanupOptions
+            };
 
             return service.AddSourceToAsync(document, symbolCompilation, symbol, options, cancellationToken);
         }

--- a/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/VisualStudioDiagnosticAnalyzerExecutorTests.cs
@@ -65,14 +65,18 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
             var ideOptions = new IdeAnalyzerOptions()
             {
-                CleanCodeGenerationOptions = new CleanCodeGenerationOptions(
-                    CSharpCodeGenerationOptions.Default,
-                    new CodeCleanupOptions(
-                        FormattingOptions: CSharpSyntaxFormattingOptions.Default,
-                        SimplifierOptions: new CSharpSimplifierOptions()
+                CleanCodeGenerationOptions = new()
+                {
+                    GenerationOptions = CSharpCodeGenerationOptions.Default,
+                    CleanupOptions = new()
+                    {
+                        FormattingOptions = CSharpSyntaxFormattingOptions.Default,
+                        SimplifierOptions = new CSharpSimplifierOptions()
                         {
                             VarWhenTypeIsApparent = new CodeStyleOption2<bool>(false, NotificationOption2.Suggestion)
-                        }))
+                        }
+                    }
+                }
             };
 
             analyzerResult = await AnalyzeAsync(workspace, workspace.CurrentSolution.ProjectIds.First(), analyzerType, ideOptions);

--- a/src/Workspaces/Core/Portable/ExtractMethod/ExtractMethodOptions.cs
+++ b/src/Workspaces/Core/Portable/ExtractMethod/ExtractMethodOptions.cs
@@ -31,15 +31,22 @@ internal readonly record struct ExtractMethodOptions
 /// Combines global <see cref="ExtractOptions"/> with document specific code generation options.
 /// </summary>
 [DataContract]
-internal readonly record struct ExtractMethodGenerationOptions(
-    [property: DataMember] CodeGenerationOptions CodeGenerationOptions)
+internal readonly record struct ExtractMethodGenerationOptions
 {
+    [DataMember] public required CodeGenerationOptions CodeGenerationOptions { get; init; }
     [DataMember] public ExtractMethodOptions ExtractOptions { get; init; } = ExtractMethodOptions.Default;
     [DataMember] public AddImportPlacementOptions AddImportOptions { get; init; } = AddImportPlacementOptions.Default;
     [DataMember] public LineFormattingOptions LineFormattingOptions { get; init; } = LineFormattingOptions.Default;
 
     public static ExtractMethodGenerationOptions GetDefault(LanguageServices languageServices)
-        => new(CodeGenerationOptions.GetDefault(languageServices));
+        => new()
+        {
+            CodeGenerationOptions = CodeGenerationOptions.GetDefault(languageServices)
+        };
+
+    public ExtractMethodGenerationOptions()
+    {
+    }
 }
 
 internal static class ExtractMethodGenerationOptionsProviders
@@ -48,16 +55,12 @@ internal static class ExtractMethodGenerationOptionsProviders
     {
         fallbackOptions ??= ExtractMethodGenerationOptions.GetDefault(document.Project.Services);
 
-        var extractOptions = fallbackOptions.Value.ExtractOptions;
-        var codeGenerationOptions = await document.GetCodeGenerationOptionsAsync(fallbackOptions.Value.CodeGenerationOptions, cancellationToken).ConfigureAwait(false);
-        var addImportOptions = await document.GetAddImportPlacementOptionsAsync(fallbackOptions.Value.AddImportOptions, cancellationToken).ConfigureAwait(false);
-        var lineFormattingOptions = await document.GetLineFormattingOptionsAsync(fallbackOptions.Value.LineFormattingOptions, cancellationToken).ConfigureAwait(false);
-
-        return new ExtractMethodGenerationOptions(codeGenerationOptions)
+        return new ExtractMethodGenerationOptions()
         {
-            ExtractOptions = extractOptions,
-            AddImportOptions = addImportOptions,
-            LineFormattingOptions = lineFormattingOptions,
+            CodeGenerationOptions = await document.GetCodeGenerationOptionsAsync(fallbackOptions.Value.CodeGenerationOptions, cancellationToken).ConfigureAwait(false),
+            ExtractOptions = fallbackOptions.Value.ExtractOptions,
+            AddImportOptions = await document.GetAddImportPlacementOptionsAsync(fallbackOptions.Value.AddImportOptions, cancellationToken).ConfigureAwait(false),
+            LineFormattingOptions = await document.GetLineFormattingOptionsAsync(fallbackOptions.Value.LineFormattingOptions, cancellationToken).ConfigureAwait(false),
         };
     }
 

--- a/src/Workspaces/CoreTestUtilities/VBOptionsFactory.cs
+++ b/src/Workspaces/CoreTestUtilities/VBOptionsFactory.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.ExtractMethod;
+
+namespace Microsoft.CodeAnalysis.UnitTests;
+
+/// <summary>
+/// Currently VB does not support required members, so it can't create instances of some of our option types.
+/// This class is a workaround until VB implements the feature.
+/// </summary>
+internal static class VBOptionsFactory
+{
+    public static ExtractMethodGenerationOptions CreateExtractMethodGenerationOptions(CodeGenerationOptions codeGenerationOptions, ExtractMethodOptions extractOptions)
+        => new ExtractMethodGenerationOptions()
+        {
+            CodeGenerationOptions = codeGenerationOptions,
+            ExtractOptions = extractOptions
+        };
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeCleanup/CodeCleanupOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeCleanup/CodeCleanupOptions.cs
@@ -20,18 +20,20 @@ using Microsoft.CodeAnalysis.OrganizeImports;
 namespace Microsoft.CodeAnalysis.CodeCleanup;
 
 [DataContract]
-internal sealed record class CodeCleanupOptions(
-    [property: DataMember] SyntaxFormattingOptions FormattingOptions,
-    [property: DataMember] SimplifierOptions SimplifierOptions)
+internal sealed record class CodeCleanupOptions
 {
+    [DataMember] public required SyntaxFormattingOptions FormattingOptions { get; init; }
+    [DataMember] public required SimplifierOptions SimplifierOptions { get; init; }
     [DataMember] public AddImportPlacementOptions AddImportOptions { get; init; } = AddImportPlacementOptions.Default;
     [DataMember] public DocumentFormattingOptions DocumentFormattingOptions { get; init; } = DocumentFormattingOptions.Default;
 
 #if !CODE_STYLE
     public static CodeCleanupOptions GetDefault(LanguageServices languageServices)
-        => new(
-            FormattingOptions: SyntaxFormattingOptions.GetDefault(languageServices),
-            SimplifierOptions: SimplifierOptions.GetDefault(languageServices));
+        => new()
+        {
+            FormattingOptions = SyntaxFormattingOptions.GetDefault(languageServices),
+            SimplifierOptions = SimplifierOptions.GetDefault(languageServices)
+        };
 
     public OrganizeImportsOptions GetOrganizeImportsOptions()
         => new()
@@ -83,18 +85,13 @@ internal static class CodeCleanupOptionsProviders
 {
 #if !CODE_STYLE
     public static CodeCleanupOptions GetCodeCleanupOptions(this AnalyzerConfigOptions options, bool allowImportsInHiddenRegions, CodeCleanupOptions? fallbackOptions, LanguageServices languageServices)
-    {
-        var formattingOptions = options.GetSyntaxFormattingOptions(fallbackOptions?.FormattingOptions, languageServices);
-        var simplifierOptions = options.GetSimplifierOptions(fallbackOptions?.SimplifierOptions, languageServices);
-        var addImportOptions = options.GetAddImportPlacementOptions(allowImportsInHiddenRegions, fallbackOptions?.AddImportOptions, languageServices);
-        var documentFormattingOptions = options.GetDocumentFormattingOptions(fallbackOptions?.DocumentFormattingOptions);
-
-        return new CodeCleanupOptions(formattingOptions, simplifierOptions)
+        => new()
         {
-            AddImportOptions = addImportOptions,
-            DocumentFormattingOptions = documentFormattingOptions
+            FormattingOptions = options.GetSyntaxFormattingOptions(fallbackOptions?.FormattingOptions, languageServices),
+            SimplifierOptions = options.GetSimplifierOptions(fallbackOptions?.SimplifierOptions, languageServices),
+            AddImportOptions = options.GetAddImportPlacementOptions(allowImportsInHiddenRegions, fallbackOptions?.AddImportOptions, languageServices),
+            DocumentFormattingOptions = options.GetDocumentFormattingOptions(fallbackOptions?.DocumentFormattingOptions),
         };
-    }
 
     public static async ValueTask<CodeCleanupOptions> GetCodeCleanupOptionsAsync(this Document document, CodeCleanupOptions? fallbackOptions, CancellationToken cancellationToken)
     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeGeneration/CleanCodeGenerationOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeGeneration/CleanCodeGenerationOptions.cs
@@ -12,17 +12,28 @@ using Microsoft.CodeAnalysis.Host;
 namespace Microsoft.CodeAnalysis.CodeGeneration;
 
 [DataContract]
-internal readonly record struct CleanCodeGenerationOptions(
-    [property: DataMember(Order = 0)] CodeGenerationOptions GenerationOptions,
-    [property: DataMember(Order = 1)] CodeCleanupOptions CleanupOptions)
+internal readonly record struct CleanCodeGenerationOptions
 {
+    [DataMember]
+    public required CodeGenerationOptions GenerationOptions { get; init; }
+
+    [DataMember]
+    public required CodeCleanupOptions CleanupOptions { get; init; }
+
 #if !CODE_STYLE
     public static CleanCodeGenerationOptions GetDefault(LanguageServices languageServices)
-        => new(CodeGenerationOptions.GetDefault(languageServices),
-               CodeCleanupOptions.GetDefault(languageServices));
+        => new()
+        {
+            GenerationOptions = CodeGenerationOptions.GetDefault(languageServices),
+            CleanupOptions = CodeCleanupOptions.GetDefault(languageServices)
+        };
 
     public CodeAndImportGenerationOptions CodeAndImportGenerationOptions
-        => new(GenerationOptions, CleanupOptions.AddImportOptions);
+        => new()
+        {
+            GenerationOptions = GenerationOptions,
+            AddImportOptions = CleanupOptions.AddImportOptions
+        };
 #endif
 }
 
@@ -60,9 +71,11 @@ internal abstract class AbstractCleanCodeGenerationOptionsProvider : AbstractCod
 internal static class CleanCodeGenerationOptionsProviders
 {
     public static async ValueTask<CleanCodeGenerationOptions> GetCleanCodeGenerationOptionsAsync(this Document document, CleanCodeGenerationOptions fallbackOptions, CancellationToken cancellationToken)
-        => new(
-            await document.GetCodeGenerationOptionsAsync(fallbackOptions.GenerationOptions, cancellationToken).ConfigureAwait(false),
-            await document.GetCodeCleanupOptionsAsync(fallbackOptions.CleanupOptions, cancellationToken).ConfigureAwait(false));
+        => new()
+        {
+            GenerationOptions = await document.GetCodeGenerationOptionsAsync(fallbackOptions.GenerationOptions, cancellationToken).ConfigureAwait(false),
+            CleanupOptions = await document.GetCodeCleanupOptionsAsync(fallbackOptions.CleanupOptions, cancellationToken).ConfigureAwait(false)
+        };
 
     public static async ValueTask<CleanCodeGenerationOptions> GetCleanCodeGenerationOptionsAsync(this Document document, CleanCodeGenerationOptionsProvider fallbackOptionsProvider, CancellationToken cancellationToken)
         => await document.GetCleanCodeGenerationOptionsAsync(await ((OptionsProvider<CleanCodeGenerationOptions>)fallbackOptionsProvider).GetOptionsAsync(document.Project.Services, cancellationToken).ConfigureAwait(false), cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeGeneration/CodeGenerationOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeGeneration/CodeGenerationOptions.cs
@@ -52,13 +52,21 @@ internal abstract class CodeGenerationOptions
 }
 
 [DataContract]
-internal readonly record struct CodeAndImportGenerationOptions(
-    [property: DataMember(Order = 0)] CodeGenerationOptions GenerationOptions,
-    [property: DataMember(Order = 1)] AddImportPlacementOptions AddImportOptions)
+internal readonly record struct CodeAndImportGenerationOptions
 {
+    [DataMember]
+    public required CodeGenerationOptions GenerationOptions { get; init; }
+
+    [DataMember]
+    public required AddImportPlacementOptions AddImportOptions { get; init; }
+
 #if !CODE_STYLE
     internal static CodeAndImportGenerationOptions GetDefault(LanguageServices languageServices)
-        => new(CodeGenerationOptions.GetDefault(languageServices), AddImportPlacementOptions.Default);
+        => new()
+        {
+            GenerationOptions = CodeGenerationOptions.GetDefault(languageServices),
+            AddImportOptions = AddImportPlacementOptions.Default
+        };
 
     internal CodeAndImportGenerationOptionsProvider CreateProvider()
         => new Provider(this);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -22,6 +22,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\NonDefaultableAttribute.cs" Link="InternalUtilities\NonDefaultableAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\NullableAttributes.cs" Link="InternalUtilities\NullableAttributes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\IsExternalInit.cs" Link="InternalUtilities\IsExternalInit.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\CompilerFeatureRequiredAttribute.cs" Link="InternalUtilities\CompilerFeatureRequiredAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\RequiredMemberAttribute.cs" Link="InternalUtilities\RequiredMemberAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SetsRequiredMembersAttribute.cs" Link="InternalUtilities\SetsRequiredMembersAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\ReferenceEqualityComparer.cs" Link="InternalUtilities\ReferenceEqualityComparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\RoslynString.cs" Link="InternalUtilities\RoslynString.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\SpecializedCollections.cs" Link="InternalUtilities\SpecializedCollections.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeFixes/CodeActionOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeFixes/CodeActionOptions.cs
@@ -51,31 +51,23 @@ namespace Microsoft.CodeAnalysis.CodeActions
         public const int DefaultConditionalExpressionWrappingLength = 120;
 
 #if !CODE_STYLE
-        [DataMember(Order = 0)] public CodeCleanupOptions CleanupOptions { get; init; }
-        [DataMember(Order = 1)] public CodeGenerationOptions CodeGenerationOptions { get; init; }
-        [DataMember(Order = 2)] public IdeCodeStyleOptions CodeStyleOptions { get; init; }
-        [DataMember(Order = 3)] public SymbolSearchOptions SearchOptions { get; init; } = SymbolSearchOptions.Default;
-        [DataMember(Order = 4)] public ImplementTypeOptions ImplementTypeOptions { get; init; } = ImplementTypeOptions.Default;
-        [DataMember(Order = 5)] public ExtractMethodOptions ExtractMethodOptions { get; init; } = ExtractMethodOptions.Default;
-        [DataMember(Order = 6)] public bool HideAdvancedMembers { get; init; } = false;
-        [DataMember(Order = 7)] public int WrappingColumn { get; init; } = DefaultWrappingColumn;
-        [DataMember(Order = 8)] public int ConditionalExpressionWrappingLength { get; init; } = DefaultConditionalExpressionWrappingLength;
-
-        public CodeActionOptions(
-            CodeCleanupOptions cleanupOptions,
-            CodeGenerationOptions codeGenerationOptions,
-            IdeCodeStyleOptions codeStyleOptions)
-        {
-            CleanupOptions = cleanupOptions;
-            CodeGenerationOptions = codeGenerationOptions;
-            CodeStyleOptions = codeStyleOptions;
-        }
+        [DataMember] public required CodeCleanupOptions CleanupOptions { get; init; }
+        [DataMember] public required CodeGenerationOptions CodeGenerationOptions { get; init; }
+        [DataMember] public required IdeCodeStyleOptions CodeStyleOptions { get; init; }
+        [DataMember] public SymbolSearchOptions SearchOptions { get; init; } = SymbolSearchOptions.Default;
+        [DataMember] public ImplementTypeOptions ImplementTypeOptions { get; init; } = ImplementTypeOptions.Default;
+        [DataMember] public ExtractMethodOptions ExtractMethodOptions { get; init; } = ExtractMethodOptions.Default;
+        [DataMember] public bool HideAdvancedMembers { get; init; } = false;
+        [DataMember] public int WrappingColumn { get; init; } = DefaultWrappingColumn;
+        [DataMember] public int ConditionalExpressionWrappingLength { get; init; } = DefaultConditionalExpressionWrappingLength;
 
         public static CodeActionOptions GetDefault(LanguageServices languageServices)
-            => new(
-                CodeCleanupOptions.GetDefault(languageServices),
-                CodeGenerationOptions.GetDefault(languageServices),
-                IdeCodeStyleOptions.GetDefault(languageServices));
+            => new()
+            {
+                CleanupOptions = CodeCleanupOptions.GetDefault(languageServices),
+                CodeGenerationOptions = CodeGenerationOptions.GetDefault(languageServices),
+                CodeStyleOptions = IdeCodeStyleOptions.GetDefault(languageServices)
+            };
 #else
         public static CodeActionOptions GetDefault(LanguageServices languageServices)
             => new();
@@ -134,13 +126,21 @@ namespace Microsoft.CodeAnalysis.CodeActions
         ValueTask<CleanCodeGenerationOptions> OptionsProvider<CleanCodeGenerationOptions>.GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
         {
             var codeActionOptions = GetOptions(languageServices);
-            return ValueTaskFactory.FromResult(new CleanCodeGenerationOptions(codeActionOptions.CodeGenerationOptions, codeActionOptions.CleanupOptions));
+            return ValueTaskFactory.FromResult(new CleanCodeGenerationOptions()
+            {
+                GenerationOptions = codeActionOptions.CodeGenerationOptions,
+                CleanupOptions = codeActionOptions.CleanupOptions
+            });
         }
 
         ValueTask<CodeAndImportGenerationOptions> OptionsProvider<CodeAndImportGenerationOptions>.GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
         {
             var codeActionOptions = GetOptions(languageServices);
-            return ValueTaskFactory.FromResult(new CodeAndImportGenerationOptions(codeActionOptions.CodeGenerationOptions, codeActionOptions.CleanupOptions.AddImportOptions));
+            return ValueTaskFactory.FromResult(new CodeAndImportGenerationOptions()
+            {
+                GenerationOptions = codeActionOptions.CodeGenerationOptions,
+                AddImportOptions = codeActionOptions.CleanupOptions.AddImportOptions
+            });
         }
 #endif
     }
@@ -180,8 +180,9 @@ namespace Microsoft.CodeAnalysis.CodeActions
         public static ExtractMethodGenerationOptions GetExtractMethodGenerationOptions(this CodeActionOptionsProvider provider, LanguageServices languageServices)
         {
             var codeActionOptions = provider.GetOptions(languageServices);
-            return new(codeActionOptions.CodeGenerationOptions)
+            return new()
             {
+                CodeGenerationOptions = codeActionOptions.CodeGenerationOptions,
                 ExtractOptions = codeActionOptions.ExtractMethodOptions,
                 AddImportOptions = codeActionOptions.CleanupOptions.AddImportOptions,
                 LineFormattingOptions = codeActionOptions.CleanupOptions.FormattingOptions.LineFormatting


### PR DESCRIPTION
Use required properties instead of passing parameters to constructors of option types.

Adds attribute types necessary for required members feature.

