### PR TITLE
[LSP] Fix bug where request contexts were not created serially

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -671,7 +671,7 @@ namespace Roslyn.Test.Utilities
                 // Some tests manually call shutdown, so avoid calling shutdown twice if already called.
                 if (!LanguageServer.HasShutdownStarted)
                 {
-                    await LanguageServer.GetTestAccessor().ShutdownServerAsync();
+                    await LanguageServer.GetTestAccessor().ShutdownServerAsync("Disposing of test lsp server");
                 }
 
                 await LanguageServer.GetTestAccessor().ExitServerAsync();

--- a/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
+++ b/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
@@ -293,9 +293,9 @@ public abstract class AbstractLanguageServer<TRequestContext> : ILifeCycleManage
 
         internal bool HasShutdownStarted() => _server.HasShutdownStarted;
 
-        internal Task ShutdownServerAsync()
+        internal Task ShutdownServerAsync(string message = "Shutting down")
         {
-            return _server.ShutdownAsync();
+            return _server.ShutdownAsync(message);
         }
 
         internal Task ExitServerAsync()

--- a/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/IQueueItem.cs
+++ b/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/IQueueItem.cs
@@ -17,9 +17,18 @@ public interface IQueueItem<TRequestContext>
     /// <summary>
     /// Executes the work specified by this queue item.
     /// </summary>
+    /// <param name="requestContext">the context created by <see cref="CreateRequestContextAsync(CancellationToken)"/></param>
     /// <param name="cancellationToken" />
     /// <returns>A <see cref="Task "/> which completes when the request has finished.</returns>
-    Task StartRequestAsync(CancellationToken cancellationToken);
+    Task StartRequestAsync(TRequestContext? requestContext, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Creates the context that is sent to the handler for this queue item.
+    /// Note - this method is always called serially inside the queue before
+    /// running the actual request in <see cref="StartRequestAsync(TRequestContext?, CancellationToken)"/>
+    /// Throwing in this method will cause the server to shutdown.
+    /// </summary>
+    Task<TRequestContext?> CreateRequestContextAsync(CancellationToken cancellationToken);
 
     ILspServices LspServices { get; }
 

--- a/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/IRequestContextFactory.cs
+++ b/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/IRequestContextFactory.cs
@@ -15,6 +15,7 @@ public interface IRequestContextFactory<TRequestContext>
 {
     /// <summary>
     /// Create a <typeparamref name="TRequestContext"/> object from the given <see cref="IQueueItem{RequestContextType}"/>.
+    /// Note - throwing in the implementation of this method will cause the server to shutdown.
     /// </summary>
     /// <param name="queueItem">The <see cref="IQueueItem{RequestContextType}"/> from which to create a request.</param>
     /// <param name="requestParam">The request parameters.</param>

--- a/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Ordering/RequestOrderingTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;


### PR DESCRIPTION
When we switched over to clasp we inadvertently introduced a bug where request contexts started being created in parallel for non-mutating requests.  This was caught by flaky tests, e.g. https://dev.azure.com/dnceng-public/public/_build/results?buildId=35727&view=ms.vss-test-web.build-test-results-tab&runId=712518&resultId=211420&paneView=dotnet-dnceng.dnceng-build-release-tasks.helix-test-information-tab