### PR TITLE
Add checks in list wrapping that we don't wrap incomplete separated lists

### DIFF
--- a/src/EditorFeatures/CSharpTest/Wrapping/ArgumentWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/ArgumentWrappingTests.cs
@@ -900,7 +900,7 @@ GetIndentionColumn(30),
 }");
         }
 
-        [Fact]
+        [Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")]
         public async Task TestMissingStartToken1()
         {
             await TestMissingAsync(
@@ -911,7 +911,7 @@ GetIndentionColumn(30),
 }");
         }
 
-        [Fact]
+        [Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")]
         public async Task TestMissingStartToken2()
         {
             await TestMissingAsync(
@@ -922,7 +922,7 @@ GetIndentionColumn(30),
 }");
         }
 
-        [Fact]
+        [Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")]
         public async Task TestMissingEndToken1()
         {
             await TestMissingAsync(
@@ -933,7 +933,7 @@ GetIndentionColumn(30),
 }");
         }
 
-        [Fact]
+        [Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")]
         public async Task TestMissingEndToken2()
         {
             await TestMissingAsync(

--- a/src/EditorFeatures/CSharpTest/Wrapping/ArgumentWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/ArgumentWrappingTests.cs
@@ -899,5 +899,49 @@ GetIndentionColumn(30),
     }
 }");
         }
+
+        [Fact]
+        public async Task TestMissingStartToken1()
+        {
+            await TestMissingAsync(
+@"class C {
+    void Bar() {
+        Goobar [||])
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestMissingStartToken2()
+        {
+            await TestMissingAsync(
+@"class C {
+    void Bar() {
+        Goobar [||]i, j)
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestMissingEndToken1()
+        {
+            await TestMissingAsync(
+@"class C {
+    void Bar() {
+        Goobar([||]
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestMissingEndToken2()
+        {
+            await TestMissingAsync(
+@"class C {
+    void Bar() {
+        Goobar([||]i, j
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Wrapping/InitializerExpressionWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/InitializerExpressionWrappingTests.cs
@@ -573,7 +573,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
 );
         }
 
-        [Fact]
+        [Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")]
         public async Task TestMissingStartToken()
         {
             await TestMissingAsync(
@@ -584,7 +584,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
 }");
         }
 
-        [Fact]
+        [Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")]
         public async Task TestMissingEndToken1()
         {
             await TestMissingAsync(
@@ -596,7 +596,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
 }");
         }
 
-        [Fact]
+        [Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")]
         public async Task TestMissingEndToken2()
         {
             await TestMissingAsync(

--- a/src/EditorFeatures/CSharpTest/Wrapping/InitializerExpressionWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/InitializerExpressionWrappingTests.cs
@@ -572,5 +572,39 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Wrapping
 }"
 );
         }
+
+        [Fact]
+        public async Task TestMissingStartToken()
+        {
+            await TestMissingAsync(
+@"class C {
+    void Bar() {
+        var test = new[] [||] 1, 2 };
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestMissingEndToken1()
+        {
+            await TestMissingAsync(
+@"class C {
+    void Bar() {
+        var test = new[] [||]{ 1, 2
+        return;
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestMissingEndToken2()
+        {
+            await TestMissingAsync(
+@"class C {
+    void Bar() {
+        var test = new[] [||]{ 1, 2 ;
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Wrapping/ParameterWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/ParameterWrappingTests.cs
@@ -986,5 +986,41 @@ GetIndentionColumn(30),
     public void UpsertRecord<T>[||]
 }");
         }
+
+        [Fact, WorkItem(61362, "https://github.com/dotnet/roslyn/issues/61362")]
+        public async Task TestWithMissingStartToken1()
+        {
+            await TestMissingAsync(
+@"class C {
+    public void UpsertRecord<T>[||])
+}");
+        }
+
+        [Fact, WorkItem(61362, "https://github.com/dotnet/roslyn/issues/61362")]
+        public async Task TestWithMissingStartToken2()
+        {
+            await TestMissingAsync(
+@"class C {
+    public void UpsertRecord<T>[||] int i, int j)
+}");
+        }
+
+        [Fact, WorkItem(61362, "https://github.com/dotnet/roslyn/issues/61362")]
+        public async Task TestWithMissingEndToken1()
+        {
+            await TestMissingAsync(
+@"class C {
+    public void UpsertRecord<T>([||]
+}");
+        }
+
+        [Fact, WorkItem(61362, "https://github.com/dotnet/roslyn/issues/61362")]
+        public async Task TestWithMissingEndToken2()
+        {
+            await TestMissingAsync(
+@"class C {
+    public void UpsertRecord<T>([||]int i, int j
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Wrapping/ParameterWrappingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Wrapping/ParameterWrappingTests.cs
@@ -987,7 +987,7 @@ GetIndentionColumn(30),
 }");
         }
 
-        [Fact, WorkItem(61362, "https://github.com/dotnet/roslyn/issues/61362")]
+        [Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")]
         public async Task TestWithMissingStartToken1()
         {
             await TestMissingAsync(
@@ -996,7 +996,7 @@ GetIndentionColumn(30),
 }");
         }
 
-        [Fact, WorkItem(61362, "https://github.com/dotnet/roslyn/issues/61362")]
+        [Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")]
         public async Task TestWithMissingStartToken2()
         {
             await TestMissingAsync(
@@ -1005,7 +1005,7 @@ GetIndentionColumn(30),
 }");
         }
 
-        [Fact, WorkItem(61362, "https://github.com/dotnet/roslyn/issues/61362")]
+        [Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")]
         public async Task TestWithMissingEndToken1()
         {
             await TestMissingAsync(
@@ -1014,7 +1014,7 @@ GetIndentionColumn(30),
 }");
         }
 
-        [Fact, WorkItem(61362, "https://github.com/dotnet/roslyn/issues/61362")]
+        [Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")]
         public async Task TestWithMissingEndToken2()
         {
             await TestMissingAsync(

--- a/src/EditorFeatures/VisualBasicTest/Wrapping/ArgumentWrappingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Wrapping/ArgumentWrappingTests.vb
@@ -784,7 +784,7 @@ end class",
 end class")
         End Function
 
-        <Fact>
+        <Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")>
         Public Async Function TestMissingStartToken1() As Task
             Await TestMissingAsync(
 "class C
@@ -794,7 +794,7 @@ end class")
 end class")
         End Function
 
-        <Fact>
+        <Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")>
         Public Async Function TestMissingStartToken2() As Task
             Await TestMissingAsync(
 "class C
@@ -804,7 +804,7 @@ end class")
 end class")
         End Function
 
-        <Fact>
+        <Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")>
         Public Async Function TestMissingEndToken1() As Task
             Await TestMissingAsync(
 "class C
@@ -814,7 +814,7 @@ end class")
 end class")
         End Function
 
-        <Fact>
+        <Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")>
         Public Async Function TestMissingEndToken2() As Task
             Await TestMissingAsync(
 "class C

--- a/src/EditorFeatures/VisualBasicTest/Wrapping/ArgumentWrappingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Wrapping/ArgumentWrappingTests.vb
@@ -783,5 +783,45 @@ end class",
     end sub
 end class")
         End Function
+
+        <Fact>
+        Public Async Function TestMissingStartToken1() As Task
+            Await TestMissingAsync(
+"class C
+    sub Bar()
+        Goobar [||])
+    end sub
+end class")
+        End Function
+
+        <Fact>
+        Public Async Function TestMissingStartToken2() As Task
+            Await TestMissingAsync(
+"class C
+    sub Bar()
+        Goobar [||]1, 2)
+    end sub
+end class")
+        End Function
+
+        <Fact>
+        Public Async Function TestMissingEndToken1() As Task
+            Await TestMissingAsync(
+"class C
+    sub Bar()
+        Goobar([||]
+    end sub
+end class")
+        End Function
+
+        <Fact>
+        Public Async Function TestMissingEndToken2() As Task
+            Await TestMissingAsync(
+"class C
+    sub Bar()
+        Goobar([||]1, 2
+    end sub
+end class")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Wrapping/InitializerExpressionWrappingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Wrapping/InitializerExpressionWrappingTests.vb
@@ -429,7 +429,7 @@ End Sub", "Public Sub F
 End Sub")
         End Function
 
-        <Fact>
+        <Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")>
         Public Async Function TestMissingStartToken1() As Task
             Await TestMissingAsync(
 "Class C
@@ -439,7 +439,7 @@ End Sub")
 End Class")
         End Function
 
-        <Fact>
+        <Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")>
         Public Async Function TestMissingStartToken2() As Task
             Await TestMissingAsync(
 "Class C
@@ -449,7 +449,7 @@ End Class")
 End Class")
         End Function
 
-        <Fact>
+        <Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")>
         Public Async Function TestMissingEndToken1() As Task
             Await TestMissingAsync(
 "Class C
@@ -459,7 +459,7 @@ End Class")
 End Class")
         End Function
 
-        <Fact>
+        <Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")>
         Public Async Function TestMissingEndToken2() As Task
             Await TestMissingAsync(
 "Class C

--- a/src/EditorFeatures/VisualBasicTest/Wrapping/InitializerExpressionWrappingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Wrapping/InitializerExpressionWrappingTests.vb
@@ -428,5 +428,45 @@ End Sub", "Public Sub F
     })
 End Sub")
         End Function
+
+        <Fact>
+        Public Async Function TestMissingStartToken1() As Task
+            Await TestMissingAsync(
+"Class C
+    Public Sub Bar()
+        Dim test() As Integer = New Integer() [||] }
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestMissingStartToken2() As Task
+            Await TestMissingAsync(
+"Class C
+    Public Sub Bar()
+        Dim test() As Integer = New Integer() [||]1, 2 }
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestMissingEndToken1() As Task
+            Await TestMissingAsync(
+"Class C
+    Public Sub Bar()
+        Dim test() As Integer = New Integer() {[||]
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestMissingEndToken2() As Task
+            Await TestMissingAsync(
+"Class C
+    Public Sub Bar()
+        Dim test() As Integer = New Integer() {[||]1, 2
+    End Sub
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Wrapping/ParameterWrappingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Wrapping/ParameterWrappingTests.vb
@@ -793,7 +793,7 @@ end class")
 end class")
         End Function
 
-        <Fact>
+        <Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")>
         Public Async Function TestMissingStartToken1() As Task
             Await TestMissingAsync(
 "class C
@@ -802,7 +802,7 @@ end class")
 end class")
         End Function
 
-        <Fact>
+        <Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")>
         Public Async Function TestMissingStartToken2() As Task
             Await TestMissingAsync(
 "class C
@@ -811,7 +811,7 @@ end class")
 end class")
         End Function
 
-        <Fact>
+        <Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")>
         Public Async Function TestMissingEndToken1() As Task
             Await TestMissingAsync(
 "class C
@@ -820,7 +820,7 @@ end class")
 end class")
         End Function
 
-        <Fact>
+        <Fact, WorkItem(63732, "https://github.com/dotnet/roslyn/issues/63732")>
         Public Async Function TestMissingEndToken2() As Task
             Await TestMissingAsync(
 "class C

--- a/src/EditorFeatures/VisualBasicTest/Wrapping/ParameterWrappingTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Wrapping/ParameterWrappingTests.vb
@@ -792,5 +792,41 @@ end class")
     end sub
 end class")
         End Function
+
+        <Fact>
+        Public Async Function TestMissingStartToken1() As Task
+            Await TestMissingAsync(
+"class C
+    sub Goobar [||])
+    end sub
+end class")
+        End Function
+
+        <Fact>
+        Public Async Function TestMissingStartToken2() As Task
+            Await TestMissingAsync(
+"class C
+    sub Goobar [||]i as integer, j as integer)
+    end sub
+end class")
+        End Function
+
+        <Fact>
+        Public Async Function TestMissingEndToken1() As Task
+            Await TestMissingAsync(
+"class C
+    sub Goobar([||]
+    end sub
+end class")
+        End Function
+
+        <Fact>
+        Public Async Function TestMissingEndToken2() As Task
+            Await TestMissingAsync(
+"class C
+    sub Goobar([||]i as integer, j as integer
+    end sub
+end class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpArgumentWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpArgumentWrapper.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Options;
@@ -34,6 +35,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
 
         protected override bool ShouldMoveCloseBraceToNewLine
             => false;
+
+        protected override SyntaxToken FirstToken(BaseArgumentListSyntax listSyntax)
+            => listSyntax.GetOpenToken();
+
+        protected override SyntaxToken LastToken(BaseArgumentListSyntax listSyntax)
+            => listSyntax.GetCloseToken();
 
         protected override SeparatedSyntaxList<ArgumentSyntax> GetListItems(BaseArgumentListSyntax listSyntax)
             => listSyntax.Arguments;

--- a/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpInitializerExpressionWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpInitializerExpressionWrapper.cs
@@ -33,6 +33,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
         protected override bool ShouldMoveCloseBraceToNewLine
             => true;
 
+        protected override SyntaxToken FirstToken(InitializerExpressionSyntax listSyntax)
+            => listSyntax.OpenBraceToken;
+
+        protected override SyntaxToken LastToken(InitializerExpressionSyntax listSyntax)
+            => listSyntax.CloseBraceToken;
+
         protected override SeparatedSyntaxList<ExpressionSyntax> GetListItems(InitializerExpressionSyntax listSyntax)
             => listSyntax.Expressions;
 

--- a/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpParameterWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpParameterWrapper.cs
@@ -35,6 +35,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
         protected override bool ShouldMoveCloseBraceToNewLine
             => false;
 
+        protected override SyntaxToken FirstToken(BaseParameterListSyntax listSyntax)
+            => listSyntax.GetOpenToken();
+
+        protected override SyntaxToken LastToken(BaseParameterListSyntax listSyntax)
+            => listSyntax.GetCloseToken();
+
         protected override SeparatedSyntaxList<ParameterSyntax> GetListItems(BaseParameterListSyntax listSyntax)
             => listSyntax.Parameters;
 

--- a/src/Features/Core/Portable/Wrapping/AbstractWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/AbstractWrapper.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Wrapping
             var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
             foreach (var item in nodesAndTokens)
             {
-                if (item == null || item.Span.IsEmpty)
+                if (item == null || item.Span.IsEmpty || item.IsMissing)
                     return true;
 
                 var firstToken = item.IsToken ? item.AsToken() : item.AsNode()!.GetFirstToken();

--- a/src/Features/Core/Portable/Wrapping/SeparatedSyntaxList/AbstractSeparatedSyntaxListWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/SeparatedSyntaxList/AbstractSeparatedSyntaxListWrapper.cs
@@ -5,7 +5,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Indentation;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.Wrapping.SeparatedSyntaxList

--- a/src/Features/Core/Portable/Wrapping/SeparatedSyntaxList/AbstractSeparatedSyntaxListWrapper.cs
+++ b/src/Features/Core/Portable/Wrapping/SeparatedSyntaxList/AbstractSeparatedSyntaxListWrapper.cs
@@ -43,6 +43,8 @@ namespace Microsoft.CodeAnalysis.Wrapping.SeparatedSyntaxList
         protected abstract bool ShouldMoveCloseBraceToNewLine { get; }
         protected abstract bool ShouldMoveOpenBraceToNewLine(SyntaxWrappingOptions options);
 
+        protected abstract SyntaxToken FirstToken(TListSyntax listSyntax);
+        protected abstract SyntaxToken LastToken(TListSyntax listSyntax);
         protected abstract TListSyntax? TryGetApplicableList(SyntaxNode node);
         protected abstract SeparatedSyntaxList<TListItemSyntax> GetListItems(TListSyntax listSyntax);
         protected abstract bool PositionIsApplicable(
@@ -53,6 +55,12 @@ namespace Microsoft.CodeAnalysis.Wrapping.SeparatedSyntaxList
         {
             var listSyntax = TryGetApplicableList(declaration);
             if (listSyntax == null || listSyntax.Span.IsEmpty)
+                return null;
+
+            var firstToken = FirstToken(listSyntax);
+            var lastToken = LastToken(listSyntax);
+
+            if (firstToken.IsMissing || lastToken.IsMissing || firstToken.Span.IsEmpty || lastToken.Span.IsEmpty)
                 return null;
 
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/VisualBasic/Portable/Wrapping/SeparatedSyntaxList/VisualBasicArgumentWrapper.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/SeparatedSyntaxList/VisualBasicArgumentWrapper.vb
@@ -25,6 +25,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Wrapping.SeparatedSyntaxList
 
         Protected Overrides ReadOnly Property ShouldMoveCloseBraceToNewLine As Boolean = False
 
+        Protected Overrides Function FirstToken(listSyntax As ArgumentListSyntax) As SyntaxToken
+            Return listSyntax.OpenParenToken
+        End Function
+
+        Protected Overrides Function LastToken(listSyntax As ArgumentListSyntax) As SyntaxToken
+            Return listSyntax.CloseParenToken
+        End Function
+
         Protected Overrides Function GetListItems(listSyntax As ArgumentListSyntax) As SeparatedSyntaxList(Of ArgumentSyntax)
             Return listSyntax.Arguments
         End Function

--- a/src/Features/VisualBasic/Portable/Wrapping/SeparatedSyntaxList/VisualBasicCollectionCreationExpressionWrapper.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/SeparatedSyntaxList/VisualBasicCollectionCreationExpressionWrapper.vb
@@ -40,6 +40,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Wrapping.SeparatedSyntaxList
 
         Protected Overrides ReadOnly Property ShouldMoveCloseBraceToNewLine As Boolean = True
 
+        Protected Overrides Function FirstToken(listSyntax As CollectionInitializerSyntax) As SyntaxToken
+            Return listSyntax.OpenBraceToken
+        End Function
+
+        Protected Overrides Function LastToken(listSyntax As CollectionInitializerSyntax) As SyntaxToken
+            Return listSyntax.CloseBraceToken
+        End Function
+
         Protected Overrides Function GetListItems(listSyntax As CollectionInitializerSyntax) As SeparatedSyntaxList(Of ExpressionSyntax)
             Return listSyntax.Initializers
         End Function

--- a/src/Features/VisualBasic/Portable/Wrapping/SeparatedSyntaxList/VisualBasicParameterWrapper.vb
+++ b/src/Features/VisualBasic/Portable/Wrapping/SeparatedSyntaxList/VisualBasicParameterWrapper.vb
@@ -26,6 +26,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Wrapping.SeparatedSyntaxList
 
         Protected Overrides ReadOnly Property ShouldMoveCloseBraceToNewLine As Boolean = False
 
+        Protected Overrides Function FirstToken(listSyntax As ParameterListSyntax) As SyntaxToken
+            Return listSyntax.OpenParenToken
+        End Function
+
+        Protected Overrides Function LastToken(listSyntax As ParameterListSyntax) As SyntaxToken
+            Return listSyntax.CloseParenToken
+        End Function
+
         Protected Overrides Function GetListItems(listSyntax As ParameterListSyntax) As SeparatedSyntaxList(Of ParameterSyntax)
             Return listSyntax.Parameters
         End Function

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CSharpWorkspaceExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CSharpWorkspaceExtensions.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CodeActions\CSharpCodeFixOptionsProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EmbeddedLanguages\VirtualChars\CSharpVirtualCharLanguageServiceFactory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\BaseParameterListSyntaxExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\BaseArgumentListSyntaxExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\BasePropertyDeclarationSyntaxExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CastExpressionSyntaxExtensions.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/BaseArgumentListSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/BaseArgumentListSyntaxExtensions.cs
@@ -9,35 +9,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
     internal static class BaseArgumentListSyntaxExtensions
     {
         public static SyntaxToken GetOpenToken(this BaseArgumentListSyntax node)
-        {
-            if (node != null)
+            => node switch
             {
-                switch (node.Kind())
-                {
-                    case SyntaxKind.ArgumentList:
-                        return ((ArgumentListSyntax)node).OpenParenToken;
-                    case SyntaxKind.BracketedArgumentList:
-                        return ((BracketedArgumentListSyntax)node).OpenBracketToken;
-                }
-            }
-
-            return default;
-        }
+                ArgumentListSyntax list => list.OpenParenToken,
+                BracketedArgumentListSyntax bracketedList => bracketedList.OpenBracketToken,
+                _ => default,
+            };
 
         public static SyntaxToken GetCloseToken(this BaseArgumentListSyntax node)
-        {
-            if (node != null)
+            => node switch
             {
-                switch (node.Kind())
-                {
-                    case SyntaxKind.ArgumentList:
-                        return ((ArgumentListSyntax)node).CloseParenToken;
-                    case SyntaxKind.BracketedArgumentList:
-                        return ((BracketedArgumentListSyntax)node).CloseBracketToken;
-                }
-            }
-
-            return default;
-        }
+                ArgumentListSyntax list => list.CloseParenToken,
+                BracketedArgumentListSyntax bracketedList => bracketedList.CloseBracketToken,
+                _ => default,
+            };
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/BaseParameterListSyntaxExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/BaseParameterListSyntaxExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.CodeAnalysis.CSharp.Extensions
+{
+    internal static class BaseParameterListSyntaxExtensions
+    {
+        public static SyntaxToken GetOpenToken(this BaseParameterListSyntax node)
+            => node switch
+            {
+                ParameterListSyntax list => list.OpenParenToken,
+                BracketedParameterListSyntax bracketedList => bracketedList.OpenBracketToken,
+                _ => default,
+            };
+
+        public static SyntaxToken GetCloseToken(this BaseParameterListSyntax node)
+            => node switch
+            {
+                ParameterListSyntax list => list.CloseParenToken,
+                BracketedParameterListSyntax bracketedList => bracketedList.CloseBracketToken,
+                _ => default,
+            };
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/63732