### PR TITLE
Truncate helix work item names to work around helix API issues

### DIFF
--- a/src/Tools/Source/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/Source/RunTests/AssemblyScheduler.cs
@@ -18,7 +18,19 @@ namespace RunTests
 {
     internal record struct WorkItemInfo(ImmutableSortedDictionary<AssemblyInfo, ImmutableArray<TestMethodInfo>> Filters, int PartitionIndex)
     {
-        internal string DisplayName => $"{string.Join("_", Filters.Keys.Select(a => Path.GetFileNameWithoutExtension(a.AssemblyName)))}_{PartitionIndex}";
+        internal string DisplayName
+        {
+            get
+            {
+                var assembliesString = string.Join("_", Filters.Keys.Select(a => Path.GetFileNameWithoutExtension(a.AssemblyName)));
+
+                // Currently some helix APIs don't work when the work item friendly name is more than 200 characters.
+                // Until that is fixed we manually truncate the name ourselves to a reasonable limit.
+                // https://github.com/dotnet/arcade/issues/11079
+                assembliesString = assembliesString.Length > 150 ? $"{assembliesString[..150]}..." : assembliesString;
+                return $"{assembliesString}_{PartitionIndex}";
+            }
+        }
     }
 
     internal sealed class AssemblyScheduler


### PR DESCRIPTION
Long work item names are causing issues with logs attached to ADO test failures and ingestion of test failures into runfo.
E.g. 
![image](https://user-images.githubusercontent.com/5749229/193361765-bdbc9709-88ef-4a16-ab6d-2501f913aeb7.png)

There's a work item tracking this on the helix side, but it sounds like it will not be necessarily trivial.  So for now we can just truncate before we send to helix.
See https://github.com/dotnet/arcade/issues/11079