### PR TITLE
Log errors for Non-mutating requests

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
@@ -200,11 +200,11 @@ public class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<TRe
                     else
                     {
                         // Non mutating are fire-and-forget because they are by definition readonly. Any errors
-                        // will be sent back to the client but we can still capture errors in queue processing
-                        // via NFW, though these errors don't put us into a bad state as far as the rest of the queue goes.
+                        // will be sent back to the client but they can also be captured via HandleNonMutatingRequestError,
+                        // though these errors don't put us into a bad state as far as the rest of the queue goes.
                         // Furthermore we use Task.Run here to protect ourselves against synchronous execution of work
                         // blocking the request queue for longer periods of time (it enforces parallelizabilty).
-                        _ = Task.Run(() => work.StartRequestAsync(context, cancellationToken), cancellationToken);
+                        _ = Task.Run(() => HandleNonMutatingRequestError(work.StartRequestAsync(context, cancellationToken)), cancellationToken);
                     }
                 }
                 catch (OperationCanceledException ex) when (ex.CancellationToken == queueItem.cancellationToken)
@@ -232,6 +232,17 @@ public class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<TRe
             await DisposeAsync().ConfigureAwait(false);
             return;
         }
+    }
+
+    /// <summary>
+    /// Provides an extensiblity point to log or otherwise inspect errors thrown from non-mutating requests,
+    /// which would otherwise be lost to the fire-and-forget task in the queue.
+    /// </summary>
+    /// <param name="nonMutatingRequestTask">The task to be inspected.</param>
+    /// <returns>The task from <paramref name="nonMutatingRequestTask"/>, to allow chained calls if needed.</returns>
+    public virtual Task HandleNonMutatingRequestError(Task nonMutatingRequestTask)
+    {
+        return nonMutatingRequestTask;
     }
 
     /// <summary>

--- a/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
@@ -204,7 +204,7 @@ public class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<TRe
                         // though these errors don't put us into a bad state as far as the rest of the queue goes.
                         // Furthermore we use Task.Run here to protect ourselves against synchronous execution of work
                         // blocking the request queue for longer periods of time (it enforces parallelizabilty).
-                        _ = Task.Run(() => HandleNonMutatingRequestError(work.StartRequestAsync(context, cancellationToken)), cancellationToken);
+                        _ = Task.Run(() => HandleNonMutatingRequestErrorAsync(work.StartRequestAsync(context, cancellationToken)), cancellationToken);
                     }
                 }
                 catch (OperationCanceledException ex) when (ex.CancellationToken == queueItem.cancellationToken)
@@ -240,7 +240,7 @@ public class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<TRe
     /// </summary>
     /// <param name="nonMutatingRequestTask">The task to be inspected.</param>
     /// <returns>The task from <paramref name="nonMutatingRequestTask"/>, to allow chained calls if needed.</returns>
-    public virtual Task HandleNonMutatingRequestError(Task nonMutatingRequestTask)
+    public virtual Task HandleNonMutatingRequestErrorAsync(Task nonMutatingRequestTask)
     {
         return nonMutatingRequestTask;
     }

--- a/src/Features/LanguageServer/Protocol/RoslynLanguageServer.cs
+++ b/src/Features/LanguageServer/Protocol/RoslynLanguageServer.cs
@@ -4,11 +4,13 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.ServerLifetime;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Roslyn.Utilities;
 using StreamJsonRpc;
 
 namespace Microsoft.CodeAnalysis.LanguageServer
@@ -43,6 +45,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         protected override ILspServices ConstructLspServices()
         {
             return _lspServiceProvider.CreateServices(_serverKind, _baseServices, _serviceCollection);
+        }
+
+        protected override IRequestExecutionQueue<RequestContext> ConstructRequestExecutionQueue()
+        {
+            var handlerProvider = GetHandlerProvider();
+            var queue = new RoslynRequestExecutionQueue(_logger, handlerProvider);
+
+            queue.Start();
+            return queue;
         }
 
         private IServiceCollection GetServiceCollection(

--- a/src/Features/LanguageServer/Protocol/RoslynRequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/RoslynRequestExecutionQueue.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CommonLanguageServerProtocol.Framework;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.LanguageServer
+{
+    internal class RoslynRequestExecutionQueue : RequestExecutionQueue<RequestContext>
+    {
+        public RoslynRequestExecutionQueue(ILspLogger logger, IHandlerProvider handlerProvider)
+            : base(logger, handlerProvider)
+        {
+        }
+
+        public override Task HandleNonMutatingRequestError(Task nonMutatingRequestTask)
+        {
+            return nonMutatingRequestTask.ReportNonFatalErrorAsync();
+        }
+    }
+}

--- a/src/Features/LanguageServer/Protocol/RoslynRequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Protocol/RoslynRequestExecutionQueue.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         {
         }
 
-        public override Task HandleNonMutatingRequestError(Task nonMutatingRequestTask)
+        public override Task HandleNonMutatingRequestErrorAsync(Task nonMutatingRequestTask)
         {
             return nonMutatingRequestTask.ReportNonFatalErrorAsync();
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/64444.

- Add an extensibility point to the RequestExecutionQueue which allows implementors to intercept errors out of Non-mutating requests.
- I debated doing it this way or creating something like `INonMutatingRequestHandler` which the queue would get off ILspServices. That seemed like it was maybe too big of a hammer, but I'm interested in people's thoughts.