### PR TITLE
Fix LSIF handling of extension methods

### DIFF
--- a/src/Features/Lsif/Generator/Generator.cs
+++ b/src/Features/Lsif/Generator/Generator.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph;
 using Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.ResultSetTracking;
 using Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 using Methods = Microsoft.VisualStudio.LanguageServer.Protocol.Methods;
 
@@ -226,7 +227,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
                     // SymbolFinder.FindSymbolAtPositionAsync where if a token is both a reference and definition we'll prefer the
                     // definition. Once we start supporting hover we'll have to remove the "original definition" part of this, since
                     // since we show different contents for different constructed types there.
-                    var symbolForLinkedResultSet = (declaredSymbol ?? referencedSymbol)!.OriginalDefinition;
+                    var symbolForLinkedResultSet = (declaredSymbol ?? referencedSymbol)!.GetOriginalUnreducedDefinition();
                     var symbolForLinkedResultSetId = symbolResultsTracker.GetResultSetIdForSymbol(symbolForLinkedResultSet);
                     lsifJsonWriter.Write(Edge.Create("next", lazyRangeVertex.Value.GetId(), symbolForLinkedResultSetId, idFactory));
 
@@ -242,7 +243,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
                         // symbol but the range can point a different symbol's resultSet. This can happen if the token is
                         // both a definition of a symbol (where we will point to the definition) but also a reference to some
                         // other symbol.
-                        var referenceResultsId = symbolResultsTracker.GetResultIdForSymbol(referencedSymbol.OriginalDefinition, Methods.TextDocumentReferencesName, () => new ReferenceResult(idFactory));
+                        var referenceResultsId = symbolResultsTracker.GetResultIdForSymbol(referencedSymbol.GetOriginalUnreducedDefinition(), Methods.TextDocumentReferencesName, () => new ReferenceResult(idFactory));
                         lsifJsonWriter.Write(new Item(referenceResultsId.As<ReferenceResult, Vertex>(), lazyRangeVertex.Value.GetId(), documentVertex.GetId(), idFactory, property: "references"));
                     }
 

--- a/src/Features/Lsif/GeneratorTest/RangeResultSetTests.vb
+++ b/src/Features/Lsif/GeneratorTest/RangeResultSetTests.vb
@@ -14,6 +14,8 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
         <Theory>
         <InlineData("class C { [|string|] s; }", "mscorlib#T:System.String", WellKnownSymbolMonikerSchemes.DotnetXmlDoc)>
         <InlineData("class C { void M() { [|M|](); } }", TestProjectAssemblyName + "#M:C.M", WellKnownSymbolMonikerSchemes.DotnetXmlDoc)>
+        <InlineData("static class C { static void [|M|](this string s, int i) { } }", TestProjectAssemblyName + "#M:C.M(System.String,System.Int32)", WellKnownSymbolMonikerSchemes.DotnetXmlDoc)>
+        <InlineData("static class C { static void M(this string s, int i) { s.[|M|](i); } }", TestProjectAssemblyName + "#M:C.M(System.String,System.Int32)", WellKnownSymbolMonikerSchemes.DotnetXmlDoc)>
         <InlineData("class C { void M(string s) { M([|s|]); } }", TestProjectAssemblyName + "#M:C.M(System.String)#s", WellKnownSymbolMonikerSchemes.DotnetXmlDoc)>
         <InlineData("class C { void M(string s) { string local = """"; M([|local|]); } }", Nothing, Nothing)>
         <InlineData("using [|S|] = System.String;", Nothing, Nothing)>


### PR DESCRIPTION
We need to unreduce them for purposes of go to definition/find references when linking to the type.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1553754