### PR TITLE
Add additional information to help F# with navigating to symbols

### DIFF
--- a/src/Features/Core/Portable/Navigation/ICrossLanguageSymbolNavigationService.cs
+++ b/src/Features/Core/Portable/Navigation/ICrossLanguageSymbolNavigationService.cs
@@ -18,6 +18,9 @@ namespace Microsoft.CodeAnalysis.Navigation
         /// defined at: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/#id-strings.  Should
         /// return <see langword="null"/> if the 3rd party language cannot navigate to this particular symbol.
         /// </summary>
-        Task<INavigableLocation?> TryGetNavigableLocationAsync(string documentationCommentId, CancellationToken cancellationToken);
+        /// <param name="assemblyName">The name of the assembly the symbol was defined in. Can be used by the
+        /// receiver to quickly filter down to the project/compilation search for the symbol.</param>
+        Task<INavigableLocation?> TryGetNavigableLocationAsync(
+            string assemblyName, string documentationCommentId, CancellationToken cancellationToken);
     }
 }

--- a/src/Tools/ExternalAccess/FSharp/Internal/Navigation/FSharpCrossLanguageSymbolNavigationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Navigation/FSharpCrossLanguageSymbolNavigationService.cs
@@ -30,13 +30,15 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Navigation
             _underlyingService = underlyingService;
         }
 
-        public async Task<INavigableLocation?> TryGetNavigableLocationAsync(string documentationCommentId, CancellationToken cancellationToken)
+        public async Task<INavigableLocation?> TryGetNavigableLocationAsync(
+            string assemblyName, string documentationCommentId, CancellationToken cancellationToken)
         {
             // Only defer to actual F# service if it exists.
             if (_underlyingService is null)
                 return null;
 
-            var location = await _underlyingService.TryGetNavigableLocationAsync(documentationCommentId, cancellationToken).ConfigureAwait(false);
+            var location = await _underlyingService.TryGetNavigableLocationAsync(
+                assemblyName, documentationCommentId, cancellationToken).ConfigureAwait(false);
             if (location == null)
                 return null;
 

--- a/src/Tools/ExternalAccess/FSharp/Navigation/IFSharpCrossLanguageSymbolNavigationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Navigation/IFSharpCrossLanguageSymbolNavigationService.cs
@@ -12,7 +12,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Navigation
     internal interface IFSharpCrossLanguageSymbolNavigationService
     {
         /// <inheritdoc cref="ICrossLanguageSymbolNavigationService.TryGetNavigableLocationAsync"/>
-        Task<IFSharpNavigableLocation?> TryGetNavigableLocationAsync(string documentationCommentId, CancellationToken cancellationToken);
+        Task<IFSharpNavigableLocation?> TryGetNavigableLocationAsync(
+            string assemblyName, string documentationCommentId, CancellationToken cancellationToken);
     }
 
     /// <inheritdoc cref="NavigationOptions"/>

--- a/src/VisualStudio/Core/Def/Workspace/VisualStudioSymbolNavigationService.cs
+++ b/src/VisualStudio/Core/Def/Workspace/VisualStudioSymbolNavigationService.cs
@@ -91,12 +91,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
             // See if there's another .Net language service that can handle navigating to this metadata symbol (for example, F#).
             var docCommentId = symbol.GetDocumentationCommentId();
-            if (docCommentId != null)
+            var assemblyName = symbol.ContainingAssembly.Identity.Name;
+            if (docCommentId != null && assemblyName != null)
             {
                 foreach (var lazyService in solution.Services.ExportProvider.GetExports<ICrossLanguageSymbolNavigationService>())
                 {
                     var crossLanguageService = lazyService.Value;
-                    var crossLanguageLocation = await crossLanguageService.TryGetNavigableLocationAsync(docCommentId, cancellationToken).ConfigureAwait(false);
+                    var crossLanguageLocation = await crossLanguageService.TryGetNavigableLocationAsync(
+                        assemblyName, docCommentId, cancellationToken).ConfigureAwait(false);
                     if (crossLanguageLocation != null)
                         return crossLanguageLocation;
                 }


### PR DESCRIPTION
This change is safe to make as F# has not yet shipped any code sitting on top of the existing EA api.  We're still prototyping it out and discovered they would benefit from having this.