### PR TITLE
Add "target type match" filter support to enum and static members providers

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProviderTests.cs
@@ -632,9 +632,9 @@ class Program
          SomeType c = $$
      }
  }";
-            await VerifyItemExistsAsync(markup, "TypeContainer", glyph: (int)Glyph.ClassPublic);
-            await VerifyItemExistsAsync(markup, "TypeContainer.Foo1", glyph: (int)Glyph.FieldPublic);
-            await VerifyItemExistsAsync(markup, "TypeContainer.Foo2", glyph: (int)Glyph.FieldPublic);
+            await VerifyItemExistsAsync(markup, "TypeContainer");
+            await VerifyItemExistsAsync(markup, "TypeContainer.Foo1");
+            await VerifyItemExistsAsync(markup, "TypeContainer.Foo2");
         }
 
         [Theory, WorkItem(828196, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/828196")]

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -6,12 +6,15 @@ Imports System.Collections.Immutable
 Imports System.Composition
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Snippets
 Imports Microsoft.CodeAnalysis.Tags
 Imports Microsoft.CodeAnalysis.VisualBasic
+Imports Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.Snippets
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Projection
@@ -3556,6 +3559,52 @@ End Class
                 state.SendInvokeCompletionList()
                 Await state.AssertCompletionItemsContainAll("e", "E", "E.A")
                 Await state.AssertCompletionItemsDoNotContainAny("e As E")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestEnumMembersMatchTargetType() As Task
+            Using state = TestStateFactory.CreateVisualBasicTestState(
+                              <Document>
+Enum Colors
+    Red
+    Green
+End Enum
+
+Class Program
+    Property Green As Program
+    Sub M()
+        Dim x As Colors = $$
+    End Sub
+End Class
+</Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForUIRenderedAsync()
+
+                Await state.AssertCompletionItemsContainAll("Colors.Red", "Colors.Green", "Colors")
+
+                Dim oldFilters = state.GetCompletionItemFilters()
+                Dim newFiltersBuilder = ArrayBuilder(Of Data.CompletionFilterWithState).GetInstance()
+
+                Dim hasTargetTypedFilter = False
+                For Each oldState In oldFilters
+
+                    If Object.ReferenceEquals(oldState.Filter, FilterSet.TargetTypedFilter) Then
+                        hasTargetTypedFilter = True
+                        newFiltersBuilder.Add(oldState.WithSelected(True))
+                        Continue For
+                    End If
+
+                    newFiltersBuilder.Add(oldState.WithSelected(False))
+                Next
+
+                Assert.True(hasTargetTypedFilter)
+
+                state.RaiseFiltersChanged(newFiltersBuilder.ToImmutableAndFree())
+
+                Await state.WaitForUIRenderedAsync()
+                Await state.AssertCompletionItemsContainAll("Colors.Red", "Colors.Green")
+                Await state.AssertCompletionItemsDoNotContainAny("Colors")
             End Using
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CompletionListTagCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CompletionListTagCompletionProviderTests.vb
@@ -273,8 +273,8 @@ Class C
 
 End Class
 ]]></Text>.Value
-            Await VerifyItemExistsAsync(markup, "ColorNamespace.Color.X", glyph:=CType(Glyph.FieldPublic, Integer))
-            Await VerifyItemExistsAsync(markup, "ColorNamespace.Color.Y", glyph:=CType(Glyph.PropertyPublic, Integer))
+            Await VerifyItemExistsAsync(markup, "ColorNamespace.Color.X")
+            Await VerifyItemExistsAsync(markup, "ColorNamespace.Color.Y")
         End Function
 
         <Fact>

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Tags;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -201,7 +202,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                         rules: CompletionItemRules.Default,
                         contextPosition: position,
                         sortText: $"{sortText}_{index:0000}",
-                        filterText: memberDisplayName).WithAdditionalFilterTexts(additionalFilterTexts));
+                        filterText: memberDisplayName,
+                        tags: WellKnownTagArrays.TargetTypeMatch)
+                        .WithAdditionalFilterTexts(additionalFilterTexts));
                 }
             }
             else if (enclosingNamedType is not null)
@@ -252,7 +255,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                         rules: CompletionItemRules.Default,
                         contextPosition: position,
                         sortText: memberDisplayName,
-                        filterText: memberDisplayName)
+                        filterText: memberDisplayName,
+                        tags: WellKnownTagArrays.TargetTypeMatch)
                         .WithAdditionalFilterTexts(additionalFilterTexts));
                 }
             }

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CompletionListTagCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CompletionListTagCompletionProvider.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.Completion.Providers
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.LanguageService
 Imports Microsoft.CodeAnalysis.PooledObjects
+Imports Microsoft.CodeAnalysis.Tags
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
@@ -110,7 +111,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                 rules:=CompletionItemRules.Default.WithMatchPriority(MatchPriority.Preselect),
                 contextPosition:=context.Position,
                 sortText:=displayText,
-                supportedPlatforms:=supportedPlatformData).WithAdditionalFilterTexts(additionalFilterTexts)
+                supportedPlatforms:=supportedPlatformData,
+                tags:=WellKnownTagArrays.TargetTypeMatch).WithAdditionalFilterTexts(additionalFilterTexts)
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.Completion.Providers
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.LanguageService
 Imports Microsoft.CodeAnalysis.PooledObjects
+Imports Microsoft.CodeAnalysis.Tags
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 
@@ -147,7 +148,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             ' promote this item during matching when user types member name only, Like "Red"
             ' instead of "Colors.Empty"
             If symbols(0).Symbol.Kind = SymbolKind.Field Then
-                item = item.WithAdditionalFilterTexts(ImmutableArray.Create(symbols(0).Symbol.Name))
+                item = item.AddTag(WellKnownTags.TargetTypeMatch).WithAdditionalFilterTexts(ImmutableArray.Create(symbols(0).Symbol.Name))
             End If
 
             Return item


### PR DESCRIPTION
Selecting target type filter (ALT - j) would include those items too

before:

![image](https://user-images.githubusercontent.com/788783/193910830-593898cc-939d-4a69-9481-a90ab1c81538.png)

after:
![image](https://user-images.githubusercontent.com/788783/193910387-fbb85c07-b58b-42f6-880f-1625dd74a300.png)
