### PR TITLE
Add back accidentally deleted activity id correlation

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
+++ b/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
@@ -51,10 +51,10 @@ public class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<TRe
     private readonly IHandlerProvider _handlerProvider;
 
     /// <summary>
-    /// The queue containing the ordered LSP requests along with a combined cancellation token
-    /// representing the queue's cancellation token and the individual request cancellation token.
+    /// The queue containing the ordered LSP requests along with the trace activityId (to associate logs with a request) and
+    ///  a combined cancellation token representing the queue's cancellation token and the individual request cancellation token.
     /// </summary>
-    protected readonly AsyncQueue<(IQueueItem<TRequestContext> queueItem, CancellationToken cancellationToken)> _queue = new();
+    protected readonly AsyncQueue<(IQueueItem<TRequestContext> queueItem, Guid ActivityId, CancellationToken cancellationToken)> _queue = new();
     private readonly CancellationTokenSource _cancelSource = new();
 
     /// <summary>
@@ -134,7 +134,7 @@ public class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<TRe
         // even when the request is cancelled or the queue is shutting down.
         _ = resultTask.ContinueWith(_ => combinedTokenSource.Dispose(), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
 
-        var didEnqueue = _queue.TryEnqueue((item, combinedCancellationToken));
+        var didEnqueue = _queue.TryEnqueue((item, Trace.CorrelationManager.ActivityId, combinedCancellationToken));
 
         // If the queue has been shut down the enqueue will fail, so we just fault the task immediately.
         // The queue itself is threadsafe (_queue.TryEnqueue and _queue.Complete use the same lock).
@@ -169,7 +169,7 @@ public class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<TRe
             {
                 // First attempt to de-queue the work item in its own try-catch.
                 // This is because before we de-queue we do not have access to the queue item's linked cancellation token.
-                (IQueueItem<TRequestContext> work, CancellationToken cancellationToken) queueItem;
+                (IQueueItem<TRequestContext> work, Guid activityId, CancellationToken cancellationToken) queueItem;
                 try
                 {
                     queueItem = await _queue.DequeueAsync(_cancelSource.Token).ConfigureAwait(false);
@@ -183,11 +183,13 @@ public class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<TRe
 
                 try
                 {
-                    var (work, cancellationToken) = queueItem;
+                    var (work, activityId, cancellationToken) = queueItem;
                     lspServices = work.LspServices;
 
                     var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken, cancellationToken);
 
+                    // Restore our activity id so that logging/tracking works across asynchronous calls.
+                    Trace.CorrelationManager.ActivityId = activityId;
                     // The request context must be created serially inside the queue to so that requests always run
                     // on the correct snapshot as of the last request.
                     var context = await work.CreateRequestContextAsync(cancellationToken).ConfigureAwait(false);
@@ -291,7 +293,7 @@ public class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<TRe
         {
             while (!_queue._queue.IsEmpty)
             {
-                var (_, cancellationToken) = await _queue._queue.DequeueAsync().ConfigureAwait(false);
+                var (_, _, cancellationToken) = await _queue._queue.DequeueAsync().ConfigureAwait(false);
                 if (!cancellationToken.IsCancellationRequested)
                     return false;
             }


### PR DESCRIPTION
Was accidentally removed in clasp refactor.  This is required in order for the logging trace source to correlate logs between requests.