### PR TITLE
Remove dependency on ms.extensions.dependencyinjection from roslyn lsp

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/ServerLifetime/ExitHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/ServerLifetime/ExitHandler.cs
@@ -14,8 +14,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.ServerLifetime;
 [Method(Methods.ExitName)]
 internal class ExitHandler : ILspServiceNotificationHandler
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public ExitHandler()
     {
     }

--- a/src/Features/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
@@ -14,8 +14,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 [Method(Methods.InitializeName)]
 internal class InitializeHandler : ILspServiceRequestHandler<InitializeParams, InitializeResult>
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public InitializeHandler()
     {
     }

--- a/src/Features/LanguageServer/Protocol/Handler/ServerLifetime/InitializedHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/ServerLifetime/InitializedHandler.cs
@@ -14,8 +14,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 [Method(Methods.InitializedName)]
 internal class InitializedHandler : ILspServiceNotificationHandler<InitializedParams>
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public InitializedHandler()
     {
     }

--- a/src/Features/LanguageServer/Protocol/Handler/ServerLifetime/ShutdownHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/ServerLifetime/ShutdownHandler.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 [Method(Methods.ShutdownName)]
 internal class ShutdownHandler : ILspServiceNotificationHandler
 {
-    [ImportingConstructor]
-    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public ShutdownHandler()
     {
     }

--- a/src/Features/LanguageServer/Protocol/LspServices/AbstractLspServiceProvider.cs
+++ b/src/Features/LanguageServer/Protocol/LspServices/AbstractLspServiceProvider.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 
 namespace Microsoft.CodeAnalysis.LanguageServer;
 
@@ -22,9 +22,9 @@ internal class AbstractLspServiceProvider
         _lspServiceFactories = specificLspServiceFactories.ToImmutableArray();
     }
 
-    public LspServices CreateServices(WellKnownLspServerKinds serverKind, ImmutableArray<Lazy<ILspService, LspServiceMetadataView>> baseServices, IServiceCollection serviceCollection)
+    public LspServices CreateServices(WellKnownLspServerKinds serverKind, ImmutableDictionary<Type, ImmutableArray<Func<ILspServices, object>>> baseServices)
     {
-        var lspServices = new LspServices(_lspServices, _lspServiceFactories, serverKind, baseServices, serviceCollection);
+        var lspServices = new LspServices(_lspServices, _lspServiceFactories, serverKind, baseServices);
 
         return lspServices;
     }

--- a/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
+++ b/src/Features/LanguageServer/Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj
@@ -19,7 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" Version="$(MicrosoftVisualStudioLanguageServerClientVersion)" PrivateAssets="all" NoWarn="NU1701" />
     <!-- Explicit reference to Shell.15.0 et. al. with NU1701 only until the LSP client targets netstandard2.0 https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1369985/ -->
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150Version)" PrivateAssets="all" ExcludeAssets="all" NoWarn="NU1701" />

--- a/src/Features/LanguageServer/Protocol/RoslynLanguageServer.cs
+++ b/src/Features/LanguageServer/Protocol/RoslynLanguageServer.cs
@@ -3,12 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.ServerLifetime;
 using Microsoft.CommonLanguageServerProtocol.Framework;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Roslyn.Utilities;
 using StreamJsonRpc;
@@ -18,8 +18,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
     internal class RoslynLanguageServer : AbstractLanguageServer<RequestContext>, IClientCapabilitiesProvider
     {
         private readonly AbstractLspServiceProvider _lspServiceProvider;
-        private readonly ImmutableArray<Lazy<ILspService, LspServiceMetadataView>> _baseServices;
-        private readonly IServiceCollection _serviceCollection;
+        private readonly ImmutableDictionary<Type, ImmutableArray<Func<ILspServices, object>>> _baseServices;
         private readonly WellKnownLspServerKinds _serverKind;
 
         public RoslynLanguageServer(
@@ -35,8 +34,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             _serverKind = serverKind;
 
             // Create services that require base dependencies (jsonrpc) or are more complex to create to the set manually.
-            _baseServices = GetBaseServices();
-            _serviceCollection = GetServiceCollection(jsonRpc, this, logger, capabilitiesProvider, serverKind, supportedLanguages);
+            _baseServices = GetBaseServices(jsonRpc, this, logger, capabilitiesProvider, serverKind, supportedLanguages);
 
             // This spins up the queue and ensure the LSP is ready to start receiving requests
             Initialize();
@@ -44,7 +42,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
 
         protected override ILspServices ConstructLspServices()
         {
-            return _lspServiceProvider.CreateServices(_serverKind, _baseServices, _serviceCollection);
+            return _lspServiceProvider.CreateServices(_serverKind, _baseServices);
         }
 
         protected override IRequestExecutionQueue<RequestContext> ConstructRequestExecutionQueue()
@@ -56,7 +54,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             return queue;
         }
 
-        private IServiceCollection GetServiceCollection(
+        private ImmutableDictionary<Type, ImmutableArray<Func<ILspServices, object>>> GetBaseServices(
             JsonRpc jsonRpc,
             IClientCapabilitiesProvider clientCapabilitiesProvider,
             ILspServiceLogger logger,
@@ -64,38 +62,37 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             WellKnownLspServerKinds serverKind,
             ImmutableArray<string> supportedLanguages)
         {
+            var baseServices = new Dictionary<Type, ImmutableArray<Func<ILspServices, object>>>();
             var clientLanguageServerManager = new ClientLanguageServerManager(jsonRpc);
             var lifeCycleManager = new LspServiceLifeCycleManager(this, logger, clientLanguageServerManager);
 
-            var serviceCollection = new ServiceCollection()
-                .AddSingleton<IClientLanguageServerManager>(clientLanguageServerManager)
-                .AddSingleton<ILspLogger>(logger)
-                .AddSingleton<ILspServiceLogger>(logger)
-                .AddSingleton<IClientCapabilitiesProvider>(clientCapabilitiesProvider)
-                .AddSingleton<ICapabilitiesProvider>(capabilitiesProvider)
-                .AddSingleton<ILifeCycleManager>(lifeCycleManager)
-                .AddSingleton(new ServerInfoProvider(serverKind, supportedLanguages))
-                .AddSingleton<IRequestContextFactory<RequestContext>, RequestContextFactory>()
-                .AddSingleton<IRequestExecutionQueue<RequestContext>>((serviceProvider) => GetRequestExecutionQueue())
-                .AddSingleton<IClientCapabilitiesManager, ClientCapabilitiesManager>();
-            AddHandler<InitializeHandler>(serviceCollection);
-            AddHandler<InitializedHandler>(serviceCollection);
-            AddHandler<ShutdownHandler>(serviceCollection);
-            AddHandler<ExitHandler>(serviceCollection);
+            AddBaseService<IClientLanguageServerManager>(clientLanguageServerManager);
+            AddBaseService<ILspLogger>(logger);
+            AddBaseService<ILspServiceLogger>(logger);
+            AddBaseService<IClientCapabilitiesProvider>(clientCapabilitiesProvider);
+            AddBaseService<ICapabilitiesProvider>(capabilitiesProvider);
+            AddBaseService<ILifeCycleManager>(lifeCycleManager);
+            AddBaseService(new ServerInfoProvider(serverKind, supportedLanguages));
+            AddBaseServiceFromFunc<IRequestContextFactory<RequestContext>>((lspServices) => new RequestContextFactory(lspServices));
+            AddBaseServiceFromFunc<IRequestExecutionQueue<RequestContext>>((_) => GetRequestExecutionQueue());
+            AddBaseService<IClientCapabilitiesManager>(new ClientCapabilitiesManager());
+            AddBaseService<IMethodHandler>(new InitializeHandler());
+            AddBaseService<IMethodHandler>(new InitializedHandler());
+            AddBaseService<IMethodHandler>(new ShutdownHandler());
+            AddBaseService<IMethodHandler>(new ExitHandler());
 
-            return serviceCollection;
-        }
+            return baseServices.ToImmutableDictionary();
 
-        private static void AddHandler<THandler>(IServiceCollection serviceCollection) where THandler : class, IMethodHandler
-        {
-            _ = serviceCollection.AddSingleton<IMethodHandler, THandler>();
-        }
+            void AddBaseService<T>(T instance) where T : class
+            {
+                AddBaseServiceFromFunc<T>((_) => instance);
+            }
 
-        private static ImmutableArray<Lazy<ILspService, LspServiceMetadataView>> GetBaseServices()
-        {
-            var baseServices = ImmutableArray.Create<Lazy<ILspService, LspServiceMetadataView>>();
-
-            return baseServices;
+            void AddBaseServiceFromFunc<T>(Func<ILspServices, object> creatorFunc)
+            {
+                var added = baseServices.GetValueOrDefault(typeof(T), ImmutableArray<Func<ILspServices, object>>.Empty).Add(creatorFunc);
+                baseServices[typeof(T)] = added;
+            }
         }
 
         public ClientCapabilities GetClientCapabilities()

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -115,8 +115,6 @@
       <_Dependency Remove="Microsoft.Build"/>
       <_Dependency Remove="Microsoft.Build.Framework"/>
       <_Dependency Remove="Microsoft.Diagnostics.Tracing.EventSource.Redist"/>
-      <_Dependency Remove="Microsoft.Extensions.DependencyInjection" />
-      <_Dependency Remove="Microsoft.Extensions.DependencyInjection.Abstractions" />
       <_Dependency Remove="Microsoft.MSXML"/>
       <_Dependency Remove="Microsoft.Internal.Performance.CodeMarkers.DesignTime"/>
       <_Dependency Remove="Microsoft.Win32.Registry"/>


### PR DESCRIPTION
it might be better to take this for now to unblock and followup if we really need it later.  I have a few ideas in this area.