### PR TITLE
Add analyzer info for detecting IntPtr/UintPtr behavioral changes

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -102,11 +102,11 @@ Possible workarounds are:
 Also, implicit conversions between `IntPtr`/`UIntPtr` and other numeric types are treated as standard
 conversions on such platforms. This can affect overload resolution in some cases.
 
-These changes could cause behavioral change in case the user code logic was depending on overflowing in
-unchecked context, or in case it was not expecting exception throwing when overflow in checked context. We added
-[an analyzer in 7.0](https://github.com/dotnet/runtime/issues/74022) to help detect such behavioral changes
-and take appropriate action. The analyzer would inform you with potential behavioral changes, you could increase
-the severity of the analyzer to get warnings instead.
+These changes could cause a behavioral change if the user code was depending on overflow exceptions in an
+unchecked context, or if it was not expecting overflow exceptions in a checked context. An analyzer was 
+[added in 7.0](https://github.com/dotnet/runtime/issues/74022) to help detect such behavioral changes
+and take appropriate action. The analyzer will produce diagnostics on potential behavioral changes, which default
+to info severity but can be upgraded to warnings via [editorconfig](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/configuration-options#severity-level).
 
 ## Addition of System.UIntPtr and System.Int32
 

--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -102,6 +102,12 @@ Possible workarounds are:
 Also, implicit conversions between `IntPtr`/`UIntPtr` and other numeric types are treated as standard
 conversions on such platforms. This can affect overload resolution in some cases.
 
+These changes could cause behavioral change in case the user code logic was depending on overflowing in
+unchecked context, or in case it was not expecting exception throwing when overflow in checked context. We added
+[an analyzer in 7.0](https://github.com/dotnet/runtime/issues/74022) to help detect such behavioral changes
+and take appropriate action. The analyzer would inform you with potential behavioral changes, you could increase
+the severity of the analyzer to get warnings instead.
+
 ## Addition of System.UIntPtr and System.Int32
 
 ***Introduced in .NET SDK 7.0.100, Visual Studio 2022 version 17.3.***


### PR DESCRIPTION
Related to [Prevent behavioral change in built-in operators for IntPtr and UIntPtr analyzer](https://github.com/dotnet/runtime/issues/74022)

Initially we wanted to warn for potential behavioral changes detected, but after testing the analyzer with [runtime](https://github.com/dotnet/runtime/pull/75557) and few other repos we decided to degrade the analysis level to info as there were very few cases that could cause a real behavioral change.

As now users will not be warned if their code had a potential behavioral changes we want to inform them that there is an analyzer that they could use for detecting such breaking behavioral changes in this doc (I did not found any other breaking change doc except this one)

CC @jeffhandley @tannergooding 