### PR TITLE
Move to a simpler model of writing assets out to OOP

### DIFF
--- a/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
@@ -347,6 +347,10 @@ namespace Microsoft.CodeAnalysis.Remote
 
                     throw;
                 }
+                finally
+                {
+                    await pipe.Writer.CompleteAsync().ConfigureAwait(false);
+                }
             }, mustNotCancelToken);
 
             var readerTask = Task.Run(

--- a/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
+++ b/src/Workspaces/Remote/Core/BrokeredServiceConnection.cs
@@ -344,12 +344,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     // before the writer is passed to the RPC proxy. Once it's passed to the proxy 
                     // the proxy should complete it as soon as the remote side completes it.
                     await pipe.Writer.CompleteAsync(e).ConfigureAwait(false);
-
                     throw;
-                }
-                finally
-                {
-                    await pipe.Writer.CompleteAsync().ConfigureAwait(false);
                 }
             }, mustNotCancelToken);
 

--- a/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
@@ -16,9 +16,9 @@ namespace Microsoft.CodeAnalysis.Remote
         /// <summary>
         /// Streams serialized assets into the given stream.
         /// </summary>
-        /// <param name="pipeWriter">The writer to write the assets into.  The caller fo this method owns this writer
-        /// and is responsible for calling <see cref="PipeWriter.Complete"/> on it.  Implementations of this
-        /// method do not need to do that.</param>
+        /// <param name="pipeWriter">The writer to write the assets into.  Implementations of this method must call<see
+        /// cref="PipeWriter.Complete"/> on it (in the event of failure or success).  Failing to do so will lead to
+        /// hangs on the code that reads from the corresponding <see cref="PipeReader"/> side of this.</param>
         ValueTask GetAssetsAsync(PipeWriter pipeWriter, Checksum solutionChecksum, Checksum[] checksums, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/ISolutionAssetProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
-using System.IO;
 using System.IO.Pipelines;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,6 +16,9 @@ namespace Microsoft.CodeAnalysis.Remote
         /// <summary>
         /// Streams serialized assets into the given stream.
         /// </summary>
+        /// <param name="pipeWriter">The writer to write the assets into.  The caller fo this method owns this writer
+        /// and is responsible for calling <see cref="PipeWriter.Complete"/> on it.  Implementations of this
+        /// method do not need to do that.</param>
         ValueTask GetAssetsAsync(PipeWriter pipeWriter, Checksum solutionChecksum, Checksum[] checksums, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
+++ b/src/Workspaces/Remote/Core/RemoteHostAssetSerialization.cs
@@ -19,8 +19,8 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal static class RemoteHostAssetSerialization
     {
-        public static void WriteData(
-            ObjectWriter writer,
+        public static async ValueTask WriteDataAsync(
+            Stream stream,
             SolutionAsset? singleAsset,
             IReadOnlyDictionary<Checksum, SolutionAsset>? assetMap,
             ISerializerService serializer,
@@ -29,6 +29,8 @@ namespace Microsoft.CodeAnalysis.Remote
             Checksum[] checksums,
             CancellationToken cancellationToken)
         {
+            using var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken);
+
             // This information is not actually needed on the receiving end.  However, we still send it so that the
             // receiver can assert that both sides are talking about the same solution snapshot and no weird invariant
             // breaks have occurred.
@@ -54,7 +56,12 @@ namespace Microsoft.CodeAnalysis.Remote
             foreach (var (checksum, asset) in assetMap)
             {
                 WriteAsset(writer, serializer, context, checksum, asset, cancellationToken);
+
+                // Flush after each item as a reasonably chunk of data to want to send over the pipe.
+                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
+
+            return;
 
             static void WriteAsset(ObjectWriter writer, ISerializerService serializer, SolutionReplicationContext context, Checksum checksum, SolutionAsset asset, CancellationToken cancellationToken)
             {

--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -73,11 +73,11 @@ namespace Microsoft.CodeAnalysis.Remote
         /// </summary>
         private class PipeWriterStream : Stream, IDisposableObservable
         {
-            private readonly PipeWriter writer;
+            private readonly PipeWriter _writer;
 
             internal PipeWriterStream(PipeWriter writer)
             {
-                this.writer = writer ?? throw new ArgumentNullException(nameof(writer));
+                _writer = writer ?? throw new ArgumentNullException(nameof(writer));
             }
 
             public override bool CanRead => false;
@@ -140,9 +140,9 @@ namespace Microsoft.CodeAnalysis.Remote
                 Requires.NotNull(buffer, nameof(buffer));
                 Verify.NotDisposed(this);
 
-                var span = this.writer.GetSpan(count);
+                var span = _writer.GetSpan(count);
                 buffer.AsSpan(offset, count).CopyTo(span);
-                this.writer.Advance(count);
+                _writer.Advance(count);
             }
 
             public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
@@ -155,9 +155,9 @@ namespace Microsoft.CodeAnalysis.Remote
             public override void WriteByte(byte value)
             {
                 Verify.NotDisposed(this);
-                var span = this.writer.GetSpan(1);
+                var span = _writer.GetSpan(1);
                 span[0] = value;
-                this.writer.Advance(1);
+                _writer.Advance(1);
             }
 
 #if !NETSTANDARD
@@ -165,9 +165,9 @@ namespace Microsoft.CodeAnalysis.Remote
             public override void Write(ReadOnlySpan<byte> buffer)
             {
                 Verify.NotDisposed(this);
-                var span = this.writer.GetSpan(buffer.Length);
+                var span = _writer.GetSpan(buffer.Length);
                 buffer.CopyTo(span);
-                this.writer.Advance(buffer.Length);
+                _writer.Advance(buffer.Length);
             }
 
             public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)

--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -35,6 +35,9 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public async ValueTask GetAssetsAsync(PipeWriter pipeWriter, Checksum solutionChecksum, Checksum[] checksums, CancellationToken cancellationToken)
         {
+            // The responsibility is on us (as per the requirements of RemoteCallback.InvokeAsync) to Complete the
+            // pipewriter.  This will signal to streamjsonrpc that the writer passed into it is complete, which will
+            // allow the calling side know to stop reading results.
             try
             {
                 await GetAssetsWorkerAsync(pipeWriter, solutionChecksum, checksums, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -123,17 +123,18 @@ namespace Microsoft.CodeAnalysis.Remote
 
             public override bool CanWrite => !this.IsDisposed;
 
+            /// <summary>
+            /// Intentionally a no op. We know that we and <see cref="RemoteHostAssetSerialization.WriteDataAsync"/>
+            /// will call <see cref="FlushAsync"/> at appropriate times to ensure data is being sent through the writer
+            /// at a reasonable cadence (once per asset).
+            /// </summary>
             public override void Flush()
             {
                 Verify.NotDisposed(this);
-
-                // intentionally a no op. We know that we and RemoteHostAssetSerialization.WriteDataAsync will call
-                // FlushAsync at appropriate times to ensure data is being sent through the writer at a reasonable
-                // cadence (once per asset).
             }
 
             public override async Task FlushAsync(CancellationToken cancellationToken)
-                => await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+                => await _writer.FlushAsync(cancellationToken).ConfigureAwait(false);
 
             public override void Write(byte[] buffer, int offset, int count)
             {

--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -35,6 +35,23 @@ namespace Microsoft.CodeAnalysis.Remote
 
         public async ValueTask GetAssetsAsync(PipeWriter pipeWriter, Checksum solutionChecksum, Checksum[] checksums, CancellationToken cancellationToken)
         {
+            try
+            {
+                await GetAssetsWorkerAsync(pipeWriter, solutionChecksum, checksums, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                await pipeWriter.CompleteAsync(ex).ConfigureAwait(false);
+                throw;
+            }
+            finally
+            {
+                await pipeWriter.CompleteAsync().ConfigureAwait(false);
+            }
+        }
+
+        private async ValueTask GetAssetsWorkerAsync(PipeWriter pipeWriter, Checksum solutionChecksum, Checksum[] checksums, CancellationToken cancellationToken)
+        {
             var assetStorage = _services.GetRequiredService<ISolutionAssetStorageProvider>().AssetStorage;
             var serializer = _services.GetRequiredService<ISerializerService>();
             var scope = assetStorage.GetScope(solutionChecksum);

--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -67,8 +67,9 @@ namespace Microsoft.CodeAnalysis.Remote
         /// Simple port of
         /// https://github.com/AArnott/Nerdbank.Streams/blob/dafeb5846702bc29e261c9ddf60f42feae01654c/src/Nerdbank.Streams/BufferWriterStream.cs#L16.
         /// Wraps a <see cref="PipeWriter"/> in a <see cref="Stream"/> interface.  Preferred over <see
-        /// cref="PipeWriter.AsStream(bool)"/> as that API produces a stream that will synchronously flush after ever
-        /// write.  That's undesirable as that will then block a thread pool thread on the actual 
+        /// cref="PipeWriter.AsStream(bool)"/> as that API produces a stream that will synchronously flush after
+        /// <em>every</em> write.  That's undesirable as that will then block a thread pool thread on the actual
+        /// asynchronous flush call to the underlying PipeWriter
         /// </summary>
         private class PipeWriterStream : Stream, IDisposableObservable
         {


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/64476.

High level idea is that we wrap a PIpeWriter with a normal synchronous stream.  We then write out each asset to the stream *synchronously* (just liek before), however, we can do a nice async-flush from the stream to the PIpeWRiter after each asset is written.  That allows us to keep the code simple, while not having to worry about sync-blocking-on-async that comes from using hte normal AsStream helper.