### PR TITLE
Add and use TargetFramework.Net70

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,6 +53,7 @@
     <BasicReferenceAssembliesNetStandard20Version>1.2.4</BasicReferenceAssembliesNetStandard20Version>
     <BasicReferenceAssembliesNet50Version>1.2.4</BasicReferenceAssembliesNet50Version>
     <BasicReferenceAssembliesNet60Version>1.2.4</BasicReferenceAssembliesNet60Version>
+    <BasicReferenceAssembliesNet70Version>1.3.0</BasicReferenceAssembliesNet70Version>
     <BasicReferenceAssembliesNetStandard13Version>1.2.4</BasicReferenceAssembliesNetStandard13Version>
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
     <BenchmarkDotNetDiagnosticsWindowsVersion>0.13.0</BenchmarkDotNetDiagnosticsWindowsVersion>

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -467,22 +467,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal bool RuntimeSupportsUnmanagedSignatureCallingConvention
             => RuntimeSupportsFeature(SpecialMember.System_Runtime_CompilerServices_RuntimeFeature__UnmanagedSignatureCallingConvention);
 
-        internal virtual bool RuntimeSupportsByRefFields
-        {
-            get
-            {
-                // CorLibrary should never be null, but that invariant is broken in some cases for MissingAssemblySymbol.
-                // Tracked by https://github.com/dotnet/roslyn/issues/61262
-                return CorLibrary?.RuntimeSupportsByRefFields == true;
-            }
-
-            set
-            {
-                // The setter should be removed once TargetFramework.Net70 is added
-                // Tracked by https://github.com/dotnet/roslyn/issues/61463
-                CorLibrary.RuntimeSupportsByRefFields = value;
-            }
-        }
+        internal bool RuntimeSupportsByRefFields
+            => RuntimeSupportsFeature(SpecialMember.System_Runtime_CompilerServices_RuntimeFeature__ByRefFields);
 
         /// <summary>
         /// True if the target runtime support covariant returns of methods declared in classes.

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -442,19 +442,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         /// <summary>
         /// Whether the target runtime supports numeric IntPtr types.
-        /// This test hook should be removed once TargetFramework.Net70 is added.
-        /// Tracked by https://github.com/dotnet/roslyn/issues/61235
         /// </summary>
-        internal virtual bool RuntimeSupportsNumericIntPtr
+        internal bool RuntimeSupportsNumericIntPtr
         {
             get
             {
                 // CorLibrary should never be null, but that invariant is broken in some cases for MissingAssemblySymbol.
                 // Tracked by https://github.com/dotnet/roslyn/issues/61262
-                return CorLibrary?.RuntimeSupportsNumericIntPtr == true;
+                return CorLibrary is not null &&
+                    RuntimeSupportsFeature(SpecialMember.System_Runtime_CompilerServices_RuntimeFeature__NumericIntPtr);
             }
-
-            set => CorLibrary.RuntimeSupportsNumericIntPtr = value;
         }
 
         protected bool RuntimeSupportsFeature(SpecialMember feature)

--- a/src/Compilers/CSharp/Portable/Symbols/MetadataOrSourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MetadataOrSourceAssemblySymbol.cs
@@ -32,38 +32,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private int _cachedSpecialTypes;
 
         private NativeIntegerTypeSymbol[] _lazyNativeIntegerTypes;
-        private ThreeState _lazyRuntimeSupportsNumericIntPtr = ThreeState.Unknown;
-
-        internal override bool RuntimeSupportsNumericIntPtr
-        {
-            get
-            {
-                if ((object)CorLibrary == this)
-                {
-                    if (!_lazyRuntimeSupportsNumericIntPtr.HasValue())
-                    {
-                        _lazyRuntimeSupportsNumericIntPtr = RuntimeSupportsFeature(SpecialMember.System_Runtime_CompilerServices_RuntimeFeature__NumericIntPtr).ToThreeState();
-                    }
-
-                    return _lazyRuntimeSupportsNumericIntPtr.Value();
-                }
-
-                return base.RuntimeSupportsNumericIntPtr;
-            }
-            set
-            {
-                Debug.Assert(value);
-                Debug.Assert(!RuntimeSupportsFeature(SpecialMember.System_Runtime_CompilerServices_RuntimeFeature__NumericIntPtr));
-                if ((object)CorLibrary == this)
-                {
-                    Debug.Assert(!_lazyRuntimeSupportsNumericIntPtr.HasValue());
-                    _lazyRuntimeSupportsNumericIntPtr = value.ToThreeState();
-                    return;
-                }
-
-                base.RuntimeSupportsNumericIntPtr = value;
-            }
-        }
 
         /// <summary>
         /// Lookup declaration for predefined CorLib type in this Assembly.

--- a/src/Compilers/CSharp/Portable/Symbols/MetadataOrSourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MetadataOrSourceAssemblySymbol.cs
@@ -33,7 +33,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private NativeIntegerTypeSymbol[] _lazyNativeIntegerTypes;
         private ThreeState _lazyRuntimeSupportsNumericIntPtr = ThreeState.Unknown;
-        private ThreeState _lazyRuntimeSupportsByRefFields = ThreeState.Unknown;
 
         internal override bool RuntimeSupportsNumericIntPtr
         {
@@ -63,37 +62,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 base.RuntimeSupportsNumericIntPtr = value;
-            }
-        }
-
-        internal override bool RuntimeSupportsByRefFields
-        {
-            get
-            {
-                if ((object)CorLibrary == this)
-                {
-                    if (!_lazyRuntimeSupportsByRefFields.HasValue())
-                    {
-                        _lazyRuntimeSupportsByRefFields = RuntimeSupportsFeature(SpecialMember.System_Runtime_CompilerServices_RuntimeFeature__ByRefFields).ToThreeState();
-                    }
-
-                    return _lazyRuntimeSupportsByRefFields.Value();
-                }
-
-                return base.RuntimeSupportsByRefFields;
-            }
-            set
-            {
-                Debug.Assert(value);
-                Debug.Assert(!RuntimeSupportsFeature(SpecialMember.System_Runtime_CompilerServices_RuntimeFeature__ByRefFields));
-                if ((object)CorLibrary == this)
-                {
-                    Debug.Assert(!_lazyRuntimeSupportsByRefFields.HasValue());
-                    _lazyRuntimeSupportsByRefFields = value.ToThreeState();
-                    return;
-                }
-
-                base.RuntimeSupportsByRefFields = value;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/MissingCorLibrarySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingCorLibrarySymbol.cs
@@ -79,20 +79,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 throw ExceptionUtilities.Unreachable();
             }
         }
-
-        internal override bool RuntimeSupportsByRefFields
-        {
-            get
-            {
-                // For now we assume that it is not supported by default
-                Debug.Assert((object)CorLibrary == this);
-                return false;
-            }
-            set
-            {
-                Debug.Assert((object)CorLibrary == this);
-                throw ExceptionUtilities.Unreachable();
-            }
-        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/MissingCorLibrarySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingCorLibrarySymbol.cs
@@ -64,20 +64,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             return _lazySpecialTypes[(int)type];
         }
-
-        internal override bool RuntimeSupportsNumericIntPtr
-        {
-            get
-            {
-                // For now we assume that it is not supported by default
-                Debug.Assert((object)CorLibrary == this);
-                return false;
-            }
-            set
-            {
-                Debug.Assert((object)CorLibrary == this);
-                throw ExceptionUtilities.Unreachable();
-            }
-        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -9039,14 +9039,8 @@ class Program
                     return;
                 }
 
-<<<<<<< HEAD
-                CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(expectedResult)).VerifyDiagnostics(expectedDiagnostics);
-||||||| c47866ea2d9
-                CompileAndVerify(comp, expectedOutput: expectedResult).VerifyDiagnostics(expectedDiagnostics);
-=======
                 // Investigating flaky IL verification issue. Tracked by https://github.com/dotnet/roslyn/issues/63782
-                CompileAndVerify(comp, expectedOutput: expectedResult, verify: Verification.PassesOrFailFast).VerifyDiagnostics(expectedDiagnostics);
->>>>>>> dotnet/main
+                CompileAndVerify(comp, verify: Verification.FailsPEVerify | Verification.PassesOrFailFast, expectedOutput: IncludeExpectedOutput(expectedResult)).VerifyDiagnostics(expectedDiagnostics);
                 Assert.NotNull(expectedResult);
             }
         }

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -28,6 +28,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 {
     public class NumericIntPtrTests : CSharpTestBase
     {
+        private static string IncludeExpectedOutput(string expectedOutput) =>
+#if NET7_0_OR_GREATER
+            expectedOutput ;
+#else
+            null;
+#endif
+
         internal static readonly ConversionKind[] Identity = new[] { ConversionKind.Identity };
         internal static readonly ConversionKind[] NoConversion = new[] { ConversionKind.NoConversion };
         internal static readonly ConversionKind[] Boxing = new[] { ConversionKind.Boxing };
@@ -929,19 +936,18 @@ class A4 : IA
     void IA.F1(System.IntPtr x, nuint y) { }
 }";
 
-            var mscorlibRefWithoutSharing = MscorlibRefWithoutSharingCachedSymbols;
-            var comp = CreateNumericIntPtrCompilation(new[] { sourceA, sourceB }, references: new[] { mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(new[] { sourceA, sourceB }, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
 
-            comp = CreateEmptyCompilation(sourceA, references: new[] { mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(sourceA, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
             var ref1 = comp.ToMetadataReference();
             var ref2 = comp.EmitToImageReference();
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { ref1, mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(sourceB, references: new[] { ref1 }, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { ref2, mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(sourceB, references: new[] { ref2 }, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
         }
 
@@ -992,19 +998,18 @@ class B4 : A
                 Diagnostic(ErrorCode.WRN_NewNotRequired, "F2").WithArguments("B3.F2(nint)").WithLocation(14, 21)
             };
 
-            var mscorlibRefWithoutSharing = MscorlibRefWithoutSharingCachedSymbols;
-            var comp = CreateNumericIntPtrCompilation(new[] { sourceA, sourceB }, references: new[] { mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(new[] { sourceA, sourceB }, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(diagnostics);
 
-            comp = CreateEmptyCompilation(sourceA, references: new[] { mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(sourceA, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
             var ref1 = comp.ToMetadataReference();
             var ref2 = comp.EmitToImageReference();
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { ref1, mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(sourceB, references: new[] { ref1 }, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(diagnostics);
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { ref2, mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(sourceB, references: new[] { ref2 }, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(diagnostics);
         }
 
@@ -1019,10 +1024,10 @@ class B4 : A
     static partial void F1(nint x) { }
     static partial void F2(nuint x);
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseDll.WithWarningLevel(5), parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(5), parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
 
-            comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithWarningLevel(6), parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
         }
 
@@ -1037,7 +1042,7 @@ class C
     UIntPtr M(UIntPtr i, int j) => i + j;
 }
 ";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (6,36): error CS0034: Operator '+' is ambiguous on operands of type 'nuint' and 'int'
                 //     UIntPtr M(UIntPtr i, int j) => i + j;
@@ -1067,7 +1072,7 @@ class C
 {
     nuint M(nuint i, int j) => i + j;
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (4,32): error CS0034: Operator '+' is ambiguous on operands of type 'nuint' and 'int'
                 //     nuint M(nuint i, int j) => i + j;
@@ -1092,9 +1097,9 @@ class C
 {
     IntPtr M(IntPtr i, int j) => i + j;
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp);
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
             verifier.VerifyIL("C.M", @"
 {
   // Code size        5 (0x5)
@@ -1130,9 +1135,9 @@ class C
 {
     nint M(nint i, int j) => i + j;
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp);
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
             verifier.VerifyIL("C.M", @"
 {
   // Code size        5 (0x5)
@@ -1186,19 +1191,18 @@ public class B4 : A<System.UIntPtr> { }
     }
 }";
 
-            var mscorlibRefWithoutSharing = MscorlibRefWithoutSharingCachedSymbols;
-            var comp = CreateNumericIntPtrCompilation(new[] { sourceA, sourceB }, references: new[] { mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(new[] { sourceA, sourceB }, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
 
-            comp = CreateEmptyCompilation(sourceA, references: new[] { mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(sourceA, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
             var ref1 = comp.ToMetadataReference();
             var ref2 = comp.EmitToImageReference();
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { ref1, mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(sourceB, references: new[] { ref1 }, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { ref2, mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(sourceB, references: new[] { ref2 }, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
         }
 
@@ -1230,10 +1234,10 @@ class AAttribute : System.Attribute
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "nuint").WithArguments("nuint").WithLocation(2, 5)
             };
 
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(expectedDiagnostics);
 
-            comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(expectedDiagnostics);
         }
 
@@ -1252,7 +1256,7 @@ class Program
 }";
 
 
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (6,34): error CS0103: The name 'nint' does not exist in the current context
                 //         Console.WriteLine(nameof(nint));
@@ -1275,10 +1279,10 @@ class Program
     }
 }";
 
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular8);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular8, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
 
-            comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
         }
 
@@ -1296,7 +1300,7 @@ class Program
         _ = sizeof(nuint);
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
             comp.VerifyDiagnostics(
                 // (5,13): error CS0233: 'nint' does not have a predefined size, therefore sizeof can only be used in an unsafe context
@@ -1328,9 +1332,9 @@ class Program
         Console.Write(sizeof(nuint));
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.UnsafeReleaseExe, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             int size = IntPtr.Size;
-            var verifier = CompileAndVerify(comp, expectedOutput: $"{size}{size}{size}{size}");
+            var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput($"{size}{size}{size}{size}"), verify: Verification.FailsPEVerify);
             verifier.VerifyIL("Program.Main",
 @"{
   // Code size       45 (0x2d)
@@ -1362,7 +1366,7 @@ unsafe class Program
         yield return sizeof(System.UIntPtr);
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseDll, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (6,22): error CS1629: Unsafe code may not appear in iterators
                 //         yield return sizeof(nint);
@@ -1398,13 +1402,13 @@ class Program
         WriteLine((object)t2 == t4);
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
-            CompileAndVerify(comp, expectedOutput:
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 @"System.IntPtr
 System.UIntPtr
 False
 True
-True");
+True"));
         }
 
         [Fact]
@@ -1422,8 +1426,8 @@ class Program
         System.Console.WriteLine(F());
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe);
-            var verifier = CompileAndVerify(comp, expectedOutput: @"1");
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net70);
+            var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput(@"1"), verify: Verification.FailsPEVerify);
             verifier.VerifyIL("Program.F",
 @"{
   // Code size       16 (0x10)
@@ -1457,10 +1461,10 @@ class Program
         System.Console.WriteLine(F2(42));
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
-            var verifier = CompileAndVerify(comp, expectedOutput:
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 @"-42
-42");
+42"));
             verifier.VerifyIL("Program.F1",
 @"{
   // Code size        8 (0x8)
@@ -1486,7 +1490,7 @@ class Program
         [Fact]
         public void BuiltInOperators()
         {
-            var comp = CreateNumericIntPtrCompilation("", new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation("", parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
             comp.VerifyDiagnostics();
             verifyOperators(comp);
@@ -1591,8 +1595,7 @@ public class A
     public static {{nuintType}}? F4;
 }
 """;
-            var mscorlibRefWithoutSharing = MscorlibRefWithoutSharingCachedSymbols;
-            var comp = CreateNumericIntPtrCompilation(sourceA, references: new[] { mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(sourceA, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
 
             var sourceB =
@@ -1613,9 +1616,9 @@ public class A
         F4 = w;
     }
 }";
-            comp = CreateEmptyCompilation(sourceB, references: new[] { AsReference(comp, useCompilationReference), mscorlibRefWithoutSharing }, parseOptions: useLatest ? TestOptions.Regular9 : TestOptions.Regular8);
+            comp = CreateCompilation(sourceB, references: new[] { AsReference(comp, useCompilationReference) }, parseOptions: useLatest ? TestOptions.Regular9 : TestOptions.Regular8, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp);
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
             verifier.VerifyIL("B.M1",
 @"{
   // Code size       59 (0x3b)
@@ -1629,18 +1632,18 @@ public class A
   IL_000c:  ldsfld     ""nint? A.F3""
   IL_0011:  stloc.0
   IL_0012:  ldloca.s   V_0
-  IL_0014:  call       ""bool nint?.HasValue.get""
+  IL_0014:  call       ""readonly bool nint?.HasValue.get""
   IL_0019:  brfalse.s  IL_0023
   IL_001b:  ldloca.s   V_0
-  IL_001d:  call       ""nint nint?.GetValueOrDefault()""
+  IL_001d:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_0022:  pop
   IL_0023:  ldsfld     ""nuint? A.F4""
   IL_0028:  stloc.1
   IL_0029:  ldloca.s   V_1
-  IL_002b:  call       ""bool nuint?.HasValue.get""
+  IL_002b:  call       ""readonly bool nuint?.HasValue.get""
   IL_0030:  brfalse.s  IL_003a
   IL_0032:  ldloca.s   V_1
-  IL_0034:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0034:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_0039:  pop
   IL_003a:  ret
 }");
@@ -1661,28 +1664,28 @@ public class A
   IL_000e:  ldarg.2
   IL_000f:  stloc.0
   IL_0010:  ldloca.s   V_0
-  IL_0012:  call       ""bool int?.HasValue.get""
+  IL_0012:  call       ""readonly bool int?.HasValue.get""
   IL_0017:  brtrue.s   IL_0024
   IL_0019:  ldloca.s   V_1
   IL_001b:  initobj    ""nint?""
   IL_0021:  ldloc.1
   IL_0022:  br.s       IL_0031
   IL_0024:  ldloca.s   V_0
-  IL_0026:  call       ""int int?.GetValueOrDefault()""
+  IL_0026:  call       ""readonly int int?.GetValueOrDefault()""
   IL_002b:  conv.i
   IL_002c:  newobj     ""nint?..ctor(nint)""
   IL_0031:  stsfld     ""nint? A.F3""
   IL_0036:  ldarg.3
   IL_0037:  stloc.2
   IL_0038:  ldloca.s   V_2
-  IL_003a:  call       ""bool uint?.HasValue.get""
+  IL_003a:  call       ""readonly bool uint?.HasValue.get""
   IL_003f:  brtrue.s   IL_004c
   IL_0041:  ldloca.s   V_3
   IL_0043:  initobj    ""nuint?""
   IL_0049:  ldloc.3
   IL_004a:  br.s       IL_0059
   IL_004c:  ldloca.s   V_2
-  IL_004e:  call       ""uint uint?.GetValueOrDefault()""
+  IL_004e:  call       ""readonly uint uint?.GetValueOrDefault()""
   IL_0053:  conv.u
   IL_0054:  newobj     ""nuint?..ctor(nuint)""
   IL_0059:  stsfld     ""nuint? A.F4""
@@ -1705,8 +1708,7 @@ public class A
     public static {{nuintType}}? F4;
 }
 """;
-            var mscorlibRefWithoutSharing = MscorlibRefWithoutSharingCachedSymbols;
-            var comp = CreateNumericIntPtrCompilation(sourceA, references: new[] { mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(sourceA, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
             var refA = AsReference(comp, useCompilationReference);
 
@@ -1725,9 +1727,9 @@ public class A
         F4 = F4 / F2;
     }
 }";
-            comp = CreateEmptyCompilation(sourceB, references: new[] { refA, mscorlibRefWithoutSharing }, parseOptions: useCSharp9 ? TestOptions.Regular9 : TestOptions.Regular8);
+            comp = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: useCSharp9 ? TestOptions.Regular9 : TestOptions.Regular8, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp);
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
             verifier.VerifyIL("B.Main",
 @"{
   // Code size      247 (0xf7)
@@ -1746,28 +1748,28 @@ public class A
   IL_0015:  ldsfld     ""nint? A.F3""
   IL_001a:  stloc.0
   IL_001b:  ldloca.s   V_0
-  IL_001d:  call       ""bool nint?.HasValue.get""
+  IL_001d:  call       ""readonly bool nint?.HasValue.get""
   IL_0022:  brtrue.s   IL_002f
   IL_0024:  ldloca.s   V_1
   IL_0026:  initobj    ""nint?""
   IL_002c:  ldloc.1
   IL_002d:  br.s       IL_003c
   IL_002f:  ldloca.s   V_0
-  IL_0031:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0031:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_0036:  neg
   IL_0037:  newobj     ""nint?..ctor(nint)""
   IL_003c:  stsfld     ""nint? A.F3""
   IL_0041:  ldsfld     ""nuint? A.F4""
   IL_0046:  stloc.2
   IL_0047:  ldloca.s   V_2
-  IL_0049:  call       ""bool nuint?.HasValue.get""
+  IL_0049:  call       ""readonly bool nuint?.HasValue.get""
   IL_004e:  brtrue.s   IL_005b
   IL_0050:  ldloca.s   V_3
   IL_0052:  initobj    ""nuint?""
   IL_0058:  ldloc.3
   IL_0059:  br.s       IL_0067
   IL_005b:  ldloca.s   V_2
-  IL_005d:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_005d:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_0062:  newobj     ""nuint?..ctor(nuint)""
   IL_0067:  stsfld     ""nuint? A.F4""
   IL_006c:  ldsfld     ""nint A.F1""
@@ -1783,14 +1785,14 @@ public class A
   IL_0092:  ldsfld     ""nint A.F1""
   IL_0097:  stloc.s    V_4
   IL_0099:  ldloca.s   V_0
-  IL_009b:  call       ""bool nint?.HasValue.get""
+  IL_009b:  call       ""readonly bool nint?.HasValue.get""
   IL_00a0:  brtrue.s   IL_00ad
   IL_00a2:  ldloca.s   V_1
   IL_00a4:  initobj    ""nint?""
   IL_00aa:  ldloc.1
   IL_00ab:  br.s       IL_00bc
   IL_00ad:  ldloca.s   V_0
-  IL_00af:  call       ""nint nint?.GetValueOrDefault()""
+  IL_00af:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_00b4:  ldloc.s    V_4
   IL_00b6:  mul
   IL_00b7:  newobj     ""nint?..ctor(nint)""
@@ -1800,14 +1802,14 @@ public class A
   IL_00c7:  ldsfld     ""nuint A.F2""
   IL_00cc:  stloc.s    V_5
   IL_00ce:  ldloca.s   V_2
-  IL_00d0:  call       ""bool nuint?.HasValue.get""
+  IL_00d0:  call       ""readonly bool nuint?.HasValue.get""
   IL_00d5:  brtrue.s   IL_00e2
   IL_00d7:  ldloca.s   V_3
   IL_00d9:  initobj    ""nuint?""
   IL_00df:  ldloc.3
   IL_00e0:  br.s       IL_00f1
   IL_00e2:  ldloca.s   V_2
-  IL_00e4:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_00e4:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_00e9:  ldloc.s    V_5
   IL_00eb:  div.un
   IL_00ec:  newobj     ""nuint?..ctor(nuint)""
@@ -1833,10 +1835,10 @@ class C
     }
 }
 """;
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular7_3);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular7_3, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
 
-            comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
         }
 
@@ -1881,7 +1883,7 @@ $@"class Program
         _ = ~y;
     }}
 }}";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics();
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -1933,7 +1935,7 @@ $@"class Program
         _ = x >> 1;
     }}
 }}";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics();
             var tree = comp.SyntaxTrees[0];
             var model = comp.GetSemanticModel(tree);
@@ -2016,7 +2018,7 @@ class Program
     }}
 }}";
 
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
             comp.VerifyDiagnostics(
                 // (15,17): error CS0266: Cannot implicitly convert type 'uint' to 'nint'. An explicit conversion exists (are you missing a cast?)
@@ -2118,7 +2120,7 @@ class Program
     }}
 }}";
 
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
             comp.VerifyDiagnostics(
                 // (9,24): error CS0266: Cannot implicitly convert type 'nint' to 'sbyte'. An explicit conversion exists (are you missing a cast?)
@@ -2191,7 +2193,7 @@ class Program
         Console.WriteLine(y);
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
             comp.VerifyDiagnostics(
                 // (7,26): error CS0133: The expression being assigned to 'y' must be constant
@@ -2219,12 +2221,12 @@ class Program
         }
     }
 }";
-            comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (9,30): warning CS8778: Constant value '1152921504606846975' may overflow 'nint' at runtime (use 'unchecked' syntax to override)
                 //             nint y = checked((nint)x);
                 Diagnostic(ErrorCode.WRN_ConstOutOfRangeChecked, "(nint)x").WithArguments("1152921504606846975", "nint").WithLocation(9, 30));
-            CompileAndVerify(comp, expectedOutput: IntPtr.Size == 4 ? "System.OverflowException" : "1152921504606846975");
+            CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput(IntPtr.Size == 4 ? "System.OverflowException" : "1152921504606846975"), verify: Verification.FailsPEVerify);
         }
 
         [WorkItem(45531, "https://github.com/dotnet/roslyn/issues/45531")]
@@ -2242,7 +2244,7 @@ class Program
         Console.WriteLine(y);
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
             comp.VerifyDiagnostics(
                 // (7,26): error CS0133: The expression being assigned to 'y' must be constant
@@ -2260,9 +2262,9 @@ class Program
         Console.WriteLine(y);
     }
 }";
-            comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: IntPtr.Size == 4 ? "-1" : "1152921504606846975");
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(IntPtr.Size == 4 ? "-1" : "1152921504606846975"));
         }
 
         [Fact]
@@ -2375,12 +2377,12 @@ class Program
         Console.Write(y);
     }}
 }}";
-                var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+                var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
                 comp.VerifyDiagnostics(expectedError is null ? Array.Empty<DiagnosticDescription>() : new[] { expectedError });
                 if (expectedError == null || ErrorFacts.IsWarning((ErrorCode)expectedError.Code))
                 {
-                    CompileAndVerify(comp, expectedOutput: expectedOutput);
+                    CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(expectedOutput));
                 }
             }
         }
@@ -2425,7 +2427,7 @@ $@"class Program
         System.Console.WriteLine(n);
     }}
 }}";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             string expectedOutput =
 @"0
 -2147483648
@@ -2451,7 +2453,7 @@ $@"class Program
 65535
 65536
 2147483647";
-            var verifier = CompileAndVerify(comp, expectedOutput: expectedOutput);
+            var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput(expectedOutput), verify: Verification.FailsPEVerify);
             string expectedIL =
 @"{
   // Code size      209 (0xd1)
@@ -2566,7 +2568,7 @@ $@"class Program
         System.Console.WriteLine(n);
     }}
 }}";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             string expectedOutput =
 @"0
 0
@@ -2585,7 +2587,7 @@ $@"class Program
 2147483647
 2147483648
 4294967295";
-            var verifier = CompileAndVerify(comp, expectedOutput: expectedOutput);
+            var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput(expectedOutput), verify: Verification.FailsPEVerify);
             string expectedIL =
 @"{
   // Code size      141 (0x8d)
@@ -2679,7 +2681,7 @@ $@"class Program
     {
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (5,19): error CS1503: Argument 1: cannot convert from 'sbyte' to 'ushort'
                 //         F<ushort>(sbyte.MaxValue); // 1
@@ -2744,7 +2746,7 @@ class Program
         const nuint d = default;
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
         }
 
@@ -2764,10 +2766,10 @@ class Program
         System.Console.Write($""{A}, {B}, {C}, {D}"");
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net70);
 
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "0, 0, 0, 0");
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput("0, 0, 0, 0"));
         }
 
         [Fact]
@@ -2779,8 +2781,7 @@ class Program
     public const nint C1 = -42;
     public const nuint C2 = 42;
 }";
-            var mscorlibRefWithoutSharing = MscorlibRefWithoutSharingCachedSymbols;
-            var comp = CreateNumericIntPtrCompilation(source0, references: new[] { mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source0, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             var ref0 = comp.EmitToImageReference();
             var source1 =
 @"using System;
@@ -2792,10 +2793,10 @@ class B
         Console.WriteLine(A.C2);
     }
 }";
-            comp = CreateEmptyCompilation(source1, references: new[] { ref0, mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, expectedOutput:
+            comp = CreateCompilation(source1, references: new[] { ref0 }, parseOptions: TestOptions.Regular9, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net70);
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 @"-42
-42");
+42"));
         }
 
         [Fact]
@@ -2809,8 +2810,7 @@ class B
     public static System.UIntPtr F3(System.UIntPtr u = 42) => u;
     public static nuint F4(nuint u = 42) => u;
 }";
-            var mscorlibRefWithoutSharing = MscorlibRefWithoutSharingCachedSymbols;
-            var comp = CreateNumericIntPtrCompilation(source0, references: new[] { mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source0, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
             var ref0 = comp.EmitToImageReference();
             var source1 =
@@ -2825,13 +2825,13 @@ class B
         Console.WriteLine(A.F4());
     }
 }";
-            comp = CreateEmptyCompilation(source1, references: new[] { ref0, mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9, options: TestOptions.ReleaseExe);
+            comp = CreateCompilation(source1, references: new[] { ref0 }, parseOptions: TestOptions.Regular9, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net70);
 
-            CompileAndVerify(comp, expectedOutput:
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 @"-42
 -42
 42
-42");
+42"));
         }
 
         [Fact]
@@ -2847,7 +2847,7 @@ class Program
     const UIntPtr D = 0;
     const UIntPtr E = uint.MaxValue;
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
             comp.VerifyDiagnostics();
             verify((FieldSymbol)comp.GetMember("Program.A"), int.MinValue, signed: true, negative: true);
@@ -2889,7 +2889,7 @@ class A : System.Attribute
 class B
 {
 }";
-            var comp = CreateNumericIntPtrCompilation(source0, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source0, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
             comp.VerifyDiagnostics(
                 // (8,4): error CS0182: An attribute argument must be a constant expression, typeof expression or array creation expression of an attribute parameter type
@@ -2922,7 +2922,7 @@ class A : System.Attribute
 class B
 {
 }";
-            var comp = CreateNumericIntPtrCompilation(source0, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source0, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
             comp.VerifyDiagnostics(
                 // (8,2): error CS0181: Attribute constructor parameter 'value' has type 'nint', which is not a valid attribute parameter type
@@ -3022,25 +3022,24 @@ null
 -3
 4";
 
-            var mscorlibRefWithoutSharing = MscorlibRefWithoutSharingCachedSymbols;
-            var comp = CreateNumericIntPtrCompilation(new[] { sourceA, sourceB }, references: new[] { mscorlibRefWithoutSharing }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
-            CompileAndVerify(comp, expectedOutput: expectedOutput);
+            var comp = CreateCompilation(new[] { sourceA, sourceB }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
+            CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput(expectedOutput), verify: Verification.FailsPEVerify);
 
-            comp = CreateEmptyCompilation(sourceA, references: new[] { mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+            comp = CreateCompilation(sourceA, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             var ref1 = comp.ToMetadataReference();
             var ref2 = comp.EmitToImageReference();
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { ref1, mscorlibRefWithoutSharing }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
-            CompileAndVerify(comp, expectedOutput: expectedOutput);
+            comp = CreateCompilation(sourceB, references: new[] { ref1 }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
+            CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput(expectedOutput), verify: Verification.FailsPEVerify);
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { ref2, mscorlibRefWithoutSharing }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
-            CompileAndVerify(comp, expectedOutput: expectedOutput);
+            comp = CreateCompilation(sourceB, references: new[] { ref2 }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
+            CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput(expectedOutput), verify: Verification.FailsPEVerify);
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { ref1, mscorlibRefWithoutSharing }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular8);
-            CompileAndVerify(comp, expectedOutput: expectedOutput);
+            comp = CreateCompilation(sourceB, references: new[] { ref1 }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular8, targetFramework: TargetFramework.Net70);
+            CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput(expectedOutput), verify: Verification.FailsPEVerify);
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { ref2, mscorlibRefWithoutSharing }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular8);
-            CompileAndVerify(comp, expectedOutput: expectedOutput);
+            comp = CreateCompilation(sourceB, references: new[] { ref2 }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular8, targetFramework: TargetFramework.Net70);
+            CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput(expectedOutput), verify: Verification.FailsPEVerify);
         }
 
         [Fact]
@@ -3096,16 +3095,16 @@ class Program
         Console.WriteLine(M(6));
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
-            var verifier = CompileAndVerify(comp, expectedOutput:
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 @"case 6: 5
 case 2: 4
 case 0xff: 3
 case 0: 2
 case 9999: 1
 default: 0
-0");
+0"));
             verifier.VerifyIL("Program.M", @"
     {
       // Code size      201 (0xc9)
@@ -3264,16 +3263,16 @@ class Program
         Console.WriteLine(M(6));
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
-            var verifier = CompileAndVerify(comp, expectedOutput:
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 @"case 6: 5
 case 2: 4
 case 0xff: 3
 case 0: 2
 case 9999: 1
 default: 0
-0");
+0"));
             verifier.VerifyIL("Program.M", @"
     {
       // Code size      184 (0xb8)
@@ -3405,7 +3404,7 @@ $@"{{
   // Code size        9 (0x9)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""{sourceType} {sourceType}?.Value.get""
+  IL_0002:  call       ""readonly {sourceType} {sourceType}?.Value.get""
   IL_0007:  {conversion}
   IL_0008:  ret
 }}";
@@ -3414,7 +3413,7 @@ $@"{{
   // Code size       10 (0xa)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""{sourceType} {sourceType}?.Value.get""
+  IL_0002:  call       ""readonly {sourceType} {sourceType}?.Value.get""
   IL_0007:  conv.r.un
   IL_0008:  {conversion}
   IL_0009:  ret
@@ -3447,14 +3446,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool {sourceType}?.HasValue.get""
+  IL_0004:  call       ""readonly bool {sourceType}?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""{destType}?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""{sourceType} {sourceType}?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly {sourceType} {sourceType}?.GetValueOrDefault()""
   IL_001c:  {conversion}
   IL_001d:  newobj     ""{destType}?..ctor({destType})""
   IL_0022:  ret
@@ -3468,14 +3467,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool {sourceType}?.HasValue.get""
+  IL_0004:  call       ""readonly bool {sourceType}?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""{destType}?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""{sourceType} {sourceType}?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly {sourceType} {sourceType}?.GetValueOrDefault()""
   IL_001c:  conv.r.un
   IL_001d:  {conversion}
   IL_001e:  newobj     ""{destType}?..ctor({destType})""
@@ -3489,13 +3488,13 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool {sourceType}?.HasValue.get""
+  IL_0004:  call       ""readonly bool {sourceType}?.HasValue.get""
   IL_0009:  brtrue.s   IL_000e
   IL_000b:  ldc.i4.0
   IL_000c:  conv.u
   IL_000d:  ret
   IL_000e:  ldloca.s   V_0
-  IL_0010:  call       ""{sourceType} {sourceType}?.GetValueOrDefault()""
+  IL_0010:  call       ""readonly {sourceType} {sourceType}?.GetValueOrDefault()""
   IL_0015:  call       ""{method}""
   IL_001a:  ret
 }}";
@@ -3605,7 +3604,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nint nint?.Value.get""
+  IL_0002:  call       ""readonly nint nint?.Value.get""
   IL_0007:  ret
 }");
             conversions(sourceType: "nuint?", destType: "nint", ExplicitNullableNumeric, expectedImplicitIL: null, expectedExplicitIL:
@@ -3614,7 +3613,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nuint nuint?.Value.get""
+  IL_0002:  call       ""readonly nuint nuint?.Value.get""
   IL_0007:  ret
 }
 ",
@@ -3626,7 +3625,7 @@ $@"{{
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""decimal decimal?.Value.get""
+  IL_0002:  call       ""readonly decimal decimal?.Value.get""
   IL_0007:  call       ""long decimal.op_Explicit(decimal)""
   IL_000c:  conv.i
   IL_000d:  ret
@@ -3635,7 +3634,7 @@ $@"{{
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""decimal decimal?.Value.get""
+  IL_0002:  call       ""readonly decimal decimal?.Value.get""
   IL_0007:  call       ""long decimal.op_Explicit(decimal)""
   IL_000c:  conv.ovf.i
   IL_000d:  ret
@@ -3645,7 +3644,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nint nint?.Value.get""
+  IL_0002:  call       ""readonly nint nint?.Value.get""
   IL_0007:  ret
 }");
             conversions(sourceType: "System.UIntPtr?", destType: "nint", ExplicitNullableNumeric, expectedImplicitIL: null, expectedExplicitIL:
@@ -3654,7 +3653,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nuint nuint?.Value.get""
+  IL_0002:  call       ""readonly nuint nuint?.Value.get""
   IL_0007:  ret
 }
 ",
@@ -3810,14 +3809,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001c:  newobj     ""nint?..ctor(nint)""
   IL_0021:  ret
 }
@@ -3834,14 +3833,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool decimal?.HasValue.get""
+  IL_0004:  call       ""readonly bool decimal?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""decimal decimal?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly decimal decimal?.GetValueOrDefault()""
   IL_001c:  call       ""long decimal.op_Explicit(decimal)""
   IL_0021:  conv.i
   IL_0022:  newobj     ""nint?..ctor(nint)""
@@ -3855,14 +3854,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool decimal?.HasValue.get""
+  IL_0004:  call       ""readonly bool decimal?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""decimal decimal?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly decimal decimal?.GetValueOrDefault()""
   IL_001c:  call       ""long decimal.op_Explicit(decimal)""
   IL_0021:  conv.ovf.i
   IL_0022:  newobj     ""nint?..ctor(nint)""
@@ -3879,14 +3878,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001c:  newobj     ""nint?..ctor(nint)""
   IL_0021:  ret
 }
@@ -4042,7 +4041,7 @@ $@"{{
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nint nint?.Value.get""
+  IL_0002:  call       ""readonly nint nint?.Value.get""
   IL_0007:  conv.i8
   IL_0008:  call       ""decimal decimal.op_Implicit(long)""
   IL_000d:  ret
@@ -4052,7 +4051,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nint nint?.Value.get""
+  IL_0002:  call       ""readonly nint nint?.Value.get""
   IL_0007:  ret
 }");
             conversions(sourceType: "nint?", destType: "System.UIntPtr", ExplicitNullableNumeric, expectedImplicitIL: null, expectedExplicitIL:
@@ -4061,7 +4060,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nint nint?.Value.get""
+  IL_0002:  call       ""readonly nint nint?.Value.get""
   IL_0007:  ret
 }
 ",
@@ -4090,14 +4089,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""decimal?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001c:  conv.i8
   IL_001d:  call       ""decimal decimal.op_Implicit(long)""
   IL_0022:  newobj     ""decimal?..ctor(decimal)""
@@ -4111,14 +4110,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""decimal?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001c:  conv.i8
   IL_001d:  call       ""decimal decimal.op_Implicit(long)""
   IL_0022:  newobj     ""decimal?..ctor(decimal)""
@@ -4135,14 +4134,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001c:  newobj     ""nuint?..ctor(nuint)""
   IL_0021:  ret
 }
@@ -4214,7 +4213,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nint nint?.Value.get""
+  IL_0002:  call       ""readonly nint nint?.Value.get""
   IL_0007:  ret
 }
 ",
@@ -4224,7 +4223,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nuint nuint?.Value.get""
+  IL_0002:  call       ""readonly nuint nuint?.Value.get""
   IL_0007:  ret
 }");
             conversions(sourceType: "float?", destType: "nuint", ExplicitNullableNumeric, expectedImplicitIL: null, expectedExplicitIL: convFromNullableT("conv.u", "float"), expectedCheckedIL: convFromNullableT("conv.ovf.u", "float"));
@@ -4234,7 +4233,7 @@ $@"{{
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""decimal decimal?.Value.get""
+  IL_0002:  call       ""readonly decimal decimal?.Value.get""
   IL_0007:  call       ""ulong decimal.op_Explicit(decimal)""
   IL_000c:  conv.u
   IL_000d:  ret
@@ -4243,7 +4242,7 @@ $@"{{
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""decimal decimal?.Value.get""
+  IL_0002:  call       ""readonly decimal decimal?.Value.get""
   IL_0007:  call       ""ulong decimal.op_Explicit(decimal)""
   IL_000c:  conv.ovf.u.un
   IL_000d:  ret
@@ -4253,7 +4252,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nint nint?.Value.get""
+  IL_0002:  call       ""readonly nint nint?.Value.get""
   IL_0007:  ret
 }",
                 expectedCheckedIL: convFromNullableT("conv.ovf.u", "nint"));
@@ -4262,7 +4261,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nuint nuint?.Value.get""
+  IL_0002:  call       ""readonly nuint nuint?.Value.get""
   IL_0007:  ret
 }");
 
@@ -4399,14 +4398,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001c:  newobj     ""nuint?..ctor(nuint)""
   IL_0021:  ret
 }
@@ -4424,14 +4423,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool decimal?.HasValue.get""
+  IL_0004:  call       ""readonly bool decimal?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""decimal decimal?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly decimal decimal?.GetValueOrDefault()""
   IL_001c:  call       ""ulong decimal.op_Explicit(decimal)""
   IL_0021:  conv.u
   IL_0022:  newobj     ""nuint?..ctor(nuint)""
@@ -4445,14 +4444,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool decimal?.HasValue.get""
+  IL_0004:  call       ""readonly bool decimal?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""decimal decimal?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly decimal decimal?.GetValueOrDefault()""
   IL_001c:  call       ""ulong decimal.op_Explicit(decimal)""
   IL_0021:  conv.ovf.u.un
   IL_0022:  newobj     ""nuint?..ctor(nuint)""
@@ -4468,14 +4467,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001c:  newobj     ""nuint?..ctor(nuint)""
   IL_0021:  ret
 }
@@ -4632,7 +4631,7 @@ $@"{{
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nuint nuint?.Value.get""
+  IL_0002:  call       ""readonly nuint nuint?.Value.get""
   IL_0007:  conv.u8
   IL_0008:  call       ""decimal decimal.op_Implicit(ulong)""
   IL_000d:  ret
@@ -4643,7 +4642,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nuint nuint?.Value.get""
+  IL_0002:  call       ""readonly nuint nuint?.Value.get""
   IL_0007:  ret
 }
 ",
@@ -4653,7 +4652,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nuint nuint?.Value.get""
+  IL_0002:  call       ""readonly nuint nuint?.Value.get""
   IL_0007:  ret
 }");
 
@@ -4680,14 +4679,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""decimal?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001c:  conv.u8
   IL_001d:  call       ""decimal decimal.op_Implicit(ulong)""
   IL_0022:  newobj     ""decimal?..ctor(decimal)""
@@ -4701,14 +4700,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""decimal?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001c:  conv.u8
   IL_001d:  call       ""decimal decimal.op_Implicit(ulong)""
   IL_0022:  newobj     ""decimal?..ctor(decimal)""
@@ -4724,14 +4723,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001c:  newobj     ""nint?..ctor(nint)""
   IL_0021:  ret
 }
@@ -4891,7 +4890,7 @@ $@"{{
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nint nint?.Value.get""
+  IL_0002:  call       ""readonly nint nint?.Value.get""
   IL_0007:  conv.i8
   IL_0008:  call       ""decimal decimal.op_Implicit(long)""
   IL_000d:  ret
@@ -4901,7 +4900,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nint nint?.Value.get""
+  IL_0002:  call       ""readonly nint nint?.Value.get""
   IL_0007:  ret
 }");
             conversions(sourceType: "System.IntPtr?", destType: "System.UIntPtr", ExplicitNullableNumeric, expectedImplicitIL: null, expectedExplicitIL:
@@ -4910,7 +4909,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nint nint?.Value.get""
+  IL_0002:  call       ""readonly nint nint?.Value.get""
   IL_0007:  ret
 }
 ",
@@ -4939,14 +4938,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""decimal?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001c:  conv.i8
   IL_001d:  call       ""decimal decimal.op_Implicit(long)""
   IL_0022:  newobj     ""decimal?..ctor(decimal)""
@@ -4960,14 +4959,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""decimal?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001c:  conv.i8
   IL_001d:  call       ""decimal decimal.op_Implicit(long)""
   IL_0022:  newobj     ""decimal?..ctor(decimal)""
@@ -4984,14 +4983,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001c:  newobj     ""nuint?..ctor(nuint)""
   IL_0021:  ret
 }
@@ -5188,7 +5187,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nint nint?.Value.get""
+  IL_0002:  call       ""readonly nint nint?.Value.get""
   IL_0007:  ret
 }");
             conversions(sourceType: "nuint?", destType: "System.IntPtr", ExplicitNullableNumeric, expectedImplicitIL: null, expectedExplicitIL:
@@ -5197,7 +5196,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nuint nuint?.Value.get""
+  IL_0002:  call       ""readonly nuint nuint?.Value.get""
   IL_0007:  ret
 }
 ",
@@ -5209,7 +5208,7 @@ $@"{{
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""decimal decimal?.Value.get""
+  IL_0002:  call       ""readonly decimal decimal?.Value.get""
   IL_0007:  call       ""long decimal.op_Explicit(decimal)""
   IL_000c:  conv.i
   IL_000d:  ret
@@ -5218,7 +5217,7 @@ $@"{{
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""decimal decimal?.Value.get""
+  IL_0002:  call       ""readonly decimal decimal?.Value.get""
   IL_0007:  call       ""long decimal.op_Explicit(decimal)""
   IL_000c:  conv.ovf.i
   IL_000d:  ret
@@ -5228,7 +5227,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nint nint?.Value.get""
+  IL_0002:  call       ""readonly nint nint?.Value.get""
   IL_0007:  ret
 }");
             conversions(sourceType: "System.UIntPtr?", destType: "System.IntPtr", ExplicitNullableNumeric, expectedImplicitIL: null, expectedExplicitIL:
@@ -5237,7 +5236,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nuint nuint?.Value.get""
+  IL_0002:  call       ""readonly nuint nuint?.Value.get""
   IL_0007:  ret
 }
 ",
@@ -5266,14 +5265,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001c:  newobj     ""nint?..ctor(nint)""
   IL_0021:  ret
 }
@@ -5290,14 +5289,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool decimal?.HasValue.get""
+  IL_0004:  call       ""readonly bool decimal?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""decimal decimal?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly decimal decimal?.GetValueOrDefault()""
   IL_001c:  call       ""long decimal.op_Explicit(decimal)""
   IL_0021:  conv.i
   IL_0022:  newobj     ""nint?..ctor(nint)""
@@ -5311,14 +5310,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool decimal?.HasValue.get""
+  IL_0004:  call       ""readonly bool decimal?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""decimal decimal?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly decimal decimal?.GetValueOrDefault()""
   IL_001c:  call       ""long decimal.op_Explicit(decimal)""
   IL_0021:  conv.ovf.i
   IL_0022:  newobj     ""nint?..ctor(nint)""
@@ -5335,14 +5334,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001c:  newobj     ""nint?..ctor(nint)""
   IL_0021:  ret
 }
@@ -5498,7 +5497,7 @@ $@"{{
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nuint nuint?.Value.get""
+  IL_0002:  call       ""readonly nuint nuint?.Value.get""
   IL_0007:  conv.u8
   IL_0008:  call       ""decimal decimal.op_Implicit(ulong)""
   IL_000d:  ret
@@ -5509,7 +5508,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nuint nuint?.Value.get""
+  IL_0002:  call       ""readonly nuint nuint?.Value.get""
   IL_0007:  ret
 }
 ",
@@ -5519,7 +5518,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nuint nuint?.Value.get""
+  IL_0002:  call       ""readonly nuint nuint?.Value.get""
   IL_0007:  ret
 }");
 
@@ -5546,14 +5545,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""decimal?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001c:  conv.u8
   IL_001d:  call       ""decimal decimal.op_Implicit(ulong)""
   IL_0022:  newobj     ""decimal?..ctor(decimal)""
@@ -5567,14 +5566,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""decimal?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001c:  conv.u8
   IL_001d:  call       ""decimal decimal.op_Implicit(ulong)""
   IL_0022:  newobj     ""decimal?..ctor(decimal)""
@@ -5590,14 +5589,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001c:  newobj     ""nint?..ctor(nint)""
   IL_0021:  ret
 }
@@ -5781,7 +5780,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nint nint?.Value.get""
+  IL_0002:  call       ""readonly nint nint?.Value.get""
   IL_0007:  ret
 }
 ",
@@ -5791,7 +5790,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nuint nuint?.Value.get""
+  IL_0002:  call       ""readonly nuint nuint?.Value.get""
   IL_0007:  ret
 }");
             conversions(sourceType: "float?", destType: "System.UIntPtr", ExplicitNullableNumeric, expectedImplicitIL: null, expectedExplicitIL: convFromNullableT("conv.u", "float"), expectedCheckedIL: convFromNullableT("conv.ovf.u", "float"));
@@ -5801,7 +5800,7 @@ $@"{{
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""decimal decimal?.Value.get""
+  IL_0002:  call       ""readonly decimal decimal?.Value.get""
   IL_0007:  call       ""ulong decimal.op_Explicit(decimal)""
   IL_000c:  conv.u
   IL_000d:  ret
@@ -5810,7 +5809,7 @@ $@"{{
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""decimal decimal?.Value.get""
+  IL_0002:  call       ""readonly decimal decimal?.Value.get""
   IL_0007:  call       ""ulong decimal.op_Explicit(decimal)""
   IL_000c:  conv.ovf.u.un
   IL_000d:  ret
@@ -5821,7 +5820,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nint nint?.Value.get""
+  IL_0002:  call       ""readonly nint nint?.Value.get""
   IL_0007:  ret
 }
 ",
@@ -5831,7 +5830,7 @@ $@"{{
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       ""nuint nuint?.Value.get""
+  IL_0002:  call       ""readonly nuint nuint?.Value.get""
   IL_0007:  ret
 }");
 
@@ -5857,14 +5856,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001c:  newobj     ""nuint?..ctor(nuint)""
   IL_0021:  ret
 }
@@ -5882,14 +5881,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool decimal?.HasValue.get""
+  IL_0004:  call       ""readonly bool decimal?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""decimal decimal?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly decimal decimal?.GetValueOrDefault()""
   IL_001c:  call       ""ulong decimal.op_Explicit(decimal)""
   IL_0021:  conv.u
   IL_0022:  newobj     ""nuint?..ctor(nuint)""
@@ -5903,14 +5902,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool decimal?.HasValue.get""
+  IL_0004:  call       ""readonly bool decimal?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""decimal decimal?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly decimal decimal?.GetValueOrDefault()""
   IL_001c:  call       ""ulong decimal.op_Explicit(decimal)""
   IL_0021:  conv.ovf.u.un
   IL_0022:  newobj     ""nuint?..ctor(nuint)""
@@ -5926,14 +5925,14 @@ $@"{{
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001c:  newobj     ""nuint?..ctor(nuint)""
   IL_0021:  ret
 }
@@ -5974,7 +5973,7 @@ $@"class Program
 }}
 enum E {{ }}
 ";
-                var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseDll.WithAllowUnsafe(useUnsafeContext), parseOptions: TestOptions.Regular9);
+                var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithAllowUnsafe(useUnsafeContext), parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
                 comp.VerifyDiagnostics(expectedDiagnostics);
 
@@ -5993,7 +5992,7 @@ enum E {{ }}
 
                 if (expectedIL != null)
                 {
-                    var verifier = CompileAndVerify(comp, verify: useUnsafeContext ? Verification.Skipped : Verification.Passes);
+                    var verifier = CompileAndVerify(comp, verify: useUnsafeContext ? Verification.Skipped : Verification.FailsPEVerify);
                     verifier.VerifyIL("Program.Convert", expectedIL);
                 }
 
@@ -6089,14 +6088,14 @@ enum E {{ }}
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001c:  newobj     ""nint?..ctor(nint)""
   IL_0021:  ret
 }");
@@ -6109,14 +6108,14 @@ enum E {{ }}
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001c:  newobj     ""nuint?..ctor(nuint)""
   IL_0021:  ret
 }");
@@ -6131,14 +6130,14 @@ enum E {{ }}
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001c:  neg
   IL_001d:  newobj     ""nint?..ctor(nint)""
   IL_0022:  ret
@@ -6163,14 +6162,14 @@ enum E {{ }}
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001c:  not
   IL_001d:  newobj     ""nint?..ctor(nint)""
   IL_0022:  ret
@@ -6184,14 +6183,14 @@ enum E {{ }}
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0017:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001c:  not
   IL_001d:  newobj     ""nuint?..ctor(nuint)""
   IL_0022:  ret
@@ -6211,7 +6210,7 @@ $@"class Program
         System.Console.WriteLine(Evaluate({operand}));
     }}
 }}";
-                var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+                var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
                 comp.VerifyDiagnostics(expectedDiagnostics);
 
                 var tree = comp.SyntaxTrees[0];
@@ -6222,7 +6221,7 @@ $@"class Program
 
                 if (expectedDiagnostics.Length == 0)
                 {
-                    var verifier = CompileAndVerify(comp, expectedOutput: expectedResult);
+                    var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(expectedResult));
                     verifier.VerifyIL("Program.Evaluate", expectedIL);
                 }
             }
@@ -6277,14 +6276,14 @@ $@"class Program
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0016
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  br.s       IL_0024
   IL_0016:  ldloca.s   V_0
-  IL_0018:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0018:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001d:  ldc.i4.1
   IL_001e:  add
   IL_001f:  newobj     ""nint?..ctor(nint)""
@@ -6313,14 +6312,14 @@ $@"class Program
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0016
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  br.s       IL_0024
   IL_0016:  ldloca.s   V_0
-  IL_0018:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0018:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001d:  ldc.i4.1
   IL_001e:  add
   IL_001f:  newobj     ""nuint?..ctor(nuint)""
@@ -6349,14 +6348,14 @@ $@"class Program
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0016
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  br.s       IL_0024
   IL_0016:  ldloca.s   V_0
-  IL_0018:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0018:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001d:  ldc.i4.1
   IL_001e:  sub
   IL_001f:  newobj     ""nint?..ctor(nint)""
@@ -6385,14 +6384,14 @@ $@"class Program
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0016
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  br.s       IL_0024
   IL_0016:  ldloca.s   V_0
-  IL_0018:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0018:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001d:  ldc.i4.1
   IL_001e:  sub
   IL_001f:  newobj     ""nuint?..ctor(nuint)""
@@ -6422,14 +6421,14 @@ $@"class Program
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0016
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  br.s       IL_0024
   IL_0016:  ldloca.s   V_0
-  IL_0018:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0018:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001d:  ldc.i4.1
   IL_001e:  add.ovf
   IL_001f:  newobj     ""nint?..ctor(nint)""
@@ -6458,14 +6457,14 @@ $@"class Program
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0016
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  br.s       IL_0024
   IL_0016:  ldloca.s   V_0
-  IL_0018:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0018:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001d:  ldc.i4.1
   IL_001e:  add.ovf.un
   IL_001f:  newobj     ""nuint?..ctor(nuint)""
@@ -6494,14 +6493,14 @@ $@"class Program
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0016
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nint?""
   IL_0013:  ldloc.1
   IL_0014:  br.s       IL_0024
   IL_0016:  ldloca.s   V_0
-  IL_0018:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0018:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_001d:  ldc.i4.1
   IL_001e:  sub.ovf
   IL_001f:  newobj     ""nint?..ctor(nint)""
@@ -6530,14 +6529,14 @@ $@"class Program
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool nuint?.HasValue.get""
+  IL_0004:  call       ""readonly bool nuint?.HasValue.get""
   IL_0009:  brtrue.s   IL_0016
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""nuint?""
   IL_0013:  ldloc.1
   IL_0014:  br.s       IL_0024
   IL_0016:  ldloca.s   V_0
-  IL_0018:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_0018:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_001d:  ldc.i4.1
   IL_001e:  sub.ovf.un
   IL_001f:  newobj     ""nuint?..ctor(nuint)""
@@ -6584,7 +6583,7 @@ class Program
         }}
     }}
 }}";
-                var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+                var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
                 comp.VerifyDiagnostics(expectedDiagnostics);
 
                 var tree = comp.SyntaxTrees[0];
@@ -6598,7 +6597,7 @@ class Program
 
                 if (expectedDiagnostics.Length == 0)
                 {
-                    var verifier = CompileAndVerify(comp, expectedOutput: expectedResult);
+                    var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(expectedResult));
                     verifier.VerifyIL("Program.Evaluate", expectedIL);
                 }
             }
@@ -6654,14 +6653,14 @@ class Program
   IL_0002:  ldobj      ""nint?""
   IL_0007:  stloc.0
   IL_0008:  ldloca.s   V_0
-  IL_000a:  call       ""bool nint?.HasValue.get""
+  IL_000a:  call       ""readonly bool nint?.HasValue.get""
   IL_000f:  brtrue.s   IL_001c
   IL_0011:  ldloca.s   V_1
   IL_0013:  initobj    ""nint?""
   IL_0019:  ldloc.1
   IL_001a:  br.s       IL_002a
   IL_001c:  ldloca.s   V_0
-  IL_001e:  call       ""nint nint?.GetValueOrDefault()""
+  IL_001e:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_0023:  ldc.i4.1
   IL_0024:  add
   IL_0025:  newobj     ""nint?..ctor(nint)""
@@ -6692,14 +6691,14 @@ class Program
   IL_0002:  ldobj      ""nuint?""
   IL_0007:  stloc.0
   IL_0008:  ldloca.s   V_0
-  IL_000a:  call       ""bool nuint?.HasValue.get""
+  IL_000a:  call       ""readonly bool nuint?.HasValue.get""
   IL_000f:  brtrue.s   IL_001c
   IL_0011:  ldloca.s   V_1
   IL_0013:  initobj    ""nuint?""
   IL_0019:  ldloc.1
   IL_001a:  br.s       IL_002a
   IL_001c:  ldloca.s   V_0
-  IL_001e:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_001e:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_0023:  ldc.i4.1
   IL_0024:  add
   IL_0025:  newobj     ""nuint?..ctor(nuint)""
@@ -6730,14 +6729,14 @@ class Program
   IL_0002:  ldobj      ""nint?""
   IL_0007:  stloc.0
   IL_0008:  ldloca.s   V_0
-  IL_000a:  call       ""bool nint?.HasValue.get""
+  IL_000a:  call       ""readonly bool nint?.HasValue.get""
   IL_000f:  brtrue.s   IL_001c
   IL_0011:  ldloca.s   V_1
   IL_0013:  initobj    ""nint?""
   IL_0019:  ldloc.1
   IL_001a:  br.s       IL_002a
   IL_001c:  ldloca.s   V_0
-  IL_001e:  call       ""nint nint?.GetValueOrDefault()""
+  IL_001e:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_0023:  ldc.i4.1
   IL_0024:  sub
   IL_0025:  newobj     ""nint?..ctor(nint)""
@@ -6768,14 +6767,14 @@ class Program
   IL_0002:  ldobj      ""nuint?""
   IL_0007:  stloc.0
   IL_0008:  ldloca.s   V_0
-  IL_000a:  call       ""bool nuint?.HasValue.get""
+  IL_000a:  call       ""readonly bool nuint?.HasValue.get""
   IL_000f:  brtrue.s   IL_001c
   IL_0011:  ldloca.s   V_1
   IL_0013:  initobj    ""nuint?""
   IL_0019:  ldloc.1
   IL_001a:  br.s       IL_002a
   IL_001c:  ldloca.s   V_0
-  IL_001e:  call       ""nuint nuint?.GetValueOrDefault()""
+  IL_001e:  call       ""readonly nuint nuint?.GetValueOrDefault()""
   IL_0023:  ldc.i4.1
   IL_0024:  sub
   IL_0025:  newobj     ""nuint?..ctor(nuint)""
@@ -6818,7 +6817,7 @@ class Program
         }}
     }}
 }}";
-                var comp = CreateNumericIntPtrCompilation(source, new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+                var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
                 comp.VerifyDiagnostics(expectedDiagnostics);
 
                 var tree = comp.SyntaxTrees[0];
@@ -6830,7 +6829,7 @@ class Program
 
                 if (expectedDiagnostics.Length == 0)
                 {
-                    var verifier = CompileAndVerify(comp, expectedOutput: expectedResult);
+                    var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(expectedResult));
                     verifier.VerifyIL("Program.Evaluate", expectedIL);
                 }
             }
@@ -6991,7 +6990,7 @@ $@"class MyInt
         _ = x << 1;
     }
 }";
-                var comp = CreateNumericIntPtrCompilation(new[] { sourceA, sourceB }, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+                var comp = CreateCompilation(new[] { sourceA, sourceB }, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
                 comp.VerifyDiagnostics(expected);
             }
         }
@@ -8092,7 +8091,7 @@ $@"class Program
         return x {op} y;
     }}
 }}";
-                var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseDll.WithAllowUnsafe(useUnsafeContext), parseOptions: TestOptions.Regular9);
+                var comp = CreateCompilation(source, options: TestOptions.ReleaseDll.WithAllowUnsafe(useUnsafeContext), parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
                 comp.VerifyDiagnostics(expectedDiagnostics);
 
                 var tree = comp.SyntaxTrees[0];
@@ -8103,7 +8102,7 @@ $@"class Program
 
                 if (expectedDiagnostics.Length == 0)
                 {
-                    CompileAndVerify(comp);
+                    CompileAndVerify(comp, verify: Verification.FailsPEVerify);
                 }
 
                 static bool useUnsafe(string type) => type == "void*";
@@ -8153,9 +8152,9 @@ class Program
         Console.WriteLine(ShiftRight(35, 4));
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
-            var verifier = CompileAndVerify(comp, expectedOutput:
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 @"7
 -1
 12
@@ -8171,7 +8170,7 @@ False
 7
 6
 560
-2");
+2"));
             verifier.VerifyIL("Program.Add",
 @"{
   // Code size        4 (0x4)
@@ -8379,9 +8378,9 @@ class Program
         Console.WriteLine(ShiftRight(35, 4));
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
-            var verifier = CompileAndVerify(comp, expectedOutput:
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 @"7
 1
 12
@@ -8397,7 +8396,7 @@ False
 7
 6
 560
-2");
+2"));
             verifier.VerifyIL("Program.Add",
 @"{
   // Code size        4 (0x4)
@@ -8583,14 +8582,14 @@ class Program
         Console.WriteLine(Mod(5, 2));
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
-            var verifier = CompileAndVerify(comp, expectedOutput:
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 @"7
 -1
 12
 2
-1");
+1"));
             verifier.VerifyIL("Program.Add",
 @"{
   // Code size        4 (0x4)
@@ -8659,14 +8658,14 @@ class Program
         Console.WriteLine(Mod(5, 2));
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
-            var verifier = CompileAndVerify(comp, expectedOutput:
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 @"7
 1
 12
 2
-1");
+1"));
             verifier.VerifyIL("Program.Add",
 @"{
   // Code size        4 (0x4)
@@ -8984,8 +8983,7 @@ $@"public class Library
     {declarations}
     public const {opType} F = {expr};
 }}";
-                var mscorlibRefWithoutSharing = MscorlibRefWithoutSharingCachedSymbols;
-                var comp = CreateNumericIntPtrCompilation(sourceA, references: new[] { mscorlibRefWithoutSharing }, parseOptions: TestOptions.Regular9);
+                var comp = CreateCompilation(sourceA, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
                 comp.VerifyDiagnostics(expectedDiagnostics);
 
@@ -9004,9 +9002,9 @@ $@"public class Library
     }
 }";
                 var refA = comp.EmitToImageReference();
-                comp = CreateEmptyCompilation(sourceB, references: new[] { refA, mscorlibRefWithoutSharing }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+                comp = CreateCompilation(sourceB, references: new[] { refA }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
-                CompileAndVerify(comp, expectedOutput: expectedResult);
+                CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(expectedResult));
                 Assert.NotNull(expectedResult);
             }
 
@@ -9031,7 +9029,7 @@ class Program
         Console.WriteLine(result);
     }}
 }}";
-                var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+                var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
                 if (expectedDiagnostics.Any(d => ErrorFacts.GetSeverity((ErrorCode)d.Code) == DiagnosticSeverity.Error))
                 {
@@ -9040,7 +9038,7 @@ class Program
                     return;
                 }
 
-                CompileAndVerify(comp, expectedOutput: expectedResult).VerifyDiagnostics(expectedDiagnostics);
+                CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(expectedResult)).VerifyDiagnostics(expectedDiagnostics);
                 Assert.NotNull(expectedResult);
             }
         }
@@ -9059,7 +9057,7 @@ class Program
         const UIntPtr y = checked(uint.MaxValue + (UIntPtr)42);
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net70);
 
             comp.VerifyDiagnostics(
                 // (8,27): error CS0133: The expression being assigned to 'x' must be constant
@@ -9091,8 +9089,8 @@ class Program
         }
     }
 }";
-            comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, expectedOutput: IntPtr.Size == 4 ? "System.OverflowException" : "4294967337").VerifyDiagnostics(
+            comp = CreateCompilation(source, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net70);
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(IntPtr.Size == 4 ? "System.OverflowException" : "4294967337")).VerifyDiagnostics(
                 // (10,29): warning CS8973: The operation may overflow 'nuint' at runtime (use 'unchecked' syntax to override)
                 //             var y = checked(uint.MaxValue + (UIntPtr)42);
                 Diagnostic(ErrorCode.WRN_CompileTimeCheckedOverflow, "uint.MaxValue + (UIntPtr)42").WithArguments("nuint").WithLocation(10, 29)
@@ -9109,8 +9107,8 @@ class Program
         System.Console.WriteLine(y);
     }
 }";
-            comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, expectedOutput: IntPtr.Size == 4 ? "41" : "4294967337").VerifyDiagnostics();
+            comp = CreateCompilation(source, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net70);
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(IntPtr.Size == 4 ? "41" : "4294967337")).VerifyDiagnostics();
         }
 
         [Fact]
@@ -9127,7 +9125,7 @@ class Program
         const IntPtr y = checked(-(IntPtr)int.MinValue);
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (8,26): error CS0133: The expression being assigned to 'x' must be constant
                 //         const IntPtr x = unchecked(-(IntPtr)int.MinValue);
@@ -9158,8 +9156,8 @@ class Program
         }
     }
 }";
-            comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, expectedOutput: IntPtr.Size == 4 ? "System.OverflowException" : "2147483648").VerifyDiagnostics(
+            comp = CreateCompilation(source, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net70);
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(IntPtr.Size == 4 ? "System.OverflowException" : "2147483648")).VerifyDiagnostics(
                 // (10,29): warning CS8973: The operation may overflow 'nint' at runtime (use 'unchecked' syntax to override)
                 //             var y = checked(-(IntPtr)int.MinValue);
                 Diagnostic(ErrorCode.WRN_CompileTimeCheckedOverflow, "-(IntPtr)int.MinValue").WithArguments("nint").WithLocation(10, 29)
@@ -9176,8 +9174,8 @@ class Program
         System.Console.WriteLine(y);
     }
 }";
-            comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, expectedOutput: IntPtr.Size == 4 ? "-2147483648" : "2147483648").VerifyDiagnostics();
+            comp = CreateCompilation(source, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net70);
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(IntPtr.Size == 4 ? "-2147483648" : "2147483648")).VerifyDiagnostics();
         }
 
         // OverflowException behavior is consistent with unchecked int division.
@@ -9215,9 +9213,9 @@ class Program
     static nint NativeIntDivision(IntPtr x, IntPtr y) => unchecked(x / y);
     static nint NativeIntRemainder(IntPtr x, IntPtr y) => unchecked(x % y);
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
-            CompileAndVerify(comp, expectedOutput:
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 $@"2147483647
 System.OverflowException
 0
@@ -9225,7 +9223,7 @@ System.OverflowException
 2147483647
 {(IntPtr.Size == 4 ? "System.OverflowException" : "2147483648")}
 0
-{(IntPtr.Size == 4 ? "System.OverflowException" : "0")}");
+{(IntPtr.Size == 4 ? "System.OverflowException" : "0")}"));
         }
 
         [Fact]
@@ -9244,12 +9242,12 @@ class Program
     static nint LeftShift(nint x, int y) => unchecked(x << y);
     static void Report(long l) => Console.WriteLine(""{0:x}"", l);
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
             var expectedValue = IntPtr.Size == 4 ? "fffffffffffffffe" : "fffffffe";
-            CompileAndVerify(comp, expectedOutput:
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 $@"{expectedValue}
-{expectedValue}");
+{expectedValue}"));
         }
 
         [Fact]
@@ -9268,12 +9266,12 @@ class Program
     static nuint LeftShift(nuint x, int y) => unchecked(x << y);
     static void Report(ulong u) => Console.WriteLine(""{0:x}"", u);
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
             var expectedValue = IntPtr.Size == 4 ? "fffffffe" : "1fffffffe";
-            CompileAndVerify(comp, expectedOutput:
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 $@"{expectedValue}
-{expectedValue}");
+{expectedValue}"));
         }
 
         [Fact]
@@ -9297,7 +9295,7 @@ class C : I
     S<nint> I.F3() => default;
     S<System.IntPtr> I.F4() => default;
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
             comp.VerifyEmitDiagnostics();
 
@@ -9332,7 +9330,7 @@ class B : A
     public override nint[] F3() => null;
     public override System.IntPtr[] F4() => null;
 }";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics();
 
             var type = comp.GetTypeByMetadataName("A");
@@ -9397,11 +9395,11 @@ class Program
         Console.WriteLine(Execute(() => ConvertChecked(value)));
     }}
 }}";
-                var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.UnsafeReleaseExe, parseOptions: TestOptions.Regular9);
+                var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
-                var verifier = CompileAndVerify(comp, expectedOutput:
+                var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 $@"{toValueUnchecked}
-{toValueChecked}");
+{toValueChecked}"));
 
                 verifier.VerifyIL("Program.Convert", toConvUnchecked is null ?
 @"
@@ -9478,7 +9476,7 @@ unsafe class Program
         Console.WriteLine(Execute(() => (ulong)ToPointer4(uint.MaxValue)));
     }}
 }}";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.UnsafeReleaseExe, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             string expectedOutput =
 $@"-42
 -42
@@ -9504,7 +9502,7 @@ System.OverflowException
 42
 System.OverflowException
 4294967295";
-            var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: expectedOutput);
+            var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: IncludeExpectedOutput(expectedOutput));
             verifier.VerifyIL("Program.ToPointer1",
 @"{
   // Code size        2 (0x2)
@@ -9616,7 +9614,7 @@ class Program
         u = E.B;
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(new[] { sourceA, sourceB }, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(new[] { sourceA, sourceB }, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (10,13): error CS0266: Cannot implicitly convert type 'nint' to 'E'. An explicit conversion exists (are you missing a cast?)
                 //         e = i1;
@@ -9672,12 +9670,12 @@ class Program
         WriteLine(F4(E.B));
     }
 }";
-            var comp = CreateNumericIntPtrCompilation(new[] { sourceA, sourceB }, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9, options: TestOptions.ReleaseExe);
-            CompileAndVerify(comp, expectedOutput:
+            var comp = CreateCompilation(new[] { sourceA, sourceB }, parseOptions: TestOptions.Regular9, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net70);
+            CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 @"A
 B
 -1
-1");
+1"));
         }
 
         [Fact]
@@ -9802,11 +9800,11 @@ class Program
         Console.WriteLine(Execute(() => ConvertChecked(value)));
     }}
 }}";
-                var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9, options: TestOptions.ReleaseExe);
+                var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net70);
 
-                var verifier = CompileAndVerify(comp, expectedOutput:
+                var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(
 $@"{toValueUnchecked}
-{toValueChecked}");
+{toValueChecked}"));
 
                 verifier.VerifyIL("Program.Convert",
 $@"{{
@@ -9874,7 +9872,7 @@ unsafe class Program
             ToPointer();
     }}
 }}";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9, options: TestOptions.UnsafeReleaseDll);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
         }
 
@@ -9887,7 +9885,7 @@ class C1<T, U> where U : I<nint>, I<nint> { }
 class C2<T, U> where U : I<nint>, I<System.IntPtr> { }
 class C3<T, U> where U : I<System.UIntPtr>, I<System.IntPtr>, I<nuint> { }
 ";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (2,35): error CS0405: Duplicate constraint 'I<nint>' for type parameter 'U'
                 // class C1<T, U> where U : I<nint>, I<nint> { }
@@ -9909,7 +9907,7 @@ class C1 : I<nint>, I<nint> { }
 class C2 : I<nint>, I<System.IntPtr> { }
 class C3 : I<System.UIntPtr>, I<System.IntPtr>, I<nuint> { }
 ";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.Regular9);
+            var comp = CreateCompilation(source, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (2,21): error CS0528: 'I<nint>' is already listed in interface list
                 // class C1 : I<nint>, I<nint> { }
@@ -9941,7 +9939,7 @@ $@"static class NativeInts
     static {type} Checked4(long x) => checked(x); // 9
     static {type} Checked5(nint x) => checked(x); // 10
 }}";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (3,40): error CS0266: Cannot implicitly convert type 'sbyte' to 'nuint'. An explicit conversion exists (are you missing a cast?)
                 //     static nuint Implicit1(sbyte x) => x; // 1
@@ -9994,8 +9992,8 @@ $@"static class NativeInts
     static {type} Checked4(long x) => checked(({type})x);
     static {type} Checked5(nint x) => checked(({type})x);
 }}";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
-            var verifier = CompileAndVerify(comp);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
             string expectedExplicitILNop =
 @"{
   // Code size        2 (0x2)
@@ -10244,7 +10242,7 @@ unsafe class FinalType
 }
 enum E { }
 """;
-                var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.UnsafeDebugDll);
+                var comp = CreateCompilation(source, options: TestOptions.UnsafeDebugDll, targetFramework: TargetFramework.Net70);
 
                 if (noConversion)
                 {
@@ -10471,7 +10469,7 @@ class Indexers2
     System.UIntPtr Property4 => throw null;
 }
 ";
-            var comp = CreateNumericIntPtrCompilation(new[] { source }, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateCompilation(new[] { source }, targetFramework: TargetFramework.Net70);
 
             comp.VerifyDiagnostics();
             VerifyNoNativeIntegerAttributeEmitted(comp);
@@ -10547,7 +10545,7 @@ class C2 { }
 
 class D<T> { }
 ";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
         }
 
@@ -10558,7 +10556,7 @@ class D<T> { }
 class C<T> where T : unmanaged { }
 class D : C<System.IntPtr> { }
 ";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
 
             comp.VerifyDiagnostics();
         }
@@ -10680,9 +10678,9 @@ System.UIntPtr x4 = 3;
 
 System.Console.Write($""{array[x1]}, {array[x2]}, {array[x3]}, {array[x4]}"");
 ";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
 
-            CompileAndVerify(comp, expectedOutput: "1, 2, 3, 4");
+            CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("1, 2, 3, 4"), verify: Verification.FailsPEVerify);
         }
 
         [Fact]
@@ -10693,12 +10691,12 @@ public class C
 {
     public nint M() { throw null; }
 }";
-            var comp = CreateEmptyCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             var image = comp.EmitToImageReference();
 
-            var comp2 = CreateNumericIntPtrCompilation(source, references: new[] { image, MscorlibRefWithoutSharingCachedSymbols });
+            var comp2 = CreateCompilation(source, references: new[] { image }, targetFramework: TargetFramework.Net70);
 
-            CompileAndVerify(comp2, sourceSymbolValidator: verify, symbolValidator: verify);
+            CompileAndVerify(comp2, sourceSymbolValidator: verify, symbolValidator: verify, verify: Verification.FailsPEVerify);
 
             static void verify(ModuleSymbol module)
             {
@@ -10730,7 +10728,7 @@ _ = y switch // 3
 };
 
 ";
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (3,7): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '> (nint)int.MaxValue' is not covered.
                 // _ = x switch // 1
@@ -10798,13 +10796,13 @@ public class C
     public static void M9(byte{{s2Nullable}} x) { Write("M9(byte)"); }
 }
 """;
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
 
             // Note: conversions ushort->nint, ushort?->nint?, ushort->nint? are implicit (so rule 1 kicks in), but ushort?->nint is explicit (so rule 3 kicks in)
             var expected = (nullable1, nullable2) is (false, true)
                 ? "M1 M2 M3 M4 M5(nint) M6 M7 M8 M9(nint)"
                 : "M1 M2 M3 M4 M5(ushort) M6 M7 M8 M9(byte)";
-            CompileAndVerify(comp, expectedOutput: expected);
+            CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput(expected), verify: Verification.FailsPEVerify);
         }
 
         [Theory, CombinatorialData]
@@ -10866,13 +10864,13 @@ public class C
     public static void M10(byte{{s2Nullable}} x) { Write("M10(byte)"); }
 }
 """;
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
 
             // Note: conversions ushort->nint, ushort?->nint?, ushort->nint? are implicit (so rule 1 kicks in), but ushort?->nint is explicit (so rule 3 kicks in)
             var expected = (nullable1, nullable2) is (false, true)
                 ? "M1 M2 M3 M4 M5 M6(IntPtr) M7 M8 M9 M10(IntPtr)"
                 : "M1 M2 M3 M4 M5 M6(ushort) M7 M8 M9 M10(byte)";
-            CompileAndVerify(comp, expectedOutput: expected);
+            CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput(expected), verify: Verification.FailsPEVerify);
         }
 
         [Fact]
@@ -10893,17 +10891,8 @@ public class Derived : Base
     public override nint M() => 0;
 }
 """;
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { libComp.ToMetadataReference(), MscorlibRefWithoutSharingCachedSymbols });
-            comp.VerifyDiagnostics(
-                // warning CS1701: Assuming assembly reference 'mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' used by 'lib' matches identity 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' of 'mscorlib', you may need to supply runtime policy
-                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin).WithArguments("mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "lib", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "mscorlib").WithLocation(1, 1),
-                // warning CS1701: Assuming assembly reference 'mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' used by 'lib' matches identity 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' of 'mscorlib', you may need to supply runtime policy
-                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin).WithArguments("mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "lib", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "mscorlib").WithLocation(1, 1),
-                // warning CS1701: Assuming assembly reference 'mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' used by 'lib' matches identity 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' of 'mscorlib', you may need to supply runtime policy
-                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin).WithArguments("mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "lib", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "mscorlib").WithLocation(1, 1),
-                // warning CS1701: Assuming assembly reference 'mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' used by 'lib' matches identity 'mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' of 'mscorlib', you may need to supply runtime policy
-                Diagnostic(ErrorCode.WRN_UnifyReferenceMajMin).WithArguments("mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "lib", "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "mscorlib").WithLocation(1, 1)
-                );
+            var comp = CreateCompilation(source, references: new[] { libComp.ToMetadataReference() }, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics();
 
             var baseM = (RetargetingMethodSymbol)comp.GlobalNamespace.GetMember("Base.M");
             var baseNint = (PENamedTypeSymbol)baseM.ReturnType;
@@ -10924,7 +10913,7 @@ public class Base
     public virtual nint M() => 0;
 }
 """;
-            var libComp = CreateNumericIntPtrCompilation(lib_cs, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, assemblyName: "lib");
+            var libComp = CreateCompilation(lib_cs, assemblyName: "lib", targetFramework: TargetFramework.Net70);
             libComp.VerifyDiagnostics();
 
             string source = """
@@ -10934,7 +10923,11 @@ public class Derived : Base
 }
 """;
             var comp = CreateEmptyCompilation(source, references: new[] { libComp.ToMetadataReference(), MscorlibRef_v46 });
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (1,24): error CS0012: The type 'Object' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
+                // public class Derived : Base
+                Diagnostic(ErrorCode.ERR_NoTypeDef, "Base").WithArguments("System.Object", "System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a").WithLocation(1, 24)
+                );
 
             var baseM = (RetargetingMethodSymbol)comp.GlobalNamespace.GetMember("Base.M");
             var baseNint = (PENamedTypeSymbol)baseM.ReturnType;
@@ -10962,9 +10955,9 @@ public class C
     System.UIntPtr M6(System.UIntPtr x, int count) => x >>> count;
 }
 """;
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp);
+            var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify);
             verifier.VerifyIL("C.M1", shiftRight("nint"));
             verifier.VerifyIL("C.M2", shiftRight("nuint"));
             verifier.VerifyIL("C.M3", shiftRight("nint"));
@@ -11024,13 +11017,13 @@ class C
     }
 }
 """;
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.UnsafeReleaseExe);
+            var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseExe, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "OVERFLOW RAN", verify: Verification.Skipped);
+            CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("OVERFLOW RAN"), verify: Verification.Skipped);
 
             comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseExe);
             comp.VerifyDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "RAN", verify: Verification.Skipped);
+            CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("RAN"), verify: Verification.Skipped);
         }
 
         [Fact]
@@ -11145,7 +11138,7 @@ public class C
 /// <summary>Summary <see cref="{{type}}"/>.</summary>
 class C { }
 """;
-            var comp = CreateNumericIntPtrCompilation(src, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.RegularWithDocumentationComments);
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularWithDocumentationComments, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees.Single();
@@ -11168,7 +11161,7 @@ using @nint = System.String;
 class C { }
 """;
 
-            var comp = CreateNumericIntPtrCompilation(src, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.RegularWithDocumentationComments);
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularWithDocumentationComments, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees.Single();
@@ -11196,7 +11189,7 @@ public class C
 }
 """;
 
-            var comp = CreateNumericIntPtrCompilation(src, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.RegularWithDocumentationComments);
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularWithDocumentationComments, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees.Single();
@@ -11221,7 +11214,7 @@ public class C
 }
 """;
 
-            var comp = CreateNumericIntPtrCompilation(src, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.RegularWithDocumentationComments);
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularWithDocumentationComments, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees.Single();
@@ -11246,7 +11239,7 @@ public class C
 }
 """;
 
-            var comp = CreateNumericIntPtrCompilation(src, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.RegularWithDocumentationComments);
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularWithDocumentationComments, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (1,33): warning CS1574: XML comment has cref attribute 'type' that could not be resolved
                 // /// <summary>Summary <see cref="type"/>.</summary>
@@ -11266,7 +11259,7 @@ public class C
 }
 """;
 
-            var comp = CreateNumericIntPtrCompilation(src, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, parseOptions: TestOptions.RegularWithDocumentationComments);
+            var comp = CreateCompilation(src, parseOptions: TestOptions.RegularWithDocumentationComments, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
 
             var tree = comp.SyntaxTrees.Single();
@@ -11385,7 +11378,7 @@ class C
   IL_0002:  ldarg.2
   IL_0003:  stloc.1
   IL_0004:  ldloca.s   V_1
-  IL_0006:  call       ""bool int?.HasValue.get""
+  IL_0006:  call       ""readonly bool int?.HasValue.get""
   IL_000b:  brtrue.s   IL_0017
   IL_000d:  ldloca.s   V_2
   IL_000f:  initobj    ""nint?""
@@ -11393,7 +11386,7 @@ class C
   IL_0016:  ret
   IL_0017:  ldloc.0
   IL_0018:  ldloca.s   V_1
-  IL_001a:  call       ""int int?.GetValueOrDefault()""
+  IL_001a:  call       ""readonly int int?.GetValueOrDefault()""
   IL_001f:  sizeof     ""nint""
   IL_0025:  ldc.i4.8
   IL_0026:  mul
@@ -11425,9 +11418,9 @@ class C
   IL_0002:  ldarg.2
   IL_0003:  stloc.1
   IL_0004:  ldloca.s   V_0
-  IL_0006:  call       ""bool nint?.HasValue.get""
+  IL_0006:  call       ""readonly bool nint?.HasValue.get""
   IL_000b:  ldloca.s   V_1
-  IL_000d:  call       ""bool int?.HasValue.get""
+  IL_000d:  call       ""readonly bool int?.HasValue.get""
   IL_0012:  and
   IL_0013:  brtrue.s   IL_001f
   IL_0015:  ldloca.s   V_2
@@ -11435,9 +11428,9 @@ class C
   IL_001d:  ldloc.2
   IL_001e:  ret
   IL_001f:  ldloca.s   V_0
-  IL_0021:  call       ""nint nint?.GetValueOrDefault()""
+  IL_0021:  call       ""readonly nint nint?.GetValueOrDefault()""
   IL_0026:  ldloca.s   V_1
-  IL_0028:  call       ""int int?.GetValueOrDefault()""
+  IL_0028:  call       ""readonly int int?.GetValueOrDefault()""
   IL_002d:  sizeof     ""nint""
   IL_0033:  ldc.i4.8
   IL_0034:  mul
@@ -11531,14 +11524,14 @@ class C
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool {type}.HasValue.get""
+  IL_0004:  call       ""readonly bool {type}.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""{type}""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""{strippedType} {type}.GetValueOrDefault()""
+  IL_0017:  call       ""readonly {strippedType} {type}.GetValueOrDefault()""
   IL_001c:  newobj     ""{type}..ctor({strippedType})""
   IL_0021:  ret
 }}";
@@ -11555,14 +11548,14 @@ class C
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool {type}.HasValue.get""
+  IL_0004:  call       ""readonly bool {type}.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""{type}""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""{strippedType} {type}.GetValueOrDefault()""
+  IL_0017:  call       ""readonly {strippedType} {type}.GetValueOrDefault()""
   IL_001c:  ldc.i4.1
   IL_001d:  {op}
   IL_001e:  newobj     ""{type}..ctor({strippedType})""
@@ -11582,14 +11575,14 @@ class C
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       ""bool {type}.HasValue.get""
+  IL_0004:  call       ""readonly bool {type}.HasValue.get""
   IL_0009:  brtrue.s   IL_0015
   IL_000b:  ldloca.s   V_1
   IL_000d:  initobj    ""{type}""
   IL_0013:  ldloc.1
   IL_0014:  ret
   IL_0015:  ldloca.s   V_0
-  IL_0017:  call       ""{strippedType} {type}.GetValueOrDefault()""
+  IL_0017:  call       ""readonly {strippedType} {type}.GetValueOrDefault()""
   IL_001c:  ldc.i4.s   {count}
   IL_001e:  sizeof     ""{strippedType}""
   IL_0024:  ldc.i4.8
@@ -11606,8 +11599,8 @@ class C
 
             CompilationVerifier compileAndVerify(CSharpTestSource source)
             {
-                var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols });
-                return CompileAndVerify(comp);
+                var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+                return CompileAndVerify(comp, verify: Verification.FailsPEVerify);
             }
 
             void validate(string type, string value, string binaryOp, string result32Bits, string result64Bits, string expectedIL)
@@ -11664,8 +11657,8 @@ class C
     }
 }
 """;
-                var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.UnsafeReleaseExe);
-                var verifier = CompileAndVerify(comp, expectedOutput: "RAN");
+                var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseExe, targetFramework: TargetFramework.Net70);
+                var verifier = CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput("RAN"));
                 verifier.VerifyIL("C.M", expectedIL);
             }
         }
@@ -11681,9 +11674,9 @@ static class C
     public static nint ShiftRight(nint x) => x >> (-62);
 }
 """;
-            var comp = CreateNumericIntPtrCompilation(source, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.UnsafeReleaseExe);
+            var comp = CreateCompilation(source, options: TestOptions.UnsafeReleaseExe, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp, expectedOutput: "63");
+            var verifier = CompileAndVerify(comp, expectedOutput: IncludeExpectedOutput("63"), verify: Verification.FailsPEVerify);
             verifier.VerifyIL("C.ShiftRight", @"
 {
   // Code size       16 (0x10)
@@ -11725,13 +11718,13 @@ class Program
             var comp = CreateCompilation(new[] { SpanSource, source }, options: TestOptions.UnsafeReleaseExe);
             verify(comp);
 
-            comp = CreateNumericIntPtrCompilation(new[] { SpanSource, source }, references: new[] { MscorlibRefWithoutSharingCachedSymbols }, options: TestOptions.UnsafeReleaseExe);
+            comp = CreateCompilation(new[] { source }, options: TestOptions.UnsafeReleaseExe, targetFramework: TargetFramework.Net70);
             verify(comp);
 
             void verify(CSharpCompilation comp)
             {
                 comp.VerifyEmitDiagnostics();
-                var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: "00");
+                var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: IncludeExpectedOutput("00"));
                 verifier.VerifyIL("Program.F", """
 {
   // Code size       48 (0x30)
@@ -11781,18 +11774,6 @@ class Program
                 emitOptions: new EmitOptions(runtimeMetadataVersion: "v5.1", debugInformationFormat: DebugInformationFormat.PortablePdb),
                 symbolValidator: module => Assert.Equal("", NativeIntegerAttributesVisitor.GetString((PEModuleSymbol)module)),
                 verify: Verification.Skipped);
-        }
-
-        private static MetadataReference MscorlibRefWithoutSharingCachedSymbols
-        {
-            get
-            {
-                // Avoid sharing mscorlib symbols with other tests since we are about to change
-                // RuntimeSupportsNumericIntPtr property for it.
-
-                return ((AssemblyMetadata)((MetadataImageReference)MscorlibRef).GetMetadata()).CopyWithoutSharingCachedSymbols().
-                    GetReference(display: "mscorlib.v4_0_30319.dll");
-            }
         }
 
         const string RuntimeFeature_NumericIntPtr = @"

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -9004,14 +9004,8 @@ $@"public class Library
                 var refA = comp.EmitToImageReference();
                 comp = CreateCompilation(sourceB, references: new[] { refA }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
-<<<<<<< HEAD
-                CompileAndVerify(comp, verify: Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(expectedResult));
-||||||| c47866ea2d9
-                CompileAndVerify(comp, expectedOutput: expectedResult);
-=======
                 // Investigating flaky IL verification issue. Tracked by https://github.com/dotnet/roslyn/issues/63782
-                CompileAndVerify(comp, expectedOutput: expectedResult, verify: Verification.PassesOrFailFast);
->>>>>>> dotnet/main
+                CompileAndVerify(comp, verify: Verification.PassesOrFailFast | Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(expectedResult));
                 Assert.NotNull(expectedResult);
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -99,12 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         M2(ref s5.F1);
     }
 }";
-            var mscorlibRefWithRefFields = GetMscorlibRefWithoutSharingCachedSymbols();
-
-            // Note: we use skipExtraValidation so that nobody pulls
-            // on the compilation or its references before we set the RuntimeSupportsByRefFields flag.
-            var comp = CreateEmptyCompilation(sourceA, references: new[] { mscorlibRefWithRefFields }, parseOptions: TestOptions.Regular10, skipExtraValidation: true);
-            comp.Assembly.RuntimeSupportsByRefFields = true;
+            var comp = CreateCompilation(sourceA, parseOptions: TestOptions.Regular10, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
                 // (3,12): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
                 //     public ref T F1;
@@ -116,7 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 //         scoped S<T> s2;
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion10, "scoped").WithArguments("ref fields", "11.0").WithLocation(25, 9));
 
-            comp = CreateEmptyCompilation(sourceA, references: new[] { mscorlibRefWithRefFields });
+            comp = CreateCompilation(sourceA, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics();
             var refA = AsReference(comp, useCompilationReference);
 
@@ -145,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     }
 }";
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { refA, mscorlibRefWithRefFields }, parseOptions: TestOptions.Regular10);
+            comp = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: TestOptions.Regular10, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
                 // (8,25): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
                 //         s1 = new S<T> { F1 = t };
@@ -169,7 +164,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             VerifyFieldSymbol(comp.GetMember<FieldSymbol>("S.F1"), "ref T S<T>.F1", RefKind.Ref, new string[0]);
             VerifyFieldSymbol(comp.GetMember<FieldSymbol>("S.F2"), "ref readonly T S<T>.F2", RefKind.RefReadOnly, new string[0]);
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { refA, mscorlibRefWithRefFields }, parseOptions: TestOptions.Regular11);
+            comp = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: TestOptions.Regular11, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics();
 
             VerifyFieldSymbol(comp.GetMember<FieldSymbol>("S.F1"), "ref T S<T>.F1", RefKind.Ref, new string[0]);
@@ -186,14 +181,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public ref T F;
     public S(ref T t) { F = ref t; }
 }";
-            // Avoid sharing mscorlib symbols with other tests since we are about to change
-            // RuntimeSupportsByRefFields property for it.
-            var mscorlibRefWithRefFields = GetMscorlibRefWithoutSharingCachedSymbols();
-
-            // Note: we use skipExtraValidation so that nobody pulls
-            // on the compilation or its references before we set the RuntimeSupportsByRefFields flag.
-            var comp = CreateEmptyCompilation(sourceA, references: new[] { mscorlibRefWithRefFields }, parseOptions: TestOptions.Regular10, skipExtraValidation: true);
-            comp.Assembly.RuntimeSupportsByRefFields = true;
+            var comp = CreateCompilation(sourceA, parseOptions: TestOptions.Regular10, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
                 // (3,12): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
                 //     public ref T F;
@@ -201,7 +189,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             VerifyFieldSymbol(comp.GetMember<FieldSymbol>("S.F"), "ref T S<T>.F", RefKind.Ref, new string[0]);
 
-            comp = CreateEmptyCompilation(sourceA, references: new[] { mscorlibRefWithRefFields });
+            comp = CreateCompilation(sourceA, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics();
             var refA = AsReference(comp, useCompilationReference);
             VerifyFieldSymbol(comp.GetMember<FieldSymbol>("S.F"), "ref T S<T>.F", RefKind.Ref, new string[0]);
@@ -223,7 +211,7 @@ class Program
     }
 }";
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { refA, mscorlibRefWithRefFields }, parseOptions: TestOptions.Regular10);
+            comp = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: TestOptions.Regular10, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
                 // (8,9): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
                 //         s.F = 2;
@@ -237,7 +225,7 @@ class Program
 
             VerifyFieldSymbol(comp.GetMember<FieldSymbol>("S.F"), "ref T S<T>.F", RefKind.Ref, new string[0]);
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { refA, mscorlibRefWithRefFields }, parseOptions: TestOptions.Regular11, options: TestOptions.ReleaseExe);
+            comp = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: TestOptions.Regular11, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net70);
             var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: IncludeExpectedOutput(
 @"2
 2
@@ -261,14 +249,8 @@ class Program
         F = ref t;
     }
 }";
-            // Avoid sharing mscorlib symbols with other tests since we are about to change
-            // RuntimeSupportsByRefFields property for it.
-            var mscorlibRefWithRefFields = GetMscorlibRefWithoutSharingCachedSymbols();
 
-            // Note: we use skipExtraValidation so that nobody pulls
-            // on the compilation or its references before we set the RuntimeSupportsByRefFields flag.
-            var comp = CreateEmptyCompilation(sourceA, references: new[] { mscorlibRefWithRefFields }, parseOptions: TestOptions.Regular10, skipExtraValidation: true);
-            comp.Assembly.RuntimeSupportsByRefFields = true;
+            var comp = CreateCompilation(sourceA, parseOptions: TestOptions.Regular10, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
                 // (3,12): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
                 //     public ref readonly T F;
@@ -276,7 +258,7 @@ class Program
 
             VerifyFieldSymbol(comp.GetMember<FieldSymbol>("S.F"), "ref readonly T S<T>.F", RefKind.RefReadOnly, new string[0]);
 
-            comp = CreateEmptyCompilation(sourceA, references: new[] { mscorlibRefWithRefFields });
+            comp = CreateCompilation(sourceA, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics();
             var refA = AsReference(comp, useCompilationReference);
             VerifyFieldSymbol(comp.GetMember<FieldSymbol>("S.F"), "ref readonly T S<T>.F", RefKind.RefReadOnly, new string[0]);
@@ -303,7 +285,7 @@ class Program
     }
 }";
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { refA, mscorlibRefWithRefFields }, parseOptions: TestOptions.Regular10);
+            comp = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: TestOptions.Regular10, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
                 // (13,9): error CS8936: Feature 'ref fields' is not available in C# 10.0. Please use language version 11.0 or greater.
                 //         s.F.G = 2;
@@ -317,7 +299,7 @@ class Program
 
             VerifyFieldSymbol(comp.GetMember<FieldSymbol>("S.F"), "ref readonly T S<T>.F", RefKind.RefReadOnly, new string[0]);
 
-            comp = CreateEmptyCompilation(sourceB, references: new[] { refA, mscorlibRefWithRefFields }, parseOptions: TestOptions.Regular11, options: TestOptions.ReleaseExe);
+            comp = CreateCompilation(sourceB, references: new[] { refA }, parseOptions: TestOptions.Regular11, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net70);
             var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: IncludeExpectedOutput(
 @"2
 2
@@ -3200,55 +3182,55 @@ class Program
     {
         T t = default;
         U u = default;
-        return F2(t, in u); 
+        return F2(t, in u);
     }
     static T G2B<T, U>()
     {
         T t = default;
         U u = default;
-        return F2(t, u); 
+        return F2(t, u);
     }
     static T G3<T, U>()
     {
         T t = default;
         U u = default;
-        return F3(t, out u); 
+        return F3(t, out u);
     }
     static T G4<T, U>()
     {
         T t = default;
         U u = default;
-        return F4(ref t, ref u); 
+        return F4(ref t, ref u);
     }
     static T G5A<T, U>()
     {
         T t = default;
         U u = default;
-        return F5(ref t, in u); 
+        return F5(ref t, in u);
     }
     static T G5B<T, U>()
     {
         T t = default;
         U u = default;
-        return F5(ref t, u); 
+        return F5(ref t, u);
     }
     static T G6<T, U>()
     {
         T t = default;
         U u = default;
-        return F6(ref t, out u); 
+        return F6(ref t, out u);
     }
     static T G7A<T, U>()
     {
         T t = default;
         U u = default;
-        return F7(in t, in u); 
+        return F7(in t, in u);
     }
     static T G7B<T, U>()
     {
         T t = default;
         U u = default;
-        return F7(t, u); 
+        return F7(t, u);
     }
     static T G8A<T, U>()
     {
@@ -3266,7 +3248,7 @@ class Program
     {
         T t = default;
         U u = default;
-        return F9(out t, out u); 
+        return F9(out t, out u);
     }
 }";
 
@@ -3688,7 +3670,7 @@ class Program
     static ref T F05<T>(ref R<T> x) { R<T> y = default; return ref F5(ref x, ref y); }
 
     static ref T F20<T>(scoped ref R<T> x) { R<T> y = default; return ref F0(ref x, ref y); } // 2
-    static ref T F22<T>(scoped ref R<T> x) { R<T> y = default; return ref F2(ref x, ref y); } // 3 
+    static ref T F22<T>(scoped ref R<T> x) { R<T> y = default; return ref F2(ref x, ref y); } // 3
     static ref T F25<T>(scoped ref R<T> x) { R<T> y = default; return ref F5(ref x, ref y); }
 }
 ref struct R<T> { }
@@ -3708,10 +3690,10 @@ ref struct R<T> { }
                 //     static ref T F20<T>(scoped ref R<T> x) { R<T> y = default; return ref F0(ref x, ref y); } // 2
                 Diagnostic(ErrorCode.ERR_RefReturnScopedParameter, "x").WithArguments("x").WithLocation(13, 82),
                 // (14,75): error CS8347: Cannot use a result of 'Program.F2<T>(ref R<T>, scoped ref R<T>)' in this context because it may expose variables referenced by parameter 'x' outside of their declaration scope
-                //     static ref T F22<T>(scoped ref R<T> x) { R<T> y = default; return ref F2(ref x, ref y); } // 3 
+                //     static ref T F22<T>(scoped ref R<T> x) { R<T> y = default; return ref F2(ref x, ref y); } // 3
                 Diagnostic(ErrorCode.ERR_EscapeCall, "F2(ref x, ref y)").WithArguments("Program.F2<T>(ref R<T>, scoped ref R<T>)", "x").WithLocation(14, 75),
                 // (14,82): error CS9075: Cannot return a parameter by reference 'x' because it is scoped to the current method
-                //     static ref T F22<T>(scoped ref R<T> x) { R<T> y = default; return ref F2(ref x, ref y); } // 3 
+                //     static ref T F22<T>(scoped ref R<T> x) { R<T> y = default; return ref F2(ref x, ref y); } // 3
                 Diagnostic(ErrorCode.ERR_RefReturnScopedParameter, "x").WithArguments("x").WithLocation(14, 82));
         }
 
@@ -4017,7 +3999,7 @@ class Program
             comp.VerifyEmitDiagnostics();
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/64471")]
         public void MethodArgumentsMustMatch_07_2()
         {
             var source =
@@ -4058,7 +4040,7 @@ class Program
                 Diagnostic(ErrorCode.ERR_RefAssignNarrower, "r.RB = ref r.B").WithArguments("RB", "r.B").WithLocation(17, 9));
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/64471")]
         public void MethodArgumentsMustMatch_07_3()
         {
             // demonstrate the non-ref-fields behavior.
@@ -6078,8 +6060,8 @@ class Program
 
     static void AssignValueToOut<T>(out S<T> sOut, T tValue) { sOut = default; sOut.F = ref tValue; } // 9
     static void AssignRefToOut<T>(out S<T> sOut, ref T tRef) { sOut = default; sOut.F = ref tRef; }
-    static void AssignOutToOut<T>(out S<T> sOut, out T tOut) { sOut = default; tOut = default; sOut.F = ref tOut; } // 10 
-    static void AssignInToOut<T>(out S<T> sOut, in T tIn)    { sOut = default; sOut.F = ref tIn; } // 11 
+    static void AssignOutToOut<T>(out S<T> sOut, out T tOut) { sOut = default; tOut = default; sOut.F = ref tOut; } // 10
+    static void AssignInToOut<T>(out S<T> sOut, in T tIn)    { sOut = default; sOut.F = ref tIn; } // 11
 
     static void AssignValueToIn<T>(in S<T> sIn, T tValue) { sIn.F = ref tValue; } // 12
     static void AssignRefToIn<T>(in S<T> sIn, ref T tRef) { sIn.F = ref tRef; } // 13
@@ -6116,10 +6098,10 @@ class Program
                 //     static void AssignValueToOut<T>(out S<T> sOut, T tValue) { sOut = default; sOut.F = ref tValue; } // 9
                 Diagnostic(ErrorCode.ERR_RefAssignNarrower, "sOut.F = ref tValue").WithArguments("F", "tValue").WithLocation(19, 80),
                 // (21,96): error CS8374: Cannot ref-assign 'tOut' to 'F' because 'tOut' has a narrower escape scope than 'F'.
-                //     static void AssignOutToOut<T>(out S<T> sOut, out T tOut) { sOut = default; tOut = default; sOut.F = ref tOut; } // 10 
+                //     static void AssignOutToOut<T>(out S<T> sOut, out T tOut) { sOut = default; tOut = default; sOut.F = ref tOut; } // 10
                 Diagnostic(ErrorCode.ERR_RefAssignNarrower, "sOut.F = ref tOut").WithArguments("F", "tOut").WithLocation(21, 96),
                 // (22,93): error CS8331: Cannot assign to variable 'tIn' or use it as the right hand side of a ref assignment because it is a readonly variable
-                //     static void AssignInToOut<T>(out S<T> sOut, in T tIn)    { sOut = default; sOut.F = ref tIn; } // 11 
+                //     static void AssignInToOut<T>(out S<T> sOut, in T tIn)    { sOut = default; sOut.F = ref tIn; } // 11
                 Diagnostic(ErrorCode.ERR_AssignReadonlyNotField, "tIn").WithArguments("variable", "tIn").WithLocation(22, 93),
                 // (24,61): error CS8332: Cannot assign to a member of variable 'sIn' or use it as the right hand side of a ref assignment because it is a readonly variable
                 //     static void AssignValueToIn<T>(in S<T> sIn, T tValue) { sIn.F = ref tValue; } // 12
@@ -7996,10 +7978,7 @@ class Program
     }
 }";
             var references = TargetFrameworkUtil.GetReferences(TargetFramework.Standard, additionalReferences: null);
-            // Note: we use skipExtraValidation so that nobody pulls
-            // on the compilation or its references before we set the RuntimeSupportsByRefFields flag.
-            var comp = CreateEmptyCompilation(source, references: CopyWithoutSharingCachedSymbols(references), options: TestOptions.ReleaseExe, skipExtraValidation: true);
-            comp.Assembly.RuntimeSupportsByRefFields = true;
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseExe, targetFramework: TargetFramework.Net70);
             var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: IncludeExpectedOutput(@"(1, Hello world)"));
             verifier.VerifyIL("Program.Deconstruct<T, U>",
 @"{
@@ -8528,10 +8507,10 @@ class C
                 // (5,7): error CS0306: The type 'StructWithIndirectRefField' may not be used as a type argument
                 //     C.M<StructWithIndirectRefField>(); // 3
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "M<StructWithIndirectRefField>").WithArguments("StructWithIndirectRefField").WithLocation(5, 7),
-                // (10,36): warning CS0649: Field 'StructWithIndirectRefField.Field' is never assigned to, and will always have its default value 
+                // (10,36): warning CS0649: Field 'StructWithIndirectRefField.Field' is never assigned to, and will always have its default value
                 //     public StructWithRefField<int> Field;
                 Diagnostic(ErrorCode.WRN_UnassignedInternalField, "Field").WithArguments("StructWithIndirectRefField.Field", "").WithLocation(10, 36),
-                // (14,18): warning CS0649: Field 'StructWithRefField<T>.RefField' is never assigned to, and will always have its default value 
+                // (14,18): warning CS0649: Field 'StructWithRefField<T>.RefField' is never assigned to, and will always have its default value
                 //     public ref T RefField;
                 Diagnostic(ErrorCode.WRN_UnassignedInternalField, "RefField").WithArguments("StructWithRefField<T>.RefField", "").WithLocation(14, 18)
                 );
@@ -10818,7 +10797,7 @@ ref struct S
 
             S s3 = s0;
             s0 = s3;
-            
+
             break;
         }
     }
@@ -11531,7 +11510,7 @@ class Enumerator1
 
             S s3 = s0;
             s0 = s3;
-            
+
             break;
         }
     }
@@ -12446,7 +12425,7 @@ class C<T>
     void M2(scoped R<T> r) { }
     object this[R<T> r] => null;
     static void M1(scoped R<T> r) { } // 1
-    void M2(R<T> r) { } // 2 
+    void M2(R<T> r) { } // 2
     object this[scoped R<T> r] => null; // 3
 }";
             var comp = CreateCompilation(source);
@@ -12455,7 +12434,7 @@ class C<T>
                 //     static void M1(scoped R<T> r) { } // 1
                 Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M1").WithArguments("M1", "C<T>").WithLocation(7, 17),
                 // (8,10): error CS0111: Type 'C<T>' already defines a member called 'M2' with the same parameter types
-                //     void M2(R<T> r) { } // 2 
+                //     void M2(R<T> r) { } // 2
                 Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M2").WithArguments("M2", "C<T>").WithLocation(8, 10),
                 // (9,12): error CS0111: Type 'C<T>' already defines a member called 'this' with the same parameter types
                 //     object this[scoped R<T> r] => null; // 3
@@ -15329,9 +15308,9 @@ class Program
         public void Scoped_Cycle()
         {
             var source =
-@"interface I 
+@"interface I
 {
-    void M<T>(T s);  
+    void M<T>(T s);
 }
 
 class C : I
@@ -15399,7 +15378,7 @@ ref struct R
 class Program
 {
     static void F(out R r)
-    { 
+    {
         Span<int> s1 = stackalloc int[10];
         R r1 = new R(s1);
         r1.F(out r);
@@ -15438,7 +15417,7 @@ class Program
 class Program
 {
     static void F(out R r)
-    { 
+    {
         int i = 0;
         R r1 = new R(ref i);
         r1.F(out r);
@@ -15520,16 +15499,6 @@ class Program
         [Fact]
         public void RefToLocalFromInstanceMethod_02()
         {
-            var sourceA =
-@"namespace System
-{
-    public ref struct Span<T>
-    {
-        unsafe public Span(void* ptr, int length) { }
-        public ref T this[int index] => throw null;
-        public static implicit operator Span<T>(T[] a) => throw null;
-    }
-}";
             var sourceB =
 @"using System;
 ref struct S
@@ -15545,7 +15514,7 @@ ref struct S
         _i = ref i;
     }
 }";
-            var comp = CreateCompilation(new[] { sourceA, sourceB }, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(sourceB, options: TestOptions.UnsafeReleaseDll, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (12,9): error CS9079: Cannot ref-assign 'i' to '_i' because 'i' can only escape the current method through a return statement.
                 //         _i = ref i;
@@ -15558,7 +15527,7 @@ ref struct S
             var source =
 @"ref struct R<T>
 {
-    public R(ref T t) { } 
+    public R(ref T t) { }
 }
 class C
 {
@@ -15714,7 +15683,7 @@ class C
                 }
                 """;
 
-            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition }, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (11,26): error CS8170: Struct members cannot return 'this' or other instance members by reference
                 //     ref int Prop1 => ref field; // 1
@@ -16758,10 +16727,7 @@ ref struct R<T>
 }
 ";
             var references = TargetFrameworkUtil.GetReferences(TargetFramework.NetCoreAppAndCSharp, additionalReferences: null);
-            // Note: we use skipExtraValidation so that nobody pulls
-            // on the compilation or its references before we set the RuntimeSupportsByRefFields flag.
-            var comp = CreateEmptyCompilation(source, references: CopyWithoutSharingCachedSymbols(references), options: TestOptions.DebugExe, skipExtraValidation: true);
-            comp.Assembly.RuntimeSupportsByRefFields = true;
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe, targetFramework: TargetFramework.Net70);
             var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: IncludeExpectedOutput("4242"));
             verifier.VerifyIL("C.Main", """
 {
@@ -17380,97 +17346,97 @@ public ref struct R
             source =
 @"ref struct R
 {
-    void M(ref scoped R parameter) 
-    { 
+    void M(ref scoped R parameter)
+    {
     }
 }";
             comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
                 // (3,16): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     void M(ref scoped R parameter) 
+                //     void M(ref scoped R parameter)
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 16),
                 // (3,25): error CS1003: Syntax error, ',' expected
-                //     void M(ref scoped R parameter) 
+                //     void M(ref scoped R parameter)
                 Diagnostic(ErrorCode.ERR_SyntaxError, "parameter").WithArguments(",").WithLocation(3, 25),
                 // (3,25): error CS0246: The type or namespace name 'parameter' could not be found (are you missing a using directive or an assembly reference?)
-                //     void M(ref scoped R parameter) 
+                //     void M(ref scoped R parameter)
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "parameter").WithArguments("parameter").WithLocation(3, 25),
                 // (3,34): error CS1001: Identifier expected
-                //     void M(ref scoped R parameter) 
+                //     void M(ref scoped R parameter)
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, ")").WithLocation(3, 34)
                 );
 
             source =
 @"ref struct R
 {
-    void M(in scoped R parameter) 
-    { 
+    void M(in scoped R parameter)
+    {
     }
 }";
             comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
                 // (3,15): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     void M(in scoped R parameter) 
+                //     void M(in scoped R parameter)
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 15),
                 // (3,24): error CS1003: Syntax error, ',' expected
-                //     void M(in scoped R parameter) 
+                //     void M(in scoped R parameter)
                 Diagnostic(ErrorCode.ERR_SyntaxError, "parameter").WithArguments(",").WithLocation(3, 24),
                 // (3,24): error CS0246: The type or namespace name 'parameter' could not be found (are you missing a using directive or an assembly reference?)
-                //     void M(in scoped R parameter) 
+                //     void M(in scoped R parameter)
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "parameter").WithArguments("parameter").WithLocation(3, 24),
                 // (3,33): error CS1001: Identifier expected
-                //     void M(in scoped R parameter) 
+                //     void M(in scoped R parameter)
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, ")").WithLocation(3, 33)
                 );
 
             source =
 @"ref struct R
 {
-    void M(out scoped R parameter) 
-    { 
+    void M(out scoped R parameter)
+    {
     }
 }";
             comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
                 // (3,10): error CS0177: The out parameter 'R' must be assigned to before control leaves the current method
-                //     void M(out scoped R parameter) 
+                //     void M(out scoped R parameter)
                 Diagnostic(ErrorCode.ERR_ParamUnassigned, "M").WithArguments("R").WithLocation(3, 10),
                 // (3,16): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     void M(out scoped R parameter) 
+                //     void M(out scoped R parameter)
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 16),
                 // (3,25): error CS1003: Syntax error, ',' expected
-                //     void M(out scoped R parameter) 
+                //     void M(out scoped R parameter)
                 Diagnostic(ErrorCode.ERR_SyntaxError, "parameter").WithArguments(",").WithLocation(3, 25),
                 // (3,25): error CS0246: The type or namespace name 'parameter' could not be found (are you missing a using directive or an assembly reference?)
-                //     void M(out scoped R parameter) 
+                //     void M(out scoped R parameter)
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "parameter").WithArguments("parameter").WithLocation(3, 25),
                 // (3,34): error CS1001: Identifier expected
-                //     void M(out scoped R parameter) 
+                //     void M(out scoped R parameter)
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, ")").WithLocation(3, 34)
                 );
 
             source =
 @"ref struct R
 {
-    void M(ref scoped scoped R parameter) 
-    { 
+    void M(ref scoped scoped R parameter)
+    {
     }
 }";
             comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
                 // (3,16): error CS0246: The type or namespace name 'scoped' could not be found (are you missing a using directive or an assembly reference?)
-                //     void M(ref scoped scoped R parameter) 
+                //     void M(ref scoped scoped R parameter)
                 Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "scoped").WithArguments("scoped").WithLocation(3, 16),
                 // (3,30): error CS1003: Syntax error, ',' expected
-                //     void M(ref scoped scoped R parameter) 
+                //     void M(ref scoped scoped R parameter)
                 Diagnostic(ErrorCode.ERR_SyntaxError, "R").WithArguments(",").WithLocation(3, 30)
                 );
 
             source =
 @"ref struct R
 {
-    void M() 
-    { 
+    void M()
+    {
         ref scoped R local;
     }
 }";
@@ -17499,8 +17465,8 @@ public ref struct R
             source =
 @"ref struct R
 {
-    void M() 
-    { 
+    void M()
+    {
         scoped ref scoped R local;
     }
 }";
@@ -17979,7 +17945,7 @@ struct B
         set { value.F = ref this; } // 2
     }
 }";
-            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition }, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (11,15): error CS8374: Cannot ref-assign 'this' to 'F' because 'this' has a narrower escape scope than 'F'.
                 //         set { value.F = ref this; } // 1
@@ -18015,7 +17981,7 @@ struct B
         init { value.F = ref this; } // 2
     }
 }";
-            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition, IsExternalInitTypeDefinition }, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (11,16): error CS8374: Cannot ref-assign 'this' to 'F' because 'this' has a narrower escape scope than 'F'.
                 //         init { value.F = ref this; } // 1
@@ -18188,14 +18154,29 @@ struct B
         r.F = ref this; // 2
     }
 }";
-            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition }, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
             comp.VerifyDiagnostics(
+                // (4,18): error CS9064: Target runtime doesn't support ref fields.
+                //     public ref T F;
+                Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportRefFields, "F").WithLocation(4, 18),
                 // (10,9): error CS8374: Cannot ref-assign 'this' to 'F' because 'this' has a narrower escape scope than 'F'.
                 //         r.F = ref this; // 1
                 Diagnostic(ErrorCode.ERR_RefAssignNarrower, "r.F = ref this").WithArguments("F", "this").WithLocation(10, 9),
                 // (15,6): error CS9063: UnscopedRefAttribute cannot be applied to this item because it is unscoped by default.
                 //     [UnscopedRef]
                 Diagnostic(ErrorCode.ERR_UnscopedRefAttributeUnsupportedTarget, "UnscopedRef").WithLocation(15, 6),
+                // (18,9): error CS8374: Cannot ref-assign 'this' to 'F' because 'this' has a narrower escape scope than 'F'.
+                //         r.F = ref this; // 2
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "r.F = ref this").WithArguments("F", "this").WithLocation(18, 9));
+
+            comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics(
+                // (10,9): error CS8374: Cannot ref-assign 'this' to 'F' because 'this' has a narrower escape scope than 'F'.
+                //         r.F = ref this; // 1
+                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "r.F = ref this").WithArguments("F", "this").WithLocation(10, 9),
+                // (15,6): error CS0592: Attribute 'UnscopedRef' is not valid on this declaration type. It is only valid on 'method, property, indexer, parameter' declarations.
+                //     [UnscopedRef]
+                Diagnostic(ErrorCode.ERR_AttributeOnBadSymbolType, "UnscopedRef").WithArguments("UnscopedRef", "method, property, indexer, parameter").WithLocation(15, 6),
                 // (18,9): error CS8374: Cannot ref-assign 'this' to 'F' because 'this' has a narrower escape scope than 'F'.
                 //         r.F = ref this; // 2
                 Diagnostic(ErrorCode.ERR_RefAssignNarrower, "r.F = ref this").WithArguments("F", "this").WithLocation(18, 9));
@@ -18302,7 +18283,7 @@ public class A<T>
         return ref r2.F;
     }
 }";
-            var comp = CreateCompilation(new[] { sourceA, UnscopedRefAttributeDefinition }, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(sourceA, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics();
             var refA = AsReference(comp, useCompilationReference);
 
@@ -18322,7 +18303,7 @@ public class A<T>
         return ref F2A(ref r); // 2
     }
 }";
-            comp = CreateCompilation(sourceB1, references: new[] { refA });
+            comp = CreateCompilation(sourceB1, references: new[] { refA }, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
                 // (7,20): error CS8347: Cannot use a result of 'A<int>.F1A(ref R<int>)' in this context because it may expose variables referenced by parameter 'r1' outside of their declaration scope
                 //         return ref F1A(ref r); // 1
@@ -18369,7 +18350,7 @@ public class A<T>
         return ref y;
     }
 }";
-            comp = CreateCompilation(sourceB2, references: new[] { refA });
+            comp = CreateCompilation(sourceB2, references: new[] { refA }, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
                 // (6,20): error CS8347: Cannot use a result of 'A<int>.F1A(ref R<int>)' in this context because it may expose variables referenced by parameter 'r1' outside of their declaration scope
                 //         return ref F1A(ref r); // 1, 2
@@ -18412,7 +18393,7 @@ public class A<T>
         throw null;
     }
 }";
-            var comp = CreateCompilation(new[] { sourceA, UnscopedRefAttributeDefinition }, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(sourceA, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
                 // (9,22): error CS9063: UnscopedRefAttribute cannot be applied to this item because it is unscoped by default.
                 //     public ref T F1([UnscopedRef] scoped ref R<T> r1) // 1
@@ -18797,7 +18778,7 @@ class B : A<int>
         return ref F4A(r); // 3
     }
 }";
-            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition }, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
                 // (17,23): error CS9063: UnscopedRefAttribute cannot be applied to this item because it is unscoped by default.
                 //     public ref T F3A([UnscopedRef] R<T> r3)
@@ -18847,7 +18828,7 @@ class Program
     static void F3<T>([UnscopedRef] in R<T> r3) { }
     static void F4<T>([UnscopedRef] out R<T> r4) { r4 = default; }
 }";
-            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition }, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
                 // (8,24): error CS9063: UnscopedRefAttribute cannot be applied to this item because it is unscoped by default.
                 //     static void F1<T>([UnscopedRef] R<T> r1) { }
@@ -19339,14 +19320,14 @@ class Program
   .method public static int32& UnscopedRefOnly([out] int32& i)
   {
     .param [1]
-    .custom instance void System.Diagnostics.CodeAnalysis.UnscopedRefAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void System.Diagnostics.CodeAnalysis.UnscopedRefAttribute::.ctor() = ( 01 00 00 00 )
     ldnull
     throw
   }
   .method public static int32& ScopedRefAndUnscopedRef([out] int32& i)
   {
     .param [1]
-    .custom instance void System.Diagnostics.CodeAnalysis.UnscopedRefAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void System.Diagnostics.CodeAnalysis.UnscopedRefAttribute::.ctor() = ( 01 00 00 00 )
     .param [1]
     .custom instance void System.Runtime.CompilerServices.ScopedRefAttribute::.ctor() = ( 01 00 00 00 )
     ldnull
@@ -20487,7 +20468,7 @@ public class C1
                 }
                 """;
 
-            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition }, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (42,15): error CS9077: Cannot return a parameter by reference 'bc' through a ref parameter; it can only be returned in a return statement
                 //         rbc = bc.ByteRef; // 1
@@ -21374,7 +21355,7 @@ struct S<T> : System.IDisposable
                 }
                 """;
 
-            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition }, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics();
         }
 
@@ -21453,7 +21434,7 @@ struct S<T> : System.IDisposable
                 }
                 """;
 
-            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition }, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (7,5): error CS8374: Cannot ref-assign 'p1.field' to 'refField' because 'p1.field' has a narrower escape scope than 'refField'.
                 //     p2.refField = ref p1.field; // 1
@@ -21569,7 +21550,7 @@ struct S<T> : System.IDisposable
                 }
                 """;
 
-            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition }, targetFramework: TargetFramework.Net70, options: TestOptions.UnsafeDebugExe);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70, options: TestOptions.UnsafeDebugExe);
             comp.VerifyDiagnostics(
                 // (7,5): warning CS9085: This ref-assigns 'p1.field' to 'refField' but 'p1.field' has a narrower escape scope than 'refField'.
                 //     p2.refField = ref p1.field; // 1
@@ -21649,7 +21630,7 @@ struct S<T> : System.IDisposable
                 }
                 """;
 
-            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition }, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (13,9): error CS8374: Cannot ref-assign 'this.field' to 'refField' because 'this.field' has a narrower escape scope than 'refField'.
                 //         p.refField = ref this.field; // 1
@@ -21718,7 +21699,7 @@ struct S<T> : System.IDisposable
                     static S2 Inner2(scoped ref S s) => new S2 { S = s };
                 }
                 """;
-            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition }, targetFramework: TargetFramework.Net70, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
                 // (13,9): warning CS9085: This ref-assigns 'this.field' to 'refField' but 'this.field' has a narrower escape scope than 'refField'.
                 //         p.refField = ref this.field; // 1
@@ -21880,7 +21861,7 @@ struct S<T> : System.IDisposable
                     static void M3(ref RS i, [UnscopedRef] out RS rs) => rs = new RS(ref i.field);
                 }
                 """;
-            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition }, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (11,49): error CS8347: Cannot use a result of 'RS.RS(ref int)' in this context because it may expose variables referenced by parameter 'i' outside of their declaration scope
                 //     static void M1(ref RS i, ref RS rs) => rs = new RS(ref i.field); // 1

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -31,14 +31,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         private static string IncludeExpectedOutput(string expectedOutput) => IsNet70OrGreater() ? expectedOutput : null;
 
-        private static IEnumerable<MetadataReference> CopyWithoutSharingCachedSymbols(IEnumerable<MetadataReference> references)
-        {
-            foreach (var reference in references)
-            {
-                yield return ((AssemblyMetadata)((MetadataImageReference)reference).GetMetadata()).CopyWithoutSharingCachedSymbols().GetReference();
-            }
-        }
-
         [CombinatorialData]
         [Theory]
         public void LanguageVersionDiagnostics(bool useCompilationReference)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -18146,22 +18146,7 @@ struct B
         r.F = ref this; // 2
     }
 }";
-            var comp = CreateCompilation(new[] { source, UnscopedRefAttributeDefinition });
-            comp.VerifyDiagnostics(
-                // (4,18): error CS9064: Target runtime doesn't support ref fields.
-                //     public ref T F;
-                Diagnostic(ErrorCode.ERR_RuntimeDoesNotSupportRefFields, "F").WithLocation(4, 18),
-                // (10,9): error CS8374: Cannot ref-assign 'this' to 'F' because 'this' has a narrower escape scope than 'F'.
-                //         r.F = ref this; // 1
-                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "r.F = ref this").WithArguments("F", "this").WithLocation(10, 9),
-                // (15,6): error CS9063: UnscopedRefAttribute cannot be applied to this item because it is unscoped by default.
-                //     [UnscopedRef]
-                Diagnostic(ErrorCode.ERR_UnscopedRefAttributeUnsupportedTarget, "UnscopedRef").WithLocation(15, 6),
-                // (18,9): error CS8374: Cannot ref-assign 'this' to 'F' because 'this' has a narrower escape scope than 'F'.
-                //         r.F = ref this; // 2
-                Diagnostic(ErrorCode.ERR_RefAssignNarrower, "r.F = ref this").WithArguments("F", "this").WithLocation(18, 9));
-
-            comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
             comp.VerifyDiagnostics(
                 // (10,9): error CS8374: Cannot ref-assign 'this' to 'F' because 'this' has a narrower escape scope than 'F'.
                 //         r.F = ref this; // 1

--- a/src/Compilers/Test/Core/CompilationVerifier.cs
+++ b/src/Compilers/Test/Core/CompilationVerifier.cs
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 ILVerify(peVerify);
 #endif
             }
-            catch (Exception) when (peVerify is Verification.PassesOrFailFast)
+            catch (Exception) when ((peVerify & Verification.PassesOrFailFast) != 0)
             {
                 var il = DumpIL();
                 Console.WriteLine(il);

--- a/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
+++ b/src/Compilers/Test/Core/Microsoft.CodeAnalysis.Test.Utilities.csproj
@@ -106,6 +106,7 @@
     <PackageReference Include="Basic.Reference.Assemblies.NetStandard20" Version="$(BasicReferenceAssembliesNetStandard20Version)" />
     <PackageReference Include="Basic.Reference.Assemblies.Net50" Version="$(BasicReferenceAssembliesNet50Version)" />
     <PackageReference Include="Basic.Reference.Assemblies.Net60" Version="$(BasicReferenceAssembliesNet60Version)" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net70" Version="$(BasicReferenceAssembliesNet70Version)" />
     <PackageReference Include="Microsoft.ILVerification" Version="$(MicrosoftILVerificationVersion)" />
   </ItemGroup>
 

--- a/src/Compilers/Test/Core/TargetFrameworkUtil.cs
+++ b/src/Compilers/Test/Core/TargetFrameworkUtil.cs
@@ -183,7 +183,7 @@ namespace Roslyn.Test.Utilities
             TargetFramework.NetStandard20 => NetStandard20References,
             TargetFramework.NetCoreApp or TargetFramework.Net50 => NetCoreApp.StandardReferences,
             TargetFramework.Net60 => ImmutableArray.CreateRange<MetadataReference>(Net60.All),
-            TargetFramework.Net70 => ImmutableArray.CreateRange<MetadataReference>(Net70.All), // TODO2
+            TargetFramework.Net70 => ImmutableArray.CreateRange<MetadataReference>(Net70.All),
             TargetFramework.NetCoreAppAndCSharp => NetCoreApp.StandardReferences.Add(NetCoreApp.MicrosoftCSharp),
             TargetFramework.NetFramework => NetFramework.StandardReferences,
 

--- a/src/Compilers/Test/Core/TargetFrameworkUtil.cs
+++ b/src/Compilers/Test/Core/TargetFrameworkUtil.cs
@@ -183,6 +183,7 @@ namespace Roslyn.Test.Utilities
             TargetFramework.NetStandard20 => NetStandard20References,
             TargetFramework.NetCoreApp or TargetFramework.Net50 => NetCoreApp.StandardReferences,
             TargetFramework.Net60 => ImmutableArray.CreateRange<MetadataReference>(Net60.All),
+            TargetFramework.Net70 => ImmutableArray.CreateRange<MetadataReference>(Net70.All), // TODO2
             TargetFramework.NetCoreAppAndCSharp => NetCoreApp.StandardReferences.Add(NetCoreApp.MicrosoftCSharp),
             TargetFramework.NetFramework => NetFramework.StandardReferences,
 

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -1221,21 +1221,6 @@ namespace System.Diagnostics.CodeAnalysis
             string sourceFileName = "",
             bool skipUsesIsNullable = false)
         {
-            if (targetFramework == TargetFramework.Net70)
-            {
-                // Avoid sharing mscorlib symbols with other tests since we are about to change
-                // RuntimeSupportsByRefFields property for it.
-                var mscorlibWithoutSharing = new[] { GetMscorlibRefWithoutSharingCachedSymbols() };
-
-                // Note: we use skipExtraValidation so that nobody pulls
-                // on the compilation or its references before we set the RuntimeSupportsByRefFields flag.
-                var comp = CreateCompilationCore(source, references is not null ? references.Concat(mscorlibWithoutSharing) : mscorlibWithoutSharing,
-                    options, parseOptions, assemblyName, sourceFileName, skipUsesIsNullable, experimentalFeature: null, skipExtraValidation: true);
-
-                comp.Assembly.RuntimeSupportsByRefFields = true;
-                return comp;
-            }
-
             return CreateEmptyCompilation(source, TargetFrameworkUtil.GetReferences(targetFramework, references), options, parseOptions, assemblyName, sourceFileName, skipUsesIsNullable);
         }
 

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -1114,21 +1114,6 @@ namespace System.Diagnostics.CodeAnalysis
             string sourceFileName = "",
             bool skipUsesIsNullable = false) => CreateCompilationCore(source, TargetFrameworkUtil.GetReferences(TargetFramework.Mscorlib45, references), options, parseOptions, assemblyName, sourceFileName, skipUsesIsNullable, experimentalFeature: feature);
 
-        internal static CSharpCompilation CreateNumericIntPtrCompilation(
-              CSharpTestSource source,
-              IEnumerable<MetadataReference> references = null,
-              CSharpCompilationOptions options = null,
-              CSharpParseOptions parseOptions = null,
-              string assemblyName = "",
-              string sourceFileName = "")
-        {
-            // Note: we use skipUsesIsNullable and skipExtraValidation so that nobody pulls
-            // on the compilation or its references before we set the RuntimeSupportsNumericIntPtr flag.
-            var comp = CreateCompilationCore(source, references, options, parseOptions, assemblyName, sourceFileName, skipUsesIsNullable: true, experimentalFeature: null, skipExtraValidation: true);
-            comp.Assembly.RuntimeSupportsNumericIntPtr = true;
-            return comp;
-        }
-
         public static CSharpCompilation CreateCompilationWithWinRT(
             CSharpTestSource source,
             IEnumerable<MetadataReference> references = null,


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/61463 (adds Net70)
Closes https://github.com/dotnet/roslyn/issues/61235 (removes RuntimeSupportsNumericIntPtr )

Relates to test plan https://github.com/dotnet/roslyn/issues/60578 (Numeric IntPtr)
Relates to test plan https://github.com/dotnet/roslyn/issues/59194 (ref fields)

Documentation of process:
1. create a package with ref assemblies (see [doc](https://github.com/jaredpar/basic-reference-assemblies/blob/main/Docs/Updating.md) and [PR](https://github.com/jaredpar/basic-reference-assemblies/pull/26) for .NET 7 ref assemblies)
2. ask First Responders to ingest resulting package from [nuget](https://www.nuget.org/packages/Basic.Reference.Assemblies.Net70) into `dotnet-public` Azure feed
3. add new `TargetFramework`, consuming that package (see first commit in this PR)
