### PR TITLE
Do not suggest `struct` after `record` with `abstract` or `sealed` modifiers

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/StructKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/StructKeywordRecommenderTests.cs
@@ -422,13 +422,16 @@ $$");
       where U : T");
         }
 
-        [Theory]
-        [InlineData("abstract")]
-        [InlineData("sealed")]
-        [WorkItem(64465, "https://github.com/dotnet/roslyn/issues/64465")]
-        public async Task TestNotAfterRecordIfHasInvalidModifier(string modifier)
+        [Fact, WorkItem(64465, "https://github.com/dotnet/roslyn/issues/64465")]
+        public async Task TestNotAfterRecord_AbstractModifier()
         {
-            await VerifyAbsenceAsync($"{modifier} record $$");
+            await VerifyAbsenceAsync("abstract record $$");
+        }
+
+        [Fact, WorkItem(64465, "https://github.com/dotnet/roslyn/issues/64465")]
+        public async Task TestNotAfterRecord_SealedModifier()
+        {
+            await VerifyAbsenceAsync("sealed record $$");
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/StructKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/StructKeywordRecommenderTests.cs
@@ -421,5 +421,14 @@ $$");
       where T : IList<$$
       where U : T");
         }
+
+        [Theory]
+        [InlineData("abstract")]
+        [InlineData("sealed")]
+        [WorkItem(64465, "https://github.com/dotnet/roslyn/issues/64465")]
+        public async Task TestNotAfterRecordIfHasInvalidModifier(string modifier)
+        {
+            await VerifyAbsenceAsync($"{modifier} record $$");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ClassKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ClassKeywordRecommender.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Threading;
-using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 
@@ -40,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations,
                     canBePartial: true,
                     cancellationToken: cancellationToken) ||
-                context.LeftToken.GetPreviousTokenIfTouchingWord(position).IsKind(SyntaxKind.RecordKeyword) ||
+                context.IsRecordDeclarationContext(s_validModifiers, cancellationToken) ||
                 syntaxTree.IsTypeParameterConstraintStartContext(position, context.LeftToken);
         }
     }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StructKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StructKeywordRecommender.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Threading;
-using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 
@@ -38,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations,
                     canBePartial: true,
                     cancellationToken: cancellationToken) ||
-                context.LeftToken.GetPreviousTokenIfTouchingWord(position).IsKind(SyntaxKind.RecordKeyword) ||
+                context.IsRecordDeclarationContext(s_validModifiers, cancellationToken) ||
                 syntaxTree.IsTypeParameterConstraintStartContext(position, context.LeftToken);
         }
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/SyntaxTreeExtensions.cs
@@ -18,9 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             => syntaxTree.GetPrecedingModifiers(position, cancellationToken, out _);
 
         public static ISet<SyntaxKind> GetPrecedingModifiers(
-#pragma warning disable IDE0060 // Remove unused parameter - Unused this parameter for consistency with other extension methods.
             this SyntaxTree syntaxTree,
-#pragma warning restore IDE0060 // Remove unused parameter
             int position,
             CancellationToken cancellationToken,
             out int positionBeforeModifiers)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
-using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
 
@@ -339,6 +338,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             CancellationToken cancellationToken = default)
         {
             return this.SyntaxTree.IsTypeDeclarationContext(this.Position, this, validModifiers, validTypeDeclarations, canBePartial, cancellationToken);
+        }
+
+        public bool IsRecordDeclarationContext(ISet<SyntaxKind> validModifiers, CancellationToken cancellationToken)
+        {
+            var previousToken = LeftToken.GetPreviousTokenIfTouchingWord(Position);
+
+            if (!previousToken.IsKind(SyntaxKind.RecordKeyword))
+                return false;
+
+            var positionBeforeRecordKeyword = previousToken.SpanStart;
+            var modifiers = SyntaxTree.GetPrecedingModifiers(positionBeforeRecordKeyword, cancellationToken);
+
+            return modifiers.IsProperSubsetOf(validModifiers);
         }
 
         public bool IsMemberAttributeContext(ISet<SyntaxKind> validTypeDeclarations, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/64465