### PR TITLE
Fix negation of is true and is false patterns with non-Boolean values

### DIFF
--- a/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpUseNotPatternTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpUseNotPatternTests.cs
@@ -83,8 +83,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
             await new VerifyCS.Test
             {
                 TestCode =
-@"#nullable enable
-class C
+@"class C
 {
     void M(bool x)
     {
@@ -94,8 +93,7 @@ class C
     }
 }",
                 FixedCode =
-@"#nullable enable
-class C
+@"class C
 {
     void M(bool x)
     {
@@ -114,8 +112,7 @@ class C
             await new VerifyCS.Test
             {
                 TestCode =
-@"#nullable enable
-class C
+@"class C
 {
     void M(object x)
     {
@@ -125,8 +122,7 @@ class C
     }
 }",
                 FixedCode =
-@"#nullable enable
-class C
+@"class C
 {
     void M(object x)
     {

--- a/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpUseNotPatternTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpUseNotPatternTests.cs
@@ -77,6 +77,68 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
             }.RunAsync();
         }
 
+        [Fact, WorkItem(64292, "https://github.com/dotnet/roslyn/issues/64292")]
+        public async Task BooleanValueConstantPattern()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode =
+@"#nullable enable
+class C
+{
+    void M(bool x)
+    {
+        if (!(x [|is|] true))
+        {
+        }
+    }
+}",
+                FixedCode =
+@"#nullable enable
+class C
+{
+    void M(bool x)
+    {
+        if (x is false)
+        {
+        }
+    }
+}",
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact, WorkItem(64292, "https://github.com/dotnet/roslyn/issues/64292")]
+        public async Task NonBooleanValueConstantPattern()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode =
+@"#nullable enable
+class C
+{
+    void M(object x)
+    {
+        if (!(x [|is|] true))
+        {
+        }
+    }
+}",
+                FixedCode =
+@"#nullable enable
+class C
+{
+    void M(object x)
+    {
+        if (x is not true)
+        {
+        }
+    }
+}",
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
         [Fact, WorkItem(46699, "https://github.com/dotnet/roslyn/issues/46699")]
         public async Task UseNotPattern()
         {

--- a/src/EditorFeatures/CSharpTest/InvertLogical/InvertLogicalTests.cs
+++ b/src/EditorFeatures/CSharpTest/InvertLogical/InvertLogicalTests.cs
@@ -495,7 +495,27 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InvertLogical
         }
 
         [Fact, WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
-        public async Task InvertIsTruePattern1_CSharp9()
+        public async Task InvertBooleanIsTruePattern1_CSharp9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& x is true;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || x is false);
+    }
+}", parseOptions: CSharp9);
+        }
+
+        [Fact, WorkItem(64292, "https://github.com/dotnet/roslyn/issues/64292")]
+        public async Task InvertNonBooleanIsTruePattern1_CSharp9()
         {
             await TestInRegularAndScriptAsync(
 @"class C
@@ -509,7 +529,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InvertLogical
 {
     void M(bool x, int a, object b)
     {
-        var c = !(a <= 10 || b is false);
+        var c = !(a <= 10 || b is not true);
     }
 }", parseOptions: CSharp9);
         }
@@ -535,7 +555,27 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InvertLogical
         }
 
         [Fact, WorkItem(42368, "https://github.com/dotnet/roslyn/issues/42368")]
-        public async Task InvertIsFalsePattern1_CSharp9()
+        public async Task InvertBooleanIsFalsePattern1_CSharp9()
+        {
+            await TestInRegularAndScriptAsync(
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = a > 10 [||]&& x is false;
+    }
+}",
+@"class C
+{
+    void M(bool x, int a, object b)
+    {
+        var c = !(a <= 10 || x is true);
+    }
+}", parseOptions: CSharp9);
+        }
+
+        [Fact, WorkItem(64292, "https://github.com/dotnet/roslyn/issues/64292")]
+        public async Task InvertNonBooleanIsFalsePattern1_CSharp9()
         {
             await TestInRegularAndScriptAsync(
 @"class C
@@ -549,7 +589,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.InvertLogical
 {
     void M(bool x, int a, object b)
     {
-        var c = !(a <= 10 || b is true);
+        var c = !(a <= 10 || b is not false);
     }
 }", parseOptions: CSharp9);
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -49,6 +49,18 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             bool negateBinary,
             CancellationToken cancellationToken)
         {
+            return Negate(generator, generatorInternal, expressionOrPattern, semanticModel, negateBinary, swapBooleans: true, cancellationToken);
+        }
+
+        public static SyntaxNode Negate(
+            this SyntaxGenerator generator,
+            SyntaxGeneratorInternal generatorInternal,
+            SyntaxNode expressionOrPattern,
+            SemanticModel semanticModel,
+            bool negateBinary,
+            bool swapBooleans,
+            CancellationToken cancellationToken)
+        {
             var options = semanticModel.SyntaxTree.Options;
             var syntaxFacts = generatorInternal.SyntaxFacts;
 
@@ -93,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return GetNegationOfBinaryPattern(expressionOrPattern, generator, generatorInternal, semanticModel, cancellationToken);
 
             if (syntaxFacts.IsConstantPattern(expressionOrPattern))
-                return GetNegationOfConstantPattern(expressionOrPattern, generator, generatorInternal);
+                return GetNegationOfConstantPattern(expressionOrPattern, generator, generatorInternal, swapBooleans);
 
             if (syntaxFacts.IsUnaryPattern(expressionOrPattern))
                 return GetNegationOfUnaryPattern(expressionOrPattern, generator, generatorInternal, syntaxFacts);
@@ -229,7 +241,10 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             if (syntaxFacts.SupportsNotPattern(semanticModel.SyntaxTree.Options))
             {
                 // We do support 'not' patterns.  So attempt to push a 'not' pattern into the current is-pattern RHS.
-                negatedPattern = generator.Negate(generatorInternal, pattern, semanticModel, cancellationToken);
+                // If the value isn't a Boolean and the pattern `is true/false`, swapping to `is false/true` is incorrect since non-Booleans match neither.
+                var operation = semanticModel.GetOperation(isExpression, cancellationToken);
+                var isValueBoolean = operation is IIsPatternOperation isPatternOperation && isPatternOperation.Value.Type?.SpecialType == SpecialType.System_Boolean;
+                negatedPattern = generator.Negate(generatorInternal, pattern, semanticModel, negateBinary: true, swapBooleans: isValueBoolean, cancellationToken);
             }
             else if (syntaxFacts.IsNotPattern(pattern))
             {
@@ -423,18 +438,21 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         private static SyntaxNode GetNegationOfConstantPattern(
             SyntaxNode pattern,
             SyntaxGenerator generator,
-            SyntaxGeneratorInternal generatorInternal)
+            SyntaxGeneratorInternal generatorInternal,
+            bool swapBooleans)
         {
             var syntaxFacts = generatorInternal.SyntaxFacts;
 
-            // If we have `is true/false` just swap that to be `is false/true`.
+            // If we have `is true/false` just swap that to be `is false/true` if allowed.
+            if (swapBooleans)
+            {
+                var expression = syntaxFacts.GetExpressionOfConstantPattern(pattern);
+                if (syntaxFacts.IsTrueLiteralExpression(expression))
+                    return generatorInternal.ConstantPattern(generator.FalseLiteralExpression());
 
-            var expression = syntaxFacts.GetExpressionOfConstantPattern(pattern);
-            if (syntaxFacts.IsTrueLiteralExpression(expression))
-                return generatorInternal.ConstantPattern(generator.FalseLiteralExpression());
-
-            if (syntaxFacts.IsFalseLiteralExpression(expression))
-                return generatorInternal.ConstantPattern(generator.TrueLiteralExpression());
+                if (syntaxFacts.IsFalseLiteralExpression(expression))
+                    return generatorInternal.ConstantPattern(generator.TrueLiteralExpression());
+            }
 
             // Otherwise, just negate the entire pattern, we don't have anything else special we can do here.
             return generatorInternal.NotPattern(pattern);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -242,6 +242,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             {
                 // We do support 'not' patterns.  So attempt to push a 'not' pattern into the current is-pattern RHS.
                 // If the value isn't a Boolean and the pattern `is true/false`, swapping to `is false/true` is incorrect since non-Booleans match neither.
+                // As an example, `!(new object() is true)` is equivalent to `new object() is not true` but not `new object() is false`.
                 var operation = semanticModel.GetOperation(isExpression, cancellationToken);
                 var isValueBoolean = operation is IIsPatternOperation isPatternOperation && isPatternOperation.Value.Type?.SpecialType == SpecialType.System_Boolean;
                 negatedPattern = generator.Negate(generatorInternal, pattern, semanticModel, negateBinary: true, allowSwappingBooleans: isValueBoolean, cancellationToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/SyntaxGeneratorExtensions_Negate.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             bool negateBinary,
             CancellationToken cancellationToken)
         {
-            return Negate(generator, generatorInternal, expressionOrPattern, semanticModel, negateBinary, swapBooleans: true, cancellationToken);
+            return Negate(generator, generatorInternal, expressionOrPattern, semanticModel, negateBinary, allowSwappingBooleans: true, cancellationToken);
         }
 
         public static SyntaxNode Negate(
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             SyntaxNode expressionOrPattern,
             SemanticModel semanticModel,
             bool negateBinary,
-            bool swapBooleans,
+            bool allowSwappingBooleans,
             CancellationToken cancellationToken)
         {
             var options = semanticModel.SyntaxTree.Options;
@@ -105,7 +105,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 return GetNegationOfBinaryPattern(expressionOrPattern, generator, generatorInternal, semanticModel, cancellationToken);
 
             if (syntaxFacts.IsConstantPattern(expressionOrPattern))
-                return GetNegationOfConstantPattern(expressionOrPattern, generator, generatorInternal, swapBooleans);
+                return GetNegationOfConstantPattern(expressionOrPattern, generator, generatorInternal, allowSwappingBooleans);
 
             if (syntaxFacts.IsUnaryPattern(expressionOrPattern))
                 return GetNegationOfUnaryPattern(expressionOrPattern, generator, generatorInternal, syntaxFacts);
@@ -244,7 +244,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 // If the value isn't a Boolean and the pattern `is true/false`, swapping to `is false/true` is incorrect since non-Booleans match neither.
                 var operation = semanticModel.GetOperation(isExpression, cancellationToken);
                 var isValueBoolean = operation is IIsPatternOperation isPatternOperation && isPatternOperation.Value.Type?.SpecialType == SpecialType.System_Boolean;
-                negatedPattern = generator.Negate(generatorInternal, pattern, semanticModel, negateBinary: true, swapBooleans: isValueBoolean, cancellationToken);
+                negatedPattern = generator.Negate(generatorInternal, pattern, semanticModel, negateBinary: true, allowSwappingBooleans: isValueBoolean, cancellationToken);
             }
             else if (syntaxFacts.IsNotPattern(pattern))
             {
@@ -439,12 +439,12 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             SyntaxNode pattern,
             SyntaxGenerator generator,
             SyntaxGeneratorInternal generatorInternal,
-            bool swapBooleans)
+            bool allowSwappingBooleans)
         {
             var syntaxFacts = generatorInternal.SyntaxFacts;
 
             // If we have `is true/false` just swap that to be `is false/true` if allowed.
-            if (swapBooleans)
+            if (allowSwappingBooleans)
             {
                 var expression = syntaxFacts.GetExpressionOfConstantPattern(pattern);
                 if (syntaxFacts.IsTrueLiteralExpression(expression))


### PR DESCRIPTION
Fixes #64292.

@CyrusNajmabadi, you seem to have written this negation code originally. Can you consult on this pull request? It's my first one to the Roslyn repository, and despite reading all the documentation on contributing, I'm still a bit unsure about the exact way forward.