### PR TITLE
Create a .NET Core build of the LSIF generator

### DIFF
--- a/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
+++ b/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
@@ -6,13 +6,14 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator</RootNamespace>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <RuntimeIdentifiers>$(RoslynPortableRuntimeIdentifiers)</RuntimeIdentifiers>
 
     <!-- We want to pack this entire project and it's dependencies as a tool in the tools/ subdirectory -->
     <IsPackable>true</IsPackable>
     <IsTool>true</IsTool>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>tools</ContentTargetFolders>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_GetFilesToPackage</TargetsForTfmSpecificContentInPackage>
 
@@ -30,14 +31,14 @@
     <IsShipping>false</IsShipping>
   </PropertyGroup>
 
-  <Target Name="_GetFilesToPackage" DependsOnTargets="ResolveReferences">
+  <Target Name="_GetFilesToPackage" DependsOnTargets="ResolveReferences;BuiltProjectOutputGroup">
     <ItemGroup>
       <!-- Include all dependencies; the DestinationSubDierctory is to handle culture-specific resource files that should be placed in
            subdirectories -->
-      <TfmSpecificPackageFile Include="@(ReferenceCopyLocalPaths)" PackagePath="tools\%(ReferenceCopyLocalPaths.DestinationSubDirectory)" />
+      <TfmSpecificPackageFile Include="@(ReferenceCopyLocalPaths)" PackagePath="tools\$(TargetFramework)\any\%(ReferenceCopyLocalPaths.DestinationSubDirectory)" />
 
-      <!-- Include our app.config with generated binding redirects -->
-      <TfmSpecificPackageFile Include="@(AppConfigWithTargetPath)" PackagePath="tools" />
+      <TfmSpecificPackageFile Include="@(BuiltProjectOutputGroupOutput)" PackagePath="tools\$(TargetFramework)\any" />
+
     </ItemGroup>
   </Target>
 

--- a/src/Features/Lsif/Generator/ResultSetTracking/SymbolHoldingResultSetTracker.cs
+++ b/src/Features/Lsif/Generator/ResultSetTracking/SymbolHoldingResultSetTracker.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable annotations
-
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -37,7 +35,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.ResultSetTr
 
         private TrackedResultSet GetTrackedResultSet(ISymbol symbol)
         {
-            TrackedResultSet trackedResultSet;
+            TrackedResultSet? trackedResultSet;
 
             // First acquire a simple read lock to see if we already have a result set; we do this with
             // just a read lock to ensure we aren't contending a lot if the symbol already exists which


### PR DESCRIPTION
The only "interesting" bit here is trying to create the NuGet package. Ideally, I'd just pack this as a dotnet tool, but the dotnet pack support for that simply blocks the ability to create a tool if you are also targeting .NET Framework, since there's no official support there whatsoever. For now I still want to pack a net472 version in case we run into compatibility issues; thus I change the current existing hacks for packing to put each TFM into it's own subfolder, matching the path that dotnet pack would pack a tool in, at least for net60.

Fixes https://github.com/dotnet/roslyn/issues/64510