### PR TITLE
Wait application idle in navigate to test

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpNavigateTo.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpNavigateTo.cs
@@ -38,7 +38,7 @@ class FirstClass
             await TestServices.SolutionExplorer.AddFileAsync(project, "test2.cs", open: true, contents: @"
 ", cancellationToken: HangMitigatingCancellationToken);
 
-            await TestServices.Shell.ExecuteCommandAsync(VSConstants.VSStd12CmdID.NavigateTo, HangMitigatingCancellationToken);
+            await TestServices.Shell.OpenCodeAndFeatureSearchWindowAsync(HangMitigatingCancellationToken);
             await TestServices.Input.SendToNavigateToAsync("FirstMethod", VirtualKeyCode.RETURN);
             await TestServices.Workarounds.WaitForNavigationAsync(HangMitigatingCancellationToken);
             Assert.Equal($"test1.cs", await TestServices.Shell.GetActiveWindowCaptionAsync(HangMitigatingCancellationToken));
@@ -49,7 +49,7 @@ class FirstClass
             await TestServices.SolutionExplorer.AddProjectAsync(vbProject, WellKnownProjectTemplates.ClassLibrary, LanguageNames.VisualBasic, HangMitigatingCancellationToken);
             await TestServices.SolutionExplorer.AddFileAsync(vbProject, "vbfile.vb", open: true, cancellationToken: HangMitigatingCancellationToken);
 
-            await TestServices.Shell.ExecuteCommandAsync(VSConstants.VSStd12CmdID.NavigateTo, HangMitigatingCancellationToken);
+            await TestServices.Shell.OpenCodeAndFeatureSearchWindowAsync(HangMitigatingCancellationToken);
             await TestServices.Input.SendToNavigateToAsync("FirstClass", VirtualKeyCode.RETURN);
             await TestServices.Workarounds.WaitForNavigationAsync(HangMitigatingCancellationToken);
             Assert.Equal($"test1.cs", await TestServices.Shell.GetActiveWindowCaptionAsync(HangMitigatingCancellationToken));

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ShellInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ShellInProcess.cs
@@ -79,6 +79,13 @@ namespace Microsoft.VisualStudio.Extensibility.Testing
             }
         }
 
+        public async Task OpenCodeAndFeatureSearchWindowAsync(CancellationToken cancellationToken)
+        {
+            await TestServices.Shell.ExecuteCommandAsync(VSConstants.VSStd12CmdID.NavigateTo, cancellationToken);
+            // Search window is opened async.
+            await WaitForApplicationIdleAsync(cancellationToken);
+        }
+
         public readonly struct PauseFileChangesRestorer : IAsyncDisposable
         {
             private readonly IVsFileChangeEx3 _fileChangeService;

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicNavigateTo.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicNavigateTo.cs
@@ -36,7 +36,7 @@ End Class", cancellationToken: HangMitigatingCancellationToken);
 
             await TestServices.SolutionExplorer.AddFileAsync(project, "test2.vb", open: true, contents: @"
 ", cancellationToken: HangMitigatingCancellationToken);
-            await TestServices.Shell.ExecuteCommandAsync(VSConstants.VSStd12CmdID.NavigateTo, HangMitigatingCancellationToken);
+            await TestServices.Shell.OpenCodeAndFeatureSearchWindowAsync(HangMitigatingCancellationToken);
             await TestServices.Input.SendToNavigateToAsync("FirstMethod", VirtualKeyCode.RETURN);
             await TestServices.Workarounds.WaitForNavigationAsync(HangMitigatingCancellationToken);
             Assert.Equal($"test1.vb", await TestServices.Shell.GetActiveWindowCaptionAsync(HangMitigatingCancellationToken));
@@ -46,7 +46,7 @@ End Class", cancellationToken: HangMitigatingCancellationToken);
             await TestServices.SolutionExplorer.AddProjectAsync(csProject, WellKnownProjectTemplates.ClassLibrary, LanguageNames.CSharp, HangMitigatingCancellationToken);
             await TestServices.SolutionExplorer.AddFileAsync(csProject, "csfile.cs", open: true, cancellationToken: HangMitigatingCancellationToken);
 
-            await TestServices.Shell.ExecuteCommandAsync(VSConstants.VSStd12CmdID.NavigateTo, HangMitigatingCancellationToken);
+            await TestServices.Shell.OpenCodeAndFeatureSearchWindowAsync(HangMitigatingCancellationToken);
             await TestServices.Input.SendToNavigateToAsync("FirstClass", VirtualKeyCode.RETURN);
             await TestServices.Workarounds.WaitForNavigationAsync(HangMitigatingCancellationToken);
             Assert.Equal($"test1.vb", await TestServices.Shell.GetActiveWindowCaptionAsync(HangMitigatingCancellationToken));


### PR DESCRIPTION
The search window is opened in async way. So our tests becomes flaky.
Try wait the applicaiton to become idle to see if it fix