### PR TITLE
Remove assert that fires for old CodeStyle NuGet packages

### DIFF
--- a/src/EditorFeatures/Core/Diagnostics/DiagnosticsClassificationTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Diagnostics/DiagnosticsClassificationTaggerProvider.cs
@@ -73,13 +73,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             if (!data.CustomTags.Contains(WellKnownDiagnosticTags.Unnecessary))
             {
-                // All unnecessary code diagnostics should have the 'Unnecessary' custom tag.
-                // Below assert ensures that we do no report unnecessary code diagnostics that
-                // want to fade out multiple locations which are encoded as
-                // additional location indices in the diagnostic's property bag
-                // without the 'Unnecessary' custom tag. 
-                Debug.Assert(!data.TryGetUnnecessaryLocationIndices(out _));
-
                 return false;
             }
 


### PR DESCRIPTION
Fixes [AB#1581291](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1581291)

Added assert works fine for latest CodeStyle NuGet packages and analyzers in the Features layer, but fires for older CodeStyle packages.