### PR TITLE
Enable diagnostics token tor solution crawler in code action test

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -979,7 +979,7 @@ class OtherType
                 new[]
                 {
                     FeatureAttribute.Workspace,
-                    //FeatureAttribute.SolutionCrawlerLegacy,
+                    FeatureAttribute.SolutionCrawlerLegacy,
                     FeatureAttribute.DiagnosticService,
                     FeatureAttribute.ErrorSquiggles
                 },
@@ -1145,7 +1145,7 @@ class OtherType2
                 new[]
                 {
                     FeatureAttribute.Workspace,
-                    //FeatureAttribute.SolutionCrawlerLegacy,
+                    FeatureAttribute.SolutionCrawlerLegacy,
                     FeatureAttribute.DiagnosticService,
                     FeatureAttribute.ErrorSquiggles
                 },
@@ -1225,7 +1225,7 @@ class C2
                 new[]
                 {
                     FeatureAttribute.Workspace,
-                    //FeatureAttribute.SolutionCrawlerLegacy,
+                    FeatureAttribute.SolutionCrawlerLegacy,
                     FeatureAttribute.DiagnosticService,
                     FeatureAttribute.ErrorSquiggles
                 },
@@ -1359,7 +1359,7 @@ class C2
                 new[]
                 {
                     FeatureAttribute.Workspace,
-                    //FeatureAttribute.SolutionCrawlerLegacy,
+                    FeatureAttribute.SolutionCrawlerLegacy,
                     FeatureAttribute.DiagnosticService,
                     FeatureAttribute.ErrorSquiggles
                 },

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpCodeActions.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpCodeActions.cs
@@ -979,7 +979,7 @@ class OtherType
                 new[]
                 {
                     FeatureAttribute.Workspace,
-                    FeatureAttribute.SolutionCrawlerLegacy,
+                    //FeatureAttribute.SolutionCrawlerLegacy,
                     FeatureAttribute.DiagnosticService,
                     FeatureAttribute.ErrorSquiggles
                 },
@@ -1145,7 +1145,7 @@ class OtherType2
                 new[]
                 {
                     FeatureAttribute.Workspace,
-                    FeatureAttribute.SolutionCrawlerLegacy,
+                    //FeatureAttribute.SolutionCrawlerLegacy,
                     FeatureAttribute.DiagnosticService,
                     FeatureAttribute.ErrorSquiggles
                 },
@@ -1225,7 +1225,7 @@ class C2
                 new[]
                 {
                     FeatureAttribute.Workspace,
-                    FeatureAttribute.SolutionCrawlerLegacy,
+                    //FeatureAttribute.SolutionCrawlerLegacy,
                     FeatureAttribute.DiagnosticService,
                     FeatureAttribute.ErrorSquiggles
                 },
@@ -1359,7 +1359,7 @@ class C2
                 new[]
                 {
                     FeatureAttribute.Workspace,
-                    FeatureAttribute.SolutionCrawlerLegacy,
+                    //FeatureAttribute.SolutionCrawlerLegacy,
                     FeatureAttribute.DiagnosticService,
                     FeatureAttribute.ErrorSquiggles
                 },

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/WorkspaceInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/WorkspaceInProcess.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.Extensibility.Testing
 
         internal static void EnableAsynchronousOperationTracking()
         {
-            AsynchronousOperationListenerProvider.Enable(true);
+            AsynchronousOperationListenerProvider.Enable(true, diagnostics: true);
         }
 
         protected override async Task InitializeCoreAsync()


### PR DESCRIPTION
Dump [here](https://dev.azure.com/dnceng-public/public/_build/results?buildId=42755&view=artifacts&pathAsName=false&type=publishedArtifacts) shows that our the code action test is waiting at this [line](https://sourceroslyn.io/#Microsoft.VisualStudio.LanguageServices.New.IntegrationTests/InProcess/WorkspaceInProcess.cs,145)
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/24360909/194427798-3a7612d1-22de-476b-b972-be4a8255f01d.png"> forever, and it times out.

The four features it waits for are
<img width="495" alt="image" src="https://user-images.githubusercontent.com/24360909/194427941-b0f0c793-0d84-4640-8e53-7f7c8deedc9e.png">

And each of the listeners:
<img width="710" alt="image" src="https://user-images.githubusercontent.com/24360909/194427990-92473bef-06be-4010-b127-fc4ca0fe17ca.png">
<img width="730" alt="image" src="https://user-images.githubusercontent.com/24360909/194428048-c76d010b-a408-4de2-a455-823a885f7cec.png">
<img width="729" alt="image" src="https://user-images.githubusercontent.com/24360909/194428081-4276d7ea-4045-4bb1-8c79-940e7efebd61.png">
<img width="749" alt="image" src="https://user-images.githubusercontent.com/24360909/194428119-35e23ef7-f734-43b5-98aa-d54ccbea279b.png">

Looks like SolutionCrawler is very busy and keeps waiting for tasks.
Enable diagnostics token to check more details
