### PR TITLE
Adjust CSharpStructuredTriviaFormatEngine inheritance

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpFormatEngine.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         protected CSharpFormatEngine(
             TreeData treeData,
             SyntaxFormattingOptions options,
-            IEnumerable<AbstractFormattingRule> formattingRules,
+            ChainedFormattingRules formattingRules,
             SyntaxToken startToken,
             SyntaxToken endToken)
             : base(treeData,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpFormatEngine.cs
@@ -27,6 +27,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         {
         }
 
+        protected CSharpFormatEngine(
+            TreeData treeData,
+            SyntaxFormattingOptions options,
+            IEnumerable<AbstractFormattingRule> formattingRules,
+            SyntaxToken startToken,
+            SyntaxToken endToken)
+            : base(treeData,
+                 options,
+                 formattingRules,
+                 startToken,
+                 endToken)
+        {
+        }
+
         internal override IHeaderFacts HeaderFacts => CSharpHeaderFacts.Instance;
 
         protected override AbstractTriviaDataFactory CreateTriviaFactory()

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpStructuredTriviaFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/CSharpStructuredTriviaFormatEngine.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.LanguageService;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting
 {
-    internal class CSharpStructuredTriviaFormatEngine : AbstractFormatEngine
+    internal class CSharpStructuredTriviaFormatEngine : CSharpFormatEngine
     {
         public static IFormattingResult Format(
             SyntaxTrivia trivia,
@@ -40,11 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         {
         }
 
-        internal override IHeaderFacts HeaderFacts => CSharpHeaderFacts.Instance;
-
-        protected override AbstractTriviaDataFactory CreateTriviaFactory()
-            => new TriviaDataFactory(this.TreeData, this.Options);
-
         protected override FormattingContext CreateFormattingContext(TokenStream tokenStream, CancellationToken cancellationToken)
             => new(this, tokenStream);
 
@@ -53,8 +48,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // ignore all node operations for structured trivia since it is not possible for this to have any impact currently.
             return NodeOperations.Empty;
         }
-
-        protected override AbstractFormattingResult CreateFormattingResult(TokenStream tokenStream)
-            => new FormattingResult(this.TreeData, tokenStream, this.SpanToFormat);
     }
 }


### PR DESCRIPTION
This could be debatable, so feel free to close if you think it's not worth it to change the base type.