### PR TITLE
Revert "Remove unused TS brace completion code"

### DIFF
--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptBraceMatcherImplementation.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/Api/IVSTypeScriptBraceMatcherImplementation.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api
+{
+    internal interface IVSTypeScriptBraceMatcherImplementation
+    {
+        Task<VSTypeScriptBraceMatchingResult?> FindBracesAsync(Document document, int position, CancellationToken cancellationToken);
+    }
+
+    internal readonly record struct VSTypeScriptBraceMatchingResult(TextSpan LeftSpan, TextSpan RightSpan);
+}

--- a/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptBraceMatcher.cs
+++ b/src/EditorFeatures/Core/ExternalAccess/VSTypeScript/VSTypeScriptBraceMatcher.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.BraceMatching;
+using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript
+{
+    [ExportBraceMatcher(InternalLanguageNames.TypeScript), Shared]
+    internal sealed class VSTypeScriptBraceMatcher : IBraceMatcher
+    {
+        private readonly IVSTypeScriptBraceMatcherImplementation _impl;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public VSTypeScriptBraceMatcher(IVSTypeScriptBraceMatcherImplementation impl)
+        {
+            _impl = impl;
+        }
+
+        public async Task<BraceMatchingResult?> FindBracesAsync(Document document, int position, BraceMatchingOptions options, CancellationToken cancellationToken)
+        {
+            var result = await _impl.FindBracesAsync(document, position, cancellationToken).ConfigureAwait(false);
+            return result.HasValue ? new BraceMatchingResult(result.Value.LeftSpan, result.Value.RightSpan) : null;
+        }
+    }
+}


### PR DESCRIPTION
Reverts dotnet/roslyn#64226

This change regressed ngen
```
10/07/2022 09:28:27.804 [3792]: 4>Warning: System.TypeLoadException: Could not load type 'Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api.VSTypeScriptBraceMatchingResult' from assembly 'Microsoft.CodeAnalysis.EditorFeatures, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. while resolving 0x10000b6 - Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api.VSTypeScriptBraceMatchingResult.
10/07/2022 09:28:27.914 [3792]: 4>Warning: System.TypeLoadException: Could not load type 'Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api.VSTypeScriptBraceMatchingResult' from assembly 'Microsoft.CodeAnalysis.EditorFeatures, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. while resolving 0x1b000141 - .
10/07/2022 09:28:27.961 [3792]: 2>    Compiling assembly C:\VisualStudio\Common7\IDE\CommonExtensions\Microsoft\TypeScript\Microsoft.VisualStudio.LanguageServices.TypeScript.dll (CLR v4.0.30319) ...
10/07/2022 09:28:27.976 [3792]: 4>Warning: System.TypeLoadException: Could not load type 'Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api.VSTypeScriptBraceMatchingResult' from assembly 'Microsoft.CodeAnalysis.EditorFeatures, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. while resolving 0xa00034a - Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api.VSTypeScriptBraceMatchingResult..ctor.
10/07/2022 09:28:28.304 [3792]: 4>Could not load type 'Microsoft.CodeAnalysis.ExternalAccess.VSTypeScript.Api.VSTypeScriptBraceMatchingResult' from assembly 'Microsoft.CodeAnalysis.EditorFeatures, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. while compiling method TSServerProxy.GetBraceMatchingAtPosition
```

Turns our TS still has [reference ](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/TypeScript-VS?path=/VS/LanguageService/TypeScriptLanguageService/ScriptServices/TSServerProxy.Protocol.cs&version=GBmain&line=1222&lineEnd=1223&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents) to the deleted type

FYI @MariaSolOs We can revert this once TS deleted the reference and inserted