### PR TITLE
Enable rich LSIF hover information.

### DIFF
--- a/src/EditorFeatures/Core/LanguageServer/Handlers/Hover/HoverHandler.cs
+++ b/src/EditorFeatures/Core/LanguageServer/Handlers/Hover/HoverHandler.cs
@@ -69,6 +69,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             int position,
             SymbolDescriptionOptions options,
             LanguageServices languageServices,
+            ClientCapabilities clientCapabilities,
             CancellationToken cancellationToken)
         {
             Debug.Assert(semanticModel.Language is LanguageNames.CSharp or LanguageNames.VisualBasic);
@@ -83,7 +84,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             }
 
             var text = await semanticModel.SyntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            return await GetHoverAsync(info, text, semanticModel.Language, document: null, classificationOptions: null, clientCapabilities: null, cancellationToken).ConfigureAwait(false);
+            return await GetHoverAsync(info, text, semanticModel.Language, document: null, classificationOptions: null, clientCapabilities, cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task<Hover> GetHoverAsync(

--- a/src/Features/Lsif/Generator/Generator.cs
+++ b/src/Features/Lsif/Generator/Generator.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
+using LspProtocol = Microsoft.VisualStudio.LanguageServer.Protocol;
 using Methods = Microsoft.VisualStudio.LanguageServer.Protocol.Methods;
 
 namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
@@ -33,6 +34,20 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
         private const bool FoldingRangeProvider = true;
         private const bool DiagnosticProvider = false;
 
+        private static readonly LspProtocol.ClientCapabilities LspClientCapabilities = new()
+        {
+            TextDocument = new LspProtocol.TextDocumentClientCapabilities()
+            {
+                Hover = new LspProtocol.HoverSetting()
+                {
+                    ContentFormat = new[]
+                    {
+                        LspProtocol.MarkupKind.PlainText,
+                        LspProtocol.MarkupKind.Markdown,
+                    }
+                }
+            }
+        };
         private readonly ILsifJsonWriter _lsifJsonWriter;
         private readonly IdFactory _idFactory = new IdFactory();
 
@@ -252,7 +267,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
                     // See https://github.com/Microsoft/language-server-protocol/blob/main/indexFormat/specification.md#resultset for an example.
                     if (symbolResultsTracker.ResultSetNeedsInformationalEdgeAdded(symbolForLinkedResultSet, Methods.TextDocumentHoverName))
                     {
-                        var hover = await HoverHandler.GetHoverAsync(semanticModel, syntaxToken.SpanStart, options.SymbolDescriptionOptions, languageServices, CancellationToken.None);
+                        var hover = await HoverHandler.GetHoverAsync(semanticModel, syntaxToken.SpanStart, options.SymbolDescriptionOptions, languageServices, LspClientCapabilities, CancellationToken.None);
                         if (hover != null)
                         {
                             var hoverResult = new HoverResult(hover, idFactory);

--- a/src/Features/Lsif/Generator/Generator.cs
+++ b/src/Features/Lsif/Generator/Generator.cs
@@ -48,6 +48,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
                 }
             }
         };
+
         private readonly ILsifJsonWriter _lsifJsonWriter;
         private readonly IdFactory _idFactory = new IdFactory();
 

--- a/src/Features/Lsif/GeneratorTest/HoverTests.vb
+++ b/src/Features/Lsif/GeneratorTest/HoverTests.vb
@@ -42,28 +42,46 @@ class C
             Dim expectedHoverContents As String
             Select Case code
                 Case "class [|C|] { string s; }"
-                    expectedHoverContents = "class C"
+                    expectedHoverContents = "```csharp
+class C
+```
+  "
                 Case "class C { void [|M|]() { } }"
-                    expectedHoverContents = "void C.M()"
+                    expectedHoverContents = "```csharp
+void C.M()
+```
+  "
                 Case "class C { string [|s|]; }"
-                    expectedHoverContents = $"({FeaturesResources.field}) string C.s"
+                    expectedHoverContents = $"```csharp
+({FeaturesResources.field}) string C.s
+```
+  "
                 Case "class C { void M(string [|s|]) { M(s); } }"
-                    expectedHoverContents = $"({FeaturesResources.parameter}) string s"
+                    expectedHoverContents = $"```csharp
+({FeaturesResources.parameter}) string s
+```
+  "
                 Case "class C { void M(string s) { string [|local|] = """"; } }"
-                    expectedHoverContents = $"({FeaturesResources.local_variable}) string local"
+                    expectedHoverContents = $"```csharp
+({FeaturesResources.local_variable}) string local
+```
+  "
                 Case "
 class C
 {
     /// <summary>Doc Comment</summary>
     void [|M|]() { }
 }"
-                    expectedHoverContents = "void C.M()
-Doc Comment"
+                    expectedHoverContents = "```csharp
+void C.M()
+```
+  
+Doc&nbsp;Comment  "
                 Case Else
                     Throw TestExceptionUtilities.UnexpectedValue(code)
             End Select
 
-            Assert.Equal(MarkupKind.PlainText, hoverMarkupContent.Kind)
+            Assert.Equal(MarkupKind.Markdown, hoverMarkupContent.Kind)
             Assert.Equal(expectedHoverContents + Environment.NewLine, hoverMarkupContent.Value)
         End Function
 

--- a/src/Features/Lsif/GeneratorTest/HoverTests.vb
+++ b/src/Features/Lsif/GeneratorTest/HoverTests.vb
@@ -117,29 +117,50 @@ class C
             Dim expectedHoverContents As String
             Select Case code
                 Case "class C { [|string|] s; }"
-                    expectedHoverContents = "class System.String"
+                    expectedHoverContents = "```csharp
+class System.String
+```
+  "
                 Case "class C { void M() { [|M|](); } }"
-                    expectedHoverContents = "void C.M()"
+                    expectedHoverContents = "```csharp
+void C.M()
+```
+  "
                 Case "class C { void M(string s) { M([|s|]); } }"
-                    expectedHoverContents = $"({FeaturesResources.parameter}) string s"
+                    expectedHoverContents = $"```csharp
+({FeaturesResources.parameter}) string s
+```
+  "
                 Case "class C { void M(string s) { string local = """"; M([|local|]); } }"
-                    expectedHoverContents = $"({FeaturesResources.local_variable}) string local"
+                    expectedHoverContents = $"```csharp
+({FeaturesResources.local_variable}) string local
+```
+  "
                 Case "using [|S|] = System.String;"
-                    expectedHoverContents = "class System.String"
+                    expectedHoverContents = "```csharp
+class System.String
+```
+  "
                 Case "class C { [|global|]::System.String s; }"
-                    expectedHoverContents = "<global namespace>"
+                    expectedHoverContents = "```csharp
+<global namespace>
+```
+  "
                 Case "
 class C
 {
     /// <see cref=""C.[|M|]()"" />
     void M() { }
 }"
-                    expectedHoverContents = "void C.M()"
+                    expectedHoverContents = "```csharp
+void C.M()
+```
+  "
                 Case Else
                     Throw TestExceptionUtilities.UnexpectedValue(code)
             End Select
 
-            Assert.Equal(MarkupKind.PlainText, hoverMarkupContent.Kind)
+            Assert.Equal(MarkupKind.Markdown, hoverMarkupContent.Kind)
             Assert.Equal(expectedHoverContents + Environment.NewLine, hoverMarkupContent.Value)
         End Function
 
@@ -179,8 +200,11 @@ class C
             Next
 
             Dim hoverMarkupContent = DirectCast(hoverVertex.Result.Contents.Value.Fourth, MarkupContent)
-            Assert.Equal(MarkupKind.PlainText, hoverMarkupContent.Kind)
-            Assert.Equal("class System.String" + Environment.NewLine, hoverMarkupContent.Value)
+            Assert.Equal(MarkupKind.Markdown, hoverMarkupContent.Kind)
+            Assert.Equal("```csharp
+class System.String
+```
+  " + Environment.NewLine, hoverMarkupContent.Value)
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
- This changeset adds a fake set of LSP client capabilities that the LSIF generator can pass into corresponding APIs. I've currently filled the capabilities with hover based information so that underlying systems can see that clients support Markdown and therefore.
- Updated tests to reflect the new behavior.

## Before
![image](https://i.imgur.com/UWX0Fhi.png)

## After

![image](https://i.imgur.com/VxIbNK7.png)