### PR TITLE
Update NavigateTo tests to support AllInOneSearch

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpSourceGenerators.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpSourceGenerators.cs
@@ -148,7 +148,7 @@ internal static class Program
         [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/60477")]
         public async Task InvokeNavigateToForGeneratedFile()
         {
-            await TestServices.Shell.ExecuteCommandAsync(VSConstants.VSStd12CmdID.NavigateTo, HangMitigatingCancellationToken);
+            await TestServices.Shell.ShowNavigateToDialogAsync(HangMitigatingCancellationToken);
 
             await TestServices.Input.SendToNavigateToAsync(HelloWorldGenerator.GeneratedEnglishClassName, VirtualKeyCode.RETURN);
             await TestServices.Workarounds.WaitForNavigationAsync(HangMitigatingCancellationToken);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InputInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/InputInProcess.cs
@@ -91,6 +91,8 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
             {
                 await TestServices.JoinableTaskFactory.SwitchToMainThreadAsync();
                 var searchBox = Assert.IsAssignableFrom<Control>(Keyboard.FocusedElement);
+                // Validate the focused control against the "old" search experience as well as the 
+                // all-in-one search experience.
                 Assert.Contains(searchBox.Name, new[] { "PART_SearchBox", "SearchBoxControl" });
             });
 
@@ -99,6 +101,9 @@ namespace Roslyn.VisualStudio.IntegrationTests.InProcess
             {
                 key.Apply(inputSimulator);
 
+                // Since the all-in-one search experience populates its results asychronously we need
+                // to give it time to update prior to applying the next InputKey otherwise we may apply
+                // a Return key meant to select an item before it is in the result set.
                 await Task.Delay(1000);
             }
 

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ShellInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ShellInProcess.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.Extensibility.Testing
                     }
 
                     // If the dialog has not been displayed, then wait some time for it to show. The
-                    // cancellation token passed into should be hang mitigating to avoid possible
+                    // cancellation token passed in should be hang mitigating to avoid possible
                     // infinite loop.
                     await Task.Delay(100);
                 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ShellInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ShellInProcess.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.Extensibility.Testing
 
                 while (true)
                 {
-                    //cancellationToken.ThrowIfCancellationRequested();
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     // Take no direct action regarding activation, but assert the correct item already has focus
                     TestServices.JoinableTaskFactory.Run(async () =>
@@ -59,6 +59,9 @@ namespace Microsoft.VisualStudio.Extensibility.Testing
                         return isAllInOneSearchActive.Value;
                     }
 
+                    // If the dialog has not been displayed, then wait some time for it to show. The
+                    // cancellation token passed into should be hang mitigating to avoid possible
+                    // infinite loop.
                     await Task.Delay(100);
                 }
             }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicNavigateTo.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/VisualBasic/BasicNavigateTo.cs
@@ -36,7 +36,7 @@ End Class", cancellationToken: HangMitigatingCancellationToken);
 
             await TestServices.SolutionExplorer.AddFileAsync(project, "test2.vb", open: true, contents: @"
 ", cancellationToken: HangMitigatingCancellationToken);
-            await TestServices.Shell.ExecuteCommandAsync(VSConstants.VSStd12CmdID.NavigateTo, HangMitigatingCancellationToken);
+            await TestServices.Shell.ShowNavigateToDialogAsync(HangMitigatingCancellationToken);
             await TestServices.Input.SendToNavigateToAsync("FirstMethod", VirtualKeyCode.RETURN);
             await TestServices.Workarounds.WaitForNavigationAsync(HangMitigatingCancellationToken);
             Assert.Equal($"test1.vb", await TestServices.Shell.GetActiveWindowCaptionAsync(HangMitigatingCancellationToken));
@@ -46,7 +46,7 @@ End Class", cancellationToken: HangMitigatingCancellationToken);
             await TestServices.SolutionExplorer.AddProjectAsync(csProject, WellKnownProjectTemplates.ClassLibrary, LanguageNames.CSharp, HangMitigatingCancellationToken);
             await TestServices.SolutionExplorer.AddFileAsync(csProject, "csfile.cs", open: true, cancellationToken: HangMitigatingCancellationToken);
 
-            await TestServices.Shell.ExecuteCommandAsync(VSConstants.VSStd12CmdID.NavigateTo, HangMitigatingCancellationToken);
+            await TestServices.Shell.ShowNavigateToDialogAsync(HangMitigatingCancellationToken);
             await TestServices.Input.SendToNavigateToAsync("FirstClass", VirtualKeyCode.RETURN);
             await TestServices.Workarounds.WaitForNavigationAsync(HangMitigatingCancellationToken);
             Assert.Equal($"test1.vb", await TestServices.Shell.GetActiveWindowCaptionAsync(HangMitigatingCancellationToken));


### PR DESCRIPTION
- Add ShowNavigateToDialogAsync method which executes the NavigateTo command and waits for the dialog to be active.
- Update the SendToNavigateToAsync method to pause between applying InputKey to give the search dialog time to update.
- Update the telemetry events being verified to support AllInOneSearch events

Resolves bullet 1 from https://github.com/dotnet/roslyn/issues/64545#issuecomment-1270632215