### PR TITLE
"Generate method" codefix supports 'in' parameters

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -740,8 +740,7 @@ class Class
 }");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
-        [WorkItem(54212, "https://github.com/dotnet/roslyn/issues/54212")]
+        [Fact, WorkItem(54212, "https://github.com/dotnet/roslyn/issues/54212")]
         public async Task TestInArgument()
         {
             await TestInRegularAndScriptAsync(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -740,6 +740,40 @@ class Class
 }");
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [WorkItem(54212, "https://github.com/dotnet/roslyn/issues/54212")]
+        public async Task TestInArgument()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+using System;
+
+class Example
+{
+    void M()
+    {
+        int i = 0;
+        [|M2(in i)|];
+    }
+}",
+@"
+using System;
+
+class Example
+{
+    void M()
+    {
+        int i = 0;
+        [|M2(in i)|];
+    }
+
+    private void M2(in int i)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
         [Fact]
         public async Task TestMemberAccessArgumentName()
         {

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
@@ -131,12 +131,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
             }
 
             protected override ImmutableArray<RefKind> DetermineParameterModifiers(CancellationToken cancellationToken)
-            {
-                return
-                    _invocationExpression.ArgumentList.Arguments.Select(
-                        a => a.RefOrOutKeyword.Kind() == SyntaxKind.RefKeyword ? RefKind.Ref :
-                             a.RefOrOutKeyword.Kind() == SyntaxKind.OutKeyword ? RefKind.Out : RefKind.None).ToImmutableArray();
-            }
+                => _invocationExpression.ArgumentList.Arguments.Select(a => a.GetRefKind()).ToImmutableArray();
 
             protected override ImmutableArray<ITypeSymbol> DetermineParameterTypes(CancellationToken cancellationToken)
                 => _invocationExpression.ArgumentList.Arguments.Select(a => DetermineParameterType(a, cancellationToken)).ToImmutableArray();


### PR DESCRIPTION
Fixes #54212.