### PR TITLE
Enable already-fixed test

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -13407,7 +13407,7 @@ class C
         }
 
         [WorkItem(61831, "https://github.com/dotnet/roslyn/issues/61831")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/61831#issuecomment-1249148459")]
+        [Fact]
         public void CS0721ERR_ParameterIsStaticClass_Lambdas()
         {
             var source =


### PR DESCRIPTION
Resolves #61831 as discussed in https://github.com/dotnet/roslyn/pull/63975#discussion_r971083738. Turns out that this has been fixed by merging `main` in #64498.