### PR TITLE
Unskip CSharpSoruceGenerators.InvokeNavigateToForGeneratedFile test

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpSourceGenerators.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpSourceGenerators.cs
@@ -145,7 +145,7 @@ internal static class Program
             Assert.Equal(isPreview, await TestServices.Shell.IsActiveTabProvisionalAsync(HangMitigatingCancellationToken));
         }
 
-        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/60477")]
+        [IdeFact]
         public async Task InvokeNavigateToForGeneratedFile()
         {
             await TestServices.Shell.ShowNavigateToDialogAsync(HangMitigatingCancellationToken);


### PR DESCRIPTION
Check if https://github.com/dotnet/roslyn/issues/60477 is resolved.