### PR TITLE
Revert "Set val escape on expression variables"

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1943,11 +1943,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         parameters[argsToParamsOpt.IsDefault ? argIndex : argsToParamsOpt[argIndex]] :
                         null;
 
-                    if (mixableArguments is not null
-                        && isMixableParameter(parameter)
-                        // assume any expression variable is a valid mixing destination,
-                        // since we will infer a legal val-escape for it (if it doesn't already have a narrower one).
-                        && isMixableArgument(argument))
+                    if (mixableArguments is not null && isMixableParameter(parameter))
                     {
                         mixableArguments.Add(new MixableDestination(parameter, argument));
                     }
@@ -1971,9 +1967,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 parameter is not null &&
                 parameter.Type.IsRefLikeType &&
                 parameter.RefKind.IsWritableReference();
-
-            static bool isMixableArgument(BoundExpression argument) =>
-                argument is not (BoundDeconstructValuePlaceholder or BoundLocal { DeclarationKind: not BoundLocalDeclarationKind.None });
 
             static EscapeArgument getReceiver(Symbol symbol, BoundExpression receiver)
             {
@@ -2202,30 +2195,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return method?.UseUpdatedEscapeRules == true;
         }
 
-        private static bool ShouldInferDeclarationExpressionValEscape(BoundExpression argument, [NotNullWhen(true)] out SourceLocalSymbol? localSymbol)
-        {
-            var symbol = argument switch
-            {
-                BoundDeconstructValuePlaceholder p => p.ExpressionSymbol,
-                BoundLocal { DeclarationKind: not BoundLocalDeclarationKind.None } l => l.ExpressionSymbol,
-                _ => null
-            };
-            if (symbol is SourceLocalSymbol { ValEscapeScope: CallingMethodScope } local)
-            {
-                localSymbol = local;
-                return true;
-            }
-            else
-            {
-                // No need to infer a val escape for a global variable.
-                // These are only used in top-level statements in scripting mode,
-                // and since they are class fields, their scope is always CallingMethod.
-                Debug.Assert(symbol is null or SourceLocalSymbol or GlobalExpressionVariable);
-                localSymbol = null;
-                return false;
-            }
-        }
-
         /// <summary>
         /// Validates whether the invocation is valid per no-mixing rules.
         /// Returns <see langword="false"/> when it is not valid and produces diagnostics (possibly more than one recursively) that helps to figure the reason.
@@ -2270,7 +2239,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var escapeArguments = ArrayBuilder<EscapeArgument>.GetInstance();
             GetInvocationArgumentsForEscape(
                 symbol,
-                receiverOpt,
+                receiver: null, // receiver handled explicitly below
                 parameters,
                 argsOpt,
                 argRefKindsOpt: default,
@@ -2283,51 +2252,43 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (var (_, argument, refKind) in escapeArguments)
                 {
-                    if (ShouldInferDeclarationExpressionValEscape(argument, out _))
-                    {
-                        // assume any expression variable is a valid mixing destination,
-                        // since we will infer a legal val-escape for it (if it doesn't already have a narrower one).
-                        continue;
-                    }
-
                     if (refKind.IsWritableReference() && argument.Type?.IsRefLikeType == true)
                     {
                         escapeTo = Math.Min(escapeTo, GetValEscape(argument, scopeOfTheContainingExpression));
                     }
                 }
 
-                var hasMixingError = false;
+                if (escapeTo == scopeOfTheContainingExpression)
+                {
+                    // cannot fail. common case.
+                    return true;
+                }
 
-                // track the widest scope that arguments could safely escape to.
-                // use this scope as the inferred STE of declaration expressions.
-                var inferredDestinationValEscape = CallingMethodScope;
                 foreach (var (parameter, argument, _) in escapeArguments)
                 {
-                    // in the old rules, we assume that refs cannot escape into ref struct variables.
-                    // e.g. in `dest = M(ref arg)`, we assume `ref arg` will not escape into `dest`, but `arg` might.
-                    inferredDestinationValEscape = Math.Max(inferredDestinationValEscape, GetValEscape(argument, scopeOfTheContainingExpression));
-                    if (!hasMixingError && !CheckValEscape(argument.Syntax, argument, scopeOfTheContainingExpression, escapeTo, false, diagnostics))
+                    var valid = CheckValEscape(argument.Syntax, argument, scopeOfTheContainingExpression, escapeTo, false, diagnostics);
+
+                    if (!valid)
                     {
                         string parameterName = GetInvocationParameterName(parameter);
                         Error(diagnostics, ErrorCode.ERR_CallArgMixing, syntax, symbol, parameterName);
-                        hasMixingError = true;
+                        return false;
                     }
                 }
-
-                foreach (var (_, argument, _) in escapeArguments)
-                {
-                    if (ShouldInferDeclarationExpressionValEscape(argument, out var localSymbol))
-                    {
-                        localSymbol.SetValEscape(inferredDestinationValEscape);
-                    }
-                }
-
-                return !hasMixingError;
             }
             finally
             {
                 escapeArguments.Free();
             }
+
+            // check val escape of receiver if ref-like
+            if (receiverOpt?.Type?.IsRefLikeType == true)
+            {
+                // Should we also report ErrorCode.ERR_CallArgMixing if CheckValEscape() fails?
+                return CheckValEscape(receiverOpt.Syntax, receiverOpt, scopeOfTheContainingExpression, escapeTo, false, diagnostics);
+            }
+
+            return true;
         }
 
         private bool CheckInvocationArgMixingWithUpdatedRules(
@@ -2391,32 +2352,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            inferDeclarationExpressionValEscape();
-
             mixableArguments.Free();
             escapeValues.Free();
             return valid;
-
-            void inferDeclarationExpressionValEscape()
-            {
-                // find the widest scope that arguments could safely escape to.
-                // use this scope as the inferred STE of declaration expressions.
-                var inferredDestinationValEscape = CallingMethodScope;
-                foreach (var (_, fromArg, _, isRefEscape) in escapeValues)
-                {
-                    inferredDestinationValEscape = Math.Max(inferredDestinationValEscape, isRefEscape
-                        ? GetRefEscape(fromArg, scopeOfTheContainingExpression)
-                        : GetValEscape(fromArg, scopeOfTheContainingExpression));
-                }
-
-                foreach (var (_, fromArg, _, _) in escapeValues)
-                {
-                    if (ShouldInferDeclarationExpressionValEscape(fromArg, out var localSymbol))
-                    {
-                        localSymbol.SetValEscape(inferredDestinationValEscape);
-                    }
-                }
-            }
         }
 
         private static bool IsReceiverRefReadOnly(Symbol methodOrPropertySymbol) => methodOrPropertySymbol switch

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -318,11 +318,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal virtual void SetValEscape(uint value)
         {
-            // either we should be setting the val escape for the first time,
-            // or not contradicting what was set before.
-            Debug.Assert(
-                _valEscapeScope == Binder.CallingMethodScope
-                || _valEscapeScope == value);
             _valEscapeScope = value;
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -16001,13 +16001,23 @@ class Program
     }
 }";
             var comp = CreateCompilationWithSpanAndMemoryExtensions(source, parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
-            comp.VerifyDiagnostics(
-                // (13,9): error CS8352: Cannot use variable 'r1' in this context because it may expose referenced variables outside of their declaration scope
-                //         r1.F(out r);
-                Diagnostic(ErrorCode.ERR_EscapeVariable, "r1").WithArguments("r1").WithLocation(13, 9),
-                // (13,9): error CS8350: This combination of arguments to 'R.F(out R)' is disallowed because it may expose variables referenced by parameter 'this' outside of their declaration scope
-                //         r1.F(out r);
-                Diagnostic(ErrorCode.ERR_CallArgMixing, "r1.F(out r)").WithArguments("R.F(out R)", "this").WithLocation(13, 9));
+            if (languageVersion == LanguageVersion.CSharp10)
+            {
+                comp.VerifyDiagnostics(
+                    // (13,9): error CS8352: Cannot use variable 'r1' in this context because it may expose referenced variables outside of their declaration scope
+                    //         r1.F(out r);
+                    Diagnostic(ErrorCode.ERR_EscapeVariable, "r1").WithArguments("r1").WithLocation(13, 9));
+            }
+            else
+            {
+                comp.VerifyDiagnostics(
+                    // (13,9): error CS8352: Cannot use variable 'r1' in this context because it may expose referenced variables outside of their declaration scope
+                    //         r1.F(out r);
+                    Diagnostic(ErrorCode.ERR_EscapeVariable, "r1").WithArguments("r1").WithLocation(13, 9),
+                    // (13,9): error CS8350: This combination of arguments to 'R.F(out R)' is disallowed because it may expose variables referenced by parameter 'this' outside of their declaration scope
+                    //         r1.F(out r);
+                    Diagnostic(ErrorCode.ERR_CallArgMixing, "r1.F(out r)").WithArguments("R.F(out R)", "this").WithLocation(13, 9));
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Reverts dotnet/roslyn#64414

CI is failing with multiple deconstruction tests in RefEscapingTests and RefFieldTests. I believe it is a conflict between PR https://github.com/dotnet/roslyn/pull/64414 and https://github.com/dotnet/roslyn/pull/64470. I'm reverting the one that got merged last.