### PR TITLE
[LSP] Pass in Razor language server kind

### DIFF
--- a/src/EditorFeatures/Core/LanguageServer/AbstractInProcLanguageClient.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AbstractInProcLanguageClient.cs
@@ -159,6 +159,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
                 this,
                 serverStream,
                 serverStream,
+                ServerKind,
                 _lspLoggerFactory,
                 cancellationToken).ConfigureAwait(false);
 
@@ -192,6 +193,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             AbstractInProcLanguageClient languageClient,
             Stream inputStream,
             Stream outputStream,
+            WellKnownLspServerKinds serverKind,
             ILspServiceLoggerFactory lspLoggerFactory,
             CancellationToken cancellationToken)
         {
@@ -210,6 +212,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
             var server = languageClient.Create(
                 jsonRpc,
                 languageClient,
+                serverKind,
                 logger);
 
             jsonRpc.StartListening();
@@ -219,6 +222,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
         public AbstractLanguageServer<RequestContext> Create(
             JsonRpc jsonRpc,
             ICapabilitiesProvider capabilitiesProvider,
+            WellKnownLspServerKinds serverKind,
             ILspServiceLogger logger)
         {
             var server = new RoslynLanguageServer(
@@ -227,7 +231,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
                 capabilitiesProvider,
                 logger,
                 SupportedLanguages,
-                ServerKind);
+                serverKind);
 
             return server;
         }

--- a/src/Features/LanguageServer/Protocol/CSharpVisualBasicLanguageServerFactory.cs
+++ b/src/Features/LanguageServer/Protocol/CSharpVisualBasicLanguageServerFactory.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CommonLanguageServerProtocol.Framework;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using StreamJsonRpc;
 
 namespace Microsoft.CodeAnalysis.LanguageServer
@@ -29,6 +30,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         public AbstractLanguageServer<RequestContext> Create(
             JsonRpc jsonRpc,
             ICapabilitiesProvider capabilitiesProvider,
+            WellKnownLspServerKinds serverKind,
             ILspServiceLogger logger)
         {
             var server = new RoslynLanguageServer(
@@ -37,7 +39,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 capabilitiesProvider,
                 logger,
                 ProtocolConstants.RoslynLspLanguages,
-                WellKnownLspServerKinds.CSharpVisualBasicLspServer);
+                serverKind);
 
             return server;
         }
@@ -45,7 +47,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         public AbstractLanguageServer<RequestContext> Create(Stream input, Stream output, ICapabilitiesProvider capabilitiesProvider, ILspServiceLogger logger)
         {
             var jsonRpc = new JsonRpc(new HeaderDelimitedMessageHandler(output, input));
-            return Create(jsonRpc, capabilitiesProvider, logger);
+            return Create(jsonRpc, capabilitiesProvider, WellKnownLspServerKinds.CSharpVisualBasicLspServer, logger);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/ILanguageServerFactory.cs
+++ b/src/Features/LanguageServer/Protocol/ILanguageServerFactory.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         public AbstractLanguageServer<RequestContext> Create(
             JsonRpc jsonRpc,
             ICapabilitiesProvider capabilitiesProvider,
+            WellKnownLspServerKinds serverKind,
             ILspServiceLogger logger);
     }
 }

--- a/src/Tools/ExternalAccess/Razor/RazorLanguageServerFactoryWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorLanguageServerFactoryWrapper.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
         public IRazorLanguageServerTarget CreateLanguageServer(JsonRpc jsonRpc, IRazorCapabilitiesProvider razorCapabilitiesProvider)
         {
             var capabilitiesProvider = new RazorCapabilitiesProvider(razorCapabilitiesProvider);
-            var languageServer = _languageServerFactory.Create(jsonRpc, capabilitiesProvider, NoOpLspLogger.Instance);
+            var languageServer = _languageServerFactory.Create(jsonRpc, capabilitiesProvider, WellKnownLspServerKinds.RazorLspServer, NoOpLspLogger.Instance);
 
             return new RazorLanguageServerTargetWrapper(languageServer);
         }


### PR DESCRIPTION
@ryanbrandenburg discovered an issue where our test C# LSP server in Razor was being initialized with the wrong language server kind. This PR ensures we pass in the correct server kind upon language server initialization.