### PR TITLE
VB ConvertTupleToStruct should not include NullableAttributes in it

### DIFF
--- a/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ConvertTupleToStruct
     public class ConvertTupleToStructTests
     {
         private static OptionsCollection PreferImplicitTypeWithInfo()
-            => new OptionsCollection(LanguageNames.CSharp)
+            => new(LanguageNames.CSharp)
             {
                 { CSharpCodeStyleOptions.VarElsewhere, true, NotificationOption2.Suggestion },
                 { CSharpCodeStyleOptions.VarWhenTypeIsApparent, true, NotificationOption2.Suggestion },

--- a/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
@@ -3804,7 +3804,6 @@ partial class Other
                     {
                         ["DependencyProject"] = { Sources = { text2 } }
                     },
-                    AdditionalProjectReferences {  }
                 },
                 FixedState =
                 {

--- a/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
+++ b/src/EditorFeatures/CSharpTest/ConvertTupleToStruct/ConvertTupleToStructTests.cs
@@ -3804,6 +3804,7 @@ partial class Other
                     {
                         ["DependencyProject"] = { Sources = { text2 } }
                     },
+                    AdditionalProjectReferences {  }
                 },
                 FixedState =
                 {

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeRefactoringVerifier`1+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeRefactoringVerifier`1+Test.cs
@@ -6,17 +6,18 @@ using System.Collections.Immutable;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Testing;
-using Microsoft.CodeAnalysis.Remote.Testing;
-using Microsoft.CodeAnalysis.Test.Utilities;
 
 #if !CODE_STYLE
 using System;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Remote.Testing;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 #endif

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeRefactoringVerifier`1+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeRefactoringVerifier`1+Test.cs
@@ -17,7 +17,6 @@ using Microsoft.CodeAnalysis.VisualBasic.Testing;
 using System;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Remote.Testing;
-using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 #endif

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeRefactoringVerifier`1+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeRefactoringVerifier`1+Test.cs
@@ -9,6 +9,9 @@ using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Testing;
+using Microsoft.CodeAnalysis.Remote.Testing;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using System.Collections.Immutable;
 
 #if !CODE_STYLE
 using System;
@@ -70,10 +73,28 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
                 set => _sharedState.EditorConfig = value;
             }
 
+            /// <summary>
+            /// The set of code action <see cref="CodeAction.Title"/>s offered the user in this exact order.
+            /// Set this to ensure that a very specific set of actions is offered.
+            /// </summary>
+            public string[]? ExactActionSetOffered { get; set; }
+
             protected override async Task RunImplAsync(CancellationToken cancellationToken)
             {
                 _sharedState.Apply();
                 await base.RunImplAsync(cancellationToken);
+            }
+
+            protected override ImmutableArray<CodeAction> FilterCodeActions(ImmutableArray<CodeAction> actions)
+            {
+                var result = base.FilterCodeActions(actions);
+
+                if (ExactActionSetOffered != null)
+                {
+                    Verify.SequenceEqual(ExactActionSetOffered, result.SelectAsArray(a => a.Title));
+                }
+
+                return result;
             }
 
 #if !CODE_STYLE
@@ -83,6 +104,23 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
             protected override CodeRefactoringContext CreateCodeRefactoringContext(Document document, TextSpan span, Action<CodeAction> registerRefactoring, CancellationToken cancellationToken)
                 => new CodeRefactoringContext(document, span, (action, textSpan) => registerRefactoring(action), _sharedState.CodeActionOptions, isBlocking: false, cancellationToken);
+
+            /// <summary>
+            /// The <see cref="TestHost"/> we want this test to run in.  Defaults to <see cref="TestHost.InProcess"/> if unspecified.
+            /// </summary>
+            public TestHost TestHost { get; set; } = TestHost.InProcess;
+
+            private static readonly TestComposition s_editorFeaturesOOPComposition = EditorTestCompositions.EditorFeatures.WithTestHostParts(TestHost.OutOfProcess);
+
+            protected override Workspace CreateWorkspaceImpl()
+            {
+                if (TestHost == TestHost.InProcess)
+                    return base.CreateWorkspaceImpl();
+
+                var hostServices = s_editorFeaturesOOPComposition.GetHostServices();
+                var workspace = new AdhocWorkspace(hostServices);
+                return workspace;
+            }
 
 #endif
         }

--- a/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeRefactoringVerifier`1+Test.cs
+++ b/src/EditorFeatures/DiagnosticsTestUtilities/CodeActions/VisualBasicCodeRefactoringVerifier`1+Test.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,7 +12,6 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Testing;
 using Microsoft.CodeAnalysis.Remote.Testing;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using System.Collections.Immutable;
 
 #if !CODE_STYLE
 using System;

--- a/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/MetadataAsSourceTests.cs
@@ -1481,8 +1481,6 @@ public interface [|C|]<T>
 ' {CodeAnalysisResources.InMemoryAssembly}
 #End Region
 
-
-<NullableContextAttribute(1)>
 Public Interface [|C|](Of T)
     Function Equals(<AllowNullAttribute> other As T) As Boolean
 End Interface",

--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -393,14 +393,14 @@ End Structure
 class Test
     function Method() as (a as integer, b as integer)
         dim t1 as [||](a as integer, b as integer) = (a:=1, b:=2)
-        (b as integer, a as integer) t2 = (b:=1, a:=2)
+        dim t2 as (b as integer, a as integer) = (b:=1, a:=2)
     end function
 end class"
             Dim expected = "
 class Test
     function Method() as NewStruct
         dim t1 as NewStruct = New NewStruct(a:=1, b:=2)
-        (b as integer, a as integer) t2 = (b:=1, a:=2)
+        dim t2 as (b as integer, a as integer) = (b:=1, a:=2)
     end function
 end class
 
@@ -1230,16 +1230,16 @@ End Structure
 imports System.Collections.Generic
 
 class Test(of X as {structure})
-    sub Method(of Y as {class, new})(x as List(of X), y as Y())
-        dim t1 = [||](a:=x, b:=y)
+    sub Method(of Y as {class, new})(x as List(of X), y1 as Y())
+        dim t1 = [||](a:=x, b:=y1)
     end sub
 end class"
             Dim expected = "
 imports System.Collections.Generic
 
 class Test(of X as {structure})
-    sub Method(of Y as {class, new})(x as List(of X), y as Y())
-        dim t1 = New NewStruct(Of X, Y)(x, y)
+    sub Method(of Y as {class, new})(x as List(of X), y1 as Y())
+        dim t1 = New NewStruct(Of X, Y)(x, y1)
     end sub
 end class
 
@@ -1300,7 +1300,7 @@ end class"
             Dim expected = "
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct1|}(a:=1, b:=2)
+        dim t1 = New NewStruct1(a:=1, b:=2)
     end sub
 end class
 
@@ -1361,7 +1361,7 @@ end class"
             Dim expected = "
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct1|}(a:=1, b:=2)
+        dim t1 = New NewStruct1(a:=1, b:=2)
     end sub
 end class
 
@@ -1536,9 +1536,9 @@ imports System
 class Test
     sub Method()
         dim t1 = (a:=1, b:=2)
-        dim a = sub ()
+        dim a = function ()
                     dim t2 = [||](a:=3, b:=4)
-                end sub()
+                function sub()
     end sub
 end class"
             Dim expected = "
@@ -1547,9 +1547,9 @@ imports System
 class Test
     sub Method()
         dim t1 = New NewStruct(a:=1, b:=2)
-        dim a = sub ()
+        dim a = function ()
                     dim t2 = New NewStruct(a:=3, b:=4)
-                end sub()
+                function sub()
     end sub
 end class
 

--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -58,7 +58,7 @@ end class
             Dim expected = "
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+        dim t1 = New NewStruct(a:=1, b:=2)
     end sub
 end class
 
@@ -115,7 +115,7 @@ end class
             Dim expected = "
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+        dim t1 = New NewStruct(a:=1, b:=2)
     end sub
 end class
 
@@ -171,7 +171,7 @@ end class
             Dim expected = "
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(1, 2)
+        dim t1 = New NewStruct(1, 2)
     end sub
 end class
 
@@ -227,7 +227,7 @@ end class
             Dim expected = "
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(1, b:=2)
+        dim t1 = New NewStruct(1, b:=2)
     end sub
 end class
 
@@ -284,7 +284,7 @@ end class
             Dim expected = "
 class Test
     sub Method()
-        dim t1 as {|Rename:NewStruct|} = New NewStruct(a:=1, b:=2)
+        dim t1 as NewStruct = New NewStruct(a:=1, b:=2)
         dim t2 as NewStruct = New NewStruct(a:=1, b:=2)
     end sub
 end class
@@ -342,7 +342,7 @@ end class
             Dim expected = "
 class Test
     function Method() as NewStruct
-        dim t1 as {|Rename:NewStruct|} = New NewStruct(a:=1, b:=2)
+        dim t1 as NewStruct = New NewStruct(a:=1, b:=2)
         dim t2 as NewStruct = New NewStruct(a:=1, b:=2)
     end function
 end class
@@ -399,7 +399,7 @@ end class"
             Dim expected = "
 class Test
     function Method() as NewStruct
-        dim t1 as {|Rename:NewStruct|} = New NewStruct(a:=1, b:=2)
+        dim t1 as NewStruct = New NewStruct(a:=1, b:=2)
         (b as integer, a as integer) t2 = (b:=1, a:=2)
     end function
 end class
@@ -457,7 +457,7 @@ end class"
 class Test
     sub Method()
         dim t1 as NewStruct = New NewStruct(a:=1, b:=2)
-        dim t2 as {|Rename:NewStruct|} = New NewStruct(a:=1, b:=2)
+        dim t2 as NewStruct = New NewStruct(a:=1, b:=2)
     end sub
 end class
 
@@ -516,7 +516,7 @@ end namespace
 namespace N
     class Test
         sub Method()
-            dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+            dim t1 = New NewStruct(a:=1, b:=2)
         end sub
     end class
 
@@ -572,7 +572,7 @@ end class"
             Dim expected = "
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(Goo(), Bar())
+        dim t1 = New NewStruct(Goo(), Bar())
     end sub
 end class
 
@@ -627,7 +627,7 @@ end class"
             Dim expected = "
 class Test
     sub Method(b as integer)
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b)
+        dim t1 = New NewStruct(a:=1, b)
     end sub
 end class
 
@@ -683,7 +683,7 @@ end class"
             Dim expected = "
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+        dim t1 = New NewStruct(a:=1, b:=2)
         dim t2 = New NewStruct(a:=3, b:=4)
     end sub
 end class
@@ -740,7 +740,7 @@ end class"
             Dim expected = "
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+        dim t1 = New NewStruct(a:=1, b:=2)
         dim t2 = New NewStruct(a:=3, b:=4)
     end sub
 end class
@@ -802,7 +802,7 @@ end class"
             Dim expected = "
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+        dim t1 = New NewStruct(a:=1, b:=2)
         dim t2 = New NewStruct(a:=3, b:=4)
     end sub
 
@@ -866,7 +866,7 @@ end class"
             Dim expected = "
 class Test
     sub Method(b as integer)
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+        dim t1 = New NewStruct(a:=1, b:=2)
         dim t2 = New NewStruct(a:=3, b)
         dim t3 = (a:=4, b:=5, c:=6)
         dim t4 = (b:=5, a:=6)
@@ -927,7 +927,7 @@ end class"
             Dim expected = "
 class Test
     sub Method(b as integer)
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+        dim t1 = New NewStruct(a:=1, b:=2)
         dim t2 = New NewStruct(a:=3, b)
         dim t3 = (a:=4, b:=5, c:=6)
         dim t4 = (b:=5, a:=6)
@@ -991,7 +991,7 @@ end class"
             Dim expected = "
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+        dim t1 = New NewStruct(a:=1, b:=2)
         dim t2 = New NewStruct(a:=3, b:=4)
     end sub
 
@@ -1066,7 +1066,7 @@ Imports System.Collections.Generic
 
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(a:=1, directcast(New NewStruct(a:=1, directcast(nothing, object)), object))
+        dim t1 = New NewStruct(a:=1, directcast(New NewStruct(a:=1, directcast(nothing, object)), object))
     end sub
 end class
 
@@ -1123,7 +1123,7 @@ Imports System.Collections.Generic
 
 class Test
     sub Method()
-        dim t1 = New NewStruct(a:=1, directcast(New {|Rename:NewStruct|}(a:=1, directcast(nothing, object)), object))
+        dim t1 = New NewStruct(a:=1, directcast(New NewStruct(a:=1, directcast(nothing, object)), object))
     end sub
 end class
 
@@ -1180,7 +1180,7 @@ end class"
 class Test
     sub Method()
         dim t1 = New NewStruct(a:=1, b:=2)
-        dim t2 = New {|Rename:NewStruct|}(a:=3, b:=4)
+        dim t2 = New NewStruct(a:=3, b:=4)
     end sub
 end class
 
@@ -1239,7 +1239,7 @@ imports System.Collections.Generic
 
 class Test(of X as {structure})
     sub Method(of Y as {class, new})(x as List(of X), y as Y())
-        dim t1 = New {|Rename:NewStruct|}(Of X, Y)(x, y)
+        dim t1 = New NewStruct(Of X, Y)(x, y)
     end sub
 end class
 
@@ -1419,7 +1419,7 @@ end class"
             Dim expected = "
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(a:=1, a:=2)
+        dim t1 = New NewStruct(a:=1, a:=2)
     end sub
 end class
 
@@ -1471,9 +1471,9 @@ imports System
 class Test
     sub Method()
         dim t1 = [||](a:=1, b:=2)
-        dim a = sub ()
+        dim a = function ()
                     dim t2 = (a:=3, b:=4)
-                end sub()
+                end function()
     end sub
 end class"
             Dim expected = "
@@ -1481,10 +1481,10 @@ imports System
 
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
-        dim a = sub ()
+        dim t1 = New NewStruct(a:=1, b:=2)
+        dim a = function ()
                     dim t2 = New NewStruct(a:=3, b:=4)
-                end sub()
+                end function()
     end sub
 end class
 
@@ -1548,7 +1548,7 @@ class Test
     sub Method()
         dim t1 = New NewStruct(a:=1, b:=2)
         dim a = sub ()
-                    dim t2 = New {|Rename:NewStruct|}(a:=3, b:=4)
+                    dim t2 = New NewStruct(a:=3, b:=4)
                 end sub()
     end sub
 end class
@@ -1609,7 +1609,7 @@ end class
             Dim expected As String = "
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(1, 2)
+        dim t1 = New NewStruct(1, 2)
         dim t2 = New NewStruct(1, 2)
         dim t3 = (a:=1, b:=2)
         dim t4 = New NewStruct(item1:=1, item2:=2)
@@ -1680,7 +1680,7 @@ class Test
         dim t1 = New NewStruct(1, 2)
         dim t2 = New NewStruct(1, 2)
         dim t3 = (a:=1, b:=2)
-        dim t4 = New {|Rename:NewStruct|}(item1:=1, item2:=2)
+        dim t4 = New NewStruct(item1:=1, item2:=2)
         dim t5 = New NewStruct(item1:=1, item2:=2)
     end sub
 end class
@@ -1755,7 +1755,7 @@ end class
             Dim expected = "
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+        dim t1 = New NewStruct(a:=1, b:=2)
     end sub
 end class
 
@@ -1832,7 +1832,7 @@ Imports System.Collections.Generic
 
 class Test(of T)
     sub Method(t as T)
-        dim t1 = New {|Rename:NewStruct|}(Of T)(t, b:=2)
+        dim t1 = New NewStruct(Of T)(t, b:=2)
     end sub
 
     dim t as T
@@ -1913,7 +1913,7 @@ imports System
 
 class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+        dim t1 = New NewStruct(a:=1, b:=2)
     end sub
 
     sub Goo()
@@ -1991,7 +1991,7 @@ imports System
 
 partial class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+        dim t1 = New NewStruct(a:=1, b:=2)
     end sub
 end class
 partial class Test
@@ -2091,7 +2091,7 @@ imports System
 
 partial class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+        dim t1 = New NewStruct(a:=1, b:=2)
     end sub
 end class
 
@@ -2214,7 +2214,7 @@ imports System
 namespace N
     partial class Test
         sub Method()
-            dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+            dim t1 = New NewStruct(a:=1, b:=2)
         end sub
     end class
 
@@ -2331,7 +2331,7 @@ imports System
 
 partial class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+        dim t1 = New NewStruct(a:=1, b:=2)
     end sub
 end class
 
@@ -2439,7 +2439,7 @@ imports System
 
 partial class Test
     sub Method()
-        dim t1 = New {|Rename:NewStruct|}(a:=1, b:=2)
+        dim t1 = New NewStruct(a:=1, b:=2)
     end sub
 end class
 

--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -2211,7 +2211,7 @@ namespace N
     End Structure
 end namespace"
 
-            Dim expected2 ="
+            Dim expected2 = "
 imports System
 
 partial class Test
@@ -2261,7 +2261,7 @@ partial class Other
         dim t1 = (a:=1, b:=2)
     end sub
 end class"
-            Dim text2 ="
+            Dim text2 = "
 imports System
 
 partial class Other

--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -15,6 +15,7 @@ Imports VerifyVB = Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.VisualBas
     Microsoft.CodeAnalysis.VisualBasic.ConvertTupleToStruct.VisualBasicConvertTupleToStructCodeRefactoringProvider)
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ConvertTupleToStruct
+    <UseExportProvider>
     <Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
     Public Class ConvertTupleToStructTests
 
@@ -47,7 +48,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ConvertTupleToStru
 
 #Region "update containing member tests"
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertSingleTupleType(host As TestHost) As Task
             Dim text = "
 class Test
@@ -100,10 +101,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         <WorkItem(45451, "https://github.com/dotnet/roslyn/issues/45451")>
         Public Async Function ConvertSingleTupleType_ChangeArgumentNameCase(host As TestHost) As Task
             Dim text = "
@@ -157,10 +158,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertSingleTupleTypeNoNames(host As TestHost) As Task
             Dim text = "
 class Test
@@ -213,10 +214,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertSingleTupleTypePartialNames(host As TestHost) As Task
             Dim text = "
 class Test
@@ -269,10 +270,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertFromType(host As TestHost) As Task
             Dim text = "
 class Test
@@ -327,10 +328,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertFromType2(host As TestHost) As Task
             Dim text = "
 class Test
@@ -385,10 +386,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertFromType3(host As TestHost) As Task
             Dim text = "
 class Test
@@ -442,10 +443,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertFromType4(host As TestHost) As Task
             Dim text = "
 class Test
@@ -499,10 +500,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertSingleTupleTypeInNamespace(host As TestHost) As Task
             Dim text = "
 namespace N
@@ -559,10 +560,10 @@ namespace N
     End Structure
 end namespace
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function TestNonLiteralNames(host As TestHost) As Task
             Dim text = "
 class Test
@@ -614,10 +615,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertSingleTupleTypeWithInferredName(host As TestHost) As Task
             Dim text = "
 class Test
@@ -669,10 +670,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertMultipleInstancesInSameMethod(host As TestHost) As Task
             Dim text = "
 class Test
@@ -726,10 +727,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertMultipleInstancesInSameMethod_DifferingCase(host As TestHost) As Task
             Dim text = "
 class Test
@@ -783,10 +784,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertMultipleInstancesAcrossMethods(host As TestHost) As Task
             Dim text = "
 class Test
@@ -850,10 +851,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function OnlyConvertMatchingTypesInSameMethod(host As TestHost) As Task
             Dim text = "
 class Test
@@ -911,10 +912,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function TestFixAllMatchesInSingleMethod(host As TestHost) As Task
             Dim text = "
 class Test
@@ -972,10 +973,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function TestFixNotAcrossMethods(host As TestHost) As Task
             Dim text = "
 class Test
@@ -1039,11 +1040,11 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Fact>
-        Public Async Function NotIfReferencesAnonymousTypeInternally() As Task
+        <Theory, CombinatorialData>
+        Public Async Function NotIfReferencesAnonymousTypeInternally(host As TestHost) As Task
             Dim text = "
 class Test
     sub Method()
@@ -1051,10 +1052,10 @@ class Test
     end sub
 end class"
 
-            Await TestMissingInRegularAndScriptAsync(text)
+            Await TestAsync(text, text, host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertMultipleNestedInstancesInSameMethod1(host As TestHost) As Task
             Dim text = "
 class Test
@@ -1108,10 +1109,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertMultipleNestedInstancesInSameMethod2(host As TestHost) As Task
             Dim text = "
 class Test
@@ -1165,10 +1166,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function RenameAnnotationOnStartingPoint(host As TestHost) As Task
             Dim text = "
 class Test
@@ -1222,10 +1223,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function CapturedMethodTypeParameters(host As TestHost) As Task
             Dim text = "
 imports System.Collections.Generic
@@ -1282,13 +1283,12 @@ Friend Structure NewStruct(Of X As Structure, Y As {Class, New})
 End Structure
 "
 
-            Await TestExactActionSetOfferedAsync(text, {
+            Await TestAsync(text, expected, testHost:=host, actions:={
                 FeaturesResources.updating_usages_in_containing_member
             })
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function NewTypeNameCollision(host As TestHost) As Task
             Dim text = "
 class Test
@@ -1346,10 +1346,10 @@ Friend Structure NewStruct1
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function NewTypeNameCollision_CaseInsensitive(host As TestHost) As Task
             Dim text = "
 class Test
@@ -1407,10 +1407,10 @@ Friend Structure NewStruct1
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function TestDuplicatedName(host As TestHost) As Task
             Dim text = "
 class Test
@@ -1462,10 +1462,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function TestInLambda1(host As TestHost) As Task
             Dim text = "
 imports System
@@ -1527,10 +1527,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function TestInLambda2(host As TestHost) As Task
             Dim text = "
 imports System
@@ -1592,10 +1592,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertWithDefaultNames1(host As TestHost) As Task
             Dim text As String = "
 class Test
@@ -1656,15 +1656,14 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestExactActionSetOfferedAsync(text, {
+
+            Await TestAsync(text, expected, testHost:=host, actions:={
                 FeaturesResources.updating_usages_in_containing_member,
                 FeaturesResources.updating_usages_in_containing_type
             })
-
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertWithDefaultNames2(host As TestHost) As Task
             Dim text As String = "
 class Test
@@ -1725,15 +1724,13 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestExactActionSetOfferedAsync(text, {
+            Await TestAsync(text, expected, testHost:=host, actions:={
                 FeaturesResources.updating_usages_in_containing_member,
                 FeaturesResources.updating_usages_in_containing_type
             })
-
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function ConvertSingleTupleTypeWithInaccessibleSystemHashCode(host As TestHost) As Task
             Dim text = "
 <Workspace>
@@ -1805,18 +1802,14 @@ Friend Structure NewStruct
 End Structure
 "
 
-            Await TestInRegularAndScriptAsync(text, expected, testHost:=host)
-        End Function
-
-        Protected Overrides Function GetScriptOptions() As ParseOptions
-            Return Nothing
+            Await TestAsync(text, expected, testHost:=host)
         End Function
 
 #End Region
 
 #Region "update containing type tests"
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function TestCapturedTypeParameter_UpdateType(host As TestHost) As Task
             Dim text = "
 imports System
@@ -1892,14 +1885,13 @@ Friend Structure NewStruct(Of T)
 End Structure
 "
 
-            Await TestExactActionSetOfferedAsync(text, {
+            Await TestAsync(text, expected, index:=1, testHost:=host, actions:={
                 FeaturesResources.updating_usages_in_containing_member,
                 FeaturesResources.updating_usages_in_containing_type
             })
-            Await TestInRegularAndScriptAsync(text, expected, index:=1, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function UpdateAllInType_SinglePart_SingleFile(host As TestHost) As Task
             Dim text = "
 imports System
@@ -1973,10 +1965,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, index:=1, testHost:=host)
+            Await TestAsync(text, expected, index:=1, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function UpdateAllInType_MultiplePart_SingleFile(host As TestHost) As Task
             Dim text = "
 imports System
@@ -2052,10 +2044,10 @@ Friend Structure NewStruct
     End Operator
 End Structure
 "
-            Await TestInRegularAndScriptAsync(text, expected, index:=1, testHost:=host)
+            Await TestAsync(text, expected, index:=1, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function UpdateAllInType_MultiplePart_MultipleFile(host As TestHost) As Task
             Dim text = "
 <Workspace>
@@ -2168,14 +2160,14 @@ end class
         </Document>
     </Project>
 </Workspace>"
-            Await TestInRegularAndScriptAsync(text, expected, index:=1, testHost:=host)
+            Await TestAsync(text, expected, index:=1, testHost:=host)
         End Function
 
 #End Region
 
 #Region "update containing project tests"
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function UpdateAllInProject_MultiplePart_MultipleFile_WithNamespace(host As TestHost) As Task
             Dim text = "
 <Workspace>
@@ -2292,14 +2284,14 @@ end class
         </Document>
     </Project>
 </Workspace>"
-            Await TestInRegularAndScriptAsync(text, expected, index:=2, testHost:=host)
+            Await TestAsync(text, expected, index:=2, testHost:=host)
         End Function
 
 #End Region
 
 #Region "update dependent projects"
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function UpdateDependentProjects_DirectDependency(host As TestHost) As Task
             Dim text = "
 <Workspace>
@@ -2405,10 +2397,10 @@ end class
         </Document>
     </Project>
 </Workspace>"
-            Await TestInRegularAndScriptAsync(text, expected, index:=3, testHost:=host)
+            Await TestAsync(text, expected, index:=3, testHost:=host)
         End Function
 
-        <Theory(Skip:="https://github.com/dotnet/roslyn/issues/46291"), CombinatorialData>
+        <Theory, CombinatorialData>
         Public Async Function UpdateDependentProjects_NoDependency(host As TestHost) As Task
             Dim text = "
 <Workspace>
@@ -2512,7 +2504,7 @@ end class
         </Document>
     </Project>
 </Workspace>"
-            Await TestInRegularAndScriptAsync(text, expected, index:=3, testHost:=host)
+            Await TestAsync(text, expected, index:=3, testHost:=host)
         End Function
 
 #End Region

--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -11,17 +11,38 @@ Imports Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Remote.Testing
 Imports Microsoft.CodeAnalysis.VisualBasic.ConvertTupleToStruct
 
+Imports VerifyVB = Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.VisualBasicCodeRefactoringVerifier(Of
+    Microsoft.CodeAnalysis.VisualBasic.ConvertTupleToStruct.VisualBasicConvertTupleToStructCodeRefactoringProvider)
+
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ConvertTupleToStruct
     <Trait(Traits.Feature, Traits.Features.CodeActionsConvertTupleToStruct)>
     Public Class ConvertTupleToStructTests
-        Inherits AbstractVisualBasicCodeActionTest
 
-        Protected Overrides Function CreateCodeRefactoringProvider(workspace As Workspace, parameters As TestParameters) As CodeRefactoringProvider
-            Return New VisualBasicConvertTupleToStructCodeRefactoringProvider()
-        End Function
+        Private Shared Async Function TestAsync(
+            text As String,
+            expected As String,
+            Optional index As Integer = 0,
+            Optional equivalenceKey As String = Nothing,
+            Optional LanguageVersion As LanguageVersion = LanguageVersion.VisualBasic9,
+            Optional testHost As TestHost = TestHost.InProcess,
+            Optional actions As String() = Nothing) As Task
 
-        Protected Overrides Function MassageActions(actions As ImmutableArray(Of CodeAction)) As ImmutableArray(Of CodeAction)
-            Return FlattenActions(actions)
+            If index <> 0 Then
+                Assert.NotNull(equivalenceKey)
+            End If
+
+            ' Options ??= new OptionsCollection(LanguageNames.CSharp);
+
+            Dim test = New VerifyVB.Test With {
+                .TestCode = text,
+                .FixedCode = expected,
+                .TestHost = testHost,
+                .LanguageVersion = LanguageVersion,
+                .CodeActionIndex = index,
+                .CodeActionEquivalenceKey = equivalenceKey,
+                .ExactActionSetOffered = actions
+            }
+            Await test.RunAsync()
         End Function
 
 #Region "update containing member tests"

--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -2128,10 +2128,7 @@ end class
 
         <Theory, CombinatorialData>
         Public Async Function UpdateAllInProject_MultiplePart_MultipleFile_WithNamespace(host As TestHost) As Task
-            Dim text = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document>
+            Dim text1 = "
 imports System
 
 namespace N
@@ -2146,9 +2143,9 @@ namespace N
             dim t1 = (a:=1, b:=2)
         end sub
     end class
-end namespace
-        </Document>
-        <Document>
+end namespace"
+
+            Dim text2 = "
 imports System
 
 partial class Test
@@ -2161,15 +2158,9 @@ partial class Other
     sub Goo()
         dim t1 = (a:=1, b:=2)
     end sub
-end class
-        </Document>
-    </Project>
-</Workspace>"
+end class"
 
-            Dim expected = "
-<Workspace>
-    <Project Language=""Visual Basic"" AssemblyName=""Assembly1"" CommonReferences=""true"">
-        <Document>
+            Dim expected1 = "
 imports System
 
 namespace N
@@ -2205,10 +2196,7 @@ namespace N
         End Function
 
         Public Overrides Function GetHashCode() As Integer
-            Dim hashCode = 2118541809
-            hashCode = hashCode * -1521134295 + a.GetHashCode()
-            hashCode = hashCode * -1521134295 + b.GetHashCode()
-            Return hashCode
+            Return (a, b).GetHashCode()
         End Function
 
         Public Sub Deconstruct(ByRef a As Integer, ByRef b As Integer)
@@ -2224,9 +2212,9 @@ namespace N
             Return New NewStruct(value.a, value.b)
         End Operator
     End Structure
-end namespace
-        </Document>
-        <Document>
+end namespace"
+
+            Dim expected2 ="
 imports System
 
 partial class Test
@@ -2239,11 +2227,21 @@ partial class Other
     sub Goo()
         dim t1 = New N.NewStruct(a:=1, b:=2)
     end sub
-end class
-        </Document>
-    </Project>
-</Workspace>"
-            Await TestAsync(text, expected, index:=2, testHost:=host)
+end class"
+
+            Dim test = New VerifyVB.Test with {
+                .CodeActionIndex = 2,
+                .CodeActionEquivalenceKey = Scope.ContainingProject.ToString(),
+                .TestHost = host
+                }
+
+            test.TestState.Sources.Add(text1)
+            test.TestState.Sources.Add(text2)
+
+            test.FixedState.Sources.Add(expected1)
+            test.FixedState.Sources.Add(expected2)
+
+            Await test.RunAsync()
         End Function
 
 #End Region

--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -32,8 +32,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ConvertTupleToStru
                 Assert.NotNull(equivalenceKey)
             End If
 
-            ' Options ??= new OptionsCollection(LanguageNames.CSharp);
-
             Dim test = New VerifyVB.Test With {
                 .TestCode = text,
                 .FixedCode = expected,

--- a/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ConvertTupleToStruct/ConvertTupleToStructTests.vb
@@ -24,7 +24,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ConvertTupleToStru
             expected As String,
             Optional index As Integer = 0,
             Optional equivalenceKey As String = Nothing,
-            Optional LanguageVersion As LanguageVersion = LanguageVersion.VisualBasic9,
             Optional testHost As TestHost = TestHost.InProcess,
             Optional actions As String() = Nothing) As Task
 
@@ -38,7 +37,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ConvertTupleToStru
                 .TestCode = text,
                 .FixedCode = expected,
                 .TestHost = testHost,
-                .LanguageVersion = LanguageVersion,
                 .CodeActionIndex = index,
                 .CodeActionEquivalenceKey = equivalenceKey,
                 .ExactActionSetOffered = actions
@@ -1188,7 +1186,7 @@ end class
 
 Friend Structure NewStruct
     Public a As Integer
-    Public b As Integer
+    Public b As Integerv
 
     Public Sub New(a As Integer, b As Integer)
         Me.a = a

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/AttributeGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/AttributeGenerator.cs
@@ -81,30 +81,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
                 : null;
         }
 
-        private static bool IsCompilerInternalAttribute(AttributeData attribute)
-        {
-            // from https://github.com/dotnet/roslyn/blob/main/docs/features/nullable-metadata.md
-            var attrClass = attribute.AttributeClass;
-            if (attrClass == null)
-                return false;
-
-            var name = attrClass.Name;
-
-            if (name is not "NullableAttribute" and
-                not "NullableContextAttribute" and
-                not "NativeIntegerAttribute" and
-                not "DynamicAttribute")
-            {
-                return false;
-            }
-
-            var ns = attrClass.ContainingNamespace;
-            return ns?.Name == nameof(System.Runtime.CompilerServices) &&
-                   ns.ContainingNamespace?.Name == nameof(System.Runtime) &&
-                   ns.ContainingNamespace.ContainingNamespace?.Name == nameof(System) &&
-                   ns.ContainingNamespace.ContainingNamespace.ContainingNamespace?.IsGlobalNamespace == true;
-        }
-
         private static AttributeArgumentListSyntax? GenerateAttributeArgumentList(AttributeData attribute)
         {
             if (attribute.ConstructorArguments.Length == 0 && attribute.NamedArguments.Length == 0)

--- a/src/Workspaces/Core/Portable/CodeGeneration/AbstractCodeGenerationService.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/AbstractCodeGenerationService.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Simplification;

--- a/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationHelpers.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationHelpers.cs
@@ -396,5 +396,25 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             // Couldn't find anything with our name.  Just place us at the end of this group.
             return desiredGroupIndex;
         }
+
+        // from https://github.com/dotnet/roslyn/blob/main/docs/features/nullable-metadata.md
+        public static bool IsCompilerInternalAttribute(AttributeData attribute)
+            => attribute.AttributeClass is
+            {
+                Name: "NullableAttribute" or "NullableContextAttribute" or "NativeIntegerAttribute" or "DynamicAttribute",
+                ContainingNamespace:
+                {
+                    Name: nameof(System.Runtime.CompilerServices),
+                    ContainingNamespace:
+                    {
+                        Name: nameof(System.Runtime),
+                        ContainingNamespace:
+                        {
+                            Name: nameof(System),
+                            ContainingNamespace.IsGlobalNamespace: true,
+                        },
+                    },
+                },
+            };
     }
 }

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/AttributeGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/AttributeGenerator.vb
@@ -12,11 +12,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
     Friend Module AttributeGenerator
 
         Public Function GenerateAttributeBlocks(attributes As ImmutableArray(Of AttributeData), options As CodeGenerationContextInfo, Optional target As SyntaxToken? = Nothing) As SyntaxList(Of AttributeListSyntax)
+            attributes = attributes.WhereAsArray(Function(a) Not IsCompilerInternalAttribute(a))
+
             If Not attributes.Any() Then
                 Return Nothing
             End If
 
-            Return SyntaxFactory.List(Of AttributeListSyntax)(attributes.OrderBy(Function(a) a.AttributeClass.Name).Select(Function(a) GenerateAttributeBlock(a, options, target)))
+            Return SyntaxFactory.List(attributes.OrderBy(Function(a) a.AttributeClass.Name).Select(Function(a) GenerateAttributeBlock(a, options, target)))
         End Function
 
         Private Function GenerateAttributeBlock(attribute As AttributeData, options As CodeGenerationContextInfo, target As SyntaxToken?) As AttributeListSyntax

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicCodeGenerationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicCodeGenerationService.vb
@@ -11,7 +11,6 @@ Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.LanguageService
-Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.LanguageService


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/64639
Fixes https://github.com/dotnet/roslyn/issues/46291

Working on test now.