### PR TITLE
Save CustomAttributesBag before post decoding well known attributes.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Symbol_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol_Attributes.cs
@@ -389,17 +389,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(!earlyDecodingOnly);
 
-            this.PostDecodeWellKnownAttributes(boundAttributes, attributesToBind, diagnostics, symbolPart, wellKnownAttributeData);
-
-            removeObsoleteDiagnosticsForForwardedTypes(boundAttributes, attributesToBind, ref diagnostics);
-            Debug.Assert(diagnostics.DiagnosticBag is not null);
-
             // Store attributes into the bag.
             bool lazyAttributesStoredOnThisThread = false;
             if (lazyCustomAttributesBag.SetAttributes(boundAttributes))
             {
                 if (attributeMatchesOpt is null)
                 {
+                    this.PostDecodeWellKnownAttributes(boundAttributes, attributesToBind, diagnostics, symbolPart, wellKnownAttributeData);
+
+                    removeObsoleteDiagnosticsForForwardedTypes(boundAttributes, attributesToBind, ref diagnostics);
+                    Debug.Assert(diagnostics.DiagnosticBag is not null);
+
                     this.RecordPresenceOfBadAttributes(boundAttributes);
 
                     if (totalAttributesCount != 0)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -6894,5 +6894,63 @@ class Program
             var model = comp.GetSemanticModel(syntaxTree);
             AssertEx.Equal("System.Action", model.GetTypeInfo(action).Type.ToTestDisplayString());
         }
+
+        [Fact]
+        [WorkItem(64392, "https://github.com/dotnet/roslyn/issues/64392")]
+        public void ReferToFieldWithinLambdaInTypeAttribute_01()
+        {
+            var source = @"
+[Display(x => $""{Name}"")]
+public class Test
+{
+    [Display(Name = ""Name"")]
+    public string Name { get; }
+}
+
+public class DisplayAttribute : System.Attribute
+{
+    public DisplayAttribute() { }
+}
+";
+
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (2,2): error CS1729: 'DisplayAttribute' does not contain a constructor that takes 1 arguments
+                // [Display(x => $"{Name}")]
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, @"Display(x => $""{Name}"")").WithArguments("DisplayAttribute", "1").WithLocation(2, 2),
+                // (5,14): error CS0246: The type or namespace name 'Name' could not be found (are you missing a using directive or an assembly reference?)
+                //     [Display(Name = "Name")]
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Name").WithArguments("Name").WithLocation(5, 14)
+                );
+        }
+
+        [Fact]
+        [WorkItem(64392, "https://github.com/dotnet/roslyn/issues/64392")]
+        public void ReferToFieldWithinLambdaInTypeAttribute_02()
+        {
+            var source = @"
+[Display(x => Name)]
+public class Test
+{
+    [Display(Name = ""Name"")]
+    public string Name { get; }
+}
+
+public class DisplayAttribute : System.Attribute
+{
+    public DisplayAttribute() { }
+}
+";
+
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (2,2): error CS1729: 'DisplayAttribute' does not contain a constructor that takes 1 arguments
+                // [Display(x => Name)]
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "Display(x => Name)").WithArguments("DisplayAttribute", "1").WithLocation(2, 2),
+                // (5,14): error CS0246: The type or namespace name 'Name' could not be found (are you missing a using directive or an assembly reference?)
+                //     [Display(Name = "Name")]
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Name").WithArguments("Name").WithLocation(5, 14)
+                );
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/LambdaTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/LambdaTests.vb
@@ -2382,5 +2382,75 @@ End Class
             Dim verifier = CompileAndVerify(compilation, expectedOutput:="22")
         End Sub
 
+        <WorkItem(64392, "https://github.com/dotnet/roslyn/issues/64392")>
+        <Fact()>
+        Public Sub ReferToFieldWithinLambdaInTypeAttribute_01()
+
+            Dim compilationDef =
+"
+<Display(Function() $""{Name}"")>
+public class Test
+    <Display(Name:=""Name"")>
+    public readonly property Name As String
+end class
+
+public class DisplayAttribute
+    Inherits System.Attribute
+
+    public Sub New()
+    end Sub
+End Class
+"
+            Dim compilation = CompilationUtils.CreateCompilation(compilationDef)
+            compilation.AssertTheseEmitDiagnostics(
+<expected><![CDATA[
+BC30057: Too many arguments to 'Public Sub New()'.
+<Display(Function() $"{Name}")>
+         ~~~~~~~~~~~~~~~~~~~~
+BC30059: Constant expression is required.
+<Display(Function() $"{Name}")>
+         ~~~~~~~~~~~~~~~~~~~~
+BC30661: Field or property 'Name' is not found.
+    <Display(Name:="Name")>
+             ~~~~
+]]></expected>
+            )
+        End Sub
+
+        <WorkItem(64392, "https://github.com/dotnet/roslyn/issues/64392")>
+        <Fact()>
+        Public Sub ReferToFieldWithinLambdaInTypeAttribute_02()
+
+            Dim compilationDef =
+"
+<Display(Function() Name)>
+public class Test
+    <Display(Name:=""Name"")>
+    public readonly property Name As String
+end class
+
+public class DisplayAttribute
+    Inherits System.Attribute
+
+    public Sub New()
+    end Sub
+End Class
+"
+            Dim compilation = CompilationUtils.CreateCompilation(compilationDef)
+            compilation.AssertTheseEmitDiagnostics(
+<expected><![CDATA[
+BC30057: Too many arguments to 'Public Sub New()'.
+<Display(Function() Name)>
+         ~~~~~~~~~~~~~~~
+BC30059: Constant expression is required.
+<Display(Function() Name)>
+         ~~~~~~~~~~~~~~~
+BC30661: Field or property 'Name' is not found.
+    <Display(Name:="Name")>
+             ~~~~
+]]></expected>
+            )
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
This avoids infinite cycle in binding attributes for two or more different symbols.
Fixes #64392.