### PR TITLE
Skip Workspace ProjectProperties integration test

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/Workspace/WorkspaceBase.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/Workspace/WorkspaceBase.cs
@@ -102,7 +102,7 @@ End Class", HangMitigatingCancellationToken);
             await TestServices.EditorVerifier.CurrentTokenTypeAsync("identifier", HangMitigatingCancellationToken);
         }
 
-        [IdeFact]
+        [IdeFact(Skip = "https://github.com/dotnet/roslyn/issues/64672")]
         public async Task ProjectProperties()
         {
             await TestServices.SolutionExplorer.CreateSolutionAsync(nameof(WorkspaceBase), HangMitigatingCancellationToken);


### PR DESCRIPTION
Numerous failures caused by the QuickInfo session returned being `null`. See https://github.com/dotnet/roslyn/issues/64672