### PR TITLE
Make packed LSIF generator behave more like a tool.

### DIFF
--- a/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
+++ b/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
@@ -16,6 +16,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>tools</ContentTargetFolders>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_GetFilesToPackage</TargetsForTfmSpecificContentInPackage>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
 
     <!-- Suppress warning that we don't have anything in lib/ref folders, because since this is a tool there won't be anything there -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>


### PR DESCRIPTION
- Prior to this, when external folks consumed the C# LSIF generator via a package reference the consumers would have the entire generators package graph influence their projects. This would then result in all dependencies incorrectly getting lifted for code that isn't necessarily directly utilized. This changeset suppresses the dependencies of the C# LSIF tool upon packing which aligns it with pre-existing .NET Tools (they don't specify dependencies).

### Before
![before package info](https://user-images.githubusercontent.com/2008729/195440875-80da39be-c287-42ab-b9cc-9e7c9dc7a0d3.png)

### After
![after package info](https://user-images.githubusercontent.com/2008729/195440581-cbfbdb0e-2b65-4fb0-8620-9a35a6f525eb.png)