### PR TITLE
Inline Hints - ArgumentOutOfRangeException

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.InlineHints;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
@@ -72,19 +73,36 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             _formatMap = taggerProvider.ClassificationFormatMapService.GetClassificationFormatMap(textView);
             _hintClassification = taggerProvider.ClassificationTypeRegistryService.GetClassificationType(InlineHintsTag.TagId);
             _formatMap.ClassificationFormatMappingChanged += this.OnClassificationFormatMappingChanged;
-            //_tagAggregator.TagsChanged += OnTagAggregatorTagsChanged;
-            _tagAggregator.BatchedTagsChanged += TagAggregator_BatchedTagsChanged;
+            _tagAggregator.TagsChanged += OnTagAggregatorTagsChanged;
+            //_tagAggregator.BatchedTagsChanged += TagAggregator_BatchedTagsChanged;
         }
 
-        private void TagAggregator_BatchedTagsChanged(object sender, BatchedTagsChangedEventArgs e)
+        /*private void TagAggregator_BatchedTagsChanged(object sender, BatchedTagsChangedEventArgs e)
         {
-            var allSpans = e.Spans.SelectMany(span => span.GetSpans(_textView.TextBuffer));
-            var tags = GetTags(new NormalizedSnapshotSpanCollection(allSpans));
+            using var _ = ArrayBuilder<SnapshotSpan>.GetInstance(out var builder);
+            foreach (var mappingSpan in e.Spans)
+            {
+                var normalizedSpan = mappingSpan.GetSpans(_textView.TextSnapshot);
+                builder.AddRange(normalizedSpan);
+            }
+
+            var changedSnapshotSpans = builder.ToImmutable();
+            if (changedSnapshotSpans.Length == 0)
+            {
+                return;
+            }
+
+            var startOfChangedSpan = changedSnapshotSpans.Min(span => span.Start);
+            var endOfChangedSpan = changedSnapshotSpans.Max(span => span.End);
+            var changedSpan = new SnapshotSpan(startOfChangedSpan, endOfChangedSpan);
+
+            //var allSpans = e.Spans.SelectMany(span => span.GetSpans(_textView.TextBuffer));
+            var tags = GetTags(new NormalizedSnapshotSpanCollection(changedSpan));
             foreach (var tag in tags)
             {
                 TagsChanged?.Invoke(this, new SnapshotSpanEventArgs(tag.Span));
             }
-        }
+        }*/
 
         private void OnClassificationFormatMappingChanged(object sender, EventArgs e)
         {
@@ -104,7 +122,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             }
         }
 
-        /*private void OnTagAggregatorTagsChanged(object sender, TagsChangedEventArgs e)
+        private void OnTagAggregatorTagsChanged(object sender, TagsChangedEventArgs e)
         {
             _cacheSnapshot = null;
             var spans = e.Span.GetSpans(_buffer);
@@ -112,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             {
                 TagsChanged?.Invoke(this, new SnapshotSpanEventArgs(span));
             }
-        }*/
+        }
 
         private TextFormattingRunProperties Format
         {
@@ -193,8 +211,8 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
 
         public void Dispose()
         {
-            //_tagAggregator.TagsChanged -= OnTagAggregatorTagsChanged;
-            _tagAggregator.BatchedTagsChanged -= TagAggregator_BatchedTagsChanged;
+            _tagAggregator.TagsChanged -= OnTagAggregatorTagsChanged;
+           // _tagAggregator.BatchedTagsChanged -= TagAggregator_BatchedTagsChanged;
             _tagAggregator.Dispose();
             _formatMap.ClassificationFormatMappingChanged -= OnClassificationFormatMappingChanged;
         }

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             if (_format != null)
             {
                 _format = null;
-                _cache.Clear();
+                _cacheSnapshot = null;
 
                 // When classifications change we need to rebuild the inline tags with updated Font and Color information.
                 var tags = GetTags(new NormalizedSnapshotSpanCollection(_textView.TextViewLines.FormattedSpan));
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
 
         private void OnTagAggregatorTagsChanged(object sender, TagsChangedEventArgs e)
         {
-            _cache.Clear();
+            _cacheSnapshot = null;
             var spans = e.Span.GetSpans(_buffer);
             foreach (var span in spans)
             {

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
@@ -78,13 +78,18 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             _taggerProvider.ThreadingContext.ThrowIfNotOnUIThread();
             InvalidateCache();
 
+            var tagsChanged = TagsChanged;
+            if (tagsChanged is null)
+            {
+                return;
+            }
+
             var mappingSpans = e.Spans;
             foreach (var item in mappingSpans)
             {
                 var spans = item.GetSpans(_buffer);
                 foreach (var span in spans)
                 {
-                    var tagsChanged = TagsChanged;
                     if (tagsChanged != null)
                     {
                         tagsChanged.Invoke(this, new SnapshotSpanEventArgs(span));
@@ -123,6 +128,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
 
         private void InvalidateCache()
         {
+            _taggerProvider.ThreadingContext.ThrowIfNotOnUIThread();
             _cacheSnapshot = null;
             _cache.Clear();
         }


### PR DESCRIPTION
Race condition caused by clearing out the cache in the TagsChanged event. The TagsChanged event can be run on a background thread, which may run while GetTags is being called. 
Switched to the BatchTagsChangedEvent since that is only raised on the same thread that created the TagAggregator.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1544392