### PR TITLE
Allow packages to be not published

### DIFF
--- a/eng/publish-assets.ps1
+++ b/eng/publish-assets.ps1
@@ -80,6 +80,12 @@ function Publish-Nuget($publishData, [string]$packageDir) {
 
       $feedName = $packagesData.$nupkgWithoutVersion
 
+      # If the configured feed is none, then skip publishing.
+      if ($feedName.equals("none")) {
+        Write-Host "    Skipping publishing for $nupkg"
+        continue
+      }
+
       # If the configured feed is arcade, then skip publishing here.  Arcade will handle publishing to their feeds.
       if ($feedName.equals("arcade")) {
         Write-Host "    Skipping publishing for $nupkg as it is published by arcade"


### PR DESCRIPTION
Some packages might be created for just transporting data through our infrastructure (e.g. publishing symbols, insertion, etc.) and they are not meant to be published to a nuget feed. Allow such packages to specify "none" in PublishData.json.

To be used for packages created by https://github.com/dotnet/roslyn/pull/64581 (EE and VS implementation packages).