### PR TITLE
Cherry-pick always bind ctors

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3547,10 +3547,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             Binder bodyBinder = this.GetBinder(recordDecl);
             Debug.Assert(bodyBinder != null);
 
-            BoundExpressionStatement initializer = null;
+            BoundExpressionStatement initializer;
             if (recordDecl.PrimaryConstructorBaseTypeIfClass is PrimaryConstructorBaseTypeSyntax baseWithArguments)
             {
                 initializer = bodyBinder.BindConstructorInitializer(baseWithArguments, diagnostics);
+            }
+            else
+            {
+                initializer = bodyBinder.BindImplicitConstructorInitializer(recordDecl, diagnostics);
             }
 
             return new BoundConstructorMethodBody(recordDecl,
@@ -3604,7 +3608,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Using BindStatement to bind block to make sure we are reusing results of partial binding in SemanticModel
             return new BoundConstructorMethodBody(constructor,
                                                   bodyBinder.GetDeclaredLocalsForScope(constructor),
-                                                  initializer == null ? null : bodyBinder.BindConstructorInitializer(initializer, diagnostics),
+                                                  initializer == null ? bodyBinder.BindImplicitConstructorInitializer(constructor, diagnostics) : bodyBinder.BindConstructorInitializer(initializer, diagnostics),
                                                   constructor.Body == null ? null : (BoundBlock)bodyBinder.BindStatement(constructor.Body, diagnostics),
                                                   constructor.ExpressionBody == null ?
                                                       null :
@@ -3635,6 +3639,251 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(initializerInvocation.HasAnyErrors || constructorInitializer.IsConstructorInitializer(), "Please keep this bound node in sync with BoundNodeExtensions.IsConstructorInitializer.");
             return constructorInitializer;
         }
+
+#nullable enable
+        internal BoundExpressionStatement? BindImplicitConstructorInitializer(SyntaxNode ctorSyntax, BindingDiagnosticBag diagnostics)
+        {
+            BoundExpression? initializerInvocation;
+            initializerInvocation = BindImplicitConstructorInitializer((MethodSymbol)this.ContainingMember(), diagnostics, Compilation);
+
+            if (initializerInvocation is null)
+            {
+                return null;
+            }
+
+            //  Base WasCompilerGenerated state off of whether constructor is implicitly declared, this will ensure proper instrumentation.
+            var constructorInitializer = new BoundExpressionStatement(ctorSyntax, initializerInvocation) { WasCompilerGenerated = ((MethodSymbol)ContainingMember()).IsImplicitlyDeclared };
+            Debug.Assert(initializerInvocation.HasAnyErrors || constructorInitializer.IsConstructorInitializer(), "Please keep this bound node in sync with BoundNodeExtensions.IsConstructorInitializer.");
+            return constructorInitializer;
+        }
+
+        /// <summary>
+        /// Bind the implicit constructor initializer of a constructor symbol.
+        /// </summary>
+        /// <param name="constructor">Constructor method.</param>
+        /// <param name="diagnostics">Accumulates errors (e.g. access "this" in constructor initializer).</param>
+        /// <param name="compilation">Used to retrieve binder.</param>
+        /// <returns>A bound expression for the constructor initializer call.</returns>
+        internal static BoundExpression? BindImplicitConstructorInitializer(
+            MethodSymbol constructor, BindingDiagnosticBag diagnostics, CSharpCompilation compilation)
+        {
+            if (constructor.MethodKind != MethodKind.Constructor || constructor.IsExtern)
+            {
+                return null;
+            }
+
+            // Note that the base type can be null if we're compiling System.Object in source.
+            NamedTypeSymbol containingType = constructor.ContainingType;
+            NamedTypeSymbol baseType = containingType.BaseTypeNoUseSiteDiagnostics;
+
+            SourceMemberMethodSymbol? sourceConstructor = constructor as SourceMemberMethodSymbol;
+            Debug.Assert(sourceConstructor?.SyntaxNode is RecordDeclarationSyntax
+                || ((ConstructorDeclarationSyntax?)sourceConstructor?.SyntaxNode)?.Initializer == null);
+
+            // The common case is that the type inherits directly from object.
+            // Also, we might be trying to generate a constructor for an entirely compiler-generated class such
+            // as a closure class; in that case it is vexing to try to find a suitable binder for the non-existing
+            // constructor syntax so that we can do unnecessary overload resolution on the non-existing initializer!
+            // Simply take the early out: bind directly to the parameterless object ctor rather than attempting
+            // overload resolution.
+            if ((object)baseType != null)
+            {
+                if (baseType.SpecialType == SpecialType.System_Object)
+                {
+                    return GenerateBaseParameterlessConstructorInitializer(constructor, diagnostics);
+                }
+                else if (baseType.IsErrorType() || baseType.IsStatic)
+                {
+                    // If the base type is bad and there is no initializer then we can just bail.
+                    // We have no expressions we need to analyze to report errors on.
+                    return null;
+                }
+            }
+
+            if (containingType.IsStructType() || containingType.IsEnumType())
+            {
+                return null;
+            }
+            else if (constructor is SynthesizedRecordCopyCtor copyCtor)
+            {
+                return GenerateBaseCopyConstructorInitializer(copyCtor, diagnostics);
+            }
+
+            // Now, in order to do overload resolution, we're going to need a binder. There are
+            // two possible situations:
+            //
+            // class D1 : B { }
+            // class D2 : B { D2(int x) { } }
+            //
+            // In the first case the binder needs to be the binder associated with
+            // the *body* of D1 because if the base class ctor is protected, we need
+            // to be inside the body of a derived class in order for it to be in the
+            // accessibility domain of the protected base class ctor.
+            //
+            // In the second case the binder could be the binder associated with
+            // the body of D2; since the implicit call to base() will have no arguments
+            // there is no need to look up "x".
+            Binder outerBinder;
+
+            if ((object?)sourceConstructor == null)
+            {
+                // The constructor is implicit. We need to get the binder for the body
+                // of the enclosing class.
+                CSharpSyntaxNode containerNode = constructor.GetNonNullSyntaxNode();
+                BinderFactory binderFactory = compilation.GetBinderFactory(containerNode.SyntaxTree);
+
+                if (containerNode is RecordDeclarationSyntax recordDecl)
+                {
+                    outerBinder = binderFactory.GetInRecordBodyBinder(recordDecl);
+                }
+                else
+                {
+                    SyntaxToken bodyToken = GetImplicitConstructorBodyToken(containerNode);
+                    outerBinder = binderFactory.GetBinder(containerNode, bodyToken.Position);
+                }
+            }
+            else
+            {
+                BinderFactory binderFactory = compilation.GetBinderFactory(sourceConstructor.SyntaxTree);
+
+                switch (sourceConstructor.SyntaxNode)
+                {
+                    case ConstructorDeclarationSyntax ctorDecl:
+                        // We have a ctor in source but no explicit constructor initializer.  We can't just use the binder for the
+                        // type containing the ctor because the ctor might be marked unsafe.  Use the binder for the parameter list
+                        // as an approximation - the extra symbols won't matter because there are no identifiers to bind.
+
+                        outerBinder = binderFactory.GetBinder(ctorDecl.ParameterList);
+                        break;
+
+                    case RecordDeclarationSyntax recordDecl:
+                        outerBinder = binderFactory.GetInRecordBodyBinder(recordDecl);
+                        break;
+
+                    default:
+                        throw ExceptionUtilities.Unreachable;
+                }
+            }
+
+            // wrap in ConstructorInitializerBinder for appropriate errors
+            // Handle scoping for possible pattern variables declared in the initializer
+            Binder initializerBinder = outerBinder.WithAdditionalFlagsAndContainingMemberOrLambda(BinderFlags.ConstructorInitializer, constructor);
+
+            return initializerBinder.BindConstructorInitializer(null, constructor, diagnostics);
+        }
+
+        private static SyntaxToken GetImplicitConstructorBodyToken(CSharpSyntaxNode containerNode)
+        {
+            return ((BaseTypeDeclarationSyntax)containerNode).OpenBraceToken;
+        }
+
+        internal static BoundCall? GenerateBaseParameterlessConstructorInitializer(MethodSymbol constructor, BindingDiagnosticBag diagnostics)
+        {
+            NamedTypeSymbol baseType = constructor.ContainingType.BaseTypeNoUseSiteDiagnostics;
+            MethodSymbol? baseConstructor = null;
+            LookupResultKind resultKind = LookupResultKind.Viable;
+            Location diagnosticsLocation = constructor.Locations.IsEmpty ? NoLocation.Singleton : constructor.Locations[0];
+
+            foreach (MethodSymbol ctor in baseType.InstanceConstructors)
+            {
+                if (ctor.ParameterCount == 0)
+                {
+                    baseConstructor = ctor;
+                    break;
+                }
+            }
+
+            // UNDONE: If this happens then something is deeply wrong. Should we give a better error?
+            if ((object?)baseConstructor == null)
+            {
+                diagnostics.Add(ErrorCode.ERR_BadCtorArgCount, diagnosticsLocation, baseType, /*desired param count*/ 0);
+                return null;
+            }
+
+            if (Binder.ReportUseSite(baseConstructor, diagnostics, diagnosticsLocation))
+            {
+                return null;
+            }
+
+            // UNDONE: If this happens then something is deeply wrong. Should we give a better error?
+            bool hasErrors = false;
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, constructor.ContainingAssembly);
+            if (!AccessCheck.IsSymbolAccessible(baseConstructor, constructor.ContainingType, ref useSiteInfo))
+            {
+                diagnostics.Add(ErrorCode.ERR_BadAccess, diagnosticsLocation, baseConstructor);
+                resultKind = LookupResultKind.Inaccessible;
+                hasErrors = true;
+            }
+
+            diagnostics.Add(diagnosticsLocation, useSiteInfo);
+
+            CSharpSyntaxNode syntax = constructor.GetNonNullSyntaxNode();
+
+            BoundExpression receiver = new BoundThisReference(syntax, constructor.ContainingType) { WasCompilerGenerated = true };
+            return new BoundCall(
+                syntax: syntax,
+                receiverOpt: receiver,
+                method: baseConstructor,
+                arguments: ImmutableArray<BoundExpression>.Empty,
+                argumentNamesOpt: ImmutableArray<string>.Empty,
+                argumentRefKindsOpt: ImmutableArray<RefKind>.Empty,
+                isDelegateCall: false,
+                expanded: false,
+                invokedAsExtensionMethod: false,
+                argsToParamsOpt: ImmutableArray<int>.Empty,
+                defaultArguments: BitVector.Empty,
+                resultKind: resultKind,
+                type: baseConstructor.ReturnType,
+                hasErrors: hasErrors)
+            { WasCompilerGenerated = true };
+        }
+
+        private static BoundCall? GenerateBaseCopyConstructorInitializer(SynthesizedRecordCopyCtor constructor, BindingDiagnosticBag diagnostics)
+        {
+            NamedTypeSymbol containingType = constructor.ContainingType;
+            NamedTypeSymbol baseType = containingType.BaseTypeNoUseSiteDiagnostics;
+            Location diagnosticsLocation = constructor.Locations.FirstOrNone();
+
+            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, containingType.ContainingAssembly);
+            MethodSymbol? baseConstructor = SynthesizedRecordCopyCtor.FindCopyConstructor(baseType, containingType, ref useSiteInfo);
+
+            if (baseConstructor is null)
+            {
+                diagnostics.Add(ErrorCode.ERR_NoCopyConstructorInBaseType, diagnosticsLocation, baseType);
+                return null;
+            }
+
+            var constructorUseSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, constructor.ContainingAssembly);
+            constructorUseSiteInfo.Add(baseConstructor.GetUseSiteInfo());
+            if (Binder.ReportConstructorUseSiteDiagnostics(diagnosticsLocation, diagnostics, suppressUnsupportedRequiredMembersError: constructor.HasSetsRequiredMembers, constructorUseSiteInfo))
+            {
+                return null;
+            }
+
+            diagnostics.Add(diagnosticsLocation, useSiteInfo);
+
+            CSharpSyntaxNode syntax = constructor.GetNonNullSyntaxNode();
+            BoundExpression receiver = new BoundThisReference(syntax, constructor.ContainingType) { WasCompilerGenerated = true };
+            BoundExpression argument = new BoundParameter(syntax, constructor.Parameters[0]);
+
+            return new BoundCall(
+                syntax: syntax,
+                receiverOpt: receiver,
+                method: baseConstructor,
+                arguments: ImmutableArray.Create(argument),
+                argumentNamesOpt: default,
+                argumentRefKindsOpt: default,
+                isDelegateCall: false,
+                expanded: false,
+                invokedAsExtensionMethod: false,
+                argsToParamsOpt: default,
+                defaultArguments: default,
+                resultKind: LookupResultKind.Viable,
+                type: baseConstructor.ReturnType,
+                hasErrors: false)
+            { WasCompilerGenerated = true };
+        }
+#nullable disable
 
         private BoundNode BindMethodBody(CSharpSyntaxNode declaration, BlockSyntax blockBody, ArrowExpressionClauseSyntax expressionBody, BindingDiagnosticBag diagnostics)
         {

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -268,6 +268,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
+            public override BoundNode VisitConstructorMethodBody(BoundConstructorMethodBody node)
+            {
+                // The implicit base call shares a syntax node with the constructor body, and we don't want to
+                // put it as the lower bound node as it will give incorrect results.
+                if (node.Syntax != node.Initializer?.Syntax)
+                {
+                    this.Visit(node.Initializer);
+                }
+                this.Visit(node.BlockBody);
+                this.Visit(node.ExpressionBody);
+                return null;
+            }
+
             public override BoundNode VisitBinaryOperator(BoundBinaryOperator node)
             {
                 throw ExceptionUtilities.Unreachable;

--- a/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/AnonymousTypeMethodBodySynthesizer.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 //  explicit base constructor call
                 Debug.Assert(ContainingType.BaseTypeNoUseSiteDiagnostics.SpecialType == SpecialType.System_Object);
-                BoundExpression call = MethodCompiler.GenerateBaseParameterlessConstructorInitializer(this, diagnostics);
+                BoundExpression call = Binder.GenerateBaseParameterlessConstructorInitializer(this, diagnostics);
                 if (call == null)
                 {
                     // This may happen if Object..ctor is not found or is inaccessible

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1841,14 +1841,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                                         expressionStatement.Expression is BoundCall { Method: var initMethod } && initMethod.IsDefaultValueTypeConstructor();
                                 }
 
-                                return body;
                             }
                             else
                             {
                                 Debug.Assert(constructor.Initializer is null);
                                 Debug.Assert(constructor.Locals.IsEmpty);
+                                Debug.Assert(BindImplicitConstructorInitializerIfAny(method, compilationState, BindingDiagnosticBag.Discarded) is null);
                             }
-                            break;
+
+                            return body;
 
                         case BoundKind.NonConstructorMethodBody:
                             var nonConstructor = (BoundNonConstructorMethodBody)methodBody;
@@ -1961,7 +1962,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (method.MethodKind == MethodKind.Constructor && !method.IsExtern)
             {
                 var compilation = method.DeclaringCompilation;
-                var initializerInvocation = BindImplicitConstructorInitializer(method, diagnostics, compilation);
+                var initializerInvocation = Binder.BindImplicitConstructorInitializer(method, diagnostics, compilation);
 
                 if (initializerInvocation != null)
                 {
@@ -1985,228 +1986,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Detect and report indirect cycles in the ctor-initializer call graph.
                 compilationState.ReportCtorInitializerCycles(method, ctorCall.Method, ctorCall.Syntax, diagnostics);
             }
-        }
-
-        /// <summary>
-        /// Bind the implicit constructor initializer of a constructor symbol.
-        /// </summary>
-        /// <param name="constructor">Constructor method.</param>
-        /// <param name="diagnostics">Accumulates errors (e.g. access "this" in constructor initializer).</param>
-        /// <param name="compilation">Used to retrieve binder.</param>
-        /// <returns>A bound expression for the constructor initializer call.</returns>
-        internal static BoundExpression BindImplicitConstructorInitializer(
-            MethodSymbol constructor, BindingDiagnosticBag diagnostics, CSharpCompilation compilation)
-        {
-            // Note that the base type can be null if we're compiling System.Object in source.
-            NamedTypeSymbol containingType = constructor.ContainingType;
-            NamedTypeSymbol baseType = containingType.BaseTypeNoUseSiteDiagnostics;
-
-            SourceMemberMethodSymbol sourceConstructor = constructor as SourceMemberMethodSymbol;
-            Debug.Assert(sourceConstructor?.SyntaxNode is RecordDeclarationSyntax
-                || ((ConstructorDeclarationSyntax)sourceConstructor?.SyntaxNode)?.Initializer == null);
-
-            // The common case is that the type inherits directly from object.
-            // Also, we might be trying to generate a constructor for an entirely compiler-generated class such
-            // as a closure class; in that case it is vexing to try to find a suitable binder for the non-existing
-            // constructor syntax so that we can do unnecessary overload resolution on the non-existing initializer!
-            // Simply take the early out: bind directly to the parameterless object ctor rather than attempting
-            // overload resolution.
-            if ((object)baseType != null)
-            {
-                if (baseType.SpecialType == SpecialType.System_Object)
-                {
-                    return GenerateBaseParameterlessConstructorInitializer(constructor, diagnostics);
-                }
-                else if (baseType.IsErrorType() || baseType.IsStatic)
-                {
-                    // If the base type is bad and there is no initializer then we can just bail.
-                    // We have no expressions we need to analyze to report errors on.
-                    return null;
-                }
-            }
-
-            if (containingType.IsStructType() || containingType.IsEnumType())
-            {
-                return null;
-            }
-            else if (constructor is SynthesizedRecordCopyCtor copyCtor)
-            {
-                return GenerateBaseCopyConstructorInitializer(copyCtor, diagnostics);
-            }
-
-            // Now, in order to do overload resolution, we're going to need a binder. There are
-            // two possible situations:
-            //
-            // class D1 : B { }
-            // class D2 : B { D2(int x) { } }
-            //
-            // In the first case the binder needs to be the binder associated with
-            // the *body* of D1 because if the base class ctor is protected, we need
-            // to be inside the body of a derived class in order for it to be in the
-            // accessibility domain of the protected base class ctor.
-            //
-            // In the second case the binder could be the binder associated with
-            // the body of D2; since the implicit call to base() will have no arguments
-            // there is no need to look up "x".
-            Binder outerBinder;
-
-            if ((object)sourceConstructor == null)
-            {
-                // The constructor is implicit. We need to get the binder for the body
-                // of the enclosing class.
-                CSharpSyntaxNode containerNode = constructor.GetNonNullSyntaxNode();
-                BinderFactory binderFactory = compilation.GetBinderFactory(containerNode.SyntaxTree);
-
-                if (containerNode is RecordDeclarationSyntax recordDecl)
-                {
-                    outerBinder = binderFactory.GetInRecordBodyBinder(recordDecl);
-                }
-                else
-                {
-                    SyntaxToken bodyToken = GetImplicitConstructorBodyToken(containerNode);
-                    outerBinder = binderFactory.GetBinder(containerNode, bodyToken.Position);
-                }
-            }
-            else
-            {
-                BinderFactory binderFactory = compilation.GetBinderFactory(sourceConstructor.SyntaxTree);
-
-                switch (sourceConstructor.SyntaxNode)
-                {
-                    case ConstructorDeclarationSyntax ctorDecl:
-                        // We have a ctor in source but no explicit constructor initializer.  We can't just use the binder for the
-                        // type containing the ctor because the ctor might be marked unsafe.  Use the binder for the parameter list
-                        // as an approximation - the extra symbols won't matter because there are no identifiers to bind.
-
-                        outerBinder = binderFactory.GetBinder(ctorDecl.ParameterList);
-                        break;
-
-                    case RecordDeclarationSyntax recordDecl:
-                        outerBinder = binderFactory.GetInRecordBodyBinder(recordDecl);
-                        break;
-
-                    default:
-                        throw ExceptionUtilities.Unreachable;
-                }
-            }
-
-            // wrap in ConstructorInitializerBinder for appropriate errors
-            // Handle scoping for possible pattern variables declared in the initializer
-            Binder initializerBinder = outerBinder.WithAdditionalFlagsAndContainingMemberOrLambda(BinderFlags.ConstructorInitializer, constructor);
-
-            return initializerBinder.BindConstructorInitializer(null, constructor, diagnostics);
-        }
-
-        private static SyntaxToken GetImplicitConstructorBodyToken(CSharpSyntaxNode containerNode)
-        {
-            return ((BaseTypeDeclarationSyntax)containerNode).OpenBraceToken;
-        }
-
-        internal static BoundCall GenerateBaseParameterlessConstructorInitializer(MethodSymbol constructor, BindingDiagnosticBag diagnostics)
-        {
-            NamedTypeSymbol baseType = constructor.ContainingType.BaseTypeNoUseSiteDiagnostics;
-            MethodSymbol baseConstructor = null;
-            LookupResultKind resultKind = LookupResultKind.Viable;
-            Location diagnosticsLocation = constructor.Locations.IsEmpty ? NoLocation.Singleton : constructor.Locations[0];
-
-            foreach (MethodSymbol ctor in baseType.InstanceConstructors)
-            {
-                if (ctor.ParameterCount == 0)
-                {
-                    baseConstructor = ctor;
-                    break;
-                }
-            }
-
-            // UNDONE: If this happens then something is deeply wrong. Should we give a better error?
-            if ((object)baseConstructor == null)
-            {
-                diagnostics.Add(ErrorCode.ERR_BadCtorArgCount, diagnosticsLocation, baseType, /*desired param count*/ 0);
-                return null;
-            }
-
-            if (Binder.ReportUseSite(baseConstructor, diagnostics, diagnosticsLocation))
-            {
-                return null;
-            }
-
-            // UNDONE: If this happens then something is deeply wrong. Should we give a better error?
-            bool hasErrors = false;
-            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, constructor.ContainingAssembly);
-            if (!AccessCheck.IsSymbolAccessible(baseConstructor, constructor.ContainingType, ref useSiteInfo))
-            {
-                diagnostics.Add(ErrorCode.ERR_BadAccess, diagnosticsLocation, baseConstructor);
-                resultKind = LookupResultKind.Inaccessible;
-                hasErrors = true;
-            }
-
-            diagnostics.Add(diagnosticsLocation, useSiteInfo);
-
-            CSharpSyntaxNode syntax = constructor.GetNonNullSyntaxNode();
-
-            BoundExpression receiver = new BoundThisReference(syntax, constructor.ContainingType) { WasCompilerGenerated = true };
-            return new BoundCall(
-                syntax: syntax,
-                receiverOpt: receiver,
-                method: baseConstructor,
-                arguments: ImmutableArray<BoundExpression>.Empty,
-                argumentNamesOpt: ImmutableArray<string>.Empty,
-                argumentRefKindsOpt: ImmutableArray<RefKind>.Empty,
-                isDelegateCall: false,
-                expanded: false,
-                invokedAsExtensionMethod: false,
-                argsToParamsOpt: ImmutableArray<int>.Empty,
-                defaultArguments: BitVector.Empty,
-                resultKind: resultKind,
-                type: baseConstructor.ReturnType,
-                hasErrors: hasErrors)
-            { WasCompilerGenerated = true };
-        }
-
-        private static BoundCall GenerateBaseCopyConstructorInitializer(SynthesizedRecordCopyCtor constructor, BindingDiagnosticBag diagnostics)
-        {
-            NamedTypeSymbol containingType = constructor.ContainingType;
-            NamedTypeSymbol baseType = containingType.BaseTypeNoUseSiteDiagnostics;
-            Location diagnosticsLocation = constructor.Locations.FirstOrNone();
-
-            var useSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, containingType.ContainingAssembly);
-            MethodSymbol baseConstructor = SynthesizedRecordCopyCtor.FindCopyConstructor(baseType, containingType, ref useSiteInfo);
-
-            if (baseConstructor is null)
-            {
-                diagnostics.Add(ErrorCode.ERR_NoCopyConstructorInBaseType, diagnosticsLocation, baseType);
-                return null;
-            }
-
-            var constructorUseSiteInfo = new CompoundUseSiteInfo<AssemblySymbol>(diagnostics, constructor.ContainingAssembly);
-            constructorUseSiteInfo.Add(baseConstructor.GetUseSiteInfo());
-            if (Binder.ReportConstructorUseSiteDiagnostics(diagnosticsLocation, diagnostics, suppressUnsupportedRequiredMembersError: constructor.HasSetsRequiredMembers, constructorUseSiteInfo))
-            {
-                return null;
-            }
-
-            diagnostics.Add(diagnosticsLocation, useSiteInfo);
-
-            CSharpSyntaxNode syntax = constructor.GetNonNullSyntaxNode();
-            BoundExpression receiver = new BoundThisReference(syntax, constructor.ContainingType) { WasCompilerGenerated = true };
-            BoundExpression argument = new BoundParameter(syntax, constructor.Parameters[0]);
-
-            return new BoundCall(
-                syntax: syntax,
-                receiverOpt: receiver,
-                method: baseConstructor,
-                arguments: ImmutableArray.Create(argument),
-                argumentNamesOpt: default,
-                argumentRefKindsOpt: default,
-                isDelegateCall: false,
-                expanded: false,
-                invokedAsExtensionMethod: false,
-                argsToParamsOpt: default,
-                defaultArguments: default,
-                resultKind: LookupResultKind.Viable,
-                type: baseConstructor.ReturnType,
-                hasErrors: false)
-            { WasCompilerGenerated = true };
         }
 
         private static Cci.DebugSourceDocument CreateDebugDocumentForFile(string normalizedPath)

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedInstanceConstructor.cs
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return;
             }
 
-            var baseConstructorCall = MethodCompiler.GenerateBaseParameterlessConstructorInitializer(this, diagnostics);
+            var baseConstructorCall = Binder.GenerateBaseParameterlessConstructorInitializer(this, diagnostics);
             if (baseConstructorCall == null)
             {
                 // Attribute..ctor was not found or was inaccessible

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IConstructorBodyOperation.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IConstructorBodyOperation.cs
@@ -6,7 +6,6 @@
 
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
@@ -260,16 +259,21 @@ class C
             compilation.VerifyOperationTree(node1, expectedOperationTree:
 @"
     IConstructorBodyOperation (OperationKind.ConstructorBody, Type: null) (Syntax: 'public C() ... row null; }')
-      Initializer: 
-        null
-      BlockBody: 
+      Initializer:
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsImplicit) (Syntax: 'public C() ... row null; }')
+          Expression:
+            IInvocationOperation ( System.Object..ctor()) (OperationKind.Invocation, Type: System.Void, IsImplicit) (Syntax: 'public C() ... row null; }')
+              Instance Receiver:
+                IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C, IsImplicit) (Syntax: 'public C() ... row null; }')
+              Arguments(0)
+      BlockBody:
         IBlockOperation (1 statements) (OperationKind.Block, Type: null) (Syntax: '{ throw null; }')
           IThrowOperation (OperationKind.Throw, Type: null) (Syntax: 'throw null;')
             IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Exception, Constant: null, IsImplicit) (Syntax: 'null')
               Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
-              Operand: 
+              Operand:
                 ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'null')
-      ExpressionBody: 
+      ExpressionBody:
         null
 ");
 
@@ -280,12 +284,18 @@ class C
         Next (Regular) Block[B1]
     Block[B1] - Block
         Predecessors: [B0]
-        Statements (0)
+        Statements (1)
+            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsImplicit) (Syntax: 'public C() ... row null; }')
+              Expression:
+                IInvocationOperation ( System.Object..ctor()) (OperationKind.Invocation, Type: System.Void, IsImplicit) (Syntax: 'public C() ... row null; }')
+                  Instance Receiver:
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C, IsImplicit) (Syntax: 'public C() ... row null; }')
+                  Arguments(0)
         Next (Throw) Block[null]
             IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Exception, Constant: null, IsImplicit) (Syntax: 'null')
               Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
                 (ImplicitReference)
-              Operand: 
+              Operand:
                 ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'null')
     Block[B2] - Exit [UnReachable]
         Predecessors (0)
@@ -315,18 +325,23 @@ class C
             compilation.VerifyOperationTree(node1, expectedOperationTree:
 @"
     IConstructorBodyOperation (OperationKind.ConstructorBody, Type: null) (Syntax: 'public C() ... throw null;')
-      Initializer: 
+      Initializer:
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsImplicit) (Syntax: 'public C() ... throw null;')
+          Expression:
+            IInvocationOperation ( System.Object..ctor()) (OperationKind.Invocation, Type: System.Void, IsImplicit) (Syntax: 'public C() ... throw null;')
+              Instance Receiver:
+                IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C, IsImplicit) (Syntax: 'public C() ... throw null;')
+              Arguments(0)
+      BlockBody:
         null
-      BlockBody: 
-        null
-      ExpressionBody: 
+      ExpressionBody:
         IBlockOperation (1 statements) (OperationKind.Block, Type: null) (Syntax: '=> throw null')
           IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsImplicit) (Syntax: 'throw null')
-            Expression: 
+            Expression:
               IThrowOperation (OperationKind.Throw, Type: null) (Syntax: 'throw null')
                 IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Exception, Constant: null, IsImplicit) (Syntax: 'null')
                   Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
-                  Operand: 
+                  Operand:
                     ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'null')
 ");
 
@@ -337,12 +352,18 @@ class C
         Next (Regular) Block[B1]
     Block[B1] - Block
         Predecessors: [B0]
-        Statements (0)
+        Statements (1)
+            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsImplicit) (Syntax: 'public C() ... throw null;')
+              Expression:
+                IInvocationOperation ( System.Object..ctor()) (OperationKind.Invocation, Type: System.Void, IsImplicit) (Syntax: 'public C() ... throw null;')
+                  Instance Receiver:
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C, IsImplicit) (Syntax: 'public C() ... throw null;')
+                  Arguments(0)
         Next (Throw) Block[null]
             IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Exception, Constant: null, IsImplicit) (Syntax: 'null')
               Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
                 (ImplicitReference)
-              Operand: 
+              Operand:
                 ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'null')
     Block[B2] - Exit [UnReachable]
         Predecessors (0)
@@ -379,23 +400,28 @@ class C
             compilation.VerifyOperationTree(node1, expectedOperationTree:
 @"
     IConstructorBodyOperation (OperationKind.ConstructorBody, Type: null, IsInvalid) (Syntax: 'public C() ... throw null;')
-      Initializer: 
-        null
-      BlockBody: 
+      Initializer:
+        IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid, IsImplicit) (Syntax: 'public C() ... throw null;')
+          Expression:
+            IInvocationOperation ( System.Object..ctor()) (OperationKind.Invocation, Type: System.Void, IsInvalid, IsImplicit) (Syntax: 'public C() ... throw null;')
+              Instance Receiver:
+                IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C, IsInvalid, IsImplicit) (Syntax: 'public C() ... throw null;')
+              Arguments(0)
+      BlockBody:
         IBlockOperation (1 statements) (OperationKind.Block, Type: null, IsInvalid) (Syntax: '{ throw null; }')
           IThrowOperation (OperationKind.Throw, Type: null, IsInvalid) (Syntax: 'throw null;')
             IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Exception, Constant: null, IsInvalid, IsImplicit) (Syntax: 'null')
               Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
-              Operand: 
+              Operand:
                 ILiteralOperation (OperationKind.Literal, Type: null, Constant: null, IsInvalid) (Syntax: 'null')
-      ExpressionBody: 
+      ExpressionBody:
         IBlockOperation (1 statements) (OperationKind.Block, Type: null, IsInvalid) (Syntax: '=> throw null')
           IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid, IsImplicit) (Syntax: 'throw null')
-            Expression: 
+            Expression:
               IThrowOperation (OperationKind.Throw, Type: null, IsInvalid) (Syntax: 'throw null')
                 IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Exception, Constant: null, IsInvalid, IsImplicit) (Syntax: 'null')
                   Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
-                  Operand: 
+                  Operand:
                     ILiteralOperation (OperationKind.Literal, Type: null, Constant: null, IsInvalid) (Syntax: 'null')
 ");
 
@@ -406,12 +432,18 @@ class C
         Next (Regular) Block[B1]
     Block[B1] - Block
         Predecessors: [B0]
-        Statements (0)
+        Statements (1)
+            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid, IsImplicit) (Syntax: 'public C() ... throw null;')
+              Expression:
+                IInvocationOperation ( System.Object..ctor()) (OperationKind.Invocation, Type: System.Void, IsInvalid, IsImplicit) (Syntax: 'public C() ... throw null;')
+                  Instance Receiver:
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C, IsInvalid, IsImplicit) (Syntax: 'public C() ... throw null;')
+                  Arguments(0)
         Next (Throw) Block[null]
             IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Exception, Constant: null, IsInvalid, IsImplicit) (Syntax: 'null')
               Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
                 (ImplicitReference)
-              Operand: 
+              Operand:
                 ILiteralOperation (OperationKind.Literal, Type: null, Constant: null, IsInvalid) (Syntax: 'null')
     .erroneous body {R1}
     {
@@ -422,7 +454,7 @@ class C
                 IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Exception, Constant: null, IsInvalid, IsImplicit) (Syntax: 'null')
                   Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
                     (ImplicitReference)
-                  Operand: 
+                  Operand:
                     ILiteralOperation (OperationKind.Literal, Type: null, Constant: null, IsInvalid) (Syntax: 'null')
     }
     Block[B3] - Exit [UnReachable]
@@ -560,21 +592,31 @@ class C
 @"
     Block[B0] - Entry
         Statements (0)
-        Next (Regular) Block[B2]
+        Next (Regular) Block[B1]
+    Block[B1] - Block
+        Predecessors: [B0]
+        Statements (1)
+            IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null, IsInvalid, IsImplicit) (Syntax: 'public C() ... throw null;')
+              Expression:
+                IInvocationOperation ( System.Object..ctor()) (OperationKind.Invocation, Type: System.Void, IsInvalid, IsImplicit) (Syntax: 'public C() ... throw null;')
+                  Instance Receiver:
+                    IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C, IsInvalid, IsImplicit) (Syntax: 'public C() ... throw null;')
+                  Arguments(0)
+        Next (Regular) Block[B3]
     .erroneous body {R1}
     {
-        Block[B1] - Block [UnReachable]
+        Block[B2] - Block [UnReachable]
             Predecessors (0)
             Statements (0)
             Next (Throw) Block[null]
                 IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Exception, Constant: null, IsInvalid, IsImplicit) (Syntax: 'null')
                   Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
                     (ImplicitReference)
-                  Operand: 
+                  Operand:
                     ILiteralOperation (OperationKind.Literal, Type: null, Constant: null, IsInvalid) (Syntax: 'null')
     }
-    Block[B2] - Exit
-        Predecessors: [B0]
+    Block[B3] - Exit
+        Predecessors: [B1]
         Statements (0)
 ");
         }
@@ -1005,6 +1047,91 @@ Block[B7] - Exit
     Predecessors: [B6]
     Statements (0)
 ");
+        }
+
+        [Fact]
+        public void ConstructorBody_16()
+        {
+            string source = @"
+class C
+{
+    extern public C();
+}
+";
+            var compilation = CreateCompilation(source);
+
+            compilation.VerifyDiagnostics(
+                // (4,19): warning CS0824: Constructor 'C.C()' is marked external
+                //     extern public C();
+                Diagnostic(ErrorCode.WRN_ExternCtorNoImplementation, "C").WithArguments("C.C()").WithLocation(4, 19)
+                );
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var node1 = tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().Single();
+            Assert.Null(model.GetOperation(node1));
+        }
+
+        [Fact]
+        public void ConstructorBody_17()
+        {
+            string source = @"
+class C
+{
+    static C() { }
+}
+";
+            var compilation = CreateCompilation(source);
+
+            compilation.VerifyDiagnostics();
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var node1 = tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().Single();
+            compilation.VerifyOperationTree(node1, """
+                IConstructorBodyOperation (OperationKind.ConstructorBody, Type: null) (Syntax: 'static C() { }')
+                  Initializer:
+                    null
+                  BlockBody:
+                    IBlockOperation (0 statements) (OperationKind.Block, Type: null) (Syntax: '{ }')
+                  ExpressionBody:
+                    null
+                """);
+        }
+
+        [Fact]
+        public void ConstructorBody_18()
+        {
+            string source = @"
+namespace System
+{
+    public class Object
+    {
+        public Object() { }
+    }
+
+    public class Void { }
+}
+";
+            var compilation = CreateEmptyCompilation(source);
+
+            compilation.VerifyDiagnostics();
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var node1 = tree.GetRoot().DescendantNodes().OfType<ConstructorDeclarationSyntax>().Single();
+            compilation.VerifyOperationTree(node1, """
+                IConstructorBodyOperation (OperationKind.ConstructorBody, Type: null) (Syntax: 'public Object() { }')
+                  Initializer:
+                    null
+                  BlockBody:
+                    IBlockOperation (0 statements) (OperationKind.Block, Type: null) (Syntax: '{ }')
+                  ExpressionBody:
+                    null
+                """);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -3972,6 +3972,12 @@ public class Derived : Base
                     Prop4 = null!;
                 }
 
+                [SetsRequiredMembers]
+                public Derived(bool unused)
+                {
+                    Prop4 = null!;
+                }
+
                 public Derived() : this(0)
                 {
                     Prop1.ToString();
@@ -3991,9 +3997,15 @@ public class Derived : Base
             // (10,12): warning CS8618: Non-nullable property 'Prop1' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
             //     public Derived(int unused) : base()
             Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop1").WithLocation(10, 12),
-            // (15,24): error CS9039: This constructor must add 'SetsRequiredMembers' because it chains to a constructor that has that attribute.
+            // (16,12): warning CS8618: Non-nullable property 'Prop3' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
+            //     public Derived(bool unused)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop3").WithLocation(16, 12),
+            // (16,12): warning CS8618: Non-nullable property 'Prop1' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
+            //     public Derived(bool unused)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop1").WithLocation(16, 12),
+            // (21,24): error CS9039: This constructor must add 'SetsRequiredMembers' because it chains to a constructor that has that attribute.
             //     public Derived() : this(0)
-            Diagnostic(ErrorCode.ERR_ChainingToSetsRequiredMembersRequiresSetsRequiredMembers, "this").WithLocation(15, 24)
+            Diagnostic(ErrorCode.ERR_ChainingToSetsRequiredMembersRequiresSetsRequiredMembers, "this").WithLocation(21, 24)
         );
 
         var baseComp = CreateCompilationWithRequiredMembers(@base);
@@ -4005,9 +4017,15 @@ public class Derived : Base
             // (10,12): warning CS8618: Non-nullable property 'Prop1' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
             //     public Derived(int unused) : base()
             Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop1").WithLocation(10, 12),
-            // (15,24): error CS9039: This constructor must add 'SetsRequiredMembers' because it chains to a constructor that has that attribute.
+            // (16,12): warning CS8618: Non-nullable property 'Prop3' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
+            //     public Derived(bool unused)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop3").WithLocation(16, 12),
+            // (16,12): warning CS8618: Non-nullable property 'Prop1' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
+            //     public Derived(bool unused)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop1").WithLocation(16, 12),
+            // (21,24): error CS9039: This constructor must add 'SetsRequiredMembers' because it chains to a constructor that has that attribute.
             //     public Derived() : this(0)
-            Diagnostic(ErrorCode.ERR_ChainingToSetsRequiredMembersRequiresSetsRequiredMembers, "this").WithLocation(15, 24)
+            Diagnostic(ErrorCode.ERR_ChainingToSetsRequiredMembersRequiresSetsRequiredMembers, "this").WithLocation(21, 24)
         );
     }
 
@@ -4037,6 +4055,12 @@ public class Derived : Base
                     Field4 = null!;
                 }
 
+                [SetsRequiredMembers]
+                public Derived(bool unused)
+                {
+                    Field4 = null!;
+                }
+
                 public Derived() : this(0)
                 {
                     Field1.ToString();
@@ -4049,15 +4073,22 @@ public class Derived : Base
 
         var comp = CreateCompilationWithRequiredMembers(code);
         comp.VerifyDiagnostics(
-            // (17,12): warning CS8618: Non-nullable field 'Field3' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.
-            //     public Derived(int unused) : base()
-            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("field", "Field3").WithLocation(17, 12),
-            // (17,12): warning CS8618: Non-nullable field 'Field1' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.
-            //     public Derived(int unused) : base()
-            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("field", "Field1").WithLocation(17, 12),
-            // (22,24): error CS9039: This constructor must add 'SetsRequiredMembers' because it chains to a constructor that has that attribute.
-            //     public Derived() : this(0)
-            Diagnostic(ErrorCode.ERR_ChainingToSetsRequiredMembersRequiresSetsRequiredMembers, "this").WithLocation(22, 24)
+                // (17,12): warning CS8618: Non-nullable field 'Field3' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.
+                //     public Derived(int unused) : base()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("field", "Field3").WithLocation(17, 12),
+                // (17,12): warning CS8618: Non-nullable field 'Field1' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.
+                //     public Derived(int unused) : base()
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("field", "Field1").WithLocation(17, 12),
+                // (23,12): warning CS8618: Non-nullable field 'Field3' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.
+                //     public Derived(bool unused)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("field", "Field3").WithLocation(23, 12),
+                // (23,12): warning CS8618: Non-nullable field 'Field1' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.
+                //     public Derived(bool unused)
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("field", "Field1").WithLocation(23, 12),
+                // (28,24): error CS9039: This constructor must add 'SetsRequiredMembers' because it chains to a constructor that has that attribute.
+                //     public Derived() : this(0)
+                Diagnostic(ErrorCode.ERR_ChainingToSetsRequiredMembersRequiresSetsRequiredMembers, "this").WithLocation(28, 24)
+
         );
     }
 
@@ -4090,6 +4121,11 @@ public class Derived : Base
                 {
                 }
 
+                [SetsRequiredMembers]
+                public Derived(bool unused)
+                {
+                }
+
                 public Derived() : this(0)
                 {
                     Prop1.ToString();
@@ -4101,29 +4137,41 @@ public class Derived : Base
         var comp = CreateCompilationWithRequiredMembers(new[] { derived, @base });
 
         comp.VerifyDiagnostics(
-            // (10,12): warning CS8618: Non-nullable property 'Prop1' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
-            //     public Derived(int unused) : base()
-            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop1").WithLocation(10, 12),
             // (10,12): warning CS8618: Non-nullable property 'Prop2' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
             //     public Derived(int unused) : base()
             Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop2").WithLocation(10, 12),
-            // (14,24): error CS9039: This constructor must add 'SetsRequiredMembers' because it chains to a constructor that has that attribute.
+            // (10,12): warning CS8618: Non-nullable property 'Prop1' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
+            //     public Derived(int unused) : base()
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop1").WithLocation(10, 12),
+            // (15,12): warning CS8618: Non-nullable property 'Prop2' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
+            //     public Derived(bool unused)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop2").WithLocation(15, 12),
+            // (15,12): warning CS8618: Non-nullable property 'Prop1' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
+            //     public Derived(bool unused)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop1").WithLocation(15, 12),
+            // (19,24): error CS9039: This constructor must add 'SetsRequiredMembers' because it chains to a constructor that has that attribute.
             //     public Derived() : this(0)
-            Diagnostic(ErrorCode.ERR_ChainingToSetsRequiredMembersRequiresSetsRequiredMembers, "this").WithLocation(14, 24)
+            Diagnostic(ErrorCode.ERR_ChainingToSetsRequiredMembersRequiresSetsRequiredMembers, "this").WithLocation(19, 24)
         );
 
         var baseComp = CreateCompilationWithRequiredMembers(@base);
         comp = CreateCompilation(derived, new[] { baseComp.EmitToImageReference() });
         comp.VerifyDiagnostics(
-            // (10,12): warning CS8618: Non-nullable property 'Prop1' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
-            //     public Derived(int unused) : base()
-            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop1").WithLocation(10, 12),
             // (10,12): warning CS8618: Non-nullable property 'Prop2' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
             //     public Derived(int unused) : base()
             Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop2").WithLocation(10, 12),
-            // (14,24): error CS9039: This constructor must add 'SetsRequiredMembers' because it chains to a constructor that has that attribute.
+            // (10,12): warning CS8618: Non-nullable property 'Prop1' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
+            //     public Derived(int unused) : base()
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop1").WithLocation(10, 12),
+            // (15,12): warning CS8618: Non-nullable property 'Prop2' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
+            //     public Derived(bool unused)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop2").WithLocation(15, 12),
+            // (15,12): warning CS8618: Non-nullable property 'Prop1' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
+            //     public Derived(bool unused)
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Prop1").WithLocation(15, 12),
+            // (19,24): error CS9039: This constructor must add 'SetsRequiredMembers' because it chains to a constructor that has that attribute.
             //     public Derived() : this(0)
-            Diagnostic(ErrorCode.ERR_ChainingToSetsRequiredMembersRequiresSetsRequiredMembers, "this").WithLocation(14, 24)
+            Diagnostic(ErrorCode.ERR_ChainingToSetsRequiredMembersRequiresSetsRequiredMembers, "this").WithLocation(19, 24)
         );
     }
 
@@ -4431,6 +4479,139 @@ public class Derived : Base
         );
     }
 
+    [Fact, CompilerTrait(CompilerFeature.NullableReferenceTypes)]
+    public void RequiredMemberSuppressesNullabilityWarnings_ChainedConstructor_11()
+    {
+        var code = """
+            #nullable enable
+            public class Base
+            {
+                public required string Prop1 { get; set; }
+                public string Prop2 { get; set; } = null!;
+            }
+            
+            public class Derived : Base
+            {
+                public required string Prop3 { get; set; } = Prop1.ToString();
+                public string Prop4 { get; set; } = Prop2.ToString();
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics(
+            // (10,50): error CS0236: A field initializer cannot reference the non-static field, method, or property 'Base.Prop1'
+            //     public required string Prop3 { get; set; } = Prop1.ToString();
+            Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "Prop1").WithArguments("Base.Prop1").WithLocation(10, 50),
+            // (11,41): error CS0236: A field initializer cannot reference the non-static field, method, or property 'Base.Prop2'
+            //     public string Prop4 { get; set; } = Prop2.ToString();
+            Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "Prop2").WithArguments("Base.Prop2").WithLocation(11, 41)
+        );
+    }
+
+    [Fact, CompilerTrait(CompilerFeature.NullableReferenceTypes)]
+    public void RequiredMemberSuppressesNullabilityWarnings_ChainedConstructor_12()
+    {
+        var code = """
+            using System.Diagnostics.CodeAnalysis;
+            #nullable enable
+            public record Base
+            {
+                public required string Prop1 { get; set; }
+                public string Prop2 { get; set; } = null!;
+
+                [SetsRequiredMembers]
+                protected Base() {} // 1
+            }
+            
+            public record Derived() : Base;
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics(
+            // (9,15): warning CS8618: Non-nullable property 'Prop1' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.
+            //     protected Base() {} // 1
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Base").WithArguments("property", "Prop1").WithLocation(9, 15),
+            // (12,15): error CS9039: This constructor must add 'SetsRequiredMembers' because it chains to a constructor that has that attribute.
+            // public record Derived() : Base;
+            Diagnostic(ErrorCode.ERR_ChainingToSetsRequiredMembersRequiresSetsRequiredMembers, "Derived").WithLocation(12, 15)
+        );
+    }
+
+    [Fact]
+    public void SetsRequiredMembersRequiredForChaining_ImplicitConstructor()
+    {
+        var code = """
+            using System.Diagnostics.CodeAnalysis;
+
+            class Base
+            {
+                [SetsRequiredMembers]
+                public Base() { }
+            }
+
+            class Derived : Base { }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics(
+            // (9,7): error CS9039: This constructor must add 'SetsRequiredMembers' because it chains to a constructor that has that attribute.
+            // class Derived : Base { }
+            Diagnostic(ErrorCode.ERR_ChainingToSetsRequiredMembersRequiresSetsRequiredMembers, "Derived").WithLocation(9, 7)
+        );
+    }
+
+    [Fact]
+    public void SetsRequiredMembersRequiredForChaining_ImplicitBaseCall()
+    {
+        var code = """
+            using System.Diagnostics.CodeAnalysis;
+
+            class Base
+            {
+                [SetsRequiredMembers]
+                public Base() { }
+            }
+
+            class Derived : Base
+            {
+                public Derived() { }
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics(
+            // (11,12): error CS9039: This constructor must add 'SetsRequiredMembers' because it chains to a constructor that has that attribute.
+            //     public Derived() { }
+            Diagnostic(ErrorCode.ERR_ChainingToSetsRequiredMembersRequiresSetsRequiredMembers, "Derived").WithLocation(11, 12)
+        );
+    }
+
+    [Fact]
+    public void SetsRequiredMembersRequiredForChaining_Explicit()
+    {
+        var code = """
+            using System.Diagnostics.CodeAnalysis;
+
+            class Base
+            {
+                [SetsRequiredMembers]
+                public Base() { }
+            }
+
+            class Derived : Base
+            {
+                public Derived() : base() { } 
+            }
+            """;
+
+        var comp = CreateCompilationWithRequiredMembers(code);
+        comp.VerifyDiagnostics(
+            // (11,24): error CS9039: This constructor must add 'SetsRequiredMembers' because it chains to a constructor that has that attribute.
+            //     public Derived() : base() { } 
+            Diagnostic(ErrorCode.ERR_ChainingToSetsRequiredMembersRequiresSetsRequiredMembers, "base").WithLocation(11, 24)
+        );
+    }
+
     [Fact]
     public void SetsRequiredMembersAppliedToRecordCopyConstructor_DeclaredInType()
     {
@@ -4479,35 +4660,6 @@ public class Derived : Base
             // (1,15): error CS0656: Missing compiler required member 'System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute..ctor'
             // public record C
             Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "C").WithArguments("System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute", ".ctor").WithLocation(1, 15)
-        );
-    }
-
-    [Fact, CompilerTrait(CompilerFeature.NullableReferenceTypes)]
-    public void RequiredMemberSuppressesNullabilityWarnings_ChainedConstructor_11()
-    {
-        var code = """
-            #nullable enable
-            public class Base
-            {
-                public required string Prop1 { get; set; }
-                public string Prop2 { get; set; } = null!;
-            }
-            
-            public class Derived : Base
-            {
-                public required string Prop3 { get; set; } = Prop1.ToString();
-                public string Prop4 { get; set; } = Prop2.ToString();
-            }
-            """;
-
-        var comp = CreateCompilationWithRequiredMembers(code);
-        comp.VerifyDiagnostics(
-            // (10,50): error CS0236: A field initializer cannot reference the non-static field, method, or property 'Base.Prop1'
-            //     public required string Prop3 { get; set; } = Prop1.ToString();
-            Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "Prop1").WithArguments("Base.Prop1").WithLocation(10, 50),
-            // (11,41): error CS0236: A field initializer cannot reference the non-static field, method, or property 'Base.Prop2'
-            //     public string Prop4 { get; set; } = Prop2.ToString();
-            Diagnostic(ErrorCode.ERR_FieldInitRefNonstatic, "Prop2").WithArguments("Base.Prop2").WithLocation(11, 41)
         );
     }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEConstructorSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEConstructorSymbol.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         internal override void GenerateMethodBody(TypeCompilationState compilationState, BindingDiagnosticBag diagnostics)
         {
             var noLocals = ImmutableArray<LocalSymbol>.Empty;
-            var initializerInvocation = MethodCompiler.BindImplicitConstructorInitializer(this, diagnostics, compilationState.Compilation);
+            var initializerInvocation = Binder.BindImplicitConstructorInitializer(this, diagnostics, compilationState.Compilation);
             var syntax = initializerInvocation.Syntax;
 
             compilationState.AddSynthesizedMethod(this,


### PR DESCRIPTION
Previously approved in https://github.com/dotnet/roslyn/pull/64331 and https://github.com/dotnet/roslyn/pull/64408, backporting for 17.4.