### PR TITLE
Fix static virtual interface members not included in type parameter completion

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -11404,6 +11404,7 @@ interface I1
 interface I2
 {
     static abstract void M2();
+    static virtual void M3() { }
 }
 
 class Test
@@ -11414,9 +11415,10 @@ class Test
     }
 }
 ";
-            await VerifyItemIsAbsentAsync(source, "M0");
+            await VerifyItemExistsAsync(source, "M0");
             await VerifyItemExistsAsync(source, "M1");
             await VerifyItemExistsAsync(source, "M2");
+            await VerifyItemExistsAsync(source, "M3");
             await VerifyItemExistsAsync(source, "P1");
             await VerifyItemExistsAsync(source, "E1");
         }

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -365,7 +365,6 @@ internal partial class CSharpRecommendationService
             bool unwrapNullable,
             bool isForDereference)
         {
-            var abstractsOnly = false;
             var excludeInstance = false;
             var excludeStatic = true;
             var excludeBaseMethodsForRefStructs = true;
@@ -412,7 +411,6 @@ internal partial class CSharpRecommendationService
                     // We only want statics and not instance members.
                     excludeInstance = true;
                     excludeStatic = false;
-                    abstractsOnly = symbol.Kind == SymbolKind.TypeParameter;
                     containerSymbol = symbol;
                 }
 
@@ -440,7 +438,6 @@ internal partial class CSharpRecommendationService
                 return default;
 
             Debug.Assert(!excludeInstance || !excludeStatic);
-            Debug.Assert(!abstractsOnly || (abstractsOnly && !excludeStatic && excludeInstance));
 
             // nameof(X.|
             // Show static and instance members.
@@ -458,7 +455,7 @@ internal partial class CSharpRecommendationService
             // If we're showing instance members, don't include nested types
             var namedSymbols = excludeStatic
                 ? symbols.WhereAsArray(s => !(s.IsStatic || s is ITypeSymbol))
-                : (abstractsOnly ? symbols.WhereAsArray(s => s.IsAbstract) : symbols);
+                : symbols;
 
             //If container type is "ref struct" then we should exclude methods from object and ValueType that are not overriden
             //if recomendations are requested not in nameof context,


### PR DESCRIPTION
Ports https://github.com/dotnet/roslyn/pull/64708 to 17.4.

We would like to take thsi here as this is part of IDE min-bar for new language features, and absence of this working can both lead to customer confusion as to why things aren't working, as well as frustration as completion can interfere with them typing what they want to type.