### PR TITLE
Report obsolete diagnostics for types named var/unmanaged/notnull

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -261,7 +261,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             // Case (2)(a)(1)
                             isKeyword = false;
-                            ReportDiagnosticsIfObsolete(diagnostics, symbol, syntax, hasBaseReceiver: false);
+                            if (symbol.Kind != SymbolKind.Alias)
+                            {
+                                ReportDiagnosticsIfObsolete(diagnostics, type, syntax, hasBaseReceiver: false);
+                            }
                         }
                         else
                         {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -261,6 +261,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             // Case (2)(a)(1)
                             isKeyword = false;
+                            ReportDiagnosticsIfObsolete(diagnostics, symbol, syntax, hasBaseReceiver: false);
                         }
                         else
                         {

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -13865,5 +13865,70 @@ public class LegacyObject
                 // [Obsolete($"Do not use {nameof(LegacyObject)}{string.Empty}")]
                 Diagnostic(ErrorCode.ERR_BadAttributeArgument, @"$""Do not use {nameof(LegacyObject)}{string.Empty}""").WithLocation(11, 11));
         }
+
+        [Fact, WorkItem(64713, "https://github.com/dotnet/roslyn/issues/64713")]
+        public void ObsoleteVarType()
+        {
+            var source = """
+using System;
+
+var a = new();
+
+[Obsolete("error", true)]
+public class var
+{
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (3,1): error CS0619: 'var' is obsolete: 'error'
+                // var a = new();
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "var").WithArguments("var", "error").WithLocation(3, 1),
+                // (6,14): warning CS8981: The type name 'var' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // public class var
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "var").WithArguments("var").WithLocation(6, 14)
+            );
+        }
+
+        [Fact, WorkItem(64713, "https://github.com/dotnet/roslyn/issues/64713")]
+        public void ObsoleteUnmanagedAndNotNullTypes()
+        {
+            var source = """
+using System;
+
+public class C1<T> where T : unmanaged
+{
+}
+
+public class C2<T> where T : notnull
+{
+}
+
+[Obsolete("error", true)]
+public class unmanaged
+{
+}
+
+[Obsolete("error", true)]
+public class notnull
+{
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (3,30): error CS0619: 'unmanaged' is obsolete: 'error'
+                // public class C1<T> where T : unmanaged
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "unmanaged").WithArguments("unmanaged", "error").WithLocation(3, 30),
+                // (7,30): error CS0619: 'notnull' is obsolete: 'error'
+                // public class C2<T> where T : notnull
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "notnull").WithArguments("notnull", "error").WithLocation(7, 30),
+                // (12,14): warning CS8981: The type name 'unmanaged' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // public class unmanaged
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "unmanaged").WithArguments("unmanaged").WithLocation(12, 14),
+                // (17,14): warning CS8981: The type name 'notnull' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // public class notnull
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "notnull").WithArguments("notnull").WithLocation(17, 14)
+            );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -13891,6 +13891,34 @@ public class var
         }
 
         [Fact, WorkItem(64713, "https://github.com/dotnet/roslyn/issues/64713")]
+        public void ObsoleteVarAlias()
+        {
+            var source = """
+using System;
+using var = Legacy;
+
+var a = new();
+
+[Obsolete("error", true)]
+public class Legacy
+{
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (2,7): warning CS8981: The type name 'var' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // using var = Legacy;
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "var").WithArguments("var").WithLocation(2, 7),
+                // (4,1): error CS0619: 'Legacy' is obsolete: 'error'
+                // var a = new();
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "var").WithArguments("Legacy", "error").WithLocation(4, 1),
+                // (4,1): error CS0619: 'Legacy' is obsolete: 'error'
+                // var a = new();
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "var").WithArguments("Legacy", "error").WithLocation(4, 1)
+            );
+        }
+
+        [Fact, WorkItem(64713, "https://github.com/dotnet/roslyn/issues/64713")]
         public void ObsoleteUnmanagedAndNotNullTypes()
         {
             var source = """
@@ -13928,6 +13956,55 @@ public class notnull
                 // (17,14): warning CS8981: The type name 'notnull' only contains lower-cased ascii characters. Such names may become reserved for the language.
                 // public class notnull
                 Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "notnull").WithArguments("notnull").WithLocation(17, 14)
+            );
+        }
+
+        [Fact, WorkItem(64713, "https://github.com/dotnet/roslyn/issues/64713")]
+        public void ObsoleteUnmanagedAndNotNullAliases()
+        {
+            var source = """
+using System;
+using unmanaged = Legacy1;
+using notnull = Legacy2;
+
+public class C1<T> where T : unmanaged
+{
+}
+
+public class C2<T> where T : notnull
+{
+}
+
+[Obsolete("error", true)]
+public class Legacy1
+{
+}
+
+[Obsolete("error", true)]
+public class Legacy2
+{
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (2,7): warning CS8981: The type name 'unmanaged' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // using unmanaged = Legacy1;
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "unmanaged").WithArguments("unmanaged").WithLocation(2, 7),
+                // (3,7): warning CS8981: The type name 'notnull' only contains lower-cased ascii characters. Such names may become reserved for the language.
+                // using notnull = Legacy2;
+                Diagnostic(ErrorCode.WRN_LowerCaseTypeName, "notnull").WithArguments("notnull").WithLocation(3, 7),
+                // (5,30): error CS0619: 'Legacy1' is obsolete: 'error'
+                // public class C1<T> where T : unmanaged
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "unmanaged").WithArguments("Legacy1", "error").WithLocation(5, 30),
+                // (5,30): error CS0619: 'Legacy1' is obsolete: 'error'
+                // public class C1<T> where T : unmanaged
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "unmanaged").WithArguments("Legacy1", "error").WithLocation(5, 30),
+                // (9,30): error CS0619: 'Legacy2' is obsolete: 'error'
+                // public class C2<T> where T : notnull
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "notnull").WithArguments("Legacy2", "error").WithLocation(9, 30),
+                // (9,30): error CS0619: 'Legacy2' is obsolete: 'error'
+                // public class C2<T> where T : notnull
+                Diagnostic(ErrorCode.ERR_DeprecatedSymbolStr, "notnull").WithArguments("Legacy2", "error").WithLocation(9, 30)
             );
         }
     }


### PR DESCRIPTION
Fixes #64713

`BindTypeOrAliasOrKeyword` was missing reporting obsoletion diagnostics.

It's called specifically for `var` here:

https://github.com/dotnet/roslyn/blob/6e363702fa182afb5c5154b8dde29aa283ac9e52/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs#L109-L125

and also called when binding `notnull`/`unmanaged` constraints here:

https://github.com/dotnet/roslyn/blob/b7e32bb468194f0526d4867dd64e44ad1835f988/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs#L149-L152

This change updates `BindTypeOrAliasOrKeyword` such that it reports obsoletion diagnostic when the resolution is a single viable non-error named type.