### PR TITLE
Do not offer name completion after dotted expressions which do not bind to types

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/DeclarationNameCompletionProviderTests.cs
@@ -2804,6 +2804,19 @@ public class MyClass
             await VerifyItemExistsAsync(markup, "myClass1", glyph: (int)Glyph.Local, options: options);
         }
 
+        [Fact]
+        public async Task TestNotForNonTypeSymbol()
+        {
+            var markup = @"
+using System;
+class C
+{
+    Console.BackgroundColor $$
+}
+";
+            await VerifyItemIsAbsentAsync(markup, "consoleColor");
+        }
+
         private static NamingStylePreferences MultipleCamelCaseLocalRules()
         {
             var styles = new[]


### PR DESCRIPTION
e.g. `System.ConsoleColor $$` should offer a name, but `Console.BackgroundColor $$` should not (even though `Console.BackgroundColor`'s type is `System.ConsoleColor`).