### PR TITLE
Skip csharpsourcegenerators.findreferencesforfilewithdefinitioninsourcegeneratedfile

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpSourceGenerators.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/CSharp/CSharpSourceGenerators.cs
@@ -62,7 +62,7 @@ internal static class Program
             Assert.Equal(HelloWorldGenerator.GeneratedEnglishClassName, await TestServices.Editor.GetSelectedTextAsync(HangMitigatingCancellationToken));
         }
 
-        [IdeTheory]
+        [IdeTheory(Skip = "https://github.com/dotnet/roslyn/issues/64721")]
         [CombinatorialData]
         public async Task FindReferencesForFileWithDefinitionInSourceGeneratedFile(bool invokeFromSourceGeneratedFile)
         {


### PR DESCRIPTION
This test is failing regularly. See https://github.com/dotnet/roslyn/issues/64721