### PR TITLE
Generate different DocumentIds for duplicate generators

### DIFF
--- a/src/VisualStudio/Core/Def/Workspace/SourceGeneratedFileManager.cs
+++ b/src/VisualStudio/Core/Def/Workspace/SourceGeneratedFileManager.cs
@@ -346,7 +346,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
                     else
                     {
                         // The file isn't there anymore; do we still have the generator at all?
-                        if (project.AnalyzerReferences.Any(a => a.GetGenerators(project.Language).Any(static (g, self) => SourceGeneratorIdentity.GetGeneratorAssemblyName(g) == self._documentIdentity.Generator.AssemblyName, this)))
+                        if (project.AnalyzerReferences.Any(a => a.FullPath == _documentIdentity.Generator.AssemblyPath))
                         {
                             windowFrameMessageToShow = string.Format(ServicesVSResources.The_generator_0_that_generated_this_file_has_stopped_generating_this_file, GeneratorDisplayName);
                             windowFrameImageMonikerToShow = KnownMonikers.StatusError;

--- a/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/SourceGeneratorItem.cs
+++ b/src/VisualStudio/Core/Impl/SolutionExplorer/DiagnosticItem/SourceGeneratorItem.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             : base(name: SourceGeneratorIdentity.GetGeneratorTypeName(generator))
         {
             ProjectId = projectId;
-            Identity = new SourceGeneratorIdentity(generator);
+            Identity = new SourceGeneratorIdentity(generator, analyzerReference);
             AnalyzerReference = analyzerReference;
         }
 

--- a/src/Workspaces/Core/Portable/SourceGeneratorTelemetry/ISourceGeneratorTelemetryCollectorWorkspaceService.cs
+++ b/src/Workspaces/Core/Portable/SourceGeneratorTelemetry/ISourceGeneratorTelemetryCollectorWorkspaceService.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis.Host;
 
@@ -11,6 +12,6 @@ namespace Microsoft.CodeAnalysis.SourceGeneratorTelemetry
 {
     internal interface ISourceGeneratorTelemetryCollectorWorkspaceService : IWorkspaceService
     {
-        void CollectRunResult(GeneratorDriverRunResult driverRunResult, GeneratorDriverTimingInfo driverTimingInfo);
+        void CollectRunResult(GeneratorDriverRunResult driverRunResult, GeneratorDriverTimingInfo driverTimingInfo, ProjectState project);
     }
 }

--- a/src/Workspaces/Core/Portable/SourceGeneratorTelemetry/SourceGeneratorTelemetryCollectorWorkspaceService.cs
+++ b/src/Workspaces/Core/Portable/SourceGeneratorTelemetry/SourceGeneratorTelemetryCollectorWorkspaceService.cs
@@ -3,8 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Roslyn.Utilities;
 
@@ -14,15 +17,22 @@ namespace Microsoft.CodeAnalysis.SourceGeneratorTelemetry
     {
         private sealed record GeneratorTelemetryKey
         {
-            public GeneratorTelemetryKey(ISourceGenerator generator)
+            // TODO: mark with SetsRequiredMembers when we have the attributes in place
+            // [SetsRequiredMembers]
+            public GeneratorTelemetryKey(ISourceGenerator generator, AnalyzerReference analyzerReference)
             {
-                Identity = new SourceGeneratorIdentity(generator);
-                FileVersion = FileVersionInfo.GetVersionInfo(generator.GetGeneratorType().Assembly.Location).FileVersion ?? "(null)";
+                Identity = new SourceGeneratorIdentity(generator, analyzerReference);
+                FileVersion = "(null)";
+
+                if (Identity.AssemblyPath != null)
+                {
+                    FileVersion = FileVersionInfo.GetVersionInfo(Identity.AssemblyPath).FileVersion;
+                }
             }
 
             // TODO: mark these 'required' when we have the attributes in place
-            public SourceGeneratorIdentity Identity { get; }
-            public string FileVersion { get; }
+            public SourceGeneratorIdentity Identity { get; init; }
+            public string FileVersion { get; init; }
         }
 
         /// <summary>
@@ -34,19 +44,19 @@ namespace Microsoft.CodeAnalysis.SourceGeneratorTelemetry
         private readonly StatisticLogAggregator<GeneratorTelemetryKey> _elapsedTimeByGenerator = new();
         private readonly StatisticLogAggregator<GeneratorTelemetryKey> _producedFilesByGenerator = new();
 
-        private GeneratorTelemetryKey GetTelemetryKey(ISourceGenerator generator)
-            => _generatorTelemetryKeys.GetValue(generator, static g => new GeneratorTelemetryKey(g));
+        private GeneratorTelemetryKey GetTelemetryKey(ISourceGenerator generator, ProjectState project)
+            => _generatorTelemetryKeys.GetValue(generator, g => new GeneratorTelemetryKey(g, project.GetAnalyzerReferenceForGenerator(g)));
 
-        public void CollectRunResult(GeneratorDriverRunResult driverRunResult, GeneratorDriverTimingInfo driverTimingInfo)
+        public void CollectRunResult(GeneratorDriverRunResult driverRunResult, GeneratorDriverTimingInfo driverTimingInfo, ProjectState project)
         {
             foreach (var generatorTime in driverTimingInfo.GeneratorTimes)
             {
-                _elapsedTimeByGenerator.AddDataPoint(GetTelemetryKey(generatorTime.Generator), generatorTime.ElapsedTime);
+                _elapsedTimeByGenerator.AddDataPoint(GetTelemetryKey(generatorTime.Generator, project), generatorTime.ElapsedTime);
             }
 
             foreach (var generatorResult in driverRunResult.Results)
             {
-                _producedFilesByGenerator.AddDataPoint(GetTelemetryKey(generatorResult.Generator), generatorResult.GeneratedSources.Length);
+                _producedFilesByGenerator.AddDataPoint(GetTelemetryKey(generatorResult.Generator, project), generatorResult.GeneratedSources.Length);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationAndGeneratorDriverTranslationAction_Actions.cs
@@ -330,7 +330,7 @@ namespace Microsoft.CodeAnalysis
                     var generatorDriver = _oldGeneratorDriver.ReplaceAdditionalTexts(_newProjectState.AdditionalDocumentStates.SelectAsArray(static documentState => documentState.AdditionalText))
                                                      .WithUpdatedParseOptions(_newProjectState.ParseOptions!)
                                                      .WithUpdatedAnalyzerConfigOptions(_newProjectState.AnalyzerOptions.AnalyzerConfigOptionsProvider)
-                                                     .ReplaceGenerators(_newProjectState.SourceGenerators);
+                                                     .ReplaceGenerators(_newProjectState.SourceGenerators.ToImmutableArray());
 
                     return generatorDriver;
                 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentIdentity.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
@@ -21,23 +22,28 @@ namespace Microsoft.CodeAnalysis
     {
         public bool ShouldReuseInSerialization => true;
 
-        public static SourceGeneratedDocumentIdentity Generate(ProjectId projectId, string hintName, ISourceGenerator generator, string filePath)
+        public static SourceGeneratedDocumentIdentity Generate(ProjectId projectId, string hintName, ISourceGenerator generator, string filePath, AnalyzerReference analyzerReference)
         {
             // We want the DocumentId generated for a generated output to be stable between Compilations; this is so features that track
             // a document by DocumentId can find it after some change has happened that requires generators to run again.
             // To achieve this we'll just do a crytographic hash of the generator name and hint name; the choice of a cryptographic hash
             // as opposed to a more generic string hash is we actually want to ensure we don't have collisions.
-            var generatorIdentity = new SourceGeneratorIdentity(generator);
+            var generatorIdentity = new SourceGeneratorIdentity(generator, analyzerReference);
 
             // Combine the strings together; we'll use Encoding.Unicode since that'll match the underlying format; this can be made much
             // faster once we're on .NET Core since we could directly treat the strings as ReadOnlySpan<char>.
             var projectIdBytes = projectId.Id.ToByteArray();
-            using var _ = ArrayBuilder<byte>.GetInstance(capacity: (generatorIdentity.AssemblyName.Length + 1 + generatorIdentity.TypeName.Length + 1 + hintName.Length) * 2 + projectIdBytes.Length, out var hashInput);
+
+            // The assembly path should exist in any normal scenario; the hashing of the name only would apply if the user loaded a
+            // dynamic assembly they produced at runtime and passed us that via a custom AnalyzerReference.
+            var assemblyNameToHash = generatorIdentity.AssemblyPath ?? generatorIdentity.AssemblyName;
+
+            using var _ = ArrayBuilder<byte>.GetInstance(capacity: (assemblyNameToHash.Length + 1 + generatorIdentity.TypeName.Length + 1 + hintName.Length) * 2 + projectIdBytes.Length, out var hashInput);
             hashInput.AddRange(projectIdBytes);
 
             // Add a null to separate the generator name and hint name; since this is effectively a joining of UTF-16 bytes
             // we'll use a UTF-16 null just to make sure there's absolutely no risk of collision.
-            hashInput.AddRange(Encoding.Unicode.GetBytes(generatorIdentity.AssemblyName));
+            hashInput.AddRange(Encoding.Unicode.GetBytes(assemblyNameToHash));
             hashInput.AddRange(0, 0);
             hashInput.AddRange(Encoding.Unicode.GetBytes(generatorIdentity.TypeName));
             hashInput.AddRange(0, 0);
@@ -61,6 +67,7 @@ namespace Microsoft.CodeAnalysis
 
             writer.WriteString(HintName);
             writer.WriteString(Generator.AssemblyName);
+            writer.WriteString(Generator.AssemblyPath);
             writer.WriteString(Generator.AssemblyVersion.ToString());
             writer.WriteString(Generator.TypeName);
             writer.WriteString(FilePath);
@@ -72,6 +79,7 @@ namespace Microsoft.CodeAnalysis
 
             var hintName = reader.ReadString();
             var generatorAssemblyName = reader.ReadString();
+            var generatorAssemblyPath = reader.ReadString();
             var generatorAssemblyVersion = Version.Parse(reader.ReadString());
             var generatorTypeName = reader.ReadString();
             var filePath = reader.ReadString();
@@ -79,7 +87,13 @@ namespace Microsoft.CodeAnalysis
             return new SourceGeneratedDocumentIdentity(
                 documentId,
                 hintName,
-                new SourceGeneratorIdentity(generatorAssemblyName, generatorAssemblyVersion, generatorTypeName),
+                new SourceGeneratorIdentity
+                {
+                    AssemblyName = generatorAssemblyName,
+                    AssemblyPath = generatorAssemblyPath,
+                    AssemblyVersion = generatorAssemblyVersion,
+                    TypeName = generatorTypeName
+                },
                 filePath);
         }
     }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratorIdentity.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratorIdentity.cs
@@ -3,21 +3,38 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis
 {
-    internal record struct SourceGeneratorIdentity(string AssemblyName, Version AssemblyVersion, string TypeName)
+    /// <remarks>
+    /// Assembly path is used as a part of a generator identity to deal with the case that the user accidentally installed the same
+    /// generator twice from two different paths, or actually has two different generators that just happened to use the same name.
+    /// In the wild we've seen cases where a user has a broken project or build that results in the same generator being added twice;
+    /// we aren't going to try to deduplicate those anywhere since currently the compiler does't do any deduplication either:
+    /// you'll simply get duplicate outputs which might collide and cause compile errors. If https://github.com/dotnet/roslyn/issues/56619
+    /// is addressed, we can potentially match the compiler behavior by taking a different approach here.
+    /// </remarks>
+    internal record struct SourceGeneratorIdentity
     {
-        public SourceGeneratorIdentity(ISourceGenerator generator)
-            : this(GetGeneratorAssemblyName(generator), generator.GetGeneratorType().Assembly.GetName().Version!, GetGeneratorTypeName(generator))
-        {
-        }
+        // TODO: mark these 'required' when we have the attributes in place
+        public string AssemblyName { get; init; }
+        public string? AssemblyPath { get; init; }
+        public Version AssemblyVersion { get; init; }
+        public string TypeName { get; init; }
 
-        public static string GetGeneratorAssemblyName(ISourceGenerator generator)
+        // TODO: mark with SetsRequiredMembers when we have the attributes in place
+        // [SetsRequiredMembers]
+        public SourceGeneratorIdentity(ISourceGenerator generator, AnalyzerReference analyzerReference)
         {
-            return generator.GetGeneratorType().Assembly.GetName().Name!;
+            var generatorType = generator.GetGeneratorType();
+            var assembly = generatorType.Assembly;
+            var assemblyName = assembly.GetName();
+            AssemblyName = assemblyName.Name!;
+            AssemblyPath = analyzerReference.FullPath;
+            AssemblyVersion = assemblyName.Version!;
+            TypeName = generatorType.FullName!;
         }
 
         public static string GetGeneratorTypeName(ISourceGenerator generator)

--- a/src/Workspaces/CoreTestUtilities/TestGeneratorReference.cs
+++ b/src/Workspaces/CoreTestUtilities/TestGeneratorReference.cs
@@ -18,7 +18,7 @@ namespace Roslyn.Test.Utilities
         private readonly ISourceGenerator _generator;
         private readonly Checksum _checksum;
 
-        public TestGeneratorReference(ISourceGenerator generator)
+        public TestGeneratorReference(ISourceGenerator generator, string? analyzerFilePath = null)
         {
             _generator = generator;
             Guid = Guid.NewGuid();
@@ -31,14 +31,16 @@ namespace Roslyn.Test.Utilities
             var checksumArray = Guid.ToByteArray();
             Array.Resize(ref checksumArray, Checksum.HashSize);
             _checksum = Checksum.From(checksumArray);
+
+            FullPath = analyzerFilePath;
         }
 
-        public TestGeneratorReference(IIncrementalGenerator generator)
-            : this(generator.AsSourceGenerator())
+        public TestGeneratorReference(IIncrementalGenerator generator, string? analyzerFilePath = null)
+            : this(generator.AsSourceGenerator(), analyzerFilePath)
         {
         }
 
-        public override string? FullPath => null;
+        public override string? FullPath { get; }
         public override object Id => this;
         public Guid Guid { get; }
 


### PR DESCRIPTION
We've seen a few places in the wild where a customer ends up with a generator installed twice into their project. This was causing an issue with how we generate DocumentIds for generated documents: we compute that as a stable hash over some pieces of information so that way we geneate consistent IDs in different processes, and a generated file that disappears due to an edit and comes back can also have the same ID.

The hashing algorithm for a DocumentId included the generator's type name and the generator's assembly name, but if you have two generators with the same assembly name we'd collide. This could happen if you have two different generators with the same name, or your project file is messed up and causing a generator to be added from two different paths at once. This latter case isn't a scenario we support, but this change at least ensures Roslyn won't be throwing exceptions which ends up requiring investigation.

Related to https://github.com/dotnet/roslyn/issues/56619, but doesn't entirely close it, a duplicate generator producing duplicate files will still be confusing. This may also address
https://github.com/dotnet/roslyn/issues/57660 but the belief is there's a race condition there too, as the dumps I've seen don't show duplicate references in the project.