### PR TITLE
Fixed prop snippet caret position

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropSnippetCompletionProviderTests.cs
@@ -62,7 +62,7 @@ $$";
             var expectedCodeAfterCommit =
 @"class MyClass
 {
-    public int MyProperty {$$ get; set; }
+    public int MyProperty { get; set; }$$
 }";
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
@@ -79,7 +79,7 @@ $$";
             var expectedCodeAfterCommit =
 @"record MyRecord
 {
-    public int MyProperty {$$ get; set; }
+    public int MyProperty { get; set; }$$
 }";
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
@@ -96,7 +96,7 @@ $$";
             var expectedCodeAfterCommit =
 @"struct MyStruct
 {
-    public int MyProperty {$$ get; set; }
+    public int MyProperty { get; set; }$$
 }";
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
@@ -113,7 +113,7 @@ $$";
             var expectedCodeAfterCommit =
 @"interface MyInterface
 {
-    public int MyProperty {$$ get; set; }
+    public int MyProperty { get; set; }$$
 }";
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
@@ -132,7 +132,7 @@ $$";
 @"class MyClass
 {
     public int MyProperty { get; set; }
-    public int MyProperty1 {$$ get; set; }
+    public int MyProperty1 { get; set; }$$
 }";
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }

--- a/src/Features/CSharp/Portable/Snippets/CSharpPropSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpPropSnippetProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
         protected override int GetTargetCaretPosition(ISyntaxFactsService syntaxFacts, SyntaxNode caretTarget, SourceText sourceText)
         {
             var propertyDeclaration = (PropertyDeclarationSyntax)caretTarget;
-            return propertyDeclaration.AccessorList!.OpenBraceToken.Span.End;
+            return propertyDeclaration.AccessorList!.CloseBraceToken.Span.End;
         }
 
         protected override ImmutableArray<SnippetPlaceholder> GetPlaceHolderLocationsList(SyntaxNode node, ISyntaxFacts syntaxFacts, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/Snippets/SnippetPlaceholder.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetPlaceholder.cs
@@ -3,10 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Text;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Snippets
 {

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractPropSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractPropSnippetProvider.cs
@@ -3,12 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Text;
 

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/ISnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/ISnippetProvider.cs
@@ -2,13 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Snippets.SnippetProviders
 {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/64731

@akhera99 I don't know why you've chosen that cursor position in the first place, but I have 2 arguments for this one:
1) It matches end caret position of legacy non-semantic snippet variant
2) It has a benifit of being able to press `Enter` and jump to new line without need to move cursor with your mouse or keyboard. At the same time I don't see any clear benifits from position you've chosen