### PR TITLE
Add binding redirects for compiler binaries for the LSIF tool

### DIFF
--- a/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
+++ b/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
@@ -65,6 +65,9 @@
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
   </ItemGroup>
 
+  <!-- Since we may be loading analyzers in-process, we need to have the appropriate binding redirects in place -->
+  <Import Project="$(RepositoryEngineeringDir)targets\GenerateCompilerExecutableBindingRedirects.targets" />
+
   <ItemGroup>
     <None Include=".editorconfig" />
     <None Include="App.config" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/64491