### PR TITLE
Cache indices against our PEReference object, not the underlying metadata ID

### DIFF
--- a/src/EditorFeatures/Test/FindSymbols/SymbolTreeInfoTests.cs
+++ b/src/EditorFeatures/Test/FindSymbols/SymbolTreeInfoTests.cs
@@ -1,0 +1,109 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.FindSymbols
+{
+    [UseExportProvider]
+    public class SymbolTreeInfoTests
+    {
+        [Fact]
+        public async Task TestSymbolTreeInfoForMetadataWithDifferentProperties1()
+        {
+            using var workspace = TestWorkspace.CreateCSharp("");
+            var solution = workspace.CurrentSolution;
+            var project = solution.Projects.Single();
+
+            var reference1 = (PortableExecutableReference)project.MetadataReferences.First();
+            var reference2 = reference1.WithAliases(new[] { "Alias" });
+
+            var info1 = await SymbolTreeInfo.GetInfoForMetadataReferenceAsync(
+                solution, reference1, checksum: null, CancellationToken.None);
+
+            var info2 = await SymbolTreeInfo.GetInfoForMetadataReferenceAsync(
+                solution, reference2, checksum: null, CancellationToken.None);
+
+            Assert.NotEqual(info1.Checksum, info2.Checksum);
+            Assert.Equal(info1.Checksum, SymbolTreeInfo.GetMetadataChecksum(solution.Services, reference1, CancellationToken.None));
+            Assert.Equal(info2.Checksum, SymbolTreeInfo.GetMetadataChecksum(solution.Services, reference2, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task TestSymbolTreeInfoForMetadataWithDifferentProperties2()
+        {
+            using var workspace = TestWorkspace.CreateCSharp("");
+            var solution = workspace.CurrentSolution;
+            var project = solution.Projects.Single();
+
+            var reference1 = (PortableExecutableReference)project.MetadataReferences.First();
+            var reference2 = reference1.WithAliases(new[] { "Alias" });
+
+            var checksum1 = SymbolTreeInfo.GetMetadataChecksum(solution.Services, reference1, CancellationToken.None);
+            var info1 = await SymbolTreeInfo.GetInfoForMetadataReferenceAsync(
+                solution, reference1, checksum1, CancellationToken.None);
+
+            var checksum2 = SymbolTreeInfo.GetMetadataChecksum(solution.Services, reference2, CancellationToken.None);
+            var info2 = await SymbolTreeInfo.GetInfoForMetadataReferenceAsync(
+                solution, reference2, checksum2, CancellationToken.None);
+
+            Assert.NotEqual(info1.Checksum, info2.Checksum);
+            Assert.Equal(info1.Checksum, checksum1);
+            Assert.Equal(info2.Checksum, checksum2);
+        }
+
+        [Fact]
+        public async Task TestSymbolTreeInfoForMetadataWithDifferentProperties3()
+        {
+            using var workspace = TestWorkspace.CreateCSharp("");
+            var solution = workspace.CurrentSolution;
+            var project = solution.Projects.Single();
+
+            var reference1 = (PortableExecutableReference)project.MetadataReferences.First();
+            var reference2 = reference1.WithAliases(new[] { "Alias" });
+
+            var checksum1 = SymbolTreeInfo.GetMetadataChecksum(solution.Services, reference1, CancellationToken.None);
+            var info1 = await SymbolTreeInfo.GetInfoForMetadataReferenceAsync(
+                solution, reference1, checksum1, CancellationToken.None);
+
+            var info2 = await SymbolTreeInfo.GetInfoForMetadataReferenceAsync(
+                solution, reference2, checksum: null, CancellationToken.None);
+
+            Assert.NotEqual(info1.Checksum, info2.Checksum);
+            Assert.Equal(info1.Checksum, checksum1);
+            Assert.Equal(info2.Checksum, SymbolTreeInfo.GetMetadataChecksum(solution.Services, reference2, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task TestSymbolTreeInfoForMetadataWithDifferentProperties4()
+        {
+            using var workspace = TestWorkspace.CreateCSharp("");
+            var solution = workspace.CurrentSolution;
+            var project = solution.Projects.Single();
+
+            var reference1 = (PortableExecutableReference)project.MetadataReferences.First();
+            var reference2 = reference1.WithAliases(new[] { "Alias" });
+
+            var info1 = await SymbolTreeInfo.GetInfoForMetadataReferenceAsync(
+                solution, reference1, checksum: null, CancellationToken.None);
+
+            var checksum2 = SymbolTreeInfo.GetMetadataChecksum(solution.Services, reference2, CancellationToken.None);
+            var info2 = await SymbolTreeInfo.GetInfoForMetadataReferenceAsync(
+                solution, reference2, checksum2, CancellationToken.None);
+
+            Assert.NotEqual(info1.Checksum, info2.Checksum);
+            Assert.Equal(info1.Checksum, SymbolTreeInfo.GetMetadataChecksum(solution.Services, reference1, CancellationToken.None));
+            Assert.Equal(info2.Checksum, checksum2);
+        }
+    }
+}

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.SymbolComputer.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/ExtensionMethodImportCompletionHelper.SymbolComputer.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     await GetUpToDateCacheEntryAsync(relevantProject, cacheService, cancellationToken).ConfigureAwait(false);
 
                 foreach (var peReference in GetAllRelevantPeReferences(project))
-                    await SymbolTreeInfo.GetInfoForMetadataReferenceAsync(project.Solution, peReference, cancellationToken).ConfigureAwait(false);
+                    await SymbolTreeInfo.GetInfoForMetadataReferenceAsync(project.Solution, peReference, checksum: null, cancellationToken).ConfigureAwait(false);
             }
 
             public async Task<(ImmutableArray<IMethodSymbol> symbols, bool isPartialResult)> GetExtensionMethodSymbolsAsync(bool forceCacheCreation, bool hideAdvancedMembers, CancellationToken cancellationToken)
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 if (forceCacheCreation)
                 {
                     symbolInfo = await SymbolTreeInfo.GetInfoForMetadataReferenceAsync(
-                        _originatingDocument.Project.Solution, peReference, cancellationToken).ConfigureAwait(false);
+                        _originatingDocument.Project.Solution, peReference, checksum: null, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {

--- a/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Declarations/DeclarationFinder.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 if (reference != null)
                 {
                     var info = await SymbolTreeInfo.GetInfoForMetadataReferenceAsync(
-                        project.Solution, reference, cancellationToken).ConfigureAwait(false);
+                        project.Solution, reference, checksum: null, cancellationToken).ConfigureAwait(false);
 
                     Contract.ThrowIfNull(info);
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -412,7 +412,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             // might get false positives.  But that's fine as we still use 'tpeMatches' to make sure the match is
             // correct.
             var symbolTreeInfo = await SymbolTreeInfo.GetInfoForMetadataReferenceAsync(
-                project.Solution, reference, cancellationToken).ConfigureAwait(false);
+                project.Solution, reference, checksum: null, cancellationToken).ConfigureAwait(false);
 
             Contract.ThrowIfNull(symbolTreeInfo);
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -319,12 +319,16 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         #region Construction
 
         /// <summary>
-        /// Cache the symbol tree infos for assembly symbols that share the same underlying metadata. Generating symbol
-        /// trees for metadata can be expensive (in large metadata cases).  And it's common for us to have many threads
-        /// to want to search the same metadata simultaneously. As such, we use an AsyncLazy to compute the value that
-        /// can be shared among all callers.
+        /// Cache the symbol tree infos for assembly symbols produced from a particular <see
+        /// cref="PortableExecutableReference"/>. Generating symbol trees for metadata can be expensive (in large
+        /// metadata cases).  And it's common for us to have many threads to want to search the same metadata
+        /// simultaneously. As such, we use an AsyncLazy to compute the value that can be shared among all callers.
+        /// <para>
+        /// We store this keyed off of the <see cref="Checksum"/> produced by <see cref="GetMetadataChecksum"/>.  This
+        /// ensures that 
+        /// </para>
         /// </summary>
-        private static readonly ConditionalWeakTable<MetadataId, AsyncLazy<SymbolTreeInfo>> s_metadataIdToInfo = new();
+        private static readonly ConditionalWeakTable<PortableExecutableReference, AsyncLazy<SymbolTreeInfo>> s_peReferenceToInfo = new();
 
         private static SpellChecker CreateSpellChecker(Checksum checksum, ImmutableArray<Node> sortedNodes)
             => new(checksum, sortedNodes.Select(n => n.Name.AsMemory()));

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.cs
@@ -132,6 +132,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
         public SymbolTreeInfo WithChecksum(Checksum checksum)
         {
+            if (checksum == this.Checksum)
+                return this;
+
             return new SymbolTreeInfo(
                 checksum, _nodes, _spellChecker, _inheritanceMap, _receiverTypeNameToExtensionMethodMap);
         }
@@ -317,18 +320,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         }
 
         #region Construction
-
-        /// <summary>
-        /// Cache the symbol tree infos for assembly symbols produced from a particular <see
-        /// cref="PortableExecutableReference"/>. Generating symbol trees for metadata can be expensive (in large
-        /// metadata cases).  And it's common for us to have many threads to want to search the same metadata
-        /// simultaneously. As such, we use an AsyncLazy to compute the value that can be shared among all callers.
-        /// <para>
-        /// We store this keyed off of the <see cref="Checksum"/> produced by <see cref="GetMetadataChecksum"/>.  This
-        /// ensures that 
-        /// </para>
-        /// </summary>
-        private static readonly ConditionalWeakTable<PortableExecutableReference, AsyncLazy<SymbolTreeInfo>> s_peReferenceToInfo = new();
 
         private static SpellChecker CreateSpellChecker(Checksum checksum, ImmutableArray<Node> sortedNodes)
             => new(checksum, sortedNodes.Select(n => n.Name.AsMemory()));

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Collections;
@@ -26,6 +27,30 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 {
     internal partial class SymbolTreeInfo
     {
+        /// <summary>
+        /// Cache the symbol tree infos for assembly symbols produced from a particular <see
+        /// cref="PortableExecutableReference"/>. Generating symbol trees for metadata can be expensive (in large
+        /// metadata cases).  And it's common for us to have many threads to want to search the same metadata
+        /// simultaneously. As such, we use an AsyncLazy to compute the value that can be shared among all callers.
+        /// <para>
+        /// We store this keyed off of the <see cref="Checksum"/> produced by <see cref="GetMetadataChecksum"/>.  This
+        /// ensures that 
+        /// </para>
+        /// </summary>
+        private static readonly ConditionalWeakTable<PortableExecutableReference, AsyncLazy<SymbolTreeInfo>> s_peReferenceToInfo = new();
+
+        /// <summary>
+        /// Similar to <see cref="s_peReferenceToInfo"/> except that this caches based on metadata id.  The primary
+        /// difference here is that you can have the same MetadataId from two different <see
+        /// cref="PortableExecutableReference"/>s, while having different checksums.  For example, if the aliases of a
+        /// <see cref="PortableExecutableReference"/> are changed (see <see
+        /// cref="PortableExecutableReference.WithAliases(IEnumerable{string})"/>, then it will have a different
+        /// checksum, but same metadata ID.  As such, we can use this table to ensure we only do the expensive
+        /// computation of the <see cref="SymbolTreeInfo"/> once per <see cref="MetadataId"/>, but we may then have to
+        /// make a copy of it with a new <see cref="Checksum"/> if the checksums differ.
+        /// </summary>
+        private static readonly ConditionalWeakTable<MetadataId, AsyncLazy<SymbolTreeInfo>> s_metadataIdToSymbolTreeInfo = new();
+
         private static string GetMetadataNameWithoutBackticks(MetadataReader reader, StringHandle name)
         {
             var blobReader = reader.GetBlobReader(name);
@@ -39,6 +64,18 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 return MetadataStringDecoder.DefaultUTF8.GetString(
                     blobReader.CurrentPointer, backtickIndex);
+            }
+        }
+
+        public static MetadataId? GetMetadataIdNoThrow(PortableExecutableReference reference)
+        {
+            try
+            {
+                return reference.GetMetadataId();
+            }
+            catch (Exception e) when (e is BadImageFormatException or IOException)
+            {
+                return null;
             }
         }
 
@@ -89,9 +126,13 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                // Important: this captured async lazy may live a long time *without* computing the final results. As such,
-                // it is important that it note capture any large state.  For example, it should not hold onto a Solution
-                // instance.
+                // Important: this captured async lazy may live a long time *without* computing the final results. As
+                // such, it is important that it not capture any large state.  For example, it should not hold onto a
+                // Solution instance.
+                //
+                // this is keyed per reference, so that have unique SymbolTreeInfo's per reference with their own
+                // correct checksum.  Ensuring we only compute this once per *Metadata* instance though is handled below in 
+                // CreateMetadataSymbolTreeInfoAsync
                 var asyncLazy = s_peReferenceToInfo.GetValue(
                     reference,
                     id => new AsyncLazy<SymbolTreeInfo>(
@@ -99,6 +140,38 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                         cacheResult: true));
 
                 return await asyncLazy.GetValueAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            static async Task<SymbolTreeInfo> CreateMetadataSymbolTreeInfoAsync(
+                SolutionServices services,
+                SolutionKey solutionKey,
+                PortableExecutableReference reference,
+                Checksum checksum,
+                CancellationToken cancellationToken)
+            {
+                var metadataId = GetMetadataIdNoThrow(reference);
+                if (metadataId == null)
+                    return CreateEmpty(checksum);
+
+                var asyncLazy = s_metadataIdToSymbolTreeInfo.GetValue(
+                    metadataId,
+                    metadataId => new AsyncLazy<SymbolTreeInfo>(
+                        cancellationToken => LoadOrCreateAsync(
+                            services,
+                            solutionKey,
+                            checksum,
+                            createAsync: checksum => new ValueTask<SymbolTreeInfo>(new MetadataInfoCreator(checksum, GetMetadataNoThrow(reference)).Create()),
+                            keySuffix: GetMetadataKeySuffix(reference),
+                            cancellationToken),
+                        cacheResult: true));
+
+                var metadataIdSymbolTreeInfo = await asyncLazy.GetValueAsync(cancellationToken).ConfigureAwait(false);
+
+                // we got the info that was originally computed against this particular metadata-id.  However, the same
+                // ID could be reused across different PEReferences/checksums (for example, a PEReference whose aliases
+                // were changed).  As such, if this doesn't correspond to the same checksum, make a copy of this tree
+                // specific to the checksum we were asked for.
+                return metadataIdSymbolTreeInfo.WithChecksum(checksum);
             }
         }
 
@@ -143,22 +216,6 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private static string GetMetadataKeySuffix(PortableExecutableReference reference)
             => "_Metadata_" + reference.FilePath;
 
-        private static Task<SymbolTreeInfo> CreateMetadataSymbolTreeInfoAsync(
-            SolutionServices services,
-            SolutionKey solutionKey,
-            PortableExecutableReference reference,
-            Checksum checksum,
-            CancellationToken cancellationToken)
-        {
-            return LoadOrCreateAsync(
-                services,
-                solutionKey,
-                checksum,
-                createAsync: checksum => new ValueTask<SymbolTreeInfo>(new MetadataInfoCreator(checksum, reference).Create()),
-                keySuffix: GetMetadataKeySuffix(reference),
-                cancellationToken);
-        }
-
         /// <summary>
         /// Loads any info we have for this reference from our persistence store.  Will succeed regardless of the
         /// checksum of the <paramref name="reference"/>.  Should only be used by clients that are ok with potentially
@@ -184,7 +241,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             private static readonly ObjectPool<List<string>> s_stringListPool = SharedPools.Default<List<string>>();
 
             private readonly Checksum _checksum;
-            private readonly PortableExecutableReference _reference;
+            private readonly Metadata? _metadata;
 
             private readonly OrderPreservingMultiDictionary<string, string> _inheritanceMap;
             private readonly OrderPreservingMultiDictionary<MetadataNode, MetadataNode> _parentToChildren;
@@ -204,10 +261,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             private bool _containsExtensionsMethod;
 
             public MetadataInfoCreator(
-                Checksum checksum, PortableExecutableReference reference)
+                Checksum checksum, Metadata? metadata)
             {
                 _checksum = checksum;
-                _reference = reference;
+                _metadata = metadata;
                 _containsExtensionsMethod = false;
 
                 _inheritanceMap = OrderPreservingMultiDictionary<string, string>.GetInstance();
@@ -240,7 +297,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
             internal SymbolTreeInfo Create()
             {
-                foreach (var moduleMetadata in GetModuleMetadata(GetMetadataNoThrow(_reference)))
+                foreach (var moduleMetadata in GetModuleMetadata(_metadata))
                 {
                     try
                     {

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Metadata.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             if (s_peReferenceToInfo.TryGetValue(reference, out var infoTask))
             {
                 var info = await infoTask.GetValueAsync(cancellationToken).ConfigureAwait(false);
-                Contract.ThrowIfFalse(info.Checksum != checksum, "How could the info stored for a particular PEReference now have a different checksum?");
+                Contract.ThrowIfTrue(info.Checksum != checksum, "How could the info stored for a particular PEReference now have a different checksum?");
                 return info;
             }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo_Source.cs
@@ -33,14 +33,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             => "_Source_" + project.FilePath;
 
         public static Task<SymbolTreeInfo> GetInfoForSourceAssemblyAsync(
-            Project project, CancellationToken cancellationToken)
+            Project project, Checksum checksum, CancellationToken cancellationToken)
         {
             var solution = project.Solution;
 
             return LoadOrCreateAsync(
                 solution.Services,
                 SolutionKey.ToSolutionKey(solution),
-                getChecksumAsync: async () => await GetSourceSymbolsChecksumAsync(project, cancellationToken).ConfigureAwait(false),
+                checksum,
                 createAsync: checksum => CreateSourceSymbolTreeInfoAsync(project, checksum, cancellationToken),
                 keySuffix: GetSourceKeySuffix(project),
                 cancellationToken);


### PR DESCRIPTION
I broke this in https://github.com/dotnet/roslyn/pull/63449

The core issue here is that we base our Checksum off of the PEReference, but cache using a key based off a MetadataId.  Two PERefs can have the MetadataId, but different checksums.  For example, if you just change the metadata-properties of a PERef (like the 'Aliases' it has, or if interop types are embedded), then teh metadata for it stays the same.

This was problematic as we were assuming that if the metadataId was the same, you'd always have the same checksum.

Working on test now.