### PR TITLE
Recover from the Exception in IdleProcessor

### DIFF
--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingIdleProcessor.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingIdleProcessor.cs
@@ -6,6 +6,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Roslyn.Utilities;
 
@@ -146,6 +147,10 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
                 catch (OperationCanceledException)
                 {
                     // ignore cancellation exception
+                }
+                catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
+                {
+                    // In case any error happen during the execution, don't exit the loop and continue to work on the next item.
                 }
             }
         }

--- a/src/Features/Core/Portable/SolutionCrawler/IdleProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/IdleProcessor.cs
@@ -6,6 +6,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Roslyn.Utilities;
 
@@ -143,9 +144,9 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         await ExecuteAsync().ConfigureAwait(false);
                     }
                 }
-                catch (OperationCanceledException)
+                catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
                 {
-                    // ignore cancellation exception
+                    // In case any error happen during the execution, don't exit the loop and continue to work on the next item.
                 }
             }
         }

--- a/src/Features/Core/Portable/SolutionCrawler/IdleProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/IdleProcessor.cs
@@ -144,6 +144,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         await ExecuteAsync().ConfigureAwait(false);
                     }
                 }
+                catch (OperationCanceledException)
+                {
+                    // ignore cancellation exception
+                }
                 catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e))
                 {
                     // In case any error happen during the execution, don't exit the loop and continue to work on the next item.


### PR DESCRIPTION
There are three queues in SolutionCrawler.
Low priority, medium priority, and high priority.
And the work in each queue is put queue into a different thread in a Task [here](https://github.com/dotnet/roslyn/blob/c84dd3c12d7bc3bca7e20686b0a47356f1ef3110/src/Features/Core/Portable/SolutionCrawler/IdleProcessor.cs#L59) in a [loop](https://github.com/dotnet/roslyn/blob/c84dd3c12d7bc3bca7e20686b0a47356f1ef3110/src/Features/Core/Portable/SolutionCrawler/IdleProcessor.cs#L127) 
Currently we don't catch all the exceptions in the loop.

so, when either an incremental analzyer throws an exception, the task would become in a fault state, causing all the other items in the queue to wait forever.
This means, because the low priority queue is always waiting for the medium & high priority queues. if there is one error happens in meduim/high queue, low/medium queues are also blocked.

This might be the root reason of many timeout in our integration test pipeline like [this](https://dev.azure.com/dnceng-public/public/_build/results?buildId=51061&view=results)
Medium priority queue crashes because of an exception
<img width="1190" alt="image" src="https://user-images.githubusercontent.com/24360909/195953134-acfdbe8a-59e6-49e0-845e-29fe4bf8ddd0.png">
And the low priority queue is also blocked.