### PR TITLE
Track local constant usage in attributes applied to local methods or lambdas

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -1697,10 +1697,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Marks attribute arguments as used.
         /// </summary>
-        private void VisitAttributes(ImmutableArray<BoundAttribute> boundAttributes)
+        private void VisitAttributes(ImmutableArray<(CSharpAttributeData, BoundAttribute)> boundAttributes)
         {
-            foreach (var boundAttribute in boundAttributes)
+            foreach (var (attributeData, boundAttribute) in boundAttributes)
             {
+                // Skip invalid attributes (e.g., with a non-constant argument) to avoid superfluous diagnostics.
+                if (attributeData.HasErrors)
+                {
+                    continue;
+                }
+
                 foreach (var attributeArgument in boundAttribute.ConstructorArguments)
                 {
                     VisitRvalue(attributeArgument);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -575,7 +575,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Binds attributes applied to this parameter.
         /// </summary>
-        public ImmutableArray<BoundAttribute> BindParameterAttributes()
+        public ImmutableArray<(CSharpAttributeData, BoundAttribute)> BindParameterAttributes()
         {
             return BindAttributes(GetAttributeDeclarations(), WithTypeParametersBinderOpt);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -577,23 +577,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public ImmutableArray<BoundAttribute> BindParameterAttributes()
         {
-            var binder = new ContextualAttributeBinder(WithTypeParametersBinderOpt, this);
-            var boundAttributeArrayBuilder = ArrayBuilder<BoundAttribute>.GetInstance();
-            foreach (var attributeListSyntaxList in GetAttributeDeclarations())
-            {
-                foreach (var attributeListSyntax in attributeListSyntaxList)
-                {
-                    foreach (var attributeSyntax in attributeListSyntax.Attributes)
-                    {
-                        var boundType = binder.BindType(attributeSyntax.Name, BindingDiagnosticBag.Discarded);
-                        var boundTypeSymbol = (NamedTypeSymbol)boundType.Type;
-                        var boundAttribute = new ExecutableCodeBinder(attributeSyntax, binder.ContainingMemberOrLambda, binder)
-                            .BindAttribute(attributeSyntax, boundTypeSymbol, this, BindingDiagnosticBag.Discarded);
-                        boundAttributeArrayBuilder.Add(boundAttribute);
-                    }
-                }
-            }
-            return boundAttributeArrayBuilder.ToImmutableAndFree();
+            return BindAttributes(GetAttributeDeclarations(), WithTypeParametersBinderOpt);
         }
 
         internal override void EarlyDecodeWellKnownAttributeType(NamedTypeSymbol attributeType, AttributeSyntax attributeSyntax)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -368,7 +368,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public ImmutableArray<(CSharpAttributeData, BoundAttribute)> BindMethodAttributes()
         {
-            Debug.Assert(OuterBinder is not null);
             return BindAttributes(GetAttributeDeclarations(), OuterBinder);
         }
 #nullable disable

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -362,6 +362,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             return base.EarlyDecodeWellKnownAttribute(ref arguments);
         }
+
+        /// <summary>
+        /// Binds attributes applied to this method.
+        /// </summary>
+        public ImmutableArray<BoundAttribute> BindMethodAttributes()
+        {
+            Debug.Assert(OuterBinder is not null);
+            return BindAttributes(GetAttributeDeclarations(), OuterBinder);
+        }
 #nullable disable
 
         public override bool AreLocalsZeroed

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMethodSymbolWithAttributes.cs
@@ -366,7 +366,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Binds attributes applied to this method.
         /// </summary>
-        public ImmutableArray<BoundAttribute> BindMethodAttributes()
+        public ImmutableArray<(CSharpAttributeData, BoundAttribute)> BindMethodAttributes()
         {
             Debug.Assert(OuterBinder is not null);
             return BindAttributes(GetAttributeDeclarations(), OuterBinder);

--- a/src/Compilers/CSharp/Portable/Symbols/Symbol_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Symbol_Attributes.cs
@@ -521,10 +521,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Binds attributes applied to this symbol.
         /// </summary>
-        protected ImmutableArray<BoundAttribute> BindAttributes(OneOrMany<SyntaxList<AttributeListSyntax>> attributeDeclarations, Binder rootBinder)
+        protected ImmutableArray<(CSharpAttributeData, BoundAttribute)> BindAttributes(OneOrMany<SyntaxList<AttributeListSyntax>> attributeDeclarations, Binder rootBinder)
         {
             var binder = new ContextualAttributeBinder(rootBinder, this);
-            var boundAttributeArrayBuilder = ArrayBuilder<BoundAttribute>.GetInstance();
+            var boundAttributeArrayBuilder = ArrayBuilder<(CSharpAttributeData, BoundAttribute)>.GetInstance();
             foreach (var attributeListSyntaxList in attributeDeclarations)
             {
                 foreach (var attributeListSyntax in attributeListSyntaxList)
@@ -533,8 +533,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var boundType = binder.BindType(attributeSyntax.Name, BindingDiagnosticBag.Discarded);
                         var boundTypeSymbol = (NamedTypeSymbol)boundType.Type;
-                        var boundAttribute = new ExecutableCodeBinder(attributeSyntax, binder.ContainingMemberOrLambda, binder)
-                            .BindAttribute(attributeSyntax, boundTypeSymbol, this, BindingDiagnosticBag.Discarded);
+                        var boundAttribute = binder.GetAttribute(attributeSyntax, boundTypeSymbol,
+                            beforeAttributePartBound: null, afterAttributePartBound: null, BindingDiagnosticBag.Discarded);
                         boundAttributeArrayBuilder.Add(boundAttribute);
                     }
                 }

--- a/src/Compilers/CSharp/Test/Emit2/FlowAnalysis/FlowTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/FlowAnalysis/FlowTests.cs
@@ -5691,6 +5691,30 @@ class C
         }
 
         [Fact, WorkItem(60645, "https://github.com/dotnet/roslyn/issues/60645")]
+        public void LocalMethod_AttributeArguments_GenericParameter()
+        {
+            var source = """
+                using System;
+                class A : Attribute
+                {
+                    public A(int param) { }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        [A(default(T))] void F<T>() { }
+                        F<int>();
+                    }
+                }
+                """;
+            CreateCompilation(source).VerifyDiagnostics(
+                // (10,20): error CS0246: The type or namespace name 'T' could not be found (are you missing a using directive or an assembly reference?)
+                //         [A(default(T))] void F<T>() { }
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "T").WithArguments("T").WithLocation(10, 20));
+        }
+
+        [Fact, WorkItem(60645, "https://github.com/dotnet/roslyn/issues/60645")]
         public void LocalMethod_AttributeArguments_StringInterpolation()
         {
             var source = """

--- a/src/Compilers/CSharp/Test/Emit2/FlowAnalysis/FlowTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/FlowAnalysis/FlowTests.cs
@@ -5642,5 +5642,57 @@ class C
                 """;
             CreateCompilation(source).VerifyDiagnostics();
         }
+
+        [Fact, WorkItem(1614551, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1614551")]
+        public void LocalMethod_Attribute()
+        {
+            var source = """
+                using System;
+                class A : Attribute
+                {
+                    public A(int param) { }
+                    public int Prop { get; set; }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        const int N1 = 10;
+                        const int N2 = 20;
+                        const int N3 = 30;
+                        const int N4 = 40;
+                        [A(N1, Prop = N2)][return: A(N3, Prop = N4)] int F() => 50;
+                        F();
+                    }
+                }
+                """;
+            CreateCompilation(source).VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem(1614551, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1614551")]
+        public void LambdaMethod_Attribute()
+        {
+            var source = """
+                using System;
+                class A : Attribute
+                {
+                    public A(int param) { }
+                    public int Prop { get; set; }
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        const int N1 = 10;
+                        const int N2 = 20;
+                        const int N3 = 30;
+                        const int N4 = 40;
+                        var lam = [A(N1, Prop = N2)][return: A(N3, Prop = N4)] () => 50;
+                        lam();
+                    }
+                }
+                """;
+            CreateCompilation(source).VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
Follow up on #64660 which fixed similar issue for attributes applied to method/lamba parameters only, i.e.,
```cs
void lam = ([Attr(constant)] int x) => { };
```
whereas this PR fixes the same for attributes applied to whole methods/lambdas, i.e.,
```cs
void lam = [Attr(constant)] (int x) => { };
```

Fixes [AB#1614551](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1614551)
Fixes #60645
Fixes #47619
Closes #62158