### PR TITLE
Merge spell checking fix into 17.4 release

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
@@ -681,5 +681,17 @@ class Program : IInterface
 
             await TestInRegularAndScriptAsync(text, expected);
         }
+
+        [Fact, WorkItem(1640728, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1640728")]
+        public async Task TestMisspelledWordThatIsAlsoSnippetName()
+        {
+            await TestInRegularAndScriptAsync(
+@"public [|interfacce|] IWhatever
+{
+}",
+@"public interface IWhatever
+{
+}");
+        }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
@@ -20,6 +20,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
 {
     internal abstract class AbstractSnippetCompletionProvider : CompletionProvider
     {
+        internal override bool IsSnippetProvider => true;
+
         public override async Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, char? commitKey = null, CancellationToken cancellationToken = default)
         {
             // This retrieves the document without the text used to invoke completion


### PR DESCRIPTION
Spellchecking needs to ignore snippets, this is a bug fix introduced in 17.5 P1 that ensures that the new semantic snippet experience is skipped.

Ports #64622 and tracked for 17.4 with https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1643584