### PR TITLE
Fix MSBuild tests and run them in CI again

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -62,7 +62,7 @@
     <HumanizerCoreVersion>2.14.1</HumanizerCoreVersion>
     <ICSharpCodeDecompilerVersion>7.1.0.6543</ICSharpCodeDecompilerVersion>
     <InputSimulatorPlusVersion>1.0.7</InputSimulatorPlusVersion>
-    <MicrosoftBuildLocatorVersion>1.4.1</MicrosoftBuildLocatorVersion>
+    <MicrosoftBuildLocatorVersion>1.5.5</MicrosoftBuildLocatorVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>6.0.0</MicrosoftExtensionsDependencyInjectionVersion>
     <!--
       SourceBuild will requires that all dependencies also be source buildable. We are referencing a

--- a/src/Workspaces/MSBuildTest/Resources/SolutionFiles/VisualBasic.sln
+++ b/src/Workspaces/MSBuildTest/Resources/SolutionFiles/VisualBasic.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "VisualBasicProject", "VisualBasicProject\VisualBasicProject.vbproj", "{AC25ECDA-DE94-4FCF-A688-EB3A2BE3670C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AC25ECDA-DE94-4FCF-A688-EB3A2BE3670C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC25ECDA-DE94-4FCF-A688-EB3A2BE3670C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC25ECDA-DE94-4FCF-A688-EB3A2BE3670C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC25ECDA-DE94-4FCF-A688-EB3A2BE3670C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
+++ b/src/Workspaces/MSBuildTest/TestFiles/Resources.cs
@@ -103,6 +103,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.TestFiles
             public static string NonExistentProject => GetText("SolutionFiles.NonExistentProject.sln");
             public static string ProjectLoadErrorOnMissingDebugType => GetText("SolutionFiles.ProjectLoadErrorOnMissingDebugType.sln");
             public static string SolutionFolder => GetText("SolutionFiles.SolutionFolder.sln");
+            public static string VisualBasic => GetText("SolutionFiles.VisualBasic.sln");
             public static string VB_and_CSharp => GetText("SolutionFiles.VB_and_CSharp.sln");
         }
 

--- a/src/Workspaces/MSBuildTest/Utilities/VisualStudioMSBuildInstalled.cs
+++ b/src/Workspaces/MSBuildTest/Utilities/VisualStudioMSBuildInstalled.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
-using System.Linq;
 using Microsoft.Build.Locator;
 using Roslyn.Test.Utilities;
 
@@ -13,6 +11,7 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
     internal class VisualStudioMSBuildInstalled : ExecutionCondition
     {
 #if NET472_OR_GREATER
+
         private static readonly VisualStudioInstance? s_instance;
         private readonly Version _minimumVersion;
 
@@ -33,21 +32,20 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
                 s_instance = latestInstalledInstance;
             }
         }
+
 #endif
 
         public VisualStudioMSBuildInstalled()
-#if NET472_OR_GREATER
-            : this(new Version(16, 9))
-#endif
+            : this(new Version(17, 0))
         {
         }
 
-#if NET472_OR_GREATER
         internal VisualStudioMSBuildInstalled(Version minimumVersion)
         {
+#if NET472_OR_GREATER
             _minimumVersion = minimumVersion;
-        }
 #endif
+        }
 
         public override bool ShouldSkip
 #if NET472_OR_GREATER

--- a/src/Workspaces/MSBuildTest/Utilities/VisualStudioMSBuildInstalled.cs
+++ b/src/Workspaces/MSBuildTest/Utilities/VisualStudioMSBuildInstalled.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.Build.Locator;
 using Roslyn.Test.Utilities;
@@ -17,15 +18,19 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
 
         static VisualStudioMSBuildInstalled()
         {
-            var installedVisualStudios = MSBuildLocator.QueryVisualStudioInstances().ToArray();
-            foreach (var visualStudioInstall in installedVisualStudios)
+            var latestInstalledInstance = (VisualStudioInstance?)null;
+            foreach (var visualStudioInstance in MSBuildLocator.QueryVisualStudioInstances())
             {
-                if (visualStudioInstall.Version.Major == 17 &&
-                    visualStudioInstall.Version.Minor == 0)
+                if (latestInstalledInstance == null || visualStudioInstance.Version > latestInstalledInstance.Version)
                 {
-                    MSBuildLocator.RegisterInstance(visualStudioInstall);
-                    s_instance = visualStudioInstall;
+                    latestInstalledInstance = visualStudioInstance;
                 }
+            }
+
+            if (latestInstalledInstance != null)
+            {
+                MSBuildLocator.RegisterInstance(latestInstalledInstance);
+                s_instance = latestInstalledInstance;
             }
         }
 #endif

--- a/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.MSBuild.UnitTests
         {
             var files = language == LanguageNames.CSharp ?
                 GetSimpleCSharpSolutionFiles().WithFile(@"CSharpProject\CSharpProject.csproj", Resources.ProjectFiles.CSharp.WithChecksumAlgorithm) :
-                GetSimpleVisualBasicSolutionFiles().WithFile(@"VisualBasicProject\VisualBasicProject.csproj", Resources.ProjectFiles.VisualBasic.WithChecksumAlgorithm);
+                GetSimpleVisualBasicSolutionFiles().WithFile(@"VisualBasicProject\VisualBasicProject.vbproj", Resources.ProjectFiles.VisualBasic.WithChecksumAlgorithm);
 
             CreateFiles(files);
             var solutionFilePath = GetSolutionFileName("TestSolution.sln");

--- a/src/Workspaces/MSBuildTest/WorkspaceTestBase.cs
+++ b/src/Workspaces/MSBuildTest/WorkspaceTestBase.cs
@@ -107,6 +107,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
         protected static FileSet GetSimpleVisualBasicSolutionFiles()
         {
             return new FileSet(
+                (@"NuGet.Config", Resources.NuGet_Config),
+                (@"Directory.Build.props", Resources.Directory_Build_props),
+                (@"Directory.Build.targets", Resources.Directory_Build_targets),
+                (@"TestSolution.sln", Resources.SolutionFiles.VisualBasic),
                 (@"VisualBasicProject\VisualBasicProject.vbproj", Resources.ProjectFiles.VisualBasic.VisualBasicProject),
                 (@"VisualBasicProject\VisualBasicClass.vb", Resources.SourceFiles.VisualBasic.VisualBasicClass),
                 (@"VisualBasicProject\My Project\Application.Designer.vb", Resources.SourceFiles.VisualBasic.Application_Designer),


### PR DESCRIPTION
As @tmat observed, our tests were hard-coded to only run MSBuild tests against 17.0; when we upgraded any machines to 17.1 they started getting skipped instead. This fixes them, and also updates the tests to respond to a few behavior changes from @tmat.