### PR TITLE
Add snippets back to dev17.4

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SnippetCompletionProviderTests.cs
@@ -21,6 +21,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     [Trait(Traits.Feature, Traits.Features.Completion)]
     public class SnippetCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
+        public SnippetCompletionProviderTests()
+        {
+            ShowNewSnippetExperience = false;
+        }
+
         internal override Type GetCompletionProviderType()
             => typeof(SnippetCompletionProvider);
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
@@ -31,11 +31,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
     [Shared]
     internal sealed class SnippetCompletionProvider : LSPCompletionProvider
     {
-        private static readonly HashSet<string> s_builtInSnippets = new()
+        private static readonly HashSet<string> s_builtInSnippetsWithoutReplacement = new()
         {
-            "#if", "#region", "Attribute", "checked", "class", "ctor", "cw", "do", "else", "enum", "equals", "Exception",
-            "for", "foreach", "forr", "if", "indexer", "interface", "invoke", "iterindex", "iterator", "lock", "mbox",
-            "namespace", "prop", "propa", "propdp", "propfull", "propg", "sim", "struct", "svm", "switch", "testc", "testm",
+            "#if", "#region", "Attribute", "checked", "ctor", "do", "else", "enum", "equals", "Exception",
+            "for", "forr", "indexer", "invoke", "iterindex", "iterator", "lock", "mbox",
+            "namespace", "propa", "propdp", "propfull", "propg", "sim", "svm", "switch", "testc", "testm",
             "try", "tryf", "unchecked", "unsafe", "using", "while", "~"
         };
 
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             var snippets = service.GetSnippetsIfAvailable();
             if (context.CompletionOptions.ShouldShowNewSnippetExperience(context.Document))
             {
-                snippets = snippets.Where(snippet => !s_builtInSnippets.Contains(snippet.Shortcut));
+                snippets = snippets.Where(snippet => s_builtInSnippetsWithoutReplacement.Contains(snippet.Shortcut));
             }
 
             if (isPreProcessorContext)

--- a/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
+++ b/src/VisualStudio/Core/Test/Completion/CSharpCompletionSnippetNoteTests.vb
@@ -28,7 +28,6 @@ class C
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function SnippetExpansionNoteAddedToDescription_ExactMatch() As Task
             Using state = CreateCSharpSnippetExpansionNoteTestState(_markup, "interface")
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowNewSnippetExperience, LanguageNames.CSharp), False)
                 state.SendTypeChars("interfac")
                 Await state.AssertCompletionSession()
                 Await state.AssertSelectedCompletionItem(description:="title" & vbCrLf &
@@ -137,6 +136,7 @@ class C
 
             Dim testSnippetInfoService = DirectCast(state.Workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetService(Of ISnippetInfoService)(), TestCSharpSnippetInfoService)
             testSnippetInfoService.SetSnippetShortcuts(snippetShortcuts)
+            state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowNewSnippetExperience, LanguageNames.CSharp), False)
             Return state
         End Function
     End Class


### PR DESCRIPTION
Semantic snippets - change filter to keep old snippets in if replacement does not exist

Ports #64459 and tracked for 17.4 with https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1643974