### PR TITLE
Trigger background analyzer load when document open

### DIFF
--- a/src/Features/Core/Portable/Completion/CompletionService.ProviderManager.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.ProviderManager.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 return ValueTaskFactory.CompletedTask;
             }
 
-            private ImmutableArray<CompletionProvider> GetCachedProjectCompletionProvidersOrQueueLoadInBackground(Project? project)
+            public ImmutableArray<CompletionProvider> GetCachedProjectCompletionProvidersOrQueueLoadInBackground(Project? project)
             {
                 if (project is null || project.Solution.WorkspaceKind == WorkspaceKind.Interactive)
                 {

--- a/src/Features/Core/Portable/Completion/CompletionService.cs
+++ b/src/Features/Core/Portable/Completion/CompletionService.cs
@@ -338,6 +338,12 @@ namespace Microsoft.CodeAnalysis.Completion
         internal IReadOnlyList<Lazy<CompletionProvider, CompletionProviderMetadata>> GetLazyImportedProviders()
             => _providerManager.GetLazyImportedProviders();
 
+        /// <summary>
+        /// Don't call. Used for pre-load project providers only.
+        /// </summary>
+        internal void TriggerLoadProjectProviders(Project project)
+                => _providerManager.GetCachedProjectCompletionProvidersOrQueueLoadInBackground(project);
+
         internal CompletionProvider? GetProvider(CompletionItem item, Project? project)
             => _providerManager.GetProvider(item, project);
 

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractCreateServicesOnTextViewConnection.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractCreateServicesOnTextViewConnection.cs
@@ -85,6 +85,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 }
                 else if (Workspace.CurrentSolution.GetProject(projectId) is Project project)
                 {
+                    // Preload project completion providers at document open also helps avoid redundant file reads
+                    // from a race caused by multiple features (codefix, refactoring, etc.) attempting to get extensions
+                    // from analyzer references at the same time when they are not cached.
                     if (project.GetLanguageService<CompletionService>() is CompletionService completionService)
                         completionService.TriggerLoadProjectProviders(project);
 

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractCreateServicesOnTextViewConnection.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractCreateServicesOnTextViewConnection.cs
@@ -85,6 +85,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 }
                 else if (Workspace.CurrentSolution.GetProject(projectId) is Project project)
                 {
+                    if (project.GetLanguageService<CompletionService>() is CompletionService completionService)
+                        completionService.TriggerLoadProjectProviders(project);
+
                     await InitializeServiceForProjectWithOpenedDocumentAsync(project).ConfigureAwait(false);
                 }
             }


### PR DESCRIPTION
In https://github.com/dotnet/roslyn/pull/64719, the preload logic was removed in favor of lazy load for project completion providers. But it seems the preload also helped avoid redundant file reads due to multiple features (e.g. codefix, refactoring, etc.) trying to get extensions from analyzer references at the same time. 

This change reinstates the preload logic.