### PR TITLE
Do not treat `Nullable` null value as a constant for the purpose of IL generation.

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -48,7 +48,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     return;
                 }
 
-                if ((object)expression.Type == null || expression.Type.SpecialType != SpecialType.System_Decimal)
+                if ((object)expression.Type == null ||
+                    (expression.Type.SpecialType != SpecialType.System_Decimal &&
+                     !expression.Type.IsNullableType()))
                 {
                     EmitConstantExpression(expression.Type, constantValue, used, expression.Syntax);
                     return;


### PR DESCRIPTION
Fixes #64777.