### PR TITLE
Revert "Read required project properties from evaluation data"

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -177,16 +177,14 @@
        parse options. We'll then have to reparse them a second time which isn't great. It also means any
        cache lookups we do won't have the right options either, so the cache lookups might miss.
 
-       To help this, we'll have properties for the evaluation pass which is an "approximation" of the
-       options that would come out of CoreCompile, but only the ones that are required to be specified
-       and we don't expect them to change after evaluation phase or those that matter for parsing.
-
-       It's acceptable for the options that affect parsing to be imperfect: once the execution pass is complete we'll use those options instead,
+       To help this, we'll have a property for the evaluation pass which is an "approximation" of the
+       options that would come out of CoreCompile, but only the ones that matter for parsing. It's acceptable
+       for this to be imperfect: once the execution pass is complete we'll use those options instead,
        so any behaviors here that don't match the real command line generation will only be temporary, and
        probably won't be any worse than having no options at all. -->
+       
   <PropertyGroup>
     <CommandLineArgsForDesignTimeEvaluation>-langversion:$(LangVersion) -checksumalgorithm:$(ChecksumAlgorithm)</CommandLineArgsForDesignTimeEvaluation>
     <CommandLineArgsForDesignTimeEvaluation Condition="'$(DefineConstants)' != ''">$(CommandLineArgsForDesignTimeEvaluation) -define:$(DefineConstants)</CommandLineArgsForDesignTimeEvaluation>
-    <OutputAssemblyForDesignTimeEvaluation>@(IntermediateAssembly)</OutputAssemblyForDesignTimeEvaluation>
   </PropertyGroup>
 </Project>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -146,16 +146,14 @@
        parse options. We'll then have to reparse them a second time which isn't great. It also means any
        cache lookups we do won't have the right options either, so the cache lookups might miss.
 
-       To help this, we'll have properties for the evaluation pass which is an "approximation" of the
-       options that would come out of CoreCompile, but only the ones that are required to be specified
-       and we don't expect them to change after evaluation phase or those that matter for parsing.
-
-       It's acceptable for the options that affect parsing to be imperfect: once the execution pass is complete we'll use those options instead,
+       To help this, we'll have a property for the evaluation pass which is an "approximation" of the
+       options that would come out of CoreCompile, but only the ones that matter for parsing. It's acceptable
+       for this to be imperfect: once the execution pass is complete we'll use those options instead,
        so any behaviors here that don't match the real command line generation will only be temporary, and
        probably won't be any worse than having no options at all. -->
+       
   <PropertyGroup>
     <CommandLineArgsForDesignTimeEvaluation>-langversion:$(LangVersion) -checksumalgorithm:$(ChecksumAlgorithm)</CommandLineArgsForDesignTimeEvaluation>
     <CommandLineArgsForDesignTimeEvaluation Condition="'$(FinalDefineConstants)' != ''">$(CommandLineArgsForDesignTimeEvaluation) -define:$(FinalDefineConstants)</CommandLineArgsForDesignTimeEvaluation>
-    <OutputAssemblyForDesignTimeEvaluation>@(IntermediateAssembly)</OutputAssemblyForDesignTimeEvaluation>
   </PropertyGroup>
 </Project>

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
@@ -81,7 +81,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             var hierarchy = environment.CreateHierarchy(projectName, binOutputPath, projectRefPath: null, "CSharp");
             var cpsProjectFactory = environment.ExportProvider.GetExportedValue<IWorkspaceProjectContextFactory>();
 
-            var data = new TestEvaluationData(projectFilePath, binOutputPath, assemblyName: "", binOutputPath, checksumAlgorithm: "SHA256");
+            var data = new TestEvaluationData(projectFilePath, binOutputPath, assemblyName: "");
 
             var cpsProject = (CPSProject)await cpsProjectFactory.CreateProjectContextAsync(
                 projectGuid,
@@ -101,7 +101,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             var hierarchy = environment.CreateHierarchy(projectName, projectBinPath: null, projectRefPath: null, projectCapabilities: "");
             var cpsProjectFactory = environment.ExportProvider.GetExportedValue<IWorkspaceProjectContextFactory>();
 
-            var data = new TestEvaluationData(projectFilePath, targetPath, assemblyName: "", targetPath, checksumAlgorithm: "SHA256");
+            var data = new TestEvaluationData(projectFilePath, targetPath, assemblyName: "");
 
             return (CPSProject)await cpsProjectFactory.CreateProjectContextAsync(
                 Guid.NewGuid(),

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/TestEvaluationData.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/TestEvaluationData.cs
@@ -14,16 +14,12 @@ internal sealed class TestEvaluationData : EvaluationData
     public string ProjectFilePath { get; }
     public string TargetPath { get; }
     public string AssemblyName { get; }
-    public string OutputAssembly { get; }
-    public string ChecksumAlgorithm { get; }
 
-    public TestEvaluationData(string projectFilePath, string targetPath, string assemblyName, string outputAssembly, string checksumAlgorithm)
+    public TestEvaluationData(string projectFilePath, string targetPath, string assemblyName)
     {
         ProjectFilePath = projectFilePath;
         TargetPath = targetPath;
         AssemblyName = assemblyName;
-        OutputAssembly = outputAssembly;
-        ChecksumAlgorithm = checksumAlgorithm;
     }
 
     public override string GetPropertyValue(string name)
@@ -32,8 +28,6 @@ internal sealed class TestEvaluationData : EvaluationData
             "MSBuildProjectFullPath" => ProjectFilePath,
             "TargetPath" => TargetPath,
             "AssemblyName" => AssemblyName,
-            "OutputAssemblyForDesignTimeEvaluation" => OutputAssembly,
-            "CommandLineArgsForDesignTimeEvaluation" => "-checksumalgorithm:" + ChecksumAlgorithm,
             _ => throw ExceptionUtilities.UnexpectedValue(name)
         };
 }

--- a/src/VisualStudio/Core/Def/ProjectSystem/BuildPropertyNames.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/BuildPropertyNames.cs
@@ -29,12 +29,10 @@ internal static class BuildPropertyNames
     public const string TargetPath = nameof(TargetPath);
     public const string AssemblyName = nameof(AssemblyName);
     public const string CommandLineArgsForDesignTimeEvaluation = nameof(CommandLineArgsForDesignTimeEvaluation);
-    public const string OutputAssemblyForDesignTimeEvaluation = nameof(OutputAssemblyForDesignTimeEvaluation);
 
     public static readonly ImmutableArray<string> InitialEvaluationPropertyNames = ImmutableArray.Create(
         MSBuildProjectFullPath,
         TargetPath,
         AssemblyName,
-        CommandLineArgsForDesignTimeEvaluation,
-        OutputAssemblyForDesignTimeEvaluation);
+        CommandLineArgsForDesignTimeEvaluation);
 }

--- a/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
@@ -17,6 +16,29 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
     /// </summary>
     internal interface IWorkspaceProjectContextFactory
     {
+        /// <summary>
+        /// Creates and initializes a new Workspace project and returns a <see
+        /// cref="IWorkspaceProjectContext"/> to lazily initialize the properties and items for the
+        /// project.  This method guarantees that either the project is added (and the returned task
+        /// completes) or cancellation is observed and no project is added.
+        /// </summary>
+        /// <param name="languageName">Project language.</param>
+        /// <param name="projectUniqueName">Unique name for the project.</param>
+        /// <param name="projectFilePath">Full path to the project file for the project.</param>
+        /// <param name="projectGuid">Project guid.</param>
+        /// <param name="hierarchy">The IVsHierarchy for the project; this is used to track linked files across multiple projects when determining contexts.</param>
+        /// <param name="binOutputPath">Initial project binary output path.</param>
+        [Obsolete]
+        Task<IWorkspaceProjectContext> CreateProjectContextAsync(
+            string languageName,
+            string projectUniqueName,
+            string projectFilePath,
+            Guid projectGuid,
+            object? hierarchy,
+            string? binOutputPath,
+            string? assemblyName,
+            CancellationToken cancellationToken);
+
         /// <summary>
         /// Creates and initializes a new project and returns a <see
         /// cref="IWorkspaceProjectContext"/> to lazily initialize the properties and items for the

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -127,10 +127,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         }
 
         internal string? CompilationOutputAssemblyFilePath
-        {
-            get => _visualStudioProject.CompilationOutputAssemblyFilePath;
-            set => _visualStudioProject.CompilationOutputAssemblyFilePath = value;
-        }
+            => _visualStudioProject.CompilationOutputAssemblyFilePath;
 
         public ProjectId Id => _visualStudioProject.Id;
 


### PR DESCRIPTION
Reverts dotnet/roslyn#64749, which could be the cause of broken tests in https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/430149

[link to Val build ](https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/430281)