### PR TITLE
add telemetry log overload

### DIFF
--- a/src/Features/Core/Portable/ValueTracking/ValueTrackingService.cs
+++ b/src/Features/Core/Portable/ValueTracking/ValueTrackingService.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.ValueTracking
             Document document,
             CancellationToken cancellationToken)
         {
-            using var logger = Logger.LogBlock(FunctionId.ValueTracking_TrackValueSource, cancellationToken, LogLevel.Information);
+            using var logger = Logger.LogTelemetryBlock(FunctionId.ValueTracking_TrackValueSource, cancellationToken);
             var client = await RemoteHostClient.TryGetClientAsync(document.Project, cancellationToken).ConfigureAwait(false);
             if (client != null)
             {
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.ValueTracking
             ValueTrackedItem previousTrackedItem,
             CancellationToken cancellationToken)
         {
-            using var logger = Logger.LogBlock(FunctionId.ValueTracking_TrackValueSource, cancellationToken, LogLevel.Information);
+            using var logger = Logger.LogTelemetryBlock(FunctionId.ValueTracking_TrackValueSource, cancellationToken);
             var project = solution.GetRequiredProject(previousTrackedItem.DocumentId.ProjectId);
             var client = await RemoteHostClient.TryGetClientAsync(project, cancellationToken).ConfigureAwait(false);
             if (client != null)

--- a/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineHelper.cs
+++ b/src/VisualStudio/Core/Def/DocumentOutline/DocumentOutlineHelper.cs
@@ -174,13 +174,13 @@ namespace Microsoft.VisualStudio.LanguageServices.DocumentOutline
             cancellationToken.ThrowIfCancellationRequested();
 
             // Log which sort option was used
-            Logger.Log(sortOption switch
+            Logger.LogTelemetry(sortOption switch
             {
                 SortOption.Name => FunctionId.DocumentOutline_SortByName,
                 SortOption.Location => FunctionId.DocumentOutline_SortByOrder,
                 SortOption.Type => FunctionId.DocumentOutline_SortByType,
                 _ => throw new NotImplementedException(),
-            }, logLevel: LogLevel.Information);
+            });
 
             return SortDocumentSymbols(documentSymbolData, sortOption, cancellationToken);
 

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.VsCodeWindowManager.cs
@@ -260,7 +260,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 phwnd = _documentOutlineViewHost.Handle;
                 ppCmdTarget = null;
 
-                Logger.Log(FunctionId.DocumentOutline_WindowOpen, logLevel: LogLevel.Information);
+                Logger.LogTelemetry(FunctionId.DocumentOutline_WindowOpen);
 
                 return VSConstants.S_OK;
             }

--- a/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorerCommandHandler.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServices.StackTraceExplorer
                     await _threadingContext.JoinableTaskFactory.SwitchToMainThreadAsync();
                     var windowFrame = (IVsWindowFrame)window.Frame;
                     ErrorHandler.ThrowOnFailure(windowFrame.Show());
-                    Logger.Log(FunctionId.StackTraceToolWindow_ShowOnActivated, logLevel: LogLevel.Information);
+                    Logger.LogTelemetry(FunctionId.StackTraceToolWindow_ShowOnActivated);
                 }
             });
 

--- a/src/VisualStudio/Core/Def/UnusedReferences/UnusedReferenceAnalysisService.cs
+++ b/src/VisualStudio/Core/Def/UnusedReferences/UnusedReferenceAnalysisService.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.UnusedReferences
 
         public async Task<ImmutableArray<ReferenceInfo>> GetUnusedReferencesAsync(Solution solution, string projectFilePath, string projectAssetsFilePath, ImmutableArray<ReferenceInfo> projectReferences, CancellationToken cancellationToken)
         {
-            using var logger = Logger.LogBlock(FunctionId.UnusedReferences_GetUnusedReferences, message: null, cancellationToken, LogLevel.Information);
+            using var logger = Logger.LogTelemetryBlock(FunctionId.UnusedReferences_GetUnusedReferences, cancellationToken);
             var client = await RemoteHostClient.TryGetClientAsync(solution.Services, cancellationToken).ConfigureAwait(false);
             if (client != null)
             {

--- a/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingCommandHandler.cs
+++ b/src/VisualStudio/Core/Def/ValueTracking/ValueTrackingCommandHandler.cs
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ValueTracking
 
         public bool ExecuteCommand(ValueTrackingEditorCommandArgs args, CommandExecutionContext executionContext)
         {
-            using var logger = Logger.LogBlock(FunctionId.ValueTracking_Command, CancellationToken.None, LogLevel.Information);
+            using var logger = Logger.LogTelemetryBlock(FunctionId.ValueTracking_Command, CancellationToken.None);
 
             var cancellationToken = executionContext.OperationContext.UserCancellationToken;
             var caretPosition = args.TextView.GetCaretPoint(args.SubjectBuffer);

--- a/src/Workspaces/Core/Portable/CodeActions/Operations/ApplyChangesOperation.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/Operations/ApplyChangesOperation.cs
@@ -61,9 +61,8 @@ namespace Microsoft.CodeAnalysis.CodeActions
             {
                 var result = workspace.TryApplyChanges(changedSolution, progressTracker);
 
-                Logger.Log(
-                    result ? FunctionId.ApplyChangesOperation_WorkspaceVersionMatch_ApplicationSucceeded : FunctionId.ApplyChangesOperation_WorkspaceVersionMatch_ApplicationFailed,
-                    logLevel: LogLevel.Information);
+                Logger.LogTelemetry(
+                    result ? FunctionId.ApplyChangesOperation_WorkspaceVersionMatch_ApplicationSucceeded : FunctionId.ApplyChangesOperation_WorkspaceVersionMatch_ApplicationFailed);
 
                 return result;
             }
@@ -87,7 +86,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
                 solutionChanges.GetRemovedProjects().Any() ||
                 solutionChanges.GetRemovedAnalyzerReferences().Any())
             {
-                Logger.Log(FunctionId.ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_IncompatibleSolutionChange, logLevel: LogLevel.Information);
+                Logger.LogTelemetry(FunctionId.ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_IncompatibleSolutionChange);
                 return false;
             }
 
@@ -111,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
                     changedProject.GetRemovedMetadataReferences().Any() ||
                     changedProject.GetRemovedProjectReferences().Any())
                 {
-                    Logger.Log(FunctionId.ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_IncompatibleProjectChange, logLevel: LogLevel.Information);
+                    Logger.LogTelemetry(FunctionId.ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_IncompatibleProjectChange);
                     return false;
                 }
 
@@ -122,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
 
                 if (changedDocuments.Length == 0)
                 {
-                    Logger.Log(FunctionId.ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_NoChangedDocument, logLevel: LogLevel.Information);
+                    Logger.LogTelemetry(FunctionId.ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_NoChangedDocument);
                     return false;
                 }
 
@@ -135,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
                     // sort of change, we can't merge this operation in.
                     if (!changedDocument.HasTextChanged(originalDocument, ignoreUnchangeableDocument: false))
                     {
-                        Logger.Log(FunctionId.ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_NoTextChange, logLevel: LogLevel.Information);
+                        Logger.LogTelemetry(FunctionId.ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_NoTextChange);
                         return false;
                     }
 
@@ -143,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
                     var currentDocument = currentSolution.GetTextDocument(documentId);
                     if (currentDocument is null)
                     {
-                        Logger.Log(FunctionId.ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_DocumentRemoved, logLevel: LogLevel.Information);
+                        Logger.LogTelemetry(FunctionId.ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_DocumentRemoved);
                         return false;
                     }
 
@@ -152,7 +151,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
                     // with that.  For now though, we'll leave that out of scope.
                     if (originalDocument.HasTextChanged(currentDocument, ignoreUnchangeableDocument: false))
                     {
-                        Logger.Log(FunctionId.ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_TextChangeConflict, logLevel: LogLevel.Information);
+                        Logger.LogTelemetry(FunctionId.ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationFailed_TextChangeConflict);
                         return false;
                     }
 
@@ -160,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
                 }
             }
 
-            Logger.Log(FunctionId.ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationSucceeded, logLevel: LogLevel.Information);
+            Logger.LogTelemetry(FunctionId.ApplyChangesOperation_WorkspaceVersionMismatch_ApplicationSucceeded);
             return workspace.TryApplyChanges(forkedSolution, progressTracker);
         }
     }

--- a/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/SyntaxTreeFactory/AbstractSyntaxTreeFactoryService.AbstractRecoverableSyntaxRoot.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Host
             {
                 Contract.ThrowIfNull(_storage);
 
-                using (Logger.LogBlock(FunctionId.Workspace_Recoverable_RecoverRootAsync, _containingTree.FilePath, cancellationToken, LogLevel.Information))
+                using (Logger.LogTelemetryBlock(FunctionId.Workspace_Recoverable_RecoverRootAsync, _containingTree.FilePath, cancellationToken))
                 {
                     using var stream = await _storage.ReadStreamAsync(cancellationToken).ConfigureAwait(false);
                     return RecoverRoot(stream, cancellationToken);
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.Host
             {
                 Contract.ThrowIfNull(_storage);
 
-                using (Logger.LogBlock(FunctionId.Workspace_Recoverable_RecoverRoot, _containingTree.FilePath, cancellationToken, LogLevel.Information))
+                using (Logger.LogTelemetryBlock(FunctionId.Workspace_Recoverable_RecoverRoot, _containingTree.FilePath, cancellationToken))
                 {
                     using var stream = _storage.ReadStream(cancellationToken);
                     return RecoverRoot(stream, cancellationToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/LogLevel.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/LogLevel.cs
@@ -28,6 +28,11 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         Information = 2,
 
         /// <summary>
+        /// Logs that track the general flow of the application. These logs should have long-term value.
+        /// </summary>
+        Telemetry = Information,
+
+        /// <summary>
         /// Logs that highlight an abnormal or unexpected event in the application flow, but do not otherwise cause the application execution to stop.
         /// </summary>
         Warning = 3,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/Logger.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/Logger.cs
@@ -148,6 +148,60 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         }
 
         /// <summary>
+        /// log a specific event at the <see cref="LogLevel.Telemetry"/> severity level with a simple context message which should be very cheap to create.
+        /// </summary>
+        public static void LogTelemetry(FunctionId functionId, string? message = null)
+        {
+            Log(functionId, message, LogLevel.Telemetry);
+        }
+
+        /// <summary>
+        /// log a specific event at the <see cref="LogLevel.Telemetry"/> severity level with a context message that will only be created when it is needed.
+        /// the messageGetter should be cheap to create. in another word, it shouldn't capture any locals
+        /// </summary>
+        public static void LogTelemetry(FunctionId functionId, Func<string> messageGetter)
+        {
+            Log(functionId, messageGetter, LogLevel.Telemetry);
+        }
+
+        /// <summary>
+        /// log a specific event at the <see cref="LogLevel.Telemetry"/> severity level with a context message that requires some arguments to be created when requested.
+        /// given arguments will be passed to the messageGetter so that it can create the context message without requiring lifted locals
+        /// </summary>
+        public static void LogTelemetry<TArg>(FunctionId functionId, Func<TArg, string> messageGetter, TArg arg)
+        {
+            Log(functionId, messageGetter, arg, LogLevel.Telemetry);
+        }
+
+        /// <summary>
+        /// log a specific event at the <see cref="LogLevel.Telemetry"/> severity level with a context message that requires some arguments to be created when requested.
+        /// given arguments will be passed to the messageGetter so that it can create the context message without requiring lifted locals
+        /// </summary>
+        public static void LogTelemetry<TArg0, TArg1>(FunctionId functionId, Func<TArg0, TArg1, string> messageGetter, TArg0 arg0, TArg1 arg1)
+        {
+            Log(functionId, messageGetter, arg0, arg1, LogLevel.Telemetry);
+        }
+
+        /// <summary>
+        /// log a specific event at the <see cref="LogLevel.Telemetry"/> severity level with a context message that requires some arguments to be created when requested.
+        /// given arguments will be passed to the messageGetter so that it can create the context message without requiring lifted locals
+        /// </summary>
+        public static void LogTelemetry<TArg0, TArg1, TArg2>(FunctionId functionId, Func<TArg0, TArg1, TArg2, string> messageGetter, TArg0 arg0, TArg1 arg1, TArg2 arg2)
+        {
+            Log(functionId, messageGetter, arg0, arg1, arg2, LogLevel.Telemetry);
+        }
+
+
+        /// <summary>
+        /// log a specific event at the <see cref="LogLevel.Telemetry"/> severity level with a context message that requires some arguments to be created when requested.
+        /// given arguments will be passed to the messageGetter so that it can create the context message without requiring lifted locals
+        /// </summary>
+        public static void LogTelemetry<TArg0, TArg1, TArg2, TArg3>(FunctionId functionId, Func<TArg0, TArg1, TArg2, TArg3, string> messageGetter, TArg0 arg0, TArg1 arg1, TArg2 arg2, TArg3 arg3)
+        {
+            Log(functionId, messageGetter, arg0, arg1, arg2, arg3, LogLevel.Telemetry);
+        }
+
+        /// <summary>
         /// return next unique pair id
         /// </summary>
         private static int GetNextUniqueBlockId()
@@ -219,5 +273,66 @@ namespace Microsoft.CodeAnalysis.Internal.Log
             => TryGetActiveLogger(functionId, out _) ?
                 CreateLogBlock(functionId, logMessage, GetNextUniqueBlockId(), token) :
                 EmptyLogBlock.Instance;
+
+        /// <summary>
+        /// simplest way to log a start and end pair at the <see cref="LogLevel.Telemetry"/> severity level.
+        /// </summary>
+        public static IDisposable LogTelemetryBlock(FunctionId functionId, CancellationToken token)
+        {
+            return LogBlock(functionId, token, LogLevel.Telemetry);
+        }
+
+        /// <summary>
+        /// simplest way to log a start and end pair at the <see cref="LogLevel.Telemetry"/> severity level with a simple context message which should be very cheap to create
+        /// </summary>
+        public static IDisposable LogTelemetryBlock(FunctionId functionId, string? message, CancellationToken token)
+        {
+            return LogBlock(functionId, message, token, LogLevel.Telemetry);
+        }
+
+        /// <summary>
+        /// log a start and end pair at the <see cref="LogLevel.Telemetry"/> severity level with a context message that requires some arguments to be created when requested.
+        /// given arguments will be passed to the messageGetter so that it can create the context message without requiring lifted locals
+        /// </summary>
+        public static IDisposable LogTelemetryBlock(FunctionId functionId, Func<string> messageGetter, CancellationToken token)
+        {
+            return LogBlock(functionId, messageGetter, token, LogLevel.Telemetry);
+        }
+
+        /// <summary>
+        /// log a start and end pair  at the <see cref="LogLevel.Telemetry"/> severity level with a context message that requires some arguments to be created when requested.
+        /// given arguments will be passed to the messageGetter so that it can create the context message without requiring lifted locals
+        /// </summary>
+        public static IDisposable LogTelemetryBlock<TArg>(FunctionId functionId, Func<TArg, string> messageGetter, TArg arg, CancellationToken token)
+        {
+            return LogBlock(functionId, messageGetter, arg, token, LogLevel.Telemetry);
+        }
+
+        /// <summary>
+        /// log a start and end pair  at the <see cref="LogLevel.Telemetry"/> severity level with a context message that requires some arguments to be created when requested.
+        /// given arguments will be passed to the messageGetter so that it can create the context message without requiring lifted locals
+        /// </summary>
+        public static IDisposable LogTelemetryBlock<TArg0, TArg1>(FunctionId functionId, Func<TArg0, TArg1, string> messageGetter, TArg0 arg0, TArg1 arg1, CancellationToken token)
+        {
+            return LogBlock(functionId, messageGetter, arg0, arg1, token, LogLevel.Telemetry);
+        }
+
+        /// <summary>
+        /// log a start and end pair  at the <see cref="LogLevel.Telemetry"/> severity level with a context message that requires some arguments to be created when requested.
+        /// given arguments will be passed to the messageGetter so that it can create the context message without requiring lifted locals
+        /// </summary>
+        public static IDisposable LogTelemetryBlock<TArg0, TArg1, TArg2>(FunctionId functionId, Func<TArg0, TArg1, TArg2, string> messageGetter, TArg0 arg0, TArg1 arg1, TArg2 arg2, CancellationToken token)
+        {
+            return LogBlock(functionId, messageGetter, arg0, arg1, arg2, token, LogLevel.Telemetry);
+        }
+
+        /// <summary>
+        /// log a start and end pair at the <see cref="LogLevel.Telemetry"/> severity level with a context message that requires some arguments to be created when requested.
+        /// given arguments will be passed to the messageGetter so that it can create the context message without requiring lifted locals
+        /// </summary>
+        public static IDisposable LogTelemetryBlock<TArg0, TArg1, TArg2, TArg3>(FunctionId functionId, Func<TArg0, TArg1, TArg2, TArg3, string> messageGetter, TArg0 arg0, TArg1 arg1, TArg2 arg2, TArg3 arg3, CancellationToken token)
+        {
+            return LogBlock(functionId, messageGetter, arg0, arg1, arg2, arg3, token, LogLevel.Telemetry);
+        }
     }
 }


### PR DESCRIPTION
In the course of human events, I've seen folks assume that `Logger.Log(FunctionId.Something)` will log telemetry data.

This is not the case. The default severity value for `Logger.Log` is `LogLevel.Debug` which is never logged in the telemetry system. This had led to cases where we have shipped features and where unaware that we had no telemetry being logged for them.

I propose adding a `LogLevel.Telemetry` and set of `LogTelemetry` and `LogTelemetryBlock` overloads that make it explicit that the developer intends this info to be sent to our telemetry system, in the hopes that this mistake is made less often.