### PR TITLE
Semantic snippets - remove option in 17.4

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpSnippetCompletionProviderTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 
         protected AbstractCSharpSnippetCompletionProviderTests()
         {
-            ShowNewSnippetExperience = true;
+            SnippetCompletion = true;
         }
 
         internal override Type GetCompletionProviderType()

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpSnippetCompletionProviderTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 
         protected AbstractCSharpSnippetCompletionProviderTests()
         {
-            SnippetCompletion = true;
+            ShowNewSnippetExperience = true;
         }
 
         internal override Type GetCompletionProviderType()

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -10501,7 +10501,7 @@ class MyClass
             End Function
         End Class
 
-        <WpfFact>
+        <WpfTheory(Skip:="https://github.com/dotnet/roslyn/issues/64804"), CombinatorialData>
         <Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestSortingOfSameNamedCompletionItems() As Task
             Using state = TestStateFactory.CreateCSharpTestState(

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         protected bool? ForceExpandedCompletionIndexCreation { get; set; }
         protected bool? HideAdvancedMembers { get; set; }
         protected bool? ShowNameSuggestions { get; set; }
-        protected bool? ShowNewSnippetExperience { get; set; }
+        protected bool? SnippetCompletion { get; set; }
 
         protected AbstractCompletionProviderTests()
         {
@@ -85,8 +85,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             if (ShowNameSuggestions.HasValue)
                 options = options with { ShowNameSuggestions = ShowNameSuggestions.Value };
 
-            if (ShowNewSnippetExperience.HasValue)
-                options = options with { ShowNewSnippetExperience = ShowNewSnippetExperience.Value };
+            if (SnippetCompletion.HasValue)
+                options = options with { SnippetCompletion = SnippetCompletion.Value };
 
             return options;
         }

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         protected bool? ForceExpandedCompletionIndexCreation { get; set; }
         protected bool? HideAdvancedMembers { get; set; }
         protected bool? ShowNameSuggestions { get; set; }
-        protected bool? SnippetCompletion { get; set; }
+        protected bool? ShowNewSnippetExperience { get; set; }
 
         protected AbstractCompletionProviderTests()
         {
@@ -85,8 +85,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             if (ShowNameSuggestions.HasValue)
                 options = options with { ShowNameSuggestions = ShowNameSuggestions.Value };
 
-            if (SnippetCompletion.HasValue)
-                options = options with { SnippetCompletion = SnippetCompletion.Value };
+            if (ShowNewSnippetExperience.HasValue)
+                options = options with { ShowNewSnippetExperience = ShowNewSnippetExperience.Value };
 
             return options;
         }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
@@ -157,10 +157,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return ImmutableArray<CompletionItem>.Empty;
 
             var snippets = service.GetSnippetsIfAvailable();
-            if (context.CompletionOptions.ShouldShowNewSnippetExperience(context.Document))
-            {
-                snippets = snippets.Where(snippet => !s_builtInSnippets.Contains(snippet.Shortcut));
-            }
 
             if (isPreProcessorContext)
             {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
@@ -31,14 +31,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
     [Shared]
     internal sealed class SnippetCompletionProvider : LSPCompletionProvider
     {
-        private static readonly HashSet<string> s_builtInSnippets = new()
-        {
-            "#if", "#region", "Attribute", "checked", "class", "ctor", "cw", "do", "else", "enum", "equals", "Exception",
-            "for", "foreach", "forr", "if", "indexer", "interface", "invoke", "iterindex", "iterator", "lock", "mbox",
-            "namespace", "prop", "propa", "propdp", "propfull", "propg", "sim", "struct", "svm", "switch", "testc", "testm",
-            "try", "tryf", "unchecked", "unsafe", "using", "while", "~"
-        };
-
         internal override bool IsSnippetProvider => true;
 
         [ImportingConstructor]
@@ -126,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                         SyntaxKind.WarningKeyword))
                 {
                     return GetSnippetCompletionItems(
-                        completionContext, document.Project.Solution.Services, semanticModel, isPreProcessorContext: true);
+                        document.Project.Solution.Services, semanticModel, isPreProcessorContext: true);
                 }
             }
             else
@@ -142,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     semanticFacts.IsLabelContext(semanticModel, position, cancellationToken))
                 {
                     return GetSnippetCompletionItems(
-                        completionContext, document.Project.Solution.Services, semanticModel, isPreProcessorContext: false);
+                        document.Project.Solution.Services, semanticModel, isPreProcessorContext: false);
                 }
             }
 
@@ -150,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         private static ImmutableArray<CompletionItem> GetSnippetCompletionItems(
-            CompletionContext context, SolutionServices services, SemanticModel semanticModel, bool isPreProcessorContext)
+            SolutionServices services, SemanticModel semanticModel, bool isPreProcessorContext)
         {
             var service = services.GetLanguageServices(semanticModel.Language).GetService<ISnippetInfoService>();
             if (service == null)

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -50,15 +50,5 @@ namespace Microsoft.CodeAnalysis.Completion
             // Don't trigger import completion if the option value is "default" and the experiment is disabled for the user. 
             return ShowItemsFromUnimportedNamespaces ?? TypeImportCompletion;
         }
-
-        /// <summary>
-        /// Whether items from new snippet experience should be included in the completion list.
-        /// This takes into consideration the experiment we are running in addition to the value
-        /// from user facing options.
-        /// </summary>
-        public bool ShouldShowNewSnippetExperience()
-        {
-            return ShowNewSnippetExperience;
-        }
     }
 }

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -29,8 +29,7 @@ namespace Microsoft.CodeAnalysis.Completion
         public bool UpdateImportCompletionCacheInBackground { get; init; } = false;
         public bool FilterOutOfScopeLocals { get; init; } = true;
         public bool ShowXmlDocCommentCompletion { get; init; } = true;
-        public bool? ShowNewSnippetExperience { get; init; } = null;
-        public bool SnippetCompletion { get; init; } = true;
+        public bool SnippetCompletion { get; init; } = false;
         public ExpandedCompletionMode ExpandedCompletionBehavior { get; init; } = ExpandedCompletionMode.AllItems;
         public NamingStylePreferences? NamingStyleFallbackOptions { get; init; } = null;
 
@@ -57,23 +56,9 @@ namespace Microsoft.CodeAnalysis.Completion
         /// This takes into consideration the experiment we are running in addition to the value
         /// from user facing options.
         /// </summary>
-        public bool ShouldShowNewSnippetExperience(Document document)
+        public bool ShouldShowNewSnippetExperience()
         {
-            // Will be removed once semantic snippets will be added to razor.
-            var solution = document.Project.Solution;
-            var documentSupportsFeatureService = solution.Services.GetRequiredService<IDocumentSupportsFeatureService>();
-            if (!documentSupportsFeatureService.SupportsSemanticSnippets(document))
-            {
-                return false;
-            }
-
-            if (document.IsRazorDocument())
-            {
-                return false;
-            }
-
-            // Don't trigger snippet completion if the option value is "default" and the experiment is disabled for the user. 
-            return ShowNewSnippetExperience ?? SnippetCompletion;
+            return SnippetCompletion;
         }
     }
 }

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Completion
         public bool UpdateImportCompletionCacheInBackground { get; init; } = false;
         public bool FilterOutOfScopeLocals { get; init; } = true;
         public bool ShowXmlDocCommentCompletion { get; init; } = true;
-        public bool SnippetCompletion { get; init; } = false;
+        public bool ShowNewSnippetExperience { get; init; } = false;
         public ExpandedCompletionMode ExpandedCompletionBehavior { get; init; } = ExpandedCompletionMode.AllItems;
         public NamingStylePreferences? NamingStyleFallbackOptions { get; init; } = null;
 
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Completion
         /// </summary>
         public bool ShouldShowNewSnippetExperience()
         {
-            return SnippetCompletion;
+            return ShowNewSnippetExperience;
         }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
 
         public override async Task ProvideCompletionsAsync(CompletionContext context)
         {
-            if (!context.CompletionOptions.ShouldShowNewSnippetExperience())
+            if (!context.CompletionOptions.ShowNewSnippetExperience)
             {
                 return;
             }

--- a/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/AbstractSnippetCompletionProvider.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
 
         public override async Task ProvideCompletionsAsync(CompletionContext context)
         {
-            if (!context.CompletionOptions.ShouldShowNewSnippetExperience(context.Document))
+            if (!context.CompletionOptions.ShouldShowNewSnippetExperience())
             {
                 return;
             }

--- a/src/Features/LanguageServer/Protocol/Features/Options/CompletionOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/CompletionOptionsStorage.cs
@@ -82,6 +82,10 @@ internal static class CompletionOptionsStorage
     public static readonly Option2<bool> ForceExpandedCompletionIndexCreation
         = new(nameof(CompletionOptions), nameof(ForceExpandedCompletionIndexCreation), defaultValue: false);
 
+    public static readonly PerLanguageOption2<bool?> ShowNewSnippetExperience
+        = new(nameof(CompletionOptions), nameof(ShowNewSnippetExperience), CompletionOptions.Default.ShowNewSnippetExperience,
+            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowNewSnippetExperience"));
+
     // Set to true to update import completion cache in background if the provider isn't supposed to be triggered in the context.
     // (cache will alsways be refreshed when provider is triggered)
     public static readonly Option2<bool> UpdateImportCompletionCacheInBackground

--- a/src/Features/LanguageServer/Protocol/Features/Options/CompletionOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/CompletionOptionsStorage.cs
@@ -29,8 +29,6 @@ internal static class CompletionOptionsStorage
             ForceExpandedCompletionIndexCreation = options.GetOption(ForceExpandedCompletionIndexCreation),
             UpdateImportCompletionCacheInBackground = options.GetOption(UpdateImportCompletionCacheInBackground),
             NamingStyleFallbackOptions = options.GetNamingStylePreferences(language),
-            ShowNewSnippetExperience = options.GetOption(ShowNewSnippetExperience, language),
-            SnippetCompletion = options.GetOption(ShowNewSnippetExperienceFeatureFlag)
         };
 
     // feature flags
@@ -42,10 +40,6 @@ internal static class CompletionOptionsStorage
     public static readonly Option2<bool> UnnamedSymbolCompletionDisabledFeatureFlag = new(nameof(CompletionOptions), nameof(UnnamedSymbolCompletionDisabledFeatureFlag),
         CompletionOptions.Default.UnnamedSymbolCompletionDisabled,
         new FeatureFlagStorageLocation("Roslyn.UnnamedSymbolCompletionDisabled"));
-
-    public static readonly Option2<bool> ShowNewSnippetExperienceFeatureFlag = new(nameof(CompletionOptions), nameof(ShowNewSnippetExperienceFeatureFlag),
-        CompletionOptions.Default.SnippetCompletion,
-        new FeatureFlagStorageLocation("Roslyn.SnippetCompletion"));
 
     public static readonly PerLanguageOption2<bool> HideAdvancedMembers = new(
         "CompletionOptions", "HideAdvancedMembers", CompletionOptions.Default.HideAdvancedMembers,
@@ -109,7 +103,4 @@ internal static class CompletionOptionsStorage
             CompletionOptions.Default.ProvideDateAndTimeCompletions,
             storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ProvideDateAndTimeCompletions"));
 
-    public static readonly PerLanguageOption2<bool?> ShowNewSnippetExperience
-        = new(nameof(CompletionOptions), nameof(ShowNewSnippetExperience), CompletionOptions.Default.ShowNewSnippetExperience,
-            storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.ShowNewSnippetExperience"));
 }

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
@@ -655,7 +655,4 @@
   <data name="Collapse_usings_on_file_open" xml:space="preserve">
     <value>Collapse usings on file open</value>
   </data>
-  <data name="Show_new_snippet_experience_experimental" xml:space="preserve">
-    <value>Show new snippet experience (experimental)</value>
-  </data>
 </root>

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml
@@ -87,14 +87,6 @@
                               Unchecked="Tab_twice_to_insert_arguments_CheckedChanged"
                               Indeterminate="Tab_twice_to_insert_arguments_CheckedChanged"
                               IsThreeState="True"/>
-
-                    <CheckBox x:Uid="Show_new_snippet_experience"
-                                  x:Name="Show_new_snippet_experience"
-                                  Content="{x:Static local:IntelliSenseOptionPageStrings.Option_Show_new_snippet_experience_experimental}"
-                              Checked="Show_new_snippet_experience_CheckedChanged"
-                              Unchecked="Show_new_snippet_experience_CheckedChanged"
-                              Indeterminate="Show_new_snippet_experience_CheckedChanged"
-                              IsThreeState="True"/>
                 </StackPanel>
             </GroupBox>
         </StackPanel>

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageControl.xaml.cs
@@ -44,9 +44,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
             Tab_twice_to_insert_arguments.IsChecked = this.OptionStore.GetOption(CompletionViewOptions.EnableArgumentCompletionSnippets, LanguageNames.CSharp);
             AddSearchHandler(Tab_twice_to_insert_arguments);
-
-            Show_new_snippet_experience.IsChecked = this.OptionStore.GetOption(CompletionOptionsStorage.ShowNewSnippetExperience, LanguageNames.CSharp);
-            AddSearchHandler(Show_new_snippet_experience);
         }
 
         private void Show_completion_list_after_a_character_is_typed_Checked(object sender, RoutedEventArgs e)
@@ -75,12 +72,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             Tab_twice_to_insert_arguments.IsThreeState = false;
             this.OptionStore.SetOption(CompletionViewOptions.EnableArgumentCompletionSnippets, LanguageNames.CSharp, value: Tab_twice_to_insert_arguments.IsChecked);
-        }
-
-        private void Show_new_snippet_experience_CheckedChanged(object sender, RoutedEventArgs e)
-        {
-            Show_new_snippet_experience.IsThreeState = false;
-            this.OptionStore.SetOption(CompletionOptionsStorage.ShowNewSnippetExperience, LanguageNames.CSharp, value: Show_new_snippet_experience.IsChecked);
         }
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageStrings.cs
@@ -77,8 +77,5 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
         public static string Automatically_show_completion_list_in_argument_lists =>
             CSharpVSResources.Automatically_show_completion_list_in_argument_lists;
-
-        public static string Option_Show_new_snippet_experience_experimental =>
-            CSharpVSResources.Show_new_snippet_experience_experimental;
     }
 }

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.cs.xlf
@@ -182,11 +182,6 @@
         <target state="translated">Zobrazit položky z neimportovaných oborů názvů</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Zobrazit nové prostředí fragmentů kódu (experimentální)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Show_remarks_in_Quick_Info">
         <source>Show remarks in Quick Info</source>
         <target state="translated">Zobrazit poznámky v Rychlých informacích</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.de.xlf
@@ -182,11 +182,6 @@
         <target state="translated">Elemente aus nicht importierten Namespaces anzeigen</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Neue Ausschnittsoberfläche anzeigen (experimentell)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Show_remarks_in_Quick_Info">
         <source>Show remarks in Quick Info</source>
         <target state="translated">Hinweise in QuickInfo anzeigen</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.es.xlf
@@ -182,11 +182,6 @@
         <target state="translated">Mostrar elementos de espacios de nombres no importados</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Mostrar nueva experiencia de fragmento de código (experimental)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Show_remarks_in_Quick_Info">
         <source>Show remarks in Quick Info</source>
         <target state="translated">Mostrar comentarios en Información rápida</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.fr.xlf
@@ -182,11 +182,6 @@
         <target state="translated">Afficher les éléments des espaces de noms qui ne sont pas importés</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Afficher une nouvelle expérience d’extrait de code (expérimental)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Show_remarks_in_Quick_Info">
         <source>Show remarks in Quick Info</source>
         <target state="translated">Afficher les notes dans Info express</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.it.xlf
@@ -182,11 +182,6 @@
         <target state="translated">Mostra elementi da spazi dei nomi non importati</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Mostra nuova esperienza del frammento (sperimentale)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Show_remarks_in_Quick_Info">
         <source>Show remarks in Quick Info</source>
         <target state="translated">Mostra i commenti in Informazioni rapide</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ja.xlf
@@ -182,11 +182,6 @@
         <target state="translated">インポートされていない名前空間の項目を表示する</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">新しいスニペット エクスペリエンスの表示 (試験段階)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Show_remarks_in_Quick_Info">
         <source>Show remarks in Quick Info</source>
         <target state="translated">クイック ヒントに注釈を表示する</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ko.xlf
@@ -182,11 +182,6 @@
         <target state="translated">가져오지 않은 네임스페이스의 항목 표시</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">새 코드 조각 환경 표시(실험적)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Show_remarks_in_Quick_Info">
         <source>Show remarks in Quick Info</source>
         <target state="translated">요약 정보에 설명 표시</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pl.xlf
@@ -182,11 +182,6 @@
         <target state="translated">Pokaż elementy z nieimportowanych przestrzeni nazw</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Pokaż nowe środowisko fragmentu kodu (eksperymentalne)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Show_remarks_in_Quick_Info">
         <source>Show remarks in Quick Info</source>
         <target state="translated">Pokaż uwagi w szybkich podpowiedziach</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.pt-BR.xlf
@@ -182,11 +182,6 @@
         <target state="translated">Mostrar os itens de namespaces não importados</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Mostrar nova experiência de snippet de código (experimental)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Show_remarks_in_Quick_Info">
         <source>Show remarks in Quick Info</source>
         <target state="translated">Mostrar os comentários nas Informações Rápidas</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.ru.xlf
@@ -182,11 +182,6 @@
         <target state="translated">Отображать элементы из неимпортированных пространств имен</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Показывать новый интерфейс фрагмента кода (экспериментальная функция)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Show_remarks_in_Quick_Info">
         <source>Show remarks in Quick Info</source>
         <target state="translated">Показать заметки в кратких сведениях</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.tr.xlf
@@ -182,11 +182,6 @@
         <target state="translated">İçeri aktarılmayan ad alanlarındaki öğeleri göster</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">Yeni kod parçacığı deneyimini göster (deneysel)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Show_remarks_in_Quick_Info">
         <source>Show remarks in Quick Info</source>
         <target state="translated">Hızlı Bilgi notlarını göster</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hans.xlf
@@ -182,11 +182,6 @@
         <target state="translated">显示 unimported 命名空间中的项</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">显示新的代码片段体验(试验)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Show_remarks_in_Quick_Info">
         <source>Show remarks in Quick Info</source>
         <target state="translated">在快速信息中显示备注</target>

--- a/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
+++ b/src/VisualStudio/CSharp/Impl/xlf/CSharpVSResources.zh-Hant.xlf
@@ -182,11 +182,6 @@
         <target state="translated">顯示來自未匯入命名空間的項目</target>
         <note />
       </trans-unit>
-      <trans-unit id="Show_new_snippet_experience_experimental">
-        <source>Show new snippet experience (experimental)</source>
-        <target state="translated">顯示新的程式碼片段體驗 (實驗性)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Show_remarks_in_Quick_Info">
         <source>Show remarks in Quick Info</source>
         <target state="translated">在快速諮詢中顯示備註</target>


### PR DESCRIPTION
To tackle #64782 and #64779, just remove the option for snippets from the Intellisense options page and ensure that snippets don't appear in the completion list.

Will be enabled in 17.5