### PR TITLE
Support caller info and nullability attributes in lambdas

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8921,8 +8921,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             var parameterDefaultValues = parameters.Any(p => p.HasExplicitDefaultValue) ?
                 parameters.SelectAsArray(p => p.ExplicitDefaultConstantValue) :
                 default;
+            var parameterSymbolsForAttributes = parameters.All(p => p is SourceComplexParameterSymbolBase) ?
+                parameters.SelectAsArray(p => (SourceComplexParameterSymbolBase)p) :
+                default;
 
-            return GetMethodGroupOrLambdaDelegateType(node.Syntax, method.RefKind, method.ReturnTypeWithAnnotations, method.ParameterRefKinds, parameterScopes, method.ParameterTypesWithAnnotations, parameterDefaultValues: parameterDefaultValues);
+            return GetMethodGroupOrLambdaDelegateType(node.Syntax, method.RefKind, method.ReturnTypeWithAnnotations, method.ParameterRefKinds, parameterScopes, method.ParameterTypesWithAnnotations, parameterDefaultValues, parameterSymbolsForAttributes);
         }
 
         /// <summary>
@@ -9009,7 +9012,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<RefKind> parameterRefKinds,
             ImmutableArray<DeclarationScope> parameterScopes,
             ImmutableArray<TypeWithAnnotations> parameterTypes,
-            ImmutableArray<ConstantValue?> parameterDefaultValues)
+            ImmutableArray<ConstantValue?> parameterDefaultValues,
+            ImmutableArray<SourceComplexParameterSymbolBase> parameterSymbolsForAttributes)
         {
             Debug.Assert(ContainingMemberOrLambda is { });
             Debug.Assert(parameterRefKinds.IsDefault || parameterRefKinds.Length == parameterTypes.Length);
@@ -9069,7 +9073,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         parameterTypes[i],
                         parameterRefKinds.IsDefault ? RefKind.None : parameterRefKinds[i],
                         parameterScopes.IsDefault ? DeclarationScope.Unscoped : parameterScopes[i],
-                        parameterDefaultValues.IsDefault ? null : parameterDefaultValues[i])
+                        parameterDefaultValues.IsDefault ? null : parameterDefaultValues[i],
+                        parameterSymbolsForAttributes.IsDefault ? null : parameterSymbolsForAttributes[i])
                     );
             }
             fieldsBuilder.Add(new AnonymousTypeField(name: "", location, returnType, returnRefKind, DeclarationScope.Unscoped));

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -722,6 +722,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 returnType = TypeWithAnnotations.Create(Binder.Compilation.GetSpecialType(SpecialType.System_Void));
             }
 
+            var parameterSymbolsForAttributes = lambdaSymbol.Parameters.All(p => p is SourceComplexParameterSymbolBase)
+                ? lambdaSymbol.Parameters.SelectAsArray(p => (SourceComplexParameterSymbolBase)p) : default;
+
             return Binder.GetMethodGroupOrLambdaDelegateType(
                 _unboundLambda.Syntax,
                 returnRefKind,
@@ -729,7 +732,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 parameterRefKinds,
                 parameterEffectiveScopesBuilder.ToImmutableAndFree(),
                 parameterTypes,
-                parameterDefaultValues);
+                parameterDefaultValues,
+                parameterSymbolsForAttributes);
 
             LambdaSymbol createLambdaSymbol()
             {

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeField.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeField.cs
@@ -26,11 +26,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public readonly ConstantValue? DefaultValue;
 
+        public readonly SourceComplexParameterSymbolBase? ParameterSymbolForAttributes;
+
         /// <summary>Anonymous type field type</summary>
         public TypeSymbol Type => TypeWithAnnotations.Type;
 
         // PROTOTYPE: Sync with IDE about the addition of DefaultValue to AnonymousTypeField to see how it will affect their usage of anonymous type symbols
-        public AnonymousTypeField(string name, Location location, TypeWithAnnotations typeWithAnnotations, RefKind refKind, DeclarationScope scope, ConstantValue? defaultValue = null)
+        public AnonymousTypeField(string name, Location location, TypeWithAnnotations typeWithAnnotations, RefKind refKind, DeclarationScope scope, ConstantValue? defaultValue = null, SourceComplexParameterSymbolBase? parameterSymbolForAttributes = null)
         {
             this.Name = name;
             this.Location = location;
@@ -38,6 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             this.RefKind = refKind;
             this.Scope = scope;
             this.DefaultValue = defaultValue;
+            this.ParameterSymbolForAttributes = parameterSymbolForAttributes;
         }
 
         [Conditional("DEBUG")]

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.DelegatePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.DelegatePublicSymbol.cs
@@ -54,11 +54,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var constructor = new SynthesizedDelegateConstructor(this, Manager.System_Object, Manager.System_IntPtr);
                 var fields = TypeDescriptor.Fields;
                 int parameterCount = fields.Length - 1;
-                var parameters = ArrayBuilder<(TypeWithAnnotations, RefKind, DeclarationScope, ConstantValue?)>.GetInstance(parameterCount);
+                var parameters = ArrayBuilder<(TypeWithAnnotations, RefKind, DeclarationScope, ConstantValue?, SourceComplexParameterSymbolBase?)>.GetInstance(parameterCount);
                 for (int i = 0; i < parameterCount; i++)
                 {
                     var field = fields[i];
-                    parameters.Add((field.TypeWithAnnotations, field.RefKind, field.Scope, field.DefaultValue));
+                    parameters.Add((field.TypeWithAnnotations, field.RefKind, field.Scope, field.DefaultValue, field.ParameterSymbolForAttributes));
                 }
                 var returnField = fields.Last();
                 var invokeMethod = new SynthesizedDelegateInvokeMethod(this, parameters, returnField.TypeWithAnnotations, returnField.RefKind);

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.DelegateTemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.DelegateTemplateSymbol.cs
@@ -53,10 +53,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var typeParams = containingType.TypeParameters;
 
                     int parameterCount = typeParams.Length - (voidReturnTypeOpt is null ? 1 : 0);
-                    var parameters = ArrayBuilder<(TypeWithAnnotations, RefKind, DeclarationScope, ConstantValue?)>.GetInstance(parameterCount);
+                    var parameters = ArrayBuilder<(TypeWithAnnotations, RefKind, DeclarationScope, ConstantValue?, SourceComplexParameterSymbolBase?)>.GetInstance(parameterCount);
                     for (int i = 0; i < parameterCount; i++)
                     {
-                        parameters.Add((TypeWithAnnotations.Create(typeParams[i]), refKinds.IsNull ? RefKind.None : refKinds[i], DeclarationScope.Unscoped, null));
+                        parameters.Add((TypeWithAnnotations.Create(typeParams[i]), refKinds.IsNull ? RefKind.None : refKinds[i], DeclarationScope.Unscoped, null, null));
                     }
 
                     // if we are given Void type the method returns Void, otherwise its return type is the last type parameter of the delegate:
@@ -127,11 +127,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     TypeMap typeMap)
                 {
                     var parameterCount = fields.Length - 1;
-                    var parameters = ArrayBuilder<(TypeWithAnnotations, RefKind, DeclarationScope, ConstantValue?)>.GetInstance(parameterCount);
+                    var parameters = ArrayBuilder<(TypeWithAnnotations, RefKind, DeclarationScope, ConstantValue?, SourceComplexParameterSymbolBase?)>.GetInstance(parameterCount);
                     for (int i = 0; i < parameterCount; i++)
                     {
                         var field = fields[i];
-                        parameters.Add((typeMap.SubstituteType(field.Type), field.RefKind, field.Scope, field.DefaultValue));
+                        parameters.Add((typeMap.SubstituteType(field.Type), field.RefKind, field.Scope, field.DefaultValue, field.ParameterSymbolForAttributes));
                     }
 
                     var returnParameter = fields[^1];

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
@@ -32,12 +32,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private readonly NamedTypeSymbol _containingType;
 
-        internal SynthesizedDelegateInvokeMethod(NamedTypeSymbol containingType, ArrayBuilder<(TypeWithAnnotations Type, RefKind RefKind, DeclarationScope Scope, ConstantValue? DefaultValue)> parameterDescriptions, TypeWithAnnotations returnType, RefKind refKind)
+        internal SynthesizedDelegateInvokeMethod(NamedTypeSymbol containingType, ArrayBuilder<(TypeWithAnnotations Type, RefKind RefKind, DeclarationScope Scope, ConstantValue? DefaultValue, SourceComplexParameterSymbolBase? ParameterSymbolForAttributes)> parameterDescriptions, TypeWithAnnotations returnType, RefKind refKind)
         {
             _containingType = containingType;
 
             Parameters = parameterDescriptions.SelectAsArrayWithIndex(static (p, i, a) =>
-                SynthesizedParameterSymbol.Create(a.Method, p.Type, i, p.RefKind, GeneratedNames.AnonymousDelegateParameterName(i, a.ParameterCount), p.Scope, defaultValue: p.DefaultValue),
+                SynthesizedParameterSymbol.Create(a.Method, p.Type, i, p.RefKind, GeneratedNames.AnonymousDelegateParameterName(i, a.ParameterCount), p.Scope, defaultValue: p.DefaultValue, baseParameterForAttributes: p.ParameterSymbolForAttributes),
                 (Method: this, ParameterCount: parameterDescriptions.Count));
             ReturnTypeWithAnnotations = returnType;
             RefKind = refKind;

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedParameterSymbol.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override int CallerArgumentExpressionParameterIndex
         {
-            get { return -1; }
+            get { throw ExceptionUtilities.Unreachable(); }
         }
 
         internal override FlowAnalysisAnnotations FlowAnalysisAnnotations
@@ -318,7 +318,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override MarshalPseudoCustomAttributeData? MarshallingInformation => _baseParameterForAttributes?.MarshallingInformation;
 
-        internal override bool IsMetadataOptional => _baseParameterForAttributes?.IsMetadataOptional ?? base.IsMetadataOptional;
+        internal override bool IsMetadataOptional => _defaultValue is not null || (_baseParameterForAttributes?.IsMetadataOptional ?? base.IsMetadataOptional);
 
         internal override bool IsCallerLineNumber
         {
@@ -335,28 +335,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get => _baseParameterForAttributes?.IsCallerMemberName ?? false;
         }
 
+        internal override int CallerArgumentExpressionParameterIndex
+        {
+            get => _baseParameterForAttributes?.CallerArgumentExpressionParameterIndex ?? -1;
+        }
+
         internal override bool IsMetadataIn => RefKind == RefKind.In || _baseParameterForAttributes?.GetDecodedWellKnownAttributeData()?.HasInAttribute == true;
 
         internal override bool IsMetadataOut => RefKind == RefKind.Out || _baseParameterForAttributes?.GetDecodedWellKnownAttributeData()?.HasOutAttribute == true;
 
-        internal override ConstantValue? ExplicitDefaultConstantValue => _baseParameterForAttributes?.ExplicitDefaultConstantValue ?? _defaultValue;
+        internal override ConstantValue? ExplicitDefaultConstantValue => _defaultValue ?? _baseParameterForAttributes?.ExplicitDefaultConstantValue;
 
-        internal override FlowAnalysisAnnotations FlowAnalysisAnnotations
-        {
-            get
-            {
-                Debug.Assert(_baseParameterForAttributes is null);
-                return base.FlowAnalysisAnnotations;
-            }
-        }
+        internal override FlowAnalysisAnnotations FlowAnalysisAnnotations => _baseParameterForAttributes?.FlowAnalysisAnnotations ?? base.FlowAnalysisAnnotations;
 
-        internal override ImmutableHashSet<string> NotNullIfParameterNotNull
-        {
-            get
-            {
-                Debug.Assert(_baseParameterForAttributes is null);
-                return base.NotNullIfParameterNotNull;
-            }
-        }
+        internal override ImmutableHashSet<string> NotNullIfParameterNotNull => _baseParameterForAttributes?.NotNullIfParameterNotNull ?? base.NotNullIfParameterNotNull;
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -12538,11 +12538,6 @@ class Program
             CompileAndVerify(source, expectedOutput: "0.3333333333333333333333333333");
         }
 
-
-        // PROTOTYPE: Do we want to allow [Caller{MemberName, LineNumber, FilePath, ArgumentExpression}] attributes for lambdas since
-        // we now have default parameters? The current behavior is to ignore these attributes so that the provided
-        // default would always be used in these cases.
-
         [Fact]
         public void CallerAttributesOnLambdaWithDefaultParam()
         {
@@ -12559,9 +12554,8 @@ class Program
     }
 }
 """;
-            CompileAndVerify(source, expectedOutput: "file::member:0");
+            CompileAndVerify(source, expectedOutput: "::Main:9");
         }
-
 
         [Fact]
         public void CallerArgumentExpressionAttributeOnLambdaWithDefaultParam()
@@ -12581,7 +12575,7 @@ class Program
 """;
             CompileAndVerify(source, targetFramework: TargetFramework.Net60,
                                      verify: ExecutionConditionUtil.IsCoreClr ? Verification.Passes : Verification.Skipped,
-                                     expectedOutput: ExecutionConditionUtil.IsCoreClr ? "callerArgExpression" : null);
+                                     expectedOutput: ExecutionConditionUtil.IsCoreClr ? "3" : null);
         }
 
         [Fact]


### PR DESCRIPTION
Adds support for `[CallerMemberName]`+friends and `[AllowNull]`+friends in lambdas by forwarding them from a lambda declaration into its synthesized delegate type. In fact, with the proposed implementation, all well-known attributes forwarded by `SynthesizedComplexParameterSymbol` are supported.