### PR TITLE
Snippets - turn on by default in 17.5

### DIFF
--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Completion
         public bool FilterOutOfScopeLocals { get; init; } = true;
         public bool ShowXmlDocCommentCompletion { get; init; } = true;
         public bool? ShowNewSnippetExperience { get; init; } = null;
-        public bool SnippetCompletion { get; init; } = false;
+        public bool SnippetCompletion { get; init; } = true;
         public ExpandedCompletionMode ExpandedCompletionBehavior { get; init; } = ExpandedCompletionMode.AllItems;
         public NamingStylePreferences? NamingStyleFallbackOptions { get; init; } = null;
 


### PR DESCRIPTION
Reverts change accidentally made in merge of release/dev17.4 into main