### PR TITLE
Fix color contrast for highlighted item

### DIFF
--- a/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorer.xaml
+++ b/src/VisualStudio/Core/Def/StackTraceExplorer/StackTraceExplorer.xaml
@@ -28,18 +28,50 @@
             SelectedItem="{Binding Selection, Mode=TwoWay}" 
             MouseDoubleClick="ListViewItem_MouseDoubleClick" 
             Visibility="{Binding IsListVisible, Converter={StaticResource BooleanToVisibilityConverter}}"
-            BorderThickness="0"
             Background="Transparent"
             Focusable="True"
             AutomationProperties.Name="{Binding StackTrace}">
             <ListView.ItemContainerStyle>
                 <Style TargetType="ListViewItem">
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type ListViewItem}">
+                                <Border
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    Margin="{TemplateBinding Margin}"
+                                    Padding="{TemplateBinding Padding}"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                    HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                                    VerticalAlignment="{TemplateBinding VerticalAlignment}">
+
+                                    <ContentPresenter />
+                                </Border>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding ShowMouseOver}" Value="False">
                             <DataTrigger.Setters>
                                 <Setter Property="IsHitTestVisible" Value="False" />
                             </DataTrigger.Setters>
                         </DataTrigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Trigger.Setters>
+                                <Setter Property="Background" Value="Transparent" />
+                                <Setter Property="BorderBrush" Value="{StaticResource {x:Static vsshell:VsBrushes.ActiveBorderKey}}" />
+                                <Setter Property="BorderThickness" Value="2" />
+                                <Setter Property="Padding" Value="1" />
+                            </Trigger.Setters>
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="False">
+                            <Trigger.Setters>
+                                <Setter Property="Background" Value="Transparent" />
+                                <Setter Property="BorderThickness" Value="0" />
+                                <Setter Property="Padding" Value="3" />
+                            </Trigger.Setters>
+                        </Trigger>
                     </Style.Triggers>
                 </Style>
             </ListView.ItemContainerStyle>


### PR DESCRIPTION
Fixes [AB#1614420](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1614420) by keeping the background the same and only using a border for selected items. 

### Dark Theme 

![fef7c6fa-ffff-4657-999b-883a69143c92](https://user-images.githubusercontent.com/475144/196817713-80f1952d-4952-45da-be17-f0bb8b1c89ab.gif)


### Light Theme

![06931d5e-48e8-4e22-bf1b-0b93c32b5b4c](https://user-images.githubusercontent.com/475144/196817929-a580a6c0-8af0-4523-b911-50d553f59164.gif)
