### PR TITLE
Only write out inVs properties when appropriate

### DIFF
--- a/src/Features/Lsif/Generator/Writing/LsifConverter.cs
+++ b/src/Features/Lsif/Generator/Writing/LsifConverter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 using Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph;
 using Newtonsoft.Json;
 
@@ -12,8 +13,18 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing
     {
         public override bool CanConvert(Type objectType)
         {
-            return typeof(ISerializableId).IsAssignableFrom(objectType) ||
-                   objectType == typeof(Uri);
+            if (typeof(ISerializableId).IsAssignableFrom(objectType) ||
+                objectType == typeof(Uri))
+            {
+                return true;
+            }
+
+            if (objectType.IsConstructedGenericType && objectType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                return CanConvert(objectType.GenericTypeArguments.Single());
+            }
+
+            return false;
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)

--- a/src/Features/Lsif/GeneratorTest/OutputFormatTests.vb
+++ b/src/Features/Lsif/GeneratorTest/OutputFormatTests.vb
@@ -32,7 +32,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
 {""kind"":""begin"",""scope"":""document"",""data"":4,""id"":5,""type"":""vertex"",""label"":""$event""}
 {""outV"":4,""inVs"":[],""id"":6,""type"":""edge"",""label"":""contains""}
 {""result"":[],""id"":7,""type"":""vertex"",""label"":""foldingRangeResult""}
-{""outV"":4,""inVs"":[7],""id"":8,""type"":""edge"",""label"":""textDocument/foldingRange""}
+{""outV"":4,""inV"":7,""id"":8,""type"":""edge"",""label"":""textDocument/foldingRange""}
 {""kind"":""end"",""scope"":""document"",""data"":4,""id"":9,""type"":""vertex"",""label"":""$event""}
 {""outV"":2,""inVs"":[4],""id"":10,""type"":""edge"",""label"":""contains""}
 {""kind"":""end"",""scope"":""project"",""data"":2,""id"":11,""type"":""vertex"",""label"":""$event""}
@@ -114,9 +114,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
   },
   {
     ""outV"": 4,
-    ""inVs"": [
-      7
-    ],
+    ""inV"": 7,
     ""id"": 8,
     ""type"": ""edge"",
     ""label"": ""textDocument/foldingRange""

--- a/src/Features/Lsif/GeneratorTest/Utilities/TestLsifJsonWriter.vb
+++ b/src/Features/Lsif/GeneratorTest/Utilities/TestLsifJsonWriter.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests.U
                     ' that an edge can only be written after all the vertices it writes to already exist.
                     Dim outVertex = GetElementById(edge.OutVertex)
 
-                    For Each inVertexId In edge.InVertices
+                    For Each inVertexId In edge.GetInVerticies()
                         ' We are ignoring the return, but this call implicitly validates the element
                         ' exists and is of the correct type.
                         GetElementById(inVertexId)
@@ -78,7 +78,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests.U
 
                 Dim edges As List(Of Edge) = Nothing
                 If _edgesByOutVertex.TryGetValue(vertex, edges) Then
-                    Dim inVerticesId = edges.Where(predicate).SelectMany(Function(e) e.InVertices)
+                    Dim inVerticesId = edges.Where(predicate).SelectMany(Function(e) e.GetInVerticies())
 
                     For Each inVertexId In inVerticesId
                         ' This is an unsafe "cast" if you will converting the ID to the expected type;


### PR DESCRIPTION
LSIF edges nodes can use "inV" properties to indicate one-to-one edges, or "inVs" (plural) to indicate one-to-many edges. I previously cheated and used "inVs" everywhere when we wrote out JSON, and it just happened that there was only ever a single vertex in the list when it was supposed to be one-to-one. Some import tools were OK with this, but validation tools still flag this as spec violation, so let's do it properly.

Fixes https://github.com/dotnet/roslyn/issues/63841