### PR TITLE
Allow and emit `params` arrays in lambdas

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
@@ -46,6 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             public override int ParameterCount { get { return _parameters.Length; } }
             public override bool IsAsync { get { return false; } }
             public override bool IsStatic => false;
+            public override bool HasParamsArray => false;
             public override RefKind RefKind(int index) { return Microsoft.CodeAnalysis.RefKind.None; }
             public override DeclarationScope DeclaredScope(int index) => DeclarationScope.Unscoped;
             public override MessageID MessageID { get { return MessageID.IDS_FeatureQueryExpression; } } // TODO: what is the correct ID here?

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -8921,8 +8921,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             var parameterDefaultValues = parameters.Any(p => p.HasExplicitDefaultValue) ?
                 parameters.SelectAsArray(p => p.ExplicitDefaultConstantValue) :
                 default;
+            var hasParamsArray = !parameters.IsEmpty && parameters[^1].IsParams;
 
-            return GetMethodGroupOrLambdaDelegateType(node.Syntax, method.RefKind, method.ReturnTypeWithAnnotations, method.ParameterRefKinds, parameterScopes, method.ParameterTypesWithAnnotations, parameterDefaultValues: parameterDefaultValues);
+            return GetMethodGroupOrLambdaDelegateType(node.Syntax, method.RefKind, method.ReturnTypeWithAnnotations, method.ParameterRefKinds, parameterScopes, method.ParameterTypesWithAnnotations, parameterDefaultValues, hasParamsArray);
         }
 
         /// <summary>
@@ -9009,12 +9010,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<RefKind> parameterRefKinds,
             ImmutableArray<DeclarationScope> parameterScopes,
             ImmutableArray<TypeWithAnnotations> parameterTypes,
-            ImmutableArray<ConstantValue?> parameterDefaultValues)
+            ImmutableArray<ConstantValue?> parameterDefaultValues,
+            bool hasParamsArray)
         {
             Debug.Assert(ContainingMemberOrLambda is { });
             Debug.Assert(parameterRefKinds.IsDefault || parameterRefKinds.Length == parameterTypes.Length);
             Debug.Assert(parameterDefaultValues.IsDefault || parameterDefaultValues.Length == parameterTypes.Length);
             Debug.Assert(returnType.Type is { }); // Expecting System.Void rather than null return type.
+            Debug.Assert(!hasParamsArray || parameterTypes.Length != 0);
 
             bool returnsVoid = returnType.Type.IsVoidType();
             var typeArguments = returnsVoid ? parameterTypes : parameterTypes.Add(returnType);
@@ -9032,7 +9035,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Use System.Action<...> or System.Func<...> if possible.
-            if (returnRefKind == RefKind.None &&
+            if (!hasParamsArray &&
+                returnRefKind == RefKind.None &&
                 parameterDefaultValues.IsDefault &&
                 (parameterRefKinds.IsDefault || parameterRefKinds.All(refKind => refKind == RefKind.None)) &&
                 (parameterScopes.IsDefault || parameterScopes.All(scope => scope == DeclarationScope.Unscoped)))
@@ -9069,7 +9073,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         parameterTypes[i],
                         parameterRefKinds.IsDefault ? RefKind.None : parameterRefKinds[i],
                         parameterScopes.IsDefault ? DeclarationScope.Unscoped : parameterScopes[i],
-                        parameterDefaultValues.IsDefault ? null : parameterDefaultValues[i])
+                        parameterDefaultValues.IsDefault ? null : parameterDefaultValues[i],
+                        isParams: hasParamsArray && i == parameterTypes.Length - 1)
                     );
             }
             fieldsBuilder.Add(new AnonymousTypeField(name: "", location, returnType, returnRefKind, DeclarationScope.Unscoped));

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
@@ -92,6 +92,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var isAsync = syntax.Modifiers.Any(SyntaxKind.AsyncKeyword);
             var isStatic = syntax.Modifiers.Any(SyntaxKind.StaticKeyword);
+            var hasParamsArray = false;
 
             if (parameterSyntaxList != null)
             {
@@ -140,7 +141,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         type = BindType(typeSyntax, diagnostics);
                         ParameterHelpers.CheckParameterModifiers(p, diagnostics, parsingFunctionPointerParams: false, parsingLambdaParams: true);
-                        refKind = ParameterHelpers.GetModifiers(p.Modifiers, out _, out _, out _, out scope);
+                        refKind = ParameterHelpers.GetModifiers(p.Modifiers, out _, out var paramsKeyword, out _, out scope);
+                        if (paramsKeyword.Kind() != SyntaxKind.None)
+                        {
+                            hasParamsArray = true;
+                        }
                     }
 
                     namesBuilder.Add(p.Identifier.ValueText);
@@ -192,7 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             namesBuilder.Free();
 
-            return UnboundLambda.Create(syntax, this, diagnostics.AccumulatesDependencies, returnRefKind, returnType, parameterAttributes, refKinds, scopes, types, names, discardsOpt, parameterSyntaxList, defaultValues, isAsync, isStatic);
+            return UnboundLambda.Create(syntax, this, diagnostics.AccumulatesDependencies, returnRefKind, returnType, parameterAttributes, refKinds, scopes, types, names, discardsOpt, parameterSyntaxList, defaultValues, isAsync, isStatic, hasParamsArray);
 
             static ImmutableArray<bool> computeDiscards(SeparatedSyntaxList<ParameterSyntax> parameters, int underscoresCount)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
@@ -140,7 +140,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     else
                     {
                         type = BindType(typeSyntax, diagnostics);
-                        ParameterHelpers.CheckParameterModifiers(p, diagnostics, parsingFunctionPointerParams: false, parsingLambdaParams: true);
+                        ParameterHelpers.CheckParameterModifiers(p, diagnostics, parsingFunctionPointerParams: false, parsingLambdaParams: true,
+                            parsingAnonymousMethod: syntax.Kind() == SyntaxKind.AnonymousMethodExpression);
                         refKind = ParameterHelpers.GetModifiers(p.Modifiers, out _, out var paramsKeyword, out _, out scope);
                         if (paramsKeyword.Kind() != SyntaxKind.None)
                         {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             namesBuilder.Free();
 
-            return UnboundLambda.Create(syntax, this, diagnostics.AccumulatesDependencies, returnRefKind, returnType, parameterAttributes, refKinds, scopes, types, names, discardsOpt, parameterSyntaxList, defaultValues, isAsync, isStatic, hasParamsArray);
+            return UnboundLambda.Create(syntax, this, diagnostics.AccumulatesDependencies, returnRefKind, returnType, parameterAttributes, refKinds, scopes, types, names, discardsOpt, parameterSyntaxList, defaultValues, isAsync: isAsync, isStatic: isStatic, hasParamsArray: hasParamsArray);
 
             static ImmutableArray<bool> computeDiscards(SeparatedSyntaxList<ParameterSyntax> parameters, int underscoresCount)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
@@ -143,8 +143,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     else
                     {
                         type = BindType(typeSyntax, diagnostics);
-                        ParameterHelpers.CheckParameterModifiers(p, diagnostics, parsingFunctionPointerParams: false, parsingLambdaParams: true,
-                            parsingAnonymousMethod: syntax.IsKind(SyntaxKind.AnonymousMethodExpression));
+                        var isAnonymousMethod = syntax.IsKind(SyntaxKind.AnonymousMethodExpression);
+                        ParameterHelpers.CheckParameterModifiers(p, diagnostics, parsingFunctionPointerParams: false,
+                            parsingLambdaParams: !isAnonymousMethod,
+                            parsingAnonymousMethodParams: isAnonymousMethod);
                         refKind = ParameterHelpers.GetModifiers(p.Modifiers, out _, out var paramsKeyword, out _, out scope);
 
                         var isLastParameter = parameterCount == parameterSyntaxList.Value.Count;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
@@ -112,9 +112,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // However, we still want to give errors on every bad type in the list, even if one
                 // is missing.
 
+                int parameterCount = 0;
                 int underscoresCount = 0;
                 foreach (var p in parameterSyntaxList.Value)
                 {
+                    parameterCount++;
+
                     if (p.Identifier.IsUnderscoreToken())
                     {
                         underscoresCount++;
@@ -143,7 +146,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         ParameterHelpers.CheckParameterModifiers(p, diagnostics, parsingFunctionPointerParams: false, parsingLambdaParams: true,
                             parsingAnonymousMethod: syntax.Kind() == SyntaxKind.AnonymousMethodExpression);
                         refKind = ParameterHelpers.GetModifiers(p.Modifiers, out _, out var paramsKeyword, out _, out scope);
-                        if (paramsKeyword.Kind() != SyntaxKind.None)
+
+                        var isLastParameter = parameterCount == parameterSyntaxList.Value.Count;
+                        if (isLastParameter && paramsKeyword.Kind() != SyntaxKind.None)
                         {
                             hasParamsArray = true;
                         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
@@ -326,6 +326,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     // UNDONE: Where do we report improper use of pointer types?
+                    // PROTOTYPE: Set `isParams` to report errors about them.
                     ParameterHelpers.ReportParameterErrors(owner: null, paramSyntax, ordinal: i, isParams: false, lambda.ParameterTypeWithAnnotations(i),
                          lambda.RefKind(i), lambda.DeclaredScope(i), containingSymbol: null, thisKeyword: default, paramsKeyword: default, firstDefault, diagnostics);
                 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         type = BindType(typeSyntax, diagnostics);
                         ParameterHelpers.CheckParameterModifiers(p, diagnostics, parsingFunctionPointerParams: false, parsingLambdaParams: true,
-                            parsingAnonymousMethod: syntax.Kind() == SyntaxKind.AnonymousMethodExpression);
+                            parsingAnonymousMethod: syntax.IsKind(SyntaxKind.AnonymousMethodExpression));
                         refKind = ParameterHelpers.GetModifiers(p.Modifiers, out _, out var paramsKeyword, out _, out scope);
 
                         var isLastParameter = parameterCount == parameterSyntaxList.Value.Count;

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -398,7 +398,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool hasErrors = !types.IsDefault && types.Any(static t => t.Type?.Kind == SymbolKind.ErrorType);
 
             var functionType = FunctionTypeSymbol.CreateIfFeatureEnabled(syntax, binder, static (binder, expr) => ((UnboundLambda)expr).Data.InferDelegateType());
-            var data = new PlainUnboundLambdaState(binder, returnRefKind, returnType, parameterAttributes, names, discardsOpt, types, refKinds, declaredScopes, defaultValues, syntaxList, isAsync, isStatic, hasParamsArray, includeCache: true);
+            var data = new PlainUnboundLambdaState(binder, returnRefKind, returnType, parameterAttributes, names, discardsOpt, types, refKinds, declaredScopes, defaultValues, syntaxList, isAsync: isAsync, isStatic: isStatic, hasParamsArray: hasParamsArray, includeCache: true);
             var lambda = new UnboundLambda(syntax, data, functionType, withDependencies, hasErrors: hasErrors);
             data.SetUnboundLambda(lambda);
             functionType?.SetExpression(lambda.WithNoCache());
@@ -1615,7 +1615,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override UnboundLambdaState WithCachingCore(bool includeCache)
         {
-            return new PlainUnboundLambdaState(Binder, _returnRefKind, _returnType, _parameterAttributes, _parameterNames, _parameterIsDiscardOpt, _parameterTypesWithAnnotations, _parameterRefKinds, _parameterDeclaredScopes, _defaultValues, _parameterSyntaxList, _isAsync, _isStatic, _hasParamsArray, includeCache);
+            return new PlainUnboundLambdaState(Binder, _returnRefKind, _returnType, _parameterAttributes, _parameterNames, _parameterIsDiscardOpt, _parameterTypesWithAnnotations, _parameterRefKinds, _parameterDeclaredScopes, _defaultValues, _parameterSyntaxList, isAsync: _isAsync, isStatic: _isStatic, hasParamsArray: _hasParamsArray, includeCache: includeCache);
         }
 
         protected override BoundExpression? GetLambdaExpressionBody(BoundBlock body)

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -390,14 +390,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             SeparatedSyntaxList<ParameterSyntax>? syntaxList,
             ImmutableArray<EqualsValueClauseSyntax?> defaultValues,
             bool isAsync,
-            bool isStatic)
+            bool isStatic,
+            bool hasParamsArray)
         {
             Debug.Assert(binder != null);
             Debug.Assert(syntax.IsAnonymousFunction());
             bool hasErrors = !types.IsDefault && types.Any(static t => t.Type?.Kind == SymbolKind.ErrorType);
 
             var functionType = FunctionTypeSymbol.CreateIfFeatureEnabled(syntax, binder, static (binder, expr) => ((UnboundLambda)expr).Data.InferDelegateType());
-            var data = new PlainUnboundLambdaState(binder, returnRefKind, returnType, parameterAttributes, names, discardsOpt, types, refKinds, declaredScopes, defaultValues, syntaxList, isAsync, isStatic, includeCache: true);
+            var data = new PlainUnboundLambdaState(binder, returnRefKind, returnType, parameterAttributes, names, discardsOpt, types, refKinds, declaredScopes, defaultValues, syntaxList, isAsync, isStatic, hasParamsArray, includeCache: true);
             var lambda = new UnboundLambda(syntax, data, functionType, withDependencies, hasErrors: hasErrors);
             data.SetUnboundLambda(lambda);
             functionType?.SetExpression(lambda.WithNoCache());
@@ -462,6 +463,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public bool GenerateSummaryErrors(BindingDiagnosticBag diagnostics) { return Data.GenerateSummaryErrors(diagnostics); }
         public bool IsAsync { get { return Data.IsAsync; } }
         public bool IsStatic => Data.IsStatic;
+        public bool HasParamsArray => Data.HasParamsArray;
         public SyntaxList<AttributeListSyntax> ParameterAttributes(int index) { return Data.ParameterAttributes(index); }
         public TypeWithAnnotations ParameterTypeWithAnnotations(int index) { return Data.ParameterTypeWithAnnotations(index); }
         public TypeSymbol ParameterType(int index) { return ParameterTypeWithAnnotations(index).Type; }
@@ -535,6 +537,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public abstract int ParameterCount { get; }
         public abstract bool IsAsync { get; }
         public abstract bool IsStatic { get; }
+        public abstract bool HasParamsArray { get; }
         public abstract Location ParameterLocation(int index);
         public abstract TypeWithAnnotations ParameterTypeWithAnnotations(int index);
         public abstract RefKind RefKind(int index);
@@ -729,7 +732,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 parameterRefKinds,
                 parameterEffectiveScopesBuilder.ToImmutableAndFree(),
                 parameterTypes,
-                parameterDefaultValues);
+                parameterDefaultValues,
+                _unboundLambda.HasParamsArray);
 
             LambdaSymbol createLambdaSymbol()
             {
@@ -1485,6 +1489,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly SeparatedSyntaxList<ParameterSyntax>? _parameterSyntaxList;
         private readonly bool _isAsync;
         private readonly bool _isStatic;
+        private readonly bool _hasParamsArray;
 
         internal PlainUnboundLambdaState(
             Binder binder,
@@ -1500,6 +1505,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             SeparatedSyntaxList<ParameterSyntax>? parameterSyntaxList,
             bool isAsync,
             bool isStatic,
+            bool hasParamsArray,
             bool includeCache)
             : base(binder, includeCache)
         {
@@ -1515,6 +1521,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _parameterSyntaxList = parameterSyntaxList;
             _isAsync = isAsync;
             _isStatic = isStatic;
+            _hasParamsArray = hasParamsArray;
         }
 
         public override bool HasSignature { get { return !_parameterNames.IsDefault; } }
@@ -1533,6 +1540,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override bool IsAsync { get { return _isAsync; } }
 
         public override bool IsStatic => _isStatic;
+
+        public override bool HasParamsArray => _hasParamsArray;
 
         public override MessageID MessageID { get { return this.UnboundLambda.Syntax.Kind() == SyntaxKind.AnonymousMethodExpression ? MessageID.IDS_AnonMethod : MessageID.IDS_Lambda; } }
 
@@ -1606,7 +1615,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override UnboundLambdaState WithCachingCore(bool includeCache)
         {
-            return new PlainUnboundLambdaState(Binder, _returnRefKind, _returnType, _parameterAttributes, _parameterNames, _parameterIsDiscardOpt, _parameterTypesWithAnnotations, _parameterRefKinds, _parameterDeclaredScopes, _defaultValues, _parameterSyntaxList, _isAsync, _isStatic, includeCache);
+            return new PlainUnboundLambdaState(Binder, _returnRefKind, _returnType, _parameterAttributes, _parameterNames, _parameterIsDiscardOpt, _parameterTypesWithAnnotations, _parameterRefKinds, _parameterDeclaredScopes, _defaultValues, _parameterSyntaxList, _isAsync, _isStatic, _hasParamsArray, includeCache);
         }
 
         protected override BoundExpression? GetLambdaExpressionBody(BoundBlock body)

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeDescriptor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeDescriptor.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return Fields.SequenceEqual(
                 other.Fields,
                 comparison,
-                static (x, y, comparison) => x.TypeWithAnnotations.Equals(y.TypeWithAnnotations, comparison) && x.RefKind == y.RefKind && x.Scope == y.Scope && x.DefaultValue == y.DefaultValue);
+                static (x, y, comparison) => x.TypeWithAnnotations.Equals(y.TypeWithAnnotations, comparison) && x.RefKind == y.RefKind && x.Scope == y.Scope && x.DefaultValue == y.DefaultValue && x.IsParams == y.IsParams);
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(!newFieldTypes.IsDefault);
             Debug.Assert(newFieldTypes.Length == this.Fields.Length);
 
-            var newFields = Fields.ZipAsArray(newFieldTypes, static (field, type) => new AnonymousTypeField(field.Name, field.Location, type, field.RefKind, field.Scope, field.DefaultValue));
+            var newFields = Fields.ZipAsArray(newFieldTypes, static (field, type) => new AnonymousTypeField(field.Name, field.Location, type, field.RefKind, field.Scope, field.DefaultValue, field.IsParams));
             return new AnonymousTypeDescriptor(newFields, this.Location);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeField.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeField.cs
@@ -26,11 +26,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public readonly ConstantValue? DefaultValue;
 
+        public readonly bool IsParams;
+
         /// <summary>Anonymous type field type</summary>
         public TypeSymbol Type => TypeWithAnnotations.Type;
 
-        // PROTOTYPE: Sync with IDE about the addition of DefaultValue to AnonymousTypeField to see how it will affect their usage of anonymous type symbols
-        public AnonymousTypeField(string name, Location location, TypeWithAnnotations typeWithAnnotations, RefKind refKind, DeclarationScope scope, ConstantValue? defaultValue = null)
+        // PROTOTYPE: Sync with IDE about the addition of DefaultValue and IsParams to AnonymousTypeField to see how it will affect their usage of anonymous type symbols
+        public AnonymousTypeField(string name, Location location, TypeWithAnnotations typeWithAnnotations, RefKind refKind, DeclarationScope scope, ConstantValue? defaultValue = null, bool isParams = false)
         {
             this.Name = name;
             this.Location = location;
@@ -38,6 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             this.RefKind = refKind;
             this.Scope = scope;
             this.DefaultValue = defaultValue;
+            this.IsParams = isParams;
         }
 
         [Conditional("DEBUG")]

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.Templates.cs
@@ -271,7 +271,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             static bool isValidTypeArgument(bool useUpdatedEscapeRules, AnonymousTypeField field)
             {
-                return hasDefaultScope(useUpdatedEscapeRules, field) &&
+                return !field.IsParams &&
+                    hasDefaultScope(useUpdatedEscapeRules, field) &&
                     field.DefaultValue is null &&
                     field.Type is { } type &&
                     !type.IsPointerOrFunctionPointer() &&

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.DelegatePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.DelegatePublicSymbol.cs
@@ -54,11 +54,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var constructor = new SynthesizedDelegateConstructor(this, Manager.System_Object, Manager.System_IntPtr);
                 var fields = TypeDescriptor.Fields;
                 int parameterCount = fields.Length - 1;
-                var parameters = ArrayBuilder<(TypeWithAnnotations, RefKind, DeclarationScope, ConstantValue?)>.GetInstance(parameterCount);
+                var parameters = ArrayBuilder<(TypeWithAnnotations, RefKind, DeclarationScope, ConstantValue?, bool)>.GetInstance(parameterCount);
                 for (int i = 0; i < parameterCount; i++)
                 {
                     var field = fields[i];
-                    parameters.Add((field.TypeWithAnnotations, field.RefKind, field.Scope, field.DefaultValue));
+                    parameters.Add((field.TypeWithAnnotations, field.RefKind, field.Scope, field.DefaultValue, field.IsParams));
                 }
                 var returnField = fields.Last();
                 var invokeMethod = new SynthesizedDelegateInvokeMethod(this, parameters, returnField.TypeWithAnnotations, returnField.RefKind);

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.DelegateTemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.DelegateTemplateSymbol.cs
@@ -53,10 +53,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var typeParams = containingType.TypeParameters;
 
                     int parameterCount = typeParams.Length - (voidReturnTypeOpt is null ? 1 : 0);
-                    var parameters = ArrayBuilder<(TypeWithAnnotations, RefKind, DeclarationScope, ConstantValue?, bool)>.GetInstance(parameterCount);
+                    var parameters = ArrayBuilder<(TypeWithAnnotations Type, RefKind RefKind, DeclarationScope Scope, ConstantValue? DefaultValue, bool IsParams)>.GetInstance(parameterCount);
                     for (int i = 0; i < parameterCount; i++)
                     {
-                        parameters.Add((TypeWithAnnotations.Create(typeParams[i]), refKinds.IsNull ? RefKind.None : refKinds[i], DeclarationScope.Unscoped, null, false));
+                        parameters.Add((TypeWithAnnotations.Create(typeParams[i]), refKinds.IsNull ? RefKind.None : refKinds[i], DeclarationScope.Unscoped, DefaultValue: null, IsParams: false));
                     }
 
                     // if we are given Void type the method returns Void, otherwise its return type is the last type parameter of the delegate:

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.DelegateTemplateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousType.DelegateTemplateSymbol.cs
@@ -53,10 +53,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var typeParams = containingType.TypeParameters;
 
                     int parameterCount = typeParams.Length - (voidReturnTypeOpt is null ? 1 : 0);
-                    var parameters = ArrayBuilder<(TypeWithAnnotations, RefKind, DeclarationScope, ConstantValue?)>.GetInstance(parameterCount);
+                    var parameters = ArrayBuilder<(TypeWithAnnotations, RefKind, DeclarationScope, ConstantValue?, bool)>.GetInstance(parameterCount);
                     for (int i = 0; i < parameterCount; i++)
                     {
-                        parameters.Add((TypeWithAnnotations.Create(typeParams[i]), refKinds.IsNull ? RefKind.None : refKinds[i], DeclarationScope.Unscoped, null));
+                        parameters.Add((TypeWithAnnotations.Create(typeParams[i]), refKinds.IsNull ? RefKind.None : refKinds[i], DeclarationScope.Unscoped, null, false));
                     }
 
                     // if we are given Void type the method returns Void, otherwise its return type is the last type parameter of the delegate:
@@ -127,11 +127,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     TypeMap typeMap)
                 {
                     var parameterCount = fields.Length - 1;
-                    var parameters = ArrayBuilder<(TypeWithAnnotations, RefKind, DeclarationScope, ConstantValue?)>.GetInstance(parameterCount);
+                    var parameters = ArrayBuilder<(TypeWithAnnotations, RefKind, DeclarationScope, ConstantValue?, bool)>.GetInstance(parameterCount);
                     for (int i = 0; i < parameterCount; i++)
                     {
                         var field = fields[i];
-                        parameters.Add((typeMap.SubstituteType(field.Type), field.RefKind, field.Scope, field.DefaultValue));
+                        parameters.Add((typeMap.SubstituteType(field.Type), field.RefKind, field.Scope, field.DefaultValue, field.IsParams));
                     }
 
                     var returnParameter = fields[^1];

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaParameterSymbol.cs
@@ -25,8 +25,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
            DeclarationScope? effectiveScope,
            string name,
            bool isDiscard,
+           bool isParams,
            ImmutableArray<Location> locations)
-           : base(owner, ordinal, parameterType, refKind, name, locations, syntaxRef, isParams: false, isExtensionMethodThis: false, scope: declaredScope)
+           : base(owner, ordinal, parameterType, refKind, name, locations, syntaxRef, isParams, isExtensionMethodThis: false, scope: declaredScope)
         {
             Debug.Assert(declaredScope.HasValue != effectiveScope.HasValue);
             _attributeLists = attributeLists;
@@ -37,11 +38,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override bool IsDiscard { get; }
 
         internal override DeclarationScope EffectiveScope => _effectiveScope ?? base.EffectiveScope;
-
-        public override bool IsParams
-        {
-            get { return false; }
-        }
 
         public override ImmutableArray<CustomModifier> RefCustomModifiers
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -371,7 +371,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var name = unboundLambda.ParameterName(p);
                 var location = unboundLambda.ParameterLocation(p);
                 var locations = location == null ? ImmutableArray<Location>.Empty : ImmutableArray.Create<Location>(location);
-                var isParams = unboundLambda.HasParamsArray && p == unboundLambda.ParameterCount - 1;
+                var isParams = paramSyntax?.Modifiers.Any(static m => m.Kind() == SyntaxKind.ParamsKeyword) ?? false;
 
                 var parameter = new LambdaParameterSymbol(owner: this, paramSyntax?.GetReference(), attributeLists, type, ordinal: p, refKind, declaredScope, effectiveScope, name, unboundLambda.ParameterIsDiscard(p), isParams, locations);
                 builder.Add(parameter);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -371,8 +371,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var name = unboundLambda.ParameterName(p);
                 var location = unboundLambda.ParameterLocation(p);
                 var locations = location == null ? ImmutableArray<Location>.Empty : ImmutableArray.Create<Location>(location);
+                var isParams = unboundLambda.HasParamsArray && p == unboundLambda.ParameterCount - 1;
 
-                var parameter = new LambdaParameterSymbol(owner: this, paramSyntax?.GetReference(), attributeLists, type, ordinal: p, refKind, declaredScope, effectiveScope, name, unboundLambda.ParameterIsDiscard(p), locations);
+                var parameter = new LambdaParameterSymbol(owner: this, paramSyntax?.GetReference(), attributeLists, type, ordinal: p, refKind, declaredScope, effectiveScope, name, unboundLambda.ParameterIsDiscard(p), isParams, locations);
                 builder.Add(parameter);
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -371,7 +371,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var name = unboundLambda.ParameterName(p);
                 var location = unboundLambda.ParameterLocation(p);
                 var locations = location == null ? ImmutableArray<Location>.Empty : ImmutableArray.Create<Location>(location);
-                var isParams = paramSyntax?.Modifiers.Any(static m => m.Kind() == SyntaxKind.ParamsKeyword) ?? false;
+                var isParams = paramSyntax?.Modifiers.Any(static m => m.IsKind(SyntaxKind.ParamsKeyword)) ?? false;
 
                 var parameter = new LambdaParameterSymbol(owner: this, paramSyntax?.GetReference(), attributeLists, type, ordinal: p, refKind, declaredScope, effectiveScope, name, unboundLambda.ParameterIsDiscard(p), isParams, locations);
                 builder.Add(parameter);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (parameterIndex > lastIndex) break;
 
-                CheckParameterModifiers(parameterSyntax, diagnostics, parsingFunctionPointer, parsingLambdaParams: false, parsingAnonymousMethod: false);
+                CheckParameterModifiers(parameterSyntax, diagnostics, parsingFunctionPointer, parsingLambdaParams: false, parsingAnonymousMethodParams: false);
 
                 var refKind = GetModifiers(parameterSyntax.Modifiers, out SyntaxToken refnessKeyword, out SyntaxToken paramsKeyword, out SyntaxToken thisKeyword, out DeclarationScope scope);
                 if (thisKeyword.Kind() != SyntaxKind.None && !allowThis)
@@ -410,9 +410,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             BindingDiagnosticBag diagnostics,
             bool parsingFunctionPointerParams,
             bool parsingLambdaParams,
-            bool parsingAnonymousMethod)
+            bool parsingAnonymousMethodParams)
         {
-            Debug.Assert(!parsingAnonymousMethod || parsingLambdaParams);
+            Debug.Assert(!parsingLambdaParams || !parsingAnonymousMethodParams);
 
             var seenThis = false;
             var seenRef = false;
@@ -433,7 +433,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             Binder.CheckFeatureAvailability(modifier, MessageID.IDS_FeatureRefExtensionMethods, diagnostics);
                         }
 
-                        if (parsingLambdaParams)
+                        if (parsingLambdaParams || parsingAnonymousMethodParams)
                         {
                             diagnostics.Add(ErrorCode.ERR_ThisInBadContext, modifier.GetLocation());
                         }
@@ -511,7 +511,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case SyntaxKind.ParamsKeyword when !parsingFunctionPointerParams:
-                        if (parsingAnonymousMethod)
+                        if (parsingAnonymousMethodParams)
                         {
                             diagnostics.Add(ErrorCode.ERR_IllegalParams, modifier.GetLocation());
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -508,11 +508,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         break;
 
                     case SyntaxKind.ParamsKeyword when !parsingFunctionPointerParams:
-                        if (parsingLambdaParams)
-                        {
-                            diagnostics.Add(ErrorCode.ERR_IllegalParams, modifier.GetLocation());
-                        }
-                        else if (seenParams)
+                        if (seenParams)
                         {
                             addERR_DupParamMod(diagnostics, modifier);
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -1492,7 +1492,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal sealed override MarshalPseudoCustomAttributeData MarshallingInformation
             => GetDecodedWellKnownAttributeData()?.MarshallingInformation;
 
-        public override bool IsParams => (_parameterSyntaxKind & ParameterSyntaxKind.ParamsParameter) != 0;
+        public sealed override bool IsParams => (_parameterSyntaxKind & ParameterSyntaxKind.ParamsParameter) != 0;
 
         internal override bool IsExtensionMethodThis => (_parameterSyntaxKind & ParameterSyntaxKind.ExtensionThisParameter) != 0;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedDelegateSymbol.cs
@@ -32,12 +32,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private readonly NamedTypeSymbol _containingType;
 
-        internal SynthesizedDelegateInvokeMethod(NamedTypeSymbol containingType, ArrayBuilder<(TypeWithAnnotations Type, RefKind RefKind, DeclarationScope Scope, ConstantValue? DefaultValue)> parameterDescriptions, TypeWithAnnotations returnType, RefKind refKind)
+        internal SynthesizedDelegateInvokeMethod(NamedTypeSymbol containingType, ArrayBuilder<(TypeWithAnnotations Type, RefKind RefKind, DeclarationScope Scope, ConstantValue? DefaultValue, bool IsParams)> parameterDescriptions, TypeWithAnnotations returnType, RefKind refKind)
         {
             _containingType = containingType;
 
             Parameters = parameterDescriptions.SelectAsArrayWithIndex(static (p, i, a) =>
-                SynthesizedParameterSymbol.Create(a.Method, p.Type, i, p.RefKind, GeneratedNames.AnonymousDelegateParameterName(i, a.ParameterCount), p.Scope, defaultValue: p.DefaultValue),
+                SynthesizedParameterSymbol.Create(a.Method, p.Type, i, p.RefKind, GeneratedNames.AnonymousDelegateParameterName(i, a.ParameterCount), p.Scope, p.DefaultValue, isParams: p.IsParams),
                 (Method: this, ParameterCount: parameterDescriptions.Count));
             ReturnTypeWithAnnotations = returnType;
             RefKind = refKind;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -13773,6 +13773,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0]
                 int Method2(params int[] ys) => ys.Length;
                 var del2 = Method2;
                 Report(lam2, del2);
+                Report(lam1, lam2);
 
                 var lam3 = (int[] xs) => xs.Length;
                 int Method3(int[] xs) => xs.Length;
@@ -13800,6 +13801,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0]
                 Report(lam7, del7);
                 """;
             CompileAndVerify(source, expectedOutput: """
+                True, <>f__AnonymousDelegate0
                 True, <>f__AnonymousDelegate0
                 True, <>f__AnonymousDelegate0
                 True, System.Func`2[System.Int32[],System.Int32]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -13780,13 +13780,13 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0]
                 var del3 = Method3;
                 Report(lam3, del3);
 
-                var lam4 = (int a, int b, int[] xs) => { };
-                void Method4(int a, int b, int[] xs) { }
+                var lam4 = (ref int a, int b, int[] xs) => { };
+                void Method4(ref int a, int b, int[] xs) { }
                 var del4 = Method4;
                 Report(lam4, del4);
 
-                var lam5 = (int a, int b, params int[] xs) => { };
-                void Method5(int a, int b, params int[] xs) { }
+                var lam5 = (ref int a, int b, params int[] xs) => { };
+                void Method5(ref int a, int b, params int[] xs) { }
                 var del5 = Method5;
                 Report(lam5, del5);
 
@@ -13805,7 +13805,7 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0]
                 True, <>f__AnonymousDelegate0
                 True, <>f__AnonymousDelegate0
                 True, System.Func`2[System.Int32[],System.Int32]
-                True, System.Action`3[System.Int32,System.Int32,System.Int32[]]
+                True, <>A{00000001}`3[System.Int32,System.Int32,System.Int32[]]
                 True, <>f__AnonymousDelegate1
                 True, <>f__AnonymousDelegate2
                 True, <>f__AnonymousDelegate2

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DelegateTypeTests.cs
@@ -13759,38 +13759,59 @@ $@"{s_expressionOfTDelegate1ArgTypeName}[<>f__AnonymousDelegate0]
         }
 
         [Fact]
-        public void LambdaParamsArray_SynthesizedTypesMatch()
+        public void ParamsArray_SynthesizedTypesMatch()
         {
             var source = """
-                static void Report(object obj) => System.Console.WriteLine(obj.GetType());
+                static void Report(object obj1, object obj2) => System.Console.WriteLine($"{obj1.GetType() == obj2.GetType()}, {obj1.GetType()}");
+
                 var lam1 = (params int[] xs) => xs.Length;
-                Report(lam1);
+                int Method1(params int[] xs) => xs.Length;
+                var del1 = Method1;
+                Report(lam1, del1);
+
                 var lam2 = (params int[] ys) => ys.Length;
-                Report(lam2);
+                int Method2(params int[] ys) => ys.Length;
+                var del2 = Method2;
+                Report(lam2, del2);
+
                 var lam3 = (int[] xs) => xs.Length;
-                Report(lam3);
+                int Method3(int[] xs) => xs.Length;
+                var del3 = Method3;
+                Report(lam3, del3);
+
                 var lam4 = (int a, int b, int[] xs) => { };
-                Report(lam4);
+                void Method4(int a, int b, int[] xs) { }
+                var del4 = Method4;
+                Report(lam4, del4);
+
                 var lam5 = (int a, int b, params int[] xs) => { };
-                Report(lam5);
+                void Method5(int a, int b, params int[] xs) { }
+                var del5 = Method5;
+                Report(lam5, del5);
+
                 var lam6 = (int a, System.TypedReference b, params int[] xs) => { };
-                Report(lam6);
-                var lam7 = (int x, System.TypedReference y, params int[] xs) => { };
-                Report(lam7);
+                void Method6(int a, System.TypedReference b, params int[] xs) { }
+                var del6 = Method6;
+                Report(lam6, del6);
+
+                var lam7 = (int x, System.TypedReference y, params int[] ys) => { };
+                void Method7(int x, System.TypedReference y, params int[] ys) { }
+                var del7 = Method7;
+                Report(lam7, del7);
                 """;
             CompileAndVerify(source, expectedOutput: """
-                <>f__AnonymousDelegate0
-                <>f__AnonymousDelegate0
-                System.Func`2[System.Int32[],System.Int32]
-                System.Action`3[System.Int32,System.Int32,System.Int32[]]
-                <>f__AnonymousDelegate1
-                <>f__AnonymousDelegate2
-                <>f__AnonymousDelegate2
+                True, <>f__AnonymousDelegate0
+                True, <>f__AnonymousDelegate0
+                True, System.Func`2[System.Int32[],System.Int32]
+                True, System.Action`3[System.Int32,System.Int32,System.Int32[]]
+                True, <>f__AnonymousDelegate1
+                True, <>f__AnonymousDelegate2
+                True, <>f__AnonymousDelegate2
                 """).VerifyDiagnostics();
         }
 
         [Fact]
-        public void LambdaParamsArray_SynthesizedDelegateIL()
+        public void ParamsArray_SynthesizedDelegateIL()
         {
             var source = """
                 static void Report(object obj) => System.Console.WriteLine(obj.GetType());

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -7850,17 +7850,19 @@ class Program
         public void ParamsArray_Call()
         {
             var source = """
-                var lam = (params int[] xs) => System.Console.WriteLine(xs.Length);
+                var lam = (params int[] xs) => System.Console.WriteLine(xs?.Length.ToString() ?? "null");
                 lam();
                 lam(1);
                 lam(1, 2, 3);
                 lam(new[] { 1, 2, 3 });
+                lam(null);
                 """;
             CompileAndVerify(source, expectedOutput: """
                 0
                 1
                 3
                 3
+                null
                 """).VerifyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -7905,12 +7905,43 @@ class Program
             var exprs = tree.GetRoot().DescendantNodes().OfType<LambdaExpressionSyntax>().ToImmutableArray();
             var lambdas = exprs.SelectAsArray(e => GetLambdaSymbol(model, e));
             Assert.Equal(3, lambdas.Length);
+            // lam1
             Assert.True(((SourceParameterSymbol)lambdas[0].Parameters.Single()).IsParams);
+            // lam2
             Assert.False(((SourceParameterSymbol)lambdas[1].Parameters.Single()).IsParams);
+            // lam3
             Assert.Equal(2, lambdas[2].ParameterCount);
             Assert.Equal(2, lambdas[2].Parameters.Length);
             Assert.False(((SourceParameterSymbol)lambdas[2].Parameters[0]).IsParams);
             Assert.True(((SourceParameterSymbol)lambdas[2].Parameters[1]).IsParams);
+        }
+
+        [Fact]
+        public void ParamsArray_Symbol_MultipleParamsArrays()
+        {
+            var source = """
+                var lam1 = (params int[] xs, params int[] ys, int[] zs) => xs.Length + ys.Length + zs.Length;
+                var lam2 = (params int[] xs, int[] ys, params int[] zs) => xs.Length + ys.Length + zs.Length;
+                """;
+            var comp = CreateCompilation(source);
+
+            var tree = comp.SyntaxTrees[0];
+            var model = comp.GetSemanticModel(tree);
+            var exprs = tree.GetRoot().DescendantNodes().OfType<LambdaExpressionSyntax>().ToImmutableArray();
+            var lambdas = exprs.SelectAsArray(e => GetLambdaSymbol(model, e));
+            Assert.Equal(2, lambdas.Length);
+            // lam1
+            Assert.Equal(3, lambdas[0].ParameterCount);
+            Assert.Equal(3, lambdas[0].Parameters.Length);
+            Assert.True(((SourceParameterSymbol)lambdas[0].Parameters[0]).IsParams);
+            Assert.True(((SourceParameterSymbol)lambdas[0].Parameters[1]).IsParams);
+            Assert.False(((SourceParameterSymbol)lambdas[0].Parameters[2]).IsParams);
+            // lam2
+            Assert.Equal(3, lambdas[1].ParameterCount);
+            Assert.Equal(3, lambdas[1].Parameters.Length);
+            Assert.True(((SourceParameterSymbol)lambdas[1].Parameters[0]).IsParams);
+            Assert.False(((SourceParameterSymbol)lambdas[1].Parameters[1]).IsParams);
+            Assert.True(((SourceParameterSymbol)lambdas[1].Parameters[2]).IsParams);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -228,6 +228,9 @@ class C
                 // (62,44): warning CS0162: Unreachable code detected
                 //         Func<double> q15 = ()=>{if (false) return 1m; else return 0; };
                 Diagnostic(ErrorCode.WRN_UnreachableCode, "return").WithLocation(62, 44),
+                // (66,39): error CS1670: params is not valid in this context
+                //         Action<int[]> q16 = delegate (params int[] p) { };
+                Diagnostic(ErrorCode.ERR_IllegalParams, "params").WithLocation(66, 39),
                 // (70,34): error CS1593: Delegate 'Action' does not take 1 arguments
                 //         object q19 = new Action( (int x)=>{} );
                 Diagnostic(ErrorCode.ERR_BadDelArgCount, "(int x)=>{}").WithArguments("System.Action", "1").WithLocation(70, 34),


### PR DESCRIPTION
Adds basic support for `params` arrays in lambdas. Parsing support is already there, so this PR only removes an error around the `params` modifier and propagates the modifier into `UnboundLambda`, `LambdaParameterSymbol`, and the synthesized delegate type.

Error reporting around `params` and delegate conversions will be addressed in subsequent PRs.