### PR TITLE
Revert "Use IAsyncEnumerable in DesignerAttributeScanning as well."

### DIFF
--- a/src/Features/Core/Portable/DesignerAttribute/AbstractDesignerAttributeIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/DesignerAttribute/AbstractDesignerAttributeIncrementalAnalyzer.cs
@@ -3,12 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
-using System.Runtime.CompilerServices;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -19,51 +22,154 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
     [ExportWorkspaceService(typeof(IDesignerAttributeDiscoveryService)), Shared]
     internal sealed partial class DesignerAttributeDiscoveryService : IDesignerAttributeDiscoveryService
     {
+        /// <summary>
+        /// Protects mutable state in this type.
+        /// </summary>
+        private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
+
+        /// <summary>
+        /// Keep track of the last information we reported.  We will avoid notifying the host if we recompute and these
+        /// don't change.
+        /// </summary>
+        private readonly ConcurrentDictionary<DocumentId, (string? category, VersionStamp projectVersion)> _documentToLastReportedInformation = new();
+
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public DesignerAttributeDiscoveryService()
         {
         }
 
-        public async IAsyncEnumerable<DesignerAttributeData> ProcessProjectAsync(
-            Project project,
+        public async ValueTask ProcessSolutionAsync(
+            Solution solution,
             DocumentId? priorityDocumentId,
-            [EnumeratorCancellation] CancellationToken cancellationToken)
+            IDesignerAttributeDiscoveryService.ICallback callback,
+            CancellationToken cancellationToken)
         {
-            // Ignore projects that don't support compilation or don't even have the DesignerCategoryAttribute in it.
+            using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
+            {
+                // Remove any documents that are now gone.
+                foreach (var docId in _documentToLastReportedInformation.Keys)
+                {
+                    if (!solution.ContainsDocument(docId))
+                        _documentToLastReportedInformation.TryRemove(docId, out _);
+                }
+
+                // Handle the priority doc first.
+                var priorityDocument = solution.GetDocument(priorityDocumentId);
+                if (priorityDocument != null)
+                    await ProcessProjectAsync(priorityDocument.Project, priorityDocument, callback, cancellationToken).ConfigureAwait(false);
+
+                // Process the rest of the projects in dependency order so that their data is ready when we hit the 
+                // projects that depend on them.
+                var dependencyGraph = solution.GetProjectDependencyGraph();
+                foreach (var projectId in dependencyGraph.GetTopologicallySortedProjects(cancellationToken))
+                {
+                    if (projectId != priorityDocumentId?.ProjectId)
+                        await ProcessProjectAsync(solution.GetRequiredProject(projectId), specificDocument: null, callback, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        private async Task ProcessProjectAsync(
+            Project project,
+            Document? specificDocument,
+            IDesignerAttributeDiscoveryService.ICallback callback,
+            CancellationToken cancellationToken)
+        {
             if (!project.SupportsCompilation)
-                yield break;
+                return;
 
             var compilation = await project.GetRequiredCompilationAsync(cancellationToken).ConfigureAwait(false);
             var designerCategoryType = compilation.DesignerCategoryAttributeType();
             if (designerCategoryType == null)
-                yield break;
+                return;
 
-            // If there is a priority doc, then scan that first.
-            var priorityDocument = priorityDocumentId == null ? null : project.GetDocument(priorityDocumentId);
-            if (priorityDocument is { FilePath: not null })
-            {
-                var data = await ComputeDesignerAttributeDataAsync(designerCategoryType, priorityDocument, cancellationToken).ConfigureAwait(false);
-                if (data != null)
-                    yield return data.Value;
-            }
+            await ScanForDesignerCategoryUsageAsync(
+                project, specificDocument, callback, designerCategoryType, cancellationToken).ConfigureAwait(false);
 
-            // now process the rest of the documents.
-            using var _ = ArrayBuilder<Task<DesignerAttributeData?>>.GetInstance(out var tasks);
+            // If we scanned just a specific document in the project, now scan the rest of the files.
+            if (specificDocument != null)
+                await ScanForDesignerCategoryUsageAsync(project, specificDocument: null, callback, designerCategoryType, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task ScanForDesignerCategoryUsageAsync(
+            Project project,
+            Document? specificDocument,
+            IDesignerAttributeDiscoveryService.ICallback callback,
+            INamedTypeSymbol designerCategoryType,
+            CancellationToken cancellationToken)
+        {
+            // We need to reanalyze the project whenever it (or any of its dependencies) have
+            // changed.  We need to know about dependencies since if a downstream project adds the
+            // DesignerCategory attribute to a class, that can affect us when we examine the classes
+            // in this project.
+            var projectVersion = await project.GetDependentSemanticVersionAsync(cancellationToken).ConfigureAwait(false);
+
+            // Now get all the values that actually changed and notify VS about them. We don't need
+            // to tell it about the ones that didn't change since that will have no effect on the
+            // user experience.
+            var changedData = await ComputeChangedDataAsync(
+                project, specificDocument, projectVersion, designerCategoryType, cancellationToken).ConfigureAwait(false);
+
+            // Only bother reporting non-empty information to save an unnecessary RPC.
+            if (!changedData.IsEmpty)
+                await callback.ReportDesignerAttributeDataAsync(changedData, cancellationToken).ConfigureAwait(false);
+
+            // Now, keep track of what we've reported to the host so we won't report unchanged files in the future. We
+            // do this after the report has gone through as we want to make sure that if it cancels for any reason we
+            // don't hold onto values that may not have made it all the way to the project system.
+            foreach (var data in changedData)
+                _documentToLastReportedInformation[data.DocumentId] = (data.Category, projectVersion);
+        }
+
+        private async Task<ImmutableArray<DesignerAttributeData>> ComputeChangedDataAsync(
+            Project project,
+            Document? specificDocument,
+            VersionStamp projectVersion,
+            INamedTypeSymbol designerCategoryType,
+            CancellationToken cancellationToken)
+        {
+            using var _1 = ArrayBuilder<Task<DesignerAttributeData?>>.GetInstance(out var tasks);
             foreach (var document in project.Documents)
             {
-                if (document == priorityDocument || document.FilePath is null)
+                // If we're only analyzing a specific document, then skip the rest.
+                if (specificDocument != null && document != specificDocument)
                     continue;
+
+                // If we don't have a path for this document, we cant proceed with it.
+                // We need that path to inform the project system which file we're referring to.
+                if (document.FilePath == null)
+                    continue;
+
+                // If nothing has changed at the top level between the last time we analyzed this document and now, then
+                // no need to analyze again.
+                if (_documentToLastReportedInformation.TryGetValue(document.Id, out var existingInfo) &&
+                    existingInfo.projectVersion == projectVersion)
+                {
+                    continue;
+                }
 
                 tasks.Add(ComputeDesignerAttributeDataAsync(designerCategoryType, document, cancellationToken));
             }
 
-            // Convert the tasks into one final stream we can read all the results from.
-            await foreach (var dataOpt in tasks.ToImmutable().StreamAsync(cancellationToken).ConfigureAwait(false))
+            using var _2 = ArrayBuilder<DesignerAttributeData>.GetInstance(tasks.Count, out var results);
+
+            // Avoid unnecessary allocation of result array.
+            await Task.WhenAll((IEnumerable<Task>)tasks).ConfigureAwait(false);
+
+            foreach (var task in tasks)
             {
-                if (dataOpt != null)
-                    yield return dataOpt.Value;
+                var dataOpt = await task.ConfigureAwait(false);
+                if (dataOpt == null)
+                    continue;
+
+                var data = dataOpt.Value;
+                _documentToLastReportedInformation.TryGetValue(data.DocumentId, out var existingInfo);
+                if (existingInfo.category != data.Category)
+                    results.Add(data);
             }
+
+            return results.ToImmutableAndClear();
         }
 
         private static async Task<DesignerAttributeData?> ComputeDesignerAttributeDataAsync(
@@ -73,16 +179,18 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
             {
                 Contract.ThrowIfNull(document.FilePath);
 
+                // We either haven't computed the designer info, or our data was out of date.  We need
+                // So recompute here.  Figure out what the current category is, and if that's different
+                // from what we previously stored.
                 var category = await DesignerAttributeHelpers.ComputeDesignerAttributeCategoryAsync(
                     designerCategoryType, document, cancellationToken).ConfigureAwait(false);
 
-                // If there's no category (the common case) don't return anything.  The host itself will see no results
-                // returned and can handle that case (for example, if a type previously had the attribute but doesn't
-                // any longer).
-                if (category == null)
-                    return null;
-
-                return new DesignerAttributeData(category, document.Id, document.FilePath);
+                return new DesignerAttributeData
+                {
+                    Category = category,
+                    DocumentId = document.Id,
+                    FilePath = document.FilePath,
+                };
             }
             catch (Exception e) when (FatalError.ReportAndCatchUnlessCanceled(e, cancellationToken))
             {

--- a/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeData.cs
+++ b/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeData.cs
@@ -10,34 +10,24 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
     /// Serialization typed used to pass information to/from OOP and VS.
     /// </summary>
     [DataContract]
-    internal readonly struct DesignerAttributeData
+    internal struct DesignerAttributeData
     {
         /// <summary>
         /// The category specified in a <c>[DesignerCategory("...")]</c> attribute.
         /// </summary>
         [DataMember(Order = 0)]
-        public readonly string? Category;
+        public string? Category;
 
         /// <summary>
         /// The document this <see cref="Category"/> applies to.
         /// </summary>
         [DataMember(Order = 1)]
-        public readonly DocumentId DocumentId;
+        public DocumentId DocumentId;
 
         /// <summary>
         /// Path for this <see cref="DocumentId"/>.
         /// </summary>
         [DataMember(Order = 2)]
-        public readonly string FilePath;
-
-        public DesignerAttributeData(string? category, DocumentId documentId, string filePath)
-        {
-            Category = category;
-            DocumentId = documentId;
-            FilePath = filePath;
-        }
-
-        public DesignerAttributeData WithCategory(string? category)
-            => new(category, DocumentId, FilePath);
+        public string FilePath;
     }
 }

--- a/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeHelpers.cs
+++ b/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeHelpers.cs
@@ -54,9 +54,6 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
             }
 
             return null;
-
-            static string? GetArgumentString(TypedConstant argument)
-                => argument is { IsNull: false, Type.SpecialType: SpecialType.System_String, Value: string stringValue } ? stringValue.Trim() : null;
         }
 
         private static SyntaxNode? FindFirstNonNestedClass(
@@ -79,6 +76,19 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
             }
 
             return null;
+        }
+
+        private static string? GetArgumentString(TypedConstant argument)
+        {
+            if (argument.Type == null ||
+                argument.Type.SpecialType != SpecialType.System_String ||
+                argument.IsNull ||
+                argument.Value is not string stringValue)
+            {
+                return null;
+            }
+
+            return stringValue.Trim();
         }
     }
 }

--- a/src/Features/Core/Portable/DesignerAttribute/IDesignerAttributeDiscoveryService.cs
+++ b/src/Features/Core/Portable/DesignerAttribute/IDesignerAttributeDiscoveryService.cs
@@ -2,14 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System;
+using System.Collections.Immutable;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.DesignerAttribute
 {
-    internal interface IDesignerAttributeDiscoveryService : IWorkspaceService
+    internal partial interface IDesignerAttributeDiscoveryService : IWorkspaceService
     {
-        IAsyncEnumerable<DesignerAttributeData> ProcessProjectAsync(Project project, DocumentId? priorityDocumentId, CancellationToken cancellationToken);
+        public interface ICallback
+        {
+            ValueTask ReportDesignerAttributeDataAsync(ImmutableArray<DesignerAttributeData> data, CancellationToken cancellationToken);
+        }
+
+        ValueTask ProcessSolutionAsync(Solution solution, DocumentId? priorityDocumentId, ICallback callback, CancellationToken cancellationToken);
     }
 }

--- a/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
+++ b/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
@@ -5,24 +5,24 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using EnvDTE;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.DesignerAttribute;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.VisualStudio.Designer.Interfaces;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
-using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.Services;
 using Roslyn.Utilities;
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
 {
     [ExportEventListener(WellKnownEventListeners.Workspace, WorkspaceKind.Host), Shared]
     internal class VisualStudioDesignerAttributeService :
-        ForegroundThreadAffinitizedObject, IEventListener<object>, IDisposable
+        ForegroundThreadAffinitizedObject, IDesignerAttributeDiscoveryService.ICallback, IEventListener<object>, IDisposable
     {
         private readonly VisualStudioWorkspaceImpl _workspace;
 
@@ -52,37 +52,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
         /// </summary>
         private IVSMDDesignerService? _legacyDesignerService;
 
-        /// <summary>
-        /// Queue that tells us to recompute designer attributes when workspace changes happen.  This queue is
-        /// cancellable and will be restarted when new changes come in.  That way we can be quickly update the designer
-        /// attribute for a file when a user edits it.
-        /// </summary>
         private readonly AsyncBatchingWorkQueue _workQueue;
 
-        /// <summary>
-        /// We'll get notifications from the OOP server about new attribute arguments. Collect those notifications and
-        /// deliver them to VS in batches to prevent flooding the UI thread.  Importantly, we do not cancel this queue.
-        /// Once we've decided to update the project system, we want to allow that to proceed.
-        /// <para>
-        /// This queue both sends the individual data objects we get back, or the solution instance once we're done with
-        /// a particular project request.  The latter is used so that we can determine which documents are now gone, so
-        /// we can dump our cached data for them.
-        /// </para>
-        /// </summary>
-        private readonly AsyncBatchingWorkQueue<(CodeAnalysis.Solution? solution, DesignerAttributeData? data)> _projectSystemNotificationQueue;
-
-        /// <summary>
-        /// Keep track of the last version we were at when we processed a project.  We'll skip reprocessing projects if
-        /// that version hasn't changed.
-        /// </summary>
-        private readonly ConcurrentDictionary<ProjectId, VersionStamp> _projectToLastComputedDependentSemanticVersion = new();
-
-        /// <summary>
-        /// Keep track of the last information we reported per document.  We will avoid notifying the host if we
-        /// recompute and these don't change.  Note: we keep track if we reported <see langword="null"/> as well to
-        /// represent that the file is not designable.
-        /// </summary>
-        private readonly ConcurrentDictionary<DocumentId, string?> _documentToLastReportedCategory = new();
+        // We'll get notifications from the OOP server about new attribute arguments. Collect those notifications and
+        // deliver them to VS in batches to prevent flooding the UI thread.
+        private readonly AsyncBatchingWorkQueue<DesignerAttributeData> _projectSystemNotificationQueue;
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
@@ -104,7 +78,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
                 listener,
                 ThreadingContext.DisposalToken);
 
-            _projectSystemNotificationQueue = new AsyncBatchingWorkQueue<(CodeAnalysis.Solution? solution, DesignerAttributeData? data)>(
+            _projectSystemNotificationQueue = new AsyncBatchingWorkQueue<DesignerAttributeData>(
                 TimeSpan.FromSeconds(1),
                 this.NotifyProjectSystemAsync,
                 listener,
@@ -121,14 +95,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
             if (workspace != _workspace)
                 return;
 
-            // Register for changes, and kick off hte initial scan.
             _workspace.WorkspaceChanged += OnWorkspaceChanged;
             _workQueue.AddWork(cancelExistingWork: true);
         }
 
         private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
         {
-            // cancel any existing work and start rescanning.  this way we can respond to edits to a file very quickly.
             _workQueue.AddWork(cancelExistingWork: true);
         }
 
@@ -139,117 +111,38 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var client = await RemoteHostClient.TryGetClientAsync(_workspace, cancellationToken).ConfigureAwait(false);
-            if (client == null)
-                return;
-
             var solution = _workspace.CurrentSolution;
-
-            // remove any data for projects that are no longer around.
-            HandRemovedProjects(solution);
-
-            // Now process all the projects we do have, prioritizing the active project/document first.
-            var trackingService = _workspace.Services.GetRequiredService<IDocumentTrackingService>();
-
-            var priorityDocument = solution.GetDocument(trackingService.TryGetActiveDocument());
-            if (priorityDocument != null)
-                await ProcessProjectAsync(client, priorityDocument.Project, priorityDocument.Id, cancellationToken).ConfigureAwait(false);
-
-            // Process the rest of the projects in dependency order so that their data is ready when we hit the 
-            // projects that depend on them.
-            var dependencyGraph = solution.GetProjectDependencyGraph();
-            foreach (var projectId in dependencyGraph.GetTopologicallySortedProjects(cancellationToken))
-            {
-                // skip the prioritized project we handled above.
-                if (projectId == priorityDocument?.Id.ProjectId)
-                    continue;
-
-                await ProcessProjectAsync(client, solution.GetRequiredProject(projectId), priorityDocumentId: null, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        private void HandRemovedProjects(CodeAnalysis.Solution solution)
-        {
             foreach (var (projectId, _) in _cpsProjects)
             {
                 if (!solution.ContainsProject(projectId))
                     _cpsProjects.TryRemove(projectId, out _);
             }
 
-            // when a project is removed, remove our cached attribute data for it.  No point in actually notifying the
-            // host as there isn't any project anymore to notify it about.
+            var client = await RemoteHostClient.TryGetClientAsync(_workspace, cancellationToken).ConfigureAwait(false);
+            if (client == null)
+                return;
 
-            foreach (var (projectId, _) in _projectToLastComputedDependentSemanticVersion)
-            {
-                if (!solution.ContainsProject(projectId))
-                    _projectToLastComputedDependentSemanticVersion.TryRemove(projectId, out _);
-            }
-        }
+            var trackingService = _workspace.Services.GetRequiredService<IDocumentTrackingService>();
+            var priorityDocument = trackingService.TryGetActiveDocument();
 
-        private async Task ProcessProjectAsync(
-            RemoteHostClient client,
-            CodeAnalysis.Project project,
-            DocumentId? priorityDocumentId,
-            CancellationToken cancellationToken)
-        {
-            // We need to recompute the designer attributes for a project if it's own semantic-version changes, or the
-            // semantic-version of any dependent projects change.  The reason for checking dependent projects is that we
-            // look for the designer attribute on subclasses as well (so we have to walk the inheritance tree).  This
-            // tree may be unfortunately be affected by dependent projects.  In an ideal design we would require the
-            // attribute be on the declaration point so we could only check things that are known to directly have an
-            // attribute on them, and we wouldn't have to look up the inheritance hierarchy.
-            var dependentSemanticVersion = await project.GetDependentSemanticVersionAsync(cancellationToken).ConfigureAwait(false);
-
-            if (!_projectToLastComputedDependentSemanticVersion.TryGetValue(project.Id, out var lastComputedVersion) ||
-                lastComputedVersion != dependentSemanticVersion)
-            {
-                var stream = client.TryInvokeStreamAsync<IRemoteDesignerAttributeDiscoveryService, DesignerAttributeData>(
-                    project,
-                    (service, checksum, cancellationToken) => service.DiscoverDesignerAttributesAsync(checksum, project.Id, priorityDocumentId, cancellationToken),
-                    cancellationToken);
-
-                using var _ = PooledHashSet<DocumentId>.GetInstance(out var seenDocuments);
-
-                // get the results and add all the documents we hear about to the notification queue so they can be batched up.
-                await foreach (var data in stream.ConfigureAwait(false))
-                {
-                    seenDocuments.Add(data.DocumentId);
-                    _projectSystemNotificationQueue.AddWork((solution: null, data));
-                }
-
-                // Also, for any documents we didn't hear about, ensure we emit a clear on its category if we have
-                // currently stored for it.  This also ensures we initially report about all non-designer files when a
-                // solution is opened.  This is needed in case the project file says it is designable, but the user made
-                // some change outside of VS that makes it non-designable. We will pick this up here and ensure the data
-                // is cleared.  From that point on, we won't issue any more notifications about those files unless the
-                // category actually does change.
-                foreach (var document in project.Documents)
-                {
-                    if (document.FilePath != null && !seenDocuments.Contains(document.Id))
-                        _projectSystemNotificationQueue.AddWork((solution: null, new DesignerAttributeData(null, document.Id, document.FilePath)));
-                }
-
-                // once done, also enqueue the solution as well so that the project-system queue can cleanup
-                // any stale data about it.
-                _projectSystemNotificationQueue.AddWork((project.Solution, data: null));
-
-                // now that we're done processing the project, record this version-stamp so we don't have to process it again in the future.
-                _projectToLastComputedDependentSemanticVersion[project.Id] = dependentSemanticVersion;
-            }
+            await client.TryInvokeAsync<IRemoteDesignerAttributeDiscoveryService>(
+                solution,
+                (service, checksum, callbackId, cancellationToken) => service.DiscoverDesignerAttributesAsync(callbackId, checksum, priorityDocument, cancellationToken),
+                callbackTarget: this,
+                cancellationToken).ConfigureAwait(false);
         }
 
         private async ValueTask NotifyProjectSystemAsync(
-            ImmutableSegmentedList<(CodeAnalysis.Solution? solution, DesignerAttributeData? data)> dataList, CancellationToken cancellationToken)
+            ImmutableSegmentedList<DesignerAttributeData> data, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            using var _1 = ArrayBuilder<DesignerAttributeData>.GetInstance(out var changedData);
-            using var _2 = ArrayBuilder<Task>.GetInstance(out var tasks);
-
-            var latestSolution = AddChangedData(dataList, changedData);
+            using var _1 = ArrayBuilder<DesignerAttributeData>.GetInstance(out var filteredInfos);
+            AddFilteredInfos(data, filteredInfos);
 
             // Now, group all the notifications by project and update all the projects in parallel.
-            foreach (var group in changedData.GroupBy(a => a.DocumentId.ProjectId))
+            using var _2 = ArrayBuilder<Task>.GetInstance(out var tasks);
+            foreach (var group in filteredInfos.GroupBy(a => a.DocumentId.ProjectId))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 tasks.Add(NotifyProjectSystemAsync(group.Key, group, cancellationToken));
@@ -257,78 +150,40 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
 
             // Wait until all project updates have happened before processing the next batch.
             await Task.WhenAll(tasks).ConfigureAwait(false);
-
-            // now that we've reported this data, record that we've done so so that we don't report the same data again in the future.
-            foreach (var data in changedData)
-                _documentToLastReportedCategory[data.DocumentId] = data.Category;
-
-            // Now, check the documents we've stored against the changed projects to see if they're no longer around. If
-            // so, dump what we have.  No need to notify anyone about this as the files are literally not in the
-            // solution anymore.  this is just to ensure we don't hold onto data forever.
-            if (latestSolution != null)
-            {
-                foreach (var (documentId, _) in _documentToLastReportedCategory)
-                {
-                    if (!latestSolution.ContainsDocument(documentId))
-                        _documentToLastReportedCategory.TryRemove(documentId, out _);
-                }
-            }
         }
 
-        private CodeAnalysis.Solution? AddChangedData(
-            ImmutableSegmentedList<(CodeAnalysis.Solution? solution, DesignerAttributeData? data)> dataList,
-            ArrayBuilder<DesignerAttributeData> changedData)
+        private static void AddFilteredInfos(ImmutableSegmentedList<DesignerAttributeData> data, ArrayBuilder<DesignerAttributeData> filteredData)
         {
-            using var _1 = PooledHashSet<DocumentId>.GetInstance(out var seenDocumentIds);
-            using var _2 = ArrayBuilder<DesignerAttributeData>.GetInstance(out var latestData);
+            using var _ = PooledHashSet<DocumentId>.GetInstance(out var seenDocumentIds);
 
-            CodeAnalysis.Solution? lastSolution = null;
-
-            for (var i = dataList.Count - 1; i >= 0; i--)
+            // Walk the list of designer items in reverse, and skip any items for a project once
+            // we've already seen it once.  That way, we're only reporting the most up to date
+            // information for a project, and we're skipping the stale information.
+            for (var i = data.Count - 1; i >= 0; i--)
             {
-                // go in reverse order so that results about the same document only take the later value.
-                var (solution, data) = dataList[i];
-
-                if (data != null)
-                {
-                    if (seenDocumentIds.Add(data.Value.DocumentId))
-                        latestData.Add(data.Value);
-                }
-
-                lastSolution ??= solution;
+                var info = data[i];
+                if (seenDocumentIds.Add(info.DocumentId))
+                    filteredData.Add(info);
             }
-
-            foreach (var data in latestData)
-            {
-                // only issue a change notification for files we haven't issued a notification for, or for files that
-                // changed their category.
-                if (!_documentToLastReportedCategory.TryGetValue(data.DocumentId, out var existingCategory) ||
-                    existingCategory != data.Category)
-                {
-                    changedData.Add(data);
-                }
-            }
-
-            return lastSolution;
         }
 
         private async Task NotifyProjectSystemAsync(
             ProjectId projectId,
-            IEnumerable<DesignerAttributeData> dataList,
+            IEnumerable<DesignerAttributeData> data,
             CancellationToken cancellationToken)
         {
             // Delegate to the CPS or legacy notification services as necessary.
             var cpsUpdateService = await GetUpdateServiceIfCpsProjectAsync(projectId, cancellationToken).ConfigureAwait(false);
             var task = cpsUpdateService == null
-                ? NotifyLegacyProjectSystemAsync(projectId, dataList, cancellationToken)
-                : NotifyCpsProjectSystemAsync(projectId, cpsUpdateService, dataList, cancellationToken);
+                ? NotifyLegacyProjectSystemAsync(projectId, data, cancellationToken)
+                : NotifyCpsProjectSystemAsync(projectId, cpsUpdateService, data, cancellationToken);
 
             await task.ConfigureAwait(false);
         }
 
         private async Task NotifyLegacyProjectSystemAsync(
             ProjectId projectId,
-            IEnumerable<DesignerAttributeData> dataList,
+            IEnumerable<DesignerAttributeData> data,
             CancellationToken cancellationToken)
         {
             // legacy project system can only be talked to on the UI thread.
@@ -344,10 +199,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
             if (hierarchy == null)
                 return;
 
-            foreach (var data in dataList)
+            foreach (var info in data)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                NotifyLegacyProjectSystemOnUIThread(designerService, hierarchy, data);
+                NotifyLegacyProjectSystemOnUIThread(designerService, hierarchy, info);
             }
         }
 
@@ -389,7 +244,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
         private async Task NotifyCpsProjectSystemAsync(
             ProjectId projectId,
             IProjectItemDesignerTypeUpdateService updateService,
-            IEnumerable<DesignerAttributeData> dataList,
+            IEnumerable<DesignerAttributeData> data,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -404,10 +259,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
 
             using var _ = ArrayBuilder<Task>.GetInstance(out var tasks);
 
-            foreach (var data in dataList)
+            foreach (var info in data)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                tasks.Add(NotifyCpsProjectSystemAsync(updateService, data, cancellationToken));
+                tasks.Add(NotifyCpsProjectSystemAsync(updateService, info, cancellationToken));
             }
 
             await Task.WhenAll(tasks).ConfigureAwait(false);
@@ -461,6 +316,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
                 var serviceProvider = new Shell.ServiceProvider(projectServiceProvider);
                 return serviceProvider.GetService(typeof(IProjectItemDesignerTypeUpdateService)) as IProjectItemDesignerTypeUpdateService;
             }
+        }
+
+        /// <summary>
+        /// Callback from the OOP service back into us.
+        /// </summary>
+        public ValueTask ReportDesignerAttributeDataAsync(ImmutableArray<DesignerAttributeData> data, CancellationToken cancellationToken)
+        {
+            Contract.ThrowIfNull(_projectSystemNotificationQueue);
+            _projectSystemNotificationQueue.AddWork(data);
+            return ValueTaskFactory.CompletedTask;
         }
     }
 }

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -136,24 +136,38 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
             var solutionChecksum = await solution.State.GetChecksumAsync(CancellationToken.None);
             await remoteWorkspace.UpdatePrimaryBranchSolutionAsync(assetProvider, solutionChecksum, solution.WorkspaceVersion, CancellationToken.None);
 
-            using var connection = client.CreateConnection<IRemoteDesignerAttributeDiscoveryService>(callbackTarget: null);
+            var callback = new DesignerAttributeComputerCallback();
 
-            var stream = connection.TryInvokeStreamAsync(
+            using var connection = client.CreateConnection<IRemoteDesignerAttributeDiscoveryService>(callback);
+
+            var invokeTask = connection.TryInvokeAsync(
                 solution,
-                (service, checksum, cancellationToken) => service.DiscoverDesignerAttributesAsync(checksum, solution.Projects.Single().Id, priorityDocument: null, cancellationToken),
+                (service, checksum, callbackId, cancellationToken) => service.DiscoverDesignerAttributesAsync(callbackId, checksum, priorityDocument: null, cancellationToken),
                 cancellationTokenSource.Token);
 
-            var items = new List<DesignerAttributeData>();
-            await foreach (var item in stream)
-                items.Add(item);
+            var infos = await callback.Infos;
+            Assert.Equal(1, infos.Length);
 
-            Assert.Equal(1, items.Count);
-
-            var info = items[0];
+            var info = infos[0];
             Assert.Equal("Form", info.Category);
             Assert.Equal(solution.Projects.Single().Documents.Single().Id, info.DocumentId);
 
             cancellationTokenSource.Cancel();
+
+            Assert.True(await invokeTask);
+        }
+
+        private class DesignerAttributeComputerCallback : IDesignerAttributeDiscoveryService.ICallback
+        {
+            private readonly TaskCompletionSource<ImmutableArray<DesignerAttributeData>> _infosSource = new();
+
+            public Task<ImmutableArray<DesignerAttributeData>> Infos => _infosSource.Task;
+
+            public ValueTask ReportDesignerAttributeDataAsync(ImmutableArray<DesignerAttributeData> infos, CancellationToken cancellationToken)
+            {
+                _infosSource.SetResult(infos);
+                return ValueTaskFactory.CompletedTask;
+            }
         }
 
         [Fact]

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IAsyncEnumerableExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IAsyncEnumerableExtensions.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
@@ -80,22 +79,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     while (reader.TryRead(out var item))
                         yield return item;
                 }
-            }
-        }
-
-        /// <summary>
-        /// Tasks an array of value producing tasks and produces a stream of results out of them.  Like <see
-        /// cref="MergeAsync{T}"/> absolutely no ordering guarantee is provided.  It will be expected that the
-        /// individual values from distinct tasks will be interleaved together.
-        /// </summary>
-        public static IAsyncEnumerable<T> StreamAsync<T>(this ImmutableArray<Task<T>> tasks, CancellationToken cancellationToken)
-        {
-            return tasks.SelectAsArray(static (t, cancellationToken) => CreateStream(t, cancellationToken), cancellationToken).MergeAsync(cancellationToken);
-
-            static async IAsyncEnumerable<T> CreateStream(
-                Task<T> task, [EnumeratorCancellation] CancellationToken cancellationToken)
-            {
-                yield return await task.ConfigureAwait(false);
             }
         }
     }

--- a/src/Workspaces/Remote/Core/ServiceDescriptors.cs
+++ b/src/Workspaces/Remote/Core/ServiceDescriptors.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Remote
             (typeof(IRemoteAssetSynchronizationService), null),
             (typeof(IRemoteAsynchronousOperationListenerService), null),
             (typeof(IRemoteTaskListService), null),
-            (typeof(IRemoteDesignerAttributeDiscoveryService), null),
+            (typeof(IRemoteDesignerAttributeDiscoveryService), typeof(IRemoteDesignerAttributeDiscoveryService.ICallback)),
             (typeof(IRemoteDiagnosticAnalyzerService), null),
             (typeof(IRemoteSemanticClassificationService), null),
             (typeof(IRemoteDocumentHighlightsService), null),

--- a/src/Workspaces/Remote/ServiceHub/Services/DesignerAttributeDiscovery/RemoteDesignerAttributeDiscoveryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DesignerAttributeDiscovery/RemoteDesignerAttributeDiscoveryService.cs
@@ -2,55 +2,62 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.DesignerAttribute;
-using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SolutionCrawler;
-using StreamJsonRpc;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
     internal sealed class RemoteDesignerAttributeDiscoveryService : BrokeredServiceBase, IRemoteDesignerAttributeDiscoveryService
     {
-        /// <summary>
-        /// Allow designer attribute computation to continue on on the server, even while the client is processing the
-        /// last batch of results.
-        /// </summary>
-        /// <remarks>
-        /// This value was not determined empirically.
-        /// </remarks>
-        private const int MaxReadAhead = 64;
-
-        internal sealed class Factory : FactoryBase<IRemoteDesignerAttributeDiscoveryService>
+        private sealed class CallbackWrapper : IDesignerAttributeDiscoveryService.ICallback
         {
-            protected override IRemoteDesignerAttributeDiscoveryService CreateService(in ServiceConstructionArguments arguments)
-                => new RemoteDesignerAttributeDiscoveryService(arguments);
+            private readonly RemoteCallback<IRemoteDesignerAttributeDiscoveryService.ICallback> _callback;
+            private readonly RemoteServiceCallbackId _callbackId;
+
+            public CallbackWrapper(
+                RemoteCallback<IRemoteDesignerAttributeDiscoveryService.ICallback> callback,
+                RemoteServiceCallbackId callbackId)
+            {
+                _callback = callback;
+                _callbackId = callbackId;
+            }
+
+            public ValueTask ReportDesignerAttributeDataAsync(ImmutableArray<DesignerAttributeData> data, CancellationToken cancellationToken)
+                => _callback.InvokeAsync((callback, cancellationToken) => callback.ReportDesignerAttributeDataAsync(_callbackId, data, cancellationToken), cancellationToken);
         }
 
-        public RemoteDesignerAttributeDiscoveryService(in ServiceConstructionArguments arguments)
+        internal sealed class Factory : FactoryBase<IRemoteDesignerAttributeDiscoveryService, IRemoteDesignerAttributeDiscoveryService.ICallback>
+        {
+            protected override IRemoteDesignerAttributeDiscoveryService CreateService(in ServiceConstructionArguments arguments, RemoteCallback<IRemoteDesignerAttributeDiscoveryService.ICallback> callback)
+                => new RemoteDesignerAttributeDiscoveryService(arguments, callback);
+        }
+
+        private readonly RemoteCallback<IRemoteDesignerAttributeDiscoveryService.ICallback> _callback;
+
+        public RemoteDesignerAttributeDiscoveryService(in ServiceConstructionArguments arguments, RemoteCallback<IRemoteDesignerAttributeDiscoveryService.ICallback> callback)
             : base(arguments)
         {
+            _callback = callback;
         }
 
-        public IAsyncEnumerable<DesignerAttributeData> DiscoverDesignerAttributesAsync(
+        public ValueTask DiscoverDesignerAttributesAsync(
+            RemoteServiceCallbackId callbackId,
             Checksum solutionChecksum,
-            ProjectId projectId,
             DocumentId? priorityDocument,
             CancellationToken cancellationToken)
         {
-            var stream = StreamWithSolutionAsync(
+            return RunServiceAsync(
                 solutionChecksum,
-                (solution, cancellationToken) =>
+                solution =>
                 {
-                    var project = solution.GetRequiredProject(projectId);
                     var service = solution.Services.GetRequiredService<IDesignerAttributeDiscoveryService>();
-                    return service.ProcessProjectAsync(project, priorityDocument, cancellationToken);
-                }, cancellationToken);
-            return stream.WithJsonRpcSettings(new JsonRpcEnumerableSettings { MaxReadAhead = MaxReadAhead });
+                    return service.ProcessSolutionAsync(
+                        solution, priorityDocument, new CallbackWrapper(_callback, callbackId), cancellationToken);
+                },
+                cancellationToken);
         }
     }
 }


### PR DESCRIPTION
Reverts dotnet/roslyn#64616 to fix regression in [insertion](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/VS/pullrequest/430655)

1. See https://github.com/dotnet/roslyn/pull/64616#discussion_r1001012370
 
2. This also caused an assembly load in UWP test. It seems the assembly "Microsoft.VisualStudio.Design.ni.dll" is loaded in baseline too, but only after "0200.Xaml Designer Load" scenario completed, but now we are loading it before "0200.Xaml Designer Load" starts.
```
Name
 Image Load Microsoft.VisualStudio.Design.ni.dll (C:\Windows\assembly\NativeImages_v4.0.30319_64\Microsoft.V1de0ecc7#\5d1368f8dfbb87b7d62c2a3f9f13ca1a\)
+ module ntoskrnl <<ntoskrnl!?>>
 + module ntdll <<ntdll!LdrLoadDll>>
  + module kernelbase <<kernelbase!LoadLibraryExW>>
   + module clr <<clr!AssemblyNative::Load>>
    + module mscorlib.ni <<mscorlib.ni!DomainNeutralILStubClass.IL_STUB_COMtoCLR(IntPtr, IntPtr, IntPtr)>>
     + module clr <<clr!GenericComCallStub>>
      + module msenv <<msenv!?>>
       + module microsoft.visualstudio.interop.ni <<microsoft.visualstudio.interop.ni!DomainBoundILStubClass.IL_STUB_CLRtoCOM(System.Guid ByRef, System.Guid ByRef, IntPtr ByRef)>>
        + module microsoft.visualstudio.shell.framework.ni <<microsoft.visualstudio.shell.framework.ni!ServiceProvider.GetService>>
         + module microsoft.visualstudio.languageservices.ni <<microsoft.visualstudio.languageservices.ni!Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribute.VisualStudioDesignerAttributeService+<NotifyLegacyProjectSystemAsync>d__18.MoveNext()>>

```

FYI @CyrusNajmabadi to investigate

