### PR TITLE
Update the global.json pinned SDK to .NET 7 RC2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -220,7 +220,7 @@
       is expected by the NET SDK used in the Workspace.MSBuild UnitTests. In order to test against the same verion of NuGet
       as our configured SDK, we must set the version to be the same.
      -->
-    <NuGetCommonVersion>6.4.0-preview.1.54</NuGetCommonVersion>
+    <NuGetCommonVersion>6.4.0-preview.3.88</NuGetCommonVersion>
     <NuGetConfigurationVersion>$(NuGetCommonVersion)</NuGetConfigurationVersion>
     <NuGetFrameworksVersion>$(NuGetCommonVersion)</NuGetFrameworksVersion>
     <NuGetPackagingVersion>$(NuGetCommonVersion)</NuGetPackagingVersion>

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "7.0.100-rc.1.22431.12",
+    "version": "7.0.100-rc.2.22477.23",
     "allowPrerelease": true,
     "rollForward": "latestPatch"
   },
   "tools": {
-    "dotnet": "7.0.100-rc.1.22431.12",
+    "dotnet": "7.0.100-rc.2.22477.23",
     "vs": {
       "version": "17.2"
     },


### PR DESCRIPTION
This is a test to see if we can get our DartLab integration tests running again.

Test Run: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=6855794&view=results (microsoft)