### PR TITLE
Expose a way to change the document service provider to Razor

### DIFF
--- a/src/Tools/ExternalAccess/Razor/InternalAPI.Unshipped.txt
+++ b/src/Tools/ExternalAccess/Razor/InternalAPI.Unshipped.txt
@@ -63,6 +63,7 @@ Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorDynamicFileInfo.FilePath.get ->
 Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorDynamicFileInfo.RazorDynamicFileInfo(string! filePath, Microsoft.CodeAnalysis.SourceCodeKind sourceCodeKind, Microsoft.CodeAnalysis.TextLoader! textLoader, Microsoft.CodeAnalysis.ExternalAccess.Razor.IRazorDocumentServiceProvider! documentServiceProvider) -> void
 Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorDynamicFileInfo.SourceCodeKind.get -> Microsoft.CodeAnalysis.SourceCodeKind
 Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorDynamicFileInfo.TextLoader.get -> Microsoft.CodeAnalysis.TextLoader!
+Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorDynamicFileInfo.ToUpdatedDocumentInfo(Microsoft.CodeAnalysis.DocumentInfo! existingDocumentInfo) -> Microsoft.CodeAnalysis.DocumentInfo!
 Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorDynamicFileInfoProviderWrapper
 Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorDynamicFileInfoProviderWrapper.GetDynamicFileInfoAsync(Microsoft.CodeAnalysis.ProjectId! projectId, string! projectFilePath, string! filePath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Host.DynamicFileInfo?>!
 Microsoft.CodeAnalysis.ExternalAccess.Razor.RazorDynamicFileInfoProviderWrapper.RazorDynamicFileInfoProviderWrapper(System.Lazy<Microsoft.CodeAnalysis.ExternalAccess.Razor.IRazorDynamicFileInfoProvider!>! innerDynamicFileInfoProvider) -> void

--- a/src/Tools/ExternalAccess/Razor/RazorDynamicFileInfo.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorDynamicFileInfo.cs
@@ -41,5 +41,15 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
         /// return <see cref="IRazorDocumentServiceProvider"/> for the contents it provides
         /// </summary>
         public IRazorDocumentServiceProvider DocumentServiceProvider { get; }
+
+        /// <summary>
+        /// Constructs a new <see cref="DocumentInfo"/> from an existing <see cref="DocumentInfo"/> but with updated
+        /// text loader and document service provider coming from this instance.
+        /// </summary>
+        public DocumentInfo ToUpdatedDocumentInfo(DocumentInfo existingDocumentInfo)
+        {
+            var serviceProvider = new RazorDocumentServiceProviderWrapper(this.DocumentServiceProvider);
+            return new DocumentInfo(existingDocumentInfo.Attributes, this.TextLoader, serviceProvider);
+        }
     }
 }


### PR DESCRIPTION
This exposes a way to update the `DocumentServiceProvider` of a `DocumentInfo`, which fixes a colourization issue in Razor files on VS Mac, namely https://github.com/dotnet/razor-tooling/issues/6725. This is the Roslyn part of fixing [AB#1643651](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1643651)

This is not a problem on Windows because Roslyn does this in the VS layer:
https://github.com/dotnet/roslyn/blob/157d34acf5c19fc6780ac00ca09e58d40873864a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProject.BatchingDocumentCollection.cs#L482