### PR TITLE
Make SyntaxToken.WriteTo(writer, leading, trailing) public

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Writes the text of this token to the specified TextWriter, optionally including trivia.
         /// </summary>
-        internal void WriteTo(System.IO.TextWriter writer, bool leading, bool trailing)
+        public void WriteTo(System.IO.TextWriter writer, bool leading, bool trailing)
         {
             Node?.WriteTo(writer, leading, trailing);
         }


### PR DESCRIPTION
Is there any reason why some of these methods are internal? Was trying to write high performance source generator without string allocations but I have to write strings without spaces for proper comparisons.