### PR TITLE
Revert "Revert "Read required project properties from evaluation data""

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -470,6 +470,14 @@ function TestUsingRunTests() {
         Write-Host "No ServiceHub logs found to copy"
       }
 
+      $projectFaultLogs = Join-Path $TempDir "VsProjectFault_*.failure.txt"
+      if (Test-Path $projectFaultLogs) {
+        Write-Host "Copying VsProjectFault logs to $LogDir"
+        Copy-Item -Path $serviceHubLogs -Destination $LogDir
+      } else {
+        Write-Host "No VsProjectFault logs found to copy"
+      }
+
       if ($lspEditor) {
         $lspLogs = Join-Path $TempDir "VSLogs"
         $telemetryLog = Join-Path $TempDir "VSTelemetryLog"

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -473,7 +473,7 @@ function TestUsingRunTests() {
       $projectFaultLogs = Join-Path $TempDir "VsProjectFault_*.failure.txt"
       if (Test-Path $projectFaultLogs) {
         Write-Host "Copying VsProjectFault logs to $LogDir"
-        Copy-Item -Path $serviceHubLogs -Destination $LogDir
+        Copy-Item -Path $projectFaultLogs -Destination $LogDir
       } else {
         Write-Host "No VsProjectFault logs found to copy"
       }

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -178,14 +178,16 @@
        parse options. We'll then have to reparse them a second time which isn't great. It also means any
        cache lookups we do won't have the right options either, so the cache lookups might miss.
 
-       To help this, we'll have a property for the evaluation pass which is an "approximation" of the
-       options that would come out of CoreCompile, but only the ones that matter for parsing. It's acceptable
-       for this to be imperfect: once the execution pass is complete we'll use those options instead,
+       To help this, we'll have properties for the evaluation pass which is an "approximation" of the
+       options that would come out of CoreCompile, but only the ones that are required to be specified
+       and we don't expect them to change after evaluation phase or those that matter for parsing.
+
+       It's acceptable for the options that affect parsing to be imperfect: once the execution pass is complete we'll use those options instead,
        so any behaviors here that don't match the real command line generation will only be temporary, and
        probably won't be any worse than having no options at all. -->
-       
   <PropertyGroup>
     <CommandLineArgsForDesignTimeEvaluation>-langversion:$(LangVersion) -checksumalgorithm:$(ChecksumAlgorithm)</CommandLineArgsForDesignTimeEvaluation>
     <CommandLineArgsForDesignTimeEvaluation Condition="'$(DefineConstants)' != ''">$(CommandLineArgsForDesignTimeEvaluation) -define:$(DefineConstants)</CommandLineArgsForDesignTimeEvaluation>
+    <OutputAssemblyForDesignTimeEvaluation>@(IntermediateAssembly)</OutputAssemblyForDesignTimeEvaluation>
   </PropertyGroup>
 </Project>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -186,8 +186,8 @@
        so any behaviors here that don't match the real command line generation will only be temporary, and
        probably won't be any worse than having no options at all. -->
   <PropertyGroup>
-    <CommandLineArgsForDesignTimeEvaluation>-langversion:$(LangVersion) -checksumalgorithm:$(ChecksumAlgorithm)</CommandLineArgsForDesignTimeEvaluation>
+    <CommandLineArgsForDesignTimeEvaluation>-langversion:$(LangVersion)</CommandLineArgsForDesignTimeEvaluation>
+    <CommandLineArgsForDesignTimeEvaluation Condition="'$(ChecksumAlgorithm)' != ''">$(CommandLineArgsForDesignTimeEvaluation) -checksumalgorithm:$(ChecksumAlgorithm)</CommandLineArgsForDesignTimeEvaluation>
     <CommandLineArgsForDesignTimeEvaluation Condition="'$(DefineConstants)' != ''">$(CommandLineArgsForDesignTimeEvaluation) -define:$(DefineConstants)</CommandLineArgsForDesignTimeEvaluation>
-    <OutputAssemblyForDesignTimeEvaluation>@(IntermediateAssembly)</OutputAssemblyForDesignTimeEvaluation>
   </PropertyGroup>
 </Project>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -147,14 +147,16 @@
        parse options. We'll then have to reparse them a second time which isn't great. It also means any
        cache lookups we do won't have the right options either, so the cache lookups might miss.
 
-       To help this, we'll have a property for the evaluation pass which is an "approximation" of the
-       options that would come out of CoreCompile, but only the ones that matter for parsing. It's acceptable
-       for this to be imperfect: once the execution pass is complete we'll use those options instead,
+       To help this, we'll have properties for the evaluation pass which is an "approximation" of the
+       options that would come out of CoreCompile, but only the ones that are required to be specified
+       and we don't expect them to change after evaluation phase or those that matter for parsing.
+
+       It's acceptable for the options that affect parsing to be imperfect: once the execution pass is complete we'll use those options instead,
        so any behaviors here that don't match the real command line generation will only be temporary, and
        probably won't be any worse than having no options at all. -->
-       
   <PropertyGroup>
     <CommandLineArgsForDesignTimeEvaluation>-langversion:$(LangVersion) -checksumalgorithm:$(ChecksumAlgorithm)</CommandLineArgsForDesignTimeEvaluation>
     <CommandLineArgsForDesignTimeEvaluation Condition="'$(FinalDefineConstants)' != ''">$(CommandLineArgsForDesignTimeEvaluation) -define:$(FinalDefineConstants)</CommandLineArgsForDesignTimeEvaluation>
+    <OutputAssemblyForDesignTimeEvaluation>@(IntermediateAssembly)</OutputAssemblyForDesignTimeEvaluation>
   </PropertyGroup>
 </Project>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.VisualBasic.Core.targets
@@ -155,8 +155,8 @@
        so any behaviors here that don't match the real command line generation will only be temporary, and
        probably won't be any worse than having no options at all. -->
   <PropertyGroup>
-    <CommandLineArgsForDesignTimeEvaluation>-langversion:$(LangVersion) -checksumalgorithm:$(ChecksumAlgorithm)</CommandLineArgsForDesignTimeEvaluation>
+    <CommandLineArgsForDesignTimeEvaluation>-langversion:$(LangVersion)</CommandLineArgsForDesignTimeEvaluation>
+    <CommandLineArgsForDesignTimeEvaluation Condition="'$(ChecksumAlgorithm)' != ''">$(CommandLineArgsForDesignTimeEvaluation) -checksumalgorithm:$(ChecksumAlgorithm)</CommandLineArgsForDesignTimeEvaluation>
     <CommandLineArgsForDesignTimeEvaluation Condition="'$(FinalDefineConstants)' != ''">$(CommandLineArgsForDesignTimeEvaluation) -define:$(FinalDefineConstants)</CommandLineArgsForDesignTimeEvaluation>
-    <OutputAssemblyForDesignTimeEvaluation>@(IntermediateAssembly)</OutputAssemblyForDesignTimeEvaluation>
   </PropertyGroup>
 </Project>

--- a/src/Tools/ExternalAccess/FSharp/VS/IFSharpWorkspaceProjectContextFactory.cs
+++ b/src/Tools/ExternalAccess/FSharp/VS/IFSharpWorkspaceProjectContextFactory.cs
@@ -92,6 +92,9 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp
                     BuildPropertyNames.TargetPath => _binOutputPath ?? "",
                     _ => "",
                 };
+
+            public override ImmutableArray<string> GetItemValues(string name)
+                => ImmutableArray<string>.Empty;
         }
     }
 

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
@@ -81,7 +81,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             var hierarchy = environment.CreateHierarchy(projectName, binOutputPath, projectRefPath: null, "CSharp");
             var cpsProjectFactory = environment.ExportProvider.GetExportedValue<IWorkspaceProjectContextFactory>();
 
-            var data = new TestEvaluationData(projectFilePath, binOutputPath, assemblyName: "");
+            var data = new TestEvaluationData(projectFilePath, binOutputPath, assemblyName: "", binOutputPath, checksumAlgorithm: "SHA256");
 
             var cpsProject = (CPSProject)await cpsProjectFactory.CreateProjectContextAsync(
                 projectGuid,
@@ -101,7 +101,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             var hierarchy = environment.CreateHierarchy(projectName, projectBinPath: null, projectRefPath: null, projectCapabilities: "");
             var cpsProjectFactory = environment.ExportProvider.GetExportedValue<IWorkspaceProjectContextFactory>();
 
-            var data = new TestEvaluationData(projectFilePath, targetPath, assemblyName: "");
+            var data = new TestEvaluationData(projectFilePath, targetPath, assemblyName: "", targetPath, checksumAlgorithm: "SHA256");
 
             return (CPSProject)await cpsProjectFactory.CreateProjectContextAsync(
                 Guid.NewGuid(),

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/TestEvaluationData.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/TestEvaluationData.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Roslyn.Utilities;
 
@@ -14,12 +15,16 @@ internal sealed class TestEvaluationData : EvaluationData
     public string ProjectFilePath { get; }
     public string TargetPath { get; }
     public string AssemblyName { get; }
+    public string OutputAssembly { get; }
+    public string ChecksumAlgorithm { get; }
 
-    public TestEvaluationData(string projectFilePath, string targetPath, string assemblyName)
+    public TestEvaluationData(string projectFilePath, string targetPath, string assemblyName, string outputAssembly, string checksumAlgorithm)
     {
         ProjectFilePath = projectFilePath;
         TargetPath = targetPath;
         AssemblyName = assemblyName;
+        OutputAssembly = outputAssembly;
+        ChecksumAlgorithm = checksumAlgorithm;
     }
 
     public override string GetPropertyValue(string name)
@@ -28,6 +33,14 @@ internal sealed class TestEvaluationData : EvaluationData
             "MSBuildProjectFullPath" => ProjectFilePath,
             "TargetPath" => TargetPath,
             "AssemblyName" => AssemblyName,
+            "CommandLineArgsForDesignTimeEvaluation" => "-checksumalgorithm:" + ChecksumAlgorithm,
+            _ => throw ExceptionUtilities.UnexpectedValue(name)
+        };
+
+    public override ImmutableArray<string> GetItemValues(string name)
+        => name switch
+        {
+            "IntermediateAssembly" => ImmutableArray.Create(OutputAssembly),
             _ => throw ExceptionUtilities.UnexpectedValue(name)
         };
 }

--- a/src/VisualStudio/Core/Def/ProjectSystem/BuildPropertyNames.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/BuildPropertyNames.cs
@@ -29,6 +29,7 @@ internal static class BuildPropertyNames
     public const string TargetPath = nameof(TargetPath);
     public const string AssemblyName = nameof(AssemblyName);
     public const string CommandLineArgsForDesignTimeEvaluation = nameof(CommandLineArgsForDesignTimeEvaluation);
+    public const string IntermediateAssembly = nameof(IntermediateAssembly);
 
     public static readonly ImmutableArray<string> InitialEvaluationPropertyNames = ImmutableArray.Create(
         MSBuildProjectFullPath,
@@ -36,5 +37,6 @@ internal static class BuildPropertyNames
         AssemblyName,
         CommandLineArgsForDesignTimeEvaluation);
 
-    public static readonly ImmutableArray<string> InitialEvaluationItemNames = ImmutableArray<string>.Empty;
+    public static readonly ImmutableArray<string> InitialEvaluationItemNames = ImmutableArray.Create(
+        IntermediateAssembly);
 }

--- a/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs
@@ -18,6 +18,29 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
     internal interface IWorkspaceProjectContextFactory
     {
         /// <summary>
+        /// Creates and initializes a new Workspace project and returns a <see
+        /// cref="IWorkspaceProjectContext"/> to lazily initialize the properties and items for the
+        /// project.  This method guarantees that either the project is added (and the returned task
+        /// completes) or cancellation is observed and no project is added.
+        /// </summary>
+        /// <param name="languageName">Project language.</param>
+        /// <param name="projectUniqueName">Unique name for the project.</param>
+        /// <param name="projectFilePath">Full path to the project file for the project.</param>
+        /// <param name="projectGuid">Project guid.</param>
+        /// <param name="hierarchy">The IVsHierarchy for the project; this is used to track linked files across multiple projects when determining contexts.</param>
+        /// <param name="binOutputPath">Initial project binary output path.</param>
+        [Obsolete]
+        Task<IWorkspaceProjectContext> CreateProjectContextAsync(
+            string languageName,
+            string projectUniqueName,
+            string projectFilePath,
+            Guid projectGuid,
+            object? hierarchy,
+            string? binOutputPath,
+            string? assemblyName,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Creates and initializes a new project and returns a <see
         /// cref="IWorkspaceProjectContext"/> to lazily initialize the properties and items for the
         /// project.  This method guarantees that either the project is added (and the returned task

--- a/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
@@ -16,29 +17,6 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
     /// </summary>
     internal interface IWorkspaceProjectContextFactory
     {
-        /// <summary>
-        /// Creates and initializes a new Workspace project and returns a <see
-        /// cref="IWorkspaceProjectContext"/> to lazily initialize the properties and items for the
-        /// project.  This method guarantees that either the project is added (and the returned task
-        /// completes) or cancellation is observed and no project is added.
-        /// </summary>
-        /// <param name="languageName">Project language.</param>
-        /// <param name="projectUniqueName">Unique name for the project.</param>
-        /// <param name="projectFilePath">Full path to the project file for the project.</param>
-        /// <param name="projectGuid">Project guid.</param>
-        /// <param name="hierarchy">The IVsHierarchy for the project; this is used to track linked files across multiple projects when determining contexts.</param>
-        /// <param name="binOutputPath">Initial project binary output path.</param>
-        [Obsolete]
-        Task<IWorkspaceProjectContext> CreateProjectContextAsync(
-            string languageName,
-            string projectUniqueName,
-            string projectFilePath,
-            Guid projectGuid,
-            object? hierarchy,
-            string? binOutputPath,
-            string? assemblyName,
-            CancellationToken cancellationToken);
-
         /// <summary>
         /// Creates and initializes a new project and returns a <see
         /// cref="IWorkspaceProjectContext"/> to lazily initialize the properties and items for the
@@ -89,8 +67,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
         /// <exception cref="InvalidProjectDataException">
         /// The <paramref name="name"/> is not listed in <see cref="IWorkspaceProjectContextFactory.EvaluationItemNames"/>
         /// </exception>
-        public virtual ImmutableArray<string> GetItemValues(string name)
-            => ImmutableArray<string>.Empty;
+        public abstract ImmutableArray<string> GetItemValues(string name);
 
         public string GetRequiredPropertyValue(string name)
         {

--- a/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/CPS/IWorkspaceProjectContextFactory.cs
@@ -67,7 +67,8 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
         /// <exception cref="InvalidProjectDataException">
         /// The <paramref name="name"/> is not listed in <see cref="IWorkspaceProjectContextFactory.EvaluationItemNames"/>
         /// </exception>
-        public abstract ImmutableArray<string> GetItemValues(string name);
+        public virtual ImmutableArray<string> GetItemValues(string name)
+            => ImmutableArray<string>.Empty;
 
         public string GetRequiredPropertyValue(string name)
         {

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
@@ -126,15 +126,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             return project;
         }
 
-        private static string GetIntermediateAssemblyPath(EvaluationData data, string projectFilePath)
+        private static string? GetIntermediateAssemblyPath(EvaluationData data, string projectFilePath)
         {
             const string itemName = BuildPropertyNames.IntermediateAssembly;
 
             var values = data.GetItemValues(itemName);
             if (values.Length != 1)
             {
-                var joinedValues = string.Join(";", values);
-                throw new InvalidProjectDataException(itemName, joinedValues, $"Item group '{itemName}' is required to specify a single value: '{joinedValues}'.");
+                // TODO: Throw once we update integration tests to the latest VS (https://github.com/dotnet/roslyn/issues/65439)
+                // var joinedValues = string.Join(";", values);
+                // throw new InvalidProjectDataException(itemName, joinedValues, $"Item group '{itemName}' is required to specify a single value: '{joinedValues}'.");
+                return null;
             }
 
             var path = values[0];

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
@@ -106,7 +106,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
                 };
         }
 
-
         public async Task<IWorkspaceProjectContext> CreateProjectContextAsync(Guid id, string uniqueName, string languageName, EvaluationData data, object? hostObject, CancellationToken cancellationToken)
         {
             // Read all required properties from EvaluationData before we start updating anything.

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -127,7 +127,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         }
 
         internal string? CompilationOutputAssemblyFilePath
-            => _visualStudioProject.CompilationOutputAssemblyFilePath;
+        {
+            get => _visualStudioProject.CompilationOutputAssemblyFilePath;
+            set => _visualStudioProject.CompilationOutputAssemblyFilePath = value;
+        }
 
         public ProjectId Id => _visualStudioProject.Id;
 


### PR DESCRIPTION
Reverts dotnet/roslyn#64801

Requires https://github.com/dotnet/project-system/pull/8647

The fix on project system was inserted in https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/430730?_a=overview

validation insertion
~~https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/431223~~
~~https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=6873802&view=results~~
~~https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/431722~~
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=6950263&view=results