### PR TITLE
Reduce the packaged size of the LSIF generator

### DIFF
--- a/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
+++ b/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
@@ -30,16 +30,24 @@
     For more information about LSIF, see https://code.visualstudio.com/blogs/2019/02/19/lsif</PackageDescription>
 
     <IsShipping>false</IsShipping>
+
+    <!-- Don't include other languages; at this point we don't have a end-to-end experience for LSIF indexing in other languages,
+         but until then we can save the download/deploy cost for each indexing job. -->
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
   </PropertyGroup>
 
   <Target Name="_GetFilesToPackage" DependsOnTargets="ResolveReferences;BuiltProjectOutputGroup">
     <ItemGroup>
-      <!-- Include all dependencies; the DestinationSubDierctory is to handle culture-specific resource files that should be placed in
+      <!-- Include all dependencies; the DestinationSubDirectory is to handle culture-specific resource files that should be placed in
            subdirectories -->
-      <TfmSpecificPackageFile Include="@(ReferenceCopyLocalPaths)" PackagePath="tools\$(TargetFramework)\any\%(ReferenceCopyLocalPaths.DestinationSubDirectory)" />
+
+      <!-- HACK: Setting SatelliteResourceLanguages still seems to be bringing satellite resources from other project references along,
+           so we'll filter this in the condition here. --> 
+      <TfmSpecificPackageFile Include="@(ReferenceCopyLocalPaths)"
+                              PackagePath="tools\$(TargetFramework)\any\%(ReferenceCopyLocalPaths.DestinationSubDirectory)"
+                              Condition="'%(ReferenceCopyLocalPaths.DestinationSubDirectory)' == '' and '%(Extension)' != '.pdb' and '%(Extension)' != '.xml'" />
 
       <TfmSpecificPackageFile Include="@(BuiltProjectOutputGroupOutput)" PackagePath="tools\$(TargetFramework)\any" />
-
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This excludes .pdbs, .xml files and satellite resource files from the packaged file, which we don't need at this point. This reduces the package size by 26% which can save on download times.