### PR TITLE
Reverting Code Index ingestion

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -52,7 +52,7 @@ jobs:
       displayName: Build
       inputs:
         filePath: eng/build.ps1
-        arguments: -ci -restore -build -binaryLog -configuration Debug -prepareMachine
+        arguments: -ci -restore -build -configuration Debug -prepareMachine
 
     - task: RichCodeNavIndexer@0
       displayName: RichCodeNav Upload


### PR DESCRIPTION
The Code Index pipeline is currently having some problems with ingestion using binlogs. Removing the BinLog build option, so the ingestion reverts back to a working state until we have a solution to the problem.