### PR TITLE
Update 17.4 version to preview 6

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
     <MajorVersion>4</MajorVersion>
     <MinorVersion>4</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>4</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>6</PreReleaseVersionLabel>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <!--
       By default the assembly version in official builds is "$(MajorVersion).$(MinorVersion).0.0".


### PR DESCRIPTION
It looks like we forgot to do this for preview 5. I'm not sure whether this step is actually necessary, it just seems consistent to do it. Not urgent to merge until we get a QB bug going into 17.4 again. cc @genlu @JoeRobich @dotnet/roslyn-infrastructure.