### PR TITLE
Upload xunit results as an attachment from helix

### DIFF
--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -207,6 +208,7 @@ namespace RunTests
                 AddRehydrateTestFoldersCommand(command, workItemInfo, isUnix);
 
                 var xmlResultsFilePath = ProcessTestExecutor.GetResultsFilePath(workItemInfo, options, "xml");
+                Contract.Assert(!options.IncludeHtml);
 
                 // Build an rsp file to send to dotnet test that contains all the assemblies and tests to run.
                 // This gets around command line length limitations and avoids weird escaping issues.


### PR DESCRIPTION
Xunit results sometimes contain more information, like the reason a test was skipped.  We can copy this file to the helix attachment directory so it gets uploaded

For failed runs, this shows up on the artifacts tab.  For passing runs this can be found using the jobId and workitem name in kusto, e.g.
```
cluster('engsrvprod').database('engineeringdata').Files
| where JobName == "aa3297b7-5b7f-4a73-8f96-2d4eb450697a"
| where WorkItemFriendlyName == "Microsoft.CodeAnalysis.VisualBasic.Semantic.UnitTests_Microsoft.CodeAnalysis.VisualBasic.Symbol.UnitTests_Microsoft.CodeAnalysis.VisualBasic.Syntax.Un..._24"
```