### PR TITLE
Disallow default parameter values in anonymous method expressions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lambda.cs
@@ -125,6 +125,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     checkAttributes(syntax, p.AttributeLists, diagnostics);
 
+                    var isAnonymousMethod = syntax.IsKind(SyntaxKind.AnonymousMethodExpression);
+                    if (p.Default != null && isAnonymousMethod)
+                    {
+                        Error(diagnostics, ErrorCode.ERR_DefaultValueNotAllowed, p.Default.EqualsToken);
+                    }
+
                     if (p.IsArgList)
                     {
                         Error(diagnostics, ErrorCode.ERR_IllegalVarArgs, p);
@@ -143,7 +149,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     else
                     {
                         type = BindType(typeSyntax, diagnostics);
-                        var isAnonymousMethod = syntax.IsKind(SyntaxKind.AnonymousMethodExpression);
                         ParameterHelpers.CheckParameterModifiers(p, diagnostics, parsingFunctionPointerParams: false,
                             parsingLambdaParams: !isAnonymousMethod,
                             parsingAnonymousMethodParams: isAnonymousMethod);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaDiscardParametersTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaDiscardParametersTests.cs
@@ -346,7 +346,10 @@ public class C
                 Diagnostic(ErrorCode.ERR_AttributesNotAllowed, "[System.Obsolete]").WithLocation(6, 51),
                 // (6,79): error CS9501: Parameter 2 has default value 'default(int)' in lambda and '<missing>' in the target delegate type.
                 //         System.Func<int, int, long> f1 = delegate([System.Obsolete]int _, int _ = 0) { return 3L; };
-                Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "_").WithArguments("2", "default(int)", "<missing>").WithLocation(6, 79));
+                Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "_").WithArguments("2", "default(int)", "<missing>").WithLocation(6, 79),
+                // (6,81): error CS1065: Default values are not valid in this context.
+                //         System.Func<int, int, long> f1 = delegate([System.Obsolete]int _, int _ = 0) { return 3L; };
+                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(6, 81));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -7057,8 +7057,6 @@ public class DisplayAttribute : System.Attribute
             comp.VerifyDiagnostics();
         }
 
-
-        // PROTOTYPE: Add separate test cases for lang version 11 vs. lang version 11 preview
         [Fact]
         public void AnonymousMethodWithExplicitDefaultParam()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -7074,7 +7074,10 @@ class Program
 
 """;
             var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (5,34): error CS1065: Default values are not valid in this context.
+                //         var lam = delegate(int x = 7) { return x; };
+                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(5, 34));
         }
 
         [Fact]
@@ -7160,6 +7163,9 @@ class Program
 
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
+                // (5,34): error CS1065: Default values are not valid in this context.
+                //         var lam = delegate(int a = 3, int b) { return a + b; };
+                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(5, 34),
                 // (5,44): error CS1737: Optional parameters must appear after all required parameters
                 //         var lam = delegate(int a = 3, int b) { return a + b; };
                 Diagnostic(ErrorCode.ERR_DefaultValueBeforeRequiredValue, ")").WithLocation(5, 44));
@@ -7199,6 +7205,9 @@ class Program
 ";
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
+                    // (5,41): error CS1065: Default values are not valid in this context.
+                    //         var lam = delegate(int x, int y = 3, int z) { return x + y + z; };
+                    Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(5, 41),
                     // (5,51): error CS1737: Optional parameters must appear after all required parameters
                     //         var lam = delegate(int x, int y = 3, int z) { return x + y + z; };
                     Diagnostic(ErrorCode.ERR_DefaultValueBeforeRequiredValue, ")").WithLocation(5, 51));
@@ -7239,7 +7248,10 @@ class Program
             comp.VerifyDiagnostics(
                 // (5,32): error CS1750: A value of type 'string' cannot be used as a default parameter because there are no standard conversions to type 'int'
                 //         var lam = delegate(int x = "abcdef") { return x; };
-                Diagnostic(ErrorCode.ERR_NoConversionForDefaultParam, "x").WithArguments("string", "int").WithLocation(5, 32));
+                Diagnostic(ErrorCode.ERR_NoConversionForDefaultParam, "x").WithArguments("string", "int").WithLocation(5, 32),
+                // (5,34): error CS1065: Default values are not valid in this context.
+                //         var lam = delegate(int x = "abcdef") { return x; };
+                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(5, 34));
         }
 
         [Fact]
@@ -7295,6 +7307,9 @@ class Program
 """;
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
+                // (14,32): error CS1065: Default values are not valid in this context.
+                //         var lam = delegate(C c = new C(null)) { return c.Field; };
+                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(14, 32),
                 // (14,34): error CS1736: Default parameter value for 'c' must be a compile-time constant
                 //         var lam = delegate(C c = new C(null)) { return c.Field; };
                 Diagnostic(ErrorCode.ERR_DefaultValueMustBeConstant, "new C(null)").WithArguments("c").WithLocation(14, 34));
@@ -7336,6 +7351,9 @@ class Program
 """;
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
+                // (7,37): error CS1065: Default values are not valid in this context.
+                //         var lam = delegate(string s = add(1, 2)) { return s; };
+                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(7, 37),
                 // (7,39): error CS1736: Default parameter value for 's' must be a compile-time constant
                 //         var lam = delegate(string s = add(1, 2)) { return s; };
                 Diagnostic(ErrorCode.ERR_DefaultValueMustBeConstant, "add(1, 2)").WithArguments("s").WithLocation(7, 39));
@@ -7385,7 +7403,10 @@ class Program
 }
 """;
             var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (12,35): error CS1065: Default values are not valid in this context.
+                //         var fn = delegate(int arg = b1 ? num1 : b2 ? num2 : num3) { return arg; };
+                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(12, 35));
         }
 
         [ConditionalFact(typeof(NoIOperationValidation))]
@@ -7421,7 +7442,10 @@ class Program
 }
 """;
             var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (7,37): error CS1065: Default values are not valid in this context.
+                //         var func = delegate(int arg = i1 + i2) { return arg + 1; };
+                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(7, 37));
         }
 
         [Fact]
@@ -7486,7 +7510,10 @@ class Program
 }
 """;
             var comp = CreateCompilation(source);
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (5,62): error CS1065: Default values are not valid in this context.
+                //         var lam = delegate(ref int x, out object y, double c = 4.59) { y = c + (double) x; };
+                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(5, 62));
         }
 
         [Fact]
@@ -7544,6 +7571,9 @@ class Program
 """;
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
+                // (5,31): error CS1065: Default values are not valid in this context.
+                //        var _ = delegate(int i = M2(a)) { }; // parameter 'a' should be considered read/used
+                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(5, 31),
                 // (5,33): error CS1736: Default parameter value for 'i' must be a compile-time constant
                 //        var _ = delegate(int i = M2(a)) { }; // parameter 'a' should be considered read/used
                 Diagnostic(ErrorCode.ERR_DefaultValueMustBeConstant, "M2(a)").WithArguments("i").WithLocation(5, 33));

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -33599,15 +33599,27 @@ class C
             // of a lambda parameter is that default expression.
             var compilation = CreateCompilationWithMscorlib45(text);
             compilation.GetDiagnostics().Verify(
+                    // (7,56): error CS1065: Default values are not valid in this context.
+                    //                                                 bool b = M(M(out int z1), z1), 
+                    Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(7, 56),
                     // (7,58): error CS1736: Default parameter value for 'b' must be a compile-time constant
                     //                                                 bool b = M(M(out int z1), z1), 
                     Diagnostic(ErrorCode.ERR_DefaultValueMustBeConstant, "M(M(out int z1), z1)").WithArguments("b").WithLocation(7, 58),
+                    // (8,56): error CS1065: Default values are not valid in this context.
+                    //                                                 int s2 = z1) 
+                    Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(8, 56),
                     // (8,58): error CS0103: The name 'z1' does not exist in the current context
                     //                                                 int s2 = z1) 
                     Diagnostic(ErrorCode.ERR_NameNotInContext, "z1").WithArguments("z1").WithLocation(8, 58),
+                    // (11,56): error CS1065: Default values are not valid in this context.
+                    //                                                 bool b = M(M(out var z2), z2), 
+                    Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(11, 56),
                     // (11,58): error CS1736: Default parameter value for 'b' must be a compile-time constant
                     //                                                 bool b = M(M(out var z2), z2), 
                     Diagnostic(ErrorCode.ERR_DefaultValueMustBeConstant, "M(M(out var z2), z2)").WithArguments("b").WithLocation(11, 58),
+                    // (12,56): error CS1065: Default values are not valid in this context.
+                    //                                                 int s2 = z2)  
+                    Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(12, 56),
                     // (12,58): error CS0103: The name 'z2' does not exist in the current context
                     //                                                 int s2 = z2)  
                     Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(12, 58),

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -5798,7 +5798,10 @@ class C {
             CreateCompilation(text).VerifyDiagnostics(
                 // (5,26): error CS9501: Parameter 1 has default value 'default(int)' in lambda and '<missing>' in the target delegate type.
                 //      F f = delegate (int x = 0) { };
-                Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "x").WithArguments("1", "default(int)", "<missing>").WithLocation(5, 26));
+                Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "x").WithArguments("1", "default(int)", "<missing>").WithLocation(5, 26),
+                // (5,28): error CS1065: Default values are not valid in this context.
+                //      F f = delegate (int x = 0) { };
+                Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(5, 28));
         }
 
         [WorkItem(537865, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537865")]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -3248,7 +3248,10 @@ class A
             CreateCompilation(test).VerifyDiagnostics(
                     // (5,25): error CS9501: Parameter 1 has default value '42' in lambda and '<missing>' in the target delegate type.
                     //     D d1 = delegate(int x = 42) { };
-                    Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "x").WithArguments("1", "42", "<missing>").WithLocation(5, 25));
+                    Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "x").WithArguments("1", "42", "<missing>").WithLocation(5, 25),
+                    // (5,27): error CS1065: Default values are not valid in this context.
+                    //     D d1 = delegate(int x = 42) { };
+                    Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(5, 27));
         }
 
         [Fact]
@@ -3265,7 +3268,10 @@ class A
             CreateCompilation(test).VerifyDiagnostics(
                     // (5,32): error CS9501: Parameter 2 has default value '42' in lambda and '<missing>' in the target delegate type.
                     //     D d1 = delegate(int x, int y = 42) { };
-                    Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "y").WithArguments("2", "42", "<missing>").WithLocation(5, 32));
+                    Diagnostic(ErrorCode.ERR_OptionalParamValueMismatch, "y").WithArguments("2", "42", "<missing>").WithLocation(5, 32),
+                    // (5,34): error CS1065: Default values are not valid in this context.
+                    //     D d1 = delegate(int x, int y = 42) { };
+                    Diagnostic(ErrorCode.ERR_DefaultValueNotAllowed, "=").WithLocation(5, 34));
         }
 
         [Fact, WorkItem(540251, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540251")]


### PR DESCRIPTION
Disallows `delegate (int x = 5) { }` as discussed in https://github.com/dotnet/csharplang/pull/6542#discussion_r997477527.

Essentially brings back this previously-deleted check:
https://github.com/dotnet/roslyn/pull/62958/files#diff-3cdd8d415a6f2ca6c73690bf528a66c47495d97b47df561a0197b89e45c6fb58L122-L125

Relates to test plan https://github.com/dotnet/roslyn/issues/62485