### PR TITLE
Inline Hints - Fix bug where hints swap

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,7 +25,7 @@
     <MicrosoftVisualStudioExtensibilityTestingVersion>0.1.149-beta</MicrosoftVisualStudioExtensibilityTestingVersion>
     <!-- CodeStyleAnalyzerVersion should we updated together with version of dotnet-format in dotnet-tools.json -->
     <CodeStyleAnalyzerVersion>4.3.0-1.final</CodeStyleAnalyzerVersion>
-    <VisualStudioEditorPackagesVersion>17.4.203-preview</VisualStudioEditorPackagesVersion>
+    <VisualStudioEditorPackagesVersion>17.5.42-preview</VisualStudioEditorPackagesVersion>
     <!-- This should generally be set to $(VisualStudioEditorPackagesVersion),
          but sometimes EditorFeatures.Cocoa specifically requires a newer editor build. -->
     <VisualStudioMacEditorPackagesVersion>17.3.133-preview</VisualStudioMacEditorPackagesVersion>
@@ -33,7 +33,7 @@
     <ILDAsmPackageVersion>5.0.0-preview.1.20112.8</ILDAsmPackageVersion>
     <MicrosoftVisualStudioLanguageServerClientPackagesVersion>17.3.3101</MicrosoftVisualStudioLanguageServerClientPackagesVersion>
     <MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>17.4.1004-preview</MicrosoftVisualStudioLanguageServerProtocolPackagesVersion>
-    <MicrosoftVisualStudioShellPackagesVersion>17.3.32809.331</MicrosoftVisualStudioShellPackagesVersion>
+    <MicrosoftVisualStudioShellPackagesVersion>17.4.0-preview-2-32826-307</MicrosoftVisualStudioShellPackagesVersion>
     <RefOnlyMicrosoftBuildPackagesVersion>16.5.0</RefOnlyMicrosoftBuildPackagesVersion>
     <!-- The version of Roslyn we build Source Generators against that are built in this
          repository. This must be lower than MicrosoftNetCompilersToolsetVersion,
@@ -41,8 +41,8 @@
          the generators we build would load on the command line but not load in IDEs. -->
     <SourceGeneratorMicrosoftCodeAnalysisVersion>4.1.0</SourceGeneratorMicrosoftCodeAnalysisVersion>
     <MicrosoftILVerificationVersion>7.0.0-alpha.1.22060.1</MicrosoftILVerificationVersion>
-    <MicrosoftServiceHubVersion>4.0.2048</MicrosoftServiceHubVersion>
-    <MicrosoftVisualStudioThreadingPackagesVersion>17.3.44</MicrosoftVisualStudioThreadingPackagesVersion>
+    <MicrosoftServiceHubVersion>4.0.4070</MicrosoftServiceHubVersion>
+    <MicrosoftVisualStudioThreadingPackagesVersion>17.4.16-alpha</MicrosoftVisualStudioThreadingPackagesVersion>
     <MicrosoftTestPlatformVersion>17.4.0-preview-20220707-01</MicrosoftTestPlatformVersion>
   </PropertyGroup>
   <!--
@@ -136,7 +136,7 @@
     <MicrosoftVisualStudioCacheVersion>17.3.26-alpha</MicrosoftVisualStudioCacheVersion>
     <MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>15.8.27812-alpha</MicrosoftVisualStudioCallHierarchyPackageDefinitionsVersion>
     <MicrosoftVisualStudioCodeAnalysisSdkUIVersion>15.8.27812-alpha</MicrosoftVisualStudioCodeAnalysisSdkUIVersion>
-    <MicrosoftVisualStudioComponentModelHostVersion>17.3.198</MicrosoftVisualStudioComponentModelHostVersion>
+    <MicrosoftVisualStudioComponentModelHostVersion>17.4.143-preview</MicrosoftVisualStudioComponentModelHostVersion>
     <MicrosoftVisualStudioCompositionVersion>16.9.20</MicrosoftVisualStudioCompositionVersion>
     <MicrosoftVisualStudioCoreUtilityVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioCoreUtilityVersion>
     <MicrosoftVisualStudioDebuggerUIInterfacesVersion>17.4.0-beta.22368.1</MicrosoftVisualStudioDebuggerUIInterfacesVersion>
@@ -184,7 +184,7 @@
     <MicrosoftVisualStudioShell150Version>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShell150Version>
     <MicrosoftVisualStudioShellFrameworkVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShellFrameworkVersion>
     <MicrosoftVisualStudioShellDesignVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShellDesignVersion>
-    <MicrosoftVisualStudioTelemetryVersion>16.4.137</MicrosoftVisualStudioTelemetryVersion>
+    <MicrosoftVisualStudioTelemetryVersion>16.5.2</MicrosoftVisualStudioTelemetryVersion>
     <MicrosoftVisualStudioTemplateWizardInterfaceVersion>8.0.0.0-alpha</MicrosoftVisualStudioTemplateWizardInterfaceVersion>
     <MicrosoftVisualStudioTextDataVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioTextDataVersion>
     <MicrosoftVisualStudioTextInternalVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioTextInternalVersion>
@@ -206,7 +206,7 @@
     <MDbgVersion>0.1.0</MDbgVersion>
     <MonoOptionsVersion>6.6.0.161</MonoOptionsVersion>
     <MoqVersion>4.10.1</MoqVersion>
-    <NerdbankStreamsVersion>2.8.57</NerdbankStreamsVersion>
+    <NerdbankStreamsVersion>2.9.87-alpha</NerdbankStreamsVersion>
     <NuGetVisualStudioVersion>6.0.0-preview.0.15</NuGetVisualStudioVersion>
     <NuGetSolutionRestoreManagerInteropVersion>4.8.0</NuGetSolutionRestoreManagerInteropVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta1-62506-02</MicrosoftDiaSymReaderPdb2PdbVersion>
@@ -286,7 +286,7 @@
       create a test insertion in Visual Studio to validate.
     -->
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
-    <StreamJsonRpcVersion>2.12.27</StreamJsonRpcVersion>
+    <StreamJsonRpcVersion>2.13.21-alpha</StreamJsonRpcVersion>
     <!--
       When updating the S.C.I or S.R.M version please let the MSBuild team know in advance so they
       can update to the same version. Version changes require a VS test insertion for validation.

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
@@ -47,10 +47,16 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             ITextView textView,
             SnapshotSpan span,
             InlineHint hint,
-            InlineHintsTaggerProvider taggerProvider)
+            InlineHintsTaggerProvider taggerProvider,
+            int ranking)
             : base(adornment,
                    removalCallback: null,
-                   PositionAffinity.Predecessor)
+                   topSpace: null,
+                   baseline: null,
+                   textHeight: null,
+                   bottomSpace: null,
+                   PositionAffinity.Predecessor,
+                   ranking)
         {
             _textView = textView;
             _span = span;
@@ -82,11 +88,12 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             SnapshotSpan span,
             InlineHintsTaggerProvider taggerProvider,
             IClassificationFormatMap formatMap,
-            bool classify)
+            bool classify,
+            int ranking)
         {
             return new InlineHintsTag(
                 CreateElement(hint.DisplayParts, textView, format, formatMap, taggerProvider.TypeMap, classify),
-                textView, span, hint, taggerProvider);
+                textView, span, hint, taggerProvider, ranking);
         }
 
         public async Task<IReadOnlyCollection<object>> CreateDescriptionAsync(CancellationToken cancellationToken)
@@ -119,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             ClassificationTypeMap typeMap,
             bool classify)
         {
-            // Constructs the hint block which gets assigned parameter name and fontstyles according to the options
+            // Constructs the hint block which gets assigned parameter name and FontStyles according to the options
             // page. Calculates a inline tag that will be 3/4s the size of a normal line. This shrink size tends to work
             // well with VS at any zoom level or font size.
             var block = new TextBlock
@@ -151,7 +158,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
 
             block.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
 
-            // Encapsulates the textblock within a border. Gets foreground/background colors from the options menu.
+            // Encapsulates the TextBlock within a border. Gets foreground/background colors from the options menu.
             // If the tag is started or followed by a space, we trim that off but represent the space as buffer on hte
             // left or right side.
             var left = leftPadding * 5;
@@ -172,7 +179,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             {
                 Height = dockPanelHeight,
                 LastChildFill = false,
-                // VerticalAlignment is set to Top because it will rest to the top relative to the stackpanel
+                // VerticalAlignment is set to Top because it will rest to the top relative to the StackPanel
                 VerticalAlignment = VerticalAlignment.Top
             };
 
@@ -187,7 +194,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             };
 
             stackPanel.Children.Add(dockPanel);
-            // Need to set these properties to avoid unnecessary reformatting because some dependancy properties
+            // Need to set these properties to avoid unnecessary reformatting because some dependency properties
             // affect layout
             TextOptions.SetTextFormattingMode(stackPanel, TextOptions.GetTextFormattingMode(textView.VisualElement));
             TextOptions.SetTextHintingMode(stackPanel, TextOptions.GetTextHintingMode(textView.VisualElement));

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTag.cs
@@ -47,8 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             ITextView textView,
             SnapshotSpan span,
             InlineHint hint,
-            InlineHintsTaggerProvider taggerProvider,
-            int ranking)
+            InlineHintsTaggerProvider taggerProvider)
             : base(adornment,
                    removalCallback: null,
                    topSpace: null,
@@ -56,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
                    textHeight: null,
                    bottomSpace: null,
                    PositionAffinity.Predecessor,
-                   ranking)
+                   hint.Ranking)
         {
             _textView = textView;
             _span = span;
@@ -88,12 +87,11 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
             SnapshotSpan span,
             InlineHintsTaggerProvider taggerProvider,
             IClassificationFormatMap formatMap,
-            bool classify,
-            int ranking)
+            bool classify)
         {
             return new InlineHintsTag(
                 CreateElement(hint.DisplayParts, textView, format, formatMap, taggerProvider.TypeMap, classify),
-                textView, span, hint, taggerProvider, ranking);
+                textView, span, hint, taggerProvider);
         }
 
         public async Task<IReadOnlyCollection<object>> CreateDescriptionAsync(CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
                     {
                         // Gets the associated span from the snapshot span and creates the IntraTextAdornmentTag from the data
                         // tags. Only dealing with the dataTagSpans if the count is 1 because we do not see a multi-buffer case
-                        // occuring
+                        // occurring
                         var dataTagSpans = tag.Span.GetSpans(snapshot);
                         if (dataTagSpans.Count == 1)
                         {
@@ -180,8 +180,13 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
                         {
                             if (_cache[i].tagSpan is not { } hintTagSpan)
                             {
+                                var inlineHintDataTag = _cache[i].mappingTagSpan.Tag.Hint;
+                                var ranking = inlineHintDataTag.DisplayParts.Length > 1
+                                    ? 1
+                                    : 0;
+
                                 var hintUITag = InlineHintsTag.Create(
-                                        _cache[i].mappingTagSpan.Tag.Hint, Format, _textView, tagSpan, _taggerProvider, _formatMap, classify);
+                                        _cache[i].mappingTagSpan.Tag.Hint, Format, _textView, tagSpan, _taggerProvider, _formatMap, classify, ranking);
 
                                 hintTagSpan = new TagSpan<IntraTextAdornmentTag>(tagSpan, hintUITag);
                                 _cache[i] = (_cache[i].mappingTagSpan, hintTagSpan);

--- a/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineHints/InlineHintsTagger.cs
@@ -180,13 +180,8 @@ namespace Microsoft.CodeAnalysis.Editor.InlineHints
                         {
                             if (_cache[i].tagSpan is not { } hintTagSpan)
                             {
-                                var inlineHintDataTag = _cache[i].mappingTagSpan.Tag.Hint;
-                                var ranking = inlineHintDataTag.DisplayParts.Length > 1
-                                    ? 1
-                                    : 0;
-
                                 var hintUITag = InlineHintsTag.Create(
-                                        _cache[i].mappingTagSpan.Tag.Hint, Format, _textView, tagSpan, _taggerProvider, _formatMap, classify, ranking);
+                                        _cache[i].mappingTagSpan.Tag.Hint, Format, _textView, tagSpan, _taggerProvider, _formatMap, classify);
 
                                 hintTagSpan = new TagSpan<IntraTextAdornmentTag>(tagSpan, hintUITag);
                                 _cache[i] = (_cache[i].mappingTagSpan, hintTagSpan);

--- a/src/Features/Core/Portable/InlineHints/AbstractInlineParameterNameHintsService.cs
+++ b/src/Features/Core/Portable/InlineHints/AbstractInlineParameterNameHintsService.cs
@@ -18,6 +18,12 @@ namespace Microsoft.CodeAnalysis.InlineHints
 {
     internal abstract class AbstractInlineParameterNameHintsService : IInlineParameterNameHintsService
     {
+        /// <summary>
+        /// Used as a tiebreaker to position coincident type and parameter hints.
+        /// Parameter hints will always appear first.
+        /// </summary>
+        private const double Ranking = 0.0;
+
         protected enum HintKind
         {
             Literal,
@@ -104,7 +110,7 @@ namespace Microsoft.CodeAnalysis.InlineHints
                             textSpan,
                             ImmutableArray.Create(new TaggedText(TextTags.Text, parameter.Name + ": ")),
                             new TextChange(textSpan, inlineHintText),
-                            ranking: 0.0,
+                            ranking: Ranking,
                             InlineHintHelpers.GetDescriptionFunction(position, parameter.GetSymbolKey(cancellationToken: cancellationToken), displayOptions)));
                     }
                 }

--- a/src/Features/Core/Portable/InlineHints/AbstractInlineParameterNameHintsService.cs
+++ b/src/Features/Core/Portable/InlineHints/AbstractInlineParameterNameHintsService.cs
@@ -104,6 +104,7 @@ namespace Microsoft.CodeAnalysis.InlineHints
                             textSpan,
                             ImmutableArray.Create(new TaggedText(TextTags.Text, parameter.Name + ": ")),
                             new TextChange(textSpan, inlineHintText),
+                            ranking: 0.0,
                             InlineHintHelpers.GetDescriptionFunction(position, parameter.GetSymbolKey(cancellationToken: cancellationToken), displayOptions)));
                     }
                 }

--- a/src/Features/Core/Portable/InlineHints/AbstractInlineTypeHintsService.cs
+++ b/src/Features/Core/Portable/InlineHints/AbstractInlineTypeHintsService.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.InlineHints
                 var taggedText = finalParts.ToTaggedText();
 
                 result.Add(new InlineHint(
-                    span, taggedText, textChange,
+                    span, taggedText, textChange, ranking: 1.0,
                     InlineHintHelpers.GetDescriptionFunction(span.Start, type.GetSymbolKey(cancellationToken: cancellationToken), displayOptions)));
             }
 

--- a/src/Features/Core/Portable/InlineHints/AbstractInlineTypeHintsService.cs
+++ b/src/Features/Core/Portable/InlineHints/AbstractInlineTypeHintsService.cs
@@ -18,6 +18,12 @@ namespace Microsoft.CodeAnalysis.InlineHints
 {
     internal abstract class AbstractInlineTypeHintsService : IInlineTypeHintsService
     {
+        /// <summary>
+        /// Used as a tiebreaker to position coincident type and parameter hints.
+        /// Type hints will always appear second.
+        /// </summary>
+        private const double Ranking = 1.0;
+
         protected static readonly SymbolDisplayFormat s_minimalTypeStyle = new SymbolDisplayFormat(
             genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
             miscellaneousOptions: SymbolDisplayMiscellaneousOptions.AllowDefaultLiteral | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier | SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
@@ -81,7 +87,7 @@ namespace Microsoft.CodeAnalysis.InlineHints
                 var taggedText = finalParts.ToTaggedText();
 
                 result.Add(new InlineHint(
-                    span, taggedText, textChange, ranking: 1.0,
+                    span, taggedText, textChange, ranking: Ranking,
                     InlineHintHelpers.GetDescriptionFunction(span.Start, type.GetSymbolKey(cancellationToken: cancellationToken), displayOptions)));
             }
 

--- a/src/Features/Core/Portable/InlineHints/InlineHint.cs
+++ b/src/Features/Core/Portable/InlineHints/InlineHint.cs
@@ -31,6 +31,15 @@ namespace Microsoft.CodeAnalysis.InlineHints
             TextSpan span,
             ImmutableArray<TaggedText> displayParts,
             TextChange? replacementTextChange,
+            Func<Document, CancellationToken, Task<ImmutableArray<TaggedText>>>? getDescriptionAsync = null)
+            : this(span, displayParts, replacementTextChange, ranking: 0.0, getDescriptionAsync)
+        {
+        }
+
+        public InlineHint(
+            TextSpan span,
+            ImmutableArray<TaggedText> displayParts,
+            TextChange? replacementTextChange,
             double ranking,
             Func<Document, CancellationToken, Task<ImmutableArray<TaggedText>>>? getDescriptionAsync = null)
         {

--- a/src/Features/Core/Portable/InlineHints/InlineHint.cs
+++ b/src/Features/Core/Portable/InlineHints/InlineHint.cs
@@ -16,13 +16,14 @@ namespace Microsoft.CodeAnalysis.InlineHints
         public readonly TextSpan Span;
         public readonly ImmutableArray<TaggedText> DisplayParts;
         public readonly TextChange? ReplacementTextChange;
+        public readonly double Ranking;
         private readonly Func<Document, CancellationToken, Task<ImmutableArray<TaggedText>>>? _getDescriptionAsync;
 
         public InlineHint(
             TextSpan span,
             ImmutableArray<TaggedText> displayParts,
             Func<Document, CancellationToken, Task<ImmutableArray<TaggedText>>>? getDescriptionAsync = null)
-            : this(span, displayParts, replacementTextChange: null, getDescriptionAsync)
+            : this(span, displayParts, replacementTextChange: null, ranking: 0.0, getDescriptionAsync)
         {
         }
 
@@ -30,6 +31,7 @@ namespace Microsoft.CodeAnalysis.InlineHints
             TextSpan span,
             ImmutableArray<TaggedText> displayParts,
             TextChange? replacementTextChange,
+            double ranking,
             Func<Document, CancellationToken, Task<ImmutableArray<TaggedText>>>? getDescriptionAsync = null)
         {
             if (displayParts.Length == 0)
@@ -39,6 +41,7 @@ namespace Microsoft.CodeAnalysis.InlineHints
             DisplayParts = displayParts;
             _getDescriptionAsync = getDescriptionAsync;
             ReplacementTextChange = replacementTextChange;
+            Ranking = ranking;
         }
 
         /// <summary>

--- a/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
+++ b/src/Setup/DevDivInsertionFiles/DevDivInsertionFiles.csproj
@@ -117,6 +117,7 @@
       <_Dependency Remove="Microsoft.Diagnostics.Tracing.EventSource.Redist"/>
       <_Dependency Remove="Microsoft.MSXML"/>
       <_Dependency Remove="Microsoft.Internal.Performance.CodeMarkers.DesignTime"/>
+      <_Dependency Remove="Microsoft.NET.StringTools"/>
       <_Dependency Remove="Microsoft.Win32.Registry"/>
       <_Dependency Remove="Nerdbank.NetStandardBridge" />
       <_Dependency Remove="Nerdbank.Streams"/>


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1463148/

Adds a ranking to the InlineHintTag to ensure that parameter hints always appear prior to type hints. 