### PR TITLE
Don't directly reenter back into the workpsace when initializing listeners.

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/SolutionCrawler/MiscSolutionCrawlerWorkspaceEventListener.cs
+++ b/src/Features/LanguageServer/Protocol/Features/SolutionCrawler/MiscSolutionCrawlerWorkspaceEventListener.cs
@@ -3,36 +3,75 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.SolutionCrawler
 {
     [ExportEventListener(WellKnownEventListeners.Workspace, WorkspaceKind.MiscellaneousFiles), Shared]
-    internal sealed class MiscSolutionCrawlerWorkspaceEventListener : IEventListener<object>, IEventListenerStoppable
+    internal sealed class MiscSolutionCrawlerWorkspaceEventListener : IEventListener<object>, IEventListenerStoppable, IDisposable
     {
         private readonly IGlobalOptionService _globalOptions;
 
+        /// <summary>
+        /// A queue that we put our diagnostic-provider configuration work onto. We queue this work up so that we don't
+        /// re-enter into the workspace as it is calling into us on the IEventXXX apis.
+        /// </summary>
+        private readonly AsyncBatchingWorkQueue<(bool enabled, Workspace workspace)> _workQueue;
+        private readonly CancellationTokenSource _tokenSource = new();
+
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public MiscSolutionCrawlerWorkspaceEventListener(IGlobalOptionService globalOptions)
+        public MiscSolutionCrawlerWorkspaceEventListener(
+            IGlobalOptionService globalOptions,
+            IAsynchronousOperationListenerProvider listenerProvider)
         {
             _globalOptions = globalOptions;
+            _workQueue = new AsyncBatchingWorkQueue<(bool enabled, Workspace workspace)>(
+                DelayTimeSpan.Short,
+                ProcessWorkQueueAsync,
+                EqualityComparer<(bool, Workspace)>.Default,
+                listenerProvider.GetListener(FeatureAttribute.Workspace),
+                _tokenSource.Token);
         }
+
+        public void Dispose()
+            => _tokenSource.Cancel();
 
         public void StartListening(Workspace workspace, object serviceOpt)
-        {
-            if (_globalOptions.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler))
-            {
-                // misc workspace will enable syntax errors and semantic errors for script files for
-                // all participating projects in the workspace
-                DiagnosticProvider.Enable(workspace, DiagnosticProvider.Options.Syntax | DiagnosticProvider.Options.ScriptSemantic);
-            }
-        }
+            => _workQueue.AddWork((true, workspace));
 
         public void StopListening(Workspace workspace)
-            => DiagnosticProvider.Disable(workspace);
+            => _workQueue.AddWork((false, workspace));
+
+        private ValueTask ProcessWorkQueueAsync(ImmutableSegmentedList<(bool enabled, Workspace workspace)> list, CancellationToken cancellationToken)
+        {
+            foreach (var (enabled, workspace) in list)
+            {
+                if (enabled)
+                {
+                    if (_globalOptions.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler))
+                    {
+                        // misc workspace will enable syntax errors and semantic errors for script files for
+                        // all participating projects in the workspace
+                        DiagnosticProvider.Enable(workspace, DiagnosticProvider.Options.Syntax | DiagnosticProvider.Options.ScriptSemantic);
+                    }
+                }
+                else
+                {
+                    DiagnosticProvider.Disable(workspace);
+                }
+            }
+
+            return ValueTaskFactory.CompletedTask;
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -248,10 +248,6 @@ namespace Microsoft.CodeAnalysis
 
             var oldSolution = Volatile.Read(ref _latestSolution);
 
-            // Ensure our event handlers are realized prior to taking this lock.  We don't want to deadlock trying
-            // to obtain them when calling one of our callbacks. See https://github.com/dotnet/roslyn/issues/64681
-            EnsureEventListeners();
-
             while (true)
             {
                 // Run the transformation outside of the lock as it should not be making any state changes to us.

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
@@ -246,13 +246,8 @@ namespace Microsoft.CodeAnalysis
         {
             // this will register features that want to listen to workspace events
             // lazily first time workspace event is actually fired
-            EnsureEventListeners();
-            return _eventMap.GetEventHandlers<EventHandler<T>>(eventName);
-        }
-
-        private void EnsureEventListeners()
-        {
             this.Services.GetService<IWorkspaceEventListenerService>()?.EnsureListeners();
+            return _eventMap.GetEventHandlers<EventHandler<T>>(eventName);
         }
     }
 }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1656376

Internal VS tests found another reentrancy hang here.  So i'm just changing the component in question to not re-enter into the workspace (to mutate it) when it hears about workspace events.  That seems like the safest thing we can do.