### PR TITLE
Extend pattern explainer for more complicated graphs

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
@@ -110,8 +110,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static void VisitPathsToNode(BoundDecisionDagNode rootNode, BoundDecisionDagNode targetNode, bool nullPaths,
             Func<ImmutableArray<BoundDecisionDagNode>, bool, bool> handler)
         {
-            var pathBuilder = new ArrayBuilder<BoundDecisionDagNode>();
+            var pathBuilder = ArrayBuilder<BoundDecisionDagNode>.GetInstance();
             exploreToNode(rootNode, currentRequiresFalseWhenClause: false);
+            pathBuilder.Free();
             return;
 
             // Recursive exploration helper
@@ -184,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             out bool unnamedEnumValue)
         {
 #if DEBUG
-            // Excercise enumeration of all paths to node
+            // Exercise enumeration of all paths to node
             VisitPathsToNode(nodes[0], targetNode, nullPaths: true, handler: (currentPathToNode, currentRequiresFalseWhenClause) => true);
             VisitPathsToNode(nodes[0], targetNode, nullPaths: false, handler: (currentPathToNode, currentRequiresFalseWhenClause) => true);
 #endif

--- a/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
@@ -128,6 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 switch (currentNode)
                 {
+                    case null:
                     case BoundLeafDecisionDagNode:
                         break;
 

--- a/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <param name="nodes">The set of nodes in topological order.</param>
         /// <param name="targetNode">The node of interest.</param>
         /// <param name="nullPaths">Whether to permit following paths that test for null.</param>
-        /// <param name="handler">Handler to call back for every pather to the target node.</param>
+        /// <param name="handler">Handler to call back for every path to the target node.</param>
         private static void VisitPathsToNode(ImmutableArray<BoundDecisionDagNode> nodes, BoundDecisionDagNode targetNode, bool nullPaths,
             Func<ImmutableArray<BoundDecisionDagNode>, bool, bool> handler)
         {

--- a/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
@@ -157,10 +157,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     case BoundWhenDecisionDagNode whenNode:
                         pathBuilder.Pop();
-                        if (!exploreToNode(whenNode.WhenFalse, currentRequiresFalseWhenClause: true))
-                            return false;
-
-                        return true; // already popped
+                        return exploreToNode(whenNode.WhenFalse, currentRequiresFalseWhenClause: true);
 
                     default:
                         throw ExceptionUtilities.UnexpectedValue(currentNode.Kind);

--- a/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternExplainer.cs
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // In rare cases, the shortest path isn't the one that yields a sample
-            string? altSamplePatternForTemp = null;
+            string altSamplePatternForTemp = null;
             bool altRequiresFalseWhenClause = false;
             bool altUnnamedEnumValue = false;
 

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests5.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests5.cs
@@ -2613,5 +2613,503 @@ _ = x is { Length.Error: > 0 };
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics();
         }
+
+        [Fact]
+        public void ShortestPathToDefaultNodeYieldsNoRemainingValues()
+        {
+            var source = """
+public enum Enum
+{
+    Zero = 0,
+    One = 1,
+    Two = 2,
+}
+
+class N
+{
+    private static int M(Enum e1, Enum e2)
+    {
+        return (e1, e2) switch
+        {
+            (Enum.Two, _) => 0,
+            (_, Enum.Two) => 0,
+            (Enum.Zero, Enum.Zero) => 0,
+            (Enum.Zero, Enum.One) => 0,
+            (Enum.One, Enum.Zero) => 0,
+            ( < 0 or > Enum.Two, _) => 0,
+            (_, < 0 or > Enum.Two) => 0,
+        };
+    }
+}
+""";
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (12,25): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One)' is not covered.
+                //         return (e1, e2) switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(Enum.One, Enum.One)").WithLocation(12, 25)
+                );
+        }
+
+        [Fact]
+        public void ShortestPathToDefaultNodeYieldsNoRemainingValues_RequiringFalseWhenClause()
+        {
+            var source = """
+public enum Enum
+{
+    Zero = 0,
+    One = 1,
+    Two = 2,
+}
+
+class N
+{
+    private static int M(Enum e1, Enum e2, bool b)
+    {
+        return (e1, e2) switch
+        {
+            (Enum.One, Enum.One) when b => 0,
+            (Enum.Two, _) => 0,
+            (_, Enum.Two) => 0,
+            (Enum.Zero, Enum.Zero) => 0,
+            (Enum.Zero, Enum.One) => 0,
+            (Enum.One, Enum.Zero) => 0,
+            ( < 0 or > Enum.Two, _) => 0,
+            (_, < 0 or > Enum.Two) => 0,
+        };
+    }
+}
+""";
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (12,25): warning CS8846: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One)' is not covered. However, a pattern with a 'when' clause might successfully match this value.
+                //         return (e1, e2) switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveWithWhen, "switch").WithArguments("(Enum.One, Enum.One)").WithLocation(12, 25)
+                );
+        }
+
+        [Fact]
+        public void ShortestPathToDefaultNodeYieldsNoRemainingValues_Nullability()
+        {
+            var source = """
+#nullable enable
+
+public enum Enum
+{
+    Zero = 0,
+    One = 1,
+    Two = 2,
+}
+
+class N
+{
+    private static int M(Enum e1, Enum e2, string s)
+    {
+        return (e1, e2, s) switch
+        {
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, _) => 0,
+            (_, _, string) => 0,
+        };
+    }
+}
+""";
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void ShortestPathToDefaultNodeYieldsNoRemainingValues_Nullability_NullableString()
+        {
+            var source = """
+#nullable enable
+
+public enum Enum
+{
+    Zero = 0,
+    One = 1,
+    Two = 2,
+}
+
+class N
+{
+    private static int M1(Enum e1, Enum e2, string? s)
+    {
+        return (e1, e2, s) switch // 1
+        {
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, null) => 0,
+            (_, _, null) => 1,
+        };
+    }
+
+    private static int M2(Enum e1, Enum e2, string? s)
+    {
+        return (e1, e2, s) switch // 2
+        {
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, _) => 0,
+            (_, _, "") => 1,
+        };
+    }
+
+    private static int M3(Enum e1, Enum e2, string? s)
+    {
+        return (e1, e2, s) switch // 3
+        {
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, _) => 0,
+            (_, _, string) => 1,
+        };
+    }
+
+    private static int M4(Enum e1, Enum e2, string? s)
+    {
+        return (e1, e2, s) switch // 4
+        {
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, null) => 1,
+        };
+    }
+
+    private static int M5(Enum e1, Enum e2, string? s)
+    {
+        return (e1, e2, s) switch // 5
+        {
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, "") => 1,
+        };
+    }
+
+    private static int M6(Enum e1, Enum e2, string? s)
+    {
+        return (e1, e2, s) switch // 6
+        {
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, string) => 1,
+        };
+    }
+}
+""";
+
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (14,28): warning CS8524: The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value. For example, the pattern '(Enum.Zero, (Enum)-1, not null)' is not covered.
+                //         return (e1, e2, s) switch // 1
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveWithUnnamedEnumValue, "switch").WithArguments("(Enum.Zero, (Enum)-1, not null)").WithLocation(14, 28),
+                // (29,28): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, "A")' is not covered.
+                //         return (e1, e2, s) switch // 2
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(Enum.One, Enum.One, \"A\")").WithLocation(29, 28),
+                // (44,28): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, null)' is not covered.
+                //         return (e1, e2, s) switch // 3
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("(Enum.One, Enum.One, null)").WithLocation(44, 28),
+                // (59,28): warning CS8524: The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value. For example, the pattern '(Enum.Zero, (Enum)-1, not null)' is not covered.
+                //         return (e1, e2, s) switch // 4
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveWithUnnamedEnumValue, "switch").WithArguments("(Enum.Zero, (Enum)-1, not null)").WithLocation(59, 28),
+                // (73,28): warning CS8524: The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value. For example, the pattern '(Enum.Zero, (Enum)-1, "A")' is not covered.
+                //         return (e1, e2, s) switch // 5
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveWithUnnamedEnumValue, "switch").WithArguments("(Enum.Zero, (Enum)-1, \"A\")").WithLocation(73, 28),
+                // (87,28): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, _)' is not covered.
+                //         return (e1, e2, s) switch // 6
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(Enum.One, Enum.One, _)").WithLocation(87, 28)
+                );
+        }
+
+        [Theory, CombinatorialData]
+        public void ShortestPathToDefaultNodeYieldsNoRemainingValues_Nullability_Deconstruction(bool nullableEnable)
+        {
+            var source = """
+public enum Enum
+{
+    Zero = 0,
+    One = 1,
+    Two = 2,
+}
+
+class N
+{
+    private int M1()
+    {
+        return this switch // 1
+        {
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, _) => 0,
+            (_, _, not null) => 1,
+        };
+    }
+
+    private int M2()
+    {
+        return this switch // 2
+        {
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, _) => 0,
+            (_, _, true) => 1,
+            (_, _, false) => 1,
+        };
+    }
+
+    private int M3()
+    {
+        return this switch // 3
+        {
+            null => 1,
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, _) => 0,
+            (_, _, true) => 1,
+            (_, _, false) => 1,
+        };
+    }
+
+    private int M4()
+    {
+        return this switch // 4
+        {
+            null => 1,
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, _) => 0,
+            (_, _, true) => 1,
+        };
+    }
+
+    private int M5()
+    {
+        return this switch // 5
+        {
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, not null) => 1,
+        };
+    }
+
+    private int M6()
+    {
+        return this switch // 6
+        {
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, true) => 1,
+            (_, < 0 or > Enum.Two, false) => 1,
+        };
+    }
+
+    private int M7()
+    {
+        return this switch // 7
+        {
+            null => 1,
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, true) => 1,
+            (_, < 0 or > Enum.Two, false) => 1,
+        };
+    }
+
+    private int M8()
+    {
+        return this switch // 8
+        {
+            null => 1,
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, true) => 1,
+        };
+    }
+
+    void Deconstruct(out Enum e1, out Enum e2, out bool? s) => throw null!;
+}
+""";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll.WithNullableContextOptions(nullableEnable ? NullableContextOptions.Enable : NullableContextOptions.Disable));
+            if (nullableEnable)
+            {
+                comp.VerifyDiagnostics(
+                    // (12,21): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                    //         return this switch // 1
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(12, 21),
+                    // (27,21): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern 'null' is not covered.
+                    //         return this switch // 2
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("null").WithLocation(27, 21),
+                    // (43,21): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, null)' is not covered.
+                    //         return this switch // 3
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("(Enum.One, Enum.One, null)").WithLocation(43, 21),
+                    // (60,21): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, false)' is not covered.
+                    //         return this switch // 4
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(Enum.One, Enum.One, false)").WithLocation(60, 21),
+                    // (76,21): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, _)' is not covered.
+                    //         return this switch // 5
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(Enum.One, Enum.One, _)").WithLocation(76, 21),
+                    // (90,21): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, _)' is not covered.
+                    //         return this switch // 6
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(Enum.One, Enum.One, _)").WithLocation(90, 21),
+                    // (105,21): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, _)' is not covered.
+                    //         return this switch // 7
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(Enum.One, Enum.One, _)").WithLocation(105, 21),
+                    // (121,21): warning CS8524: The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value. For example, the pattern '(Enum.Zero, (Enum)-1, false)' is not covered.
+                    //         return this switch // 8
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveWithUnnamedEnumValue, "switch").WithArguments("(Enum.Zero, (Enum)-1, false)").WithLocation(121, 21)
+                    );
+            }
+            else
+            {
+                comp.VerifyDiagnostics(
+                    // (60,21): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, false)' is not covered.
+                    //         return this switch // 4
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(Enum.One, Enum.One, false)").WithLocation(60, 21),
+                    // (76,21): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, _)' is not covered.
+                    //         return this switch // 5
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(Enum.One, Enum.One, _)").WithLocation(76, 21),
+                    // (90,21): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, _)' is not covered.
+                    //         return this switch // 6
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(Enum.One, Enum.One, _)").WithLocation(90, 21),
+                    // (105,21): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, _)' is not covered.
+                    //         return this switch // 7
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(Enum.One, Enum.One, _)").WithLocation(105, 21),
+                    // (121,21): warning CS8524: The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value. For example, the pattern '(Enum.Zero, (Enum)-1, false)' is not covered.
+                    //         return this switch // 8
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveWithUnnamedEnumValue, "switch").WithArguments("(Enum.Zero, (Enum)-1, false)").WithLocation(121, 21)
+                    );
+            }
+        }
+
+        [Theory, CombinatorialData]
+        public void ShortestPathToDefaultNodeYieldsNoRemainingValues_Nullability_NullableBool(bool nullableEnable)
+        {
+            var source = """
+public enum Enum
+{
+    Zero = 0,
+    One = 1,
+    Two = 2,
+}
+
+class N
+{
+    private static int M1(Enum e1, Enum e2, bool? i)
+    {
+        return (e1, e2, i) switch // 1
+        {
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, _) => 0,
+            (_, _, true) => 1,
+        };
+    }
+
+    private static int M2(Enum e1, Enum e2, bool? i)
+    {
+        return (e1, e2, i) switch // 2
+        {
+            (Enum.Two, _, _) => 0,
+            (_, Enum.Two, _) => 0,
+            (Enum.Zero, Enum.Zero, _) => 0,
+            (Enum.Zero, Enum.One, _) => 0,
+            (Enum.One, Enum.Zero, _) => 0,
+            ( < 0 or > Enum.Two, _, _) => 0,
+            (_, < 0 or > Enum.Two, _) => 0,
+            (_, _, true) => 1,
+            (_, _, false) => 1,
+        };
+    }
+}
+""";
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll.WithNullableContextOptions(nullableEnable ? NullableContextOptions.Enable : NullableContextOptions.Disable));
+            if (nullableEnable)
+            {
+                comp.VerifyDiagnostics(
+                    // (12,28): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, false)' is not covered.
+                    //         return (e1, e2, i) switch // 1
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(Enum.One, Enum.One, false)").WithLocation(12, 28),
+                    // (27,28): warning CS8655: The switch expression does not handle some null inputs (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, null)' is not covered.
+                    //         return (e1, e2, i) switch // 2
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveForNull, "switch").WithArguments("(Enum.One, Enum.One, null)").WithLocation(27, 28)
+                    );
+            }
+            else
+            {
+                comp.VerifyDiagnostics(
+                    // (12,28): warning CS8509: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One, false)' is not covered.
+                    //         return (e1, e2, i) switch // 1
+                    Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustive, "switch").WithArguments("(Enum.One, Enum.One, false)").WithLocation(12, 28)
+                    );
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests5.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests5.cs
@@ -2721,9 +2721,9 @@ class N
 
             var comp = CreateCompilation(source);
             comp.VerifyDiagnostics(
-                // (12,25): warning CS8846: The switch expression does not handle all possible values of its input type (it is not exhaustive). For example, the pattern '(Enum.One, Enum.One)' is not covered. However, a pattern with a 'when' clause might successfully match this value.
-                //         return (e1, e2) switch
-                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveWithWhen, "switch").WithArguments("(Enum.One, Enum.One)").WithLocation(12, 25)
+                // (12,28): warning CS8524: The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value. For example, the pattern '(Enum.One, (Enum)-1, _)' is not covered.
+                //         return (e1, e2, o) switch
+                Diagnostic(ErrorCode.WRN_SwitchExpressionNotExhaustiveWithUnnamedEnumValue, "switch").WithArguments("(Enum.One, (Enum)-1, _)").WithLocation(12, 28)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests5.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests5.cs
@@ -2614,7 +2614,7 @@ _ = x is { Length.Error: > 0 };
             comp.VerifyDiagnostics();
         }
 
-        [Fact]
+        [Fact, WorkItem(64399, "https://github.com/dotnet/roslyn/issues/64399")]
         public void ShortestPathToDefaultNodeYieldsNoRemainingValues()
         {
             var source = """
@@ -2651,7 +2651,7 @@ class N
                 );
         }
 
-        [Fact]
+        [Fact, WorkItem(64399, "https://github.com/dotnet/roslyn/issues/64399")]
         public void ShortestPathToDefaultNodeYieldsNoRemainingValues_RequiringFalseWhenClause()
         {
             var source = """
@@ -2689,7 +2689,7 @@ class N
                 );
         }
 
-        [Fact]
+        [Fact, WorkItem(64399, "https://github.com/dotnet/roslyn/issues/64399")]
         public void ShortestPathToDefaultNodeYieldsNoRemainingValues_Nullability()
         {
             var source = """
@@ -2725,7 +2725,7 @@ class N
             comp.VerifyDiagnostics();
         }
 
-        [Fact]
+        [Fact, WorkItem(64399, "https://github.com/dotnet/roslyn/issues/64399")]
         public void ShortestPathToDefaultNodeYieldsNoRemainingValues_Nullability_NullableString()
         {
             var source = """
@@ -2852,7 +2852,7 @@ class N
                 );
         }
 
-        [Theory, CombinatorialData]
+        [Theory, CombinatorialData, WorkItem(64399, "https://github.com/dotnet/roslyn/issues/64399")]
         public void ShortestPathToDefaultNodeYieldsNoRemainingValues_Nullability_Deconstruction(bool nullableEnable)
         {
             var source = """
@@ -3045,7 +3045,7 @@ class N
             }
         }
 
-        [Theory, CombinatorialData]
+        [Theory, CombinatorialData, WorkItem(64399, "https://github.com/dotnet/roslyn/issues/64399")]
         public void ShortestPathToDefaultNodeYieldsNoRemainingValues_Nullability_NullableBool(bool nullableEnable)
         {
             var source = """


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/64399

The problem happens when graph branches merge and arrive at the default state. It's possible for the shortest path to the default state not to yield any remaining values to use as example.

Note: there's a few possible optimizations that could be made in this PR, but I erred on the side of simplicity/readability:
1. the error case (no remaining values) is signaled by an exception
2. we could restrict our search of paths leading to the default node by filtering out irrelevant nodes first
3. we could implement specialized iterators to avoid yielding completed paths through multiple layers of iterators

----

Here's an example (note that input value `(1, 1)` is unhandled) and a representation of the part of the DAG that causes the problem.
States 9 and 12 in the DAG both lead to state 14 (states get unified when their remaining cases/tests match). From state 14, a couple failing tests (14 and 15) lead to the default state (state 17).

Pattern explanation picks the shortest path to the default state (in this case, the path goes through 9), gathers constraints from the various tests on that path and computes remaining values. 
But the unhandled value can only lead to the default state via state 12, not via state 9 (since it tests for t2=1).
So the analysis of the path through state 9 yields no remaining values and the pattern explainer crashed.

The solution is to fall back to a more extensive analysis of all paths leading to the default state.

```
        return (e1, e2) switch
        {
            (Enum.Two, _) => 0,
            (_, Enum.Two) => 0,
            (Enum.Zero, Enum.Zero) => 0,
            (Enum.Zero, Enum.One) => 0,
            (Enum.One, Enum.Zero) => 0,
            ( < 0 or > Enum.Two, _) => 0,
            (_, < 0 or > Enum.Two) => 0,
        }; // compiler crashed when trying to explain which values lead to the default state
```

```
...
State 9 REMAINING t1:[0..0] t2:[-2147483648..-1],[1..1],[3..2147483647]
    4. [(Enum.Zero, Enum.One) => Enum.One] ?DagValueTest(t2 == ConstantValueOne(1: Int32))
    7. [(_, < 0 or > Enum.Two) => throw new InvalidCastException()] OR(?DagRelationalTest(t2 < ConstantValueDefault(0: Int32)), ?DagRelationalTest(t2 > ConstantValueI32(2: Int32)))
    Test: ?DagValueTest(t2 == ConstantValueOne(1: Int32))
    TrueBranch: 10
    FalseBranch: 14
...
State 12 REMAINING t1:[1..1] t2:[-2147483648..1],[3..2147483647]
    5. [(Enum.One, Enum.Zero) => Enum.One] ?DagValueTest(t2 == ConstantValueDefault(0: Int32))
    7. [(_, < 0 or > Enum.Two) => throw new InvalidCastException()] OR(?DagRelationalTest(t2 < ConstantValueDefault(0: Int32)), ?DagRelationalTest(t2 > ConstantValueI32(2: Int32)))
    Test: ?DagValueTest(t2 == ConstantValueDefault(0: Int32))
    TrueBranch: 13
    FalseBranch: 14
...
State 14 REMAINING t1:[0..1] t2:[-2147483648..-1],[1..1],[3..2147483647]
    7. [(_, < 0 or > Enum.Two) => throw new InvalidCastException()] OR(?DagRelationalTest(t2 < ConstantValueDefault(0: Int32)), ?DagRelationalTest(t2 > ConstantValueI32(2: Int32)))
    Test: ?DagRelationalTest(t2 < ConstantValueDefault(0: Int32))
    TrueBranch: 16
    FalseBranch: 15
State 15 REMAINING t1:[0..1] t2:[1..1],[3..2147483647]
    7. [(_, < 0 or > Enum.Two) => throw new InvalidCastException()] ?DagRelationalTest(t2 > ConstantValueI32(2: Int32))
    Test: ?DagRelationalTest(t2 > ConstantValueI32(2: Int32))
    TrueBranch: 16
    FalseBranch: 17
...
*State 17 FAIL REMAINING t1:[0..1] t2:[1..1]
...
```
