### PR TITLE
Avoid infinite loop in Find All References

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/AbstractReferenceFinder.cs
@@ -160,6 +160,14 @@ namespace Microsoft.CodeAnalysis.FindSymbols.Finders
             FindReferencesDocumentState state,
             CancellationToken cancellationToken)
         {
+            if (symbol.IsAnonymousType())
+            {
+                // Anonymous types don't have a name, so we return without further searching since the text-based index
+                // and lookup never terminates if searching for an empty string.
+                // https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1655431
+                return ImmutableArray<FinderLocation>.Empty;
+            }
+
             var tokens = await FindMatchingIdentifierTokensAsync(state, identifier, cancellationToken).ConfigureAwait(false);
             return await FindReferencesInTokensAsync(symbol, state, tokens, cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
When Find All References is invoked with an anonymous type, the identifier to search for may be the empty string. FAR does not support searching for these references; return immediately to avoid looping through documents trying to find empty strings that match the anonymous type symbol.

Fixes [AB#1655431](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1655431)