### PR TITLE
Add EvaluationData.GetItemValues

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
@@ -102,8 +102,8 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
         public async Task InvalidProjectOutputBinPaths_CPS()
         {
             using var environment = new TestEnvironment();
-            await Assert.ThrowsAsync<InvalidProjectPropertyValueException>(() => CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test2", binOutputPath: ""));
-            await Assert.ThrowsAsync<InvalidProjectPropertyValueException>(() => CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test3", binOutputPath: "Test.dll"));
+            await Assert.ThrowsAsync<InvalidProjectDataException>(() => CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test2", binOutputPath: ""));
+            await Assert.ThrowsAsync<InvalidProjectDataException>(() => CSharpHelpers.CreateCSharpCPSProjectAsync(environment, "Test3", binOutputPath: "Test.dll"));
         }
 
         [WpfFact]

--- a/src/VisualStudio/Core/Def/ProjectSystem/BuildPropertyNames.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/BuildPropertyNames.cs
@@ -35,4 +35,6 @@ internal static class BuildPropertyNames
         TargetPath,
         AssemblyName,
         CommandLineArgsForDesignTimeEvaluation);
+
+    public static readonly ImmutableArray<string> InitialEvaluationItemNames = ImmutableArray<string>.Empty;
 }

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
@@ -48,6 +48,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         public ImmutableArray<string> EvaluationPropertyNames
             => BuildPropertyNames.InitialEvaluationPropertyNames;
 
+        public ImmutableArray<string> EvaluationItemNames
+            => BuildPropertyNames.InitialEvaluationItemNames;
+
         public Task<IWorkspaceProjectContext> CreateProjectContextAsync(Guid id, string uniqueName, string languageName, EvaluationData data, object? hostObject, CancellationToken cancellationToken)
             => CreateProjectContextAsync(
                 languageName: languageName,


### PR DESCRIPTION
The API will allow us to read msbuild item specs from evaluation phase. 

This is necessary since it's not possible in msbuild to convert item spec to property value (and read it via existing API) during evaluation phase.
The item we need currently is `@(IntermediateAssembly)`.