### PR TITLE
Fix generators not being added or removed correctly

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -824,7 +824,12 @@ namespace Microsoft.CodeAnalysis
                     {
                         using var generatedDocumentsBuilder = new TemporaryArray<SourceGeneratedDocumentState>();
 
-                        if (ProjectState.SourceGenerators.Any())
+                        if (!ProjectState.SourceGenerators.Any())
+                        {
+                            // We don't have any generators, so if we have a compilation from a previous run with generated files, we definitely can't use it anymore
+                            compilationWithStaleGeneratedTrees = null;
+                        }
+                        else // we have a generator
                         {
                             // If we don't already have a generator driver, we'll have to create one from scratch
                             if (generatorInfo.Driver == null)

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -2,12 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
@@ -62,7 +64,51 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
-        public async Task WithReferencesMethodCorrectlyUpdatesRunningGenerators()
+        [WorkItem(1655835, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1655835")]
+        public async Task WithReferencesMethodCorrectlyUpdatesWithEqualReferences()
+        {
+            using var workspace = CreateWorkspace();
+
+            // AnalyzerReferences may implement equality (AnalyezrFileReference does), and we want to make sure if we substitute out one
+            // reference with another reference that's equal, we correctly update generators. We'll have the underlying generators
+            // be different since two AnalyzerFileReferences that are value equal but different instances would have their own generators as well.
+            const string SharedPath = "Z:\\Generator.dll";
+            ISourceGenerator CreateGenerator() => new SingleFileTestGenerator("// StaticContent", hintName: "generated");
+
+            var analyzerReference1 = new TestGeneratorReferenceWithFilePathEquality(CreateGenerator(), SharedPath);
+            var analyzerReference2 = new TestGeneratorReferenceWithFilePathEquality(CreateGenerator(), SharedPath);
+
+            var project = AddEmptyProject(workspace.CurrentSolution)
+                .AddAnalyzerReference(analyzerReference1);
+
+            Assert.Single((await project.GetRequiredCompilationAsync(CancellationToken.None)).SyntaxTrees);
+
+            // Go from one analyzer reference to the other
+            project = project.WithAnalyzerReferences(new[] { analyzerReference2 });
+
+            Assert.Single((await project.GetRequiredCompilationAsync(CancellationToken.None)).SyntaxTrees);
+        }
+
+        private class TestGeneratorReferenceWithFilePathEquality : TestGeneratorReference, IEquatable<AnalyzerReference>
+        {
+            public TestGeneratorReferenceWithFilePathEquality(ISourceGenerator generator, string analyzerFilePath) : base(generator)
+            {
+                FullPath = analyzerFilePath;
+            }
+
+            public override bool Equals(object? obj) => Equals(obj as AnalyzerReference);
+            public override string FullPath { get; }
+            public override int GetHashCode() => this.FullPath.GetHashCode();
+
+            public bool Equals(AnalyzerReference? other)
+            {
+                return other is TestGeneratorReferenceWithFilePathEquality otherReference &&
+                    this.FullPath == otherReference.FullPath;
+            }
+        }
+
+        [Fact]
+        public async Task WithReferencesMethodCorrectlyAddsAndRemovesRunningGenerators()
         {
             using var workspace = CreateWorkspace();
 

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -87,6 +87,11 @@ namespace Microsoft.CodeAnalysis.UnitTests
             project = project.WithAnalyzerReferences(new[] { analyzerReference2 });
 
             Assert.Single((await project.GetRequiredCompilationAsync(CancellationToken.None)).SyntaxTrees);
+
+            // Now remove and confirm that we don't have any files
+            project = project.WithAnalyzerReferences(SpecializedCollections.EmptyEnumerable<AnalyzerReference>());
+
+            Assert.Empty((await project.GetRequiredCompilationAsync(CancellationToken.None)).SyntaxTrees);
         }
 
         private class TestGeneratorReferenceWithFilePathEquality : TestGeneratorReference, IEquatable<AnalyzerReference>

--- a/src/Workspaces/CoreTestUtilities/TestGeneratorReference.cs
+++ b/src/Workspaces/CoreTestUtilities/TestGeneratorReference.cs
@@ -13,7 +13,7 @@ namespace Roslyn.Test.Utilities
     /// A simple deriviation of <see cref="AnalyzerReference"/> that returns the source generator
     /// passed, for ease in unit tests.
     /// </summary>
-    public sealed class TestGeneratorReference : AnalyzerReference, IChecksummedObject
+    public class TestGeneratorReference : AnalyzerReference, IChecksummedObject
     {
         private readonly ISourceGenerator _generator;
         private readonly Checksum _checksum;


### PR DESCRIPTION
When the list of analyzer references change for a project, we produce a new list of AnalyzerFileReferences and pass that into Project.WithAnalyzerReferences. The implementation of that method figures out which references are added or removed, and also uses those changes to update the list of generators being held by the generator.

This seems innocent enough, except that the AnalyzerFileReferences here implement value equality: two references are equal if they have the same file path. These references however will not return the same generator instances, because each reference does it's own loading and caching of that list. Thus, when we computed the list of analyzers that are added or removed, we won't see analyzer references that are equal, and won't update the generator driver. Later code that expects those to be in sync will then start throwing exceptions.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1655835
Fixes https://github.com/dotnet/roslyn/issues/57660

While then writing tests for that, I found a second issue:

If the last generator was removed, and it was generating trees, we would have potentially left that tree in the Compilation that was returned. I believe this would have been a transient issue -- any later change to the project would have created a new CompilationTracker with an InProgress state; the code that processes an InProgress state into the final state would have correctly seen we no longer had a generator and would have dropped the old compilation at that point. 