### PR TITLE
Reduce amount of allocated MissingMetadataTypeSymbol symbols during various lookup operations.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -2414,7 +2414,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Compilation.Assembly.Modules[0].GetReferencedAssemblySymbols())
             {
                 var forwardedType =
-                    referencedAssembly.TryLookupForwardedMetadataType(ref metadataName);
+                    referencedAssembly.TryLookupForwardedMetadataTypeWithCycleDetection(ref metadataName, visitedAssemblies: null);
                 if ((object)forwardedType != null)
                 {
                     if (forwardedType.Kind == SymbolKind.ErrorType)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1574,7 +1574,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal TypeSymbol GetTypeByReflectionType(Type type, BindingDiagnosticBag diagnostics)
         {
-            var result = Assembly.GetTypeByReflectionType(type, includeReferences: true);
+            var result = Assembly.GetTypeByReflectionType(type);
             if (result is null)
             {
                 var errorType = new ExtendedErrorTypeSymbol(this, type.Name, 0, CreateReflectionTypeNotFoundError(type));
@@ -1603,7 +1603,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (HostObjectType != null && _lazyHostObjectTypeSymbol is null)
             {
-                TypeSymbol? symbol = Assembly.GetTypeByReflectionType(HostObjectType, includeReferences: true);
+                TypeSymbol? symbol = Assembly.GetTypeByReflectionType(HostObjectType);
 
                 if (symbol is null)
                 {
@@ -1637,7 +1637,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         internal new NamedTypeSymbol? GetTypeByMetadataName(string fullyQualifiedMetadataName)
         {
-            return this.Assembly.GetTypeByMetadataName(fullyQualifiedMetadataName, includeReferences: true, isWellKnownType: false, conflicts: out var _);
+            var result = this.Assembly.GetTypeByMetadataName(fullyQualifiedMetadataName, includeReferences: true, isWellKnownType: false, conflicts: out var _);
+            Debug.Assert(result?.IsErrorType() != true);
+            return result;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEAssemblyBuilder.cs
@@ -509,17 +509,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             }
         }
 
+#nullable enable
+
         private void AddDiagnosticsForExistingAttribute(AttributeDescription description, BindingDiagnosticBag diagnostics)
         {
             var attributeMetadataName = MetadataTypeName.FromFullName(description.FullName);
             var userDefinedAttribute = _sourceAssembly.SourceModule.LookupTopLevelMetadataType(ref attributeMetadataName);
-            Debug.Assert((object)userDefinedAttribute.ContainingModule == _sourceAssembly.SourceModule);
+            Debug.Assert(userDefinedAttribute is null || (object)userDefinedAttribute.ContainingModule == _sourceAssembly.SourceModule);
+            Debug.Assert(userDefinedAttribute?.IsErrorType() != true);
 
-            if (!(userDefinedAttribute is MissingMetadataTypeSymbol))
+            if (userDefinedAttribute is not null)
             {
                 diagnostics.Add(ErrorCode.ERR_TypeReserved, userDefinedAttribute.Locations[0], description.FullName);
             }
         }
+
+#nullable disable
 
         private NamespaceSymbol GetOrSynthesizeNamespace(string namespaceFullName)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -644,22 +644,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 for (int i = 1; i < parts.Length; i++)
                 {
                     mdName = MetadataTypeName.FromTypeName(parts[i]);
-                    NamedTypeSymbol? temp = type.LookupMetadataType(ref mdName);
+                    type = type.LookupMetadataType(ref mdName);
 
-                    if (temp is null)
+                    if (type is null)
                     {
                         return null;
                     }
 
-                    Debug.Assert(!temp.IsErrorType());
-                    Debug.Assert((object)type == temp.ContainingSymbol);
+                    Debug.Assert(!type.IsErrorType());
 
-                    if (isWellKnownType && !IsValidWellKnownType(temp))
+                    if (isWellKnownType && !IsValidWellKnownType(type))
                     {
                         return null;
                     }
-
-                    type = temp;
                 }
             }
             else

--- a/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs
@@ -312,6 +312,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+#nullable enable
         /// <summary>
         /// Lookup a top level type referenced from metadata, names should be
         /// compared case-sensitively.
@@ -319,14 +320,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <param name="emittedName">
         /// Full type name with generic name mangling.
         /// </param>
-        /// <param name="digThroughForwardedTypes">
-        /// Take forwarded types into account.
-        /// </param>
         /// <remarks></remarks>
-        internal NamedTypeSymbol LookupTopLevelMetadataType(ref MetadataTypeName emittedName, bool digThroughForwardedTypes)
-        {
-            return LookupTopLevelMetadataTypeWithCycleDetection(ref emittedName, visitedAssemblies: null, digThroughForwardedTypes: digThroughForwardedTypes);
-        }
+        /// <returns>The symbol for the type declared in this assembly, or null.</returns>
+        internal abstract NamedTypeSymbol? LookupDeclaredTopLevelMetadataType(ref MetadataTypeName emittedName);
 
         /// <summary>
         /// Lookup a top level type referenced from metadata, names should be
@@ -338,17 +334,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <param name="visitedAssemblies">
         /// List of assemblies lookup has already visited (since type forwarding can introduce cycles).
         /// </param>
-        /// <param name="digThroughForwardedTypes">
-        /// Take forwarded types into account.
-        /// </param>
-        internal abstract NamedTypeSymbol LookupTopLevelMetadataTypeWithCycleDetection(ref MetadataTypeName emittedName, ConsList<AssemblySymbol> visitedAssemblies, bool digThroughForwardedTypes);
+        internal abstract NamedTypeSymbol LookupDeclaredOrForwardedTopLevelMetadataType(ref MetadataTypeName emittedName, ConsList<AssemblySymbol>? visitedAssemblies);
 
         /// <summary>
-        /// Returns the type symbol for a forwarded type based its canonical CLR metadata name.
+        /// Returns the type symbol for a forwarded type based on its canonical CLR metadata name.
         /// The name should refer to a non-nested type. If type with this name is not forwarded,
         /// null is returned.
         /// </summary>
-        public NamedTypeSymbol ResolveForwardedType(string fullyQualifiedMetadataName)
+        public NamedTypeSymbol? ResolveForwardedType(string fullyQualifiedMetadataName)
         {
             if (fullyQualifiedMetadataName == null)
             {
@@ -356,21 +349,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             var emittedName = MetadataTypeName.FromFullName(fullyQualifiedMetadataName);
-            return TryLookupForwardedMetadataType(ref emittedName);
-        }
-
-        /// <summary>
-        /// Look up the given metadata type, if it is forwarded.
-        /// </summary>
-        internal NamedTypeSymbol TryLookupForwardedMetadataType(ref MetadataTypeName emittedName)
-        {
             return TryLookupForwardedMetadataTypeWithCycleDetection(ref emittedName, visitedAssemblies: null);
         }
 
         /// <summary>
         /// Look up the given metadata type, if it is forwarded.
         /// </summary>
-        internal virtual NamedTypeSymbol TryLookupForwardedMetadataTypeWithCycleDetection(ref MetadataTypeName emittedName, ConsList<AssemblySymbol> visitedAssemblies)
+        internal virtual NamedTypeSymbol? TryLookupForwardedMetadataTypeWithCycleDetection(ref MetadataTypeName emittedName, ConsList<AssemblySymbol>? visitedAssemblies)
         {
             return null;
         }
@@ -388,6 +373,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal abstract IEnumerable<NamedTypeSymbol> GetAllTopLevelForwardedTypes();
+
+#nullable disable
 
         /// <summary>
         /// Lookup declaration for predefined CorLib type in this Assembly.
@@ -596,7 +583,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 throw new ArgumentNullException(nameof(fullyQualifiedMetadataName));
             }
 
-            return this.GetTypeByMetadataName(fullyQualifiedMetadataName, includeReferences: false, isWellKnownType: false, conflicts: out var _);
+            var result = this.GetTypeByMetadataName(fullyQualifiedMetadataName, includeReferences: false, isWellKnownType: false, conflicts: out var _);
+            Debug.Assert(result?.IsErrorType() != true);
+            return result;
         }
 
         /// <summary>
@@ -645,11 +634,32 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 type = GetTopLevelTypeByMetadataName(ref mdName, assemblyOpt: null, includeReferences: includeReferences, isWellKnownType: isWellKnownType,
                     conflicts: out conflicts, warnings: warnings, ignoreCorLibraryDuplicatedTypes: ignoreCorLibraryDuplicatedTypes);
 
-                for (int i = 1; type is object && !type.IsErrorType() && i < parts.Length; i++)
+                if (type is null)
+                {
+                    return null;
+                }
+
+                Debug.Assert(!type.IsErrorType());
+
+                for (int i = 1; i < parts.Length; i++)
                 {
                     mdName = MetadataTypeName.FromTypeName(parts[i]);
-                    NamedTypeSymbol temp = type.LookupMetadataType(ref mdName);
-                    type = (!isWellKnownType || IsValidWellKnownType(temp)) ? temp : null;
+                    NamedTypeSymbol? temp = type.LookupMetadataType(ref mdName);
+
+                    if (temp is null)
+                    {
+                        return null;
+                    }
+
+                    Debug.Assert(!temp.IsErrorType());
+                    Debug.Assert((object)type == temp.ContainingSymbol);
+
+                    if (isWellKnownType && !IsValidWellKnownType(temp))
+                    {
+                        return null;
+                    }
+
+                    type = temp;
                 }
             }
             else
@@ -659,7 +669,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     conflicts: out conflicts, warnings: warnings, ignoreCorLibraryDuplicatedTypes: ignoreCorLibraryDuplicatedTypes);
             }
 
-            return (type is null || type.IsErrorType()) ? null : type;
+            Debug.Assert(type?.IsErrorType() != true);
+
+            return type;
         }
 
         private static readonly char[] s_nestedTypeNameSeparators = new char[] { '+' };
@@ -669,9 +681,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// its referenced assemblies.
         /// </summary>
         /// <param name="type">The type to resolve.</param>
-        /// <param name="includeReferences">Use referenced assemblies for resolution.</param>
         /// <returns>The resolved symbol if successful or null on failure.</returns>
-        internal TypeSymbol? GetTypeByReflectionType(Type type, bool includeReferences)
+        internal TypeSymbol? GetTypeByReflectionType(Type type)
         {
             System.Reflection.TypeInfo typeInfo = type.GetTypeInfo();
 
@@ -682,7 +693,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (typeInfo.IsArray)
             {
-                TypeSymbol? symbol = GetTypeByReflectionType(typeInfo.GetElementType()!, includeReferences);
+                TypeSymbol? symbol = GetTypeByReflectionType(typeInfo.GetElementType()!);
                 if (symbol is null)
                 {
                     return null;
@@ -694,7 +705,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (typeInfo.IsPointer)
             {
-                TypeSymbol? symbol = GetTypeByReflectionType(typeInfo.GetElementType()!, includeReferences);
+                TypeSymbol? symbol = GetTypeByReflectionType(typeInfo.GetElementType()!);
                 if (symbol is null)
                 {
                     return null;
@@ -726,7 +737,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 int i = nestedTypes.Count - 1;
-                var symbol = (NamedTypeSymbol?)GetTypeByReflectionType(nestedTypes[i].AsType(), includeReferences);
+                var symbol = (NamedTypeSymbol?)GetTypeByReflectionType(nestedTypes[i].AsType());
                 if (symbol is null)
                 {
                     return null;
@@ -738,12 +749,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     MetadataTypeName mdName = MetadataTypeName.FromTypeName(nestedTypes[i].Name, forcedArity: forcedArity);
 
                     symbol = symbol.LookupMetadataType(ref mdName);
-                    if (symbol is null || symbol.IsErrorType())
+                    Debug.Assert(symbol?.IsErrorType() != true);
+
+                    if (symbol is null)
                     {
                         return null;
                     }
 
-                    symbol = ApplyGenericArguments(symbol, genericArguments, ref typeArgumentIndex, includeReferences);
+                    symbol = ApplyGenericArguments(symbol, genericArguments, ref typeArgumentIndex);
                     if (symbol is null)
                     {
                         return null;
@@ -763,22 +776,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     typeInfo.Name,
                     forcedArity: typeInfo.GenericTypeArguments.Length);
 
-                NamedTypeSymbol? symbol = GetTopLevelTypeByMetadataName(ref mdName, assemblyId, includeReferences, isWellKnownType: false, conflicts: out var _);
+                NamedTypeSymbol? symbol = GetTopLevelTypeByMetadataName(ref mdName, assemblyId, includeReferences: true, isWellKnownType: false, conflicts: out var _);
 
-                if (symbol is null || symbol.IsErrorType())
+                if (symbol is null)
                 {
                     return null;
                 }
 
+                Debug.Assert(!symbol.IsErrorType());
+
                 int typeArgumentIndex = 0;
                 Type[] genericArguments = typeInfo.GenericTypeArguments;
-                symbol = ApplyGenericArguments(symbol, genericArguments, ref typeArgumentIndex, includeReferences);
+                symbol = ApplyGenericArguments(symbol, genericArguments, ref typeArgumentIndex);
                 Debug.Assert(typeArgumentIndex == genericArguments.Length);
                 return symbol;
             }
         }
 
-        private NamedTypeSymbol? ApplyGenericArguments(NamedTypeSymbol symbol, Type[] typeArguments, ref int currentTypeArgument, bool includeReferences)
+        private NamedTypeSymbol? ApplyGenericArguments(NamedTypeSymbol symbol, Type[] typeArguments, ref int currentTypeArgument)
         {
             int remainingTypeArguments = typeArguments.Length - currentTypeArgument;
 
@@ -794,7 +809,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var typeArgumentSymbols = ArrayBuilder<TypeWithAnnotations>.GetInstance(length);
             for (int i = 0; i < length; i++)
             {
-                var argSymbol = GetTypeByReflectionType(typeArguments[currentTypeArgument++], includeReferences);
+                var argSymbol = GetTypeByReflectionType(typeArguments[currentTypeArgument++]);
                 if (argSymbol is null)
                 {
                     return null;
@@ -828,6 +843,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // First try this assembly
             result = GetTopLevelTypeByMetadataName(this, ref metadataName, assemblyOpt);
+            Debug.Assert(result?.IsErrorType() != true);
 
             if (isWellKnownType && !IsValidWellKnownType(result))
             {
@@ -849,6 +865,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 !isWellKnownTypeBeforeCSharp7 && !ignoreCorLibraryDuplicatedTypes)
             {
                 NamedTypeSymbol? corLibCandidate = GetTopLevelTypeByMetadataName(CorLibrary, ref metadataName, assemblyOpt);
+                Debug.Assert(corLibCandidate?.IsErrorType() != true);
                 skipCorLibrary = true;
 
                 if (isValidCandidate(corLibCandidate, isWellKnownType))
@@ -883,6 +900,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 NamedTypeSymbol? candidate = GetTopLevelTypeByMetadataName(assembly, ref metadataName, assemblyOpt);
+                Debug.Assert(candidate?.IsErrorType() != true);
 
                 if (!isValidCandidate(candidate, isWellKnownType))
                 {
@@ -927,6 +945,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             assemblies.Free();
+            Debug.Assert(result?.IsErrorType() != true);
             return result;
 
             bool isValidCandidate([NotNullWhen(true)] NamedTypeSymbol? candidate, bool isWellKnownType)
@@ -957,23 +976,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private static NamedTypeSymbol? GetTopLevelTypeByMetadataName(AssemblySymbol assembly, ref MetadataTypeName metadataName, AssemblyIdentity? assemblyOpt)
         {
-            var result = assembly.LookupTopLevelMetadataType(ref metadataName, digThroughForwardedTypes: false);
-            if (!IsAcceptableMatchForGetTypeByMetadataName(result))
-            {
-                return null;
-            }
-
             if (assemblyOpt != null && !assemblyOpt.Equals(assembly.Identity))
             {
                 return null;
             }
 
-            return result;
-        }
+            var result = assembly.LookupDeclaredTopLevelMetadataType(ref metadataName);
+            Debug.Assert(result?.IsErrorType() != true);
+            Debug.Assert(result is null || ReferenceEquals(result.ContainingAssembly, assembly));
 
-        private static bool IsAcceptableMatchForGetTypeByMetadataName(NamedTypeSymbol candidate)
-        {
-            return candidate.Kind != SymbolKind.ErrorType || !(candidate is MissingMetadataTypeSymbol);
+            return result;
         }
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -145,11 +145,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     result = this.Assembly.GetTypeByMetadataName(
                         mdName, includeReferences: true, useCLSCompliantNameArityEncoding: true, isWellKnownType: true, conflicts: out conflicts,
                         warnings: legacyWarnings, ignoreCorLibraryDuplicatedTypes: ignoreCorLibraryDuplicatedTypes);
+                    Debug.Assert(result?.IsErrorType() != true);
                 }
 
                 if (result is null)
                 {
-                    // TODO: should GetTypeByMetadataName rather return a missing symbol?
                     MetadataTypeName emittedName = MetadataTypeName.FromFullName(mdName, useCLSCompliantNameArityEncoding: true);
                     if (type.IsValueTupleType())
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
@@ -207,13 +207,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     string typeName = "CallConv" + specifierText;
                     var metadataName = MetadataTypeName.FromNamespaceAndTypeName("System.Runtime.CompilerServices", typeName, useCLSCompliantNameArityEncoding: true, forcedArity: 0);
-                    NamedTypeSymbol specifierType;
-                    specifierType = compilation.Assembly.CorLibrary.LookupTopLevelMetadataType(ref metadataName, digThroughForwardedTypes: false);
+                    NamedTypeSymbol? specifierType;
+                    specifierType = compilation.Assembly.CorLibrary.LookupDeclaredTopLevelMetadataType(ref metadataName);
+                    Debug.Assert(specifierType?.IsErrorType() != true);
+                    Debug.Assert(specifierType is null || ReferenceEquals(specifierType.ContainingAssembly, compilation.Assembly.CorLibrary));
 
-                    if (specifierType is MissingMetadataTypeSymbol)
+                    if (specifierType is null)
                     {
-                        // Replace the existing missing type symbol with one that has a better error message
-                        specifierType = new MissingMetadataTypeSymbol.TopLevel(specifierType.ContainingModule, ref metadataName, new CSDiagnosticInfo(ErrorCode.ERR_TypeNotFound, typeName));
+                        specifierType = new MissingMetadataTypeSymbol.TopLevel(compilation.Assembly.CorLibrary.Modules[0], ref metadataName, new CSDiagnosticInfo(ErrorCode.ERR_TypeNotFound, typeName));
                     }
                     else if (specifierType.DeclaredAccessibility != Accessibility.Public)
                     {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
@@ -113,12 +113,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return moduleSymbol.TypeRefHandleToTypeMap;
         }
 
+#nullable enable
+
         protected override TypeSymbol LookupNestedTypeDefSymbol(TypeSymbol container, ref MetadataTypeName emittedName)
         {
             var result = container.LookupMetadataType(ref emittedName);
-            Debug.Assert((object)result != null);
+            Debug.Assert(result?.IsErrorType() != true);
 
-            return result;
+            return result ?? new MissingMetadataTypeSymbol.Nested((NamedTypeSymbol)container, ref emittedName);
+
         }
 
         /// <summary>
@@ -138,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             try
             {
-                return assembly.LookupTopLevelMetadataType(ref emittedName, digThroughForwardedTypes: true);
+                return assembly.LookupDeclaredOrForwardedTopLevelMetadataType(ref emittedName, visitedAssemblies: null);
             }
             catch (Exception e) when (FatalError.ReportAndPropagate(e)) // Trying to get more useful Watson dumps.
             {
@@ -157,12 +160,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 {
                     if ((object)m == (object)moduleSymbol)
                     {
-                        return moduleSymbol.LookupTopLevelMetadataType(ref emittedName, out isNoPiaLocalType);
+                        return moduleSymbol.LookupTopLevelMetadataTypeWithNoPiaLocalTypeUnification(ref emittedName, out isNoPiaLocalType);
                     }
                     else
                     {
                         isNoPiaLocalType = false;
-                        return m.LookupTopLevelMetadataType(ref emittedName);
+                        var result = m.LookupTopLevelMetadataType(ref emittedName);
+                        Debug.Assert(result?.IsErrorType() != true);
+
+                        return result ?? new MissingMetadataTypeSymbol.TopLevel(m, ref emittedName);
                     }
                 }
             }
@@ -180,8 +186,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         /// </summary>
         protected override TypeSymbol LookupTopLevelTypeDefSymbol(ref MetadataTypeName emittedName, out bool isNoPiaLocalType)
         {
-            return moduleSymbol.LookupTopLevelMetadataType(ref emittedName, out isNoPiaLocalType);
+            return moduleSymbol.LookupTopLevelMetadataTypeWithNoPiaLocalTypeUnification(ref emittedName, out isNoPiaLocalType);
         }
+
+#nullable disable
 
         protected override int GetIndexOfReferencedAssembly(AssemblyIdentity identity)
         {
@@ -310,6 +318,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return newresult;
         }
 
+#nullable enable
+
         /// <summary>
         /// Find canonical type for NoPia embedded type.
         /// </summary>
@@ -320,12 +330,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             ref MetadataTypeName name,
             bool isInterface,
             TypeSymbol baseType,
-            string interfaceGuid,
-            string scope,
-            string identifier,
+            string? interfaceGuid,
+            string? scope,
+            string? identifier,
             AssemblySymbol referringAssembly)
         {
-            NamedTypeSymbol result = null;
+            NamedTypeSymbol? result = null;
 
             Guid interfaceGuidValue = new Guid();
             bool haveInterfaceGuidValue = false;
@@ -357,12 +367,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                     continue;
                 }
 
-                NamedTypeSymbol candidate = assembly.LookupTopLevelMetadataType(ref name, digThroughForwardedTypes: false);
-                Debug.Assert(!candidate.IsGenericType);
+                // Ignore type forwarders
+                NamedTypeSymbol? candidate = assembly.LookupDeclaredTopLevelMetadataType(ref name);
+                Debug.Assert(candidate?.IsGenericType != true);
+                Debug.Assert(candidate?.IsErrorType() != true);
+                Debug.Assert(candidate is null || ReferenceEquals(candidate.ContainingAssembly, assembly));
 
-                // Ignore type forwarders, error symbols and non-public types
-                if (candidate.Kind == SymbolKind.ErrorType ||
-                    !ReferenceEquals(candidate.ContainingAssembly, assembly) ||
+                // Ignore non-public types
+                if (candidate is null ||
                     candidate.DeclaredAccessibility != Accessibility.Public)
                 {
                     continue;
@@ -448,7 +460,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 }
 
                 // OK. It looks like we found canonical type definition.
-                if ((object)result != null)
+                if ((object?)result != null)
                 {
                     // Ambiguity 
                     result = new NoPiaAmbiguousCanonicalTypeSymbol(referringAssembly, result, candidate);
@@ -458,7 +470,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 result = candidate;
             }
 
-            if ((object)result == null)
+            if ((object?)result == null)
             {
                 result = new NoPiaMissingCanonicalTypeSymbol(
                                 referringAssembly,
@@ -470,6 +482,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
             return result;
         }
+
+#nullable disable
 
         protected override MethodSymbol FindMethodSymbolInType(TypeSymbol typeSymbol, MethodDefinitionHandle targetMethodDef)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEAssemblySymbol.cs
@@ -171,7 +171,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return this.PrimaryModule.GetForwardedTypes();
         }
 
-        internal override NamedTypeSymbol TryLookupForwardedMetadataTypeWithCycleDetection(ref MetadataTypeName emittedName, ConsList<AssemblySymbol> visitedAssemblies)
+#nullable enable
+
+        internal override NamedTypeSymbol? TryLookupForwardedMetadataTypeWithCycleDetection(ref MetadataTypeName emittedName, ConsList<AssemblySymbol>? visitedAssemblies)
         {
             // Check if it is a forwarded type.
             (AssemblySymbol firstSymbol, AssemblySymbol secondSymbol) = LookupAssembliesForForwardedMetadataType(ref emittedName);
@@ -192,12 +194,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 else
                 {
                     visitedAssemblies = new ConsList<AssemblySymbol>(this, visitedAssemblies ?? ConsList<AssemblySymbol>.Empty);
-                    return firstSymbol.LookupTopLevelMetadataTypeWithCycleDetection(ref emittedName, visitedAssemblies, digThroughForwardedTypes: true);
+                    return firstSymbol.LookupDeclaredOrForwardedTopLevelMetadataType(ref emittedName, visitedAssemblies);
                 }
             }
 
             return null;
         }
+
+#nullable disable
 
         internal override ImmutableArray<AssemblySymbol> GetNoPiaResolutionAssemblies()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PEModuleSymbol.cs
@@ -41,13 +41,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         /// </summary>
         private readonly PENamespaceSymbol _globalNamespace;
 
+#nullable enable
+
         /// <summary>
         /// Cache the symbol for well-known type System.Type because we use it frequently
         /// (for attributes).
         /// </summary>
-        private NamedTypeSymbol _lazySystemTypeSymbol;
-        private NamedTypeSymbol _lazyEventRegistrationTokenSymbol;
-        private NamedTypeSymbol _lazyEventRegistrationTokenTableSymbol;
+        private NamedTypeSymbol? _lazySystemTypeSymbol;
+        private NamedTypeSymbol? _lazyEventRegistrationTokenSymbol;
+        private NamedTypeSymbol? _lazyEventRegistrationTokenTableSymbol;
+
+#nullable disable
 
         /// <summary>
         /// The same value as ConcurrentDictionary.DEFAULT_CAPACITY
@@ -533,11 +537,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             }
         }
 
+#nullable enable
+
         internal NamedTypeSymbol EventRegistrationToken
         {
             get
             {
-                if ((object)_lazyEventRegistrationTokenSymbol == null)
+                if ((object?)_lazyEventRegistrationTokenSymbol == null)
                 {
                     Interlocked.CompareExchange(ref _lazyEventRegistrationTokenSymbol,
                                                 GetTypeSymbolForWellKnownType(
@@ -554,7 +560,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                if ((object)_lazyEventRegistrationTokenTableSymbol == null)
+                if ((object?)_lazyEventRegistrationTokenTableSymbol == null)
                 {
                     Interlocked.CompareExchange(ref _lazyEventRegistrationTokenTableSymbol,
                                                 GetTypeSymbolForWellKnownType(
@@ -571,7 +577,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             get
             {
-                if ((object)_lazySystemTypeSymbol == null)
+                if ((object?)_lazySystemTypeSymbol == null)
                 {
                     Interlocked.CompareExchange(ref _lazySystemTypeSymbol,
                                                 GetTypeSymbolForWellKnownType(WellKnownType.System_Type),
@@ -586,23 +592,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         {
             MetadataTypeName emittedName = MetadataTypeName.FromFullName(type.GetMetadataName(), useCLSCompliantNameArityEncoding: true);
             // First, check this module
-            NamedTypeSymbol currentModuleResult = this.LookupTopLevelMetadataType(ref emittedName);
+            NamedTypeSymbol? currentModuleResult = this.LookupTopLevelMetadataType(ref emittedName);
+            Debug.Assert(currentModuleResult?.IsErrorType() != true);
 
-            if (IsAcceptableSystemTypeSymbol(currentModuleResult))
+            if (currentModuleResult is not null)
             {
+                Debug.Assert(isAcceptableSystemTypeSymbol(currentModuleResult));
+
                 // It doesn't matter if there's another of this type in a referenced assembly -
                 // we prefer the one in the current module.
                 return currentModuleResult;
             }
 
             // If we didn't find it in this module, check the referenced assemblies
-            NamedTypeSymbol referencedAssemblyResult = null;
+            NamedTypeSymbol? referencedAssemblyResult = null;
             foreach (AssemblySymbol assembly in this.GetReferencedAssemblySymbols())
             {
-                NamedTypeSymbol currResult = assembly.LookupTopLevelMetadataType(ref emittedName, digThroughForwardedTypes: true);
-                if (IsAcceptableSystemTypeSymbol(currResult))
+                NamedTypeSymbol currResult = assembly.LookupDeclaredOrForwardedTopLevelMetadataType(ref emittedName, visitedAssemblies: null);
+                if (isAcceptableSystemTypeSymbol(currResult))
                 {
-                    if ((object)referencedAssemblyResult == null)
+                    if ((object?)referencedAssemblyResult == null)
                     {
                         referencedAssemblyResult = currResult;
                     }
@@ -621,20 +630,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 }
             }
 
-            if ((object)referencedAssemblyResult != null)
+            if ((object?)referencedAssemblyResult != null)
             {
-                Debug.Assert(IsAcceptableSystemTypeSymbol(referencedAssemblyResult));
+                Debug.Assert(isAcceptableSystemTypeSymbol(referencedAssemblyResult));
                 return referencedAssemblyResult;
             }
 
-            Debug.Assert((object)currentModuleResult != null);
-            return currentModuleResult;
+            return new MissingMetadataTypeSymbol.TopLevel(this, ref emittedName);
+
+            static bool isAcceptableSystemTypeSymbol(NamedTypeSymbol candidate)
+            {
+                return candidate.Kind != SymbolKind.ErrorType || !(candidate is MissingMetadataTypeSymbol);
+            }
         }
 
-        private static bool IsAcceptableSystemTypeSymbol(NamedTypeSymbol candidate)
-        {
-            return candidate.Kind != SymbolKind.ErrorType || !(candidate is MissingMetadataTypeSymbol);
-        }
+#nullable disable
 
         internal override bool HasAssemblyCompilationRelaxationsAttribute
         {
@@ -668,25 +678,39 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             get { return null; }
         }
 
-        internal NamedTypeSymbol LookupTopLevelMetadataType(ref MetadataTypeName emittedName, out bool isNoPiaLocalType)
-        {
-            NamedTypeSymbol result;
-            PENamespaceSymbol scope = (PENamespaceSymbol)this.GlobalNamespace.LookupNestedNamespace(emittedName.NamespaceSegments);
+#nullable enable
 
-            if ((object)scope == null)
+        internal NamedTypeSymbol LookupTopLevelMetadataTypeWithNoPiaLocalTypeUnification(ref MetadataTypeName emittedName, out bool isNoPiaLocalType)
+        {
+            NamedTypeSymbol? result;
+            var scope = (PENamespaceSymbol?)this.GlobalNamespace.LookupNestedNamespace(emittedName.NamespaceSegments);
+
+            if ((object?)scope == null)
             {
                 // We failed to locate the namespace
-                isNoPiaLocalType = false;
-                result = new MissingMetadataTypeSymbol.TopLevel(this, ref emittedName);
+                result = null;
             }
             else
             {
-                result = scope.LookupMetadataType(ref emittedName, out isNoPiaLocalType);
-                Debug.Assert((object)result != null);
+                result = scope.LookupMetadataType(ref emittedName);
+                Debug.Assert(result?.IsErrorType() != true);
+
+                if (result is null)
+                {
+                    result = scope.UnifyIfNoPiaLocalType(ref emittedName);
+                    if (result is not null)
+                    {
+                        isNoPiaLocalType = true;
+                        return result;
+                    }
+                }
             }
 
-            return result;
+            isNoPiaLocalType = false;
+            return result ?? new MissingMetadataTypeSymbol.TopLevel(this, ref emittedName);
         }
+
+#nullable disable
 
         /// <summary>
         /// Returns a tuple of the assemblies this module forwards the given type to.
@@ -717,6 +741,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             return (firstSymbol, secondSymbol);
         }
 
+#nullable enable
+
         internal IEnumerable<NamedTypeSymbol> GetForwardedTypes()
         {
             foreach (KeyValuePair<string, (int FirstIndex, int SecondIndex)> forwarder in Module.GetForwardedTypes())
@@ -736,11 +762,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 }
                 else
                 {
-                    yield return firstSymbol.LookupTopLevelMetadataType(ref name, digThroughForwardedTypes: true);
+                    yield return firstSymbol.LookupDeclaredOrForwardedTopLevelMetadataType(ref name, visitedAssemblies: null);
                 }
             }
         }
 
+#nullable disable
         public override ModuleMetadata GetMetadata() => _module.GetNonDisposableMetadata();
 
         internal bool ShouldDecodeNullableAttributes(Symbol symbol)

--- a/src/Compilers/CSharp/Portable/Symbols/MetadataOrSourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MetadataOrSourceAssemblySymbol.cs
@@ -33,6 +33,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private NativeIntegerTypeSymbol[] _lazyNativeIntegerTypes;
 
+#nullable enable 
+
         /// <summary>
         /// Lookup declaration for predefined CorLib type in this Assembly.
         /// </summary>
@@ -51,16 +53,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 MetadataTypeName emittedName = MetadataTypeName.FromFullName(type.GetMetadataName(), useCLSCompliantNameArityEncoding: true);
                 ModuleSymbol module = this.Modules[0];
-                NamedTypeSymbol result = module.LookupTopLevelMetadataType(ref emittedName);
-                if (result.Kind != SymbolKind.ErrorType && result.DeclaredAccessibility != Accessibility.Public)
+                NamedTypeSymbol? result = module.LookupTopLevelMetadataType(ref emittedName);
+
+                Debug.Assert(result?.IsErrorType() != true);
+
+                if (result is null || result.DeclaredAccessibility != Accessibility.Public)
                 {
                     result = new MissingMetadataTypeSymbol.TopLevel(module, ref emittedName, type);
                 }
+
                 RegisterDeclaredSpecialType(result);
             }
 
+            Debug.Assert(_lazySpecialTypes is not null);
             return _lazySpecialTypes[(int)type];
         }
+
+#nullable disable
 
         /// <summary>
         /// Register declaration of predefined CorLib type in this Assembly.

--- a/src/Compilers/CSharp/Portable/Symbols/MissingAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingAssemblySymbol.cs
@@ -161,12 +161,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override NamedTypeSymbol LookupTopLevelMetadataTypeWithCycleDetection(ref MetadataTypeName emittedName, ConsList<AssemblySymbol> visitedAssemblies, bool digThroughForwardedTypes)
+#nullable enable
+
+        internal override NamedTypeSymbol LookupDeclaredOrForwardedTopLevelMetadataType(ref MetadataTypeName emittedName, ConsList<AssemblySymbol>? visitedAssemblies)
         {
-            var result = this.moduleSymbol.LookupTopLevelMetadataType(ref emittedName);
-            Debug.Assert(result is MissingMetadataTypeSymbol);
-            return result;
+            return new MissingMetadataTypeSymbol.TopLevel(this.moduleSymbol, ref emittedName);
         }
+
+        internal override NamedTypeSymbol? LookupDeclaredTopLevelMetadataType(ref MetadataTypeName emittedName)
+        {
+            return null;
+        }
+
+#nullable disable
 
         internal override NamedTypeSymbol GetDeclaredSpecialType(SpecialType type)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingModuleSymbol.cs
@@ -143,10 +143,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override NamedTypeSymbol LookupTopLevelMetadataType(ref MetadataTypeName emittedName)
+#nullable enable
+        internal override NamedTypeSymbol? LookupTopLevelMetadataType(ref MetadataTypeName emittedName)
         {
-            return new MissingMetadataTypeSymbol.TopLevel(this, ref emittedName);
+            return null;
         }
+#nullable disable
 
         internal override ImmutableArray<AssemblyIdentity> GetReferencedAssemblies()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ModuleSymbol.cs
@@ -298,6 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </remarks>
         internal abstract bool GetUnificationUseSiteDiagnostic(ref DiagnosticInfo result, TypeSymbol dependentType);
 
+#nullable enable
         /// <summary>
         /// Lookup a top level type referenced from metadata, names should be
         /// compared case-sensitively.
@@ -306,10 +307,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Full type name, possibly with generic name mangling.
         /// </param>
         /// <returns>
-        /// Symbol for the type, or MissingMetadataSymbol if the type isn't found.
+        /// Symbol for the type, or null if the type isn't found.
         /// </returns>
         /// <remarks></remarks>
-        internal abstract NamedTypeSymbol LookupTopLevelMetadataType(ref MetadataTypeName emittedName);
+        internal abstract NamedTypeSymbol? LookupTopLevelMetadataType(ref MetadataTypeName emittedName);
+#nullable disable
 
         internal abstract ICollection<string> TypeNames { get; }
 

--- a/src/Compilers/CSharp/Portable/Symbols/NamespaceOrTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamespaceOrTypeSymbol.cs
@@ -239,9 +239,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Simple type name, possibly with generic name mangling.
         /// </param>
         /// <returns>
-        /// Symbol for the type, or MissingMetadataSymbol if the type isn't found.
+        /// Symbol for the type, or null if the type isn't found.
         /// </returns>
-        internal virtual NamedTypeSymbol LookupMetadataType(ref MetadataTypeName emittedTypeName)
+        internal virtual NamedTypeSymbol? LookupMetadataType(ref MetadataTypeName emittedTypeName)
         {
             Debug.Assert(!emittedTypeName.IsNull);
 
@@ -250,7 +250,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (scope.Kind == SymbolKind.ErrorType)
             {
-                return new MissingMetadataTypeSymbol.Nested((NamedTypeSymbol)scope, ref emittedTypeName);
+                return null;
             }
 
             NamedTypeSymbol? namedType = null;
@@ -356,18 +356,6 @@ Done:
 
                         namedType = named;
                     }
-                }
-            }
-
-            if ((object?)namedType == null)
-            {
-                if (isTopLevel)
-                {
-                    return new MissingMetadataTypeSymbol.TopLevel(scope.ContainingModule, ref emittedTypeName);
-                }
-                else
-                {
-                    return new MissingMetadataTypeSymbol.Nested((NamedTypeSymbol)scope, ref emittedTypeName);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/NoPiaMissingCanonicalTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NoPiaMissingCanonicalTypeSymbol.cs
@@ -22,16 +22,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private readonly AssemblySymbol _embeddingAssembly;
         private readonly string _fullTypeName;
-        private readonly string _guid;
-        private readonly string _scope;
-        private readonly string _identifier;
+        private readonly string? _guid;
+        private readonly string? _scope;
+        private readonly string? _identifier;
 
         public NoPiaMissingCanonicalTypeSymbol(
             AssemblySymbol embeddingAssembly,
             string fullTypeName,
-            string guid,
-            string scope,
-            string identifier,
+            string? guid,
+            string? scope,
+            string? identifier,
             TupleExtraData? tupleData = null)
             : base(tupleData)
         {
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override FileIdentifier? AssociatedFileIdentifier => null;
 
-        public string Guid
+        public string? Guid
         {
             get
             {
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public string Scope
+        public string? Scope
         {
             get
             {
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public string Identifier
+        public string? Identifier
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/NonMissingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NonMissingModuleSymbol.cs
@@ -172,6 +172,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(_moduleReferences != null);
         }
 
+#nullable enable 
+
         /// <summary>
         /// Lookup a top level type referenced from metadata, names should be
         /// compared case-sensitively.
@@ -180,25 +182,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Full type name, possibly with generic name mangling.
         /// </param>
         /// <returns>
-        /// Symbol for the type, or MissingMetadataSymbol if the type isn't found.
+        /// Symbol for the type, or null if the type isn't found.
         /// </returns>
         /// <remarks></remarks>
-        internal sealed override NamedTypeSymbol LookupTopLevelMetadataType(ref MetadataTypeName emittedName)
+        internal sealed override NamedTypeSymbol? LookupTopLevelMetadataType(ref MetadataTypeName emittedName)
         {
-            NamedTypeSymbol result;
-            NamespaceSymbol scope = this.GlobalNamespace.LookupNestedNamespace(emittedName.NamespaceSegments);
+            NamedTypeSymbol? result;
+            NamespaceSymbol? scope = this.GlobalNamespace.LookupNestedNamespace(emittedName.NamespaceSegments);
 
-            if ((object)scope == null)
+            if ((object?)scope == null)
             {
                 // We failed to locate the namespace
-                result = new MissingMetadataTypeSymbol.TopLevel(this, ref emittedName);
+                result = null;
             }
             else
             {
                 result = scope.LookupMetadataType(ref emittedName);
             }
 
-            Debug.Assert((object)result != null);
+            Debug.Assert(result?.IsErrorType() != true);
             return result;
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingAssemblySymbol.cs
@@ -278,17 +278,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             return _underlyingAssembly.GetGuidString(out guidString);
         }
 
-        internal override NamedTypeSymbol TryLookupForwardedMetadataTypeWithCycleDetection(ref MetadataTypeName emittedName, ConsList<AssemblySymbol> visitedAssemblies)
-        {
-            NamedTypeSymbol underlying = _underlyingAssembly.TryLookupForwardedMetadataType(ref emittedName);
+#nullable enable
 
-            if ((object)underlying == null)
+        internal override NamedTypeSymbol? TryLookupForwardedMetadataTypeWithCycleDetection(ref MetadataTypeName emittedName, ConsList<AssemblySymbol>? visitedAssemblies)
+        {
+            NamedTypeSymbol? underlying = _underlyingAssembly.TryLookupForwardedMetadataTypeWithCycleDetection(ref emittedName, visitedAssemblies: null);
+
+            if ((object?)underlying == null)
             {
                 return null;
             }
 
             return this.RetargetingTranslator.Retarget(underlying, RetargetOptions.RetargetPrimitiveTypesByName);
         }
+
+#nullable disable
 
         internal override IEnumerable<NamedTypeSymbol> GetAllTopLevelForwardedTypes()
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         private struct DestinationData
         {
             public AssemblySymbol To;
-            private ConcurrentDictionary<NamedTypeSymbol, NamedTypeSymbol> _symbolMap;
+            private ConcurrentDictionary<NamedTypeSymbol, NamedTypeSymbol>? _symbolMap;
 
             public ConcurrentDictionary<NamedTypeSymbol, NamedTypeSymbol> SymbolMap => LazyInitializer.EnsureInitialized(ref _symbolMap);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingModuleSymbol.cs
@@ -49,6 +49,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
         private readonly Dictionary<AssemblySymbol, DestinationData> _retargetingAssemblyMap =
             new Dictionary<AssemblySymbol, DestinationData>();
 
+#nullable enable
+
         private struct DestinationData
         {
             public AssemblySymbol To;
@@ -56,6 +58,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 
             public ConcurrentDictionary<NamedTypeSymbol, NamedTypeSymbol> SymbolMap => LazyInitializer.EnsureInitialized(ref _symbolMap);
         }
+
+#nullable disable
 
         internal readonly RetargetingSymbolTranslator RetargetingTranslator;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.cs
@@ -250,10 +250,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             }
         }
 
-        internal override NamedTypeSymbol LookupMetadataType(ref MetadataTypeName typeName)
+#nullable enable
+
+        internal override NamedTypeSymbol? LookupMetadataType(ref MetadataTypeName typeName)
         {
-            return this.RetargetingTranslator.Retarget(_underlyingType.LookupMetadataType(ref typeName), RetargetOptions.RetargetPrimitiveTypesByName);
+            NamedTypeSymbol? underlyingResult = _underlyingType.LookupMetadataType(ref typeName);
+
+            if (underlyingResult is null)
+            {
+                return null;
+            }
+
+            Debug.Assert(!underlyingResult.IsErrorType());
+            Debug.Assert((object)_underlyingType == underlyingResult.ContainingSymbol);
+
+            return this.RetargetingTranslator.Retarget(underlyingResult, RetargetOptions.RetargetPrimitiveTypesByName);
         }
+
+#nullable disable
 
         private static ExtendedErrorTypeSymbol CyclicInheritanceError(TypeSymbol declaredBase)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamespaceSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingNamespaceSymbol.cs
@@ -203,23 +203,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             return _underlyingNamespace.GetDocumentationCommentXml(preferredCulture, expandIncludes, cancellationToken);
         }
 
-        internal override NamedTypeSymbol LookupMetadataType(ref MetadataTypeName typeName)
+#nullable enable
+
+        internal override NamedTypeSymbol? LookupMetadataType(ref MetadataTypeName typeName)
         {
             // This method is invoked when looking up a type by metadata type
             // name through a RetargetingAssemblySymbol. For instance, in
             // UnitTests.Symbols.Metadata.PE.NoPia.LocalTypeSubstitution2.
-            NamedTypeSymbol underlying = _underlyingNamespace.LookupMetadataType(ref typeName);
+            NamedTypeSymbol? underlying = _underlyingNamespace.LookupMetadataType(ref typeName);
+
+            if (underlying is null)
+            {
+                return null;
+            }
 
             Debug.Assert((object)underlying.ContainingModule == (object)_retargetingModule.UnderlyingModule);
+            Debug.Assert(!underlying.IsErrorType());
 
-            if (!underlying.IsErrorType() && underlying.IsExplicitDefinitionOfNoPiaLocalType)
+            if (underlying.IsExplicitDefinitionOfNoPiaLocalType)
             {
                 // Explicitly defined local types should be hidden.
-                return new MissingMetadataTypeSymbol.TopLevel(_retargetingModule, ref typeName);
+                return null;
             }
 
             return this.RetargetingTranslator.Retarget(underlying, RetargetOptions.RetargetPrimitiveTypesByName);
         }
+
+#nullable disable
 
         internal override void GetExtensionMethods(ArrayBuilder<MethodSymbol> methods, string nameOpt, int arity, LookupOptions options)
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
@@ -396,7 +396,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                 return cached;
             }
 
- #nullable enable
+#nullable enable
 
             private static NamedTypeSymbol RetargetNamedTypeDefinition(PENamedTypeSymbol type, PEModuleSymbol addedModule)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
@@ -396,19 +396,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                 return cached;
             }
 
+ #nullable enable
+
             private static NamedTypeSymbol RetargetNamedTypeDefinition(PENamedTypeSymbol type, PEModuleSymbol addedModule)
             {
                 Debug.Assert(!type.ContainingModule.Equals(addedModule) &&
                              ReferenceEquals(((PEModuleSymbol)type.ContainingModule).Module, addedModule.Module));
 
-                TypeSymbol cached;
+                TypeSymbol? cached;
 
                 if (addedModule.TypeHandleToTypeMap.TryGetValue(type.Handle, out cached))
                 {
                     return (NamedTypeSymbol)cached;
                 }
 
-                NamedTypeSymbol result;
+                NamedTypeSymbol? result;
 
                 NamedTypeSymbol containingType = type.ContainingType;
                 MetadataTypeName mdName;
@@ -422,16 +424,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 
                     mdName = MetadataTypeName.FromTypeName(type.MetadataName, forcedArity: type.Arity);
                     result = scope.LookupMetadataType(ref mdName);
-                    Debug.Assert((object)result != null && result.Arity == type.Arity);
                 }
                 else
                 {
                     string namespaceName = type.ContainingNamespace.ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat);
                     mdName = MetadataTypeName.FromNamespaceAndTypeName(namespaceName, type.MetadataName, forcedArity: type.Arity);
                     result = addedModule.LookupTopLevelMetadataType(ref mdName);
-
-                    Debug.Assert(result.Arity == type.Arity);
                 }
+
+                Debug.Assert(result is PENamedTypeSymbol peResult && peResult.Handle == type.Handle);
 
                 return result;
             }
@@ -440,13 +441,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                 ref DestinationData destination,
                 NamedTypeSymbol type)
             {
-                NamedTypeSymbol result;
+                NamedTypeSymbol? result;
 
                 if (!destination.SymbolMap.TryGetValue(type, out result))
                 {
                     // Lookup by name as a TypeRef.
                     NamedTypeSymbol containingType = type.ContainingType;
-                    NamedTypeSymbol result1;
+                    NamedTypeSymbol? result1;
                     MetadataTypeName mdName;
 
                     if ((object)containingType != null)
@@ -457,16 +458,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                         NamedTypeSymbol scope = PerformTypeRetargeting(ref destination, containingType);
                         mdName = MetadataTypeName.FromTypeName(type.MetadataName, forcedArity: type.Arity);
                         result1 = scope.LookupMetadataType(ref mdName);
-                        Debug.Assert((object)result1 != null && result1.Arity == type.Arity);
+                        Debug.Assert(result1?.IsErrorType() != true);
+
+                        result1 ??= new MissingMetadataTypeSymbol.Nested(scope, ref mdName);
                     }
                     else
                     {
                         string namespaceName = type.ContainingNamespace.ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat);
                         mdName = MetadataTypeName.FromNamespaceAndTypeName(namespaceName, type.MetadataName, forcedArity: type.Arity);
-                        result1 = destination.To.LookupTopLevelMetadataType(ref mdName, digThroughForwardedTypes: true);
-
-                        Debug.Assert(result1.Arity == type.Arity);
+                        result1 = destination.To.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     }
+
+                    Debug.Assert(result1.Arity == type.Arity);
 
                     result = destination.SymbolMap.GetOrAdd(type, result1);
                     Debug.Assert(TypeSymbol.Equals(result1, result, TypeCompareKind.ConsiderEverything2));
@@ -474,6 +477,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
 
                 return result;
             }
+
+#nullable disable
 
             public NamedTypeSymbol Retarget(NamedTypeSymbol type, RetargetOptions options)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -71,7 +71,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         private CustomAttributesBag<CSharpAttributeData> _lazyNetModuleAttributesBag;
 
+#nullable enable 
+
         private IDictionary<string, NamedTypeSymbol> _lazyForwardedTypesFromSource;
+
+#nullable disable
 
         /// <summary>
         /// Indices of attributes that will not be emitted for one of two reasons:
@@ -2752,7 +2756,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override NamedTypeSymbol TryLookupForwardedMetadataTypeWithCycleDetection(ref MetadataTypeName emittedName, ConsList<AssemblySymbol> visitedAssemblies)
+#nullable enable
+
+        internal override NamedTypeSymbol? TryLookupForwardedMetadataTypeWithCycleDetection(ref MetadataTypeName emittedName, ConsList<AssemblySymbol>? visitedAssemblies)
         {
             int forcedArity = emittedName.ForcedArity;
 
@@ -2800,7 +2806,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 _lazyForwardedTypesFromSource = forwardedTypesFromSource;
             }
 
-            NamedTypeSymbol result;
+            NamedTypeSymbol? result;
 
             if (_lazyForwardedTypesFromSource.TryGetValue(emittedName.FullName, out result))
             {
@@ -2836,7 +2842,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         else
                         {
                             visitedAssemblies = new ConsList<AssemblySymbol>(this, visitedAssemblies ?? ConsList<AssemblySymbol>.Empty);
-                            return firstSymbol.LookupTopLevelMetadataTypeWithCycleDetection(ref emittedName, visitedAssemblies, digThroughForwardedTypes: true);
+                            return firstSymbol.LookupDeclaredOrForwardedTopLevelMetadataType(ref emittedName, visitedAssemblies);
                         }
                     }
                 }
@@ -2844,6 +2850,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             return null;
         }
+
+#nullable disable
 
         internal override IEnumerable<NamedTypeSymbol> GetAllTopLevelForwardedTypes()
         {

--- a/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
@@ -4600,7 +4600,7 @@ class UsePia5
             var compilation1 = CreateCompilationWithMscorlib40(consumer, options: TestOptions.ReleaseExe,
                 references: new MetadataReference[] { new CSharpCompilationReference(piaCompilation2, embedInteropTypes: true) });
 
-            Assert.IsType<MissingMetadataTypeSymbol.TopLevel>(compilation1.SourceModule.GetReferencedAssemblySymbols()[1].Modules[0].LookupTopLevelMetadataType(ref fullName));
+            Assert.Null(compilation1.SourceModule.GetReferencedAssemblySymbols()[1].Modules[0].LookupTopLevelMetadataType(ref fullName));
             Assert.Null(compilation1.SourceModule.GetReferencedAssemblySymbols()[1].GetTypeByMetadataName(fullName.FullName));
 
             VerifyEmitDiagnostics(compilation1, false, expected);
@@ -4608,9 +4608,9 @@ class UsePia5
             var compilation2 = CreateCompilationWithMscorlib40(consumer, options: TestOptions.ReleaseExe,
                 references: new MetadataReference[] { piaCompilation2.EmitToImageReference(embedInteropTypes: true) });
 
-            Assert.IsType<NoPiaMissingCanonicalTypeSymbol>(((PEModuleSymbol)compilation2.SourceModule.GetReferencedAssemblySymbols()[1].Modules[0]).LookupTopLevelMetadataType(ref fullName, out isNoPiaLocalType));
+            Assert.IsType<NoPiaMissingCanonicalTypeSymbol>(((PEModuleSymbol)compilation2.SourceModule.GetReferencedAssemblySymbols()[1].Modules[0]).LookupTopLevelMetadataTypeWithNoPiaLocalTypeUnification(ref fullName, out isNoPiaLocalType));
             Assert.True(isNoPiaLocalType);
-            Assert.IsType<MissingMetadataTypeSymbol.TopLevel>(compilation2.SourceModule.GetReferencedAssemblySymbols()[1].Modules[0].LookupTopLevelMetadataType(ref fullName));
+            Assert.Null(compilation2.SourceModule.GetReferencedAssemblySymbols()[1].Modules[0].LookupTopLevelMetadataType(ref fullName));
             Assert.Null(compilation2.SourceModule.GetReferencedAssemblySymbols()[1].GetTypeByMetadataName(fullName.FullName));
 
             VerifyEmitDiagnostics(compilation2, false, expected);
@@ -4618,7 +4618,7 @@ class UsePia5
             var compilation3 = CreateCompilationWithMscorlib40(consumer, options: TestOptions.ReleaseExe,
                 references: new MetadataReference[] { new CSharpCompilationReference(piaCompilation2) });
 
-            Assert.IsType<MissingMetadataTypeSymbol.TopLevel>(compilation3.SourceModule.GetReferencedAssemblySymbols()[1].Modules[0].LookupTopLevelMetadataType(ref fullName));
+            Assert.Null(compilation3.SourceModule.GetReferencedAssemblySymbols()[1].Modules[0].LookupTopLevelMetadataType(ref fullName));
             Assert.Null(compilation3.SourceModule.GetReferencedAssemblySymbols()[1].GetTypeByMetadataName(fullName.FullName));
 
             CompileAndVerify(compilation3);
@@ -4626,9 +4626,9 @@ class UsePia5
             var compilation4 = CreateCompilationWithMscorlib40(consumer, options: TestOptions.ReleaseExe,
                 references: new MetadataReference[] { MetadataReference.CreateFromStream(piaCompilation2.EmitToStream()) });
 
-            Assert.IsType<NoPiaMissingCanonicalTypeSymbol>(((PEModuleSymbol)compilation4.SourceModule.GetReferencedAssemblySymbols()[1].Modules[0]).LookupTopLevelMetadataType(ref fullName, out isNoPiaLocalType));
+            Assert.IsType<NoPiaMissingCanonicalTypeSymbol>(((PEModuleSymbol)compilation4.SourceModule.GetReferencedAssemblySymbols()[1].Modules[0]).LookupTopLevelMetadataTypeWithNoPiaLocalTypeUnification(ref fullName, out isNoPiaLocalType));
             Assert.True(isNoPiaLocalType);
-            Assert.IsType<MissingMetadataTypeSymbol.TopLevel>(compilation4.SourceModule.GetReferencedAssemblySymbols()[1].Modules[0].LookupTopLevelMetadataType(ref fullName));
+            Assert.Null(compilation4.SourceModule.GetReferencedAssemblySymbols()[1].Modules[0].LookupTopLevelMetadataType(ref fullName));
             Assert.Null(compilation4.SourceModule.GetReferencedAssemblySymbols()[1].GetTypeByMetadataName(fullName.FullName));
 
             CompileAndVerify(compilation4);

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_Security.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_Security.cs
@@ -48,7 +48,7 @@ public struct EventDescriptor
 
                     // Get System.Security.Permissions.HostProtection
                     var emittedName = MetadataTypeName.FromNamespaceAndTypeName("System.Security.Permissions", "HostProtectionAttribute");
-                    NamedTypeSymbol hostProtectionAttr = sourceAssembly.CorLibrary.LookupTopLevelMetadataType(ref emittedName, true);
+                    NamedTypeSymbol hostProtectionAttr = sourceAssembly.CorLibrary.LookupDeclaredTopLevelMetadataType(ref emittedName);
                     Assert.NotNull(hostProtectionAttr);
 
                     // Verify type security attributes

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UseSiteErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UseSiteErrorTests.cs
@@ -1084,9 +1084,9 @@ class B : C, I { }
             var main = CreateCompilation(mainSource, new[] { new CSharpCompilationReference(lib) }, assemblyName: "Main");
 
             main.VerifyDiagnostics(
-                // (2,7): error CS7068: Reference to type 'X' claims it is defined in this assembly, but it is not defined in source or any added modules
+                // (2,7): error CS7069: Reference to type 'X' claims it is defined in 'Test', but it could not be found
                 // class B : C, I { }
-                Diagnostic(ErrorCode.ERR_MissingTypeInSource, "B").WithArguments("X"));
+                Diagnostic(ErrorCode.ERR_MissingTypeInAssembly, "B").WithArguments("X", "Test").WithLocation(2, 7));
         }
 
         [Fact, WorkItem(530974, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530974")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -3896,35 +3896,35 @@ class C : I
                     AssemblySymbol asm = i2.ContainingAssembly;
 
                     mdName = MetadataTypeName.FromFullName("I3`1", false, -1);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.False(t.IsErrorType());
                     Assert.Equal("I3", t.Name);
                     Assert.True(t.MangleName);
                     Assert.Equal(1, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I3`1", false, 0);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.True(t.IsErrorType());
                     Assert.Equal("I3`1", t.Name);
                     Assert.False(t.MangleName);
                     Assert.Equal(0, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I3`1", false, 1);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.False(t.IsErrorType());
                     Assert.Equal("I3", t.Name);
                     Assert.True(t.MangleName);
                     Assert.Equal(1, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I3`1", false, 2);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.True(t.IsErrorType());
                     Assert.Equal("I3`1", t.Name);
                     Assert.False(t.MangleName);
                     Assert.Equal(2, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I3`1", true, -1);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.False(t.IsErrorType());
                     Assert.Equal("I3", t.Name);
                     Assert.True(t.MangleName);
@@ -3938,7 +3938,7 @@ class C : I
                     //Assert.Equal(0, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I3`1", true, 1);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.False(t.IsErrorType());
                     Assert.Equal("I3", t.Name);
                     Assert.True(t.MangleName);
@@ -3952,35 +3952,35 @@ class C : I
                     //Assert.Equal(2, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I", false, -1);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.False(t.IsErrorType());
                     Assert.Equal("I", t.Name);
                     Assert.False(t.MangleName);
                     Assert.Equal(0, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I", false, 0);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.False(t.IsErrorType());
                     Assert.Equal("I", t.Name);
                     Assert.False(t.MangleName);
                     Assert.Equal(0, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I", false, 1);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.True(t.IsErrorType());
                     Assert.Equal("I", t.Name);
                     Assert.False(t.MangleName);
                     Assert.Equal(1, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I", true, -1);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.False(t.IsErrorType());
                     Assert.Equal("I", t.Name);
                     Assert.False(t.MangleName);
                     Assert.Equal(0, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I", true, 0);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.False(t.IsErrorType());
                     Assert.Equal("I", t.Name);
                     Assert.False(t.MangleName);
@@ -3994,35 +3994,35 @@ class C : I
                     //Assert.Equal(1, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I2`1", false, -1);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.False(t.IsErrorType());
                     Assert.Equal("I2`1", t.Name);
                     Assert.False(t.MangleName);
                     Assert.Equal(0, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I2`1", false, 0);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.False(t.IsErrorType());
                     Assert.Equal("I2`1", t.Name);
                     Assert.False(t.MangleName);
                     Assert.Equal(0, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I2`1", false, 1);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.True(t.IsErrorType());
                     Assert.Equal("I2", t.Name);
                     Assert.True(t.MangleName);
                     Assert.Equal(1, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I2`1", false, 2);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.True(t.IsErrorType());
                     Assert.Equal("I2`1", t.Name);
                     Assert.False(t.MangleName);
                     Assert.Equal(2, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I2`1", true, -1);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.True(t.IsErrorType());
                     Assert.Equal("I2", t.Name);
                     Assert.True(t.MangleName);
@@ -4036,7 +4036,7 @@ class C : I
                     //Assert.Equal(0, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I2`1", true, 1);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.True(t.IsErrorType());
                     Assert.Equal("I2", t.Name);
                     Assert.True(t.MangleName);
@@ -4050,35 +4050,35 @@ class C : I
                     //Assert.Equal(2, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I4`2", false, -1);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.False(t.IsErrorType());
                     Assert.Equal("I4`2", t.Name);
                     Assert.False(t.MangleName);
                     Assert.Equal(1, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I4`2", false, 0);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.True(t.IsErrorType());
                     Assert.Equal("I4`2", t.Name);
                     Assert.False(t.MangleName);
                     Assert.Equal(0, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I4`2", false, 1);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.False(t.IsErrorType());
                     Assert.Equal("I4`2", t.Name);
                     Assert.False(t.MangleName);
                     Assert.Equal(1, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I4`2", false, 2);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.True(t.IsErrorType());
                     Assert.Equal("I4", t.Name);
                     Assert.True(t.MangleName);
                     Assert.Equal(2, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I4`2", true, -1);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.True(t.IsErrorType());
                     Assert.Equal("I4", t.Name);
                     Assert.True(t.MangleName);
@@ -4099,7 +4099,7 @@ class C : I
                     //Assert.Equal(1, t.Arity);
 
                     mdName = MetadataTypeName.FromFullName("I4`2", true, 2);
-                    t = asm.LookupTopLevelMetadataType(ref mdName, true);
+                    t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(ref mdName, visitedAssemblies: null);
                     Assert.True(t.IsErrorType());
                     Assert.Equal("I4", t.Name);
                     Assert.True(t.MangleName);
@@ -4116,10 +4116,7 @@ class C : I
 
                     mdName = MetadataTypeName.FromFullName("I3`1", false, 0);
                     t = containingType.LookupMetadataType(ref mdName);
-                    Assert.True(t.IsErrorType());
-                    Assert.Equal("I3`1", t.Name);
-                    Assert.False(t.MangleName);
-                    Assert.Equal(0, t.Arity);
+                    Assert.Null(t);
 
                     mdName = MetadataTypeName.FromFullName("I3`1", false, 1);
                     t = containingType.LookupMetadataType(ref mdName);
@@ -4130,10 +4127,7 @@ class C : I
 
                     mdName = MetadataTypeName.FromFullName("I3`1", false, 2);
                     t = containingType.LookupMetadataType(ref mdName);
-                    Assert.True(t.IsErrorType());
-                    Assert.Equal("I3`1", t.Name);
-                    Assert.False(t.MangleName);
-                    Assert.Equal(2, t.Arity);
+                    Assert.Null(t);
 
                     mdName = MetadataTypeName.FromFullName("I3`1", true, -1);
                     t = containingType.LookupMetadataType(ref mdName);
@@ -4179,10 +4173,7 @@ class C : I
 
                     mdName = MetadataTypeName.FromFullName("I", false, 1);
                     t = containingType.LookupMetadataType(ref mdName);
-                    Assert.True(t.IsErrorType());
-                    Assert.Equal("I", t.Name);
-                    Assert.False(t.MangleName);
-                    Assert.Equal(1, t.Arity);
+                    Assert.Null(t);
 
                     mdName = MetadataTypeName.FromFullName("I", true, -1);
                     t = containingType.LookupMetadataType(ref mdName);
@@ -4221,24 +4212,15 @@ class C : I
 
                     mdName = MetadataTypeName.FromFullName("I2`1", false, 1);
                     t = containingType.LookupMetadataType(ref mdName);
-                    Assert.True(t.IsErrorType());
-                    Assert.Equal("I2", t.Name);
-                    Assert.True(t.MangleName);
-                    Assert.Equal(1, t.Arity);
+                    Assert.Null(t);
 
                     mdName = MetadataTypeName.FromFullName("I2`1", false, 2);
                     t = containingType.LookupMetadataType(ref mdName);
-                    Assert.True(t.IsErrorType());
-                    Assert.Equal("I2`1", t.Name);
-                    Assert.False(t.MangleName);
-                    Assert.Equal(2, t.Arity);
+                    Assert.Null(t);
 
                     mdName = MetadataTypeName.FromFullName("I2`1", true, -1);
                     t = containingType.LookupMetadataType(ref mdName);
-                    Assert.True(t.IsErrorType());
-                    Assert.Equal("I2", t.Name);
-                    Assert.True(t.MangleName);
-                    Assert.Equal(1, t.Arity);
+                    Assert.Null(t);
 
                     //mdName = MetadataTypeName.FromFullName("I2`1", true, 0);
                     //t = containingType.LookupMetadataType(ref mdName);
@@ -4249,10 +4231,7 @@ class C : I
 
                     mdName = MetadataTypeName.FromFullName("I2`1", true, 1);
                     t = containingType.LookupMetadataType(ref mdName);
-                    Assert.True(t.IsErrorType());
-                    Assert.Equal("I2", t.Name);
-                    Assert.True(t.MangleName);
-                    Assert.Equal(1, t.Arity);
+                    Assert.Null(t);
 
                     //mdName = MetadataTypeName.FromFullName("I2`1", true, 2);
                     //t = containingType.LookupMetadataType(ref mdName);
@@ -4270,10 +4249,7 @@ class C : I
 
                     mdName = MetadataTypeName.FromFullName("I4`2", false, 0);
                     t = containingType.LookupMetadataType(ref mdName);
-                    Assert.True(t.IsErrorType());
-                    Assert.Equal("I4`2", t.Name);
-                    Assert.False(t.MangleName);
-                    Assert.Equal(0, t.Arity);
+                    Assert.Null(t);
 
                     mdName = MetadataTypeName.FromFullName("I4`2", false, 1);
                     t = containingType.LookupMetadataType(ref mdName);
@@ -4284,17 +4260,11 @@ class C : I
 
                     mdName = MetadataTypeName.FromFullName("I4`2", false, 2);
                     t = containingType.LookupMetadataType(ref mdName);
-                    Assert.True(t.IsErrorType());
-                    Assert.Equal("I4", t.Name);
-                    Assert.True(t.MangleName);
-                    Assert.Equal(2, t.Arity);
+                    Assert.Null(t);
 
                     mdName = MetadataTypeName.FromFullName("I4`2", true, -1);
                     t = containingType.LookupMetadataType(ref mdName);
-                    Assert.True(t.IsErrorType());
-                    Assert.Equal("I4", t.Name);
-                    Assert.True(t.MangleName);
-                    Assert.Equal(2, t.Arity);
+                    Assert.Null(t);
 
                     //mdName = MetadataTypeName.FromFullName("I4`2", true, 0);
                     //t = containingType.LookupMetadataType(ref mdName);
@@ -4312,10 +4282,7 @@ class C : I
 
                     mdName = MetadataTypeName.FromFullName("I4`2", true, 2);
                     t = containingType.LookupMetadataType(ref mdName);
-                    Assert.True(t.IsErrorType());
-                    Assert.Equal("I4", t.Name);
-                    Assert.True(t.MangleName);
-                    Assert.Equal(2, t.Arity);
+                    Assert.Null(t);
                 };
 
             CompileWithCustomILSource(csharpSource, ilSource, compilationVerifier: compilationVerifier, targetFramework: TargetFramework.Mscorlib40);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
@@ -324,20 +324,20 @@ public class LocalTypes3
             var fullName_S1 = MetadataTypeName.FromFullName("S1");
             var fullName_S2 = MetadataTypeName.FromFullName("NS1.S2");
 
-            Assert.IsType<MissingMetadataTypeSymbol.TopLevel>(localTypes1.LookupTopLevelMetadataType(ref fullName_I1));
-            Assert.IsType<MissingMetadataTypeSymbol.TopLevel>(localTypes1.LookupTopLevelMetadataType(ref fullName_I2));
-            Assert.IsType<MissingMetadataTypeSymbol.TopLevel>(localTypes1.LookupTopLevelMetadataType(ref fullName_S1));
-            Assert.IsType<MissingMetadataTypeSymbol.TopLevel>(localTypes1.LookupTopLevelMetadataType(ref fullName_S2));
+            Assert.Null(localTypes1.LookupTopLevelMetadataType(ref fullName_I1));
+            Assert.Null(localTypes1.LookupTopLevelMetadataType(ref fullName_I2));
+            Assert.Null(localTypes1.LookupTopLevelMetadataType(ref fullName_S1));
+            Assert.Null(localTypes1.LookupTopLevelMetadataType(ref fullName_S2));
 
             Assert.Null(assemblies[0].GetTypeByMetadataName(fullName_I1.FullName));
             Assert.Null(assemblies[0].GetTypeByMetadataName(fullName_I2.FullName));
             Assert.Null(assemblies[0].GetTypeByMetadataName(fullName_S1.FullName));
             Assert.Null(assemblies[0].GetTypeByMetadataName(fullName_S2.FullName));
 
-            Assert.IsType<MissingMetadataTypeSymbol.TopLevel>(localTypes2.LookupTopLevelMetadataType(ref fullName_I1));
-            Assert.IsType<MissingMetadataTypeSymbol.TopLevel>(localTypes2.LookupTopLevelMetadataType(ref fullName_I2));
-            Assert.IsType<MissingMetadataTypeSymbol.TopLevel>(localTypes2.LookupTopLevelMetadataType(ref fullName_S1));
-            Assert.IsType<MissingMetadataTypeSymbol.TopLevel>(localTypes2.LookupTopLevelMetadataType(ref fullName_S2));
+            Assert.Null(localTypes2.LookupTopLevelMetadataType(ref fullName_I1));
+            Assert.Null(localTypes2.LookupTopLevelMetadataType(ref fullName_I2));
+            Assert.Null(localTypes2.LookupTopLevelMetadataType(ref fullName_S1));
+            Assert.Null(localTypes2.LookupTopLevelMetadataType(ref fullName_S2));
 
             Assert.Null(assemblies[1].GetTypeByMetadataName(fullName_I1.FullName));
             Assert.Null(assemblies[1].GetTypeByMetadataName(fullName_I2.FullName));

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeResolutionTests.cs
@@ -122,24 +122,24 @@ namespace System
                     MetadataReference.CreateFromImage(File.ReadAllBytes(typeof(TypeTests).GetTypeInfo().Assembly.Location))
                 });
 
-            var intSym = c.Assembly.GetTypeByReflectionType(typeof(int), includeReferences: true);
+            var intSym = c.Assembly.GetTypeByReflectionType(typeof(int));
             Assert.NotNull(intSym);
             Assert.Equal(SpecialType.System_Int32, intSym.SpecialType);
 
-            var strcmpSym = c.Assembly.GetTypeByReflectionType(typeof(StringComparison), includeReferences: true);
+            var strcmpSym = c.Assembly.GetTypeByReflectionType(typeof(StringComparison));
             Assert.NotNull(strcmpSym);
             Assert.Equal("System.StringComparison", strcmpSym.ToDisplayString());
 
-            var arraySym = c.Assembly.GetTypeByReflectionType(typeof(List<int>[][,,]), includeReferences: true);
+            var arraySym = c.Assembly.GetTypeByReflectionType(typeof(List<int>[][,,]));
             Assert.NotNull(arraySym);
             Assert.Equal("System.Collections.Generic.List<int>[][*,*,*]", arraySym.ToDisplayString());
 
-            var ptrSym = c.Assembly.GetTypeByReflectionType(typeof(char).MakePointerType().MakePointerType(), includeReferences: true);
+            var ptrSym = c.Assembly.GetTypeByReflectionType(typeof(char).MakePointerType().MakePointerType());
             Assert.NotNull(ptrSym);
             Assert.Equal("char**", ptrSym.ToDisplayString());
 
             string testType1 = typeof(C<,>).DeclaringType.FullName;
-            var nestedSym1 = c.Assembly.GetTypeByReflectionType(typeof(C<int, bool>.D.E<double, float>.F<byte>), includeReferences: true);
+            var nestedSym1 = c.Assembly.GetTypeByReflectionType(typeof(C<int, bool>.D.E<double, float>.F<byte>));
             Assert.Equal(testType1 + ".C<int, bool>.D.E<double, float>.F<byte>", nestedSym1.ToDisplayString());
 
             // Not supported atm:
@@ -148,16 +148,16 @@ namespace System
             //Assert.Equal(testType2 + ".C<int, bool>.D.E<double, float>.F<byte>", nestedSym2.ToDisplayString());
 
             // Process is defined in System, which isn't referenced:
-            var err = c.Assembly.GetTypeByReflectionType(typeof(C<Process, bool>.D.E<double, float>.F<byte>), includeReferences: true);
+            var err = c.Assembly.GetTypeByReflectionType(typeof(C<Process, bool>.D.E<double, float>.F<byte>));
             Assert.Null(err);
 
-            err = c.Assembly.GetTypeByReflectionType(typeof(C<int, bool>.D.E<double, Process>.F<byte>), includeReferences: true);
+            err = c.Assembly.GetTypeByReflectionType(typeof(C<int, bool>.D.E<double, Process>.F<byte>));
             Assert.Null(err);
 
-            err = c.Assembly.GetTypeByReflectionType(typeof(Process[]), includeReferences: true);
+            err = c.Assembly.GetTypeByReflectionType(typeof(Process[]));
             Assert.Null(err);
 
-            err = c.Assembly.GetTypeByReflectionType(typeof(SyntaxKind).MakePointerType(), includeReferences: true);
+            err = c.Assembly.GetTypeByReflectionType(typeof(SyntaxKind).MakePointerType());
             Assert.Null(err);
         }
 

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
@@ -503,7 +503,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Dim emittedName = MetadataTypeName.FromFullName(metadataName, useCLSCompliantNameArityEncoding:=True)
-            Return Me.ContainingModule.LookupTopLevelMetadataType(emittedName)
+            Dim result As NamedTypeSymbol = Me.ContainingModule.LookupTopLevelMetadataType(emittedName)
+            Debug.Assert(If(Not result?.IsErrorType(), True))
+
+            Return If(result, New MissingMetadataTypeSymbol.TopLevel(Me.ContainingModule, emittedName))
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1227,7 +1227,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' We are explicitly ignoring scenario where the type might be defined in an added module.
             For Each reference As AssemblySymbol In sourceAssembly.SourceModule.GetReferencedAssemblySymbols()
                 Debug.Assert(Not reference.IsMissing)
-                Dim candidate As NamedTypeSymbol = reference.LookupTopLevelMetadataType(metadataName, digThroughForwardedTypes:=False)
+                Dim candidate As NamedTypeSymbol = reference.LookupDeclaredTopLevelMetadataType(metadataName)
+                Debug.Assert(If(Not candidate?.IsErrorType(), True))
 
                 If sourceAssembly.IsValidWellKnownType(candidate) AndAlso AssemblySymbol.IsAcceptableMatchForGetTypeByNameAndArity(candidate) Then
                     Return True

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PEAssemblySymbol.vb
@@ -198,7 +198,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                         emittedName = MetadataTypeName.FromFullName(matchedName, emittedName.UseCLSCompliantNameArityEncoding, emittedName.ForcedArity)
                     End If
 
-                    Return forwardedToAssemblies.FirstSymbol.LookupTopLevelMetadataTypeWithCycleDetection(emittedName, visitedAssemblies, digThroughForwardedTypes:=True)
+                    Return forwardedToAssemblies.FirstSymbol.LookupDeclaredOrForwardedTopLevelMetadataType(emittedName, visitedAssemblies)
                 End If
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/MetadataOrSourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MetadataOrSourceAssemblySymbol.vb
@@ -50,7 +50,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 Dim [module] As ModuleSymbol = Me.Modules(0)
                 Dim result As NamedTypeSymbol = [module].LookupTopLevelMetadataType(emittedName)
-                If result.TypeKind <> TypeKind.Error AndAlso result.DeclaredAccessibility <> Accessibility.Public Then
+                Debug.Assert(If(Not result?.IsErrorType(), True))
+
+                If result Is Nothing OrElse result.DeclaredAccessibility <> Accessibility.Public Then
                     result = New MissingMetadataTypeSymbol.TopLevel([module], emittedName, type)
                 End If
                 RegisterDeclaredSpecialType(result)

--- a/src/Compilers/VisualBasic/Portable/Symbols/MissingAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MissingAssemblySymbol.vb
@@ -136,10 +136,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return False
         End Function
 
-        Friend Overrides Function LookupTopLevelMetadataTypeWithCycleDetection(ByRef emittedName As MetadataTypeName, visitedAssemblies As ConsList(Of AssemblySymbol), digThroughForwardedTypes As Boolean) As NamedTypeSymbol
-            Dim result = m_ModuleSymbol.LookupTopLevelMetadataType(emittedName)
-            Debug.Assert(TypeOf result Is MissingMetadataTypeSymbol)
-            Return result
+        Friend Overrides Function LookupDeclaredOrForwardedTopLevelMetadataType(ByRef emittedName As MetadataTypeName, visitedAssemblies As ConsList(Of AssemblySymbol)) As NamedTypeSymbol
+            Return New MissingMetadataTypeSymbol.TopLevel(m_ModuleSymbol, emittedName)
+        End Function
+
+        Friend Overrides Function LookupDeclaredTopLevelMetadataType(ByRef emittedName As MetadataTypeName) As NamedTypeSymbol
+            Return Nothing
         End Function
 
         Friend NotOverridable Overrides Function GetAllTopLevelForwardedTypes() As IEnumerable(Of NamedTypeSymbol)

--- a/src/Compilers/VisualBasic/Portable/Symbols/MissingModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MissingModuleSymbol.vb
@@ -116,7 +116,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         Friend Overrides Function LookupTopLevelMetadataType(ByRef emittedName As MetadataTypeName) As NamedTypeSymbol
-            Return New MissingMetadataTypeSymbol.TopLevel(Me, emittedName)
+            Return Nothing
         End Function
 
         Friend Overrides Function GetReferencedAssemblies() As ImmutableArray(Of AssemblyIdentity)

--- a/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ModuleSymbol.vb
@@ -220,7 +220,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' Full type name possibly with generic name mangling.
         ''' </param>
         ''' <returns>
-        ''' Symbol for the type, or MissingMetadataSymbol if the type isn't found.
+        ''' Symbol for the type, or Nothing if the type isn't found.
         ''' </returns>
         ''' <remarks></remarks>
         Friend MustOverride Function LookupTopLevelMetadataType(

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamespaceSymbol.vb
@@ -308,7 +308,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' Full type name possibly with generic name mangling.
         ''' </param>
         ''' <returns>
-        ''' Symbol for the type, or MissingMetadataSymbol if the type isn't found.
+        ''' Symbol for the type, or Nothing if the type isn't found.
         ''' </returns>
         ''' <remarks></remarks>
         Friend Overridable Function LookupMetadataType(ByRef fullEmittedName As MetadataTypeName) As NamedTypeSymbol
@@ -385,13 +385,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Next
 
 Done:
-            If namedType Is Nothing Then
-                If fullEmittedName.FullName.StartsWith("Microsoft.CodeAnalysis.VisualBasic.Syntax.SyntaxList", StringComparison.Ordinal) Then
-                    Stop
-                End If
-
-                Return New MissingMetadataTypeSymbol.TopLevel(Me.ContainingModule, fullEmittedName)
-            End If
 
             Return namedType
         End Function

--- a/src/Compilers/VisualBasic/Portable/Symbols/NonMissingModuleSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NonMissingModuleSymbol.vb
@@ -144,26 +144,26 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' Full type name, possibly with generic name mangling.
         ''' </param>
         ''' <returns>
-        ''' Symbol for the type, or MissingMetadataSymbol if the type isn't found.
+        ''' Symbol for the type, or Nothing if the type isn't found.
         ''' </returns>
         ''' <remarks></remarks>
         Friend NotOverridable Overrides Function LookupTopLevelMetadataType(
             ByRef emittedName As MetadataTypeName
         ) As NamedTypeSymbol
 
-            Dim result As NamedTypeSymbol = Nothing
+            Dim result As NamedTypeSymbol
             Dim scope As NamespaceSymbol
 
             scope = Me.GlobalNamespace.LookupNestedNamespace(emittedName.NamespaceSegments)
 
             If scope Is Nothing Then
                 ' We failed to locate the namespace
-                result = New MissingMetadataTypeSymbol.TopLevel(Me, emittedName)
+                result = Nothing
             Else
                 result = scope.LookupMetadataType(emittedName)
             End If
 
-            Debug.Assert(result IsNot Nothing)
+            Debug.Assert(If(Not result?.IsErrorType(), True))
             Return result
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.vb
@@ -491,7 +491,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
         End Property
 
         Friend Overrides Function LookupMetadataType(ByRef emittedTypeName As MetadataTypeName) As NamedTypeSymbol
-            Return RetargetingTranslator.Retarget(_underlyingType.LookupMetadataType(emittedTypeName), RetargetOptions.RetargetPrimitiveTypesByName)
+            Dim underlying As NamedTypeSymbol = _underlyingType.LookupMetadataType(emittedTypeName)
+
+            If underlying Is Nothing Then
+                Return Nothing
+            End If
+
+            Debug.Assert(Not underlying.IsErrorType())
+            Return RetargetingTranslator.Retarget(underlying, RetargetOptions.RetargetPrimitiveTypesByName)
         End Function
 
         Friend Overrides Function GetUseSiteInfo() As UseSiteInfo(Of AssemblySymbol)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingNamespaceSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingNamespaceSymbol.vb
@@ -172,11 +172,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
 
             Dim underlying As NamedTypeSymbol = _underlyingNamespace.LookupMetadataType(fullEmittedName)
 
+            If underlying Is Nothing Then
+                Return Nothing
+            End If
+
+            Debug.Assert(Not underlying.IsErrorType())
             Debug.Assert(underlying.ContainingModule Is _retargetingModule.UnderlyingModule)
 
-            If Not underlying.IsErrorType() AndAlso underlying.IsExplicitDefinitionOfNoPiaLocalType Then
+            If underlying.IsExplicitDefinitionOfNoPiaLocalType Then
                 ' Explicitly defined local types should be hidden.
-                Return New MissingMetadataTypeSymbol.TopLevel(_retargetingModule, fullEmittedName)
+                Return Nothing
             End If
 
             Return RetargetingTranslator.Retarget(underlying, RetargetOptions.RetargetPrimitiveTypesByName)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
@@ -337,14 +337,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
 
                     mdName = MetadataTypeName.FromTypeName(type.MetadataName, forcedArity:=type.Arity)
                     result = scope.LookupMetadataType(mdName)
-                    Debug.Assert(result IsNot Nothing)
-                    Debug.Assert(result.Arity = type.Arity)
                 Else
                     Dim namespaceName As String = If(type.GetEmittedNamespaceName(), type.ContainingNamespace.ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat))
                     mdName = MetadataTypeName.FromNamespaceAndTypeName(namespaceName, type.MetadataName, forcedArity:=type.Arity)
                     result = addedModule.LookupTopLevelMetadataType(mdName)
-                    Debug.Assert(result.Arity = type.Arity)
                 End If
+
+                Debug.Assert(If(TryCast(result, PENamedTypeSymbol)?.Handle = type.Handle, False))
 
                 Return result
             End Function
@@ -367,14 +366,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
                         Dim scope As NamedTypeSymbol = PerformTypeRetargeting(destination, containingType)
                         mdName = MetadataTypeName.FromTypeName(type.MetadataName, forcedArity:=type.Arity)
                         result1 = scope.LookupMetadataType(mdName)
-                        Debug.Assert(result1 IsNot Nothing)
-                        Debug.Assert(result1.Arity = type.Arity)
+
+                        If result1 Is Nothing Then
+                            result1 = New MissingMetadataTypeSymbol.Nested(scope, mdName)
+                        Else
+                            Debug.Assert(Not result1.IsErrorType())
+                        End If
                     Else
                         Dim namespaceName As String = If(type.GetEmittedNamespaceName(), type.ContainingNamespace.ToDisplayString(SymbolDisplayFormat.QualifiedNameOnlyFormat))
                         mdName = MetadataTypeName.FromNamespaceAndTypeName(namespaceName, type.MetadataName, forcedArity:=type.Arity)
-                        result1 = destination.To.LookupTopLevelMetadataType(mdName, digThroughForwardedTypes:=True)
-                        Debug.Assert(result1.Arity = type.Arity)
+                        result1 = destination.To.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
                     End If
+
+                    Debug.Assert(result1.Arity = type.Arity)
 
                     result = destination.SymbolMap.GetOrAdd(type, result1)
                     Debug.Assert(result1.Equals(result))

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -1753,7 +1753,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                 emittedName = MetadataTypeName.FromFullName(matchedName, emittedName.UseCLSCompliantNameArityEncoding, emittedName.ForcedArity)
                             End If
 
-                            Return forwardedToAssemblies.FirstSymbol.LookupTopLevelMetadataTypeWithCycleDetection(emittedName, visitedAssemblies, digThroughForwardedTypes:=True)
+                            Return forwardedToAssemblies.FirstSymbol.LookupDeclaredOrForwardedTopLevelMetadataType(emittedName, visitedAssemblies)
                         End If
                     End If
                 Next

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -355,7 +355,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' Type name.
         ''' </param>
         ''' <returns>
-        ''' Symbol for the type, or MissingMetadataSymbol if the type isn't found.
+        ''' Symbol for the type, or Nothing if the type isn't found.
         ''' </returns>
         ''' <remarks></remarks>
         Friend Overridable Function LookupMetadataType(ByRef emittedTypeName As MetadataTypeName) As NamedTypeSymbol
@@ -425,9 +425,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
 Done:
-            If namedType Is Nothing Then
-                Return New MissingMetadataTypeSymbol.Nested(DirectCast(Me, NamedTypeSymbol), emittedTypeName)
-            End If
 
             Return namedType
         End Function

--- a/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
@@ -382,6 +382,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Else
                     result = Me.Assembly.GetTypeByMetadataName(mdName, includeReferences:=True, isWellKnownType:=True, useCLSCompliantNameArityEncoding:=True, conflicts:=conflicts,
                                                                ignoreCorLibraryDuplicatedTypes:=Me.Options.IgnoreCorLibraryDuplicatedTypes)
+                    Debug.Assert(If(Not result?.IsErrorType(), True))
                 End If
 
                 If result Is Nothing Then

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -3609,7 +3609,7 @@ end structure
 
                     ' Get System.Security.Permissions.HostProtection
                     Dim emittedName = MetadataTypeName.FromNamespaceAndTypeName("System.Security.Permissions", "HostProtectionAttribute")
-                    Dim hostProtectionAttr As NamedTypeSymbol = sourceAssembly.CorLibrary.LookupTopLevelMetadataType(emittedName, True)
+                    Dim hostProtectionAttr As NamedTypeSymbol = sourceAssembly.CorLibrary.LookupDeclaredTopLevelMetadataType(emittedName)
                     Assert.NotNull(hostProtectionAttr)
 
                     ' Verify type security attributes

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -3284,7 +3284,7 @@ end namespace
                     ' Verify Assembly security attributes
                     Assert.Equal(2, assemblySecurityAttributes.Count)
                     Dim emittedName = MetadataTypeName.FromNamespaceAndTypeName("System.Security.Permissions", "SecurityPermissionAttribute")
-                    Dim securityPermissionAttr As NamedTypeSymbol = sourceAssembly.CorLibrary.LookupTopLevelMetadataType(emittedName, True)
+                    Dim securityPermissionAttr As NamedTypeSymbol = sourceAssembly.CorLibrary.LookupDeclaredTopLevelMetadataType(emittedName)
 
                     ' Verify <assembly: SecurityPermission(SecurityAction.RequestOptional, RemotingConfiguration:=true)>
                     Dim securityAttribute As Cci.SecurityAttribute = assemblySecurityAttributes.First()
@@ -3308,7 +3308,7 @@ end namespace
 
                     ' Get System.Security.Permissions.PrincipalPermissionAttribute
                     emittedName = MetadataTypeName.FromNamespaceAndTypeName("System.Security.Permissions", "PrincipalPermissionAttribute")
-                    Dim principalPermAttr As NamedTypeSymbol = sourceAssembly.CorLibrary.LookupTopLevelMetadataType(emittedName, True)
+                    Dim principalPermAttr As NamedTypeSymbol = sourceAssembly.CorLibrary.LookupDeclaredTopLevelMetadataType(emittedName)
                     Assert.NotNull(principalPermAttr)
 
                     ' Verify type security attributes: different security action

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/NoPiaEmbedTypes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/NoPiaEmbedTypes.vb
@@ -3608,7 +3608,7 @@ BC31539: Cannot find the interop type that matches the embedded type 'I1'. Are y
 
             Dim assembly = compilation1.SourceModule.GetReferencedAssemblySymbols()(1)
             Dim [module] = assembly.Modules(0)
-            Assert.IsType(Of MissingMetadataTypeSymbol.TopLevel)([module].LookupTopLevelMetadataType(fullName))
+            Assert.Null([module].LookupTopLevelMetadataType(fullName))
             Assert.Null(assembly.GetTypeByMetadataName(fullName.FullName))
 
             Dim compilation2 = CreateCompilationWithMscorlib40AndReferences(
@@ -3621,7 +3621,7 @@ BC31539: Cannot find the interop type that matches the embedded type 'I1'. Are y
             [module] = assembly.Modules(0)
             Assert.IsType(Of NoPiaMissingCanonicalTypeSymbol)(DirectCast([module], PEModuleSymbol).LookupTopLevelMetadataType(fullName, isNoPiaLocalType))
             Assert.True(isNoPiaLocalType)
-            Assert.IsType(Of MissingMetadataTypeSymbol.TopLevel)([module].LookupTopLevelMetadataType(fullName))
+            Assert.Null([module].LookupTopLevelMetadataType(fullName))
             Assert.Null(assembly.GetTypeByMetadataName(fullName.FullName))
 
             Dim compilation3 = CreateCompilationWithMscorlib40AndReferences(
@@ -3631,7 +3631,7 @@ BC31539: Cannot find the interop type that matches the embedded type 'I1'. Are y
 
             assembly = compilation3.SourceModule.GetReferencedAssemblySymbols()(1)
             [module] = assembly.Modules(0)
-            Assert.IsType(Of MissingMetadataTypeSymbol.TopLevel)([module].LookupTopLevelMetadataType(fullName))
+            Assert.Null([module].LookupTopLevelMetadataType(fullName))
             Assert.Null(assembly.GetTypeByMetadataName(fullName.FullName))
 
             Dim compilation4 = CreateCompilationWithMscorlib40AndReferences(
@@ -3643,7 +3643,7 @@ BC31539: Cannot find the interop type that matches the embedded type 'I1'. Are y
             [module] = assembly.Modules(0)
             Assert.IsType(Of NoPiaMissingCanonicalTypeSymbol)(DirectCast([module], PEModuleSymbol).LookupTopLevelMetadataType(fullName, isNoPiaLocalType))
             Assert.True(isNoPiaLocalType)
-            Assert.IsType(Of MissingMetadataTypeSymbol.TopLevel)([module].LookupTopLevelMetadataType(fullName))
+            Assert.Null([module].LookupTopLevelMetadataType(fullName))
             Assert.Null(assembly.GetTypeByMetadataName(fullName.FullName))
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/MetadataTypeTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Metadata/MetadataTypeTests.vb
@@ -590,35 +590,35 @@ End Class
             Dim asm As AssemblySymbol = i2.ContainingAssembly
 
             mdName = MetadataTypeName.FromFullName("I3`1", False, -1)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.False(t.IsErrorType())
             Assert.Equal("I3", t.Name)
             Assert.True(t.MangleName)
             Assert.Equal(1, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I3`1", False, 0)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.True(t.IsErrorType())
             Assert.Equal("I3`1", t.Name)
             Assert.False(t.MangleName)
             Assert.Equal(0, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I3`1", False, 1)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.False(t.IsErrorType())
             Assert.Equal("I3", t.Name)
             Assert.True(t.MangleName)
             Assert.Equal(1, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I3`1", False, 2)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.True(t.IsErrorType())
             Assert.Equal("I3`1", t.Name)
             Assert.False(t.MangleName)
             Assert.Equal(2, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I3`1", True, -1)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.False(t.IsErrorType())
             Assert.Equal("I3", t.Name)
             Assert.True(t.MangleName)
@@ -632,7 +632,7 @@ End Class
             'Assert.Equal(0, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I3`1", True, 1)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.False(t.IsErrorType())
             Assert.Equal("I3", t.Name)
             Assert.True(t.MangleName)
@@ -647,35 +647,35 @@ End Class
 
 
             mdName = MetadataTypeName.FromFullName("I", False, -1)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.False(t.IsErrorType())
             Assert.Equal("I", t.Name)
             Assert.False(t.MangleName)
             Assert.Equal(0, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I", False, 0)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.False(t.IsErrorType())
             Assert.Equal("I", t.Name)
             Assert.False(t.MangleName)
             Assert.Equal(0, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I", False, 1)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.True(t.IsErrorType())
             Assert.Equal("I", t.Name)
             Assert.False(t.MangleName)
             Assert.Equal(1, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I", True, -1)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.False(t.IsErrorType())
             Assert.Equal("I", t.Name)
             Assert.False(t.MangleName)
             Assert.Equal(0, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I", True, 0)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.False(t.IsErrorType())
             Assert.Equal("I", t.Name)
             Assert.False(t.MangleName)
@@ -690,35 +690,35 @@ End Class
 
 
             mdName = MetadataTypeName.FromFullName("I2`1", False, -1)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.False(t.IsErrorType())
             Assert.Equal("I2`1", t.Name)
             Assert.False(t.MangleName)
             Assert.Equal(0, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I2`1", False, 0)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.False(t.IsErrorType())
             Assert.Equal("I2`1", t.Name)
             Assert.False(t.MangleName)
             Assert.Equal(0, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I2`1", False, 1)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.True(t.IsErrorType())
             Assert.Equal("I2", t.Name)
             Assert.True(t.MangleName)
             Assert.Equal(1, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I2`1", False, 2)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.True(t.IsErrorType())
             Assert.Equal("I2`1", t.Name)
             Assert.False(t.MangleName)
             Assert.Equal(2, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I2`1", True, -1)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.True(t.IsErrorType())
             Assert.Equal("I2", t.Name)
             Assert.True(t.MangleName)
@@ -732,7 +732,7 @@ End Class
             'Assert.Equal(0, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I2`1", True, 1)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.True(t.IsErrorType())
             Assert.Equal("I2", t.Name)
             Assert.True(t.MangleName)
@@ -747,35 +747,35 @@ End Class
 
 
             mdName = MetadataTypeName.FromFullName("I4`2", False, -1)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.False(t.IsErrorType())
             Assert.Equal("I4`2", t.Name)
             Assert.False(t.MangleName)
             Assert.Equal(1, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I4`2", False, 0)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.True(t.IsErrorType())
             Assert.Equal("I4`2", t.Name)
             Assert.False(t.MangleName)
             Assert.Equal(0, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I4`2", False, 1)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.False(t.IsErrorType())
             Assert.Equal("I4`2", t.Name)
             Assert.False(t.MangleName)
             Assert.Equal(1, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I4`2", False, 2)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.True(t.IsErrorType())
             Assert.Equal("I4", t.Name)
             Assert.True(t.MangleName)
             Assert.Equal(2, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I4`2", True, -1)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.True(t.IsErrorType())
             Assert.Equal("I4", t.Name)
             Assert.True(t.MangleName)
@@ -796,7 +796,7 @@ End Class
             'Assert.Equal(1, t.Arity)
 
             mdName = MetadataTypeName.FromFullName("I4`2", True, 2)
-            t = asm.LookupTopLevelMetadataType(mdName, True)
+            t = asm.LookupDeclaredOrForwardedTopLevelMetadataType(mdName, visitedAssemblies:=Nothing)
             Assert.True(t.IsErrorType())
             Assert.Equal("I4", t.Name)
             Assert.True(t.MangleName)
@@ -813,10 +813,7 @@ End Class
 
             mdName = MetadataTypeName.FromFullName("I3`1", False, 0)
             t = containingType.LookupMetadataType(mdName)
-            Assert.True(t.IsErrorType())
-            Assert.Equal("I3`1", t.Name)
-            Assert.False(t.MangleName)
-            Assert.Equal(0, t.Arity)
+            Assert.Null(t)
 
             mdName = MetadataTypeName.FromFullName("I3`1", False, 1)
             t = containingType.LookupMetadataType(mdName)
@@ -827,10 +824,7 @@ End Class
 
             mdName = MetadataTypeName.FromFullName("I3`1", False, 2)
             t = containingType.LookupMetadataType(mdName)
-            Assert.True(t.IsErrorType())
-            Assert.Equal("I3`1", t.Name)
-            Assert.False(t.MangleName)
-            Assert.Equal(2, t.Arity)
+            Assert.Null(t)
 
             mdName = MetadataTypeName.FromFullName("I3`1", True, -1)
             t = containingType.LookupMetadataType(mdName)
@@ -877,10 +871,7 @@ End Class
 
             mdName = MetadataTypeName.FromFullName("I", False, 1)
             t = containingType.LookupMetadataType(mdName)
-            Assert.True(t.IsErrorType())
-            Assert.Equal("I", t.Name)
-            Assert.False(t.MangleName)
-            Assert.Equal(1, t.Arity)
+            Assert.Null(t)
 
             mdName = MetadataTypeName.FromFullName("I", True, -1)
             t = containingType.LookupMetadataType(mdName)
@@ -920,24 +911,15 @@ End Class
 
             mdName = MetadataTypeName.FromFullName("I2`1", False, 1)
             t = containingType.LookupMetadataType(mdName)
-            Assert.True(t.IsErrorType())
-            Assert.Equal("I2", t.Name)
-            Assert.True(t.MangleName)
-            Assert.Equal(1, t.Arity)
+            Assert.Null(t)
 
             mdName = MetadataTypeName.FromFullName("I2`1", False, 2)
             t = containingType.LookupMetadataType(mdName)
-            Assert.True(t.IsErrorType())
-            Assert.Equal("I2`1", t.Name)
-            Assert.False(t.MangleName)
-            Assert.Equal(2, t.Arity)
+            Assert.Null(t)
 
             mdName = MetadataTypeName.FromFullName("I2`1", True, -1)
             t = containingType.LookupMetadataType(mdName)
-            Assert.True(t.IsErrorType())
-            Assert.Equal("I2", t.Name)
-            Assert.True(t.MangleName)
-            Assert.Equal(1, t.Arity)
+            Assert.Null(t)
 
             'mdName = MetadataTypeName.FromFullName("I2`1", True, 0)
             't = containingType.LookupMetadataType(mdName)
@@ -948,10 +930,7 @@ End Class
 
             mdName = MetadataTypeName.FromFullName("I2`1", True, 1)
             t = containingType.LookupMetadataType(mdName)
-            Assert.True(t.IsErrorType())
-            Assert.Equal("I2", t.Name)
-            Assert.True(t.MangleName)
-            Assert.Equal(1, t.Arity)
+            Assert.Null(t)
 
             'mdName = MetadataTypeName.FromFullName("I2`1", True, 2)
             't = containingType.LookupMetadataType(mdName)
@@ -970,10 +949,7 @@ End Class
 
             mdName = MetadataTypeName.FromFullName("I4`2", False, 0)
             t = containingType.LookupMetadataType(mdName)
-            Assert.True(t.IsErrorType())
-            Assert.Equal("I4`2", t.Name)
-            Assert.False(t.MangleName)
-            Assert.Equal(0, t.Arity)
+            Assert.Null(t)
 
             mdName = MetadataTypeName.FromFullName("I4`2", False, 1)
             t = containingType.LookupMetadataType(mdName)
@@ -984,17 +960,11 @@ End Class
 
             mdName = MetadataTypeName.FromFullName("I4`2", False, 2)
             t = containingType.LookupMetadataType(mdName)
-            Assert.True(t.IsErrorType())
-            Assert.Equal("I4", t.Name)
-            Assert.True(t.MangleName)
-            Assert.Equal(2, t.Arity)
+            Assert.Null(t)
 
             mdName = MetadataTypeName.FromFullName("I4`2", True, -1)
             t = containingType.LookupMetadataType(mdName)
-            Assert.True(t.IsErrorType())
-            Assert.Equal("I4", t.Name)
-            Assert.True(t.MangleName)
-            Assert.Equal(2, t.Arity)
+            Assert.Null(t)
 
             'mdName = MetadataTypeName.FromFullName("I4`2", True, 0)
             't = containingType.LookupMetadataType(mdName)
@@ -1012,10 +982,7 @@ End Class
 
             mdName = MetadataTypeName.FromFullName("I4`2", True, 2)
             t = containingType.LookupMetadataType(mdName)
-            Assert.True(t.IsErrorType())
-            Assert.Equal("I4", t.Name)
-            Assert.True(t.MangleName)
-            Assert.Equal(2, t.Arity)
+            Assert.Null(t)
 
             CompileAndVerify(compilation)
         End Sub

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/NoPia.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Retargeting/NoPia.vb
@@ -261,20 +261,20 @@ End Class
             Dim fullName_S1 = MetadataTypeName.FromFullName("S1")
             Dim fullName_S2 = MetadataTypeName.FromFullName("NS1.S2")
 
-            Assert.IsType(Of MissingMetadataTypeSymbol.TopLevel)(localTypes1.LookupTopLevelMetadataType(fullName_I1))
-            Assert.IsType(Of MissingMetadataTypeSymbol.TopLevel)(localTypes1.LookupTopLevelMetadataType(fullName_I2))
-            Assert.IsType(Of MissingMetadataTypeSymbol.TopLevel)(localTypes1.LookupTopLevelMetadataType(fullName_S1))
-            Assert.IsType(Of MissingMetadataTypeSymbol.TopLevel)(localTypes1.LookupTopLevelMetadataType(fullName_S2))
+            Assert.Null(localTypes1.LookupTopLevelMetadataType(fullName_I1))
+            Assert.Null(localTypes1.LookupTopLevelMetadataType(fullName_I2))
+            Assert.Null(localTypes1.LookupTopLevelMetadataType(fullName_S1))
+            Assert.Null(localTypes1.LookupTopLevelMetadataType(fullName_S2))
 
             Assert.Null(assemblies(0).GetTypeByMetadataName(fullName_I1.FullName))
             Assert.Null(assemblies(0).GetTypeByMetadataName(fullName_I2.FullName))
             Assert.Null(assemblies(0).GetTypeByMetadataName(fullName_S1.FullName))
             Assert.Null(assemblies(0).GetTypeByMetadataName(fullName_S2.FullName))
 
-            Assert.IsType(Of MissingMetadataTypeSymbol.TopLevel)(localTypes2.LookupTopLevelMetadataType(fullName_I1))
-            Assert.IsType(Of MissingMetadataTypeSymbol.TopLevel)(localTypes2.LookupTopLevelMetadataType(fullName_I2))
-            Assert.IsType(Of MissingMetadataTypeSymbol.TopLevel)(localTypes2.LookupTopLevelMetadataType(fullName_S1))
-            Assert.IsType(Of MissingMetadataTypeSymbol.TopLevel)(localTypes2.LookupTopLevelMetadataType(fullName_S2))
+            Assert.Null(localTypes2.LookupTopLevelMetadataType(fullName_I1))
+            Assert.Null(localTypes2.LookupTopLevelMetadataType(fullName_I2))
+            Assert.Null(localTypes2.LookupTopLevelMetadataType(fullName_S1))
+            Assert.Null(localTypes2.LookupTopLevelMetadataType(fullName_S2))
 
             Assert.Null(assemblies(1).GetTypeByMetadataName(fullName_I1.FullName))
             Assert.Null(assemblies(1).GetTypeByMetadataName(fullName_I2.FullName))

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EETypeNameDecoder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EETypeNameDecoder.cs
@@ -55,7 +55,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         protected override TypeSymbol LookupNestedTypeDefSymbol(TypeSymbol container, ref MetadataTypeName emittedName)
         {
-            return container.LookupMetadataType(ref emittedName);
+            return container.LookupMetadataType(ref emittedName) ??
+                       new MissingMetadataTypeSymbol.Nested((NamedTypeSymbol)container, ref emittedName);
         }
 
         protected override TypeSymbol LookupTopLevelTypeDefSymbol(int referencedAssemblyIndex, ref MetadataTypeName emittedName)
@@ -63,12 +64,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             var assembly = Module.GetReferencedAssemblySymbol(referencedAssemblyIndex);
             // GetReferencedAssemblySymbol should not return null since referencedAssemblyIndex
             // was obtained from GetIndexOfReferencedAssembly above.
-            return assembly.LookupTopLevelMetadataType(ref emittedName, digThroughForwardedTypes: true);
+            return assembly.LookupDeclaredOrForwardedTopLevelMetadataType(ref emittedName, visitedAssemblies: null);
         }
 
         protected override TypeSymbol LookupTopLevelTypeDefSymbol(ref MetadataTypeName emittedName, out bool isNoPiaLocalType)
         {
-            return moduleSymbol.LookupTopLevelMetadataType(ref emittedName, out isNoPiaLocalType);
+            return moduleSymbol.LookupTopLevelMetadataTypeWithNoPiaLocalTypeUnification(ref emittedName, out isNoPiaLocalType);
         }
 
         private static AssemblyIdentity GetComponentAssemblyIdentity(ModuleSymbol module)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EETypeNameDecoder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EETypeNameDecoder.vb
@@ -48,14 +48,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         End Function
 
         Protected Overrides Function LookupNestedTypeDefSymbol(container As TypeSymbol, ByRef emittedName As MetadataTypeName) As TypeSymbol
-            Return container.LookupMetadataType(emittedName)
+            Dim result As NamedTypeSymbol = container.LookupMetadataType(emittedName)
+            Debug.Assert(If(Not result?.IsErrorType(), True))
+
+            Return If(result, New MissingMetadataTypeSymbol.Nested(DirectCast(container, NamedTypeSymbol), emittedName))
         End Function
 
         Protected Overrides Function LookupTopLevelTypeDefSymbol(referencedAssemblyIndex As Integer, ByRef emittedName As MetadataTypeName) As TypeSymbol
             Dim assembly As AssemblySymbol = Me.Module.GetReferencedAssemblySymbol(referencedAssemblyIndex)
             ' GetReferencedAssemblySymbol should not return Nothing since referencedAssemblyIndex
             ' was obtained from GetIndexOfReferencedAssembly above.
-            Return assembly.LookupTopLevelMetadataType(emittedName, digThroughForwardedTypes:=True)
+            Return assembly.LookupDeclaredOrForwardedTopLevelMetadataType(emittedName, visitedAssemblies:=Nothing)
         End Function
 
         Protected Overrides Function LookupTopLevelTypeDefSymbol(ByRef emittedName As MetadataTypeName, ByRef isNoPiaLocalType As Boolean) As TypeSymbol


### PR DESCRIPTION
Fixes #64142.