### PR TITLE
Add support for finding indexer references used in an object initializer

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.IndexerSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.IndexerSymbols.vb
@@ -320,5 +320,24 @@ class D
 </Workspace>
             Await TestAPIAndFeature(input, kind, host)
         End Function
+
+        <WorkItem(40978, "https://github.com/dotnet/roslyn/issues/40978")>
+        <WpfTheory, CombinatorialData>
+        Public Async Function TestImplicitElementAccessExpression1(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+public class Test
+{
+  int {|Definition:$$this|}[int index] { get => 0; set { } }
+
+  Test Create() { return new Test() { [||][0] = 0, [||][1] = 1 }; }
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal partial class AbstractSyntaxIndex<TIndex> : IObjectWritable
     {
         private static readonly string s_persistenceName = typeof(TIndex).Name;
-        private static readonly Checksum s_serializationFormatChecksum = Checksum.Create("33");
+        private static readonly Checksum s_serializationFormatChecksum = Checksum.Create("34");
 
         /// <summary>
         /// Cache of ParseOptions to a checksum for the <see cref="ParseOptions.PreprocessorSymbolNames"/> contained

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex.ContextInfo.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 bool containsQueryExpression,
                 bool containsThisConstructorInitializer,
                 bool containsBaseConstructorInitializer,
-                bool containsElementAccessExpression,
+                bool containsExplicitOrImplicitElementAccessExpression,
                 bool containsIndexerMemberCref,
                 bool containsDeconstruction,
                 bool containsAwait,
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                          containsQueryExpression,
                          containsThisConstructorInitializer,
                          containsBaseConstructorInitializer,
-                         containsElementAccessExpression,
+                         containsExplicitOrImplicitElementAccessExpression,
                          containsIndexerMemberCref,
                          containsDeconstruction,
                          containsAwait,
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 bool containsQueryExpression,
                 bool containsThisConstructorInitializer,
                 bool containsBaseConstructorInitializer,
-                bool containsElementAccessExpression,
+                bool containsExplicitOrImplicitElementAccessExpression,
                 bool containsIndexerMemberCref,
                 bool containsDeconstruction,
                 bool containsAwait,
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 containingNodes |= containsQueryExpression ? ContainingNodes.ContainsQueryExpression : 0;
                 containingNodes |= containsThisConstructorInitializer ? ContainingNodes.ContainsThisConstructorInitializer : 0;
                 containingNodes |= containsBaseConstructorInitializer ? ContainingNodes.ContainsBaseConstructorInitializer : 0;
-                containingNodes |= containsElementAccessExpression ? ContainingNodes.ContainsElementAccessExpression : 0;
+                containingNodes |= containsExplicitOrImplicitElementAccessExpression ? ContainingNodes.ContainsExplicitOrImplicitElementAccessExpression : 0;
                 containingNodes |= containsIndexerMemberCref ? ContainingNodes.ContainsIndexerMemberCref : 0;
                 containingNodes |= containsDeconstruction ? ContainingNodes.ContainsDeconstruction : 0;
                 containingNodes |= containsAwait ? ContainingNodes.ContainsAwait : 0;
@@ -132,8 +132,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             public bool ContainsBaseConstructorInitializer
                 => (_containingNodes & ContainingNodes.ContainsBaseConstructorInitializer) == ContainingNodes.ContainsBaseConstructorInitializer;
 
-            public bool ContainsElementAccessExpression
-                => (_containingNodes & ContainingNodes.ContainsElementAccessExpression) == ContainingNodes.ContainsElementAccessExpression;
+            public bool ContainsExplicitOrImplicitElementAccessExpression
+                => (_containingNodes & ContainingNodes.ContainsExplicitOrImplicitElementAccessExpression) == ContainingNodes.ContainsExplicitOrImplicitElementAccessExpression;
 
             public bool ContainsIndexerMemberCref
                 => (_containingNodes & ContainingNodes.ContainsIndexerMemberCref) == ContainingNodes.ContainsIndexerMemberCref;
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 ContainsQueryExpression = 1 << 3,
                 ContainsThisConstructorInitializer = 1 << 4,
                 ContainsBaseConstructorInitializer = 1 << 5,
-                ContainsElementAccessExpression = 1 << 6,
+                ContainsExplicitOrImplicitElementAccessExpression = 1 << 6,
                 ContainsIndexerMemberCref = 1 << 7,
                 ContainsDeconstruction = 1 << 8,
                 ContainsAwait = 1 << 9,

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Create.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                             containsLockStatement = containsLockStatement || syntaxFacts.IsLockStatement(node);
                             containsUsingStatement = containsUsingStatement || syntaxFacts.IsUsingStatement(node);
                             containsQueryExpression = containsQueryExpression || syntaxFacts.IsQueryExpression(node);
-                            containsElementAccess = containsElementAccess || syntaxFacts.IsElementAccessExpression(node);
+                            containsElementAccess = containsElementAccess || (syntaxFacts.IsElementAccessExpression(node) || syntaxFacts.IsImplicitElementAccess(node));
                             containsIndexerMemberCref = containsIndexerMemberCref || syntaxFacts.IsIndexerMemberCref(node);
 
                             containsDeconstruction = containsDeconstruction || syntaxFacts.IsDeconstructionAssignment(node)

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeIndex_Forwarders.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         public bool ContainsBaseConstructorInitializer => _contextInfo.ContainsBaseConstructorInitializer;
         public bool ContainsConversion => _contextInfo.ContainsConversion;
         public bool ContainsDeconstruction => _contextInfo.ContainsDeconstruction;
-        public bool ContainsElementAccessExpression => _contextInfo.ContainsElementAccessExpression;
+        public bool ContainsExplicitOrImplicitElementAccessExpression => _contextInfo.ContainsExplicitOrImplicitElementAccessExpression;
         public bool ContainsForEachStatement => _contextInfo.ContainsForEachStatement;
         public bool ContainsGlobalKeyword => _contextInfo.ContainsGlobalKeyword;
         public bool ContainsGlobalSuppressMessageAttribute => _contextInfo.ContainsGlobalSuppressMessageAttribute;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -1694,6 +1694,9 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageService
 
         #region GetXXXOfYYY members
 
+        public SyntaxNode GetArgumentListOfImplicitElementAccess(SyntaxNode node)
+            => ((ImplicitElementAccessSyntax)node).ArgumentList;
+
         public SyntaxNode GetExpressionOfAwaitExpression(SyntaxNode node)
             => ((AwaitExpressionSyntax)node).Expression;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxKinds.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxKinds.cs
@@ -141,6 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageService
 
         public int EqualsValueClause => (int)SyntaxKind.EqualsValueClause;
 
+        public int? ImplicitElementAccess => (int)SyntaxKind.ImplicitElementAccess;
         public int Interpolation => (int)SyntaxKind.Interpolation;
         public int InterpolatedStringExpression => (int)SyntaxKind.InterpolatedStringExpression;
         public int InterpolatedStringText => (int)SyntaxKind.InterpolatedStringText;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -536,6 +536,8 @@ namespace Microsoft.CodeAnalysis.LanguageService
         // ISyntaxFacts should have a GetPartsOfXXX helper instead, and GetXXXOfYYY should be built off of that
         // inside ISyntaxFactsExtensions
 
+        SyntaxNode GetArgumentListOfImplicitElementAccess(SyntaxNode node);
+
         SyntaxNode GetExpressionOfAwaitExpression(SyntaxNode node);
         SyntaxNode GetExpressionOfExpressionStatement(SyntaxNode node);
         SyntaxNode GetExpressionOfRefExpression(SyntaxNode node);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFactsExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFactsExtensions.cs
@@ -964,6 +964,9 @@ namespace Microsoft.CodeAnalysis.LanguageService
 
         #region other
 
+        public static bool IsImplicitElementAccess(this ISyntaxFacts syntaxFacts, [NotNullWhen(true)] SyntaxNode? node)
+            => node?.RawKind == syntaxFacts.SyntaxKinds.ImplicitElementAccess;
+
         public static bool IsIndexerMemberCref(this ISyntaxFacts syntaxFacts, [NotNullWhen(true)] SyntaxNode? node)
             => node?.RawKind == syntaxFacts.SyntaxKinds.IndexerMemberCref;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxKinds.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxKinds.cs
@@ -201,6 +201,7 @@ namespace Microsoft.CodeAnalysis.LanguageService
 
         #region other
 
+        int? ImplicitElementAccess { get; }
         int Interpolation { get; }
         int InterpolatedStringText { get; }
         int? IndexerMemberCref { get; }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxFacts.vb
@@ -1881,12 +1881,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
 
 #Region "GetXXXOfYYY members"
 
+        Public Function GetArgumentListOfImplicitElementAccess(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.GetArgumentListOfImplicitElementAccess
+            Throw New InvalidOperationException(DoesNotExistInVBErrorMessage)
+        End Function
+
         Public Function GetExpressionOfAwaitExpression(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.GetExpressionOfAwaitExpression
             Return DirectCast(node, AwaitExpressionSyntax).Expression
         End Function
 
         Public Function GetExpressionOfThrowExpression(node As SyntaxNode) As SyntaxNode Implements ISyntaxFacts.GetExpressionOfThrowExpression
-            ' ThrowExpression doesn't exist in VB
             Throw New InvalidOperationException(DoesNotExistInVBErrorMessage)
         End Function
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxKinds.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicSyntaxKinds.vb
@@ -144,6 +144,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
 
         Public ReadOnly Property EqualsValueClause As Integer = SyntaxKind.EqualsValue Implements ISyntaxKinds.EqualsValueClause
 
+        Public ReadOnly Property ImplicitElementAccess As Integer? Implements ISyntaxKinds.ImplicitElementAccess
         Public ReadOnly Property Interpolation As Integer = SyntaxKind.Interpolation Implements ISyntaxKinds.Interpolation
         Public ReadOnly Property InterpolatedStringExpression As Integer = SyntaxKind.InterpolatedStringExpression Implements ISyntaxKinds.InterpolatedStringExpression
         Public ReadOnly Property InterpolatedStringText As Integer = SyntaxKind.InterpolatedStringText Implements ISyntaxKinds.InterpolatedStringText


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/40978