### PR TITLE
Do not move global-usings inside namespaces.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/MisplacedUsingDirectives/MisplacedUsingDirectivesDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MisplacedUsingDirectives/MisplacedUsingDirectivesDiagnosticAnalyzer.cs
@@ -74,9 +74,12 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
                 return;
             }
 
-            // Note: We will report diagnostics when a code file contains multiple namespaces even though we will
-            // not offer a code fix in these cases.
-            ReportDiagnostics(context, s_insideDiagnosticDescriptor, compilationUnit.Usings, option);
+            // Only report for non-global usings.  Global usings must stay at the compilation unit level.
+            var nonGlobalUsings = compilationUnit.Usings.Where(u => u.GlobalKeyword == default);
+
+            // Note: We will report diagnostics when a code file contains multiple namespaces even though we will not
+            // offer a code fix in these cases.
+            ReportDiagnostics(context, s_insideDiagnosticDescriptor, nonGlobalUsings, option);
         }
 
         private static bool ShouldSuppressDiagnostic(CompilationUnitSyntax compilationUnit)

--- a/src/Analyzers/CSharp/CodeFixes/MisplacedUsingDirectives/MisplacedUsingDirectivesCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/MisplacedUsingDirectives/MisplacedUsingDirectivesCodeFixProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -14,13 +13,12 @@ using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
-using Microsoft.CodeAnalysis.CSharp.Simplification;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.LanguageService;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Utilities;
@@ -34,7 +32,13 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
     [Shared]
     internal sealed partial class MisplacedUsingDirectivesCodeFixProvider : CodeFixProvider
     {
-        private static readonly SyntaxAnnotation s_usingPlacementCodeFixAnnotation = new SyntaxAnnotation(nameof(s_usingPlacementCodeFixAnnotation));
+        private static readonly SyntaxAnnotation s_usingPlacementCodeFixAnnotation = new(nameof(s_usingPlacementCodeFixAnnotation));
+
+        /// <summary>
+        /// A blanket warning that this codefix may change code so that it does not compile.
+        /// </summary>
+        private static readonly SyntaxAnnotation s_warningAnnotation = WarningAnnotation.Create(
+            CSharpAnalyzersResources.Warning_colon_Moving_using_directives_may_change_code_meaning);
 
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
@@ -61,9 +65,8 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
             var options = await document.GetCSharpCodeFixOptionsProviderAsync(context.GetOptionsProvider(), cancellationToken).ConfigureAwait(false);
             var simplifierOptions = options.GetSimplifierOptions();
 
-            // Read the preferred placement option and verify if it can be applied to this code file.
-            // There are cases where we will not be able to fix the diagnostic and the user will need to resolve
-            // it manually.
+            // Read the preferred placement option and verify if it can be applied to this code file. There are cases
+            // where we will not be able to fix the diagnostic and the user will need to resolve it manually.
             var (placement, preferPreservation) = DeterminePlacement(compilationUnit, options.UsingDirectivePlacement);
             if (preferPreservation)
                 return;
@@ -85,37 +88,54 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
             CodeStyleOption2<AddImportPlacement> importPlacementStyleOption,
             CancellationToken cancellationToken)
         {
-            var syntaxRoot = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var compilationUnit = (CompilationUnitSyntax)syntaxRoot;
+            var compilationUnit = (CompilationUnitSyntax)await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             var (placement, preferPreservation) = DeterminePlacement(compilationUnit, importPlacementStyleOption);
             if (preferPreservation)
-            {
                 return document;
-            }
 
             // We are called from a diagnostic, but also for all new documents, so check if there are any usings at all
             // otherwise there is nothing to do.
             var allUsingDirectives = GetAllUsingDirectives(compilationUnit);
-            if (allUsingDirectives.Count == 0)
-            {
+            if (allUsingDirectives.Length == 0)
                 return document;
-            }
 
-            return await GetTransformedDocumentAsync(document, compilationUnit, allUsingDirectives, placement, simplifierOptions, cancellationToken).ConfigureAwait(false);
+            return await GetTransformedDocumentAsync(
+                document, compilationUnit, allUsingDirectives, placement, simplifierOptions, cancellationToken).ConfigureAwait(false);
         }
 
-        private static ImmutableList<UsingDirectiveSyntax> GetAllUsingDirectives(CompilationUnitSyntax compilationUnit)
+        private static ImmutableArray<UsingDirectiveSyntax> GetAllUsingDirectives(CompilationUnitSyntax compilationUnit)
         {
-            return compilationUnit
-                .DescendantNodes(node => node is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax)
-                .OfType<UsingDirectiveSyntax>().ToImmutableList();
+            using var _ = ArrayBuilder<UsingDirectiveSyntax>.GetInstance(out var result);
+
+            foreach (var usingDirective in compilationUnit.Usings)
+            {
+                // ignore global usings in teh compilation unit, they cannot be moved.
+                if (usingDirective.GlobalKeyword == default)
+                    result.Add(usingDirective);
+            }
+
+            Recurse(compilationUnit.Members);
+
+            return result.ToImmutable();
+
+            void Recurse(SyntaxList<MemberDeclarationSyntax> members)
+            {
+                foreach (var member in members)
+                {
+                    if (member is NamespaceDeclarationSyntax namespaceDeclaration)
+                    {
+                        result.AddRange(namespaceDeclaration.Usings);
+                        Recurse(namespaceDeclaration.Members);
+                    }
+                }
+            }
         }
 
         private static async Task<Document> GetTransformedDocumentAsync(
             Document document,
             CompilationUnitSyntax compilationUnit,
-            IEnumerable<UsingDirectiveSyntax> allUsingDirectives,
+            ImmutableArray<UsingDirectiveSyntax> allUsingDirectives,
             AddImportPlacement placement,
             SimplifierOptions simplifierOptions,
             CancellationToken cancellationToken)
@@ -123,17 +143,15 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
             var bannerService = document.GetRequiredLanguageService<IFileBannerFactsService>();
 
             // Expand usings so that they can be properly simplified after they are relocated.
-            var compilationUnitWithExpandedUsings = await ExpandUsingDirectivesAsync(document, compilationUnit, allUsingDirectives, cancellationToken).ConfigureAwait(false);
+            var compilationUnitWithExpandedUsings = await ExpandUsingDirectivesAsync(
+                document, compilationUnit, allUsingDirectives, cancellationToken).ConfigureAwait(false);
 
             // Remove the file header from the compilation unit so that we do not lose it when making changes to usings.
             var (compilationUnitWithoutHeader, fileHeader) = RemoveFileHeader(compilationUnitWithExpandedUsings, bannerService);
 
-            // A blanket warning that this codefix may change code so that it does not compile.
-            var warningAnnotation = WarningAnnotation.Create(CSharpAnalyzersResources.Warning_colon_Moving_using_directives_may_change_code_meaning);
-
             var newCompilationUnit = placement == AddImportPlacement.InsideNamespace
-                ? MoveUsingsInsideNamespace(compilationUnitWithoutHeader, warningAnnotation)
-                : MoveUsingsOutsideNamespaces(compilationUnitWithoutHeader, warningAnnotation);
+                ? MoveUsingsInsideNamespace(compilationUnitWithoutHeader)
+                : MoveUsingsOutsideNamespaces(compilationUnitWithoutHeader);
 
             // Re-attach the header now that using have been moved and LeadingTrivia is no longer being altered.
             var newCompilationUnitWithHeader = AddFileHeader(newCompilationUnit, fileHeader);
@@ -149,7 +167,8 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
 #endif
         }
 
-        private static async Task<CompilationUnitSyntax> ExpandUsingDirectivesAsync(Document document, CompilationUnitSyntax containerNode, IEnumerable<UsingDirectiveSyntax> allUsingDirectives, CancellationToken cancellationToken)
+        private static async Task<CompilationUnitSyntax> ExpandUsingDirectivesAsync(
+            Document document, CompilationUnitSyntax compilationUnit, ImmutableArray<UsingDirectiveSyntax> allUsingDirectives, CancellationToken cancellationToken)
         {
             // Create a map between the original node and the future expanded node.
             var expandUsingDirectiveTasks = allUsingDirectives.ToDictionary(
@@ -160,27 +179,29 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
             await Task.WhenAll(expandUsingDirectiveTasks.Values).ConfigureAwait(false);
 
             // Replace using directives with their expanded version.
-            return containerNode.ReplaceNodes(
+            return compilationUnit.ReplaceNodes(
                 expandUsingDirectiveTasks.Keys,
                 (node, _) => expandUsingDirectiveTasks[node].Result);
         }
 
-        private static async Task<SyntaxNode> ExpandUsingDirectiveAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)
+        private static async Task<SyntaxNode> ExpandUsingDirectiveAsync(Document document, UsingDirectiveSyntax usingDirective, CancellationToken cancellationToken)
         {
-            var usingDirective = (UsingDirectiveSyntax)node;
             var newName = await Simplifier.ExpandAsync(usingDirective.Name, document, cancellationToken: cancellationToken).ConfigureAwait(false);
             return usingDirective.WithName(newName);
         }
 
-        private static CompilationUnitSyntax MoveUsingsInsideNamespace(CompilationUnitSyntax compilationUnit, SyntaxAnnotation warningAnnotation)
+        private static CompilationUnitSyntax MoveUsingsInsideNamespace(CompilationUnitSyntax compilationUnit)
         {
             // Get the compilation unit usings and set them up to format when moved.
-            var usingsToAdd = compilationUnit.Usings.Select(
-                directive => directive.WithAdditionalAnnotations(Formatter.Annotation, warningAnnotation));
+            var usingsToAdd = compilationUnit.Usings
+                .Where(u => u.GlobalKeyword == default)
+                .Select(d => d.WithAdditionalAnnotations(Formatter.Annotation, s_warningAnnotation));
 
             // Remove usings and fix leading trivia for compilation unit.
-            var compilationUnitWithoutUsings = compilationUnit.WithUsings(default);
-            var compilationUnitWithoutBlankLine = RemoveLeadingBlankLinesFromFirstMember(compilationUnitWithoutUsings);
+            var compilationUnitWithoutUsings = compilationUnit.WithUsings(SyntaxFactory.List(compilationUnit.Usings.Where(u => u.GlobalKeyword != default)));
+            var compilationUnitWithoutBlankLine = compilationUnitWithoutUsings.Usings.Count == 0
+                ? RemoveLeadingBlankLinesFromFirstMember(compilationUnitWithoutUsings)
+                : compilationUnitWithoutUsings;
 
             // Fix the leading trivia for the namespace declaration.
             var namespaceDeclaration = (BaseNamespaceDeclarationSyntax)compilationUnitWithoutBlankLine.Members[0];
@@ -194,11 +215,11 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
             return compilationUnitWithoutBlankLine.ReplaceNode(namespaceDeclaration, namespaceDeclarationWithUsings);
         }
 
-        private static CompilationUnitSyntax MoveUsingsOutsideNamespaces(CompilationUnitSyntax compilationUnit, SyntaxAnnotation warningAnnotation)
+        private static CompilationUnitSyntax MoveUsingsOutsideNamespaces(CompilationUnitSyntax compilationUnit)
         {
             var namespaceDeclarations = compilationUnit.Members.OfType<BaseNamespaceDeclarationSyntax>();
             var namespaceDeclarationMap = namespaceDeclarations.ToDictionary(
-                namespaceDeclaration => namespaceDeclaration, namespaceDeclaration => RemoveUsingsFromNamespace(namespaceDeclaration));
+                namespaceDeclaration => namespaceDeclaration, RemoveUsingsFromNamespace);
 
             // Replace the namespace declarations in the compilation with the ones without using directives.
             var compilationUnitWithReplacedNamespaces = compilationUnit.ReplaceNodes(
@@ -206,7 +227,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
 
             // Get the using directives from the namespaces and set them up to format when moved.
             var usingsToAdd = namespaceDeclarationMap.Values.SelectMany(result => result.usingsFromNamespace)
-                .Select(directive => directive.WithAdditionalAnnotations(Formatter.Annotation, warningAnnotation));
+                .Select(directive => directive.WithAdditionalAnnotations(Formatter.Annotation, s_warningAnnotation));
 
             var (deduplicatedUsings, orphanedTrivia) = RemoveDuplicateUsings(compilationUnit.Usings, usingsToAdd.ToImmutableArray());
 
@@ -227,7 +248,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
             return compilationUnitWithSeparatorLine.ReplaceNode(firstMember, firstMember.WithPrependedLeadingTrivia(orphanedTrivia));
         }
 
-        private static (BaseNamespaceDeclarationSyntax namespaceWithoutUsings, IEnumerable<UsingDirectiveSyntax> usingsFromNamespace) RemoveUsingsFromNamespace(
+        private static (BaseNamespaceDeclarationSyntax namespaceWithoutUsings, ImmutableArray<UsingDirectiveSyntax> usingsFromNamespace) RemoveUsingsFromNamespace(
             BaseNamespaceDeclarationSyntax usingContainer)
         {
             var namespaceDeclarations = usingContainer.Members.OfType<BaseNamespaceDeclarationSyntax>();
@@ -236,7 +257,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
 
             // Get the using directives from the namespaces.
             var usingsFromNamespaces = namespaceDeclarationMap.Values.SelectMany(result => result.usingsFromNamespace);
-            var allUsings = usingContainer.Usings.AsEnumerable().Concat(usingsFromNamespaces);
+            var allUsings = usingContainer.Usings.AsEnumerable().Concat(usingsFromNamespaces).ToImmutableArray();
 
             // Replace the namespace declarations in the compilation with the ones without using directives.
             var namespaceDeclarationWithReplacedNamespaces = usingContainer.ReplaceNodes(
@@ -296,18 +317,14 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
         {
             var members = GetMembers(node);
             if (members.Count == 0)
-            {
                 return node;
-            }
 
             var firstMember = members.First();
             var firstMemberTrivia = firstMember.GetLeadingTrivia();
 
             // If there is no leading trivia, then return the node as it is.
             if (firstMemberTrivia.Count == 0)
-            {
                 return node;
-            }
 
             var newTrivia = SplitIntoLines(firstMemberTrivia)
                 .SkipWhile(trivia => trivia.All(t => t.IsWhitespaceOrEndOfLine()) && trivia.Last().IsKind(SyntaxKind.EndOfLineTrivia))
@@ -339,18 +356,14 @@ namespace Microsoft.CodeAnalysis.CSharp.MisplacedUsingDirectives
         {
             var members = GetMembers(node);
             if (members.Count == 0)
-            {
                 return node;
-            }
 
             var firstMember = members.First();
             var firstMemberTrivia = firstMember.GetLeadingTrivia();
 
             // If the first member already contains a leading new line then, this will already break up the usings from these members.
             if (firstMemberTrivia.Count > 0 && firstMemberTrivia.First().IsKind(SyntaxKind.EndOfLineTrivia))
-            {
                 return node;
-            }
 
             var newFirstMember = firstMember.WithLeadingTrivia(firstMemberTrivia.Insert(0, SyntaxFactory.CarriageReturnLineFeed));
             return node.ReplaceNode(firstMember, newFirstMember);

--- a/src/Analyzers/CSharp/Tests/CSharpAnalyzers.UnitTests.projitems
+++ b/src/Analyzers/CSharp/Tests/CSharpAnalyzers.UnitTests.projitems
@@ -50,7 +50,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)MakeFieldReadonly\MakeFieldReadonlyTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MakeLocalFunctionStatic\MakeLocalFunctionStaticTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MakeStructFieldsWritable\MakeStructFieldsWritableTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)MisplacedUsingDirectives\MisplacedUsingDirectivesCodeFixProviderTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)MisplacedUsingDirectives\MisplacedUsingDirectivesTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OrderModifiers\OrderModifiersCompilerErrorTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OrderModifiers\OrderModifiersTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RemoveConfusingSuppression\RemoveConfusingSuppressionTests.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/61773