### PR TITLE
Add ExternalAccess name recommender API for Pythia

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationName/DeclarationNameRecommender.NameGenerator.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationName/DeclarationNameRecommender.NameGenerator.cs
@@ -8,7 +8,6 @@ using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 using Words = System.Collections.Immutable.ImmutableArray<string>;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers.DeclarationName

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationName/DeclarationNameRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationName/DeclarationNameRecommender.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
@@ -16,6 +18,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.LanguageService;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -24,8 +27,14 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers.DeclarationName
 {
-    internal partial class DeclarationNameRecommender
+    [ExportDeclarationNameRecommender(nameof(DeclarationNameRecommender)), Shared]
+    internal sealed partial class DeclarationNameRecommender : IDeclarationNameRecommender
     {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public DeclarationNameRecommender()
+        { }
+
         public async Task<ImmutableArray<(string name, Glyph glyph)>> ProvideRecommendedNamesAsync(
             CompletionContext completionContext,
             Document document,
@@ -90,40 +99,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers.DeclarationName
             }
 
             return !type.IsSpecialType();
-        }
-
-        private static Glyph GetGlyph(SymbolKind kind, Accessibility? declaredAccessibility)
-        {
-            var publicIcon = kind switch
-            {
-                SymbolKind.Field => Glyph.FieldPublic,
-                SymbolKind.Local => Glyph.Local,
-                SymbolKind.Method => Glyph.MethodPublic,
-                SymbolKind.Parameter => Glyph.Parameter,
-                SymbolKind.Property => Glyph.PropertyPublic,
-                SymbolKind.RangeVariable => Glyph.RangeVariable,
-                SymbolKind.TypeParameter => Glyph.TypeParameter,
-                _ => throw ExceptionUtilities.UnexpectedValue(kind),
-            };
-
-            switch (declaredAccessibility)
-            {
-                case Accessibility.Private:
-                    publicIcon += Glyph.ClassPrivate - Glyph.ClassPublic;
-                    break;
-
-                case Accessibility.Protected:
-                case Accessibility.ProtectedAndInternal:
-                case Accessibility.ProtectedOrInternal:
-                    publicIcon += Glyph.ClassProtected - Glyph.ClassPublic;
-                    break;
-
-                case Accessibility.Internal:
-                    publicIcon += Glyph.ClassInternal - Glyph.ClassPublic;
-                    break;
-            }
-
-            return publicIcon;
         }
 
         private (ITypeSymbol, bool plural) UnwrapType(ITypeSymbol type, Compilation compilation, bool wasPlural, HashSet<ITypeSymbol> seenTypes)
@@ -229,13 +204,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers.DeclarationName
                 PooledHashSet<string> seenUniqueNames,
                 CancellationToken cancellationToken)
             {
-                // There's no special glyph for local functions.
-                // We don't need to differentiate them at this point.
-                var symbolKind =
-                    kind.SymbolKind.HasValue ? kind.SymbolKind.Value :
-                    kind.MethodKind.HasValue ? SymbolKind.Method :
-                    throw ExceptionUtilities.Unreachable();
-
                 var modifiers = declarationInfo.Modifiers;
                 foreach (var rule in rules)
                 {
@@ -259,8 +227,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers.DeclarationName
                                     filter: s => IsRelevantSymbolKind(s),
                                     usedNames: Enumerable.Empty<string>(),
                                     cancellationToken: cancellationToken);
+
                                 if (seenUniqueNames.Add(uniqueName.Text))
-                                    result.Add((uniqueName.Text, GetGlyph(symbolKind, declarationInfo.DeclaredAccessibility)));
+                                {
+                                    result.Add((uniqueName.Text,
+                                        NameDeclarationInfo.GetGlyph(NameDeclarationInfo.GetSymbolKind(kind), declarationInfo.DeclaredAccessibility)));
+                                }
                             }
                         }
 
@@ -303,7 +275,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers.DeclarationName
                     if (!currentParameterNames.Contains(overloadParameter.Name) &&
                         methodParameterType.Equals(overloadParameter.Type, SymbolEqualityComparer.Default))
                     {
-                        result.Add((overloadParameter.Name, GetGlyph(SymbolKind.Parameter, declarationInfo.DeclaredAccessibility)));
+                        result.Add((overloadParameter.Name, NameDeclarationInfo.GetGlyph(SymbolKind.Parameter, declarationInfo.DeclaredAccessibility)));
                     }
                 }
             }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationName/ExportDeclarationNameRecommenderAttribute.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationName/ExportDeclarationNameRecommenderAttribute.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers.DeclarationName
+{
+    [MetadataAttribute]
+    [AttributeUsage(AttributeTargets.Class)]
+    internal sealed class ExportDeclarationNameRecommenderAttribute : ExportAttribute
+    {
+        public string Name { get; }
+
+        public ExportDeclarationNameRecommenderAttribute(string name)
+            : base(typeof(IDeclarationNameRecommender))
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationName/IDeclarationNameRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/DeclarationName/IDeclarationNameRecommender.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers.DeclarationName
+{
+    internal interface IDeclarationNameRecommender
+    {
+        Task<ImmutableArray<(string name, Glyph glyph)>> ProvideRecommendedNamesAsync(
+            CompletionContext completionContext,
+            Document document,
+            CSharpSyntaxContext context,
+            NameDeclarationInfo nameInfo,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/Features/CSharp/Portable/ExternalAccess/Pythia/Api/IPythiaDeclarationNameRecommenderImplmentation.cs
+++ b/src/Features/CSharp/Portable/ExternalAccess/Pythia/Api/IPythiaDeclarationNameRecommenderImplmentation.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Completion.Providers.DeclarationName;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp.ExternalAccess.Pythia.Api
+{
+    internal interface IPythiaDeclarationNameRecommenderImplmentation
+    {
+        /// <summary>
+        /// Order of returned recommendation decides the order of those items in completion list
+        /// </summary>
+        public Task<ImmutableArray<string>> ProvideRecommendationsAsync(PythiaDeclarationNameContext context, CancellationToken cancellationToken);
+    }
+
+    internal readonly struct PythiaDeclarationNameContext
+    {
+        private readonly CSharpSyntaxContext _context;
+
+        public Document Document => _context.Document;
+
+        public int Position => _context.Position;
+
+        public SemanticModel SemanticModel => _context.SemanticModel;
+
+        /// <summary>
+        /// The token to the left of <see cref="Position"/>. This token may be touching the position.
+        /// </summary>
+        public SyntaxToken LeftToken => _context.LeftToken;
+
+        public PythiaDeclarationNameContext(CSharpSyntaxContext context)
+        {
+            _context = context;
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/ExternalAccess/Pythia/PythiaDeclarationNameRecommender.cs
+++ b/src/Features/CSharp/Portable/ExternalAccess/Pythia/PythiaDeclarationNameRecommender.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp.Completion.Providers.DeclarationName;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.CSharp.ExternalAccess.Pythia.Api;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.CSharp.ExternalAccess.Pythia
+{
+    [ExportDeclarationNameRecommender(nameof(PythiaDeclarationNameRecommender)), Shared]
+    [ExtensionOrder(Before = nameof(DeclarationNameRecommender))]
+    internal sealed class PythiaDeclarationNameRecommender : IDeclarationNameRecommender
+    {
+        private readonly Lazy<IPythiaDeclarationNameRecommenderImplmentation>? _lazyImplementation;
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public PythiaDeclarationNameRecommender([Import(AllowDefault = true)] Lazy<IPythiaDeclarationNameRecommenderImplmentation>? implementation)
+            => _lazyImplementation = implementation;
+
+        public async Task<ImmutableArray<(string name, Glyph glyph)>> ProvideRecommendedNamesAsync(
+            CompletionContext completionContext,
+            Document document,
+            CSharpSyntaxContext syntaxContext,
+            NameDeclarationInfo nameInfo,
+            CancellationToken cancellationToken)
+        {
+            if (_lazyImplementation is null || nameInfo.PossibleSymbolKinds.IsEmpty)
+                return ImmutableArray<(string, Glyph)>.Empty;
+
+            var context = new PythiaDeclarationNameContext(syntaxContext);
+
+            var _ = ArrayBuilder<(string, Glyph)>.GetInstance(out var builder);
+            var result = await _lazyImplementation.Value.ProvideRecommendationsAsync(context, cancellationToken).ConfigureAwait(false);
+            // We just pick the first possible symbol kind for glyph.
+            builder.AddRange(result.Select(name
+                => (name, NameDeclarationInfo.GetGlyph(NameDeclarationInfo.GetSymbolKind(nameInfo.PossibleSymbolKinds[0]), nameInfo.DeclaredAccessibility))));
+
+            return builder.ToImmutable();
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/ExternalAccess/Pythia/PythiaSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/ExternalAccess/Pythia/PythiaSignatureHelpProvider.cs
@@ -19,8 +19,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Pythia
     /// Ensure this is ordered before the regular invocation signature help provider.
     /// We must replace the entire list of results, including both Pythia and non-Pythia recommendations.
     /// </summary>
-    [ExportSignatureHelpProvider("PythiaSignatureHelpProvider", LanguageNames.CSharp), Shared]
-    [ExtensionOrder(Before = "InvocationExpressionSignatureHelpProvider")]
+    [ExportSignatureHelpProvider(nameof(PythiaSignatureHelpProvider), LanguageNames.CSharp), Shared]
+    [ExtensionOrder(Before = nameof(InvocationExpressionSignatureHelpProvider))]
     internal sealed class PythiaSignatureHelpProvider : InvocationExpressionSignatureHelpProviderBase
     {
         private readonly Lazy<IPythiaSignatureHelpProviderImplementation> _lazyImplementation;


### PR DESCRIPTION
Provide API to IntelliCode so they can participate in suggesting declaration names.