### PR TITLE
Skip `FunctionTypeSymbol`'s in `BoundNode.Dump()`

### DIFF
--- a/src/Compilers/Core/Portable/TreeDumper.cs
+++ b/src/Compilers/Core/Portable/TreeDumper.cs
@@ -122,6 +122,11 @@ namespace Microsoft.CodeAnalysis
                     return true;
                 }
 
+                if (node.Text is "functionType")
+                {
+                    return true;
+                }
+
                 return false;
             }
         }


### PR DESCRIPTION
`.ToString()` throws an unreachable exception (because we rely on `FunctionTypeSymbol.ISymbol`) so `BoundNode.Dump()` fails any time it contains a `FunctionTypeSymbol`. This is a simple workaround.