### PR TITLE
Add OnError handling for CoreCompile

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
@@ -165,6 +165,7 @@
     </ItemGroup>
 
     <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''" />
+    <OnError ExecuteTargets="$(TargetsTriggeredByFailedCompilation)" Condition="'$(TargetsTriggeredByFailedCompilation )' != ''" />
   </Target>
 
   <!-- When we load a project in Visual Studio, the project system first does an evaluation pass of the


### PR DESCRIPTION
Issue: https://github.com/dotnet/roslyn/issues/65085
Add the ability to handle CoreCompile CSC task failure.