### PR TITLE
Use AzDO timeline logging commands

### DIFF
--- a/src/Tools/Source/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/Source/RunTests/AssemblyScheduler.cs
@@ -78,7 +78,7 @@ namespace RunTests
             if (testHistory.IsEmpty)
             {
                 // We didn't have any test history from azure devops, just partition by test count.
-                ConsoleUtil.WriteLine($"##[warning]Could not look up test history - partitioning based on test count instead");
+                ConsoleUtil.Warning($"Could not look up test history - partitioning based on test count instead");
                 var workItemsByMethodCount = BuildWorkItems<int>(
                     orderedTypeInfos,
                     isOverLimitFunc: (accumulatedMethodCount) => accumulatedMethodCount >= s_maxMethodCount,
@@ -281,7 +281,7 @@ namespace RunTests
                 {
                     // Log a warning to the console with work item details when we were not able to partition in under our limit.
                     // This can happen when a single specific test exceeds our execution time limit.
-                    ConsoleUtil.WriteLine($"##[warning]Work item {workItem.PartitionIndex} estimated execution {totalExecutionTime} time exceeds max execution time {s_maxExecutionTime}.");
+                    ConsoleUtil.Warning($"Work item {workItem.PartitionIndex} estimated execution {totalExecutionTime} time exceeds max execution time {s_maxExecutionTime}.");
                     LogFilters(workItem, ConsoleUtil.WriteLine);
                 }
                 else

--- a/src/Tools/Source/RunTests/ConsoleUtil.cs
+++ b/src/Tools/Source/RunTests/ConsoleUtil.cs
@@ -24,6 +24,13 @@ namespace RunTests
             Logger.Log("");
         }
 
+        internal static void Warning(string message)
+        {
+            Console.Write("##vso[task.logissue type=warning]");
+            Console.WriteLine(message);
+            Logger.LogWarning(message);
+        }
+
         internal static void WriteLine(string message)
         {
             Console.WriteLine(message);

--- a/src/Tools/Source/RunTests/Logger.cs
+++ b/src/Tools/Source/RunTests/Logger.cs
@@ -18,6 +18,14 @@ namespace RunTests
 
         internal static bool HasErrors => s_hasErrors;
 
+        internal static void LogWarning(string line)
+        {
+            lock (s_lines)
+            {
+                s_lines.Add($"Warning: {line}");
+            }
+        }
+
         internal static void LogError(Exception ex, string line)
         {
             lock (s_lines)


### PR DESCRIPTION
This changes the warnings issued by RunTests to use the timeline logging format. That means they will be easily accessible in mass when looking at a build rather than having to dig into every single build log file to find them. Will make it easier for us to triage and address them.

Bonus: they'll show up in runfo summaries