### PR TITLE
Semantic Snippets - Fix snippet priority in completion list

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/Snippets/SnippetCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/SnippetCompletionItem.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
                 properties: props,
                 isComplexTextEdit: true,
                 inlineDescription: inlineDescription,
-                rules: CompletionItemRules.Default)
+                rules: CompletionItemRules.Default.WithMatchPriority(MatchPriority.Deprioritize))
                 .WithAdditionalFilterTexts(additionalFilterTexts);
         }
 

--- a/src/Features/Core/Portable/Completion/Providers/Snippets/SnippetCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/SnippetCompletionItem.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers.Snippets
                 properties: props,
                 isComplexTextEdit: true,
                 inlineDescription: inlineDescription,
-                rules: CompletionItemRules.Default.WithMatchPriority(MatchPriority.Deprioritize))
+                rules: CompletionItemRules.Default)
                 .WithAdditionalFilterTexts(additionalFilterTexts);
         }
 

--- a/src/Features/Core/Portable/Completion/Providers/Snippets/SnippetCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/SnippetCompletionItem.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;

--- a/src/Features/Core/Portable/Completion/Providers/Snippets/SnippetCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/Providers/Snippets/SnippetCompletionItem.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Snippets
 
         public override string SnippetDescription => FeaturesResources.console_writeline;
 
-        public override ImmutableArray<string> AdditionalFilterTexts { get; } = ImmutableArray.Create("Console", "WriteLine");
+        public override ImmutableArray<string> AdditionalFilterTexts { get; } = ImmutableArray.Create("WriteLine");
 
         protected override async Task<bool> IsValidSnippetLocationAsync(Document document, int position, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Made the snippet priority lower in the completion list as well as removed the Console keyword from the list of applicable FilterTexts. 