### PR TITLE
Additional ref fields tests

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -2192,7 +2192,7 @@ class Program
             Assert.True(comp.Assembly.RuntimeSupportsByRefFields);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(CoreClrOnly))]
         [CombinatorialData]
         public void RefAssembly(bool includePrivateMembers)
         {
@@ -2252,7 +2252,12 @@ public class B
     }
 }";
             // Requires full assembly for A at runtime.
-            CompileAndVerify(sourceC, references: new[] { refB, compA.EmitToImageReference() }, targetFramework: TargetFramework.Net70, expectedOutput: @"((3, 4), (4, 3))");
+            CompileAndVerify(
+                sourceC,
+                references: new[] { refB, compA.EmitToImageReference() },
+                targetFramework: TargetFramework.Net70,
+                verify: Verification.Skipped,
+                expectedOutput: @"((3, 4), (4, 3))");
 
             static void verifyFields(NamedTypeSymbol type, string[] expectedFields)
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -1702,8 +1702,7 @@ ref struct R
 }");
         }
 
-        // Test skipped because we don't allow faking runtime feature flags when using specific TargetFramework
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/61463"), WorkItem(63018, "https://github.com/dotnet/roslyn/issues/63018")]
+        [Fact, WorkItem(63018, "https://github.com/dotnet/roslyn/issues/63018")]
         public void InitRefField_UnsafeNullRef()
         {
             var source = """
@@ -1724,7 +1723,7 @@ ref struct R
     }
 }
 """;
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net60, options: TestOptions.ReleaseExe);
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70, options: TestOptions.ReleaseExe);
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, verify: Verification.Skipped, expectedOutput: IncludeExpectedOutput("explicit ctor"));
             verifier.VerifyIL("R..ctor()", @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -1380,18 +1380,18 @@ class C
     public void RefFields()
     {
         var source = """
-                #pragma warning disable 649
-                internal ref struct R1<T>
-                {
-                    internal required ref T F1;
-                    public R1() { }
-                }
-                public ref struct R2<U>
-                {
-                    public required ref readonly U F2;
-                    public R2() { }
-                }
-                """;
+            #pragma warning disable 649
+            internal ref struct R1<T>
+            {
+                internal required ref T F1;
+                public R1() { }
+            }
+            public ref struct R2<U>
+            {
+                public required ref readonly U F2;
+                public R2() { }
+            }
+            """;
         var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
         var expectedRequiredMembers = new[] { "R1.F1", "R2.F2" };
         var expectedAttributeLayout = """

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -1376,6 +1376,35 @@ class C
         );
     }
 
+    [Fact]
+    public void RefFields()
+    {
+        var source = """
+                #pragma warning disable 649
+                internal ref struct R1<T>
+                {
+                    internal required ref T F1;
+                    public R1() { }
+                }
+                public ref struct R2<U>
+                {
+                    public required ref readonly U F2;
+                    public R2() { }
+                }
+                """;
+        var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+        var expectedRequiredMembers = new[] { "R1.F1", "R2.F2" };
+        var expectedAttributeLayout = """
+            [RequiredMember] R1<T>
+                    [RequiredMember] ref T R1<T>.F1
+                [RequiredMember] R2<U>
+                    [RequiredMember] ref readonly U R2<U>.F2
+            """;
+        var symbolValidator = ValidateRequiredMembersInModule(expectedRequiredMembers, expectedAttributeLayout);
+        var verifier = CompileAndVerify(comp, verify: Verification.Skipped, sourceSymbolValidator: symbolValidator, symbolValidator: symbolValidator);
+        verifier.VerifyDiagnostics();
+    }
+
     [Theory]
     [InlineData("internal")]
     [InlineData("internal protected")]

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/RefFieldTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/RefFieldTests.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
         ''' <summary>
         ''' Ref field in ref struct.
         ''' </summary>
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/61463")>
+        <Fact>
         Public Sub RefField_01()
             Dim sourceA =
 "public ref struct S<T>
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     public ref T F;
     public S(ref T t) { F = ref t; }
 }"
-            Dim compA = CreateCSharpCompilation(GetUniqueName(), sourceA, parseOptions:=New CSharp.CSharpParseOptions(languageVersion:=CSharp.LanguageVersion.Preview))
+            Dim compA = CreateCSharpCompilation(GetUniqueName(), sourceA, referencedAssemblies:=TargetFrameworkUtil.GetReferences(TargetFramework.Net70))
             compA.VerifyDiagnostics()
             Dim refA = compA.EmitToImageReference()
 
@@ -40,6 +40,9 @@ End Module"
             Dim compB = CreateCompilation(sourceB, references:={refA})
             compB.AssertTheseDiagnostics(<expected>
 BC30668: 'S(Of Integer)' is obsolete: 'Types with embedded references are not supported in this version of your compiler.'.
+        Dim s = New S(Of Integer)()
+                    ~~~~~~~~~~~~~
+BC37319: 'S(Of T)' requires compiler feature 'RefStructs', which is not supported by this version of the Visual Basic compiler.
         Dim s = New S(Of Integer)()
                     ~~~~~~~~~~~~~
 BC30656: Field 'F' is of an unsupported type.
@@ -95,7 +98,7 @@ BC30656: Field 'F' is of an unsupported type.
             Assert.Equal(expectedDisplayString, field.ToTestDisplayString())
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/61463")>
+        <Fact>
         Public Sub MemberRefMetadataDecoder_FindFieldBySignature()
             Dim sourceA =
 ".class public sealed R<T> extends [mscorlib]System.ValueType
@@ -117,7 +120,7 @@ BC30656: Field 'F' is of an unsupported type.
     static object F2() => new R<object>().F2;
     static int F3() => new R<object>().F3;
 }"
-            Dim compB = CreateCSharpCompilation(GetUniqueName(), sourceB, parseOptions:=New CSharp.CSharpParseOptions(languageVersion:=CSharp.LanguageVersion.Preview), referencedAssemblies:={MscorlibRef, refA})
+            Dim compB = CreateCSharpCompilation(GetUniqueName(), sourceB, referencedAssemblies:=TargetFrameworkUtil.GetReferences(TargetFramework.Net70, {refA}))
             compB.VerifyDiagnostics()
             Dim refB = compB.EmitToImageReference()
 


### PR DESCRIPTION
From https://github.com/dotnet/roslyn/issues/59194:

- [x] `ref` fields _are_ emitted as `ref` for reference assemblies ...
- [x] allow updated escape rules with either `-langversion:11` or RuntimeFeature.ByRefFields (i.e. NET 7)
- [x] `required` ref fields
- [x] unskip test `RefFieldTests.InitRefField_UnsafeNullRef`
- [x] unskip tests from RefFieldTests.vb