### PR TITLE
Remove the static ConditionalWeakTable for per-project CompilationWit…

### DIFF
--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -97,7 +97,11 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 // Do not re-use cached CompilationWithAnalyzers instance in presence of an exception, as the underlying analysis state might be corrupt.
                 lock (s_gate)
                 {
-                    s_compilationWithAnalyzersCache.SetTarget(null);
+                    if (s_compilationWithAnalyzersCache.TryGetTarget(out var target) &&
+                        target?.Project == _project)
+                    {
+                        s_compilationWithAnalyzersCache.SetTarget(null);
+                    }
                 }
 
                 throw;

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -24,15 +25,18 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
     {
         /// <summary>
         /// Cache of <see cref="CompilationWithAnalyzers"/> and a map from analyzer IDs to <see cref="DiagnosticAnalyzer"/>s
-        /// for all analyzers for each project.
+        /// for all analyzers for the last project to be analyzed.
         /// The <see cref="CompilationWithAnalyzers"/> instance is shared between all the following document analyses modes for the project:
         ///  1. Span-based analysis for active document (lightbulb)
         ///  2. Background analysis for active and open documents.
         ///  
-        /// NOTE: We do not re-use this cache for project analysis as it leads to significant memory increase in the OOP process,
-        /// and CWT does not seem to drop entries until ForceGC happens.
+        /// NOTE: We do not re-use this cache for project analysis as it leads to significant memory increase in the OOP process.
+        /// Additionally, we only store the cache entry for the last project to be analyzed instead of maintaining a CWT keyed off
+        /// each project in the solution, as the CWT does not seem to drop entries until ForceGC happens, leading to significant memory
+        /// pressure when there are large number of open documents across different projects to be analyzed by background analysis.
         /// </summary>
-        private static readonly ConditionalWeakTable<Project, CompilationWithAnalyzersCacheEntry> s_compilationWithAnalyzersCache = new();
+        private static readonly WeakReference<CompilationWithAnalyzersCacheEntry?> s_compilationWithAnalyzersCache = new(null);
+        private static readonly object s_gate = new();
 
         private readonly TextDocument? _document;
         private readonly Project _project;
@@ -91,7 +95,11 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             catch
             {
                 // Do not re-use cached CompilationWithAnalyzers instance in presence of an exception, as the underlying analysis state might be corrupt.
-                s_compilationWithAnalyzersCache.Remove(_project);
+                lock (s_gate)
+                {
+                    s_compilationWithAnalyzersCache.SetTarget(null);
+                }
+
                 throw;
             }
         }
@@ -222,13 +230,23 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                     return await CreateCompilationWithAnalyzersCacheEntryAsync(cancellationToken).ConfigureAwait(false);
                 }
 
-                if (s_compilationWithAnalyzersCache.TryGetValue(_project, out var data))
+                lock (s_gate)
                 {
-                    return data;
+                    if (s_compilationWithAnalyzersCache.TryGetTarget(out var target) &&
+                        target?.Project == _project)
+                    {
+                        return target;
+                    }
                 }
 
-                data = await CreateCompilationWithAnalyzersCacheEntryAsync(cancellationToken).ConfigureAwait(false);
-                return s_compilationWithAnalyzersCache.GetValue(_project, _ => data);
+                var entry = await CreateCompilationWithAnalyzersCacheEntryAsync(cancellationToken).ConfigureAwait(false);
+
+                lock (s_gate)
+                {
+                    s_compilationWithAnalyzersCache.SetTarget(entry);
+                }
+
+                return entry;
             }
         }
 
@@ -257,7 +275,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             var compilationWithAnalyzers = await CreateCompilationWithAnalyzerAsync(analyzerBuilder.ToImmutable(), cancellationToken).ConfigureAwait(false);
             var analyzerToIdMap = new BidirectionalMap<string, DiagnosticAnalyzer>(analyzerMapBuilder);
 
-            return new CompilationWithAnalyzersCacheEntry(compilationWithAnalyzers, analyzerToIdMap);
+            return new CompilationWithAnalyzersCacheEntry(_project, compilationWithAnalyzers, analyzerToIdMap);
         }
 
         private async Task<CompilationWithAnalyzers> CreateCompilationWithAnalyzerAsync(ImmutableArray<DiagnosticAnalyzer> analyzers, CancellationToken cancellationToken)
@@ -290,11 +308,13 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
 
         private sealed class CompilationWithAnalyzersCacheEntry
         {
+            public Project Project { get; }
             public CompilationWithAnalyzers CompilationWithAnalyzers { get; }
             public BidirectionalMap<string, DiagnosticAnalyzer> AnalyzerToIdMap { get; }
 
-            public CompilationWithAnalyzersCacheEntry(CompilationWithAnalyzers compilationWithAnalyzers, BidirectionalMap<string, DiagnosticAnalyzer> analyzerToIdMap)
+            public CompilationWithAnalyzersCacheEntry(Project project, CompilationWithAnalyzers compilationWithAnalyzers, BidirectionalMap<string, DiagnosticAnalyzer> analyzerToIdMap)
             {
+                Project = project;
                 CompilationWithAnalyzers = compilationWithAnalyzers;
                 AnalyzerToIdMap = analyzerToIdMap;
             }


### PR DESCRIPTION
…hAnalyzers in the OOP process

Fixes [AB#1549502](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549502)

Currently, we maintain a static CWT to cache the per-project CompilationWithAnalyzers instance for analyzer execution in the OOP process. The primary goal is to share the same CompilationWithAnalyzers instance for document analysis for active and open documents in the project. Before this CWT was introduced, we used a fresh CompilationWithAnalayzers instance (and hence a fresh compilation instance) for every open document analyzed in background, which led to a huge performance overhead in creating compilations. However, it seems that the CWT approach is leading to the opposite problem of us holding onto too much of memory when the number of projects/open documents are large. Analysis of [AB#1549502](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1549502) shows more than 100+ instances of CompilationWithAnalyzers instances in the CWT.

This PR switches the OOP DiagnosticComputer to an in-between caching approach by only caching the CompilationWithAnalyzers instance for the last project to be analyzed. This allows us to re-use the CompilationWithAnalyzers instance for open document analysis while also not holding onto it in memory for too long. Solution crawler background analysis already ensures that it goes project by project for computing open document diagnostics, and the LSP-based diagnostics host that eventually replaces the solution crawler should take a similar approach to maximize the re-use of this cache.

Even if the approach taken in this PR turns out to be insufficient to give optimal performance characteristics, we definitely want to move away from the CWT based approach as that is definitely problematic for large solutions with many open documents as shown by the above perf bug.