### PR TITLE
Harden FileLogger against all kind of exceptions during File IO

### DIFF
--- a/src/VisualStudio/Core/Def/Telemetry/FileLogger.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/FileLogger.cs
@@ -94,9 +94,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
                         File.AppendAllText(_logFilePath, _buffer.ToString());
                         _buffer.Clear();
                     }
-                    catch (IOException)
+                    catch (Exception)
                     {
-                        // Ignore IOException, we will log the buffer contents in next Log call.
+                        // Ignore all possible exceptions that can be thrown by File IO operations, such as IOException,
+                        // UnauthorizedAccessException, SecurityException, etc.
+                        // We will log the buffer contents in next Log call.
                     }
                 }
             }, CancellationToken.None);

--- a/src/VisualStudio/Core/Def/Telemetry/FileLogger.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/FileLogger.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Telemetry
 {
@@ -84,7 +85,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
                 {
                     _buffer.AppendLine($"{DateTime.Now} ({functionId}) : {message}");
 
-                    try
+                    IOUtilities.PerformIO(() =>
                     {
                         if (!File.Exists(_logFilePath))
                         {
@@ -93,13 +94,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
 
                         File.AppendAllText(_logFilePath, _buffer.ToString());
                         _buffer.Clear();
-                    }
-                    catch (Exception)
-                    {
-                        // Ignore all possible exceptions that can be thrown by File IO operations, such as IOException,
-                        // UnauthorizedAccessException, SecurityException, etc.
-                        // We will log the buffer contents in next Log call.
-                    }
+                    });
                 }
             }, CancellationToken.None);
         }

--- a/src/VisualStudio/Core/Def/Telemetry/FileLogger.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/FileLogger.cs
@@ -9,11 +9,11 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
-using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Telemetry
 {


### PR DESCRIPTION
Fixes [AB#1557188](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1557188)

`File.AppendAllText` invoked in the `FileLogger.Log` can throw exceptions that are not sub-types of `IOException`, such as UnauthorizedAccessException, SecurityException, etc. Ensure that we catch and ignore all exceptions.