### PR TITLE
Fix assert in RemoveUnusedMembersDiagnosticAnalyzer

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedMembers/RemoveUnusedMembersTests.cs
@@ -1216,6 +1216,23 @@ class C
             await VerifyCS.VerifyCodeFixAsync(code, code);
         }
 
+        [Fact, WorkItem(48247, "https://github.com/dotnet/roslyn/issues/48247")]
+        public async Task GenericMethodInDocComment()
+        {
+            var code = @"
+class C<T>
+{
+    /// <summary>
+    /// <see cref=""C{Int32}.M2()""/>
+    /// </summary>
+    public void M1() { }
+
+    private void {|IDE0052:M2|}() { }
+}";
+
+            await VerifyCS.VerifyCodeFixAsync(code, code);
+        }
+
         [Fact]
         public async Task FieldIsOnlyWritten()
         {

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs
@@ -537,7 +537,7 @@ namespace Microsoft.CodeAnalysis.RemoveUnusedMembers
                                              .SelectMany(n => n.DescendantNodes().OfType<TIdentifierNameSyntax>()))
                     {
                         lazyModel ??= compilation.GetSemanticModel(root.SyntaxTree);
-                        var symbol = lazyModel.GetSymbolInfo(node, cancellationToken).Symbol;
+                        var symbol = lazyModel.GetSymbolInfo(node, cancellationToken).Symbol?.OriginalDefinition;
                         if (symbol != null && IsCandidateSymbol(symbol))
                         {
                             builder.Add(symbol);


### PR DESCRIPTION
Fixes #48247
Use symbol's OriginalDefinition when scanning symbol references in documentation comments.

Verified that the below assert fires for the added unit test prior to the product change: https://github.com/dotnet/roslyn/blob/523201c0e50900433b4b9d5bf9840d890beb88d6/src/Analyzers/Core/Analyzers/RemoveUnusedMembers/AbstractRemoveUnusedMembersDiagnosticAnalyzer.cs#L609-L611