### PR TITLE
Remove duplicate property

### DIFF
--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -95,13 +95,13 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
         private class TestGeneratorReferenceWithFilePathEquality : TestGeneratorReference, IEquatable<AnalyzerReference>
         {
-            public TestGeneratorReferenceWithFilePathEquality(ISourceGenerator generator, string analyzerFilePath) : base(generator)
+            public TestGeneratorReferenceWithFilePathEquality(ISourceGenerator generator, string analyzerFilePath)
+                : base(generator, analyzerFilePath)
             {
-                FullPath = analyzerFilePath;
             }
 
             public override bool Equals(object? obj) => Equals(obj as AnalyzerReference);
-            public override string FullPath { get; }
+            public override string FullPath => base.FullPath!; // This derived class always has this non-null
             public override int GetHashCode() => this.FullPath.GetHashCode();
 
             public bool Equals(AnalyzerReference? other)


### PR DESCRIPTION
Cleaning this up -- this derived class was added in our 17.4 branch but the base class's argument for the file path didn't exist yet.