### PR TITLE
Implement `EEMethodSymbol.DeclaringSyntaxReferences`

### DIFF
--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
         {
-            get { return Symbol.GetDeclaringSyntaxReferenceHelper<CSharpSyntaxNode>(_locations); }
+            get { return GetDeclaringSyntaxReferenceHelper<CSharpSyntaxNode>(_locations); }
         }
 
         public override Accessibility DeclaredAccessibility

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
         {
-            get { return ImmutableArray.Create(CSharpSyntaxTree.Dummy.GetRoot().GetReference()); }
+            get { return Symbol.GetDeclaringSyntaxReferenceHelper<CSharpSyntaxNode>(_locations); }
         }
 
         public override Accessibility DeclaredAccessibility

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
         {
-            get { throw ExceptionUtilities.Unreachable(); }
+            get { return ImmutableArray.Create(CSharpSyntaxTree.Dummy.GetRoot().GetReference()); }
         }
 
         public override Accessibility DeclaredAccessibility

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -6986,5 +6986,28 @@ class Program
   IL_0009:  ret
 }");
         }
+
+        [Fact, WorkItem(65165, "https://github.com/dotnet/roslyn/issues/65165")]
+        public void EEMethodSymbol_DeclaringSyntaxReferences()
+        {
+            var source = @"
+class Program
+{
+    static void Main()
+    {
+    }
+}";
+            Evaluate(source, OutputKind.ConsoleApplication, "Program.Main", """1 switch { 1 => "hello" }""").GetMethodData("<>x.<>m0").VerifyIL("""
+{
+  // Code size        8 (0x8)
+  .maxstack  1
+  .locals init (string V_0)
+  IL_0000:  ldstr      "hello"
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ret
+}
+""");
+        }
     }
 }

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
@@ -359,7 +359,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         Public Overrides ReadOnly Property DeclaringSyntaxReferences As ImmutableArray(Of SyntaxReference)
             Get
-                Throw ExceptionUtilities.Unreachable
+                Return GetDeclaringSyntaxReferenceHelper(Of VisualBasicSyntaxNode)(_locations)
             End Get
         End Property
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/65165