### PR TITLE
Switch DocumentKinds to a string array

### DIFF
--- a/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
+++ b/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
@@ -891,7 +891,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
 #pragma warning disable RS0034 // Exported parts should be marked with 'ImportingConstructorAttribute'
         [ExportCodeFixProvider(
             LanguageNames.CSharp,
-            DocumentKinds = new[] { TextDocumentKind.AdditionalDocument },
+            DocumentKinds = new[] { nameof(TextDocumentKind.AdditionalDocument) },
             DocumentExtensions = new[] { ".txt" })]
         [Shared]
         internal sealed class AdditionalFileFixerWithDocumentKindsAndExtensions : AbstractAdditionalFileCodeFixProvider
@@ -901,7 +901,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeFixes
 
         [ExportCodeFixProvider(
             LanguageNames.CSharp,
-            DocumentKinds = new[] { TextDocumentKind.AdditionalDocument })]
+            DocumentKinds = new[] { nameof(TextDocumentKind.AdditionalDocument) })]
         [Shared]
         internal sealed class AdditionalFileFixerWithDocumentKinds : AbstractAdditionalFileCodeFixProvider
         {

--- a/src/EditorFeatures/Test/CodeRefactorings/CodeRefactoringServiceTest.cs
+++ b/src/EditorFeatures/Test/CodeRefactorings/CodeRefactoringServiceTest.cs
@@ -265,7 +265,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeRefactoringService
 #pragma warning disable RS0034 // Exported parts should be marked with 'ImportingConstructorAttribute'
         [ExportCodeRefactoringProvider(
             LanguageNames.CSharp,
-            DocumentKinds = new[] { TextDocumentKind.AdditionalDocument, TextDocumentKind.AnalyzerConfigDocument },
+            DocumentKinds = new[] { nameof(TextDocumentKind.AdditionalDocument), nameof(TextDocumentKind.AnalyzerConfigDocument) },
             DocumentExtensions = new[] { ".txt", ".editorconfig" })]
         [Shared]
         internal sealed class NonSourceFileRefactoringWithDocumentKindsAndExtensions : AbstractNonSourceFileRefactoring
@@ -275,7 +275,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeRefactoringService
 
         [ExportCodeRefactoringProvider(
             LanguageNames.CSharp,
-            DocumentKinds = new[] { TextDocumentKind.AdditionalDocument, TextDocumentKind.AnalyzerConfigDocument })]
+            DocumentKinds = new[] { nameof(TextDocumentKind.AdditionalDocument), nameof(TextDocumentKind.AnalyzerConfigDocument) })]
         [Shared]
         internal sealed class NonSourceFileRefactoringWithDocumentKinds : AbstractNonSourceFileRefactoring
         {

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             }
 
             static ProjectCodeRefactoringProvider.ExtensionInfo GetExtensionInfo(ExportCodeRefactoringProviderAttribute attribute)
-                => new(attribute.DocumentKinds.ToImmutableArray(), attribute.DocumentExtensions);
+                => new(attribute.DocumentKinds, attribute.DocumentExtensions);
         }
 
         public async Task<bool> HasRefactoringsAsync(

--- a/src/Features/Core/Portable/Common/AbstractProjectExtensionProvider.cs
+++ b/src/Features/Core/Portable/Common/AbstractProjectExtensionProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis
         where TExportAttribute : Attribute
         where TExtension : class
     {
-        public record class ExtensionInfo(ImmutableArray<TextDocumentKind> DocumentKinds, string[]? DocumentExtensions);
+        public record class ExtensionInfo(string[] DocumentKinds, string[]? DocumentExtensions);
 
         // Following CWTs are used to cache completion providers from projects' references,
         // so we can avoid the slow path unless there's any change to the references.
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis
                 if (extensionInfo == null)
                     return true;
 
-                if (!extensionInfo.DocumentKinds.Contains(document.Kind))
+                if (!extensionInfo.DocumentKinds.Contains(document.Kind.ToString()))
                     return false;
 
                 if (document.FilePath != null &&

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -941,7 +941,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         }
 
         private static ProjectCodeFixProvider.ExtensionInfo GetExtensionInfo(ExportCodeFixProviderAttribute attribute)
-                => new(attribute.DocumentKinds.ToImmutableArray(), attribute.DocumentExtensions);
+                => new(attribute.DocumentKinds, attribute.DocumentExtensions);
 
         private sealed class FixerComparer : IComparer<CodeFixProvider>
         {

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -3,13 +3,13 @@ Microsoft.CodeAnalysis.CodeFixes.CodeFixContext.CodeFixContext(Microsoft.CodeAna
 Microsoft.CodeAnalysis.CodeFixes.CodeFixContext.TextDocument.get -> Microsoft.CodeAnalysis.TextDocument
 Microsoft.CodeAnalysis.CodeFixes.ExportCodeFixProviderAttribute.DocumentExtensions.get -> string[]
 Microsoft.CodeAnalysis.CodeFixes.ExportCodeFixProviderAttribute.DocumentExtensions.set -> void
-Microsoft.CodeAnalysis.CodeFixes.ExportCodeFixProviderAttribute.DocumentKinds.get -> Microsoft.CodeAnalysis.TextDocumentKind[]
+Microsoft.CodeAnalysis.CodeFixes.ExportCodeFixProviderAttribute.DocumentKinds.get -> string[]
 Microsoft.CodeAnalysis.CodeFixes.ExportCodeFixProviderAttribute.DocumentKinds.set -> void
 Microsoft.CodeAnalysis.CodeRefactorings.CodeRefactoringContext.CodeRefactoringContext(Microsoft.CodeAnalysis.TextDocument document, Microsoft.CodeAnalysis.Text.TextSpan span, System.Action<Microsoft.CodeAnalysis.CodeActions.CodeAction> registerRefactoring, System.Threading.CancellationToken cancellationToken) -> void
 Microsoft.CodeAnalysis.CodeRefactorings.CodeRefactoringContext.TextDocument.get -> Microsoft.CodeAnalysis.TextDocument
 Microsoft.CodeAnalysis.CodeRefactorings.ExportCodeRefactoringProviderAttribute.DocumentExtensions.get -> string[]
 Microsoft.CodeAnalysis.CodeRefactorings.ExportCodeRefactoringProviderAttribute.DocumentExtensions.set -> void
-Microsoft.CodeAnalysis.CodeRefactorings.ExportCodeRefactoringProviderAttribute.DocumentKinds.get -> Microsoft.CodeAnalysis.TextDocumentKind[]
+Microsoft.CodeAnalysis.CodeRefactorings.ExportCodeRefactoringProviderAttribute.DocumentKinds.get -> string[]
 Microsoft.CodeAnalysis.CodeRefactorings.ExportCodeRefactoringProviderAttribute.DocumentKinds.set -> void
 Microsoft.CodeAnalysis.Editing.DeclarationModifiers.IsFile.get -> bool
 Microsoft.CodeAnalysis.Editing.DeclarationModifiers.WithIsFile(bool isFile) -> Microsoft.CodeAnalysis.Editing.DeclarationModifiers

--- a/src/Workspaces/Core/Portable/WorkspacesResources.resx
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.resx
@@ -585,4 +585,7 @@
   <data name="Use_TextDocument_property_instead_of_Document_property_as_the_provider_supports_non_source_text_documents" xml:space="preserve">
     <value>Use 'TextDocument' property instead of 'Document' property as the provider supports non-source text documents.</value>
   </data>
+  <data name="Unexpected_value_0_in_DocumentKinds_array" xml:space="preserve">
+    <value>Unexpected value '{0}' in DocumentKinds array.</value>
+  </data>
 </root>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.cs.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.cs.xlf
@@ -237,6 +237,11 @@
         <target state="translated">Řešení už zadaný odkaz obsahuje.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unexpected_value_0_in_DocumentKinds_array">
+        <source>Unexpected value '{0}' in DocumentKinds array.</source>
+        <target state="new">Unexpected value '{0}' in DocumentKinds array.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>
         <target state="translated">Neznámý</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.de.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.de.xlf
@@ -237,6 +237,11 @@
         <target state="translated">Der angegebene Verweis ist bereits in der Projektmappe enthalten.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unexpected_value_0_in_DocumentKinds_array">
+        <source>Unexpected value '{0}' in DocumentKinds array.</source>
+        <target state="new">Unexpected value '{0}' in DocumentKinds array.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>
         <target state="translated">Unbekannt</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.es.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.es.xlf
@@ -237,6 +237,11 @@
         <target state="translated">La solución ya contiene la referencia especificada.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unexpected_value_0_in_DocumentKinds_array">
+        <source>Unexpected value '{0}' in DocumentKinds array.</source>
+        <target state="new">Unexpected value '{0}' in DocumentKinds array.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>
         <target state="translated">Desconocido</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.fr.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.fr.xlf
@@ -237,6 +237,11 @@
         <target state="translated">La solution contient déjà la référence spécifiée.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unexpected_value_0_in_DocumentKinds_array">
+        <source>Unexpected value '{0}' in DocumentKinds array.</source>
+        <target state="new">Unexpected value '{0}' in DocumentKinds array.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>
         <target state="translated">Inconnue</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.it.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.it.xlf
@@ -237,6 +237,11 @@
         <target state="translated">La soluzione contiene già il riferimento specificato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unexpected_value_0_in_DocumentKinds_array">
+        <source>Unexpected value '{0}' in DocumentKinds array.</source>
+        <target state="new">Unexpected value '{0}' in DocumentKinds array.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>
         <target state="translated">Unbekannt</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ja.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ja.xlf
@@ -237,6 +237,11 @@
         <target state="translated">このソリューションには、指定された参照が既に含まれています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unexpected_value_0_in_DocumentKinds_array">
+        <source>Unexpected value '{0}' in DocumentKinds array.</source>
+        <target state="new">Unexpected value '{0}' in DocumentKinds array.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>
         <target state="translated">不明</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ko.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ko.xlf
@@ -237,6 +237,11 @@
         <target state="translated">지정된 참조가 이미 솔루션에 포함되어 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unexpected_value_0_in_DocumentKinds_array">
+        <source>Unexpected value '{0}' in DocumentKinds array.</source>
+        <target state="new">Unexpected value '{0}' in DocumentKinds array.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>
         <target state="translated">알 수 없음</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pl.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pl.xlf
@@ -237,6 +237,11 @@
         <target state="translated">Rozwiązanie już zawiera określone odwołanie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unexpected_value_0_in_DocumentKinds_array">
+        <source>Unexpected value '{0}' in DocumentKinds array.</source>
+        <target state="new">Unexpected value '{0}' in DocumentKinds array.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>
         <target state="translated">Nieznany</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pt-BR.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.pt-BR.xlf
@@ -237,6 +237,11 @@
         <target state="translated">A solução já contém a referência especificada.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unexpected_value_0_in_DocumentKinds_array">
+        <source>Unexpected value '{0}' in DocumentKinds array.</source>
+        <target state="new">Unexpected value '{0}' in DocumentKinds array.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>
         <target state="translated">Desconhecido</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ru.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.ru.xlf
@@ -237,6 +237,11 @@
         <target state="translated">Решение уже содержит указанную ссылку.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unexpected_value_0_in_DocumentKinds_array">
+        <source>Unexpected value '{0}' in DocumentKinds array.</source>
+        <target state="new">Unexpected value '{0}' in DocumentKinds array.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>
         <target state="translated">Unbekannt</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.tr.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.tr.xlf
@@ -237,6 +237,11 @@
         <target state="translated">Çözüm belirtilen başvuruyu zaten içeriyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unexpected_value_0_in_DocumentKinds_array">
+        <source>Unexpected value '{0}' in DocumentKinds array.</source>
+        <target state="new">Unexpected value '{0}' in DocumentKinds array.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>
         <target state="translated">Bilinmiyor</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hans.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hans.xlf
@@ -237,6 +237,11 @@
         <target state="translated">解决方案已包含指定的引用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unexpected_value_0_in_DocumentKinds_array">
+        <source>Unexpected value '{0}' in DocumentKinds array.</source>
+        <target state="new">Unexpected value '{0}' in DocumentKinds array.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>
         <target state="translated">未知</target>

--- a/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hant.xlf
+++ b/src/Workspaces/Core/Portable/xlf/WorkspacesResources.zh-Hant.xlf
@@ -237,6 +237,11 @@
         <target state="translated">解決方案已包含指定的參考。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unexpected_value_0_in_DocumentKinds_array">
+        <source>Unexpected value '{0}' in DocumentKinds array.</source>
+        <target state="new">Unexpected value '{0}' in DocumentKinds array.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unknown">
         <source>Unknown</source>
         <target state="translated">不明</target>

--- a/src/Workspaces/TestAnalyzerReference/NonSourceFileRefactoring.cs
+++ b/src/Workspaces/TestAnalyzerReference/NonSourceFileRefactoring.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
 #pragma warning disable RS0034 // Exported parts should be marked with 'ImportingConstructorAttribute'
     [ExportCodeRefactoringProvider(
         LanguageNames.CSharp,
-        DocumentKinds = new[] { TextDocumentKind.AdditionalDocument, TextDocumentKind.AnalyzerConfigDocument },
+        DocumentKinds = new[] { nameof(TextDocumentKind.AdditionalDocument), nameof(TextDocumentKind.AnalyzerConfigDocument) },
         DocumentExtensions = new[] { ".txt", ".editorconfig" })]
     [Shared]
     public sealed class NonSourceFileRefactoring : CodeRefactoringProvider


### PR DESCRIPTION
Fixes [AB#1664285](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1664285)

Validation insertion PR [here](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/results?buildId=6915395)

Using `TextDocumentKind[]` in the export attribute causes an RPS regression as the Workspaces assembly gets eagerly loaded.