### PR TITLE
Report analyzer telemetry for lightbulb code path in OOP

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -1063,7 +1063,7 @@ class A
             var project = workspace.CurrentSolution.Projects.Single();
             var document = documentAnalysis ? project.Documents.Single() : null;
             var ideAnalyzerOptions = IdeAnalyzerOptions.GetDefault(project.Services);
-            var diagnosticComputer = new DiagnosticComputer(document, project, ideAnalyzerOptions, span: null, AnalysisKind.Semantic, new DiagnosticAnalyzerInfoCache());
+            var diagnosticComputer = new DiagnosticComputer(document, project, ideAnalyzerOptions, span: null, AnalysisKind.Semantic, new DiagnosticAnalyzerInfoCache(), workspace.Services);
             var diagnosticsMapResults = await diagnosticComputer.GetDiagnosticsAsync(analyzerIdsToRequestDiagnostics, reportSuppressedDiagnostics: false,
                 logPerformanceInfo: false, getTelemetryInfo: false, cancellationToken: CancellationToken.None);
             Assert.False(analyzer2.ReceivedSymbolCallback);
@@ -1110,7 +1110,7 @@ class A
 
             var ideAnalyzerOptions = IdeAnalyzerOptions.GetDefault(project.Services);
             var kind = actionKind == AnalyzerRegisterActionKind.SyntaxTree ? AnalysisKind.Syntax : AnalysisKind.Semantic;
-            var diagnosticComputer = new DiagnosticComputer(document, project, ideAnalyzerOptions, span: null, kind, diagnosticAnalyzerInfoCache);
+            var diagnosticComputer = new DiagnosticComputer(document, project, ideAnalyzerOptions, span: null, kind, diagnosticAnalyzerInfoCache, workspace.Services);
             var analyzerIds = new[] { analyzer.GetAnalyzerId() };
 
             // First invoke analysis with cancellation token, and verify canceled compilation and no reported diagnostics.

--- a/src/Features/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IRemoteDiagnosticAnalyzerService.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     internal interface IRemoteDiagnosticAnalyzerService
     {
         ValueTask<SerializableDiagnosticAnalysisResults> CalculateDiagnosticsAsync(Checksum solutionChecksum, DiagnosticArguments arguments, CancellationToken cancellationToken);
-        ValueTask ReportAnalyzerPerformanceAsync(ImmutableArray<AnalyzerPerformanceInfo> snapshot, int unitCount, CancellationToken cancellationToken);
+        ValueTask ReportAnalyzerPerformanceAsync(ImmutableArray<AnalyzerPerformanceInfo> snapshot, int unitCount, bool forSpanAnalysis, CancellationToken cancellationToken);
         ValueTask StartSolutionCrawlerAsync(CancellationToken cancellationToken);
     }
 

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InProcOrRemoteHostAnalyzerRunner.cs
@@ -137,11 +137,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 // +1 for project itself
                 var count = documentAnalysisScope != null ? 1 : project.DocumentIds.Count + 1;
+                var forSpanAnalysis = documentAnalysisScope?.Span.HasValue ?? false;
 
                 var performanceInfo = analysisResult.AnalyzerTelemetryInfo.ToAnalyzerPerformanceInfo(AnalyzerInfoCache).ToImmutableArray();
 
                 _ = await client.TryInvokeAsync<IRemoteDiagnosticAnalyzerService>(
-                    (service, cancellationToken) => service.ReportAnalyzerPerformanceAsync(performanceInfo, count, cancellationToken),
+                    (service, cancellationToken) => service.ReportAnalyzerPerformanceAsync(performanceInfo, count, forSpanAnalysis, cancellationToken),
                     cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (FatalError.ReportAndCatchUnlessCanceled(ex, cancellationToken))

--- a/src/VisualStudio/Core/Test.Next/Services/PerformanceTrackerServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/PerformanceTrackerServiceTests.cs
@@ -18,40 +18,40 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
 {
     public class PerformanceTrackerServiceTests
     {
-        [Fact]
-        public void TestTooFewSamples()
+        [Theory, CombinatorialData]
+        public void TestTooFewSamples(bool forSpanAnalysis)
         {
             // minimum sample is 100
-            var badAnalyzers = GetBadAnalyzers(@"TestFiles\analyzer_input.csv", to: 80);
+            var badAnalyzers = GetBadAnalyzers(@"TestFiles\analyzer_input.csv", to: 80, forSpanAnalysis);
 
             Assert.Empty(badAnalyzers);
         }
 
-        [Fact]
-        public void TestTracking()
+        [Theory, CombinatorialData]
+        public void TestTracking(bool forSpanAnalysis)
         {
-            var badAnalyzers = GetBadAnalyzers(@"TestFiles\analyzer_input.csv", to: 200);
+            var badAnalyzers = GetBadAnalyzers(@"TestFiles\analyzer_input.csv", to: 200, forSpanAnalysis);
 
             VerifyBadAnalyzer(badAnalyzers[0], "CSharpRemoveUnnecessaryCastDiagnosticAnalyzer", 101.244432561581, 54.48, 21.8163001442628);
             VerifyBadAnalyzer(badAnalyzers[1], "CSharpInlineDeclarationDiagnosticAnalyzer", 49.9389715502954, 26.6686092715232, 9.2987133054884);
             VerifyBadAnalyzer(badAnalyzers[2], "VisualBasicRemoveUnnecessaryCastDiagnosticAnalyzer", 42.0967360557792, 23.277619047619, 7.25464266261805);
         }
 
-        [Fact]
-        public void TestTrackingMaxSample()
+        [Theory, CombinatorialData]
+        public void TestTrackingMaxSample(bool forSpanAnalysis)
         {
-            var badAnalyzers = GetBadAnalyzers(@"TestFiles\analyzer_input.csv", to: 300);
+            var badAnalyzers = GetBadAnalyzers(@"TestFiles\analyzer_input.csv", to: 300, forSpanAnalysis);
 
             VerifyBadAnalyzer(badAnalyzers[0], "CSharpRemoveUnnecessaryCastDiagnosticAnalyzer", 85.6039521236341, 58.4542358078603, 18.4245217226717);
             VerifyBadAnalyzer(badAnalyzers[1], "VisualBasic.UseAutoProperty.UseAutoPropertyAnalyzer", 45.0918385052674, 29.0622535211268, 9.13728667060397);
             VerifyBadAnalyzer(badAnalyzers[2], "CSharpInlineDeclarationDiagnosticAnalyzer", 42.2014208750466, 28.7935371179039, 7.99261581900397);
         }
 
-        [Fact]
-        public void TestTrackingRolling()
+        [Theory, CombinatorialData]
+        public void TestTrackingRolling(bool forSpanAnalysis)
         {
             // data starting to rolling at 300 data points
-            var badAnalyzers = GetBadAnalyzers(@"TestFiles\analyzer_input.csv", to: 400);
+            var badAnalyzers = GetBadAnalyzers(@"TestFiles\analyzer_input.csv", to: 400, forSpanAnalysis);
 
             VerifyBadAnalyzer(badAnalyzers[0], "CSharpRemoveUnnecessaryCastDiagnosticAnalyzer", 76.2748443491852, 51.1698695652174, 17.3819563479479);
             VerifyBadAnalyzer(badAnalyzers[1], "VisualBasic.UseAutoProperty.UseAutoPropertyAnalyzer", 43.5700167914005, 29.2597857142857, 9.21213873850298);
@@ -78,7 +78,7 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
             Assert.Equal(stddev, analyzer.AdjustedStandardDeviation, precision: 4);
         }
 
-        private static List<ExpensiveAnalyzerInfo> GetBadAnalyzers(string testFileName, int to)
+        private static List<ExpensiveAnalyzerInfo> GetBadAnalyzers(string testFileName, int to, bool forSpanAnalysis)
         {
             var testFile = ReadTestFile(testFileName);
 
@@ -90,11 +90,11 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
 
             for (var i = 0; i < to; i++)
             {
-                service.AddSnapshot(CreateSnapshots(matrix, i), unitCount: 100);
+                service.AddSnapshot(CreateSnapshots(matrix, i), unitCount: 100, forSpanAnalysis);
             }
 
             var badAnalyzerInfo = new List<ExpensiveAnalyzerInfo>();
-            service.GenerateReport(badAnalyzerInfo);
+            service.GenerateReport(badAnalyzerInfo, forSpanAnalysis);
 
             return badAnalyzerInfo;
         }

--- a/src/VisualStudio/Core/Test.Next/Services/PerformanceTrackerServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/PerformanceTrackerServiceTests.cs
@@ -18,85 +18,156 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
 {
     public class PerformanceTrackerServiceTests
     {
-        [Theory, CombinatorialData]
-        public void TestTooFewSamples(bool forSpanAnalysis)
-        {
-            // minimum sample is 100
-            var badAnalyzers = GetBadAnalyzers(@"TestFiles\analyzer_input.csv", to: 80, forSpanAnalysis);
+        private const int TestMinSampleSizeForDocumentAnalysis = 100;
+        private const int TestMinSampleSizeForSpanAnalysis = 10;
 
-            Assert.Empty(badAnalyzers);
+        [Theory, CombinatorialData]
+        public void TestSampleSize(bool forSpanAnalysis)
+        {
+            var minSampleSize = forSpanAnalysis ?
+                TestMinSampleSizeForSpanAnalysis :
+                TestMinSampleSizeForDocumentAnalysis;
+
+            // Verify no analyzer infos reported when sampleSize < minSampleSize
+            var sampleSize = minSampleSize - 1;
+            var analyzerInfos = GetAnalyzerInfos(sampleSize, forSpanAnalysis);
+            Assert.Empty(analyzerInfos);
+
+            // Verify analyzer infos reported when sampleSize >= minSampleSize
+            sampleSize = minSampleSize + 1;
+            analyzerInfos = GetAnalyzerInfos(sampleSize, forSpanAnalysis);
+            Assert.NotEmpty(analyzerInfos);
+        }
+
+        [Theory, CombinatorialData]
+        public void TestNoDuplicateReportGeneration(bool forSpanAnalysis)
+        {
+            var minSampleSize = forSpanAnalysis ?
+                TestMinSampleSizeForSpanAnalysis :
+                TestMinSampleSizeForDocumentAnalysis;
+
+            var service = new PerformanceTrackerService(TestMinSampleSizeForDocumentAnalysis, TestMinSampleSizeForSpanAnalysis);
+
+            // Verify analyzer infos reported when sampleSize >= minSampleSize
+            var sampleSize = minSampleSize + 1;
+            ReadTestFileAndAddSnapshots(service, sampleSize, forSpanAnalysis);
+            var analyzerInfos = GenerateReport(service, forSpanAnalysis);
+            Assert.NotEmpty(analyzerInfos);
+
+            // Verify no analyzer infos reported when attempting to generate a duplicate
+            // report without adding any new samples.
+            analyzerInfos = GenerateReport(service, forSpanAnalysis);
+            Assert.Empty(analyzerInfos);
+
+            // Verify no analyzer infos reported after adding less than minSampleSize snapshots
+            sampleSize = minSampleSize - 1;
+            ReadTestFileAndAddSnapshots(service, sampleSize, forSpanAnalysis);
+            analyzerInfos = GenerateReport(service, forSpanAnalysis);
+            Assert.Empty(analyzerInfos);
+
+            // Verify analyzer infos reported once we the added snapshots exceeds sample size
+            sampleSize = 2;
+            ReadTestFileAndAddSnapshots(service, sampleSize, forSpanAnalysis);
+            analyzerInfos = GenerateReport(service, forSpanAnalysis);
+            Assert.NotEmpty(analyzerInfos);
         }
 
         [Theory, CombinatorialData]
         public void TestTracking(bool forSpanAnalysis)
         {
-            var badAnalyzers = GetBadAnalyzers(@"TestFiles\analyzer_input.csv", to: 200, forSpanAnalysis);
+            var analyzerInfos = GetAnalyzerInfos(to: 200, forSpanAnalysis);
 
-            VerifyBadAnalyzer(badAnalyzers[0], "CSharpRemoveUnnecessaryCastDiagnosticAnalyzer", 101.244432561581, 54.48, 21.8163001442628);
-            VerifyBadAnalyzer(badAnalyzers[1], "CSharpInlineDeclarationDiagnosticAnalyzer", 49.9389715502954, 26.6686092715232, 9.2987133054884);
-            VerifyBadAnalyzer(badAnalyzers[2], "VisualBasicRemoveUnnecessaryCastDiagnosticAnalyzer", 42.0967360557792, 23.277619047619, 7.25464266261805);
+            VerifyAnalyzerInfo(analyzerInfos, "CSharpRemoveUnnecessaryCastDiagnosticAnalyzer",
+                mean: forSpanAnalysis ? 89.2416 : 54.48,
+                stddev: forSpanAnalysis ? 78.8177 : 21.8163001442628);
+            VerifyAnalyzerInfo(analyzerInfos, "CSharpInlineDeclarationDiagnosticAnalyzer",
+                mean: forSpanAnalysis ? 48.4284 : 26.6686092715232,
+                stddev: forSpanAnalysis ? 38.5010107523771 : 9.2987133054884);
+            VerifyAnalyzerInfo(analyzerInfos, "VisualBasicRemoveUnnecessaryCastDiagnosticAnalyzer",
+                mean: forSpanAnalysis ? 26.8618181818182 : 23.277619047619,
+                stddev: forSpanAnalysis ? 6.62917030049974 : 7.25464266261805);
         }
 
         [Theory, CombinatorialData]
         public void TestTrackingMaxSample(bool forSpanAnalysis)
         {
-            var badAnalyzers = GetBadAnalyzers(@"TestFiles\analyzer_input.csv", to: 300, forSpanAnalysis);
+            var analyzerInfos = GetAnalyzerInfos(to: 300, forSpanAnalysis);
 
-            VerifyBadAnalyzer(badAnalyzers[0], "CSharpRemoveUnnecessaryCastDiagnosticAnalyzer", 85.6039521236341, 58.4542358078603, 18.4245217226717);
-            VerifyBadAnalyzer(badAnalyzers[1], "VisualBasic.UseAutoProperty.UseAutoPropertyAnalyzer", 45.0918385052674, 29.0622535211268, 9.13728667060397);
-            VerifyBadAnalyzer(badAnalyzers[2], "CSharpInlineDeclarationDiagnosticAnalyzer", 42.2014208750466, 28.7935371179039, 7.99261581900397);
+            VerifyAnalyzerInfo(analyzerInfos, "CSharpRemoveUnnecessaryCastDiagnosticAnalyzer",
+                mean: forSpanAnalysis ? 75.3678260869565 : 58.4542358078603,
+                stddev: forSpanAnalysis ? 64.7106979026339 : 18.4245217226717);
+            VerifyAnalyzerInfo(analyzerInfos, "VisualBasic.UseAutoProperty.UseAutoPropertyAnalyzer",
+                mean: forSpanAnalysis ? 0.375 : 29.0622535211268,
+                stddev: forSpanAnalysis ? 0.144592142784807 : 9.13728667060397);
+            VerifyAnalyzerInfo(analyzerInfos, "CSharpInlineDeclarationDiagnosticAnalyzer",
+                mean: forSpanAnalysis ? 37.6895652173913 : 28.7935371179039,
+                stddev: forSpanAnalysis ? 29.5179969292277 : 7.99261581900397);
         }
 
         [Theory, CombinatorialData]
         public void TestTrackingRolling(bool forSpanAnalysis)
         {
             // data starting to rolling at 300 data points
-            var badAnalyzers = GetBadAnalyzers(@"TestFiles\analyzer_input.csv", to: 400, forSpanAnalysis);
+            var analyzerInfos = GetAnalyzerInfos(to: 400, forSpanAnalysis);
 
-            VerifyBadAnalyzer(badAnalyzers[0], "CSharpRemoveUnnecessaryCastDiagnosticAnalyzer", 76.2748443491852, 51.1698695652174, 17.3819563479479);
-            VerifyBadAnalyzer(badAnalyzers[1], "VisualBasic.UseAutoProperty.UseAutoPropertyAnalyzer", 43.5700167914005, 29.2597857142857, 9.21213873850298);
-            VerifyBadAnalyzer(badAnalyzers[2], "InlineDeclaration.CSharpInlineDeclarationDiagnosticAnalyzer", 36.4336594793033, 23.9764782608696, 7.43956680199015);
+            VerifyAnalyzerInfo(analyzerInfos, "CSharpRemoveUnnecessaryCastDiagnosticAnalyzer",
+                mean: forSpanAnalysis ? 0.24304347826087 : 51.1698695652174,
+                stddev: forSpanAnalysis ? 0.1511123654363 : 17.3819563479479);
+            VerifyAnalyzerInfo(analyzerInfos, "VisualBasic.UseAutoProperty.UseAutoPropertyAnalyzer",
+                mean: forSpanAnalysis ? 44.5428571428571 : 29.2597857142857,
+                stddev: forSpanAnalysis ? 34.6949934844539 : 9.21213873850298);
+            VerifyAnalyzerInfo(analyzerInfos, "InlineDeclaration.CSharpInlineDeclarationDiagnosticAnalyzer",
+                mean: forSpanAnalysis ? 0.842608695652174 : 23.9764782608696,
+                stddev: forSpanAnalysis ? 0.312682894617701 : 7.43956680199015);
         }
 
         [Fact]
         public void TestBadAnalyzerInfoPII()
         {
-            var badAnalyzer1 = new ExpensiveAnalyzerInfo(true, "test", 0.1, 0.1, 0.1);
-            Assert.True(badAnalyzer1.PIISafeAnalyzerId == badAnalyzer1.AnalyzerId);
-            Assert.True(badAnalyzer1.PIISafeAnalyzerId == "test");
+            var analyzerInfo1 = new AnalyzerInfoForPerformanceReporting(true, "test", 0.1, 0.1);
+            Assert.True(analyzerInfo1.PIISafeAnalyzerId == analyzerInfo1.AnalyzerId);
+            Assert.True(analyzerInfo1.PIISafeAnalyzerId == "test");
 
-            var badAnalyzer2 = new ExpensiveAnalyzerInfo(false, "test", 0.1, 0.1, 0.1);
-            Assert.True(badAnalyzer2.PIISafeAnalyzerId == badAnalyzer2.AnalyzerIdHash);
-            Assert.True(badAnalyzer2.PIISafeAnalyzerId == "test".GetHashCode().ToString());
+            var analyzerInfo2 = new AnalyzerInfoForPerformanceReporting(false, "test", 0.1, 0.1);
+            Assert.True(analyzerInfo2.PIISafeAnalyzerId == analyzerInfo2.AnalyzerIdHash);
+            Assert.True(analyzerInfo2.PIISafeAnalyzerId == "test".GetHashCode().ToString());
         }
 
-        private static void VerifyBadAnalyzer(ExpensiveAnalyzerInfo analyzer, string analyzerId, double lof, double mean, double stddev)
+        private static void VerifyAnalyzerInfo(List<AnalyzerInfoForPerformanceReporting> analyzerInfos, string analyzerName, double mean, double stddev)
         {
-            Assert.True(analyzer.PIISafeAnalyzerId.IndexOf(analyzerId, StringComparison.OrdinalIgnoreCase) >= 0);
-            Assert.Equal(lof, analyzer.LocalOutlierFactor, precision: 4);
-            Assert.Equal(mean, analyzer.Average, precision: 4);
-            Assert.Equal(stddev, analyzer.AdjustedStandardDeviation, precision: 4);
+            var analyzerInfo = analyzerInfos.Single(i => i.AnalyzerId.Contains(analyzerName));
+            Assert.True(analyzerInfo.PIISafeAnalyzerId.IndexOf(analyzerName, StringComparison.OrdinalIgnoreCase) >= 0);
+            Assert.Equal(mean, analyzerInfo.Average, precision: 4);
+            Assert.Equal(stddev, analyzerInfo.AdjustedStandardDeviation, precision: 4);
         }
 
-        private static List<ExpensiveAnalyzerInfo> GetBadAnalyzers(string testFileName, int to, bool forSpanAnalysis)
+        private static List<AnalyzerInfoForPerformanceReporting> GetAnalyzerInfos(int to, bool forSpanAnalysis)
         {
-            var testFile = ReadTestFile(testFileName);
+            var service = new PerformanceTrackerService(TestMinSampleSizeForDocumentAnalysis, TestMinSampleSizeForSpanAnalysis);
+            ReadTestFileAndAddSnapshots(service, to, forSpanAnalysis);
+            return GenerateReport(service, forSpanAnalysis);
+        }
+
+        private static void ReadTestFileAndAddSnapshots(PerformanceTrackerService service, int to, bool forSpanAnalysis)
+        {
+            var testFile = ReadTestFile(@"TestFiles\analyzer_input.csv");
 
             var (matrix, dataCount) = CreateMatrix(testFile);
 
             to = Math.Min(to, dataCount);
 
-            var service = new PerformanceTrackerService(minLOFValue: 0, averageThreshold: 0, stddevThreshold: 0);
-
             for (var i = 0; i < to; i++)
             {
                 service.AddSnapshot(CreateSnapshots(matrix, i), unitCount: 100, forSpanAnalysis);
             }
+        }
 
-            var badAnalyzerInfo = new List<ExpensiveAnalyzerInfo>();
-            service.GenerateReport(badAnalyzerInfo, forSpanAnalysis);
+        private static List<AnalyzerInfoForPerformanceReporting> GenerateReport(PerformanceTrackerService service, bool forSpanAnalysis)
+        {
+            var analyzerInfos = new List<AnalyzerInfoForPerformanceReporting>();
+            service.GenerateReport(analyzerInfos, forSpanAnalysis);
 
-            return badAnalyzerInfo;
+            return analyzerInfos;
         }
 
         private static IEnumerable<AnalyzerPerformanceInfo> CreateSnapshots(Dictionary<string, double[]> matrix, int index)

--- a/src/VisualStudio/Core/Test.Next/Services/PerformanceTrackerServiceTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/PerformanceTrackerServiceTests.cs
@@ -24,9 +24,9 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
         [Theory, CombinatorialData]
         public void TestSampleSize(bool forSpanAnalysis)
         {
-            var minSampleSize = forSpanAnalysis ?
-                TestMinSampleSizeForSpanAnalysis :
-                TestMinSampleSizeForDocumentAnalysis;
+            var minSampleSize = forSpanAnalysis
+                ? TestMinSampleSizeForSpanAnalysis
+                : TestMinSampleSizeForDocumentAnalysis;
 
             // Verify no analyzer infos reported when sampleSize < minSampleSize
             var sampleSize = minSampleSize - 1;
@@ -42,9 +42,9 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Services
         [Theory, CombinatorialData]
         public void TestNoDuplicateReportGeneration(bool forSpanAnalysis)
         {
-            var minSampleSize = forSpanAnalysis ?
-                TestMinSampleSizeForSpanAnalysis :
-                TestMinSampleSizeForDocumentAnalysis;
+            var minSampleSize = forSpanAnalysis
+                ? TestMinSampleSizeForSpanAnalysis
+                : TestMinSampleSizeForDocumentAnalysis;
 
             var service = new PerformanceTrackerService(TestMinSampleSizeForDocumentAnalysis, TestMinSampleSizeForSpanAnalysis);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -134,7 +134,10 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 if (telemetryService.HasActiveSession)
                 {
                     // +1 to include project itself
-                    var unitCount = documentAnalysisScope != null ? 1 : _project.DocumentIds.Count + 1;
+                    var unitCount = 1;
+                    if (documentAnalysisScope == null)
+                        unitCount += _project.DocumentIds.Count;
+
                     _performanceTracker.AddSnapshot(analysisResult.AnalyzerTelemetryInfo.ToAnalyzerPerformanceInfo(_analyzerInfoCache), unitCount, forSpanAnalysis: _span.HasValue);
                 }
             }

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -46,6 +46,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
         private readonly AnalysisKind? _analysisKind;
         private readonly IPerformanceTrackerService? _performanceTracker;
         private readonly DiagnosticAnalyzerInfoCache _analyzerInfoCache;
+        private readonly HostWorkspaceServices _hostWorkspaceServices;
 
         public DiagnosticComputer(
             TextDocument? document,
@@ -53,7 +54,8 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             IdeAnalyzerOptions ideOptions,
             TextSpan? span,
             AnalysisKind? analysisKind,
-            DiagnosticAnalyzerInfoCache analyzerInfoCache)
+            DiagnosticAnalyzerInfoCache analyzerInfoCache,
+            HostWorkspaceServices hostWorkspaceServices)
         {
             _document = document;
             _project = project;
@@ -61,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             _span = span;
             _analysisKind = analysisKind;
             _analyzerInfoCache = analyzerInfoCache;
-
+            _hostWorkspaceServices = hostWorkspaceServices;
             _performanceTracker = project.Solution.Services.GetService<IPerformanceTrackerService>();
         }
 
@@ -130,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             {
                 // Only log telemetry snapshot is we have an active telemetry session,
                 // i.e. user has not opted out of reporting telemetry.
-                var telemetryService = _project.Solution.Workspace.Services.GetRequiredService<IWorkspaceTelemetryService>();
+                var telemetryService = _hostWorkspaceServices.GetRequiredService<IWorkspaceTelemetryService>();
                 if (telemetryService.HasActiveSession)
                 {
                     // +1 to include project itself

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             {
                 // +1 to include project itself
                 var unitCount = documentAnalysisScope != null ? 1 : _project.DocumentIds.Count + 1;
-                _performanceTracker.AddSnapshot(analysisResult.AnalyzerTelemetryInfo.ToAnalyzerPerformanceInfo(_analyzerInfoCache), unitCount);
+                _performanceTracker.AddSnapshot(analysisResult.AnalyzerTelemetryInfo.ToAnalyzerPerformanceInfo(_analyzerInfoCache), unitCount, forSpanAnalysis: _span.HasValue);
             }
 
             var builderMap = await analysisResult.ToResultBuilderMapAsync(

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/IPerformanceTrackerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/IPerformanceTrackerService.cs
@@ -12,26 +12,24 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
     internal interface IPerformanceTrackerService : IWorkspaceService
     {
         void AddSnapshot(IEnumerable<AnalyzerPerformanceInfo> snapshot, int unitCount, bool forSpanAnalysis);
-        void GenerateReport(List<ExpensiveAnalyzerInfo> badAnalyzers, bool forSpanAnalysis);
+        void GenerateReport(List<AnalyzerInfoForPerformanceReporting> analyzerInfos, bool forSpanAnalysis);
 
         event EventHandler SnapshotAdded;
     }
 
-    internal readonly struct ExpensiveAnalyzerInfo
+    internal readonly struct AnalyzerInfoForPerformanceReporting
     {
         public readonly bool BuiltIn;
         public readonly string AnalyzerId;
         public readonly string AnalyzerIdHash;
-        public readonly double LocalOutlierFactor;
         public readonly double Average;
         public readonly double AdjustedStandardDeviation;
 
-        public ExpensiveAnalyzerInfo(bool builtIn, string analyzerId, double lof_value, double average, double stddev) : this()
+        public AnalyzerInfoForPerformanceReporting(bool builtIn, string analyzerId, double average, double stddev) : this()
         {
             BuiltIn = builtIn;
             AnalyzerId = analyzerId;
             AnalyzerIdHash = analyzerId.GetHashCode().ToString();
-            LocalOutlierFactor = lof_value;
             Average = average;
             AdjustedStandardDeviation = stddev;
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/IPerformanceTrackerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/IPerformanceTrackerService.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
 {
     internal interface IPerformanceTrackerService : IWorkspaceService
     {
-        void AddSnapshot(IEnumerable<AnalyzerPerformanceInfo> snapshot, int unitCount);
-        void GenerateReport(List<ExpensiveAnalyzerInfo> badAnalyzers);
+        void AddSnapshot(IEnumerable<AnalyzerPerformanceInfo> snapshot, int unitCount, bool forSpanAnalysis);
+        void GenerateReport(List<ExpensiveAnalyzerInfo> badAnalyzers, bool forSpanAnalysis);
 
         event EventHandler SnapshotAdded;
     }

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/PerformanceQueue.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/PerformanceQueue.cs
@@ -19,17 +19,15 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
     /// <threadsafety static="false" instance="false"/>
     internal class PerformanceQueue
     {
-        // we need at least 100 samples for result to be stable
-        private const int MinSampleSize = 100;
-
-        private readonly int _maxSampleSize;
+        private readonly int _maxSampleSize, _minSampleSize;
         private readonly LinkedList<Snapshot> _snapshots;
 
-        public PerformanceQueue(int maxSampleSize)
+        public PerformanceQueue(int maxSampleSize, int minSampleSize)
         {
-            Contract.ThrowIfFalse(maxSampleSize > MinSampleSize);
+            Contract.ThrowIfFalse(maxSampleSize > minSampleSize);
 
             _maxSampleSize = maxSampleSize;
+            _minSampleSize = minSampleSize;
             _snapshots = new LinkedList<Snapshot>();
         }
 
@@ -55,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
 
         public void GetPerformanceData(Dictionary<string, (double average, double stddev)> aggregatedPerformanceDataPerAnalyzer)
         {
-            if (_snapshots.Count < MinSampleSize)
+            if (_snapshots.Count < _minSampleSize)
             {
                 // we don't have enough data to report this
                 return;
@@ -95,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
 
                 // data is only stable once we have more than certain set
                 // of samples
-                if (list.Count < MinSampleSize)
+                if (list.Count < _minSampleSize)
                 {
                     continue;
                 }

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/PerformanceQueue.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/PerformanceQueue.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
         private readonly int _maxSampleSize, _minSampleSize;
         private readonly LinkedList<Snapshot> _snapshots;
 
-        private int _spanshotsSinceLastReport;
+        private int _snapshotsSinceLastReport;
 
         public PerformanceQueue(int minSampleSize)
         {
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
 
             _minSampleSize = minSampleSize;
             _snapshots = new LinkedList<Snapshot>();
-            _spanshotsSinceLastReport = 0;
+            _snapshotsSinceLastReport = 0;
         }
 
         public int Count => _snapshots.Count;
@@ -53,18 +53,18 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 _snapshots.AddLast(first);
             }
 
-            _spanshotsSinceLastReport++;
+            _snapshotsSinceLastReport++;
         }
 
         public void GetPerformanceData(List<(string analyzerId, double average, double stddev)> aggregatedPerformanceDataPerAnalyzer)
         {
-            if (_spanshotsSinceLastReport < _minSampleSize)
+            if (_snapshotsSinceLastReport < _minSampleSize)
             {
                 // we don't have enough data to report this
                 return;
             }
 
-            _spanshotsSinceLastReport = 0;
+            _snapshotsSinceLastReport = 0;
 
             using var pooledMap = SharedPools.Default<Dictionary<int, string>>().GetPooledObject();
             using var pooledSet = SharedPools.Default<HashSet<int>>().GetPooledObject();

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/PerformanceTrackerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/PerformanceTrackerService.cs
@@ -23,19 +23,18 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
     [ExportWorkspaceService(typeof(IPerformanceTrackerService), WorkspaceKind.Host), Shared]
     internal class PerformanceTrackerService : IPerformanceTrackerService
     {
+        // We require at least 100 samples for background document analysis result to be stable.
+        private const int MinSampleSizeForDocumentAnalysis = 100;
+        // We require at least 20 samples for span/lightbulb analysis result to be stable.
+        // Note that each lightbulb invocation produces 4 samples, one for each of the below diagnostic computaion:
+        //      1. Compiler syntax diagnostics
+        //      2. Analyzer syntax diagnostics
+        //      3. Compiler semantic diagnostics
+        //      4. Analyzer semantic diagnostics
+        private const int MinSampleSizeForSpanAnalysis = 20;
+
         private static readonly Func<IEnumerable<AnalyzerPerformanceInfo>, int, bool, string> s_snapshotLogger = SnapshotLogger;
 
-        private const double DefaultMinLOFValue = 20;
-        private const double DefaultAverageThreshold = 100;
-        private const double DefaultStddevThreshold = 100;
-
-        private const double K_Value_Ratio = 2D / 3D;
-
-        private readonly double _minLOFValue;
-        private readonly double _averageThreshold;
-        private readonly double _stddevThreshold;
-
-        private readonly object _gate;
         private readonly PerformanceQueue _queueForDocumentAnalysis, _queueForSpanAnalysis;
         private readonly ConcurrentDictionary<string, bool> _builtInMap = new ConcurrentDictionary<string, bool>(concurrencyLevel: 2, capacity: 10);
 
@@ -44,25 +43,17 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public PerformanceTrackerService()
-            : this(DefaultMinLOFValue, DefaultAverageThreshold, DefaultStddevThreshold)
+            : this(MinSampleSizeForDocumentAnalysis, MinSampleSizeForSpanAnalysis)
         {
         }
 
         // internal for testing
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0034:Exported parts should have [ImportingConstructor]", Justification = "Used incorrectly by tests")]
-        internal PerformanceTrackerService(double minLOFValue, double averageThreshold, double stddevThreshold)
+        internal PerformanceTrackerService(int minSampleSizeForDocumentAnalysis, int minSampleSizeForSpanAnalysis)
         {
-            _minLOFValue = minLOFValue;
-            _averageThreshold = averageThreshold;
-            _stddevThreshold = stddevThreshold;
+            _queueForDocumentAnalysis = new PerformanceQueue(minSampleSizeForDocumentAnalysis);
 
-            _gate = new object();
-
-            // We require at least 100 samples for background document analysis result to be stable
-            _queueForDocumentAnalysis = new PerformanceQueue(maxSampleSize: 300, minSampleSize: 100);
-
-            // We require at least 10 samples for span/lightbulb analysis result to be stable
-            _queueForSpanAnalysis = new PerformanceQueue(maxSampleSize: 30, minSampleSize: 10);
+            _queueForSpanAnalysis = new PerformanceQueue(minSampleSizeForSpanAnalysis);
         }
 
         private PerformanceQueue GetQueue(bool forSpanAnalysis)
@@ -74,24 +65,26 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
 
             RecordBuiltInAnalyzers(snapshot);
 
-            lock (_gate)
+            var queue = GetQueue(forSpanAnalysis);
+            lock (queue)
             {
-                GetQueue(forSpanAnalysis).Add(snapshot.Select(entry => (entry.AnalyzerId, entry.TimeSpan)), unitCount);
+                queue.Add(snapshot.Select(entry => (entry.AnalyzerId, entry.TimeSpan)), unitCount);
             }
 
             OnSnapshotAdded();
         }
 
-        public void GenerateReport(List<ExpensiveAnalyzerInfo> badAnalyzers, bool forSpanAnalysis)
+        public void GenerateReport(List<AnalyzerInfoForPerformanceReporting> analyzerInfos, bool forSpanAnalysis)
         {
-            using var pooledRaw = SharedPools.Default<Dictionary<string, (double average, double stddev)>>().GetPooledObject();
+            using var pooledRaw = SharedPools.Default<List<(string analyzerId, double average, double stddev)>>().GetPooledObject();
 
             var rawPerformanceData = pooledRaw.Object;
 
-            lock (_gate)
+            var queue = GetQueue(forSpanAnalysis);
+            lock (queue)
             {
                 // first get raw aggregated peformance data from the queue
-                GetQueue(forSpanAnalysis).GetPerformanceData(rawPerformanceData);
+                queue.GetPerformanceData(rawPerformanceData);
             }
 
             // make sure there are some data
@@ -100,8 +93,10 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
                 return;
             }
 
-            using var generator = new ReportGenerator(this, _minLOFValue, _averageThreshold, _stddevThreshold, badAnalyzers);
-            generator.Report(rawPerformanceData);
+            foreach (var (analyzerId, average, stddev) in rawPerformanceData.OrderByDescending(k => k.average))
+            {
+                analyzerInfos.Add(new AnalyzerInfoForPerformanceReporting(AllowTelemetry(analyzerId), analyzerId, average, stddev));
+            }
         }
 
         private void RecordBuiltInAnalyzers(IEnumerable<AnalyzerPerformanceInfo> snapshot)
@@ -149,311 +144,6 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             sb.Append('*');
 
             return sb.ToString();
-        }
-
-        private sealed class ReportGenerator : IDisposable, IComparer<ExpensiveAnalyzerInfo>
-        {
-            private readonly double _minLOFValue;
-            private readonly double _averageThreshold;
-            private readonly double _stddevThreshold;
-
-            private readonly PerformanceTrackerService _owner;
-            private readonly List<ExpensiveAnalyzerInfo> _badAnalyzers;
-            private readonly PooledObject<List<IDisposable>> _pooledObjects;
-
-            public ReportGenerator(
-                PerformanceTrackerService owner,
-                double minLOFValue,
-                double averageThreshold,
-                double stddevThreshold,
-                List<ExpensiveAnalyzerInfo> badAnalyzers)
-            {
-                _pooledObjects = SharedPools.Default<List<IDisposable>>().GetPooledObject();
-
-                _owner = owner;
-
-                _minLOFValue = minLOFValue;
-                _averageThreshold = averageThreshold;
-                _stddevThreshold = stddevThreshold;
-
-                _badAnalyzers = badAnalyzers;
-            }
-
-            public void Report(Dictionary<string, (double average, double stddev)> rawPerformanceData)
-            {
-                // this is implementation of local outlier factor (LOF)
-                // see the wiki (https://en.wikipedia.org/wiki/Local_outlier_factor) for more information 
-
-                // convert string (analyzerId) to index
-                var analyzerIdIndex = GetAnalyzerIdIndex(rawPerformanceData.Keys);
-
-                // now calculate normalized value per analyzer
-                var normalizedMap = GetNormalizedPerformanceMap(analyzerIdIndex, rawPerformanceData);
-
-                // get k value
-                var k_value = (int)(rawPerformanceData.Count * K_Value_Ratio);
-
-                // calculate distances
-
-                // calculate all distance first
-                var allDistances = GetAllDistances(normalizedMap);
-
-                // find k distance from all distances
-                var kDistances = GetKDistances(allDistances, k_value);
-
-                // find k nearest neighbors
-                var kNeighborIndices = GetKNeighborIndices(allDistances, kDistances);
-
-                var analyzerCount = kNeighborIndices.Count;
-                for (var index = 0; index < analyzerCount; index++)
-                {
-                    var analyzerId = analyzerIdIndex[index];
-
-                    // if result performance is lower than our threshold, don't need to calculate
-                    // LOF value for the analyzer
-                    var (average, stddev) = rawPerformanceData[analyzerId];
-                    if (average <= _averageThreshold && stddev <= _stddevThreshold)
-                    {
-                        continue;
-                    }
-
-                    // possible bad analyzer, calculate LOF
-                    var lof_value = TryGetLocalOutlierFactor(allDistances, kNeighborIndices, kDistances, index);
-                    if (!lof_value.HasValue)
-                    {
-                        // this analyzer doesn't have lof value
-                        continue;
-                    }
-
-                    if (lof_value <= _minLOFValue)
-                    {
-                        // this doesn't stand out from other analyzers
-                        continue;
-                    }
-
-                    // report found possible bad analyzers
-                    _badAnalyzers.Add(new ExpensiveAnalyzerInfo(_owner.AllowTelemetry(analyzerId), analyzerId, lof_value.Value, average, stddev));
-                }
-
-                _badAnalyzers.Sort(this);
-            }
-
-            private static double? TryGetLocalOutlierFactor(
-                List<List<double>> allDistances, List<List<int>> kNeighborIndices, List<double> kDistances, int analyzerIndex)
-            {
-                var rowKNeighborsIndices = kNeighborIndices[analyzerIndex];
-                if (rowKNeighborsIndices.Count == 0)
-                {
-                    // nothing to calculate if there is no neighbor to compare
-                    return null;
-                }
-
-                var lrda = TryGetLocalReachabilityDensity(allDistances, kNeighborIndices, kDistances, analyzerIndex);
-                if (!lrda.HasValue)
-                {
-                    // can't calculate reachability for the analyzer. can't calculate lof for this analyzer
-                    return null;
-                }
-
-                var lrdb = 0D;
-                foreach (var neighborIndex in rowKNeighborsIndices)
-                {
-                    var reachability = TryGetLocalReachabilityDensity(allDistances, kNeighborIndices, kDistances, neighborIndex);
-                    if (!reachability.HasValue)
-                    {
-                        // this neighbor analyzer doesn't have its own neighbor. skip it
-                        continue;
-                    }
-
-                    lrdb += reachability.Value;
-                }
-
-                return (lrdb / rowKNeighborsIndices.Count) / lrda;
-            }
-
-            private static double GetReachabilityDistance(
-                List<List<double>> allDistances, List<double> kDistances, int analyzerIndex1, int analyzerIndex2)
-            {
-                return Math.Max(allDistances[analyzerIndex1][analyzerIndex2], kDistances[analyzerIndex2]);
-            }
-
-            private static double? TryGetLocalReachabilityDensity(
-                List<List<double>> allDistances, List<List<int>> kNeighborIndices, List<double> kDistances, int analyzerIndex)
-            {
-                var rowKNeighborsIndices = kNeighborIndices[analyzerIndex];
-                if (rowKNeighborsIndices.Count == 0)
-                {
-                    // no neighbor to get reachability
-                    return null;
-                }
-
-                var distanceSum = 0.0;
-                foreach (var neighborIndex in rowKNeighborsIndices)
-                {
-                    distanceSum += GetReachabilityDistance(allDistances, kDistances, analyzerIndex, neighborIndex);
-                }
-
-                return 1 / distanceSum / rowKNeighborsIndices.Count;
-            }
-
-            private List<List<int>> GetKNeighborIndices(List<List<double>> allDistances, List<double> kDistances)
-            {
-                var analyzerCount = kDistances.Count;
-                var kNeighborIndices = GetPooledListAndSetCapacity<List<int>>(analyzerCount);
-
-                for (var rowIndex = 0; rowIndex < analyzerCount; rowIndex++)
-                {
-                    var rowKNeighborIndices = GetPooledList<int>();
-
-                    var rowDistances = allDistances[rowIndex];
-                    var kDistance = kDistances[rowIndex];
-
-                    for (var colIndex = 0; colIndex < analyzerCount; colIndex++)
-                    {
-                        var value = rowDistances[colIndex];
-
-                        // get neighbors closer than k distance
-                        if (value > 0 && value <= kDistance)
-                        {
-                            rowKNeighborIndices.Add(colIndex);
-                        }
-                    }
-
-                    kNeighborIndices[rowIndex] = rowKNeighborIndices;
-                }
-
-                return kNeighborIndices;
-            }
-
-            private List<double> GetKDistances(List<List<double>> allDistances, int kValue)
-            {
-                var analyzerCount = allDistances.Count;
-                var kDistances = GetPooledListAndSetCapacity<double>(analyzerCount);
-                var sortedRowDistance = GetPooledList<double>();
-
-                for (var index = 0; index < analyzerCount; index++)
-                {
-                    sortedRowDistance.Clear();
-                    sortedRowDistance.AddRange(allDistances[index]);
-
-                    sortedRowDistance.Sort();
-
-                    kDistances[index] = sortedRowDistance[kValue];
-                }
-
-                return kDistances;
-            }
-
-            private List<List<double>> GetAllDistances(List<(double normalizedAverage, double normalizedStddev)> normalizedMap)
-            {
-                var analyzerCount = normalizedMap.Count;
-                var allDistances = GetPooledListAndSetCapacity<List<double>>(analyzerCount);
-
-                for (var rowIndex = 0; rowIndex < analyzerCount; rowIndex++)
-                {
-                    var rowDistances = GetPooledListAndSetCapacity<double>(analyzerCount);
-                    var (normaliedAverage, normalizedStddev) = normalizedMap[rowIndex];
-
-                    for (var colIndex = 0; colIndex < analyzerCount; colIndex++)
-                    {
-                        var colAnalyzer = normalizedMap[colIndex];
-                        var distance = Math.Sqrt(Math.Pow(colAnalyzer.normalizedAverage - normaliedAverage, 2) +
-                                                 Math.Pow(colAnalyzer.normalizedStddev - normalizedStddev, 2));
-
-                        rowDistances[colIndex] = distance;
-                    }
-
-                    allDistances[rowIndex] = rowDistances;
-                }
-
-                return allDistances;
-            }
-
-            private List<(double normaliedAverage, double normalizedStddev)> GetNormalizedPerformanceMap(
-                List<string> analyzerIdIndex, Dictionary<string, (double average, double stddev)> rawPerformanceData)
-            {
-                var averageMin = rawPerformanceData.Values.Select(kv => kv.average).Min();
-                var averageMax = rawPerformanceData.Values.Select(kv => kv.average).Max();
-                var averageDelta = averageMax - averageMin;
-
-                var stddevMin = rawPerformanceData.Values.Select(kv => kv.stddev).Min();
-                var stddevMax = rawPerformanceData.Values.Select(kv => kv.stddev).Max();
-                var stddevDelta = stddevMax - stddevMin;
-
-                // make sure delta is not 0
-                averageDelta = averageDelta == 0 ? 1 : averageDelta;
-                stddevDelta = stddevDelta == 0 ? 1 : stddevDelta;
-
-                // calculate normalized average and stddev and convert analyzerId string to index
-                var analyzerCount = analyzerIdIndex.Count;
-                var normalizedMap = GetPooledListAndSetCapacity<(double normalizedAverage, double normalizedStddev)>(analyzerCount);
-
-                for (var index = 0; index < analyzerCount; index++)
-                {
-                    var (average, stddev) = rawPerformanceData[analyzerIdIndex[index]];
-                    var normalizedAverage = (average - averageMin) / averageDelta;
-                    var normalizedStddev = (stddev - stddevMin) / stddevDelta;
-
-                    normalizedMap[index] = (normalizedAverage, normalizedStddev);
-                }
-
-                return normalizedMap;
-            }
-
-            private List<string> GetAnalyzerIdIndex(IEnumerable<string> analyzerIds)
-            {
-                var analyzerIdIndex = GetPooledList<string>();
-                analyzerIdIndex.AddRange(analyzerIds);
-
-                return analyzerIdIndex;
-            }
-
-            public void Dispose()
-            {
-                foreach (var disposable in _pooledObjects.Object)
-                {
-                    disposable.Dispose();
-                }
-
-                _pooledObjects.Dispose();
-            }
-
-            private List<T> GetPooledList<T>()
-            {
-                var pooledObject = SharedPools.Default<List<T>>().GetPooledObject();
-                _pooledObjects.Object.Add(pooledObject);
-
-                return pooledObject.Object;
-            }
-
-            private List<T> GetPooledListAndSetCapacity<T>(int capacity)
-            {
-                var pooledObject = SharedPools.Default<List<T>>().GetPooledObject();
-                _pooledObjects.Object.Add(pooledObject);
-
-                for (var i = 0; i < capacity; i++)
-                {
-                    pooledObject.Object.Add(default);
-                }
-
-                return pooledObject.Object;
-            }
-
-            public int Compare(ExpensiveAnalyzerInfo x, ExpensiveAnalyzerInfo y)
-            {
-                if (x.LocalOutlierFactor == y.LocalOutlierFactor)
-                {
-                    return 0;
-                }
-
-                // want reversed order
-                if (x.LocalOutlierFactor - y.LocalOutlierFactor > 0)
-                {
-                    return -1;
-                }
-
-                return 1;
-            }
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Remote
             }
         }
 
-        public ValueTask ReportAnalyzerPerformanceAsync(ImmutableArray<AnalyzerPerformanceInfo> snapshot, int unitCount, CancellationToken cancellationToken)
+        public ValueTask ReportAnalyzerPerformanceAsync(ImmutableArray<AnalyzerPerformanceInfo> snapshot, int unitCount, bool forSpanAnalysis, CancellationToken cancellationToken)
         {
             return RunServiceAsync(cancellationToken =>
             {
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Remote
                         return default;
                     }
 
-                    service.AddSnapshot(snapshot, unitCount);
+                    service.AddSnapshot(snapshot, unitCount, forSpanAnalysis);
                 }
 
                 return default;

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -72,7 +72,8 @@ namespace Microsoft.CodeAnalysis.Remote
                             : null;
                         var documentSpan = arguments.DocumentSpan;
                         var documentAnalysisKind = arguments.DocumentAnalysisKind;
-                        var diagnosticComputer = new DiagnosticComputer(document, project, arguments.IdeOptions, documentSpan, documentAnalysisKind, _analyzerInfoCache);
+                        var hostWorkspaceServices = this.GetWorkspace().Services;
+                        var diagnosticComputer = new DiagnosticComputer(document, project, arguments.IdeOptions, documentSpan, documentAnalysisKind, _analyzerInfoCache, hostWorkspaceServices);
 
                         var result = await diagnosticComputer.GetDiagnosticsAsync(
                             arguments.AnalyzerIds,

--- a/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.PerformanceReporter.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.PerformanceReporter.cs
@@ -58,6 +58,9 @@ namespace Microsoft.CodeAnalysis.Remote
 
             protected override Task ExecuteAsync()
             {
+                if (!_telemetrySession.IsOptedIn)
+                    return Task.CompletedTask;
+
                 using (RoslynLogger.LogBlock(FunctionId.Diagnostics_GeneratePerformaceReport, CancellationToken))
                 {
                     foreach (var forSpanAnalysis in new[] { false, true })

--- a/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.cs
@@ -66,15 +66,14 @@ namespace Microsoft.CodeAnalysis.Remote
                     m["Framework"] = RuntimeInformation.FrameworkDescription;
                 }));
 
-#if DEBUG
                 // start performance reporter
                 var diagnosticAnalyzerPerformanceTracker = services.GetService<IPerformanceTrackerService>();
                 if (diagnosticAnalyzerPerformanceTracker != null)
                 {
                     var globalOperationNotificationService = services.GetService<IGlobalOperationNotificationService>();
-                    _performanceReporter = new PerformanceReporter(TraceLogger, telemetrySession, diagnosticAnalyzerPerformanceTracker, globalOperationNotificationService, _shutdownCancellationSource.Token);
+                    _performanceReporter = new PerformanceReporter(telemetrySession, diagnosticAnalyzerPerformanceTracker, globalOperationNotificationService, _shutdownCancellationSource.Token);
                 }
-#endif
+
                 return ValueTaskFactory.CompletedTask;
             }, cancellationToken);
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.cs
@@ -30,13 +30,12 @@ namespace Microsoft.CodeAnalysis.Remote
                 => new RemoteProcessTelemetryService(arguments);
         }
 
-#if DEBUG
         private readonly CancellationTokenSource _shutdownCancellationSource = new();
 
 #pragma warning disable IDE0052 // Remove unread private members
         private PerformanceReporter? _performanceReporter;
 #pragma warning restore
-#endif
+
         public RemoteProcessTelemetryService(ServiceConstructionArguments arguments)
             : base(arguments)
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -417,7 +417,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         LiveTableDataSource_OnDiagnosticsUpdated = 333,
         Experiment_KeybindingsReset = 334,
         Diagnostics_GeneratePerformaceReport = 335,
-        Diagnostics_BadAnalyzer = 336,
+        // obsolete: Diagnostics_BadAnalyzer = 336,
         CodeAnalysisService_ReportAnalyzerPerformance = 337,
         PerformanceTrackerService_AddSnapshot = 338,
         // obsolete: AbstractProject_SetIntelliSenseBuild = 339,
@@ -576,6 +576,8 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         SourceGenerator_SolutionStatistics = 620,
         SourceGenerator_OtherWorkspaceSessionStatistics = 621,
+
+        Diagnostics_AnalyzerPerformanceInfo = 622,
 
         // 630-650 for sqlite errors.
         SQLite_SqlException = 630,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -577,10 +577,11 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         SourceGenerator_SolutionStatistics = 620,
         SourceGenerator_OtherWorkspaceSessionStatistics = 621,
 
-        Diagnostics_AnalyzerPerformanceInfo = 622,
-
         // 630-650 for sqlite errors.
         SQLite_SqlException = 630,
         SQLite_StorageDisabled = 631,
+
+        // 650-660 for diagnostic/fix related ids.
+        Diagnostics_AnalyzerPerformanceInfo = 651,
     }
 }


### PR DESCRIPTION
We already report analyzer temeletry in the OOP process for background analysis for open documents. Now we do so also for Ctrl + Dot lightbulb invocation code path