### PR TITLE
Filter out complex reduced extensions when we have high confidence they are not applicable.

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -10594,5 +10594,197 @@ class Goo
                 state.AssertMatchesTextStartingAtLine(7, "[Test(argument:)]")
             End Using
         End Function
+
+        <WpfFact, WorkItem(39689, "https://github.com/dotnet/roslyn/issues/39689")>
+        Public Async Function TestFilteringOfExtensionMethodsWithConstraints1() As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+using System;
+
+public interface ISomeInterface&lt;T&gt;
+{
+}
+
+public static class Extensions
+{       
+    public static bool SomeExtMethod&lt;T1, T2&gt;(this T1 builder, T2 x)
+        where T1 : ISomeInterface&lt;T2&gt;
+    {
+        return true;
+    }
+}
+public class Bar
+{
+    void M(string[] s)
+    {
+        s.$$
+    }
+}
+                </Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionItemsDoNotContainAny("SomeExtMethod")
+            End Using
+        End Function
+
+        <WpfFact, WorkItem(39689, "https://github.com/dotnet/roslyn/issues/39689")>
+        Public Async Function TestFilteringOfExtensionMethodsWithConstraints2() As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+using System;
+
+public interface ISomeInterface&lt;T&gt;
+{
+}
+
+public static class Extensions
+{       
+    public static bool SomeExtMethod&lt;T1, T2&gt;(this T1 builder, T2 x)
+        where T1 : ISomeInterface&lt;T2&gt;
+    {
+        return true;
+    }
+}
+public class Bar : ISomeInterface&lt;int&gt;
+{
+    void M(Bar s)
+    {
+        s.$$
+    }
+}
+                </Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionItemsContain("SomeExtMethod", displayTextSuffix:="<>")
+            End Using
+        End Function
+
+        <WpfFact, WorkItem(39689, "https://github.com/dotnet/roslyn/issues/39689")>
+        Public Async Function TestFilteringOfExtensionMethodsWithConstraints3() As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+using System;
+
+public interface ISomeInterface&lt;T&gt;
+{
+}
+
+public static class Extensions
+{       
+    public static bool SomeExtMethod&lt;T1, T2&gt;(this T1 builder, T2 x)
+        where T1 : ISomeInterface&lt;T2&gt;
+    {
+        return true;
+    }
+}
+public class Bar&lt;T&gt; : ISomeInterface&lt;T&gt;
+{
+    void M(Bar s)
+    {
+        s.$$
+    }
+}
+                </Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionItemsContain("SomeExtMethod", displayTextSuffix:="<>")
+            End Using
+        End Function
+
+        <WpfFact, WorkItem(39689, "https://github.com/dotnet/roslyn/issues/39689")>
+        Public Async Function TestFilteringOfExtensionMethodsWithConstraints4() As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+using System;
+
+public interface ISomeInterface&lt;T&gt;
+{
+}
+
+public static class Extensions
+{       
+    public static bool SomeExtMethod&lt;T1, T2&gt;(this T1 builder, T2 x)
+        where T1 : ISomeInterface&lt;T2&gt;
+    {
+        return true;
+    }
+}
+public class Bar&lt;T&gt;
+{
+    void M(ISomeInterface&lt;T&gt; s)
+    {
+        s.$$
+    }
+}
+                </Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionItemsContain("SomeExtMethod", displayTextSuffix:="<>")
+            End Using
+        End Function
+
+        <WpfFact, WorkItem(39689, "https://github.com/dotnet/roslyn/issues/39689")>
+        Public Async Function TestFilteringOfExtensionMethodsWithConstraints5() As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+using System;
+
+public interface ISomeInterface&lt;T&gt;
+{
+}
+
+public static class Extensions
+{       
+    public static bool SomeExtMethod&lt;T1, T2&gt;(this T1 builder, T2 x)
+        where T1 : ISomeInterface&lt;T2&gt;
+    {
+        return true;
+    }
+}
+public class Bar&lt;T&gt;
+{
+    void M(ISomeInterface&lt;int&gt; s)
+    {
+        s.$$
+    }
+}
+                </Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionItemsContain("SomeExtMethod", displayTextSuffix:="<>")
+            End Using
+        End Function
+
+        <WpfFact, WorkItem(39689, "https://github.com/dotnet/roslyn/issues/39689")>
+        Public Async Function TestFilteringOfExtensionMethodsWithConstraints6() As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+using System;
+
+public interface ISomeInterface&lt;T&gt;
+{
+}
+
+public static class Extensions
+{       
+    public static bool SomeExtMethod&lt;T1, T2&gt;(this T1 builder, T2 x)
+        where T1 : T2
+    {
+        return true;
+    }
+}
+public class Bar&lt;T&gt;
+{
+    void M(string[] s)
+    {
+        s.$$
+    }
+}
+                </Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionItemsContain("SomeExtMethod", displayTextSuffix:="<>")
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -10679,7 +10679,7 @@ public static class Extensions
 }
 public class Bar&lt;T&gt; : ISomeInterface&lt;T&gt;
 {
-    void M(Bar s)
+    void M(Bar&lt;T&gt; s)
     {
         s.$$
     }
@@ -10776,6 +10776,38 @@ public static class Extensions
 public class Bar&lt;T&gt;
 {
     void M(string[] s)
+    {
+        s.$$
+    }
+}
+                </Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionItemsContain("SomeExtMethod", displayTextSuffix:="<>")
+            End Using
+        End Function
+
+        <WpfFact, WorkItem(39689, "https://github.com/dotnet/roslyn/issues/39689")>
+        Public Async Function TestFilteringOfExtensionMethodsWithConstraints7() As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+using System;
+
+public interface ISomeInterface&lt;T&gt;
+{
+}
+
+public static class Extensions
+{       
+    public static bool SomeExtMethod&lt;T1, T2&gt;(this T1 builder, T2 x)
+        where T1 : ISomeInterface&lt;T2&gt;
+    {
+        return true;
+    }
+}
+public class Bar&lt;T&gt; : ISomeInterface&lt;T&gt;
+{
+    void M(Bar&lt;int&gt; s)
     {
         s.$$
     }

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -337,7 +337,7 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext>
                 return containerMembers;
 
             // Compiler will return reduced extension methods in the case it can't determine if constraints match.
-            // Attempt to filter out cases that will never succeed.
+            // Attempt to filter out cases we have strong confidence will never succeed.
             using var _ = ArrayBuilder<ISymbol>.GetInstance(containerMembers.Length, out var result);
 
             foreach (var member in containerMembers)

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -344,10 +344,11 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext>
             {
                 if (member.IsReducedExtension())
                 {
-                    // Get the original extension method and see if it has any base-type or base-interface constraint.
-                    // If so, confirm that the type we're on derives from or implements that interface.  Note that we do
-                    // this looking at the uninstantiated forms as there's no way to tell if the instantiations match as
-                    // the signature may not have enough information provided to answer that question.
+                    // Get the original extension method and see if it extends a type parameter that itself has any
+                    // base-type or base-interface constraints. If so, confirm that the type we're on derives from or
+                    // implements that constraint types.  Note that we do this looking at the uninstantiated forms as
+                    // there's no way to tell if the instantiations match as the signature may not have enough
+                    // information provided to answer that question accurately.
                     var originalMember = member.GetOriginalUnreducedDefinition();
                     if (originalMember is IMethodSymbol { Parameters: [{ Type: ITypeParameterSymbol parameterType }, ..] })
                     {

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -326,31 +326,110 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext>
         protected ImmutableArray<ISymbol> LookupSymbolsInContainer(
             INamespaceOrTypeSymbol container, int position, bool excludeInstance)
         {
-            return excludeInstance
-                ? _context.SemanticModel.LookupStaticMembers(position, container)
-                : SuppressDefaultTupleElements(
-                    container,
-                    _context.SemanticModel.LookupSymbols(position, container, includeReducedExtensionMethods: true));
+            if (excludeInstance)
+                return _context.SemanticModel.LookupStaticMembers(position, container);
+
+            var containerMembers = SuppressDefaultTupleElements(
+                container,
+                _context.SemanticModel.LookupSymbols(position, container, includeReducedExtensionMethods: true));
+
+            if (container is not ITypeSymbol containerType)
+                return containerMembers;
+
+            // Compiler will return reduced extension methods in the case it can't determine if constraints match.
+            // Attempt to filter out cases that will never succeed.
+            using var _ = ArrayBuilder<ISymbol>.GetInstance(containerMembers.Length, out var result);
+
+            foreach (var member in containerMembers)
+            {
+                if (member.IsReducedExtension())
+                {
+                    // Get the original extension method and see if it has any base-type or base-interface constraint.
+                    // If so, confirm that the type we're on derives from or implements that interface.  Note that we do
+                    // this looking at the uninstantiated forms as there's no way to tell if the instantiations match as
+                    // the signature may not have enough information provided to answer that question.
+                    var originalMember = (IMethodSymbol)member.GetOriginalUnreducedDefinition();
+                    if (originalMember.Parameters is [{ Type: ITypeParameterSymbol parameterType }, ..])
+                    {
+                        if (!MatchesConstraints(containerType.OriginalDefinition, parameterType.ConstraintTypes))
+                            continue;
+                    }
+                }
+
+                result.Add(member);
+            }
+
+            return result.ToImmutable();
+
+            static bool MatchesConstraints(ITypeSymbol originalContainerType, ImmutableArray<ITypeSymbol> constraintTypes)
+            {
+                // If there are no constraint types, then this type parameter was unconstrained, so could match anything.
+                if (constraintTypes.IsEmpty)
+                    return true;
+
+                // Now check that the type we're calling on matched at least one of the constraints that were specified.
+                foreach (var constraintType in constraintTypes)
+                {
+                    if (MatchesConstraint(originalContainerType, constraintType.OriginalDefinition))
+                        return true;
+                }
+
+                return false;
+            }
+
+            static bool MatchesConstraint(ITypeSymbol originalContainerType, ITypeSymbol originalConstraintType)
+            {
+                // If the type we're dotting off of *is* the constraint type, then this is def a match and we can proceed.
+                if (SymbolEqualityComparer.Default.Equals(originalContainerType, originalConstraintType))
+                    return true;
+
+                if (originalConstraintType.TypeKind == TypeKind.TypeParameter)
+                {
+                    // If it's a type parameter constrained on another type parameter, then just assume for now that
+                    // it's a match.  We could attempt to walk through these in the future, but for now this is complex
+                    // enough that we'll just allow it.
+                    return true;
+                }
+                else if (originalConstraintType.TypeKind == TypeKind.Interface)
+                {
+                    // If the constraint is an interface then see if that interface appears in the interface inheritance
+                    // hierarchy of the type we're dotting off of.
+                    foreach (var interfaceType in originalContainerType.AllInterfaces)
+                    {
+                        if (SymbolEqualityComparer.Default.Equals(interfaceType.OriginalDefinition, originalConstraintType))
+                            return true;
+                    }
+                }
+                else if (originalConstraintType.TypeKind == TypeKind.Class)
+                {
+                    // If the constraint is an interface then see if that interface appears in the base type inheritance
+                    // hierarchy of the type we're dotting off of.
+                    for (var current = originalContainerType.BaseType; current != null; current = current.BaseType)
+                    {
+                        if (SymbolEqualityComparer.Default.Equals(current.OriginalDefinition, originalConstraintType))
+                            return true;
+                    }
+                }
+                else
+                {
+                    // If we somehow have a constraint that isn't a type parameter, then we really don't know what's
+                    // going on.  Just presume that this constraint would match and show the completion item.  We can
+                    // revisit this choice if this turns out to be an issue.
+                    return true;
+                }
+
+                // For anything else, we don't consider this a match.  This can be adjusted in the future if need be.
+                return false;
+            }
         }
 
         /// <summary>
-        /// If container is a tuple type, any of its tuple element which has a friendly name will cause
-        /// the suppression of the corresponding default name (ItemN).
-        /// In that case, Rest is also removed.
+        /// If container is a tuple type, any of its tuple element which has a friendly name will cause the suppression
+        /// of the corresponding default name (ItemN). In that case, Rest is also removed.
         /// </summary>
-        protected static ImmutableArray<ISymbol> SuppressDefaultTupleElements(
-            INamespaceOrTypeSymbol container, ImmutableArray<ISymbol> symbols)
-        {
-            var namedType = container as INamedTypeSymbol;
-            if (namedType?.IsTupleType != true)
-            {
-                // container is not a tuple
-                return symbols;
-            }
-
-            //return tuple elements followed by other members that are not fields
-            return ImmutableArray<ISymbol>.CastUp(namedType.TupleElements).
-                Concat(symbols.WhereAsArray(s => s.Kind != SymbolKind.Field));
-        }
+        protected static ImmutableArray<ISymbol> SuppressDefaultTupleElements(INamespaceOrTypeSymbol container, ImmutableArray<ISymbol> symbols)
+            => container is not INamedTypeSymbol { IsTupleType: true } namedType
+                ? symbols
+                : symbols.Where(s => s is not IFieldSymbol).Concat(namedType.TupleElements).ToImmutableArray();
     }
 }

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -413,9 +413,9 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext>
                 }
                 else
                 {
-                    // If we somehow have a constraint that isn't a type parameter, then we really don't know what's
-                    // going on.  Just presume that this constraint would match and show the completion item.  We can
-                    // revisit this choice if this turns out to be an issue.
+                    // If we somehow have a constraint that isn't a type parameter, or class, or interface, then we
+                    // really don't know what's going on.  Just presume that this constraint would match and show the
+                    // completion item.  We can revisit this choice if this turns out to be an issue.
                     return true;
                 }
 

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -348,8 +348,8 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext>
                     // If so, confirm that the type we're on derives from or implements that interface.  Note that we do
                     // this looking at the uninstantiated forms as there's no way to tell if the instantiations match as
                     // the signature may not have enough information provided to answer that question.
-                    var originalMember = (IMethodSymbol)member.GetOriginalUnreducedDefinition();
-                    if (originalMember.Parameters is [{ Type: ITypeParameterSymbol parameterType }, ..])
+                    var originalMember = member.GetOriginalUnreducedDefinition();
+                    if (originalMember is IMethodSymbol { Parameters: [{ Type: ITypeParameterSymbol parameterType }, ..] })
                     {
                         if (!MatchesConstraints(containerType.OriginalDefinition, parameterType.ConstraintTypes))
                             continue;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
@@ -202,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         public static bool IsReducedExtension([NotNullWhen(returnValue: true)] this ISymbol? symbol)
-            => symbol is IMethodSymbol method && method.MethodKind == MethodKind.ReducedExtension;
+            => symbol is IMethodSymbol { MethodKind: MethodKind.ReducedExtension };
 
         public static bool IsEnumMember([NotNullWhen(returnValue: true)] this ISymbol? symbol)
             => symbol?.Kind == SymbolKind.Field && symbol.ContainingType.IsEnumType();


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/39689