### PR TITLE
Add F1 help keyword for `default` constraint

### DIFF
--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -451,10 +451,19 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 }
             }
 
-            if (token.IsKind(SyntaxKind.DefaultKeyword) && token.Parent is DefaultSwitchLabelSyntax)
+            if (token.IsKind(SyntaxKind.DefaultKeyword))
             {
-                text = Keyword("defaultcase");
-                return true;
+                if (token.Parent is DefaultSwitchLabelSyntax)
+                {
+                    text = Keyword("defaultcase");
+                    return true;
+                }
+
+                if (token.Parent is DefaultConstraintSyntax)
+                {
+                    text = Keyword("defaultconstraint");
+                    return true;
+                }
             }
 
             if (token.IsKind(SyntaxKind.ClassKeyword) && token.Parent is ClassOrStructConstraintSyntax)

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -464,6 +464,18 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                     text = Keyword("defaultconstraint");
                     return true;
                 }
+
+                if (token.Parent is DefaultSwitchLabelSyntax or GotoStatementSyntax)
+                {
+                    text = Keyword("defaultcase");
+                    return true;
+                }
+
+                if (token.Parent is LineDirectiveTriviaSyntax)
+                {
+                    text = Keyword("defaultline");
+                    return true;
+                }
             }
 
             if (token.IsKind(SyntaxKind.ClassKeyword) && token.Parent is ClassOrStructConstraintSyntax)

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -453,12 +453,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 
             if (token.IsKind(SyntaxKind.DefaultKeyword))
             {
-                if (token.Parent is DefaultSwitchLabelSyntax)
-                {
-                    text = Keyword("defaultcase");
-                    return true;
-                }
-
                 if (token.Parent is DefaultConstraintSyntax)
                 {
                     text = Keyword("defaultconstraint");

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -1739,5 +1739,20 @@ class C
                 }
                 """, "required");
         }
+
+        [Fact]
+        public async Task TestDefaultConstraint()
+        {
+            await Test_KeywordAsync("""
+                public class Base
+                {
+                    virtual void M<T>(T? t) { }
+                }
+                public class C
+                {
+                    override void M<T>() where T : def[||]ault { }
+                }
+                """, expectedText: "defaultconstraint");
+        }
     }
 }

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -1754,5 +1754,53 @@ class C
                 }
                 """, expectedText: "defaultconstraint");
         }
+
+        [Fact]
+        public async Task TestDefaultCase()
+        {
+            await Test_KeywordAsync("""
+                public class C
+                {
+                    void M(object o)
+                    {
+                        switch (o)
+                        {
+                            case 1:
+                                goto def[||]ault;
+                            default:
+                                return;
+                        }
+                    }
+                }
+                """, expectedText: "defaultcase");
+        }
+
+        [Fact]
+        public async Task TestGotoDefault()
+        {
+            await Test_KeywordAsync("""
+                public class C
+                {
+                    void M(object o)
+                    {
+                        switch (o)
+                        {
+                            case 1:
+                                goto default;
+                            def[||]ault:
+                                return;
+                        }
+                    }
+                }
+                """, expectedText: "defaultcase");
+        }
+
+        [Fact]
+        public async Task TestLineDefault()
+        {
+            await Test_KeywordAsync("""
+                #line def[||]ault
+                """, expectedText: "defaultline");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/65210

@CyrusNajmabadi I'm not familiar with F1 help. I just picked a keyword "defaultconstraint" that seems aligned with existing keywords. If I understood correctly, we can ping Bill to add that keyword and point it appropriately?