### PR TITLE
Remove ImportCompletion feature flag and enable by default

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
@@ -17,6 +17,7 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders
 {
     [UseExportProvider]
+    [Trait(Traits.Feature, Traits.Features.Completion)]
     public class TypeImportCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
         internal override Type GetCompletionProviderType()
@@ -28,46 +29,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
             ForceExpandedCompletionIndexCreation = true;
         }
 
-        #region "Option tests"
-
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task OptionSetToNull_ExpEnabled()
-        {
-            TypeImportCompletionFeatureFlag = true;
-
-            ShowImportCompletionItemsOptionValue = null;
-
-            var markup = @"
-class Bar
-{
-     $$
-}";
-
-            await VerifyAnyItemExistsAsync(markup);
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task OptionSetToNull_ExpDisabled()
-        {
-            ShowImportCompletionItemsOptionValue = null;
-            ForceExpandedCompletionIndexCreation = false;
-            var markup = @"
-class Bar
-{
-     $$
-}";
-
-            await VerifyNoItemsExistAsync(markup);
-        }
-
+        [InlineData(null)]
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task OptionSetToFalse(bool isExperimentEnabled)
+        [Theory]
+        public async Task OptionSetToTrue(bool? optionValue)
         {
-            TypeImportCompletionFeatureFlag = isExperimentEnabled;
-            ShowImportCompletionItemsOptionValue = false;
-            ForceExpandedCompletionIndexCreation = false;
+            ShowImportCompletionItemsOptionValue = optionValue;
 
             var markup = @"
 class Bar
@@ -75,27 +43,15 @@ class Bar
      $$
 }";
 
-            await VerifyNoItemsExistAsync(markup);
+            if (!optionValue.HasValue || optionValue.Value)
+            {
+                await VerifyAnyItemExistsAsync(markup);
+            }
+            else
+            {
+                await VerifyNoItemsExistAsync(markup);
+            }
         }
-
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task OptionSetToTrue(bool isExperimentEnabled)
-        {
-            TypeImportCompletionFeatureFlag = isExperimentEnabled;
-            ShowImportCompletionItemsOptionValue = true;
-
-            var markup = @"
-class Bar
-{
-     $$
-}";
-
-            await VerifyAnyItemExistsAsync(markup);
-        }
-
-        #endregion
 
         #region "CompletionItem tests"
 
@@ -104,7 +60,7 @@ class Bar
         [InlineData("struct", (int)Glyph.StructurePublic)]
         [InlineData("enum", (int)Glyph.EnumPublic)]
         [InlineData("interface", (int)Glyph.InterfacePublic)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task Show_TopLevel_NoImport_InProject(string typeKind, int glyph)
         {
             var file1 = $@"
@@ -133,7 +89,7 @@ namespace Baz
         [InlineData("struct", (int)Glyph.StructurePublic)]
         [InlineData("enum", (int)Glyph.EnumPublic)]
         [InlineData("interface", (int)Glyph.InterfacePublic)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task Show_TopLevelStatement_NoImport_InProject(string typeKind, int glyph)
         {
             var file1 = $@"
@@ -157,7 +113,7 @@ $$
         [InlineData("struct")]
         [InlineData("enum")]
         [InlineData("interface")]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task DoNotShow_TopLevel_SameNamespace_InProject(string typeKind)
         {
             var file1 = $@"
@@ -184,7 +140,7 @@ namespace Foo
         [InlineData("record", (int)Glyph.ClassPublic)]
         [InlineData("struct", (int)Glyph.StructurePublic)]
         [InlineData("interface", (int)Glyph.InterfacePublic)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task Show_TopLevel_MutipleOverrides_NoImport_InProject(string typeKind, int glyph)
         {
             var file1 = $@"
@@ -218,7 +174,7 @@ namespace Baz
         [InlineData("struct")]
         [InlineData("enum")]
         [InlineData("interface")]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task DoNotShow_NestedType_NoImport_InProject(string typeKind)
         {
             var file1 = $@"
@@ -248,7 +204,7 @@ namespace Baz
         [InlineData("struct")]
         [InlineData("enum")]
         [InlineData("interface")]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task DoNotShow_TopLevel_WithImport_InProject(string typeKind)
         {
             var file1 = $@"
@@ -274,7 +230,7 @@ namespace Baz
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task Show_TopLevel_Public_NoImport_InReference(bool isProjectReference)
         {
             var file1 = $@"
@@ -301,7 +257,7 @@ namespace Baz
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task DoNotShow_TopLevel_Public_WithImport_InReference(bool isProjectReference)
         {
             var file1 = $@"
@@ -329,7 +285,7 @@ namespace Baz
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task DoNotShow_TopLevel_Internal_NoImport_InReference(bool isProjectReference)
         {
             var file1 = $@"
@@ -356,7 +312,7 @@ namespace Baz
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task TopLevel_OverloadsWithMixedAccessibility_Internal_NoImport_InReference1(bool isProjectReference)
         {
             var file1 = $@"
@@ -383,7 +339,7 @@ namespace Baz
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task DoNotShow_TopLevel_OverloadsWithMixedAccessibility_Internal_WithImport_InReference1(bool isProjectReference)
         {
             var file1 = $@"
@@ -411,7 +367,7 @@ namespace Baz
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task TopLevel_OverloadsWithMixedAccessibility_InternalWithIVT_NoImport_InReference1(bool isProjectReference)
         {
             var file1 = $@"     
@@ -440,7 +396,7 @@ namespace Baz
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task DoNotShow_TopLevel_OverloadsWithMixedAccessibility_InternalWithIVT_WithImport_InReference1(bool isProjectReference)
         {
             var file1 = $@"     
@@ -470,7 +426,7 @@ namespace Baz
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task TopLevel_OverloadsWithMixedAccessibility_Internal_NoImport_InReference2(bool isProjectReference)
         {
             var file1 = $@"
@@ -500,7 +456,7 @@ namespace Baz
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task DoNotShow_TopLevel_OverloadsWithMixedAccessibility_Internal_SameNamespace_InReference2(bool isProjectReference)
         {
             var file1 = $@"
@@ -530,7 +486,7 @@ namespace Foo.Baz
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task TopLevel_OverloadsWithMixedAccessibility_InternalWithIVT_NoImport_InReference2(bool isProjectReference)
         {
             var file1 = $@"   
@@ -562,7 +518,7 @@ namespace Baz
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task Show_TopLevel_Internal_WithIVT_NoImport_InReference(bool isProjectReference)
         {
             var file1 = $@"
@@ -585,7 +541,7 @@ namespace Baz
             await VerifyTypeImportItemExistsAsync(markup, "Bar", glyph: (int)Glyph.ClassInternal, inlineDescription: "Foo");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task Show_TopLevel_NoImport_InVBReference()
         {
             var file1 = $@"
@@ -605,7 +561,7 @@ namespace Baz
             await VerifyTypeImportItemExistsAsync(markup, "Barr", glyph: (int)Glyph.ClassPublic, inlineDescription: "Foo.Bar");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task VB_MixedCapitalization_Test()
         {
             var file1 = $@"
@@ -634,7 +590,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Foo", inlineDescription: "na");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task VB_MixedCapitalization_WithImport_Test()
         {
             var file1 = $@"
@@ -664,7 +620,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Foo", inlineDescription: "na");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task DoNotShow_TopLevel_Internal_NoImport_InVBReference()
         {
             var file1 = $@"
@@ -684,7 +640,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Barr", inlineDescription: "Foo.Bar");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task DoNotShow_TopLevel_WithImport_InVBReference()
         {
             var file1 = $@"
@@ -707,7 +663,7 @@ namespace Baz
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task TypesWithIdenticalNameButDifferentNamespaces(bool isProjectReference)
         {
             var file1 = $@"
@@ -744,7 +700,7 @@ namespace NS
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task TestNoCompletionItemWhenThereIsAlias(bool isProjectReference)
         {
             var file1 = @"
@@ -796,7 +752,7 @@ namespace Foo1
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task TestAttributesAlias(bool isProjectReference)
         {
             var file1 = @"
@@ -831,7 +787,7 @@ namespace Foo
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task TestGenericsAliasHasNoEffect(bool isProjectReference)
         {
             var file1 = @"
@@ -877,7 +833,7 @@ namespace Foo1
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         public async Task Commit_NoImport_InProject(SourceCodeKind kind)
         {
             var file1 = $@"
@@ -912,7 +868,7 @@ namespace Baz
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         public async Task Commit_TopLevelStatement_NoImport_InProject(SourceCodeKind kind)
         {
             var file1 = $@"
@@ -935,7 +891,7 @@ Bar$$
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         public async Task Commit_TopLevelStatement_UnrelatedImport_InProject(SourceCodeKind kind)
         {
             var file1 = $@"
@@ -962,7 +918,7 @@ Bar$$
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         public async Task Commit_NoImport_InVBReference(SourceCodeKind kind)
         {
             var file1 = $@"
@@ -994,7 +950,7 @@ namespace Baz
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         public async Task Commit_NoImport_InPEReference(SourceCodeKind kind)
         {
             var markup = $@"<Workspace>
@@ -1019,7 +975,7 @@ class Bar
 
         #endregion
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task DoNotShow_TopLevel_Public_NoImport_InNonGlobalAliasedMetadataReference()
         {
             var file1 = $@"
@@ -1040,7 +996,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Bar", inlineDescription: "Foo");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task Show_TopLevel_Public_NoImport_InGlobalAliasedMetadataReference()
         {
             var file1 = $@"
@@ -1061,7 +1017,7 @@ namespace Baz
             await VerifyTypeImportItemExistsAsync(markup, "Bar", glyph: (int)Glyph.ClassPublic, inlineDescription: "Foo");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task DoNotShow_TopLevel_Public_NoImport_InNonGlobalAliasedProjectReference()
         {
             var file1 = $@"
@@ -1082,7 +1038,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Bar", inlineDescription: "Foo");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task ShorterTypeNameShouldShowBeforeLongerTypeName()
         {
             var file1 = $@"
@@ -1106,7 +1062,7 @@ namespace Baz
             AssertRelativeOrder(new List<string>() { "SomeType", "SomeTypeWithLongerName" }, completionList.ItemsList.ToImmutableArray());
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task AttributeTypeInAttributeNameContext()
         {
@@ -1134,7 +1090,7 @@ namespace Test
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task CommitAttributeTypeInAttributeNameContext(SourceCodeKind kind)
         {
@@ -1164,7 +1120,7 @@ namespace Test
             await VerifyCustomCommitProviderAsync(markup, "My", expectedCodeAfterCommit, sourceCodeKind: kind);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task AttributeTypeInNonAttributeNameContext()
         {
@@ -1194,7 +1150,7 @@ namespace Test
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task CommitAttributeTypeInNonAttributeNameContext(SourceCodeKind kind)
         {
@@ -1227,7 +1183,7 @@ namespace Test
             await VerifyCustomCommitProviderAsync(markup, "MyAttribute", expectedCodeAfterCommit, sourceCodeKind: kind);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task AttributeTypeWithoutSuffixInAttributeNameContext()
         {
@@ -1254,7 +1210,7 @@ namespace Test
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task CommitAttributeTypeWithoutSuffixInAttributeNameContext(SourceCodeKind kind)
         {
@@ -1285,7 +1241,7 @@ namespace Test
             await VerifyCustomCommitProviderAsync(markup, "Myattribute", expectedCodeAfterCommit, sourceCodeKind: kind);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task AttributeTypeWithoutSuffixInNonAttributeNameContext()
         {
@@ -1314,7 +1270,7 @@ namespace Test
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task CommitAttributeTypeWithoutSuffixInNonAttributeNameContext(SourceCodeKind kind)
         {
@@ -1348,7 +1304,7 @@ namespace Test
             await VerifyCustomCommitProviderAsync(markup, "Myattribute", expectedCodeAfterCommit, sourceCodeKind: kind);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task VBAttributeTypeWithoutSuffixInAttributeNameContext()
         {
@@ -1379,7 +1335,7 @@ namespace Test
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(37038, "https://github.com/dotnet/roslyn/issues/37038")]
         public async Task CommitTypeInUsingStaticContextShouldUseFullyQualifiedName(SourceCodeKind kind)
         {
@@ -1401,7 +1357,7 @@ using static Foo.MyClass$$";
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(37038, "https://github.com/dotnet/roslyn/issues/37038")]
         public async Task CommitGenericTypeParameterInUsingAliasContextShouldUseFullyQualifiedName(SourceCodeKind kind)
         {
@@ -1423,7 +1379,7 @@ using CollectionOfStringBuilders = System.Collections.Generic.List<Foo.MyClass$$
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(37038, "https://github.com/dotnet/roslyn/issues/37038")]
         public async Task CommitGenericTypeParameterInUsingAliasContextShouldUseFullyQualifiedName2(SourceCodeKind kind)
         {
@@ -1451,7 +1407,6 @@ namespace Foo
         }
 
         [Fact]
-        [Trait(Traits.Feature, Traits.Features.Completion)]
         [Trait(Traits.Feature, Traits.Features.Interactive)]
         [WorkItem(39027, "https://github.com/dotnet/roslyn/issues/39027")]
         public async Task TriggerCompletionInSubsequentSubmission()
@@ -1470,7 +1425,7 @@ namespace Foo
             Assert.NotEmpty(completionList.ItemsList);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task ShouldNotTriggerInsideTrivia()
         {
             var file1 = $@"
@@ -1507,7 +1462,7 @@ namespace Baz
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task TestBrowsableAwaysFromReferences(bool isProjectReference)
         {
             var srcDoc = @"
@@ -1543,7 +1498,7 @@ namespace Foo
 
         [InlineData(true)]
         [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task TestBrowsableNeverFromReferences(bool isProjectReference)
         {
             var srcDoc = @"
@@ -1591,7 +1546,7 @@ namespace Foo
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task TestBrowsableAdvancedFromReferences(bool isProjectReference, bool hideAdvancedMembers)
         {
             HideAdvancedMembers = hideAdvancedMembers;
@@ -1637,7 +1592,7 @@ namespace Foo
             }
         }
 
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         [InlineData('.')]
         [InlineData(';')]
         public async Task TestCommitWithCustomizedCommitCharForParameterlessConstructor(char commitChar)
@@ -1684,7 +1639,7 @@ namespace BB
             await VerifyProviderCommitAsync(markup, "C", expected, commitChar: commitChar, sourceCodeKind: SourceCodeKind.Regular);
         }
 
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         [InlineData('.')]
         [InlineData(';')]
         public async Task TestCommitWithCustomizedCommitCharUnderNonObjectCreationContext(char commitChar)
@@ -1731,7 +1686,7 @@ namespace BB
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(54493, "https://github.com/dotnet/roslyn/issues/54493")]
         public async Task CommitInLocalFunctionContext(SourceCodeKind kind)
         {
@@ -1774,7 +1729,7 @@ namespace Test
             await VerifyProviderCommitAsync(markup, "MyClass", expectedCodeAfterCommit, commitChar: null, sourceCodeKind: kind);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         [WorkItem(58473, "https://github.com/dotnet/roslyn/issues/58473")]
         public async Task TestGlobalUsingsInSdkAutoGeneratedFile()
         {
@@ -1797,7 +1752,7 @@ global using global::System.Threading.Tasks;
             await VerifyTypeImportItemIsAbsentAsync(markup, "Console", inlineDescription: "System");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         [WorkItem(58473, "https://github.com/dotnet/roslyn/issues/58473")]
         public async Task TestGlobalUsingsInSameFile()
         {
@@ -1813,7 +1768,6 @@ $$";
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/59088")]
-        [Trait(Traits.Feature, Traits.Features.Completion)]
         [WorkItem(58473, "https://github.com/dotnet/roslyn/issues/58473")]
         public async Task TestGlobalUsingsInUserDocument()
         {

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSource.cs
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
                 var sessionData = CompletionSessionData.GetOrCreateSessionData(session);
 
-                if (!options.ShouldShowItemsFromUnimportedNamespaces())
+                if (!options.ShouldShowItemsFromUnimportedNamespaces)
                 {
                     // No need to trigger expanded providers at all if the feature is disabled, just trigger core providers and return;
                     var (context, list) = await GetCompletionContextWorkerAsync(session, document, trigger, triggerLocation,

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -6894,7 +6894,6 @@ namespace NS2
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
 
                 ' trigger completion with import completion disabled
                 state.SendInvokeCompletionList()
@@ -7093,7 +7092,6 @@ public class AA
 }</Document>)
 
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
 
                 state.SendInvokeCompletionList()
                 Await state.WaitForUIRenderedAsync()
@@ -7877,9 +7875,6 @@ namespace NS
     class ATaAaSaKa { }
 } </Document>,
                               showCompletionInArgumentLists:=showCompletionInArgumentLists)
-
-                state.Workspace.GlobalOptions.SetGlobalOption(
-                    New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
 
                 state.SendTypeChars("task")
                 Await state.WaitForAsynchronousOperationsAsync()
@@ -10283,8 +10278,6 @@ class MyClass
                               </Document>,
                               extraExportedTypes:={GetType(ItemWithAdditionalFilterTextsProvider)}.ToList())
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
-
                 state.SendTypeChars(" ")
                 Await state.AssertCompletionItemsContainAll("Consolation", "Add code that write to console", "Add code that write line to console")
 
@@ -10374,7 +10367,6 @@ class MyClass
 }
                               </Document>)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp), True)
                 state.SendTypeChars("if")
                 Await state.AssertSelectedCompletionItem(displayText:="if", inlineDescription:=Nothing, isHardSelected:=True)
@@ -10449,7 +10441,6 @@ class MyClass
 }
                               </Document>)
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp), False)
                 state.SendInvokeCompletionList()
                 ' We should still work normally w/o pythia recommender
@@ -10473,7 +10464,6 @@ class MyClass
                               </Document>,
                               extraExportedTypes:={GetType(TestPythiaDeclarationNameRecommenderImplmentation)}.ToList())
 
-                state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowNewSnippetExperienceUserOption, LanguageNames.CSharp), False)
 
                 state.SendInvokeCompletionList()

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -47,7 +47,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         protected readonly Mock<ICompletionSession> MockCompletionSession;
 
         protected bool? ShowTargetTypedCompletionFilter { get; set; }
-        protected bool? TypeImportCompletionFeatureFlag { get; set; }
         protected bool? ShowImportCompletionItemsOptionValue { get; set; }
         protected bool? ForceExpandedCompletionIndexCreation { get; set; }
         protected bool? HideAdvancedMembers { get; set; }
@@ -68,9 +67,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
             if (ShowTargetTypedCompletionFilter.HasValue)
                 options = options with { TargetTypedCompletionFilter = ShowTargetTypedCompletionFilter.Value };
-
-            if (TypeImportCompletionFeatureFlag.HasValue)
-                options = options with { TypeImportCompletion = TypeImportCompletionFeatureFlag.Value };
 
             if (ShowImportCompletionItemsOptionValue.HasValue)
                 options = options with { ShowItemsFromUnimportedNamespaces = ShowImportCompletionItemsOptionValue.Value };

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestStateFactory.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestStateFactory.vb
@@ -2,8 +2,8 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis.CSharp
 Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.CSharp
 Imports Microsoft.CodeAnalysis.Options
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
@@ -25,8 +25,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
                                  excludedTypes, extraExportedTypes,
                                  includeFormatCommandHandler, workspaceKind:=Nothing)
 
-            testState.Workspace.GlobalOptions.SetGlobalOption(
-                New OptionKey(CompletionOptionsStorage.TriggerInArgumentLists, LanguageNames.CSharp), showCompletionInArgumentLists)
+            testState.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.TriggerInArgumentLists, LanguageNames.CSharp), showCompletionInArgumentLists)
+            testState.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), False)
 
             Return testState
         End Function
@@ -34,15 +34,19 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Shared Function CreateVisualBasicTestState(documentElement As XElement,
                                                            Optional extraExportedTypes As List(Of Type) = Nothing) As TestState
 
-            Return New TestState(<Workspace>
-                                     <Project Language="Visual Basic" CommonReferences="true">
-                                         <Document>
-                                             <%= documentElement.Value %>
-                                         </Document>
-                                     </Project>
-                                 </Workspace>,
+            Dim testState = New TestState(<Workspace>
+                                              <Project Language="Visual Basic" CommonReferences="true">
+                                                  <Document>
+                                                      <%= documentElement.Value %>
+                                                  </Document>
+                                              </Project>
+                                          </Workspace>,
                                  excludedTypes:=Nothing, extraExportedTypes,
                                  includeFormatCommandHandler:=False, workspaceKind:=Nothing)
+
+            testState.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic), False)
+
+            Return testState
         End Function
 
         Public Shared Function CreateTestStateFromWorkspace(workspaceElement As XElement,
@@ -53,8 +57,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Dim testState = New TestState(
                 workspaceElement, excludedTypes:=Nothing, extraExportedTypes, includeFormatCommandHandler:=False, workspaceKind)
 
-            testState.Workspace.GlobalOptions.SetGlobalOption(
-                New OptionKey(CompletionOptionsStorage.TriggerInArgumentLists, LanguageNames.CSharp), showCompletionInArgumentLists)
+            testState.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.TriggerInArgumentLists, LanguageNames.CSharp), showCompletionInArgumentLists)
+            testState.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.VisualBasic), False)
 
             Return testState
         End Function

--- a/src/Features/Core/Portable/Completion/CompletionOptions.cs
+++ b/src/Features/Core/Portable/Completion/CompletionOptions.cs
@@ -19,10 +19,9 @@ namespace Microsoft.CodeAnalysis.Completion
         public SnippetsRule SnippetsBehavior { get; init; } = SnippetsRule.Default;
         public bool HideAdvancedMembers { get; init; } = false;
         public bool ShowNameSuggestions { get; init; } = true;
-        public bool? ShowItemsFromUnimportedNamespaces { get; init; } = null;
+        public bool? ShowItemsFromUnimportedNamespaces { get; init; } = true;
         public bool UnnamedSymbolCompletionDisabled { get; init; } = false;
         public bool TargetTypedCompletionFilter { get; init; } = false;
-        public bool TypeImportCompletion { get; init; } = false;
         public bool ProvideDateAndTimeCompletions { get; init; } = true;
         public bool ProvideRegexCompletions { get; init; } = true;
         public bool ForceExpandedCompletionIndexCreation { get; init; } = false;
@@ -43,14 +42,9 @@ namespace Microsoft.CodeAnalysis.Completion
 
         /// <summary>
         /// Whether items from unimported namespaces should be included in the completion list.
-        /// This takes into consideration the experiment we are running in addition to the value
-        /// from user facing options.
         /// </summary>
-        public bool ShouldShowItemsFromUnimportedNamespaces()
-        {
-            // Don't trigger import completion if the option value is "default" and the experiment is disabled for the user. 
-            return ShowItemsFromUnimportedNamespaces ?? TypeImportCompletion;
-        }
+        public bool ShouldShowItemsFromUnimportedNamespaces
+            => !ShowItemsFromUnimportedNamespaces.HasValue || ShowItemsFromUnimportedNamespaces.Value;
 
         /// <summary>
         /// Whether items from new snippet experience should be included in the completion list.

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
         public override async Task ProvideCompletionsAsync(CompletionContext completionContext)
         {
-            if (!completionContext.CompletionOptions.ShouldShowItemsFromUnimportedNamespaces())
+            if (!completionContext.CompletionOptions.ShouldShowItemsFromUnimportedNamespaces)
                 return;
 
             var cancellationToken = completionContext.CancellationToken;

--- a/src/Features/LanguageServer/Protocol/Features/Options/CompletionOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/CompletionOptionsStorage.cs
@@ -23,7 +23,6 @@ internal static class CompletionOptionsStorage
             ShowNameSuggestions = options.GetOption(ShowNameSuggestions, language),
             ShowItemsFromUnimportedNamespaces = options.GetOption(ShowItemsFromUnimportedNamespaces, language),
             UnnamedSymbolCompletionDisabled = options.GetOption(UnnamedSymbolCompletionDisabledFeatureFlag),
-            TypeImportCompletion = options.GetOption(TypeImportCompletionFeatureFlag),
             ProvideDateAndTimeCompletions = options.GetOption(ProvideDateAndTimeCompletions, language),
             ProvideRegexCompletions = options.GetOption(ProvideRegexCompletions, language),
             ForceExpandedCompletionIndexCreation = options.GetOption(ForceExpandedCompletionIndexCreation),
@@ -34,10 +33,6 @@ internal static class CompletionOptionsStorage
         };
 
     // feature flags
-
-    public static readonly Option2<bool> TypeImportCompletionFeatureFlag = new(nameof(CompletionOptions), nameof(TypeImportCompletionFeatureFlag),
-        CompletionOptions.Default.TypeImportCompletion,
-        new FeatureFlagStorageLocation("Roslyn.TypeImportCompletion"));
 
     public static readonly Option2<bool> UnnamedSymbolCompletionDisabledFeatureFlag = new(nameof(CompletionOptions), nameof(UnnamedSymbolCompletionDisabledFeatureFlag),
         CompletionOptions.Default.UnnamedSymbolCompletionDisabled,


### PR DESCRIPTION
The feature flag has been enabled publicly since 17.3 rtw. This would make the feature on by default and remove the feature flag.