### PR TITLE
Semantic snippets - fix new line being added after and line removed before snippet

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpConditionalBlockSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpConditionalBlockSnippetCompletionProviderTests.cs
@@ -213,7 +213,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
                     {
                         $$
                     }
-
                     return x == y;
                 };
                 """;

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpClassSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpClassSnippetCompletionProviderTests.cs
@@ -79,7 +79,6 @@ $$";
 
             var expectedCodeAfterCommit =
 @"System.Console.WriteLine();
-
 class MyClass
 {
     $$

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpConsoleSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpConsoleSnippetCompletionProviderTests.cs
@@ -82,7 +82,6 @@ class Program
 @"using System;
 
 Console.WriteLine($$);
-
 class Program
 {
     public async Task MethodAsync()

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForEachSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpForEachSnippetCompletionProviderTests.cs
@@ -225,7 +225,6 @@ static void Main(string[] args)
     {
         $$
     }
-
     return x == y;
 };";
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit, sourceCodeKind: SourceCodeKind.Regular);
@@ -248,7 +247,6 @@ static void Main(string[] args)
     {
         $$
     }
-
     return x == y;
 };";
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit, sourceCodeKind: SourceCodeKind.Script);

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpInterfaceSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpInterfaceSnippetCompletionProviderTests.cs
@@ -79,7 +79,6 @@ $$";
 
             var expectedCodeAfterCommit =
 @"System.Console.WriteLine();
-
 interface MyInterface
 {
     $$

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpStructSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpStructSnippetCompletionProviderTests.cs
@@ -81,7 +81,6 @@ $$";
 
             var expectedCodeAfterCommit =
 @"System.Console.WriteLine();
-
 struct MyStruct
 {
     $$

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -142,16 +142,10 @@ namespace Microsoft.CodeAnalysis.Snippets
             }
 
             var allTokens = node.DescendantTokens(descendIntoTrivia: true).ToList();
-            var filteredTokens = new List<SyntaxToken>();
 
-            // Takes out the first and last token since
+            // Skips the first and last token since
             // those do not need elastic trivia added to them.
-            for (var i = 1; i < allTokens.Count - 1; i++)
-            {
-                filteredTokens.Add(allTokens[i]);
-            }
-
-            var nodeWithTrivia = node.ReplaceTokens(filteredTokens,
+            var nodeWithTrivia = node.ReplaceTokens(allTokens.Skip(1).Take(allTokens.Count - 2),
                 (oldtoken, _) => oldtoken.WithAdditionalAnnotations(SyntaxAnnotation.ElasticAnnotation)
                 .WithAppendedTrailingTrivia(syntaxFacts.ElasticMarker)
                 .WithPrependedLeadingTrivia(syntaxFacts.ElasticMarker));

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -140,7 +141,17 @@ namespace Microsoft.CodeAnalysis.Snippets
                 return null;
             }
 
-            var nodeWithTrivia = node.ReplaceTokens(node.DescendantTokens(descendIntoTrivia: true),
+            var allTokens = node.DescendantTokens(descendIntoTrivia: true).ToList();
+            var filteredTokens = new List<SyntaxToken>();
+
+            // Takes out the first and last token since
+            // those do not need elastic trivia added to them.
+            for (var i = 1; i < allTokens.Count() - 1; i++)
+            {
+                filteredTokens.Add(allTokens[i]);
+            }
+
+            var nodeWithTrivia = node.ReplaceTokens(filteredTokens,
                 (oldtoken, _) => oldtoken.WithAdditionalAnnotations(SyntaxAnnotation.ElasticAnnotation)
                 .WithAppendedTrailingTrivia(syntaxFacts.ElasticMarker)
                 .WithPrependedLeadingTrivia(syntaxFacts.ElasticMarker));

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractSnippetProvider.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Snippets
 
             // Takes out the first and last token since
             // those do not need elastic trivia added to them.
-            for (var i = 1; i < allTokens.Count() - 1; i++)
+            for (var i = 1; i < allTokens.Count - 1; i++)
             {
                 filteredTokens.Add(allTokens[i]);
             }


### PR DESCRIPTION
Fixes: #65150 #64924