### PR TITLE
Explicitly set main-vs-deps draft PRs value to false

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -154,6 +154,7 @@
       ],
       "vsBranch": "main",
       "vsMajorVersion": 17,
+      "insertionCreateDraftPR": false,
       "insertionTitlePrefix": "[d17.5p2]"
     },
     "dev/jorobich/fix-pr-val": {


### PR DESCRIPTION
It seems like the default value of `insertionCreateDraftPR` is true. We should set it explicitly to false since right now all our insertions are being created as drafts.