### PR TITLE
Inline Diagnostics - add null check

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Adornments/AbstractAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/Adornments/AbstractAdornmentManager.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Formatting;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Threading;
 using Roslyn.Utilities;
@@ -251,9 +252,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Adornments
             AddAdornmentsToAdornmentLayer_CallOnlyOnUIThread(changedSpanCollection);
         }
 
-        protected bool ShouldDrawTag(SnapshotSpan snapshotSpan, IMappingTagSpan<T> mappingTagSpan, out SnapshotPoint mappedPoint)
+        protected bool ShouldDrawTag(SnapshotSpan snapshotSpan, IMappingTagSpan<T> mappingTagSpan, out IWpfTextViewLine viewLine)
         {
-            mappedPoint = default;
+            viewLine = null;
             var point = GetMappedPoint(snapshotSpan, mappingTagSpan);
 
             if (point is null)
@@ -271,7 +272,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Adornments
                 return false;
             }
 
-            mappedPoint = point.Value;
+            var mappedPoint = point.Value;
+
+            viewLine = TextView.TextViewLines.GetTextViewLineContainingBufferPosition(mappedPoint);
+            if (viewLine is null)
+            {
+                return false;
+            }
+
             return true;
         }
 

--- a/src/EditorFeatures/Core.Wpf/Adornments/AbstractAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/Adornments/AbstractAdornmentManager.cs
@@ -263,8 +263,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Adornments
             }
 
             var mappedPoint = point.Value;
-
             viewLine = TextView.TextViewLines.GetTextViewLineContainingBufferPosition(mappedPoint);
+
+            // Unsure what the scenario is - but sometimes the SnapshotPoint is not located
+            // within any of the lines in the TextViewLineCollection. In that case, we do not want to draw a tag.
             if (viewLine is null)
             {
                 return false;

--- a/src/EditorFeatures/Core.Wpf/Adornments/AbstractAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/Adornments/AbstractAdornmentManager.cs
@@ -262,20 +262,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Adornments
                 return false;
             }
 
+            var mappedPoint = point.Value;
+
+            viewLine = TextView.TextViewLines.GetTextViewLineContainingBufferPosition(mappedPoint);
+            if (viewLine is null)
+            {
+                return false;
+            }
+
             if (!TryMapToSingleSnapshotSpan(mappingTagSpan.Span, TextView.TextSnapshot, out var span))
             {
                 return false;
             }
 
             if (!TextView.TextViewLines.IntersectsBufferSpan(span))
-            {
-                return false;
-            }
-
-            var mappedPoint = point.Value;
-
-            viewLine = TextView.TextViewLines.GetTextViewLineContainingBufferPosition(mappedPoint);
-            if (viewLine is null)
             {
                 return false;
             }

--- a/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsAdornmentManager.cs
@@ -145,14 +145,7 @@ namespace Microsoft.CodeAnalysis.Editor.InlineDiagnostics
                 var tagSpans = TagAggregator.GetTags(changedSpan);
                 foreach (var tagMappingSpan in tagSpans)
                 {
-                    if (!ShouldDrawTag(changedSpan, tagMappingSpan, out var mappedPoint))
-                    {
-                        continue;
-                    }
-
-                    var viewLine = viewLines.GetTextViewLineContainingBufferPosition(mappedPoint);
-
-                    if (viewLine is null)
+                    if (!ShouldDrawTag(changedSpan, tagMappingSpan, out var viewLine))
                     {
                         continue;
                     }

--- a/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsAdornmentManager.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineDiagnostics/InlineDiagnosticsAdornmentManager.cs
@@ -152,6 +152,11 @@ namespace Microsoft.CodeAnalysis.Editor.InlineDiagnostics
 
                     var viewLine = viewLines.GetTextViewLineContainingBufferPosition(mappedPoint);
 
+                    if (viewLine is null)
+                    {
+                        continue;
+                    }
+
                     // If the line does not have an associated tagMappingSpan and changedSpan, then add the first one.
                     if (!map.TryGetValue(viewLine, out var value))
                     {


### PR DESCRIPTION
Adds a null check in case the TextViewLineCollection does not contain the specified buffer position.