### PR TITLE
Consistently return the same value from MethodSymbol.IteratorElementTypeWithAnnotations API

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1898,19 +1898,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             ImmutableArray<LocalSymbol> locals = GetDeclaredLocalsForScope(node);
 
-            if (IsDirectlyInIterator)
-            {
-                var method = ContainingMemberOrLambda as MethodSymbol;
-                if ((object)method != null)
-                {
-                    method.IteratorElementTypeWithAnnotations = GetIteratorElementType();
-                }
-                else
-                {
-                    Debug.Assert(diagnostics.DiagnosticBag is null || !diagnostics.DiagnosticBag.IsEmptyWithoutResolution);
-                }
-            }
-
             return new BoundBlock(
                 node,
                 locals,

--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -24,7 +24,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private MultiDictionary<string, ParameterSymbol> _lazyParameterMap;
         private readonly MethodSymbol _methodSymbol;
         private SmallDictionary<string, Symbol> _lazyDefinitionMap;
-        private TypeWithAnnotations.Boxed _iteratorElementType;
 
         public InMethodBinder(MethodSymbol owner, Binder enclosing)
             : base(enclosing, enclosing.Flags & ~BinderFlags.AllClearedAtExecutableCodeBoundary)
@@ -130,18 +129,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return !elementType.IsDefault ? elementType : TypeWithAnnotations.Create(CreateErrorType());
             }
 
-            if (_iteratorElementType is null)
-            {
-                TypeWithAnnotations elementType = GetIteratorElementTypeFromReturnType(Compilation, refKind, returnType, errorLocation: null, diagnostics: null);
-                if (elementType.IsDefault)
-                {
-                    elementType = TypeWithAnnotations.Create(CreateErrorType());
-                }
-
-                Interlocked.CompareExchange(ref _iteratorElementType, new TypeWithAnnotations.Boxed(elementType), null);
-            }
-
-            return _iteratorElementType.Value;
+            return _methodSymbol.IteratorElementTypeWithAnnotations;
         }
 
         internal static TypeWithAnnotations GetIteratorElementTypeFromReturnType(CSharpCompilation compilation,

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/SynthesizedClosureMethod.cs
@@ -39,7 +39,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                    originalMethod is LocalFunctionSymbol
                     ? MakeName(topLevelMethod.Name, originalMethod.Name, topLevelMethodId, closureKind, lambdaId)
                     : MakeName(topLevelMethod.Name, topLevelMethodId, closureKind, lambdaId),
-                   MakeDeclarationModifiers(closureKind, originalMethod))
+                   MakeDeclarationModifiers(closureKind, originalMethod),
+                   isIterator: originalMethod.IsIterator)
         {
             Debug.Assert(containingType.DeclaringCompilation is not null);
 

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -697,7 +697,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private sealed partial class BaseMethodWrapperSymbol : SynthesizedMethodBaseSymbol
         {
             internal BaseMethodWrapperSymbol(NamedTypeSymbol containingType, MethodSymbol methodBeingWrapped, SyntaxNode syntax, string name)
-                : base(containingType, methodBeingWrapped, syntax.SyntaxTree.GetReference(syntax), syntax.GetLocation(), name, DeclarationModifiers.Private)
+                : base(containingType, methodBeingWrapped, syntax.SyntaxTree.GetReference(syntax), syntax.GetLocation(), name, DeclarationModifiers.Private,
+                      isIterator: false)
             {
                 Debug.Assert(containingType.ContainingModule is SourceModuleSymbol);
                 Debug.Assert(ReferenceEquals(methodBeingWrapped, methodBeingWrapped.ConstructedFrom));
@@ -724,17 +725,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 AddSynthesizedAttribute(ref attributes, this.DeclaringCompilation.TrySynthesizeAttribute(WellKnownMember.System_Diagnostics_DebuggerHiddenAttribute__ctor));
             }
-
-            internal override TypeWithAnnotations IteratorElementTypeWithAnnotations
-            {
-                get
-                {
-                    // BaseMethodWrapperSymbol should not be rewritten by the IteratorRewriter
-                    return default;
-                }
-            }
-
-            internal override bool IsIterator => false;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
@@ -244,11 +244,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 return _iteratorElementType.Value;
             }
-            set
-            {
-                Debug.Assert(!value.IsDefault);
-                Interlocked.Exchange(ref _iteratorElementType, new TypeWithAnnotations.Boxed(value));
-            }
         }
 
         internal override bool IsIterator => BaseMethod.IsIterator;

--- a/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SynthesizedMethodBaseSymbol.cs
@@ -28,15 +28,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly string _name;
         private ImmutableArray<TypeParameterSymbol> _typeParameters;
         private ImmutableArray<ParameterSymbol> _parameters;
-        private TypeWithAnnotations.Boxed _iteratorElementType;
 
         protected SynthesizedMethodBaseSymbol(NamedTypeSymbol containingType,
                                               MethodSymbol baseMethod,
                                               SyntaxReference syntaxReference,
                                               Location location,
                                               string name,
-                                              DeclarationModifiers declarationModifiers)
-            : base(containingType, syntaxReference, location, isIterator: false)
+                                              DeclarationModifiers declarationModifiers,
+                                              bool isIterator)
+            : base(containingType, syntaxReference, location, isIterator)
         {
             Debug.Assert((object)containingType != null);
             Debug.Assert((object)baseMethod != null);
@@ -230,22 +230,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get { return false; }
         }
-
-        internal override TypeWithAnnotations IteratorElementTypeWithAnnotations
-        {
-            get
-            {
-                if (_iteratorElementType is null)
-                {
-                    Interlocked.CompareExchange(ref _iteratorElementType,
-                                                new TypeWithAnnotations.Boxed(TypeMap.SubstituteType(BaseMethod.IteratorElementTypeWithAnnotations.Type)),
-                                                null);
-                }
-
-                return _iteratorElementType.Value;
-            }
-        }
-
-        internal override bool IsIterator => BaseMethod.IsIterator;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -1090,7 +1090,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         internal virtual TypeWithAnnotations IteratorElementTypeWithAnnotations
         {
             get { return default; }
-            set { throw ExceptionUtilities.Unreachable(); }
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionOrSourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionOrSourceMemberMethodSymbol.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Threading;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    internal abstract class LocalFunctionOrSourceMemberMethodSymbol : SourceMethodSymbolWithAttributes
+    {
+        private TypeWithAnnotations.Boxed? _lazyIteratorElementType;
+
+        protected LocalFunctionOrSourceMemberMethodSymbol(SyntaxReference? syntaxReferenceOpt, bool isIterator)
+            : base(syntaxReferenceOpt)
+        {
+            if (isIterator)
+            {
+                _lazyIteratorElementType = TypeWithAnnotations.Boxed.Sentinel;
+            }
+        }
+
+        internal sealed override TypeWithAnnotations IteratorElementTypeWithAnnotations
+        {
+            get
+            {
+                if (_lazyIteratorElementType == TypeWithAnnotations.Boxed.Sentinel)
+                {
+                    TypeWithAnnotations elementType = InMethodBinder.GetIteratorElementTypeFromReturnType(DeclaringCompilation, RefKind, ReturnType, errorLocation: null, diagnostics: null);
+
+                    if (elementType.IsDefault)
+                    {
+                        elementType = TypeWithAnnotations.Create(new ExtendedErrorTypeSymbol(DeclaringCompilation, name: "", arity: 0, errorInfo: null, unreported: false));
+                    }
+
+                    Interlocked.CompareExchange(ref _lazyIteratorElementType, new TypeWithAnnotations.Boxed(elementType), TypeWithAnnotations.Boxed.Sentinel);
+
+                    Debug.Assert(TypeSymbol.Equals(_lazyIteratorElementType.Value.Type, elementType.Type, TypeCompareKind.ConsiderEverything));
+                }
+
+                return _lazyIteratorElementType?.Value ?? default;
+            }
+        }
+
+        internal sealed override bool IsIterator => _lazyIteratorElementType is object;
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -317,12 +317,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
+                if (_lazyIteratorElementType == TypeWithAnnotations.Boxed.Sentinel)
+                {
+                    TypeWithAnnotations elementType = InMethodBinder.GetIteratorElementTypeFromReturnType(DeclaringCompilation, RefKind, ReturnType, errorLocation: null, diagnostics: null);
+
+                    if (elementType.IsDefault)
+                    {
+                        elementType = TypeWithAnnotations.Create(new ExtendedErrorTypeSymbol(DeclaringCompilation, name: "", arity: 0, errorInfo: null, unreported: false));
+                    }
+
+                    Interlocked.CompareExchange(ref _lazyIteratorElementType, new TypeWithAnnotations.Boxed(elementType), TypeWithAnnotations.Boxed.Sentinel);
+
+                    Debug.Assert(TypeSymbol.Equals(_lazyIteratorElementType.Value.Type, elementType.Type, TypeCompareKind.ConsiderEverything));
+                }
+
                 return _lazyIteratorElementType?.Value ?? default;
-            }
-            set
-            {
-                Debug.Assert(_lazyIteratorElementType == TypeWithAnnotations.Boxed.Sentinel || (_lazyIteratorElementType is object && TypeSymbol.Equals(_lazyIteratorElementType.Value.Type, value.Type, TypeCompareKind.ConsiderEverything2)));
-                Interlocked.CompareExchange(ref _lazyIteratorElementType, new TypeWithAnnotations.Boxed(value), TypeWithAnnotations.Boxed.Sentinel);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -12,7 +12,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
-    internal sealed class LocalFunctionSymbol : SourceMethodSymbolWithAttributes
+    internal sealed class LocalFunctionSymbol : LocalFunctionOrSourceMemberMethodSymbol
     {
         private readonly Binder _binder;
         private readonly Symbol _containingSymbol;
@@ -26,7 +26,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private ImmutableArray<ImmutableArray<TypeWithAnnotations>> _lazyTypeParameterConstraintTypes;
         private ImmutableArray<TypeParameterConstraintKind> _lazyTypeParameterConstraintKinds;
         private TypeWithAnnotations.Boxed? _lazyReturnType;
-        private TypeWithAnnotations.Boxed? _lazyIteratorElementType;
 
         // Lock for initializing lazy fields and registering their diagnostics
         // Acquire this lock when initializing lazy objects to guarantee their declaration
@@ -37,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Binder binder,
             Symbol containingSymbol,
             LocalFunctionStatementSyntax syntax)
-            : base(syntax.GetReference())
+            : base(syntax.GetReference(), isIterator: SyntaxFacts.HasYieldOperations(syntax.Body))
         {
             Debug.Assert(containingSymbol.DeclaringCompilation == binder.Compilation);
             _containingSymbol = containingSymbol;
@@ -47,11 +46,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _declarationModifiers =
                 DeclarationModifiers.Private |
                 syntax.Modifiers.ToDeclarationModifiers(diagnostics: _declarationDiagnostics.DiagnosticBag);
-
-            if (SyntaxFacts.HasYieldOperations(syntax.Body))
-            {
-                _lazyIteratorElementType = TypeWithAnnotations.Boxed.Sentinel;
-            }
 
             this.CheckUnsafeModifier(_declarationModifiers, _declarationDiagnostics);
 
@@ -312,30 +306,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     firstParam.Modifiers.Any(SyntaxKind.ThisKeyword);
             }
         }
-
-        internal override TypeWithAnnotations IteratorElementTypeWithAnnotations
-        {
-            get
-            {
-                if (_lazyIteratorElementType == TypeWithAnnotations.Boxed.Sentinel)
-                {
-                    TypeWithAnnotations elementType = InMethodBinder.GetIteratorElementTypeFromReturnType(DeclaringCompilation, RefKind, ReturnType, errorLocation: null, diagnostics: null);
-
-                    if (elementType.IsDefault)
-                    {
-                        elementType = TypeWithAnnotations.Create(new ExtendedErrorTypeSymbol(DeclaringCompilation, name: "", arity: 0, errorInfo: null, unreported: false));
-                    }
-
-                    Interlocked.CompareExchange(ref _lazyIteratorElementType, new TypeWithAnnotations.Boxed(elementType), TypeWithAnnotations.Boxed.Sentinel);
-
-                    Debug.Assert(TypeSymbol.Equals(_lazyIteratorElementType.Value.Type, elementType.Type, TypeCompareKind.ConsiderEverything));
-                }
-
-                return _lazyIteratorElementType?.Value ?? default;
-            }
-        }
-
-        internal override bool IsIterator => _lazyIteratorElementType is object;
 
         public override MethodKind MethodKind => MethodKind.LocalFunction;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -727,12 +727,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
+                if (_lazyIteratorElementType == TypeWithAnnotations.Boxed.Sentinel)
+                {
+                    TypeWithAnnotations elementType = InMethodBinder.GetIteratorElementTypeFromReturnType(DeclaringCompilation, RefKind, ReturnType, errorLocation: null, diagnostics: null);
+
+                    if (elementType.IsDefault)
+                    {
+                        elementType = TypeWithAnnotations.Create(new ExtendedErrorTypeSymbol(DeclaringCompilation, name: "", arity: 0, errorInfo: null, unreported: false));
+                    }
+
+                    Interlocked.CompareExchange(ref _lazyIteratorElementType, new TypeWithAnnotations.Boxed(elementType), TypeWithAnnotations.Boxed.Sentinel);
+
+                    Debug.Assert(TypeSymbol.Equals(_lazyIteratorElementType.Value.Type, elementType.Type, TypeCompareKind.ConsiderEverything));
+                }
+
                 return _lazyIteratorElementType?.Value ?? default;
-            }
-            set
-            {
-                Debug.Assert(_lazyIteratorElementType == TypeWithAnnotations.Boxed.Sentinel || TypeSymbol.Equals(_lazyIteratorElementType.Value.Type, value.Type, TypeCompareKind.ConsiderEverything2));
-                Interlocked.CompareExchange(ref _lazyIteratorElementType, new TypeWithAnnotations.Boxed(value), TypeWithAnnotations.Boxed.Sentinel);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/IteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/IteratorTests.cs
@@ -33,7 +33,15 @@ class Test
     }
 }";
             var comp = CreateCompilation(text);
+
+            var i = comp.GetMember<MethodSymbol>("Test.I");
+            Assert.True(i.IsIterator);
+            Assert.Equal("System.Int32", i.IteratorElementTypeWithAnnotations.ToTestDisplayString());
+
             comp.VerifyDiagnostics();
+
+            Assert.True(i.IsIterator);
+            Assert.Equal("System.Int32", i.IteratorElementTypeWithAnnotations.ToTestDisplayString());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #40014.