### PR TITLE
Gate defaults/`params` delegate type inference breaking change on langversion

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -9011,10 +9011,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 (parameters.Any(p => p.EffectiveScope != DeclarationScope.Unscoped) ?
                 parameters.SelectAsArray(p => p.EffectiveScope) :
                 default);
-            var parameterDefaultValues = parameters.Any(p => p.HasExplicitDefaultValue) ?
+            var parameterDefaultValues = syntax.IsFeatureEnabled(MessageID.IDS_FeatureLambdaOptionalParameters) && parameters.Any(p => p.HasExplicitDefaultValue) ?
                 parameters.SelectAsArray(p => p.ExplicitDefaultConstantValue) :
                 default;
-            var hasParamsArray = parameters is [.., { IsParams: true }];
+            var hasParamsArray = syntax.IsFeatureEnabled(MessageID.IDS_FeatureLambdaParamsArray) && parameters is [.., { IsParams: true }];
 
             Debug.Assert(ContainingMemberOrLambda is { });
             Debug.Assert(parameterRefKinds.IsDefault || parameterRefKinds.Length == parameterTypes.Length);


### PR DESCRIPTION
Makes the [breaking change](https://github.com/dotnet/csharplang/blob/main/proposals/lambda-method-group-defaults.md#breaking-change) only visible in C# 12, not C# 11.