### PR TITLE
Fix "Fix return type" codefix for non-Task awaitable types

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/FixReturnType/CSharpFixReturnTypeCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/FixReturnType/CSharpFixReturnTypeCodeFixProvider.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,9 +14,9 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Simplification;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.FixReturnType
 {
@@ -33,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.FixReturnType
         public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("CS0127", "CS1997", "CS0201");
 
         [ImportingConstructor]
-        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CSharpFixReturnTypeCodeFixProvider()
             : base(supportsFixAll: false)
         {

--- a/src/Analyzers/CSharp/CodeFixes/FixReturnType/CSharpFixReturnTypeCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/FixReturnType/CSharpFixReturnTypeCodeFixProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.FixReturnType
     internal class CSharpFixReturnTypeCodeFixProvider : SyntaxEditorBasedCodeFixProvider
     {
         // error CS0127: Since 'M()' returns void, a return keyword must not be followed by an object expression
-        // error CS1997: Since 'M()' is an async method that returns 'Task', a return keyword must not be followed by an object expression. Did you intend to return 'Task<T>'?
+        // error CS1997: Since 'M()' is an async method that returns 'Task', a return keyword must not be followed by an object expression
         // error CS0201: Only assignment, call, increment, decrement, await, and new object expressions can be used as a statement
         public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("CS0127", "CS1997", "CS0201");
 
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.FixReturnType
             if (returnedValue == null)
                 return default;
 
-            var (declarationTypeToFix, useTask) = TryGetDeclarationTypeToFix(node);
+            var (declarationTypeToFix, isAsync) = TryGetDeclarationTypeToFix(node);
             if (declarationTypeToFix == null)
                 return default;
 
@@ -83,13 +83,33 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.FixReturnType
             returnedType ??= semanticModel.Compilation.ObjectType;
 
             TypeSyntax fixedDeclaration;
-            if (useTask)
+            if (isAsync)
             {
-                var taskOfTType = semanticModel.Compilation.TaskOfTType();
-                if (taskOfTType is null)
+                var previousReturnType = semanticModel.GetTypeInfo(declarationTypeToFix, cancellationToken).Type;
+                if (previousReturnType is null)
                     return default;
 
-                fixedDeclaration = taskOfTType.Construct(returnedType).GenerateTypeSyntax(allowVar: false);
+                var compilation = semanticModel.Compilation;
+
+                INamedTypeSymbol? taskType = null;
+
+                // void, Task -> Task<T>
+                // ValueTask -> ValueTask<T>
+                // other type -> we cannot infer anything
+                if (previousReturnType.SpecialType is SpecialType.System_Void ||
+                    Equals(previousReturnType, compilation.TaskType()))
+                {
+                    taskType = compilation.TaskOfTType();
+                }
+                else if (Equals(previousReturnType, compilation.ValueTaskType()))
+                {
+                    taskType = compilation.ValueTaskOfTType();
+                }
+
+                if (taskType is null)
+                    return default;
+
+                fixedDeclaration = taskType.Construct(returnedType).GenerateTypeSyntax(allowVar: false);
             }
             else
             {
@@ -109,11 +129,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.FixReturnType
             editor.ReplaceNode(declarationTypeToFix, fixedDeclaration);
         }
 
-        private static (TypeSyntax type, bool useTask) TryGetDeclarationTypeToFix(SyntaxNode node)
+        private static (TypeSyntax type, bool isAsync) TryGetDeclarationTypeToFix(SyntaxNode node)
         {
             return node.GetAncestors().Select(TryGetReturnTypeToFix).FirstOrDefault(p => p.type != null);
 
-            static (TypeSyntax type, bool useTask) TryGetReturnTypeToFix(SyntaxNode containingMember)
+            static (TypeSyntax type, bool isAsync) TryGetReturnTypeToFix(SyntaxNode containingMember)
             {
                 return containingMember switch
                 {

--- a/src/Analyzers/CSharp/Tests/FixReturnType/FixReturnTypeTests.cs
+++ b/src/Analyzers/CSharp/Tests/FixReturnType/FixReturnTypeTests.cs
@@ -2,353 +2,441 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.FixReturnType;
-using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Testing;
 using Roslyn.Test.Utilities;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.FixReturnType
 {
+    using VerifyCS = CSharpCodeFixVerifier<
+        EmptyDiagnosticAnalyzer,
+        CSharpFixReturnTypeCodeFixProvider>;
+
     [Trait(Traits.Feature, Traits.Features.CodeActionsFixReturnType)]
-    public partial class FixReturnTypeTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    public partial class FixReturnTypeTests
     {
-        public FixReturnTypeTests(ITestOutputHelper logger)
-             : base(logger)
-        {
-        }
-
-        internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
-            => (null, new CSharpFixReturnTypeCodeFixProvider());
-
         [Fact]
         public async Task Simple()
         {
-            await TestInRegularAndScript1Async(
-@"class C
-{
-    void M()
-    {
-        [|return|] 1;
-    }
-}",
-@"class C
-{
-    int M()
-    {
-        return 1;
-    }
-}");
+            await VerifyCS.VerifyCodeFixAsync("""
+                class C
+                {
+                    void M()
+                    {
+                        {|CS0127:return|} 1;
+                    }
+                }
+                """, """
+                class C
+                {
+                    int M()
+                    {
+                        return 1;
+                    }
+                }
+                """);
         }
 
         [Fact]
         public async Task Simple_WithTrivia()
         {
-            await TestInRegularAndScript1Async(
-@"class C
-{
-    /*A*/ void /*B*/ M()
-    {
-        [|return|] 1;
-    }
-}",
-@"class C
-{
-    /*A*/
-    int /*B*/ M()
-    {
-        return 1;
-    }
-}");
+            await VerifyCS.VerifyCodeFixAsync("""
+                class C
+                {
+                    /*A*/ void /*B*/ M()
+                    {
+                        {|CS0127:return|} 1;
+                    }
+                }
+                """, """
+                class C
+                {
+                    /*A*/
+                    int /*B*/ M()
+                    {
+                        return 1;
+                    }
+                }
+                """);
             // Note: the formatting change is introduced by Formatter.FormatAsync
         }
 
         [Fact]
         public async Task ReturnString()
         {
-            await TestInRegularAndScript1Async(
-@"class C
-{
-    void M()
-    {
-        [|return|] """";
-    }
-}",
-@"class C
-{
-    string M()
-    {
-        return """";
-    }
-}");
+            await VerifyCS.VerifyCodeFixAsync("""
+                class C
+                {
+                    void M()
+                    {
+                        {|CS0127:return|} "";
+                    }
+                }
+                """, """
+                class C
+                {
+                    string M()
+                    {
+                        return "";
+                    }
+                }
+                """);
         }
 
         [Fact]
         public async Task ReturnNull()
         {
-            await TestInRegularAndScript1Async(
-@"class C
-{
-    void M()
-    {
-        [|return|] null;
-    }
-}",
-@"class C
-{
-    object M()
-    {
-        return null;
-    }
-}");
+            await VerifyCS.VerifyCodeFixAsync("""
+                class C
+                {
+                    void M()
+                    {
+                        {|CS0127:return|} null;
+                    }
+                }
+                """, """
+                class C
+                {
+                    object M()
+                    {
+                        return null;
+                    }
+                }
+                """);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/33481")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/65302")]
         public async Task ReturnTypelessTuple()
         {
-            await TestInRegularAndScript1Async(
-@"class C
-{
-    void M()
-    {
-        [|return|] (null, string.Empty);
-    }
-}",
-@"class C
-{
-    object M()
-    {
-        return (null, string.Empty);
-    }
-}");
+            await VerifyCS.VerifyCodeFixAsync("""
+                class C
+                {
+                    void M()
+                    {
+                        {|CS0127:return|} (null, string.Empty);
+                    }
+                }
+                """, """
+                class C
+                {
+                    (object, string) M()
+                    {
+                        return (null, string.Empty);
+                    }
+                }
+                """);
         }
 
         [Fact]
         public async Task ReturnLambda()
         {
-            await TestInRegularAndScript1Async(
-@"class C
-{
-    void M()
-    {
-        [|return|] () => {};
-    }
-}",
- @"class C
-{
-    object M()
-    {
-        return () => {};
-    }
-}");
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                class C
+                {
+                    void M()
+                    {
+                        {|CS0127:return|} () => {};
+                    }
+                }
+                """,
+                FixedCode = """
+                class C
+                {
+                    object M()
+                    {
+                        return () => {};
+                    }
+                }
+                """,
+                LanguageVersion = LanguageVersion.CSharp10
+            }.RunAsync();
         }
 
         [Fact]
         public async Task ReturnC()
         {
-            await TestInRegularAndScript1Async(
-@"class C
-{
-    void M()
-    {
-        [|return|] new C();
-    }
-}",
-@"class C
-{
-    C M()
-    {
-        return new C();
-    }
-}");
+            await VerifyCS.VerifyCodeFixAsync("""
+                class C
+                {
+                    void M()
+                    {
+                        {|CS0127:return|} new C();
+                    }
+                }
+                """, """
+                class C
+                {
+                    C M()
+                    {
+                        return new C();
+                    }
+                }
+                """);
         }
 
         [Fact]
         public async Task ReturnString_AsyncVoid()
         {
-            await TestInRegularAndScript1Async(
-@"class C
-{
-    async void M()
-    {
-        [|return|] """";
-    }
-}",
-@"class C
-{
-    async System.Threading.Tasks.Task<string> M()
-    {
-        return """";
-    }
-}");
+            await VerifyCS.VerifyCodeFixAsync("""
+                class C
+                {
+                    async void M()
+                    {
+                        {|CS0127:return|} "";
+                    }
+                }
+                """, """
+                class C
+                {
+                    async System.Threading.Tasks.Task<string> M()
+                    {
+                        return "";
+                    }
+                }
+                """);
         }
 
         [Fact]
         public async Task ReturnString_AsyncVoid_WithUsing()
         {
-            await TestInRegularAndScript1Async(
-@"
-using System.Threading.Tasks;
-class C
-{
-    async void M()
-    {
-        [|return|] """";
-    }
-}",
-@"
-using System.Threading.Tasks;
-class C
-{
-    async Task<string> M()
-    {
-        return """";
-    }
-}");
+            await VerifyCS.VerifyCodeFixAsync("""
+                using System.Threading.Tasks;
+
+                class C
+                {
+                    async void M()
+                    {
+                        {|CS0127:return|} "";
+                    }
+                }
+                """, """
+                using System.Threading.Tasks;
+
+                class C
+                {
+                    async Task<string> M()
+                    {
+                        return "";
+                    }
+                }
+                """);
         }
 
         [Fact]
         public async Task ReturnString_AsyncTask()
         {
-            await TestInRegularAndScript1Async(
-@"class C
-{
-    async System.Threading.Tasks.Task M()
-    {
-        [|return|] """";
-    }
-}",
-@"class C
-{
-    async System.Threading.Tasks.Task<string> M()
-    {
-        return """";
-    }
-}");
+            await VerifyCS.VerifyCodeFixAsync("""
+                class C
+                {
+                    async System.Threading.Tasks.Task M()
+                    {
+                        {|CS1997:return|} "";
+                    }
+                }
+                """, """
+                class C
+                {
+                    async System.Threading.Tasks.Task<string> M()
+                    {
+                        return "";
+                    }
+                }
+                """);
         }
 
         [Fact]
         public async Task ReturnString_LocalFunction()
         {
-            await TestInRegularAndScript1Async(
-@"class C
-{
-    void M()
-    {
-        void local()
-        {
-            [|return|] """";
-        }
-    }
-}",
-@"class C
-{
-    void M()
-    {
-        string local()
-        {
-            return """";
-        }
-    }
-}");
+            await VerifyCS.VerifyCodeFixAsync("""
+                class C
+                {
+                    void M()
+                    {
+                        void local()
+                        {
+                            {|CS0127:return|} "";
+                        }
+                    }
+                }
+                """, """
+                class C
+                {
+                    void M()
+                    {
+                        string local()
+                        {
+                            return "";
+                        }
+                    }
+                }
+                """);
         }
 
         [Fact]
         public async Task ReturnString_AsyncVoid_LocalFunction()
         {
-            await TestInRegularAndScript1Async(
-@"class C
-{
-    void M()
-    {
-        async void local()
-        {
-            [|return|] """";
-        }
-    }
-}",
-@"class C
-{
-    void M()
-    {
-        async System.Threading.Tasks.Task<string> local()
-        {
-            return """";
-        }
-    }
-}");
+            await VerifyCS.VerifyCodeFixAsync("""
+                class C
+                {
+                    void M()
+                    {
+                        async void local()
+                        {
+                            {|CS0127:return|} "";
+                        }
+                    }
+                }
+                """, """
+                class C
+                {
+                    void M()
+                    {
+                        async System.Threading.Tasks.Task<string> local()
+                        {
+                            return "";
+                        }
+                    }
+                }
+                """);
         }
 
         [Fact]
         public async Task ExpressionBodied()
         {
-            await TestInRegularAndScript1Async(
-@"class C
-{
-    void M() => 1[||];
-}",
-@"class C
-{
-    int M() => 1[||];
-}");
+            await VerifyCS.VerifyCodeFixAsync("""
+                class C
+                {
+                    void M() => {|CS0201:1|};
+                }
+                """, """
+                class C
+                {
+                    int M() => 1;
+                }
+                """);
         }
 
         [Fact, WorkItem(47089, "https://github.com/dotnet/roslyn/issues/47089")]
         public async Task ExpressionAndReturnTypeAreVoid()
         {
-            await TestMissingInRegularAndScriptAsync(
-@"class C
-{
-    void M()
-    {
-        return Console.WriteLine()[||];
-    }
-}");
+            var markup = """
+                using System;
+
+                class C
+                {
+                    void M()
+                    {
+                        {|CS0127:return|} Console.WriteLine();
+                    }
+                }
+                """;
+            await VerifyCS.VerifyCodeFixAsync(markup, markup);
         }
 
         [Fact, WorkItem(53574, "https://github.com/dotnet/roslyn/issues/53574")]
         public async Task TestAnonymousTypeTopLevel()
         {
-            await TestInRegularAndScript1Async(
-@"class C
-{
-    public void Method()
-    {
-        [|return|] new { A = 0, B = 1 };
-    }
-}",
-@"class C
-{
-    public object Method()
-    {
-        return new { A = 0, B = 1 };
-    }
-}");
+            await VerifyCS.VerifyCodeFixAsync("""
+                class C
+                {
+                    public void Method()
+                    {
+                        {|CS0127:return|} new { A = 0, B = 1 };
+                    }
+                }
+                """, """
+                class C
+                {
+                    public object Method()
+                    {
+                        return new { A = 0, B = 1 };
+                    }
+                }
+                """);
         }
 
         [Fact, WorkItem(53574, "https://github.com/dotnet/roslyn/issues/53574")]
         public async Task TestAnonymousTypeTopNested()
         {
-            await TestInRegularAndScript1Async(
-@"class C
-{
-    public void Method()
-    {
-        [|return|] new[] { new { A = 0, B = 1 } };
-    }
-}",
-@"class C
-{
-    public object Method()
-    {
-        return new[] { new { A = 0, B = 1 } };
-    }
-}");
+            await VerifyCS.VerifyCodeFixAsync("""
+                class C
+                {
+                    public void Method()
+                    {
+                        {|CS0127:return|} new[] { new { A = 0, B = 1 } };
+                    }
+                }
+                """, """
+                class C
+                {
+                    public object Method()
+                    {
+                        return new[] { new { A = 0, B = 1 } };
+                    }
+                }
+                """);
+        }
+
+        [Fact, WorkItem(64901, "https://github.com/dotnet/roslyn/issues/64901")]
+        public async Task ReturnString_ValueTask()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                using System.Threading.Tasks;
+                
+                class C
+                {
+                    async ValueTask M()
+                    {
+                        {|CS1997:return|} "";
+                    }
+                }
+                """,
+                FixedCode = """
+                using System.Threading.Tasks;
+                
+                class C
+                {
+                    async ValueTask<string> M()
+                    {
+                        return "";
+                    }
+                }
+                """,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            }.RunAsync();
+        }
+
+        [Fact, WorkItem(64901, "https://github.com/dotnet/roslyn/issues/64901")]
+        public async Task ReturnString_CustomTaskType()
+        {
+            var markup = """
+                using System.Runtime.CompilerServices;
+                
+                [AsyncMethodBuilder(typeof(C))]
+                class C
+                {
+                    async C M()
+                    {
+                        {|CS1997:return|} "";
+                    }
+                }
+                """;
+
+            await new VerifyCS.Test
+            {
+                TestCode = markup,
+                FixedCode = markup,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60
+            }.RunAsync();
         }
     }
 }

--- a/src/Analyzers/CSharp/Tests/FixReturnType/FixReturnTypeTests.cs
+++ b/src/Analyzers/CSharp/Tests/FixReturnType/FixReturnTypeTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.FixReturnTy
         CSharpFixReturnTypeCodeFixProvider>;
 
     [Trait(Traits.Feature, Traits.Features.CodeActionsFixReturnType)]
-    public partial class FixReturnTypeTests
+    public class FixReturnTypeTests
     {
         [Fact]
         public async Task Simple()
@@ -110,9 +110,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.FixReturnTy
                 """);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/65302")]
+        [Fact]
         public async Task ReturnTypelessTuple()
         {
+            // The fix should be smarter here and not create other compilation error after execution. See https://github.com/dotnet/roslyn/issues/65302
             await VerifyCS.VerifyCodeFixAsync("""
                 class C
                 {
@@ -124,9 +125,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.FixReturnTy
                 """, """
                 class C
                 {
-                    (object, string) M()
+                    object M()
                     {
-                        return (null, string.Empty);
+                        return {|CS8135:(null, string.Empty)|};
                     }
                 }
                 """);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/64901

Also moved tests to `VerifyCS`