### PR TITLE
Enhances the set of cases 'use pattern matching' works for.  

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/CSharpAnalyzers.projitems
+++ b/src/Analyzers/CSharp/Analyzers/CSharpAnalyzers.projitems
@@ -118,6 +118,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UseIsNullCheck\CSharpUseNullCheckOverTypeCheckDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseIsNullCheck\CSharpUseIsNullCheckForCastAndEqualityOperatorDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseIsNullCheck\CSharpUseIsNullCheckForReferenceEqualsDiagnosticAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UsePatternMatching\CSharpAsAndMemberAccessDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseTupleSwap\CSharpUseTupleSwapDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseLocalFunction\CSharpUseLocalFunctionDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseNullPropagation\CSharpUseNullPropagationDiagnosticAnalyzer.cs" />

--- a/src/Analyzers/CSharp/Analyzers/CSharpAnalyzers.projitems
+++ b/src/Analyzers/CSharp/Analyzers/CSharpAnalyzers.projitems
@@ -119,6 +119,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UseIsNullCheck\CSharpUseIsNullCheckForCastAndEqualityOperatorDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseIsNullCheck\CSharpUseIsNullCheckForReferenceEqualsDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UsePatternMatching\CSharpAsAndMemberAccessDiagnosticAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UsePatternMatching\UsePatternMatchingHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseTupleSwap\CSharpUseTupleSwapDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseLocalFunction\CSharpUseLocalFunctionDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseNullPropagation\CSharpUseNullPropagationDiagnosticAnalyzer.cs" />

--- a/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpAsAndMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpAsAndMemberAccessDiagnosticAnalyzer.cs
@@ -1,0 +1,131 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq.Expressions;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
+{
+    /// <summary>
+    /// Looks for code of the forms:
+    /// <code>
+    ///     (x as Y)?.Prop == constant
+    /// </code>
+    /// and converts it to:
+    /// <code>
+    ///     x is Y { Prop: constant }
+    /// </code>
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal partial class CSharpAsAndMemberAccessDiagnosticAnalyzer : AbstractBuiltInCodeStyleDiagnosticAnalyzer
+    {
+        public CSharpAsAndMemberAccessDiagnosticAnalyzer()
+            : base(IDEDiagnosticIds.UsePatternMatchingAsAndMemberAccessId,
+                   EnforceOnBuildValues.UsePatternMatchingAsAndMemberAccess,
+                   CSharpCodeStyleOptions.PreferPatternMatchingOverAsWithNullCheck,
+                   new LocalizableResourceString(
+                        nameof(CSharpAnalyzersResources.Use_pattern_matching), CSharpAnalyzersResources.ResourceManager, typeof(CSharpAnalyzersResources)))
+        {
+        }
+
+        public override DiagnosticAnalyzerCategory GetAnalyzerCategory()
+            => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
+
+        protected override void InitializeWorker(AnalysisContext context)
+        {
+            context.RegisterCompilationStartAction(context =>
+            {
+                // Recursive patterns (`is X { Prop: Y }`) is only available in C# 8.0 and above. Don't offer this
+                // refactoring in projects targeting a lesser version.
+                if (context.Compilation.LanguageVersion() < LanguageVersion.CSharp8)
+                    return;
+
+                context.RegisterSyntaxNodeAction(context => AnalyzeAsExpression(context), SyntaxKind.AsExpression);
+            });
+        }
+
+        private void AnalyzeAsExpression(SyntaxNodeAnalysisContext context)
+        {
+            var styleOption = context.GetCSharpAnalyzerOptions().PreferPatternMatchingOverAsWithNullCheck;
+            if (!styleOption.Value)
+            {
+                // Bail immediately if the user has disabled this feature.
+                return;
+            }
+
+            var cancellationToken = context.CancellationToken;
+            var semanticModel = context.SemanticModel;
+            var asExpression = (BinaryExpressionSyntax)context.Node;
+
+            // we're starting with `expr as T`
+
+            // has to be `(expr as T)`
+            if (asExpression.Parent is not ParenthesizedExpressionSyntax
+                {
+                    // Has to be `(expr as T)?...`
+                    Parent: ConditionalAccessExpressionSyntax conditionalAccess
+                })
+            {
+                return;
+            }
+
+            // After the `?` has to be `.X.Y.Z`
+
+            var whenNotNull = conditionalAccess.WhenNotNull;
+            while (whenNotNull is MemberAccessExpressionSyntax memberAccess)
+                whenNotNull = memberAccess.Expression;
+
+            // Ensure we have `.X`
+            if (whenNotNull is not MemberBindingExpressionSyntax)
+                return;
+
+            if (conditionalAccess.Parent is
+                    BinaryExpressionSyntax(
+                        SyntaxKind.EqualsExpression or
+                        SyntaxKind.NotEqualsExpression or
+                        SyntaxKind.GreaterThanExpression or
+                        SyntaxKind.GreaterThanEqualsToken or
+                        SyntaxKind.LessThanExpression or
+                        SyntaxKind.LessThanOrEqualExpression) binaryExpression &&
+                binaryExpression.Left == conditionalAccess)
+            {
+                // `(expr as T)?... == other_expr
+                //
+                // in this case we can only convert if other_expr is a constant.
+                var constantValue = semanticModel.GetConstantValue(binaryExpression.Right, cancellationToken);
+                if (!constantValue.HasValue)
+                    return;
+            }
+            else if (conditionalAccess.Parent is IsPatternExpressionSyntax)
+            {
+                // `(expr as T)?... is pattern
+                //
+                //  In this case we can always convert to a pattern.
+            }
+            else
+            {
+                return;
+            }
+
+            // Looks good!
+            //var additionalLocations = ImmutableArray.Create(
+            //    ifStatement.GetLocation(),
+            //    localDeclarationStatement.GetLocation());
+
+            // Put a diagnostic with the appropriate severity on the declaration-statement itself.
+            context.ReportDiagnostic(DiagnosticHelper.Create(
+                Descriptor,
+                asExpression.GetLocation(),
+                styleOption.Notification.Severity,
+                additionalLocations: null,
+                properties: null));
+        }
+    }
+}

--- a/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpAsAndMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpAsAndMemberAccessDiagnosticAnalyzer.cs
@@ -68,10 +68,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
             var asExpression = (BinaryExpressionSyntax)context.Node;
 
             if (!UsePatternMatchingHelpers.TryGetPartsOfAsAndMemberAccessCheck(
-                    asExpression, out _, out var binaryExpression, out _))
+                    asExpression, out _, out var binaryExpression, out _, out var requiredLanguageVersion))
             {
                 return;
             }
+
+            if (context.Compilation.LanguageVersion() < requiredLanguageVersion)
+                return;
 
             if (binaryExpression != null)
             {

--- a/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpAsAndMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpAsAndMemberAccessDiagnosticAnalyzer.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
@@ -124,6 +125,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                         return false;
 
                     // `(a as T)?.Prop != null` *does* have the same semantics as `a is T { Prop: not null }`.
+                    //
+                    // However, that's still only allowed if `Prop` is not a value type.
+                    var type = semanticModel.GetTypeInfo(binaryExpression.Left, cancellationToken).ConvertedType;
+                    if (type.IsNonNullableValueType())
+                        return false;
+
                     return true;
                 }
 
@@ -163,6 +170,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                         return false;
 
                     // `(a as T)?.Prop is not null` *does* have the same semantics as `a is T { Prop: not null }`.
+                    //
+                    // However, that's still only allowed if `Prop` is not a value type.
+                    var type = semanticModel.GetTypeInfo(isPatternExpression.Expression, cancellationToken).ConvertedType;
+                    if (type.IsNonNullableValueType())
+                        return false;
+
                     return true;
                 }
 

--- a/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
@@ -15,16 +15,17 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
 {
+
     /// <summary>
     /// Looks for code of the forms:
-    /// 
+    /// <code>
     ///     var x = o as Type;
     ///     if (x != null) ...
-    /// 
+    /// </code>
     /// and converts it to:
-    /// 
+    /// <code>
     ///     if (o is Type x) ...
-    ///     
+    /// </code>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal partial class CSharpAsAndNullCheckDiagnosticAnalyzer : AbstractBuiltInCodeStyleDiagnosticAnalyzer

--- a/src/Analyzers/CSharp/Analyzers/UsePatternMatching/UsePatternMatchingHelpers.cs
+++ b/src/Analyzers/CSharp/Analyzers/UsePatternMatching/UsePatternMatchingHelpers.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
+{
+    internal static class UsePatternMatchingHelpers
+    {
+        public static bool TryGetPartsOfAsAndMemberAccessCheck(
+            BinaryExpressionSyntax asExpression,
+            [NotNullWhen(true)] out ConditionalAccessExpressionSyntax? conditionalAccessExpression,
+            out BinaryExpressionSyntax? binaryExpression,
+            out IsPatternExpressionSyntax? isPatternExpression)
+        {
+            conditionalAccessExpression = null;
+            binaryExpression = null;
+            isPatternExpression = null;
+
+            if (asExpression.Kind() == SyntaxKind.AsExpression)
+            {
+                // has to be `(expr as T)`
+                if (asExpression.Parent is not ParenthesizedExpressionSyntax
+                    {
+                        // Has to be `(expr as T)?...`
+                        Parent: ConditionalAccessExpressionSyntax parentConditionalAccess
+                    })
+                {
+                    return false;
+                }
+
+                conditionalAccessExpression = parentConditionalAccess;
+
+                // After the `?` has to be `.X.Y.Z`
+
+                var whenNotNull = parentConditionalAccess.WhenNotNull;
+                while (whenNotNull is MemberAccessExpressionSyntax memberAccess)
+                    whenNotNull = memberAccess.Expression;
+
+                // Ensure we have `.X`
+                if (whenNotNull is not MemberBindingExpressionSyntax)
+                    return false;
+
+                if (conditionalAccessExpression.Parent is
+                        BinaryExpressionSyntax(
+                            SyntaxKind.EqualsExpression or
+                            SyntaxKind.NotEqualsExpression or
+                            SyntaxKind.GreaterThanExpression or
+                            SyntaxKind.GreaterThanOrEqualExpression or
+                            SyntaxKind.LessThanExpression or
+                            SyntaxKind.LessThanOrEqualExpression) parentBinaryExpression &&
+                    parentBinaryExpression.Left == conditionalAccessExpression)
+                {
+                    // `(expr as T)?... == other_expr
+                    //
+                    // Can convert if other_expr is a constant (checked by caller).
+                    binaryExpression = parentBinaryExpression;
+                    return true;
+                }
+                else if (conditionalAccessExpression.Parent is IsPatternExpressionSyntax parentIsPatternExpression)
+                {
+                    // `(expr as T)?... is pattern
+                    //
+                    //  In this case we can always convert to a pattern.
+                    isPatternExpression = parentIsPatternExpression;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixes.projitems
+++ b/src/Analyzers/CSharp/CodeFixes/CSharpCodeFixes.projitems
@@ -82,6 +82,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UseConditionalExpression\MultiLineConditionalExpressionFormattingRule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseDeconstruction\CSharpUseDeconstructionCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseIsNullCheck\UseIsNullCheckHelpers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UsePatternMatching\CSharpAsAndMemberAccessCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseTupleSwap\CSharpUseTupleSwapCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseDefaultLiteral\CSharpUseDefaultLiteralCodeFixProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseExpressionBody\UseExpressionBodyCodeFixProvider.cs" />

--- a/src/Analyzers/CSharp/CodeFixes/UsePatternMatching/CSharpAsAndMemberAccessCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UsePatternMatching/CSharpAsAndMemberAccessCodeFixProvider.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                 return;
 
             if (!UsePatternMatchingHelpers.TryGetPartsOfAsAndMemberAccessCheck(
-                    asExpression, out var conditionalAccessExpression, out var binaryExpression, out var isPatternExpression))
+                    asExpression, out var conditionalAccessExpression, out var binaryExpression, out var isPatternExpression, out _))
             {
                 return;
             }
@@ -87,9 +87,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                 Token(SyntaxKind.IsKeyword).WithTriviaFrom(asExpression.OperatorToken),
                 newPattern);
 
+            var toReplace = parent.WalkUpParentheses();
             editor.ReplaceNode(
-                parent.WalkUpParentheses(),
-                newIsExpression);
+                toReplace,
+                newIsExpression.WithTriviaFrom(toReplace));
 
             return;
 

--- a/src/Analyzers/CSharp/CodeFixes/UsePatternMatching/CSharpAsAndMemberAccessCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UsePatternMatching/CSharpAsAndMemberAccessCodeFixProvider.cs
@@ -1,0 +1,144 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
+{
+    using static SyntaxFactory;
+
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.UsePatternMatchingAsAndMemberAccess), Shared]
+    internal partial class CSharpAsAndMemberAccessCodeFixProvider : SyntaxEditorBasedCodeFixProvider
+    {
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CSharpAsAndMemberAccessCodeFixProvider()
+        {
+        }
+
+        public override ImmutableArray<string> FixableDiagnosticIds
+            => ImmutableArray.Create(IDEDiagnosticIds.UsePatternMatchingAsAndMemberAccessId);
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            RegisterCodeFix(context, CSharpAnalyzersResources.Use_pattern_matching, nameof(CSharpAnalyzersResources.Use_pattern_matching));
+            return Task.CompletedTask;
+        }
+
+        protected override Task FixAllAsync(
+            Document document, ImmutableArray<Diagnostic> diagnostics,
+            SyntaxEditor editor, CodeActionOptionsProvider fallbackOptions, CancellationToken cancellationToken)
+        {
+            foreach (var diagnostic in diagnostics.OrderByDescending(d => d.Location.SourceSpan.Start))
+                FixOne(editor, diagnostic, cancellationToken);
+
+            return Task.CompletedTask;
+        }
+
+        private static void FixOne(SyntaxEditor editor, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var node = diagnostic.Location.FindNode(getInnermostNodeForTie: true, cancellationToken);
+            if (node is not BinaryExpressionSyntax asExpression)
+                return;
+
+            if (!UsePatternMatchingHelpers.TryGetPartsOfAsAndMemberAccessCheck(
+                    asExpression, out var conditionalAccessExpression, out var binaryExpression, out var isPatternExpression))
+            {
+                return;
+            }
+
+            var parent = binaryExpression ?? (ExpressionSyntax?)isPatternExpression;
+            Contract.ThrowIfNull(parent);
+
+            // { X.Y: pattern }
+            var propertyPattern = PropertyPatternClause(
+                Token(SyntaxKind.OpenBraceToken).WithoutTrivia().WithAppendedTrailingTrivia(Space),
+                SingletonSeparatedList(
+                    Subpattern(
+                        CreateExpressionColon(conditionalAccessExpression),
+                        CreatePattern(binaryExpression, isPatternExpression).WithAppendedTrailingTrivia(Space))),
+                Token(SyntaxKind.CloseBraceToken).WithoutTrivia());
+
+            // T { X.Y: pattern }
+            var newPattern = RecursivePattern(
+                (TypeSyntax)asExpression.Right.WithAppendedTrailingTrivia(Space),
+                positionalPatternClause: null,
+                propertyPattern,
+                designation: null);
+
+            // is T { X.Y: pattern }
+            var newIsExpression = IsPatternExpression(
+                asExpression.Left,
+                Token(SyntaxKind.IsKeyword).WithTriviaFrom(asExpression.OperatorToken),
+                newPattern);
+
+            editor.ReplaceNode(
+                parent.WalkUpParentheses(),
+                newIsExpression);
+
+            return;
+
+            static BaseExpressionColonSyntax CreateExpressionColon(ConditionalAccessExpressionSyntax conditionalAccessExpression)
+            {
+                var whenNotNull = conditionalAccessExpression.WhenNotNull;
+
+                if (whenNotNull is MemberBindingExpressionSyntax { Name: IdentifierNameSyntax identifierName })
+                    return NameColon(identifierName);
+
+                return ExpressionColon(RewriteMemberBindingToExpression(whenNotNull), Token(SyntaxKind.ColonToken));
+            }
+
+            static ExpressionSyntax RewriteMemberBindingToExpression(ExpressionSyntax expression)
+            {
+                // .X => X
+                if (expression is MemberBindingExpressionSyntax memberBinding)
+                    return memberBinding.Name;
+
+                // .X.Y   recurse down left side to produce: X.Y
+                if (expression is MemberAccessExpressionSyntax memberAccessExpression)
+                    return memberAccessExpression.WithExpression(RewriteMemberBindingToExpression(memberAccessExpression.Expression));
+
+                return expression;
+            }
+
+            static PatternSyntax CreatePattern(BinaryExpressionSyntax? binaryExpression, IsPatternExpressionSyntax? isPatternExpression)
+            {
+                // if we had `.X.Y is some_pattern` we can just convert that to `X.Y: some_pattern`
+                if (isPatternExpression != null)
+                    return isPatternExpression.Pattern;
+
+                Contract.ThrowIfNull(binaryExpression);
+
+                return binaryExpression.Kind() switch
+                {
+                    // `.X.Y == expr` => `X.Y: expr`
+                    SyntaxKind.EqualsExpression => ConstantPattern(binaryExpression.Right),
+                    // `.X.Y != expr` => `X.Y: not expr`
+                    SyntaxKind.NotEqualsExpression => UnaryPattern(ConstantPattern(binaryExpression.Right)),
+                    // `.X.Y > expr` => `X.Y: > expr`
+                    // etc
+                    SyntaxKind.GreaterThanExpression or
+                    SyntaxKind.GreaterThanOrEqualExpression or
+                    SyntaxKind.LessThanExpression or
+                    SyntaxKind.LessThanOrEqualExpression => RelationalPattern(binaryExpression.OperatorToken, binaryExpression.Right),
+                    _ => throw ExceptionUtilities.Unreachable()
+                };
+            }
+        }
+    }
+}

--- a/src/Analyzers/CSharp/CodeFixes/UsePatternMatching/CSharpAsAndMemberAccessCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UsePatternMatching/CSharpAsAndMemberAccessCodeFixProvider.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
                 SingletonSeparatedList(
                     Subpattern(
                         CreateExpressionColon(conditionalAccessExpression),
-                        CreatePattern(binaryExpression, isPatternExpression).WithAppendedTrailingTrivia(Space))),
+                        CreatePattern(binaryExpression, isPatternExpression).WithTrailingTrivia(Space))),
                 Token(SyntaxKind.CloseBraceToken).WithoutTrivia());
 
             // T { X.Y: pattern }

--- a/src/Analyzers/CSharp/Tests/CSharpAnalyzers.UnitTests.projitems
+++ b/src/Analyzers/CSharp/Tests/CSharpAnalyzers.UnitTests.projitems
@@ -118,11 +118,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)UseIsNullCheck\UseNullCheckOverTypeCheckDiagnosticAnalyzerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseExplicitTupleName\UseExplicitTupleNameTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseImplicitObjectCreation\CSharpUseImplicitObjectCreationTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UsePatternMatching\CSharpAsAndNullCheckTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UsePatternMatching\CSharpAsAndMemberAccessTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseTupleSwap\UseTupleSwapTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseLocalFunction\UseLocalFunctionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseNullPropagation\UseNullPropagationTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UseObjectInitializer\UseObjectInitializerTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)UsePatternMatching\CSharpAsAndNullCheckTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UsePatternMatching\CSharpAsAndNullCheckTests_FixAllTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UsePatternMatching\CSharpUseNotPatternTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UsePatternMatching\CSharpIsAndCastCheckDiagnosticAnalyzerTests.cs" />

--- a/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpAsAndMemberAccessTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpAsAndMemberAccessTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.UsePatternMatching;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -44,6 +45,28 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
                         }
                     }
                     """,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNotInCSharp7()
+        {
+            var test = """
+                class C
+                {
+                    void M(object o)
+                    {
+                        if ((o as string)?.Length == 0)
+                        {
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp7,
             }.RunAsync();
         }
     }

--- a/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpAsAndMemberAccessTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpAsAndMemberAccessTests.cs
@@ -471,5 +471,35 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
                     """,
             }.RunAsync();
         }
+
+        [Fact]
+        public async Task TestBinaryParent()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (([|o as string|])?.Length == 0 && true)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (o is string { Length: 0 } && true)
+                            {
+                            }
+                        }
+                    }
+                    """,
+            }.RunAsync();
+        }
     }
 }

--- a/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpAsAndMemberAccessTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpAsAndMemberAccessTests.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.UsePatternMatching;
+using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
+{
+    using VerifyCS = CSharpCodeFixVerifier<
+        CSharpAsAndMemberAccessDiagnosticAnalyzer,
+        CSharpAsAndMemberAccessCodeFixProvider>;
+
+    [Trait(Traits.Feature, Traits.Features.CodeActionsUsePatternMatchingForAsAndMemberAccess)]
+    public partial class CSharpAsAndMemberAccessTests
+    {
+        [Fact]
+        public async Task TestCoreCase()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (([|o as string|])?.Length == 0)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (o is string { Length: 0 })
+                            {
+                            }
+                        }
+                    }
+                    """,
+            }.RunAsync();
+        }
+    }
+}

--- a/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpAsAndMemberAccessTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpAsAndMemberAccessTests.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
         }
 
         [Fact]
-        public async Task TestNotEqualsNull_CSharp8()
+        public async Task TestNotEqualsNull_ValueType_CSharp8()
         {
             var test = """
                 class C
@@ -204,16 +204,64 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
         }
 
         [Fact]
-        public async Task TestNotEqualsNull_CSharp9()
+        public async Task TestNotEqualsNull_ValueType_CSharp9()
+        {
+            var test = """
+                class C
+                {
+                    void M(object o)
+                    {
+                        if ((o as string)?.Length != null)
+                        {
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNotEqualsNull_ReferenceType_CSharp8()
+        {
+            var test = """
+                class C
+                {
+                    string X;
+
+                    void M(object o)
+                    {
+                        if ((o as C)?.X != null)
+                        {
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp8,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNotEqualsNull_ReferenceType_CSharp9()
         {
             await new VerifyCS.Test
             {
                 TestCode = """
                     class C
                     {
+                        string X;
+                    
                         void M(object o)
                         {
-                            if (([|o as string|])?.Length != null)
+                            if (([|o as C|])?.X != null)
                             {
                             }
                         }
@@ -222,9 +270,70 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
                 FixedCode = """
                     class C
                     {
+                        string X;
+
                         void M(object o)
                         {
-                            if (o is string { Length: not null })
+                            if (o is C { X: not null })
+                            {
+                            }
+                        }
+                    }
+                    """,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNotEqualsNull_NullableType_CSharp8()
+        {
+            var test = """
+                class C
+                {
+                    int? X;
+
+                    void M(object o)
+                    {
+                        if ((o as C)?.X != null)
+                        {
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp8,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNotEqualsNull_NullableType_CSharp9()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        int? X;
+                    
+                        void M(object o)
+                        {
+                            if (([|o as C|])?.X != null)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        int? X;
+
+                        void M(object o)
+                        {
+                            if (o is C { X: not null })
                             {
                             }
                         }

--- a/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpAsAndMemberAccessTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpAsAndMemberAccessTests.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
         }
 
         [Fact]
-        public async Task TestNotEquals_CSharp8()
+        public async Task TestNotEqualsConstant_CSharp8()
         {
             var test = """
                 class C
@@ -160,7 +160,51 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
         }
 
         [Fact]
-        public async Task TestNotEquals_CSharp9()
+        public async Task TestNotEqualsConstant_CSharp9()
+        {
+            var test = """
+                class C
+                {
+                    void M(object o)
+                    {
+                        if ((o as string)?.Length != 0)
+                        {
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNotEqualsNull_CSharp8()
+        {
+            var test = """
+                class C
+                {
+                    void M(object o)
+                    {
+                        if ((o as string)?.Length != null)
+                        {
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp8,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNotEqualsNull_CSharp9()
         {
             await new VerifyCS.Test
             {
@@ -169,7 +213,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
                     {
                         void M(object o)
                         {
-                            if (([|o as string|])?.Length != 0)
+                            if (([|o as string|])?.Length != null)
                             {
                             }
                         }
@@ -180,7 +224,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
                     {
                         void M(object o)
                         {
-                            if (o is string { Length: not 0 })
+                            if (o is string { Length: not null })
                             {
                             }
                         }
@@ -319,7 +363,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
         }
 
         [Fact]
-        public async Task TestIsPattern1()
+        public async Task TestIsConstantPattern1()
         {
             await new VerifyCS.Test
             {
@@ -349,7 +393,51 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
         }
 
         [Fact]
-        public async Task TestIsPattern2()
+        public async Task TestIsNotConstantPattern()
+        {
+            var test = """
+                class C
+                {
+                    void M(object o)
+                    {
+                        if ((o as string)?.Length is not 0)
+                        {
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestIsNullPattern()
+        {
+            var test = """
+                class C
+                {
+                    void M(object o)
+                    {
+                        if ((o as string)?.Length is null)
+                        {
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestIsNotNullPattern()
         {
             await new VerifyCS.Test
             {
@@ -358,7 +446,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
                     {
                         void M(object o)
                         {
-                            if (([|o as string|])?.Length is not 0)
+                            if (([|o as string|])?.Length is not null)
                             {
                             }
                         }
@@ -369,7 +457,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
                     {
                         void M(object o)
                         {
-                            if (o is string { Length: not 0 })
+                            if (o is string { Length: not null })
                             {
                             }
                         }

--- a/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpAsAndMemberAccessTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpAsAndMemberAccessTests.cs
@@ -226,6 +226,31 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
         }
 
         [Fact]
+        public async Task TestNotEqualsNull_ValueType2_CSharp9()
+        {
+            var test = """
+                class C
+                {
+                    C X;
+                    int Length;
+
+                    void M(object o)
+                    {
+                        if ((o as C)?.X.Length != null)
+                        {
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task TestNotEqualsNull_ReferenceType_CSharp8()
         {
             var test = """
@@ -285,6 +310,43 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
         }
 
         [Fact]
+        public async Task TestNotEqualsNull_ReferenceType_CSharp10()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        C Y;
+                        string X;
+                    
+                        void M(object o)
+                        {
+                            if (([|o as C|])?.Y.X != null)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        C Y;
+                        string X;
+
+                        void M(object o)
+                        {
+                            if (o is C { Y.X: not null })
+                            {
+                            }
+                        }
+                    }
+                    """,
+                LanguageVersion = LanguageVersion.CSharp10,
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task TestNotEqualsNull_NullableType_CSharp8()
         {
             var test = """
@@ -309,18 +371,43 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
         }
 
         [Fact]
-        public async Task TestNotEqualsNull_NullableType_CSharp9()
+        public async Task TestNotEqualsNull_NullableType2_CSharp8()
+        {
+            var test = """
+                class C
+                {
+                    int? X;
+
+                    void M(object o)
+                    {
+                        if ((o as C)?.X != null)
+                        {
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp8,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNotEqualsNull_NullableType_CSharp10()
         {
             await new VerifyCS.Test
             {
                 TestCode = """
                     class C
                     {
+                        C Y;
                         int? X;
                     
                         void M(object o)
                         {
-                            if (([|o as C|])?.X != null)
+                            if (([|o as C|])?.Y.X != null)
                             {
                             }
                         }
@@ -329,17 +416,18 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
                 FixedCode = """
                     class C
                     {
+                        C Y;
                         int? X;
 
                         void M(object o)
                         {
-                            if (o is C { X: not null })
+                            if (o is C { Y.X: not null })
                             {
                             }
                         }
                     }
                     """,
-                LanguageVersion = LanguageVersion.CSharp9,
+                LanguageVersion = LanguageVersion.CSharp10,
             }.RunAsync();
         }
 
@@ -546,16 +634,65 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
         }
 
         [Fact]
-        public async Task TestIsNotNullPattern()
+        public async Task TestIsNotNullPattern_ValueType()
+        {
+            var test = """
+                class C
+                {
+                    void M(object o)
+                    {
+                        if ((o as string)?.Length is not null)
+                        {
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestIsNotNullPattern_ValueType2()
+        {
+            var test = """
+                class C
+                {
+                    C X;
+                    int Length;
+
+                    void M(object o)
+                    {
+                        if ((o as C)?.X.Length is not null)
+                        {
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestIsNotNullPattern_ReferenceType()
         {
             await new VerifyCS.Test
             {
                 TestCode = """
                     class C
                     {
+                        string X;
+
                         void M(object o)
                         {
-                            if (([|o as string|])?.Length is not null)
+                            if (([|o as C|])?.X is not null)
                             {
                             }
                         }
@@ -564,15 +701,126 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
                 FixedCode = """
                     class C
                     {
+                        string X;
+
                         void M(object o)
                         {
-                            if (o is string { Length: not null })
+                            if (o is C { X: not null })
                             {
                             }
                         }
                     }
                     """,
                 LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestIsNotNullPattern_ReferenceType_CSharp10()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        C Y;
+                        string X;
+
+                        void M(object o)
+                        {
+                            if (([|o as C|])?.Y.X is not null)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        C Y;
+                        string X;
+
+                        void M(object o)
+                        {
+                            if (o is C { Y.X: not null })
+                            {
+                            }
+                        }
+                    }
+                    """,
+                LanguageVersion = LanguageVersion.CSharp10,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestIsNotNullPattern_NullableValueType()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        int? X;
+
+                        void M(object o)
+                        {
+                            if (([|o as C|])?.X is not null)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        int? X;
+
+                        void M(object o)
+                        {
+                            if (o is C { X: not null })
+                            {
+                            }
+                        }
+                    }
+                    """,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestIsNotNullPattern_NullableValueType_CSharp10()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        int? X;
+                        C Y;
+
+                        void M(object o)
+                        {
+                            if (([|o as C|])?.Y.X is not null)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        int? X;
+                        C Y;
+
+                        void M(object o)
+                        {
+                            if (o is C { Y.X: not null })
+                            {
+                            }
+                        }
+                    }
+                    """,
+                LanguageVersion = LanguageVersion.CSharp10,
             }.RunAsync();
         }
 

--- a/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpAsAndMemberAccessTests.cs
+++ b/src/Analyzers/CSharp/Tests/UsePatternMatching/CSharpAsAndMemberAccessTests.cs
@@ -69,5 +69,407 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UsePatternMatching
                 LanguageVersion = LanguageVersion.CSharp7,
             }.RunAsync();
         }
+
+        [Fact]
+        public async Task TestNotWithNonConstant()
+        {
+            var test = """
+                class C
+                {
+                    void M(object o, int length)
+                    {
+                        if ((o as string)?.Length == length)
+                        {
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp7,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNotWithoutTest()
+        {
+            var test = """
+                class C
+                {
+                    void M(object o, int length)
+                    {
+                        var v = (o as string)?.Length;
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp7,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNotWithNonMemberBinding1()
+        {
+            var test = """
+                class C
+                {
+                    C[] X;
+                    int Length;
+
+                    void M(object o, int length)
+                    {
+                        if ((o as C)?.X[0].Length == 0)
+                        {
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp7,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNotEquals_CSharp8()
+        {
+            var test = """
+                class C
+                {
+                    void M(object o)
+                    {
+                        if ((o as string)?.Length != 0)
+                        {
+                        }
+                    }
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp8,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNotEquals_CSharp9()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (([|o as string|])?.Length != 0)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (o is string { Length: not 0 })
+                            {
+                            }
+                        }
+                    }
+                    """,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestGreaterThan()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (([|o as string|])?.Length > 0)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (o is string { Length: > 0 })
+                            {
+                            }
+                        }
+                    }
+                    """,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestGreaterThanEquals()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (([|o as string|])?.Length >= 0)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (o is string { Length: >= 0 })
+                            {
+                            }
+                        }
+                    }
+                    """,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestLessThan()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        int Goo;
+
+                        void M(object o)
+                        {
+                            if (([|o as C|])?.Goo < 0)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        int Goo;
+
+                        void M(object o)
+                        {
+                            if (o is C { Goo: < 0 })
+                            {
+                            }
+                        }
+                    }
+                    """,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestLessThanEquals()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (([|o as string|])?.Length <= 0)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (o is string { Length: <= 0 })
+                            {
+                            }
+                        }
+                    }
+                    """,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestIsPattern1()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (([|o as string|])?.Length is 0)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (o is string { Length: 0 })
+                            {
+                            }
+                        }
+                    }
+                    """,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestIsPattern2()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (([|o as string|])?.Length is not 0)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (o is string { Length: not 0 })
+                            {
+                            }
+                        }
+                    }
+                    """,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestMemberAccess1_CSharp9()
+        {
+            var test = """
+                class C
+                {
+                    C X;
+                    int Length;
+
+                    void M(object o)
+                    {
+                        if ((o as C)?.X.Length == 0)
+                        {
+                        }
+                    }
+                }
+                """;
+
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = test,
+                LanguageVersion = LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestMemberAccess1_CSharp10()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        C X;
+                        int Length;
+
+                        void M(object o)
+                        {
+                            if (([|o as C|])?.X.Length == 0)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        C X;
+                        int Length;
+
+                        void M(object o)
+                        {
+                            if (o is C { X.Length: 0 })
+                            {
+                            }
+                        }
+                    }
+                    """,
+                LanguageVersion = LanguageVersion.CSharp10,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestParenthesizedParent()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if ((([|o as string|])?.Length == 0) || true)
+                            {
+                            }
+                        }
+                    }
+                    """,
+                FixedCode = """
+                    class C
+                    {
+                        void M(object o)
+                        {
+                            if (o is string { Length: 0 } || true)
+                            {
+                            }
+                        }
+                    }
+                    """,
+            }.RunAsync();
+        }
     }
 }

--- a/src/Analyzers/Core/Analyzers/EnforceOnBuildValues.cs
+++ b/src/Analyzers/Core/Analyzers/EnforceOnBuildValues.cs
@@ -85,6 +85,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public const EnforceOnBuild RemoveRedundantNullableDirective = /*IDE0240*/ EnforceOnBuild.Recommended;
         public const EnforceOnBuild RemoveUnnecessaryNullableDirective = /*IDE0241*/ EnforceOnBuild.Recommended;
         public const EnforceOnBuild MakeStructReadOnly = /*IDE0250*/ EnforceOnBuild.Recommended;
+        public const EnforceOnBuild UsePatternMatchingAsAndMemberAccess = /*IDE0260*/ EnforceOnBuild.Recommended;
 
         /* EnforceOnBuild.WhenExplicitlyEnabled */
         public const EnforceOnBuild RemoveUnnecessaryCast = /*IDE0004*/ EnforceOnBuild.WhenExplicitlyEnabled; // TODO: Move to 'Recommended' OR 'HighlyRecommended' bucket once performance problems are addressed: https://github.com/dotnet/roslyn/issues/43304

--- a/src/Analyzers/Core/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Analyzers/Core/Analyzers/IDEDiagnosticIds.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public const string MakeStructReadOnlyDiagnosticId = "IDE0250";
 
-        public const string UsePatternMatchingAsAndMemberAccessId = "IDE260";
+        public const string UsePatternMatchingAsAndMemberAccessId = "IDE0260";
 
         // Analyzer error Ids
         public const string AnalyzerChangedId = "IDE1001";

--- a/src/Analyzers/Core/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Analyzers/Core/Analyzers/IDEDiagnosticIds.cs
@@ -183,6 +183,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public const string MakeStructReadOnlyDiagnosticId = "IDE0250";
 
+        public const string UsePatternMatchingAsAndMemberAccessId = "IDE260";
+
         // Analyzer error Ids
         public const string AnalyzerChangedId = "IDE1001";
         public const string AnalyzerDependencyConflictId = "IDE1002";

--- a/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
+++ b/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
@@ -151,6 +151,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string UseNullPropagation = nameof(UseNullPropagation);
         public const string UseObjectInitializer = nameof(UseObjectInitializer);
         public const string UsePatternCombinators = nameof(UsePatternCombinators);
+        public const string UsePatternMatchingAsAndMemberAccess = nameof(UsePatternMatchingAsAndMemberAccess);
         public const string UsePatternMatchingAsAndNullCheck = nameof(UsePatternMatchingAsAndNullCheck);
         public const string UsePatternMatchingIsAndCastCheck = nameof(UsePatternMatchingIsAndCastCheck);
         public const string UsePatternMatchingIsAndCastCheckWithoutName = nameof(UsePatternMatchingIsAndCastCheckWithoutName);

--- a/src/Compilers/Test/Core/Traits/Traits.cs
+++ b/src/Compilers/Test/Core/Traits/Traits.cs
@@ -203,6 +203,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             public const string CodeActionsUseNamedArguments = "CodeActions.UseNamedArguments";
             public const string CodeActionsUseNotPattern = "CodeActions.UseNotPattern";
             public const string CodeActionsUsePatternCombinators = "CodeActions.UsePatternCombinators";
+            public const string CodeActionsUsePatternMatchingForAsAndMemberAccess = "CodeActions.UsePatternMatchingForAsAndMemberAccess";
             public const string CodeActionsUseRecursivePatterns = "CodeActions.UseRecursivePatterns";
             public const string CodeActionsUseNullPropagation = "CodeActions.UseNullPropagation";
             public const string CodeActionsUseObjectInitializer = "CodeActions.UseObjectInitializer";

--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -563,8 +563,8 @@ namespace A
             var expectedNumberOfUnsupportedDiagnosticIds =
                 language switch
                 {
-                    LanguageNames.CSharp => 35,
-                    LanguageNames.VisualBasic => 72,
+                    LanguageNames.CSharp => 36,
+                    LanguageNames.VisualBasic => 73,
                     _ => throw ExceptionUtilities.UnexpectedValue(language),
                 };
 

--- a/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/IDEDiagnosticIDConfigurationTests.cs
@@ -443,6 +443,9 @@ dotnet_diagnostic.IDE0241.severity = %value%
 # IDE0250
 dotnet_diagnostic.IDE0250.severity = %value%
 
+# IDE0260
+dotnet_diagnostic.IDE0260.severity = %value%
+
 # IDE1005
 dotnet_diagnostic.IDE1005.severity = %value%
 
@@ -1068,6 +1071,9 @@ No editorconfig based code style option
 
 # IDE0250, PreferReadOnlyStruct
 csharp_style_prefer_readonly_struct = true
+
+# IDE0260, PreferPatternMatchingOverAsWithNullCheck
+csharp_style_pattern_matching_over_as_with_null_check = true
 
 # IDE1005, PreferConditionalDelegateCall
 csharp_style_conditional_delegate_call = true

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
@@ -280,7 +280,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static bool IsRequired([NotNullWhen(returnValue: true)] this ISymbol? symbol)
             => symbol is IFieldSymbol { IsRequired: true } or IPropertySymbol { IsRequired: true };
 
-        public static ITypeSymbol? GetMemberType(this ISymbol symbol)
+        public static ITypeSymbol? GetMemberType(this ISymbol? symbol)
             => symbol switch
             {
                 IFieldSymbol fieldSymbol => fieldSymbol.Type,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ITypeSymbolExtensions.cs
@@ -60,12 +60,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             => symbol?.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
 
         public static bool IsNonNullableValueType([NotNullWhen(returnValue: true)] this ITypeSymbol? symbol)
-        {
-            if (symbol?.IsValueType != true)
-                return false;
-
-            return !symbol.IsNullable();
-        }
+            => symbol is { IsValueType: true } && !symbol.IsNullable();
 
         public static bool IsNullable(
             [NotNullWhen(true)] this ITypeSymbol? symbol,


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/65308

Example of what this now improves:

![image](https://user-images.githubusercontent.com/4564579/200930120-aa3db9be-3094-4221-888b-8525b1d9161d.png)

Going to test this on Roslyn.sln to see if it encounters any issues.
