### PR TITLE
Semantic snippets - don't need to add fully qualified name in syntax generation

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpConsoleSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpConsoleSnippetCompletionProviderTests.cs
@@ -154,10 +154,6 @@ class Program
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
 
-        /// <summary>
-        /// Simplifier does not work as intended, once that changes this outcome
-        /// should be able to simplify the inserted snippet.
-        /// </summary>
         [WpfFact]
         public async Task InsertConsoleSnippetInLocalFunctionTest()
         {
@@ -184,17 +180,13 @@ class Program
         var x = 5;
         void LocalMethod()
         {
-            global::System.Console.WriteLine($$);
+            Console.WriteLine($$);
         }
     }
 }";
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
 
-        /// <summary>
-        /// Simplifier does not work as intended, once that changes this outcome
-        /// should be able to simplify the inserted snippet.
-        /// </summary>
         [WpfFact]
         public async Task InsertConsoleSnippetInAnonymousFunctionTest()
         {
@@ -217,17 +209,13 @@ public delegate void Print(int value);
 static void Main(string[] args)
 {
     Print print = delegate(int val) {
-        global::System.Console.WriteLine($$);
+        Console.WriteLine($$);
     };
 
 }";
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
 
-        /// <summary>
-        /// Simplifier does not work as intended, once that changes this outcome
-        /// should be able to simplify the inserted snippet.
-        /// </summary>
         [WpfFact]
         public async Task InsertConsoleSnippetInParenthesizedLambdaExpressionTest()
         {
@@ -245,7 +233,7 @@ using System;
 
 Func<int, int, bool> testForEquality = (x, y) =>
 {
-    global::System.Console.WriteLine($$);
+    Console.WriteLine($$);
     return x == y;
 };";
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpConsoleSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpConsoleSnippetCompletionProviderTests.cs
@@ -409,6 +409,10 @@ class Program
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
 
+        /// <summary>
+        /// We want to fix this case and insert the fully qualified namespace
+        /// in a future fix.
+        /// </summary>
         [WpfFact]
         public async Task InsertConsoleSnippetWithPropertyNamedConsoleTest()
         {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpConsoleSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpConsoleSnippetCompletionProviderTests.cs
@@ -408,5 +408,34 @@ class Program
 }";
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
         }
+
+        [WpfFact]
+        public async Task InsertConsoleSnippetWithPropertyNamedConsoleTest()
+        {
+            var markupBeforeCommit =
+@"class Program
+{
+    public int Console { get; set; }
+
+    public void Method()
+    {
+        $$
+    }
+}";
+
+            var expectedCodeAfterCommit =
+@"using System;
+
+class Program
+{
+    public int Console { get; set; }
+
+    public void Method()
+    {
+        Console.WriteLine($$);
+    }
+}";
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, ItemToCommit, expectedCodeAfterCommit);
+        }
     }
 }

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
@@ -70,8 +70,8 @@ namespace Microsoft.CodeAnalysis.Snippets
 
             var invocation = isAsync
                 ? generator.AwaitExpression(generator.InvocationExpression(
-                    generator.MemberAccessExpression(generator.MemberAccessExpression(generator.IdentifierName(nameof(Console)), generator.IdentifierName(nameof(Console.Out))), "WriteLineAsync")))
-                : generator.InvocationExpression(generator.MemberAccessExpression(generator.IdentifierName(nameof(Console)), "WriteLine"));
+                    generator.MemberAccessExpression(generator.MemberAccessExpression(generator.IdentifierName(nameof(Console)), generator.IdentifierName(nameof(Console.Out))), nameof(Console.Out.WriteLineAsync))))
+                : generator.InvocationExpression(generator.MemberAccessExpression(generator.IdentifierName(nameof(Console)), nameof(Console.WriteLine)));
             var expressionStatement = generator.ExpressionStatement(invocation);
 
             // Need to normalize the whitespace for the asynchronous case because it doesn't insert a space following the await

--- a/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
+++ b/src/Features/Core/Portable/Snippets/SnippetProviders/AbstractConsoleSnippetProvider.cs
@@ -59,22 +59,19 @@ namespace Microsoft.CodeAnalysis.Snippets
 
         private async Task<TextChange> GenerateSnippetTextChangeAsync(Document document, int position, CancellationToken cancellationToken)
         {
-            var consoleSymbol = await GetSymbolFromMetaDataNameAsync(document, cancellationToken).ConfigureAwait(false);
-            Contract.ThrowIfNull(consoleSymbol);
             var generator = SyntaxGenerator.GetGenerator(document);
             var tree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var token = tree.FindTokenOnLeftOfPosition(position, cancellationToken);
 
             // We know symbol is not null at this point since it was checked when determining
             // if we are in a valid location to insert the snippet.
-            var typeExpression = generator.TypeExpression(consoleSymbol);
             var declaration = GetAsyncSupportingDeclaration(token);
             var isAsync = declaration is not null && generator.GetModifiers(declaration).IsAsync;
 
             var invocation = isAsync
                 ? generator.AwaitExpression(generator.InvocationExpression(
-                    generator.MemberAccessExpression(generator.MemberAccessExpression(typeExpression, generator.IdentifierName(nameof(Console.Out))), generator.IdentifierName(nameof(Console.Out.WriteLineAsync)))))
-                : generator.InvocationExpression(generator.MemberAccessExpression(typeExpression, generator.IdentifierName(nameof(Console.WriteLine))));
+                    generator.MemberAccessExpression(generator.MemberAccessExpression(generator.IdentifierName(nameof(Console)), generator.IdentifierName(nameof(Console.Out))), "WriteLineAsync")))
+                : generator.InvocationExpression(generator.MemberAccessExpression(generator.IdentifierName(nameof(Console)), "WriteLine"));
             var expressionStatement = generator.ExpressionStatement(invocation);
 
             // Need to normalize the whitespace for the asynchronous case because it doesn't insert a space following the await


### PR DESCRIPTION
Fixes: #64923 and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1643332

I thought the fully qualified name was necessary for the ImportAdder to add the system using, but it is not. Since the simplifier fails to remove the fully qualified name in complex cases, I now do not generate the syntax with it.