### PR TITLE
Ensure the causing syntax node is always in the timing dictionary

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -3280,5 +3280,42 @@ class C { }
             driver = driver.RunGenerators(compilation);
             Assert.True(wasCalled);
         }
+
+        [Fact]
+        public void IncrementalGenerator_Add_New_Generator_With_Syntax_After_Generation()
+        {
+            var source = @"
+class C { }
+";
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugDllThrowing, parseOptions: parseOptions);
+            compilation.VerifyDiagnostics();
+            Assert.Single(compilation.SyntaxTrees);
+
+            var generator = new IncrementalGeneratorWrapper(new PipelineCallbackGenerator(ctx =>
+            {
+                var syntax = ctx.SyntaxProvider.CreateSyntaxProvider((s, _) => true, (s, _) => s.Node);
+                ctx.RegisterSourceOutput(syntax, (spc, c) =>
+                {
+                });
+            }));
+
+            // run the generator and make sure the first node is cached
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new ISourceGenerator[] { generator }, parseOptions: parseOptions);
+            driver = driver.RunGenerators(compilation);
+
+            // now, add another syntax node from another generator
+            var generator2 = new IncrementalGeneratorWrapper(new PipelineCallbackGenerator2(ctx =>
+            {
+                var syntax = ctx.SyntaxProvider.CreateSyntaxProvider((s, _) => true, (s, _) => s.Node);
+                ctx.RegisterSourceOutput(syntax, (spc, c) =>
+                {
+                });
+            }));
+            driver = driver.AddGenerators(ImmutableArray.Create<ISourceGenerator>(generator2));
+            
+            // ensure it runs successfully
+            driver = driver.RunGenerators(compilation);
+        }
     }
 }

--- a/src/Compilers/Core/Portable/SourceGeneration/SyntaxStore.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/SyntaxStore.cs
@@ -77,6 +77,9 @@ namespace Microsoft.CodeAnalysis
 
                     if (syntaxInputBuilders.Count > 0)
                     {
+                        // Ensure that even if the node that caused the update was cached, we can still adjust it to take into account other nodes that weren't 
+                        _syntaxTimes[syntaxInputNode] = TimeSpan.Zero;
+
                         // at this point we need to grab the syntax trees from the new compilation, and optionally diff them against the old ones
                         NodeStateTable<SyntaxTree> syntaxTreeState = syntaxTreeTable;
 


### PR DESCRIPTION
When a new generator is added to a generator run that includes a syntax input node, there is the possibility (depending on load order) of throwing a `KeyNotFoundException`. 

Repro Steps:
1. The generator driver is run with a generator (1) that contains a syntax node. This is evaluated and cached.
2. A new generator (2) is added to the driver that also has a syntax input
3. The driver runs, and (1) is evaluated first. 
4. `SyntaxStore.GetSyntaxInputTable()` is called for the input node that's part of (1)
5. Because the compilation hasn't changed, and (1) has previous results, we short circuit and take [this](https://github.com/dotnet/roslyn/blob/main/src/Compilers/Core/Portable/SourceGeneration/SyntaxStore.cs#L69) path, and don't put the syntax node into the `_syntaxTimes` dictionary.
6. The newly added syntax node from (2) does not have a previous result, and so must be calculated. 
7. After calculating it, we try to adjust the calling node (from (1))'s time to account for the calculation.
8. Because the calling node was cached, we never added it to the `_syntaxTimes` dictionary, and get a `KeyNotFoundException` on [line 106](https://github.com/dotnet/roslyn/blob/main/src/Compilers/Core/Portable/SourceGeneration/SyntaxStore.cs#L106)


This PR fixes it by ensuring that the node that caused the update is always added to the timing dictionary, even if it was cached. 

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1596912/?triage=true