### PR TITLE
Fix LSP workspace diagnostics exception when a solution contains a project with no file path

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -21,6 +21,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 {
     internal abstract class AbstractDocumentPullDiagnosticHandler<TDiagnosticsParams, TReport, TReturn> : AbstractPullDiagnosticHandler<TDiagnosticsParams, TReport, TReturn>, ITextDocumentIdentifierHandler<TDiagnosticsParams, TextDocumentIdentifier?>
         where TDiagnosticsParams : IPartialResultParams<TReport[]>
+        where TReport : class
     {
         public AbstractDocumentPullDiagnosticHandler(
             IDiagnosticAnalyzerService diagnosticAnalyzerService,
@@ -38,7 +39,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
     /// <typeparam name="TDiagnosticsParams">The LSP input param type</typeparam>
     /// <typeparam name="TReport">The LSP type that is reported via IProgress</typeparam>
     /// <typeparam name="TReturn">The LSP type that is returned on completion of the request.</typeparam>
-    internal abstract partial class AbstractPullDiagnosticHandler<TDiagnosticsParams, TReport, TReturn> : ILspServiceRequestHandler<TDiagnosticsParams, TReturn?> where TDiagnosticsParams : IPartialResultParams<TReport[]>
+    internal abstract partial class AbstractPullDiagnosticHandler<TDiagnosticsParams, TReport, TReturn> : ILspServiceRequestHandler<TDiagnosticsParams, TReturn?>
+        where TDiagnosticsParams : IPartialResultParams<TReport[]>
+        where TReport : class
     {
         /// <summary>
         /// Diagnostic mode setting for Razor.  This should always be <see cref="DiagnosticMode.Pull"/> as there is no push support in Razor.
@@ -275,7 +278,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             {
                 // We are not expecting to get any diagnostics for sources that don't have a path.
                 Contract.ThrowIfFalse(diagnostics.IsEmpty);
-                return default;
+                return null;
             }
 
             context.TraceInformation($"Found {diagnostics.Length} diagnostics for {diagnosticSource.ToDisplayString()}");

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractDocumentDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractDocumentDiagnosticSource.cs
@@ -32,7 +32,7 @@ internal abstract class AbstractDocumentDiagnosticSource<TDocument> : IDiagnosti
     public ProjectOrDocumentId GetId() => new(Document.Id);
     public Project GetProject() => Document.Project;
     public TextDocumentIdentifier? GetDocumentIdentifier()
-        => Document.FilePath != null
+        => !string.IsNullOrEmpty(Document.FilePath)
             ? new VSTextDocumentIdentifier { ProjectContext = ProtocolConversions.ProjectToProjectContext(Document.Project), Uri = Document.GetURI() }
             : null;
 

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractDocumentDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractDocumentDiagnosticSource.cs
@@ -31,8 +31,12 @@ internal abstract class AbstractDocumentDiagnosticSource<TDocument> : IDiagnosti
 
     public ProjectOrDocumentId GetId() => new(Document.Id);
     public Project GetProject() => Document.Project;
-    public TextDocumentIdentifier GetDocumentIdentifier()
-        => new VSTextDocumentIdentifier { ProjectContext = ProtocolConversions.ProjectToProjectContext(Document.Project), Uri = Document.GetURI() };
+    public TextDocumentIdentifier? GetDocumentIdentifier()
+        => Document.FilePath != null
+            ? new VSTextDocumentIdentifier { ProjectContext = ProtocolConversions.ProjectToProjectContext(Document.Project), Uri = Document.GetURI() }
+            : null;
+
+    public string ToDisplayString() => $"{Document.FilePath ?? Document.Name} in {Document.Project.Name}";
 
     protected abstract bool IncludeTaskListItems { get; }
     protected abstract bool IncludeStandardDiagnostics { get; }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/IDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/IDiagnosticSource.cs
@@ -19,7 +19,8 @@ internal interface IDiagnosticSource
 {
     Project GetProject();
     ProjectOrDocumentId GetId();
-    TextDocumentIdentifier GetDocumentIdentifier();
+    TextDocumentIdentifier? GetDocumentIdentifier();
+    string ToDisplayString();
 
     Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
         IDiagnosticAnalyzerService diagnosticAnalyzerService,

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/ProjectDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/ProjectDiagnosticSource.cs
@@ -17,7 +17,7 @@ internal sealed record class ProjectDiagnosticSource(Project Project) : IDiagnos
     public ProjectOrDocumentId GetId() => new(Project.Id);
     public Project GetProject() => Project;
     public TextDocumentIdentifier? GetDocumentIdentifier()
-        => Project.FilePath != null
+        => !string.IsNullOrEmpty(Project.FilePath)
             ? new VSTextDocumentIdentifier { ProjectContext = ProtocolConversions.ProjectToProjectContext(Project), Uri = ProtocolConversions.GetUriFromFilePath(Project.FilePath) }
             : null;
 

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/ProjectDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/ProjectDiagnosticSource.cs
@@ -16,11 +16,10 @@ internal sealed record class ProjectDiagnosticSource(Project Project) : IDiagnos
 {
     public ProjectOrDocumentId GetId() => new(Project.Id);
     public Project GetProject() => Project;
-    public TextDocumentIdentifier GetDocumentIdentifier()
-    {
-        Contract.ThrowIfNull(Project.FilePath);
-        return new VSTextDocumentIdentifier { ProjectContext = ProtocolConversions.ProjectToProjectContext(Project), Uri = ProtocolConversions.GetUriFromFilePath(Project.FilePath) };
-    }
+    public TextDocumentIdentifier? GetDocumentIdentifier()
+        => Project.FilePath != null
+            ? new VSTextDocumentIdentifier { ProjectContext = ProtocolConversions.ProjectToProjectContext(Project), Uri = ProtocolConversions.GetUriFromFilePath(Project.FilePath) }
+            : null;
 
     public async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
         IDiagnosticAnalyzerService diagnosticAnalyzerService,
@@ -34,4 +33,6 @@ internal sealed record class ProjectDiagnosticSource(Project Project) : IDiagnos
         var projectDiagnostics = await diagnosticAnalyzerService.GetProjectDiagnosticsForIdsAsync(Project.Solution, Project.Id, cancellationToken: cancellationToken).ConfigureAwait(false);
         return projectDiagnostics;
     }
+
+    public string ToDisplayString() => Project.Name;
 }


### PR DESCRIPTION


Found in telemetry by @jasonmalinowski 

Sometimes 'fake' projects without file paths are created, for example for JS script blocks in ASPX files.  These were throwing exceptions when we tried to get the file path.

Now, we filter out diagnostic sources before attempting to report diagnostics.  However if the diagnostic source did have diagnostics but not file path, that indicates an error and we throw.