### PR TITLE
Add F1 help keyword for `notnull` and `unmanaged` constraints and `switch` expressions

### DIFF
--- a/docs/contributing/Compiler Test Plan.md
+++ b/docs/contributing/Compiler Test Plan.md
@@ -126,6 +126,7 @@ Interaction with IDE, Debugger, and EnC should be worked out with relevant teams
     - Typing experience and dealing with incomplete code
     - Intellisense (squiggles, dot completion)
     - "go to", Find All References, and renaming
+    - F1 help (for new keywords)
     - cref comments
     - UpgradeProject code fixer
     - More: [IDE Test Plan](https://github.com/dotnet/roslyn/blob/main/docs/contributing/IDE%20Test%20Plan.md)

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -393,6 +393,14 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                         return true;
                 }
             }
+            else if (token.ValueText is "notnull" or "unmanaged")
+            {
+                if (token.Parent is IdentifierNameSyntax { Parent: TypeConstraintSyntax { Parent: TypeParameterConstraintClauseSyntax } })
+                {
+                    text = Keyword(token.ValueText);
+                    return true;
+                }
+            }
 
             text = null;
             return false;

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpHelpContextService.cs
@@ -498,6 +498,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 return true;
             }
 
+            if (token.IsKind(SyntaxKind.SwitchKeyword) && token.Parent is SwitchExpressionSyntax)
+            {
+                text = Keyword("switch-expression");
+                return true;
+            }
+
             if (token.IsKeyword())
             {
                 text = Keyword(token.Text);

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -1867,5 +1867,53 @@ class C
                 int un[||]managed = 0;
                 """, expectedText: "System.Int32");
         }
+
+        [Fact, WorkItem(65312, "https://github.com/dotnet/roslyn/issues/65312")]
+        public async Task TestSwitchStatement()
+        {
+            await Test_KeywordAsync("""
+                swit[||]ch (1) { default: break; }
+                """, expectedText: "switch");
+        }
+
+        [Fact, WorkItem(65312, "https://github.com/dotnet/roslyn/issues/65312")]
+        public async Task TestSwitchExpression()
+        {
+            await Test_KeywordAsync("""
+                _ = 1 swit[||]ch { _ => 0 };
+                """, expectedText: "switch-expression");
+        }
+
+        [Fact]
+        public async Task TestFile()
+        {
+            await Test_KeywordAsync("""
+                fi[||]le class C { }
+                """, expectedText: "file");
+        }
+
+        [Fact]
+        public async Task TestRightShift()
+        {
+            await Test_KeywordAsync("""
+                _ = 1 >[||]> 2;
+                """, expectedText: ">>");
+        }
+
+        [Fact]
+        public async Task TestUnsignedRightShift()
+        {
+            await Test_KeywordAsync("""
+                _ = 1 >>[||]> 2;
+                """, expectedText: ">>>");
+        }
+
+        [Fact]
+        public async Task TestUnsignedRightShiftAssignment()
+        {
+            await Test_KeywordAsync("""
+                1 >>[||]>= 2;
+                """, expectedText: ">>>=");
+        }
     }
 }

--- a/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
+++ b/src/VisualStudio/CSharp/Test/F1Help/F1HelpTests.cs
@@ -1802,5 +1802,70 @@ class C
                 #line def[||]ault
                 """, expectedText: "defaultline");
         }
+
+        [Fact, WorkItem(65311, "https://github.com/dotnet/roslyn/issues/65311")]
+        public async Task TestNotnull_OnType()
+        {
+            await Test_KeywordAsync("""
+                public class C<T> where T : not[||]null
+                {
+                }
+                """, expectedText: "notnull");
+        }
+
+        [Fact, WorkItem(65311, "https://github.com/dotnet/roslyn/issues/65311")]
+        public async Task TestNotnull_OnMethod()
+        {
+            await Test_KeywordAsync("""
+                public class C
+                {
+                    void M<T>() where T : not[||]null
+                    {
+                    }
+                }
+                """, expectedText: "notnull");
+        }
+
+        [Fact, WorkItem(65311, "https://github.com/dotnet/roslyn/issues/65311")]
+        public async Task TestNotnull_FieldName()
+        {
+            await TestAsync("""
+                public class C
+                {
+                    int not[||]null = 0;
+                }
+                """, expectedText: "C.notnull");
+        }
+
+        [Fact, WorkItem(65311, "https://github.com/dotnet/roslyn/issues/65311")]
+        public async Task TestUnmanaged_OnType()
+        {
+            await Test_KeywordAsync("""
+                public class C<T> where T : un[||]managed
+                {
+                }
+                """, expectedText: "unmanaged");
+        }
+
+        [Fact, WorkItem(65311, "https://github.com/dotnet/roslyn/issues/65311")]
+        public async Task TestUnmanaged_OnMethod()
+        {
+            await Test_KeywordAsync("""
+                public class C
+                {
+                    void M<T>() where T : un[||]managed
+                    {
+                    }
+                }
+                """, expectedText: "unmanaged");
+        }
+
+        [Fact, WorkItem(65311, "https://github.com/dotnet/roslyn/issues/65311")]
+        public async Task TestUnmanaged_LocalName()
+        {
+            await TestAsync("""
+                int un[||]managed = 0;
+                """, expectedText: "System.Int32");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/65312 (switch expressions)
Fixes https://github.com/dotnet/roslyn/issues/65311 (notnull/unmanaged)