### PR TITLE
Exclude type declared as `file` from import completion

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
@@ -17,6 +17,7 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionProviders
 {
     [UseExportProvider]
+    [Trait(Traits.Feature, Traits.Features.Completion)]
     public class TypeImportCompletionProviderTests : AbstractCSharpCompletionProviderTests
     {
         internal override Type GetCompletionProviderType()
@@ -30,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 
         #region "Option tests"
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task OptionSetToNull_ExpEnabled()
         {
             TypeImportCompletionFeatureFlag = true;
@@ -46,7 +47,7 @@ class Bar
             await VerifyAnyItemExistsAsync(markup);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task OptionSetToNull_ExpDisabled()
         {
             ShowImportCompletionItemsOptionValue = null;
@@ -60,9 +61,7 @@ class Bar
             await VerifyNoItemsExistAsync(markup);
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task OptionSetToFalse(bool isExperimentEnabled)
         {
             TypeImportCompletionFeatureFlag = isExperimentEnabled;
@@ -78,9 +77,7 @@ class Bar
             await VerifyNoItemsExistAsync(markup);
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task OptionSetToTrue(bool isExperimentEnabled)
         {
             TypeImportCompletionFeatureFlag = isExperimentEnabled;
@@ -104,7 +101,7 @@ class Bar
         [InlineData("struct", (int)Glyph.StructurePublic)]
         [InlineData("enum", (int)Glyph.EnumPublic)]
         [InlineData("interface", (int)Glyph.InterfacePublic)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task Show_TopLevel_NoImport_InProject(string typeKind, int glyph)
         {
             var file1 = $@"
@@ -133,7 +130,7 @@ namespace Baz
         [InlineData("struct", (int)Glyph.StructurePublic)]
         [InlineData("enum", (int)Glyph.EnumPublic)]
         [InlineData("interface", (int)Glyph.InterfacePublic)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task Show_TopLevelStatement_NoImport_InProject(string typeKind, int glyph)
         {
             var file1 = $@"
@@ -157,7 +154,7 @@ $$
         [InlineData("struct")]
         [InlineData("enum")]
         [InlineData("interface")]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task DoNotShow_TopLevel_SameNamespace_InProject(string typeKind)
         {
             var file1 = $@"
@@ -184,7 +181,7 @@ namespace Foo
         [InlineData("record", (int)Glyph.ClassPublic)]
         [InlineData("struct", (int)Glyph.StructurePublic)]
         [InlineData("interface", (int)Glyph.InterfacePublic)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task Show_TopLevel_MutipleOverrides_NoImport_InProject(string typeKind, int glyph)
         {
             var file1 = $@"
@@ -218,7 +215,7 @@ namespace Baz
         [InlineData("struct")]
         [InlineData("enum")]
         [InlineData("interface")]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task DoNotShow_NestedType_NoImport_InProject(string typeKind)
         {
             var file1 = $@"
@@ -248,7 +245,7 @@ namespace Baz
         [InlineData("struct")]
         [InlineData("enum")]
         [InlineData("interface")]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task DoNotShow_TopLevel_WithImport_InProject(string typeKind)
         {
             var file1 = $@"
@@ -272,9 +269,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Bar", inlineDescription: "Foo");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task Show_TopLevel_Public_NoImport_InReference(bool isProjectReference)
         {
             var file1 = $@"
@@ -299,9 +294,7 @@ namespace Baz
             await VerifyTypeImportItemExistsAsync(markup, "Bar2", glyph: (int)Glyph.ClassPublic, inlineDescription: "Foo");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task DoNotShow_TopLevel_Public_WithImport_InReference(bool isProjectReference)
         {
             var file1 = $@"
@@ -327,9 +320,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Bar2", inlineDescription: "Foo");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task DoNotShow_TopLevel_Internal_NoImport_InReference(bool isProjectReference)
         {
             var file1 = $@"
@@ -354,9 +345,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Bar2", inlineDescription: "Foo");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task TopLevel_OverloadsWithMixedAccessibility_Internal_NoImport_InReference1(bool isProjectReference)
         {
             var file1 = $@"
@@ -381,9 +370,7 @@ namespace Baz
             await VerifyTypeImportItemExistsAsync(markup, "Bar", displayTextSuffix: "<>", glyph: (int)Glyph.ClassPublic, inlineDescription: "Foo");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task DoNotShow_TopLevel_OverloadsWithMixedAccessibility_Internal_WithImport_InReference1(bool isProjectReference)
         {
             var file1 = $@"
@@ -409,9 +396,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Bar", displayTextSuffix: "<>", inlineDescription: "Foo");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task TopLevel_OverloadsWithMixedAccessibility_InternalWithIVT_NoImport_InReference1(bool isProjectReference)
         {
             var file1 = $@"     
@@ -438,9 +423,7 @@ namespace Baz
             await VerifyTypeImportItemExistsAsync(markup, "Bar", displayTextSuffix: "<>", glyph: (int)Glyph.ClassPublic, inlineDescription: "Foo");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task DoNotShow_TopLevel_OverloadsWithMixedAccessibility_InternalWithIVT_WithImport_InReference1(bool isProjectReference)
         {
             var file1 = $@"     
@@ -468,9 +451,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Bar", displayTextSuffix: "<>", inlineDescription: "Foo");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task TopLevel_OverloadsWithMixedAccessibility_Internal_NoImport_InReference2(bool isProjectReference)
         {
             var file1 = $@"
@@ -498,9 +479,7 @@ namespace Baz
             await VerifyTypeImportItemExistsAsync(markup, "Bar", displayTextSuffix: "<>", glyph: (int)Glyph.ClassPublic, inlineDescription: "Foo");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task DoNotShow_TopLevel_OverloadsWithMixedAccessibility_Internal_SameNamespace_InReference2(bool isProjectReference)
         {
             var file1 = $@"
@@ -528,9 +507,7 @@ namespace Foo.Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Bar", displayTextSuffix: "<>", inlineDescription: "Foo");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task TopLevel_OverloadsWithMixedAccessibility_InternalWithIVT_NoImport_InReference2(bool isProjectReference)
         {
             var file1 = $@"   
@@ -560,9 +537,7 @@ namespace Baz
             await VerifyTypeImportItemExistsAsync(markup, "Bar", displayTextSuffix: "<>", glyph: (int)Glyph.ClassInternal, inlineDescription: "Foo");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task Show_TopLevel_Internal_WithIVT_NoImport_InReference(bool isProjectReference)
         {
             var file1 = $@"
@@ -585,7 +560,7 @@ namespace Baz
             await VerifyTypeImportItemExistsAsync(markup, "Bar", glyph: (int)Glyph.ClassInternal, inlineDescription: "Foo");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task Show_TopLevel_NoImport_InVBReference()
         {
             var file1 = $@"
@@ -605,7 +580,7 @@ namespace Baz
             await VerifyTypeImportItemExistsAsync(markup, "Barr", glyph: (int)Glyph.ClassPublic, inlineDescription: "Foo.Bar");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task VB_MixedCapitalization_Test()
         {
             var file1 = $@"
@@ -634,7 +609,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Foo", inlineDescription: "na");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task VB_MixedCapitalization_WithImport_Test()
         {
             var file1 = $@"
@@ -664,7 +639,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Foo", inlineDescription: "na");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task DoNotShow_TopLevel_Internal_NoImport_InVBReference()
         {
             var file1 = $@"
@@ -684,7 +659,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Barr", inlineDescription: "Foo.Bar");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task DoNotShow_TopLevel_WithImport_InVBReference()
         {
             var file1 = $@"
@@ -705,9 +680,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Barr", inlineDescription: "Foo.Bar");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task TypesWithIdenticalNameButDifferentNamespaces(bool isProjectReference)
         {
             var file1 = $@"
@@ -742,9 +715,7 @@ namespace NS
             await VerifyTypeImportItemExistsAsync(markup, "Bar", displayTextSuffix: "<>", glyph: (int)Glyph.ClassPublic, inlineDescription: "Baz");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task TestNoCompletionItemWhenThereIsAlias(bool isProjectReference)
         {
             var file1 = @"
@@ -794,9 +765,7 @@ namespace Foo1
             await VerifyTypeImportItemIsAbsentAsync(markup, "Foo7", "Foo1.Foo2.Foo3");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task TestAttributesAlias(bool isProjectReference)
         {
             var file1 = @"
@@ -829,9 +798,7 @@ namespace Foo
             await VerifyTypeImportItemIsAbsentAsync(markup, "BarAttributeDifferentEnding", "Foo");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task TestGenericsAliasHasNoEffect(bool isProjectReference)
         {
             var file1 = @"
@@ -877,7 +844,7 @@ namespace Foo1
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         public async Task Commit_NoImport_InProject(SourceCodeKind kind)
         {
             var file1 = $@"
@@ -912,7 +879,7 @@ namespace Baz
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         public async Task Commit_TopLevelStatement_NoImport_InProject(SourceCodeKind kind)
         {
             var file1 = $@"
@@ -935,7 +902,7 @@ Bar$$
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         public async Task Commit_TopLevelStatement_UnrelatedImport_InProject(SourceCodeKind kind)
         {
             var file1 = $@"
@@ -962,7 +929,7 @@ Bar$$
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         public async Task Commit_NoImport_InVBReference(SourceCodeKind kind)
         {
             var file1 = $@"
@@ -994,7 +961,7 @@ namespace Baz
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         public async Task Commit_NoImport_InPEReference(SourceCodeKind kind)
         {
             var markup = $@"<Workspace>
@@ -1019,7 +986,7 @@ class Bar
 
         #endregion
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task DoNotShow_TopLevel_Public_NoImport_InNonGlobalAliasedMetadataReference()
         {
             var file1 = $@"
@@ -1040,7 +1007,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Bar", inlineDescription: "Foo");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task Show_TopLevel_Public_NoImport_InGlobalAliasedMetadataReference()
         {
             var file1 = $@"
@@ -1061,7 +1028,7 @@ namespace Baz
             await VerifyTypeImportItemExistsAsync(markup, "Bar", glyph: (int)Glyph.ClassPublic, inlineDescription: "Foo");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task DoNotShow_TopLevel_Public_NoImport_InNonGlobalAliasedProjectReference()
         {
             var file1 = $@"
@@ -1082,7 +1049,7 @@ namespace Baz
             await VerifyTypeImportItemIsAbsentAsync(markup, "Bar", inlineDescription: "Foo");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task ShorterTypeNameShouldShowBeforeLongerTypeName()
         {
             var file1 = $@"
@@ -1106,7 +1073,7 @@ namespace Baz
             AssertRelativeOrder(new List<string>() { "SomeType", "SomeTypeWithLongerName" }, completionList.ItemsList.ToImmutableArray());
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task AttributeTypeInAttributeNameContext()
         {
@@ -1134,7 +1101,7 @@ namespace Test
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task CommitAttributeTypeInAttributeNameContext(SourceCodeKind kind)
         {
@@ -1164,7 +1131,7 @@ namespace Test
             await VerifyCustomCommitProviderAsync(markup, "My", expectedCodeAfterCommit, sourceCodeKind: kind);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task AttributeTypeInNonAttributeNameContext()
         {
@@ -1194,7 +1161,7 @@ namespace Test
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task CommitAttributeTypeInNonAttributeNameContext(SourceCodeKind kind)
         {
@@ -1227,7 +1194,7 @@ namespace Test
             await VerifyCustomCommitProviderAsync(markup, "MyAttribute", expectedCodeAfterCommit, sourceCodeKind: kind);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task AttributeTypeWithoutSuffixInAttributeNameContext()
         {
@@ -1254,7 +1221,7 @@ namespace Test
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task CommitAttributeTypeWithoutSuffixInAttributeNameContext(SourceCodeKind kind)
         {
@@ -1285,7 +1252,7 @@ namespace Test
             await VerifyCustomCommitProviderAsync(markup, "Myattribute", expectedCodeAfterCommit, sourceCodeKind: kind);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task AttributeTypeWithoutSuffixInNonAttributeNameContext()
         {
@@ -1314,7 +1281,7 @@ namespace Test
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task CommitAttributeTypeWithoutSuffixInNonAttributeNameContext(SourceCodeKind kind)
         {
@@ -1348,7 +1315,7 @@ namespace Test
             await VerifyCustomCommitProviderAsync(markup, "Myattribute", expectedCodeAfterCommit, sourceCodeKind: kind);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         [WorkItem(35540, "https://github.com/dotnet/roslyn/issues/35540")]
         public async Task VBAttributeTypeWithoutSuffixInAttributeNameContext()
         {
@@ -1379,7 +1346,7 @@ namespace Test
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(37038, "https://github.com/dotnet/roslyn/issues/37038")]
         public async Task CommitTypeInUsingStaticContextShouldUseFullyQualifiedName(SourceCodeKind kind)
         {
@@ -1401,7 +1368,7 @@ using static Foo.MyClass$$";
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(37038, "https://github.com/dotnet/roslyn/issues/37038")]
         public async Task CommitGenericTypeParameterInUsingAliasContextShouldUseFullyQualifiedName(SourceCodeKind kind)
         {
@@ -1423,7 +1390,7 @@ using CollectionOfStringBuilders = System.Collections.Generic.List<Foo.MyClass$$
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(37038, "https://github.com/dotnet/roslyn/issues/37038")]
         public async Task CommitGenericTypeParameterInUsingAliasContextShouldUseFullyQualifiedName2(SourceCodeKind kind)
         {
@@ -1451,7 +1418,6 @@ namespace Foo
         }
 
         [Fact]
-        [Trait(Traits.Feature, Traits.Features.Completion)]
         [Trait(Traits.Feature, Traits.Features.Interactive)]
         [WorkItem(39027, "https://github.com/dotnet/roslyn/issues/39027")]
         public async Task TriggerCompletionInSubsequentSubmission()
@@ -1470,7 +1436,7 @@ namespace Foo
             Assert.NotEmpty(completionList.ItemsList);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         public async Task ShouldNotTriggerInsideTrivia()
         {
             var file1 = $@"
@@ -1505,9 +1471,7 @@ namespace Baz
             }
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task TestBrowsableAwaysFromReferences(bool isProjectReference)
         {
             var srcDoc = @"
@@ -1541,9 +1505,7 @@ namespace Foo
                     inlineDescription: "Foo");
         }
 
-        [InlineData(true)]
-        [InlineData(false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory, CombinatorialData]
         public async Task TestBrowsableNeverFromReferences(bool isProjectReference)
         {
             var srcDoc = @"
@@ -1591,7 +1553,7 @@ namespace Foo
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         public async Task TestBrowsableAdvancedFromReferences(bool isProjectReference, bool hideAdvancedMembers)
         {
             HideAdvancedMembers = hideAdvancedMembers;
@@ -1637,7 +1599,7 @@ namespace Foo
             }
         }
 
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         [InlineData('.')]
         [InlineData(';')]
         public async Task TestCommitWithCustomizedCommitCharForParameterlessConstructor(char commitChar)
@@ -1684,7 +1646,7 @@ namespace BB
             await VerifyProviderCommitAsync(markup, "C", expected, commitChar: commitChar, sourceCodeKind: SourceCodeKind.Regular);
         }
 
-        [Theory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Theory]
         [InlineData('.')]
         [InlineData(';')]
         public async Task TestCommitWithCustomizedCommitCharUnderNonObjectCreationContext(char commitChar)
@@ -1731,7 +1693,7 @@ namespace BB
 
         [InlineData(SourceCodeKind.Regular)]
         [InlineData(SourceCodeKind.Script)]
-        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [WpfTheory]
         [WorkItem(54493, "https://github.com/dotnet/roslyn/issues/54493")]
         public async Task CommitInLocalFunctionContext(SourceCodeKind kind)
         {
@@ -1774,7 +1736,7 @@ namespace Test
             await VerifyProviderCommitAsync(markup, "MyClass", expectedCodeAfterCommit, commitChar: null, sourceCodeKind: kind);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         [WorkItem(58473, "https://github.com/dotnet/roslyn/issues/58473")]
         public async Task TestGlobalUsingsInSdkAutoGeneratedFile()
         {
@@ -1797,7 +1759,7 @@ global using global::System.Threading.Tasks;
             await VerifyTypeImportItemIsAbsentAsync(markup, "Console", inlineDescription: "System");
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        [Fact]
         [WorkItem(58473, "https://github.com/dotnet/roslyn/issues/58473")]
         public async Task TestGlobalUsingsInSameFile()
         {
@@ -1813,7 +1775,6 @@ $$";
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/59088")]
-        [Trait(Traits.Feature, Traits.Features.Completion)]
         [WorkItem(58473, "https://github.com/dotnet/roslyn/issues/58473")]
         public async Task TestGlobalUsingsInUserDocument()
         {

--- a/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/TestUtilities/Completion/AbstractCompletionProviderTests.cs
@@ -656,11 +656,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 <Workspace>
     <Project Language=""{0}"" CommonReferences=""true"" AssemblyName=""Project1"">
         <Document FilePath=""SourceDocument"">{1}</Document>
-        <MetadataReferenceFromSource Language=""{2}"" CommonReferences=""true"" IncludeXmlDocComments=""true"" DocumentationMode=""Diagnose"">
+        <MetadataReferenceFromSource Language=""{2}"" CommonReferences=""true"" IncludeXmlDocComments=""true"" DocumentationMode=""Diagnose"" {4}>
             <Document FilePath=""ReferencedDocument"">{3}</Document>
         </MetadataReferenceFromSource>
     </Project>
-</Workspace>", sourceLanguage, SecurityElement.Escape(markup), referencedLanguage, SecurityElement.Escape(metadataReferenceCode));
+</Workspace>", sourceLanguage, SecurityElement.Escape(markup), referencedLanguage, SecurityElement.Escape(metadataReferenceCode), GetLanguageVersionAttribute(referencedLanguage));
         }
 
         protected async Task VerifyItemWithAliasedMetadataReferencesAsync(string markup, string metadataAlias, string expectedItem, int expectedSymbols,
@@ -671,18 +671,23 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
             await VerifyItemWithReferenceWorkerAsync(xmlString, expectedItem, expectedSymbols);
         }
 
+        private static string GetLanguageVersionAttribute(string languageName)
+        {
+            return languageName == LanguageNames.CSharp ? @"LanguageVersion = ""preview""" : string.Empty;
+        }
+
         protected static string CreateMarkupForProjectWithAliasedMetadataReference(string markup, string metadataAlias, string referencedCode, string sourceLanguage, string referencedLanguage, bool hasGlobalAlias = true)
         {
             var aliases = hasGlobalAlias ? $"{metadataAlias},{MetadataReferenceProperties.GlobalAlias}" : $"{metadataAlias}";
             return string.Format(@"
 <Workspace>
-    <Project Language=""{0}"" CommonReferences=""true"" AssemblyName=""Project1"">
-        <Document FilePath=""SourceDocument"">{1}</Document>
-        <MetadataReferenceFromSource Language=""{2}"" CommonReferences=""true"" Aliases=""{3}"" IncludeXmlDocComments=""true"" DocumentationMode=""Diagnose"">
-            <Document FilePath=""ReferencedDocument"">{4}</Document>
+    <Project Language=""{0}"" CommonReferences=""true"" AssemblyName=""Project1"" {1}>
+        <Document FilePath=""SourceDocument"">{2}</Document>
+        <MetadataReferenceFromSource Language=""{3}"" CommonReferences=""true"" Aliases=""{4}"" IncludeXmlDocComments=""true"" DocumentationMode=""Diagnose"" {5}>
+            <Document FilePath=""ReferencedDocument"">{6}</Document>
         </MetadataReferenceFromSource>
     </Project>
-</Workspace>", sourceLanguage, SecurityElement.Escape(markup), referencedLanguage, SecurityElement.Escape(aliases), SecurityElement.Escape(referencedCode));
+</Workspace>", sourceLanguage, GetLanguageVersionAttribute(sourceLanguage), SecurityElement.Escape(markup), referencedLanguage, SecurityElement.Escape(aliases), GetLanguageVersionAttribute(referencedLanguage), SecurityElement.Escape(referencedCode));
         }
 
         protected async Task VerifyItemWithProjectReferenceAsync(string markup, string referencedCode, string expectedItem, int expectedSymbols, string sourceLanguage, string referencedLanguage)
@@ -711,15 +716,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         {
             return string.Format(@"
 <Workspace>
-    <Project Language=""{0}"" CommonReferences=""true"" AssemblyName=""Project1"">
+    <Project Language=""{0}"" CommonReferences=""true"" AssemblyName=""Project1"" {1}>
         <ProjectReference>ReferencedProject</ProjectReference>
-        <Document FilePath=""SourceDocument"">{1}</Document>
+        <Document FilePath=""SourceDocument"">{2}</Document>
     </Project>
-    <Project Language=""{2}"" CommonReferences=""true"" AssemblyName=""ReferencedProject"" IncludeXmlDocComments=""true"" DocumentationMode=""Diagnose"">
-        <Document FilePath=""ReferencedDocument"">{3}</Document>
+    <Project Language=""{3}"" CommonReferences=""true"" AssemblyName=""ReferencedProject"" IncludeXmlDocComments=""true"" DocumentationMode=""Diagnose"" {4}>
+        <Document FilePath=""ReferencedDocument"">{5}</Document>
     </Project>
     
-</Workspace>", sourceLanguage, SecurityElement.Escape(markup), referencedLanguage, SecurityElement.Escape(referencedCode));
+</Workspace>", sourceLanguage, GetLanguageVersionAttribute(sourceLanguage), SecurityElement.Escape(markup), referencedLanguage, GetLanguageVersionAttribute(referencedLanguage), SecurityElement.Escape(referencedCode));
         }
 
         protected static string CreateMarkupForProjectWithMultupleProjectReferences(string sourceText, string sourceLanguage, string referencedLanguage, string[] referencedTexts)
@@ -791,11 +796,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         {
             return string.Format(@"
 <Workspace>
-    <Project Language=""{0}"" CommonReferences=""true"" Name=""ProjectName"">
+    <Project Language=""{0}"" CommonReferences=""true"" Name=""ProjectName"" {5}>
         <Document FilePath=""{3}"">{1}</Document>
         <Document FilePath=""{4}"">{2}</Document>
     </Project>    
-</Workspace>", sourceLanguage, SecurityElement.Escape(sourceCode), SecurityElement.Escape(referencedCode), sourceFileName, referencedFileName);
+</Workspace>", sourceLanguage, SecurityElement.Escape(sourceCode), SecurityElement.Escape(referencedCode), sourceFileName, referencedFileName, GetLanguageVersionAttribute(sourceLanguage));
         }
 
         private async Task VerifyItemWithReferenceWorkerAsync(

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
@@ -258,8 +258,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 // Iterate over all top level internal and public types, keep track of "type overloads".
                 foreach (var type in types)
                 {
-                    // No need to check accessibility here, since top level types can only be internal or public.
-                    if (type.CanBeReferencedByName)
+                    // Include all top level types except those declared as `file` (i.e. all internal or public)
+                    if (type.CanBeReferencedByName && !type.IsFileLocal)
                     {
                         overloads.TryGetValue(type.Name, out var overloadInfo);
                         overloads[type.Name] = overloadInfo.Aggregate(type);


### PR DESCRIPTION
fix #65339