### PR TITLE
Fix bug in partial solutions after a document was removed and added

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -163,27 +163,14 @@ namespace Microsoft.CodeAnalysis
                 }
             }
 
-            /// <summary>
-            /// A class to help simplify the investigation of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1467404 when we
-            /// see a crash dump with the failure. The goal is just to make it easy to find the state that we operated on in memory,
-            /// when sometimes local have been optimized away.
-            /// </summary>
-            private class OldStateHolderForBug1467404Investigation
-            {
-                public CompilationTrackerState? State;
-            }
-
             public ICompilationTracker FreezePartialStateWithTree(SolutionState solution, DocumentState docState, SyntaxTree tree, CancellationToken cancellationToken)
             {
-                var stateHolder = new OldStateHolderForBug1467404Investigation();
-
                 GetPartialCompilationState(
                     solution, docState.Id,
                     out var inProgressProject,
                     out var compilationPair,
                     out var generatorInfo,
                     out var metadataReferenceToProjectId,
-                    out stateHolder.State,
                     cancellationToken);
 
                 // Ensure we actually have the tree we need in there
@@ -215,8 +202,6 @@ namespace Microsoft.CodeAnalysis
                     this.ProjectState.Id,
                     metadataReferenceToProjectId);
 
-                GC.KeepAlive(stateHolder);
-
                 return new CompilationTracker(inProgressProject, finalState, this.SkeletonReferenceCache.Clone());
             }
 
@@ -236,11 +221,9 @@ namespace Microsoft.CodeAnalysis
                 out CompilationPair compilations,
                 out CompilationTrackerGeneratorInfo generatorInfo,
                 out Dictionary<MetadataReference, ProjectId>? metadataReferenceToProjectId,
-                out CompilationTrackerState oldStateForBugInvestigation,
                 CancellationToken cancellationToken)
             {
                 var state = ReadState();
-                oldStateForBugInvestigation = state;
                 var compilationWithoutGeneratedDocuments = state.CompilationWithoutGeneratedDocuments;
 
                 // check whether we can bail out quickly for typing case

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis
                 // the tree that we have been given was directly returned from the document state that we're also being passed --
                 // the only reason we're requesting it earlier is this code is running under a lock in
                 // SolutionState.WithFrozenPartialCompilationIncludingSpecificDocument.
-                if (!compilationPair.CompilationWithoutGeneratedDocuments.SyntaxTrees.Contains(tree))
+                if (!compilationPair.CompilationWithoutGeneratedDocuments.ContainsSyntaxTree(tree))
                 {
                     // We do not have the exact tree. It either means this document was recently added, or the tree was recently changed.
                     // We now need to update both the inProgressState and the compilation. There are several possibilities we want to consider:

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -3017,11 +3017,9 @@ public class C : A {
             var project = workspace.CurrentSolution.AddProject("TestProject", "TestProject", LanguageNames.CSharp)
                 .AddDocument("RegularDocument.cs", "// Source File", filePath: "RegularDocument.cs").Project;
 
-            // Fetch the compilation and ensure it's held during forking, as otherwise we may have no in-progress state
-            // when we freeze.
+            // Fetch the compilation to ensure further changes produce in progress states
             var originalCompilation = await project.GetCompilationAsync();
             project = project.AddAdditionalDocument("Test.txt", "").Project;
-            GC.KeepAlive(originalCompilation);
 
             // Freeze semantics -- this should give us a compilation and state that don't include the additional file,
             // since the compilation won't represent that either
@@ -3046,16 +3044,13 @@ public class C : A {
                 .AddDocument(documentId2, nameof(documentId2), "// Document 2")
                 .AddDocument(documentId3, nameof(documentId3), "// Document 3");
 
-            // Fetch the compilation and ensure it's held during forking, as otherwise we may have no in-progress state
-            // when we freeze.
+            // Fetch the compilation to ensure further changes produce in progress states
             var originalCompilation = await solution.Projects.Single().GetCompilationAsync();
 
             solution = solution
                 .WithDocumentText(documentId1, SourceText.From("// Document 1 Changed"))
                 .WithDocumentText(documentId2, SourceText.From("// Document 2 Changed"))
                 .WithDocumentText(documentId3, SourceText.From("// Document 3 Changed"));
-
-            GC.KeepAlive(originalCompilation);
 
             var documentIdToFreeze = documentToFreeze == 1 ? documentId1 : documentToFreeze == 2 ? documentId2 : documentId3;
 


### PR DESCRIPTION
When we freeze a partial solution, we always ensure that frozen snapshot contains a specific document that is in sync with the compilation. We had some logic which updated an existing document if it was there, or otherwise adds the tree if the document was recently added. There was a long-standing logic issue though where if a document for a file path is removed and re-added in a rapid succession, there would be the existing tree with the same path that we'd try to replace, but since the document IDs didn't match, things went wrong.

The code change is relatively small, but while I'm here I also tried to make this a bit more robust if a tree didn't have a file path, which was suspiciously forgotten about in the original code. Tests have been added to ensure we have 100% code coverage in this function.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1467404