### PR TITLE
Implicitly-typed lambda parameters have RefKind.None

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -311,14 +311,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (!unboundLambda.HasSignature || unboundLambda.ParameterCount == 0)
             {
                 // The parameters may be omitted in source, but they are still present on the symbol.
-                return parameterTypes.SelectAsArray((type, ordinal, arg) =>
+                return parameterTypes.SelectAsArray((type, ordinal, owner) =>
                                                         SynthesizedParameterSymbol.Create(
-                                                            arg.owner,
+                                                            owner,
                                                             type,
                                                             ordinal,
-                                                            arg.refKinds[ordinal],
+                                                            RefKind.None,
                                                             GeneratedNames.LambdaCopyParameterName(ordinal)), // Make sure nothing binds to this.
-                                                     (owner: this, refKinds: parameterRefKinds));
+                                                     this);
             }
 
             var builder = ArrayBuilder<ParameterSymbol>.GetInstance(unboundLambda.ParameterCount);
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 else if (p < numDelegateParameters)
                 {
                     type = parameterTypes[p];
-                    refKind = parameterRefKinds[p];
+                    refKind = RefKind.None;
                     scope = DeclarationScope.Unscoped;
                 }
                 else

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -311,14 +311,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (!unboundLambda.HasSignature || unboundLambda.ParameterCount == 0)
             {
                 // The parameters may be omitted in source, but they are still present on the symbol.
-                return parameterTypes.SelectAsArray((type, ordinal, owner) =>
+                return parameterTypes.SelectAsArray((type, ordinal, arg) =>
                                                         SynthesizedParameterSymbol.Create(
-                                                            owner,
+                                                            arg.owner,
                                                             type,
                                                             ordinal,
-                                                            RefKind.None,
+                                                            arg.refKinds[ordinal],
                                                             GeneratedNames.LambdaCopyParameterName(ordinal)), // Make sure nothing binds to this.
-                                                     this);
+                                                     (owner: this, refKinds: parameterRefKinds));
             }
 
             var builder = ArrayBuilder<ParameterSymbol>.GetInstance(unboundLambda.ParameterCount);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -6951,7 +6951,7 @@ public class DisplayAttribute : System.Attribute
                 );
         }
 
-        [Fact]
+        [Fact, WorkItem(64985, "https://github.com/dotnet/roslyn/issues/64985")]
         public void DelegateConversions_ImplicitlyTypedParameter_RefParameter()
         {
             var source = """
@@ -6992,12 +6992,10 @@ public class DisplayAttribute : System.Attribute
             Assert.Equal("? r1", lambdaParameter1.ToTestDisplayString());
             Assert.Equal(RefKind.None, lambdaParameter1.RefKind);
 
-            // Implicitly-typed lambda parameters can get a type, but they cannot get a different ref-kind (or scoped-ness) during anonymous function conversion
-            // Tracked by https://github.com/dotnet/roslyn/issues/64985
             Assert.Equal("r2 => r2", lambdas[1].ToString());
             var lambdaParameter2 = model.GetSymbolInfo(lambdas[1]).Symbol.GetParameters()[0];
-            Assert.Equal("ref R r2", lambdaParameter2.ToTestDisplayString());
-            Assert.Equal(RefKind.Ref, lambdaParameter2.RefKind);
+            Assert.Equal("R r2", lambdaParameter2.ToTestDisplayString());
+            Assert.Equal(RefKind.None, lambdaParameter2.RefKind);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -15674,7 +15674,7 @@ class Program
             Assert.Equal("lambda expression", method.ToTestDisplayString());
             var parameters = method.GetParameters();
             Assert.Equal("R <p0>", parameters[0].ToTestDisplayString());
-            Assert.Equal("R <p1>", parameters[1].ToTestDisplayString());
+            Assert.Equal("ref R <p1>", parameters[1].ToTestDisplayString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -15635,7 +15635,7 @@ class Program
             Assert.Null(model.GetSymbolInfo(invocations[1]).Symbol);
         }
 
-        [Fact, WorkItem(64985, "https://github.com/dotnet/roslyn/issues/64985")]
+        [Fact]
         public void DelegateConversions_ImplicitlyTypedParameter_ParameterlessAnonymousMethod_Ref()
         {
             var source = """

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefFieldTests.cs
@@ -15635,7 +15635,7 @@ class Program
             Assert.Null(model.GetSymbolInfo(invocations[1]).Symbol);
         }
 
-        [Fact]
+        [Fact, WorkItem(64985, "https://github.com/dotnet/roslyn/issues/64985")]
         public void DelegateConversions_ImplicitlyTypedParameter_ParameterlessAnonymousMethod_Ref()
         {
             var source = """
@@ -15674,7 +15674,7 @@ class Program
             Assert.Equal("lambda expression", method.ToTestDisplayString());
             var parameters = method.GetParameters();
             Assert.Equal("R <p0>", parameters[0].ToTestDisplayString());
-            Assert.Equal("ref R <p1>", parameters[1].ToTestDisplayString());
+            Assert.Equal("R <p1>", parameters[1].ToTestDisplayString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
@@ -712,9 +712,6 @@ class C
     D d = async delegate { };
 }";
             CreateCompilation(source).VerifyDiagnostics(
-                // (4,17): error CS1988: Async methods cannot have ref, in or out parameters
-                //     D d = async delegate { };
-                Diagnostic(ErrorCode.ERR_BadAsyncArgType, "delegate"),
                 // (4,17): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //     D d = async delegate { };
                 Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "delegate").WithLocation(4, 17));

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
@@ -712,9 +712,61 @@ class C
     D d = async delegate { };
 }";
             CreateCompilation(source).VerifyDiagnostics(
+                // (4,17): error CS1988: Async methods cannot have ref, in or out parameters
+                //     D d = async delegate { };
+                Diagnostic(ErrorCode.ERR_BadAsyncArgType, "delegate").WithLocation(4, 17),
                 // (4,17): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
                 //     D d = async delegate { };
                 Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "delegate").WithLocation(4, 17));
+        }
+
+        [Fact]
+        public void AnonymousMethodWithRefParameter()
+        {
+            var source =
+@"delegate void D(ref int x);
+class C
+{
+    D d = delegate { };
+}";
+            var comp = CreateCompilation(source).VerifyDiagnostics();
+
+            var syntaxTree = comp.SyntaxTrees.Single();
+            var root = syntaxTree.GetRoot();
+            var model = comp.GetSemanticModel(syntaxTree);
+
+            var anonymousMethod = root.DescendantNodes().OfType<AnonymousMethodExpressionSyntax>().Single();
+
+            Assert.Equal("delegate { }", anonymousMethod.ToString());
+            var parameter = model.GetSymbolInfo(anonymousMethod).Symbol.GetParameters()[0];
+            Assert.Equal("ref System.Int32 <p0>", parameter.ToTestDisplayString());
+            Assert.Equal(RefKind.Ref, parameter.RefKind);
+        }
+
+        [Fact]
+        public void AnonymousMethodWithOutParameter()
+        {
+            var source =
+@"delegate void D(out int x);
+class C
+{
+    D d = delegate { };
+}";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (4,11): error CS1688: Cannot convert anonymous method block without a parameter list to delegate type 'D' because it has one or more out parameters
+                //     D d = delegate { };
+                Diagnostic(ErrorCode.ERR_CantConvAnonMethNoParams, "delegate { }").WithArguments("D").WithLocation(4, 11)
+                );
+
+            var syntaxTree = comp.SyntaxTrees.Single();
+            var root = syntaxTree.GetRoot();
+            var model = comp.GetSemanticModel(syntaxTree);
+
+            var anonymousMethod = root.DescendantNodes().OfType<AnonymousMethodExpressionSyntax>().Single();
+
+            Assert.Equal("delegate { }", anonymousMethod.ToString());
+            Assert.Empty(model.GetSymbolInfo(anonymousMethod).Symbol.GetParameters());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/64985

> The parameters of an anonymous function in the form of a _lambda_expression_ can be explicitly or implicitly typed. In an explicitly typed parameter list, the type of each parameter is explicitly stated. In an implicitly typed parameter list, the types of the parameters are inferred from the context in which the anonymous function occurs—specifically, when the anonymous function is converted to a compatible delegate type or expression tree type, that type provides the parameter types (§10.7).

> The parameter list of an anonymous function in the form of an _anonymous_method_expression_ is optional. If given, the parameters shall be explicitly typed. If not, the anonymous function is convertible to a delegate with any parameter list not containing out parameters.
