### PR TITLE
Stop shipping `-vs-deps` branches

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -127,7 +127,7 @@
       "vsMajorVersion": 17,
       "insertionTitlePrefix": "[d17.4]"
     },
-    "release/dev17.5-vs-deps": {
+    "release/dev17.5": {
       "nugetKind": [
         "Shipping",
         "NonShipping"
@@ -138,16 +138,6 @@
       "insertionTitlePrefix": "[d17.5p1]"
     },
     "main": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "main",
-      "vsMajorVersion": 17,
-      "insertionCreateDraftPR": true,
-      "insertionTitlePrefix": "[Validation]"
-    },
-    "main-vs-deps": {
       "nugetKind": [
         "Shipping",
         "NonShipping"


### PR DESCRIPTION
Follow up to https://github.com/dotnet/roslyn/pull/65373 and https://github.com/dotnet/roslyn/pull/65374