### PR TITLE
Fix reading indent style and indent size from VS settings

### DIFF
--- a/src/VisualStudio/Core/Def/Options/VisualStudioSettingsOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioSettingsOptionPersister.cs
@@ -116,6 +116,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                     return stringArray.ToImmutableArray();
                 }
 
+                if (optionKey.Option.Type == typeof(int) &&
+                    _settingManager.TryGetValue(storageKey, out int intValue) == GetValueResult.Success)
+                {
+                    return intValue;
+                }
+
                 if (_settingManager.TryGetValue(storageKey, out object value) == GetValueResult.Success)
                 {
                     return value;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
@@ -78,8 +78,9 @@ namespace Microsoft.CodeAnalysis.Formatting
             new(FeatureName, FormattingOptionGroups.NewLine, nameof(InsertFinalNewLine), DocumentFormattingOptions.Default.InsertFinalNewLine,
             storageLocation: EditorConfigStorageLocation.ForBoolOption("insert_final_newline"));
 
-        public static PerLanguageOption2<FormattingOptions2.IndentStyle> SmartIndent { get; } =
-            new(FeatureName, FormattingOptionGroups.IndentationAndSpacing, nameof(SmartIndent), defaultValue: IndentationOptions.DefaultIndentStyle);
+        public static PerLanguageOption2<IndentStyle> SmartIndent { get; } =
+            new(FeatureName, FormattingOptionGroups.IndentationAndSpacing, nameof(SmartIndent), defaultValue: IndentationOptions.DefaultIndentStyle,
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Indent Style"));
 
 #if !CODE_STYLE
         internal static readonly ImmutableArray<IOption> Options = ImmutableArray.Create<IOption>(


### PR DESCRIPTION
Turns out ISettingsManager stores indent size as Int64 which wasn't converted to Int32.
We were also missing storage location for Indent Style.

Fixes https://github.com/dotnet/roslyn/issues/65375 (https://developercommunity.visualstudio.com/t/Quick-actions-use-wrong-indent/10197217)

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1674009
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1675408

Fixes https://github.com/dotnet/roslyn/issues/65360

