### PR TITLE
Fix flaky test

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -5313,8 +5313,7 @@ class C
             ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 Dim oldFilters = state.GetCompletionItemFilters()
                 Dim newFilters = ArrayBuilder(Of Data.CompletionFilterWithState).GetInstance()
@@ -5325,9 +5324,7 @@ class C
 
                 newFilters.Add(New Data.CompletionFilterWithState(FilterSet.InterfaceFilter, isAvailable:=True, isSelected:=True))
 
-                state.RaiseFiltersChanged(newFilters.ToImmutableAndFree())
-
-                Await state.WaitForUIRenderedAsync()
+                Await state.RaiseFiltersChangedAndWaitForUiRenderAsync(newFilters.ToImmutableAndFree())
                 Assert.Null(state.GetSelectedItem())
             End Using
         End Function
@@ -5348,8 +5345,8 @@ class C
             ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
+
                 Dim oldFilters = state.GetCompletionItemFilters()
                 Dim newFilters = ArrayBuilder(Of Data.CompletionFilterWithState).GetInstance()
                 For Each f In oldFilters
@@ -5359,8 +5356,7 @@ class C
 
                 newFilters.Add(New Data.CompletionFilterWithState(FilterSet.InterfaceFilter, isAvailable:=True, isSelected:=True))
 
-                state.RaiseFiltersChanged(newFilters.ToImmutableAndFree())
-                Await state.WaitForUIRenderedAsync()
+                Await state.RaiseFiltersChangedAndWaitForUiRenderAsync(newFilters.ToImmutableAndFree())
                 Assert.Null(state.GetSelectedItem())
                 state.SendTab()
                 Await state.AssertNoCompletionSession()
@@ -5383,8 +5379,8 @@ class C
             ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
+
                 Dim oldFilters = state.GetCompletionItemFilters()
                 Dim newFilters = ArrayBuilder(Of Data.CompletionFilterWithState).GetInstance()
                 For Each f In oldFilters
@@ -5394,8 +5390,7 @@ class C
 
                 newFilters.Add(New Data.CompletionFilterWithState(FilterSet.InterfaceFilter, isAvailable:=True, isSelected:=True))
 
-                state.RaiseFiltersChanged(newFilters.ToImmutableAndFree())
-                Await state.WaitForUIRenderedAsync()
+                Await state.RaiseFiltersChangedAndWaitForUiRenderAsync(newFilters.ToImmutableAndFree())
                 Assert.Null(state.GetSelectedItem())
                 state.SendReturn()
                 Await state.AssertNoCompletionSession()
@@ -5418,8 +5413,8 @@ class C
             ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
+
                 Dim oldFilters = state.GetCompletionItemFilters()
                 Dim newFilters = ArrayBuilder(Of Data.CompletionFilterWithState).GetInstance()
                 For Each f In oldFilters
@@ -5429,8 +5424,7 @@ class C
 
                 newFilters.Add(New Data.CompletionFilterWithState(FilterSet.InterfaceFilter, isAvailable:=True, isSelected:=True))
 
-                state.RaiseFiltersChanged(newFilters.ToImmutableAndFree())
-                Await state.WaitForUIRenderedAsync()
+                Await state.RaiseFiltersChangedAndWaitForUiRenderAsync(newFilters.ToImmutableAndFree())
                 Assert.Null(state.GetSelectedItem())
                 state.SendTypeChars(".")
                 Await state.AssertNoCompletionSession()
@@ -5526,8 +5520,7 @@ class C
             ]]></Document>,
                   showCompletionInArgumentLists:=showCompletionInArgumentLists)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 Await state.AssertSelectedCompletionItem("Red")
                 Await state.AssertCompletionItemsContainAll("Red", "Green", "Blue", "Equals")
@@ -5538,9 +5531,8 @@ class C
                     newFiltersBuilder.Add(f.WithSelected(f.Filter.DisplayText = FilterSet.ConstantFilter.DisplayText))
                 Next
 
-                state.RaiseFiltersChanged(newFiltersBuilder.ToImmutableAndFree())
+                Await state.RaiseFiltersChangedAndWaitForUiRenderAsync(newFiltersBuilder.ToImmutableAndFree())
 
-                Await state.WaitForUIRenderedAsync()
                 Await state.AssertSelectedCompletionItem("Red")
                 Await state.AssertCompletionItemsContainAll("Red", "Green", "Blue")
                 Await state.AssertCompletionItemsDoNotContainAny("Equals")
@@ -5551,9 +5543,8 @@ class C
                     newFiltersBuilder.Add(f.WithSelected(False))
                 Next
 
-                state.RaiseFiltersChanged(newFiltersBuilder.ToImmutableAndFree())
+                Await state.RaiseFiltersChangedAndWaitForUiRenderAsync(newFiltersBuilder.ToImmutableAndFree())
 
-                Await state.WaitForUIRenderedAsync()
                 Await state.AssertSelectedCompletionItem("Red")
                 Await state.AssertCompletionItemsContainAll({"Red", "Green", "Blue", "Equals"})
             End Using
@@ -5580,8 +5571,7 @@ class C
 }
             ]]></Document>)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 Await state.AssertCompletionItemsContainAll("Color.Red", "Color.Green", "Color.Blue", "Color")
 
@@ -5607,9 +5597,8 @@ class C
 
                 Assert.True(hasEnumerFilter And hasEnumMemberFilter)
 
-                state.RaiseFiltersChanged(newFiltersBuilder.ToImmutableAndFree())
+                Await state.RaiseFiltersChangedAndWaitForUiRenderAsync(newFiltersBuilder.ToImmutableAndFree())
 
-                Await state.WaitForUIRenderedAsync()
                 Await state.AssertCompletionItemsContainAll("Color.Red", "Color.Green", "Color.Blue")
                 Await state.AssertCompletionItemsDoNotContainAny("Color")
             End Using
@@ -5636,8 +5625,7 @@ class C
 }
             ]]></Document>)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 Await state.AssertCompletionItemsContainAll("Color.Red", "Color.Green", "Color.Blue", "Color")
 
@@ -5658,9 +5646,8 @@ class C
 
                 Assert.True(hasTargetTypedFilter)
 
-                state.RaiseFiltersChanged(newFiltersBuilder.ToImmutableAndFree())
+                Await state.RaiseFiltersChangedAndWaitForUiRenderAsync(newFiltersBuilder.ToImmutableAndFree())
 
-                Await state.WaitForUIRenderedAsync()
                 Await state.AssertCompletionItemsContainAll("Color.Red", "Color.Green", "Color.Blue")
                 Await state.AssertCompletionItemsDoNotContainAny("Color")
             End Using
@@ -6809,8 +6796,7 @@ namespace NS2
                 service.QueueCacheWarmUpTask(document.Project)
                 Await state.WaitForAsynchronousOperationsAsync()
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 Await state.AssertCompletionItemsContain(displayText:="UnimportedType", displayTextSuffix:="")
 
@@ -6860,8 +6846,7 @@ namespace NS2
                 Await ExtensionMethodImportCompletionHelper.WarmUpCacheAsync(document.Project, CancellationToken.None)
                 Await state.WaitForAsynchronousOperationsAsync()
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 Await state.AssertCompletionItemsContain(displayText:="IntegerExtMethod", displayTextSuffix:="")
 
@@ -6896,29 +6881,22 @@ namespace NS2
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
 
                 ' trigger completion with import completion disabled
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 ' make sure expander is selected
-                state.SetCompletionItemExpanderState(isSelected:=True)
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SetCompletionItemExpanderStateAndWaitForUiRenderAsync(isSelected:=True)
 
                 Await state.AssertSelectedCompletionItem(displayText:="Bar", inlineDescription:="NS2")
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
 
                 ' unselect expander
-                state.SetCompletionItemExpanderState(isSelected:=False)
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SetCompletionItemExpanderStateAndWaitForUiRenderAsync(isSelected:=False)
 
                 Await state.AssertCompletionItemsDoNotContainAny("Bar")
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=False)
 
                 ' select expander again
-                state.SetCompletionItemExpanderState(isSelected:=True)
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SetCompletionItemExpanderStateAndWaitForUiRenderAsync(isSelected:=True)
 
                 Await state.AssertSelectedCompletionItem(displayText:="Bar", inlineDescription:="NS2")
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
@@ -6928,8 +6906,7 @@ namespace NS2
                 Await state.AssertNoCompletionSession()
 
                 ' trigger completion again
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 ' should not show unimported item by default
                 Await state.AssertCompletionItemsDoNotContainAny({"Bar"})
@@ -6964,13 +6941,10 @@ namespace NS2
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 ' trigger completion with import completion enabled
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 ' make sure expander is selected
-                state.SetCompletionItemExpanderState(isSelected:=True)
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SetCompletionItemExpanderStateAndWaitForUiRenderAsync(isSelected:=True)
 
                 Await state.AssertSelectedCompletionItem(displayText:="Bar", inlineDescription:="NS2")
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
@@ -6980,8 +6954,7 @@ namespace NS2
                 Await state.AssertNoCompletionSession()
 
                 ' trigger completion again
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 ' show expanded items by default
                 Await state.AssertSelectedCompletionItem(displayText:="Bar", inlineDescription:="NS2")
@@ -7005,15 +6978,12 @@ namespace NS1
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 ' trigger completion with import completion enabled
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=False)
                 Dim length = state.GetCompletionItems().Count
 
-                state.SetCompletionItemExpanderState(isSelected:=True)
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SetCompletionItemExpanderStateAndWaitForUiRenderAsync(isSelected:=True)
 
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
                 Assert.Equal(length, state.GetCompletionItems().Count)
@@ -7046,8 +7016,7 @@ public class AA
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 ' import completion is disabled, so we shouldn't have expander selected by default
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=False)
@@ -7058,9 +7027,7 @@ public class AA
                 Dim sessionData = CompletionSessionData.GetOrCreateSessionData(session)
                 Assert.Null(sessionData.ExpandedItemsTask)
 
-                state.SendTypeChars("D")
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendTypeCharsAndWaitForUiRenderAsync("D")
 
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=False)
                 Await state.AssertCompletionItemsContain("DDProp1", "")
@@ -7093,17 +7060,14 @@ public class AA
 
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 ' import completion is disabled, so we shouldn't have expander selected by default
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=False)
                 Await state.AssertCompletionItemsContain("Prop1", "")
                 Await state.AssertCompletionItemsDoNotContainAny("DD")
 
-                state.SetCompletionItemExpanderState(isSelected:=True)
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SetCompletionItemExpanderStateAndWaitForUiRenderAsync(isSelected:=True)
 
                 ' since we are in exclusive context (property name provider is exclusive in this case), selceting expander is a no-op
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
@@ -7532,8 +7496,7 @@ namespace NS2
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
                 Await state.AssertSelectedCompletionItem(displayText:="Bar", displayTextSuffix:="<>")
@@ -7599,8 +7562,7 @@ namespace NS2
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
                 Await state.AssertSelectedCompletionItem(displayText:="Bar")
@@ -7666,8 +7628,7 @@ namespace NS2
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
                 Await state.AssertSelectedCompletionItem(displayText:="ABar")
@@ -7733,8 +7694,7 @@ namespace NS2
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
                 Await state.AssertSelectedCompletionItem(displayText:="Bar", inlineDescription:="")
@@ -7801,8 +7761,7 @@ namespace NS2
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 Await state.AssertSelectedCompletionItem(displayText:="Bar", inlineDescription:="NS2")
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
@@ -7838,8 +7797,7 @@ namespace OtherNS
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 Await state.AssertSelectedCompletionItem(displayText:="designer")
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
@@ -7929,13 +7887,10 @@ namespace NS2
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
                 ' trigger completion with import completion disabled
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 ' make sure expander is selected
-                state.SetCompletionItemExpanderState(isSelected:=True)
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SetCompletionItemExpanderStateAndWaitForUiRenderAsync(isSelected:=True)
 
                 state.SendEscape()
                 Await state.AssertNoCompletionSession()
@@ -8851,14 +8806,10 @@ public class AA
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation), True)
                 state.Workspace.GlobalOptions.SetGlobalOption(New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 ' Make sure expander is selected
-                state.SetCompletionItemExpanderState(isSelected:=True)
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SetCompletionItemExpanderStateAndWaitForUiRenderAsync(isSelected:=True)
 
                 Dim expectedText = $"
 using CC;
@@ -8906,14 +8857,10 @@ public class AA
                 state.Workspace.GlobalOptions.SetGlobalOption(
                     New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 ' Make sure expander is selected
-                state.SetCompletionItemExpanderState(isSelected:=True)
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SetCompletionItemExpanderStateAndWaitForUiRenderAsync(isSelected:=True)
 
                 Dim expectedText = $"
 using CC;
@@ -8955,13 +8902,9 @@ public class AA
                 state.Workspace.GlobalOptions.SetGlobalOption(
                     New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
-                state.SetCompletionItemExpanderState(isSelected:=True)
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SetCompletionItemExpanderStateAndWaitForUiRenderAsync(isSelected:=True)
 
                 Dim expectedText = "
 public class AA
@@ -8998,13 +8941,9 @@ public class AA
                 state.Workspace.GlobalOptions.SetGlobalOption(
                     New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
-                state.SetCompletionItemExpanderState(isSelected:=True)
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SetCompletionItemExpanderStateAndWaitForUiRenderAsync(isSelected:=True)
 
                 Dim expectedText = "
 using System;
@@ -9048,13 +8987,9 @@ namespace Bar1
                 state.Workspace.GlobalOptions.SetGlobalOption(
                     New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
-                state.SetCompletionItemExpanderState(isSelected:=True)
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SetCompletionItemExpanderStateAndWaitForUiRenderAsync(isSelected:=True)
 
                 Dim expectedText = "
 public class AA
@@ -9098,13 +9033,9 @@ public unsafe class AA
                 state.Workspace.GlobalOptions.SetGlobalOption(
                     New OptionKey(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp), True)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
-                state.SetCompletionItemExpanderState(isSelected:=True)
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SetCompletionItemExpanderStateAndWaitForUiRenderAsync(isSelected:=True)
 
                 Dim expectedText = "
 using System;
@@ -9309,14 +9240,8 @@ public class AA
         var y = x.$$
     }
 }</Document>)
-
-                state.SendInvokeCompletionList()
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
-
-                state.SendTypeChars("sh")
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
+                Await state.SendTypeCharsAndWaitForUiRenderAsync("sh")
 
                 ' "(short)" item has a MatchPriority of "Deprioritize", so we don't want to select it over regular item "Should"
                 ' even if it matches with filter text better in term of case-sensitivity.
@@ -9351,13 +9276,8 @@ public class AA
                                   ("item3", MatchPriority.Default),
                                   ("Item4", MatchPriority.Preselect)})
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
-
-                state.SendTypeChars("item")
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
+                Await state.SendTypeCharsAndWaitForUiRenderAsync("item")
 
                 ' always prefer case-sensitive match of highest priority, even in the presence of item with MatchPriority.Preselect
                 Await state.AssertSelectedCompletionItem("item2")
@@ -9387,13 +9307,8 @@ public class AA
                                   ("item2", MatchPriority.Default + 1),
                                   ("Item3", If(uppercaseItemIsDeprioritize, MatchPriority.Deprioritize, MatchPriority.Default - 1))})
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
-
-                state.SendTypeChars("Item")
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
+                Await state.SendTypeCharsAndWaitForUiRenderAsync("Item")
 
                 ' regardless of priority, if any uppercase letter is typed, ensure we prefer casing over match priority (including Preselect items) if uppercase is typed
                 ' even if item with best matched casing has MatchPriority.Deprioritize
@@ -9446,17 +9361,13 @@ public class AA
     }
 }</Document>)
 
-                state.SendInvokeCompletionList()
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
                 ' test prefix match
                 Await state.AssertSelectedCompletionItem("node", isHardSelected:=True)
                 Await state.AssertCompletionItemsContain("Node", "")
 
-                state.SendTypeChars("e")
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendTypeCharsAndWaitForUiRenderAsync("e")
 
                 ' test complete match
                 Await state.AssertSelectedCompletionItem("node", isHardSelected:=True)
@@ -9943,7 +9854,7 @@ class C
                 Dim provider = completionService.GetTestAccessor().GetImportedAndBuiltInProviders(ImmutableHashSet(Of String).Empty).OfType(Of TestProvider)().Single()
 
                 ' completion list shouldn't have expand item until we release the checkpoint
-                state.SendTypeChars("TestUnimp")
+                Await state.SendTypeCharsAndWaitForUiRenderAsync("TestUnimp")
                 Await state.AssertCompletionItemsDoNotContainAny("TestUnimportedItem")
 
                 Dim session = Await state.GetCompletionSession()
@@ -9954,15 +9865,13 @@ class C
                 Assert.False(expandTask.IsCompleted)
 
                 ' following up by typing a few more characters each triggers an list update
-                state.SendTypeChars("o")
+                Await state.SendTypeCharsAndWaitForUiRenderAsync("o")
                 Await state.AssertCompletionItemsDoNotContainAny("TestUnimportedItem")
                 Assert.False(expandTask.IsCompleted)
 
-                Dim uiRender = state.WaitForUIRenderedAsync()
-                state.SendTypeChars("r")
+                Await state.SendTypeCharsAndWaitForUiRenderAsync("r")
                 Await state.AssertCompletionItemsDoNotContainAny("TestUnimportedItem")
                 Assert.False(expandTask.IsCompleted)
-                Await uiRender
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=False)
 
                 provider.Checkpoint.Release()
@@ -9973,11 +9882,9 @@ class C
                 Await state.AssertCompletionItemsDoNotContainAny("TestUnimportedItem")
                 Assert.True(expandTask.IsCompleted)
 
-                uiRender = state.WaitForUIRenderedAsync()
-                state.SendTypeChars("t")
+                Await state.SendTypeCharsAndWaitForUiRenderAsync("t")
                 Await state.AssertCompletionItemsContain("TestUnimportedItem", "")
                 Await state.AssertSelectedCompletionItem("TestUnimportedItem", inlineDescription:="Test.Name.Spaces")
-                Await uiRender
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
             End Using
         End Function
@@ -10013,10 +9920,8 @@ class C
                 Assert.False(expandTask.IsCompleted)
 
                 ' following up by typing more characters each triggers an list update
-                Dim uiRender = state.WaitForUIRenderedAsync()
-                state.SendTypeChars("o")
+                Await state.SendTypeCharsAndWaitForUiRenderAsync("o")
                 Await state.AssertCompletionItemsDoNotContainAny("TestUnimportedItem")
-                Await uiRender
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=False)
                 Assert.False(expandTask.IsCompleted)
 
@@ -10029,10 +9934,7 @@ class C
                 Assert.True(expandTask.IsCompleted)
 
                 ' trigger update by using expander
-                uiRender = state.WaitForUIRenderedAsync()
-                state.SetCompletionItemExpanderState(isSelected:=True)
-                Await state.WaitForAsynchronousOperationsAsync()
-                Await uiRender
+                Await state.SetCompletionItemExpanderStateAndWaitForUiRenderAsync(isSelected:=True)
 
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
                 Await state.AssertCompletionItemsContain("TestUnimportedItem", "")
@@ -10077,12 +9979,13 @@ class C
 
                 ' Now delayed expand item task is completed, following up by typing and delete a character to trigger
                 ' update so the list would contains all items
-                Dim uiRender = state.WaitForUIRenderedAsync()
-                state.SendTypeChars("t")
+                Await state.SendTypeCharsAndWaitForUiRenderAsync("t")
                 Await state.AssertCompletionItemsContain("TestUnimportedItem", "")
+                state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
+
+                Dim uiRender = state.WaitForUIRenderedAsync()
                 state.SendBackspace()
                 Await uiRender
-                state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
 
                 ' Get the full list from session where delay happened
                 Dim list1 = state.GetCompletionItems()

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -1978,8 +1978,7 @@ Public Class C
 End Class
 
                               </Document>)
-                state.SendTypeChars("Task")
-                Await state.WaitForUIRenderedAsync()
+                Await state.SendTypeCharsAndWaitForUiRenderAsync("Task")
                 state.SendDownKey()
                 state.SendTypeChars(" ")
                 Assert.Equal("        Dim a as Task(Of ", state.GetLineTextFromCaretPosition())
@@ -3578,9 +3577,8 @@ Class Program
     End Sub
 End Class
 </Document>)
-                state.SendInvokeCompletionList()
-                Await state.WaitForUIRenderedAsync()
 
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
                 Await state.AssertCompletionItemsContainAll("Colors.Red", "Colors.Green", "Colors")
 
                 Dim oldFilters = state.GetCompletionItemFilters()
@@ -3600,9 +3598,7 @@ End Class
 
                 Assert.True(hasTargetTypedFilter)
 
-                state.RaiseFiltersChanged(newFiltersBuilder.ToImmutableAndFree())
-
-                Await state.WaitForUIRenderedAsync()
+                Await state.RaiseFiltersChangedAndWaitForUiRenderAsync(newFiltersBuilder.ToImmutableAndFree())
                 Await state.AssertCompletionItemsContainAll("Colors.Red", "Colors.Green")
                 Await state.AssertCompletionItemsDoNotContainAny("Colors")
             End Using

--- a/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
+++ b/src/EditorFeatures/TestUtilities2/Intellisense/TestState.vb
@@ -157,6 +157,12 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             MyBase.SendTypeChars(typeChars, Sub(a, n, c) ExecuteTypeCharCommand(a, n, c))
         End Sub
 
+        Public Async Function SendTypeCharsAndWaitForUiRenderAsync(typeChars As String) As Task
+            Dim uiRender = WaitForUIRenderedAsync()
+            SendTypeChars(typeChars)
+            Await uiRender
+        End Function
+
         Public Overloads Sub SendEscape()
             MyBase.SendEscape(Sub(a, n, c) EditorCompletionCommandHandler.ExecuteCommand(a, Sub() SignatureHelpAfterCompletionCommandHandler.ExecuteCommand(a, n, c), c), Sub() Return)
         End Sub
@@ -193,6 +199,12 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
         Public Overloads Sub SendInvokeCompletionList()
             MyBase.SendInvokeCompletionList(Sub(a, n, c) EditorCompletionCommandHandler.ExecuteCommand(a, n, c), Sub() Return)
         End Sub
+
+        Public Async Function SendInvokeCompletionListAndWaitForUiRenderAsync() As Task
+            Dim uiRender = WaitForUIRenderedAsync()
+            MyBase.SendInvokeCompletionList(Sub(a, n, c) EditorCompletionCommandHandler.ExecuteCommand(a, n, c), Sub() Return)
+            Await uiRender
+        End Function
 
         Public Overloads Sub SendInsertSnippetCommand()
             MyBase.SendInsertSnippetCommand(Sub(a, n, c) EditorCompletionCommandHandler.ExecuteCommand(a, n, c), Sub() Return)
@@ -472,12 +484,14 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             End If
         End Sub
 
-        Public Sub SetCompletionItemExpanderState(isSelected As Boolean)
+        Public Async Function SetCompletionItemExpanderStateAndWaitForUiRenderAsync(isSelected As Boolean) As Task
+            Dim uiRender = WaitForUIRenderedAsync()
             Dim presenter = DirectCast(CompletionPresenterProvider.GetOrCreate(Me.TextView), MockCompletionPresenter)
             Dim expander = presenter.GetExpander()
             Assert.NotNull(expander)
             presenter.SetExpander(isSelected)
-        End Sub
+            Await uiRender
+        End Function
 
         Public Async Function AssertSessionIsNothingOrNoCompletionItemLike(text As String) As Task
             Await WaitForAsynchronousOperationsAsync()
@@ -519,11 +533,13 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
             Return roslynItemData.RoslynItem
         End Function
 
-        Public Sub RaiseFiltersChanged(args As ImmutableArray(Of Data.CompletionFilterWithState))
+        Public Async Function RaiseFiltersChangedAndWaitForUiRenderAsync(args As ImmutableArray(Of Data.CompletionFilterWithState)) As Task
+            Dim uiRender = WaitForUIRenderedAsync()
             Dim presenter = DirectCast(CompletionPresenterProvider.GetOrCreate(Me.TextView), MockCompletionPresenter)
             Dim newArgs = New Data.CompletionFilterChangedEventArgs(args)
             presenter.TriggerFiltersChanged(Me, newArgs)
-        End Sub
+            Await uiRender
+        End Function
 
         Public Function GetCompletionItemFilters() As ImmutableArray(Of Data.CompletionFilterWithState)
             Dim presenter = DirectCast(CompletionPresenterProvider.GetOrCreate(Me.TextView), MockCompletionPresenter)


### PR DESCRIPTION
Might be a race that UI update event was triggered before we get the chance to hook up the event handler

Runfo: 
https://runfo.azurewebsites.net/search/tests/?q=started%3A%7E7+definition%3Aroslyn-ci+name%3ACSharpCompletionCommandHandlerTests

Fix https://github.com/dotnet/roslyn/issues/65362