### PR TITLE
Fix wrong symbol comparisons

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1039,9 +1039,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         fieldIsStatic == containing.IsStatic &&
                         (fieldIsStatic || fieldAccess.ReceiverOpt.Kind == BoundKind.ThisReference) &&
                         (Compilation.FeatureStrictEnabled
-                            ? TypeSymbol.Equals(fieldSymbol.ContainingType, containing.ContainingType, TypeCompareKind.ConsiderEverything2)
+                            ? TypeSymbol.Equals(fieldSymbol.ContainingType, containing.ContainingType, TypeCompareKind.AllNullableIgnoreOptions)
                             // We duplicate a bug in the native compiler for compatibility in non-strict mode
-                            : TypeSymbol.Equals(fieldSymbol.ContainingType.OriginalDefinition, containing.ContainingType.OriginalDefinition, TypeCompareKind.ConsiderEverything2)))
+                            : TypeSymbol.Equals(fieldSymbol.ContainingType.OriginalDefinition, containing.ContainingType.OriginalDefinition, TypeCompareKind.ConsiderEverything)))
                     {
                         if (containing.Kind == SymbolKind.Method)
                         {

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1039,9 +1039,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         fieldIsStatic == containing.IsStatic &&
                         (fieldIsStatic || fieldAccess.ReceiverOpt.Kind == BoundKind.ThisReference) &&
                         (Compilation.FeatureStrictEnabled
-                            ? TypeSymbol.Equals(fieldSymbol.ContainingType, containing.ContainingType, TypeCompareKind.AllNullableIgnoreOptions)
+                            ? TypeSymbol.Equals(fieldSymbol.ContainingType, containing.ContainingType, TypeCompareKind.AllIgnoreOptions)
                             // We duplicate a bug in the native compiler for compatibility in non-strict mode
-                            : TypeSymbol.Equals(fieldSymbol.ContainingType.OriginalDefinition, containing.ContainingType.OriginalDefinition, TypeCompareKind.ConsiderEverything)))
+                            : TypeSymbol.Equals(fieldSymbol.ContainingType.OriginalDefinition, containing.ContainingType.OriginalDefinition, TypeCompareKind.AllIgnoreOptions)))
                     {
                         if (containing.Kind == SymbolKind.Method)
                         {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1783,7 +1783,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return (object)sourceProperty != null &&
                     sourceProperty.IsAutoPropertyWithGetAccessor &&
-                    TypeSymbol.Equals(sourceProperty.ContainingType, fromMember.ContainingType, TypeCompareKind.ConsiderEverything2) &&
+                    TypeSymbol.Equals(sourceProperty.ContainingType, fromMember.ContainingType, TypeCompareKind.AllIgnoreOptions) &&
                     IsConstructorOrField(fromMember, isStatic: propertyIsStatic) &&
                     (propertyIsStatic || receiver.Kind == BoundKind.ThisReference);
         }

--- a/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
@@ -1090,7 +1090,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     NamedTypeSymbol containingType;
                     if (containingTypes.TryGetValue(contextBaseType.OriginalDefinition, out containingType))
                     {
-                        return !TypeSymbol.Equals(containingType, contextBaseType, TypeCompareKind.AllNullableIgnoreOptions);
+                        return !TypeSymbol.Equals(containingType, contextBaseType, TypeCompareKind.AllIgnoreOptions);
                     }
 
                     contextBaseType = contextBaseType.BaseTypeNoUseSiteDiagnostics;

--- a/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
@@ -1090,7 +1090,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     NamedTypeSymbol containingType;
                     if (containingTypes.TryGetValue(contextBaseType.OriginalDefinition, out containingType))
                     {
-                        return !TypeSymbol.Equals(containingType, contextBaseType, TypeCompareKind.ConsiderEverything2);
+                        return !TypeSymbol.Equals(containingType, contextBaseType, TypeCompareKind.AllNullableIgnoreOptions);
                     }
 
                     contextBaseType = contextBaseType.BaseTypeNoUseSiteDiagnostics;

--- a/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
+++ b/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // Special case: dev11 treats types instances of the declaring type in the parameter list
                     // (and return type, for conversions) as constructed with its own type parameters.
-                    if (!_inParameterOrReturnType && TypeSymbol.Equals(symbol, symbol.ConstructedFrom, TypeCompareKind.AllNullableIgnoreOptions))
+                    if (!_inParameterOrReturnType && TypeSymbol.Equals(symbol, symbol.ConstructedFrom, TypeCompareKind.AllIgnoreOptions))
                     {
                         builder.Append('`');
                         builder.Append(symbol.Arity);

--- a/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
+++ b/src/Compilers/CSharp/Portable/DocumentationComments/DocumentationCommentIDVisitor.PartVisitor.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // Special case: dev11 treats types instances of the declaring type in the parameter list
                     // (and return type, for conversions) as constructed with its own type parameters.
-                    if (!_inParameterOrReturnType && TypeSymbol.Equals(symbol, symbol.ConstructedFrom, TypeCompareKind.ConsiderEverything2))
+                    if (!_inParameterOrReturnType && TypeSymbol.Equals(symbol, symbol.ConstructedFrom, TypeCompareKind.AllNullableIgnoreOptions))
                     {
                         builder.Append('`');
                         builder.Append(symbol.Arity);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -7622,6 +7622,26 @@ String
             CompileAndVerify(text, expectedOutput: expectedOutput, verify: Verification.Fails);
         }
 
+        [Theory, WorkItem(65428, "https://github.com/dotnet/roslyn/issues/65428")]
+        [CombinatorialData]
+        public void WriteOfReadonlyStaticMemberOfAnotherInstantiation03(NullableContextOptions nullableContextOptions)
+        {
+            var text =
+@"
+class C<T>
+{
+    public static readonly int X;
+
+    static C()
+    {
+        C<T>.X = 100;
+    }
+}
+";
+
+            CreateCompilation(text, options: TestOptions.ReleaseDll.WithNullableContextOptions(nullableContextOptions), parseOptions: TestOptions.Regular.WithStrictFeature()).VerifyDiagnostics();
+        }
+
         [Fact]
         public void CS0199ERR_RefReadonlyStatic()
         {

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentIDTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentIDTests.cs
@@ -416,5 +416,25 @@ internal interface ICloneable<T>
             var method = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("Test").GetMember<MethodSymbol>("Clone").ReturnType;
             Assert.Equal("T:Test`1", method.GetDocumentationCommentId());
         }
+
+        [Theory]
+        [CombinatorialData]
+        public void Generic2(NullableContextOptions nullableContextOptions)
+        {
+            var source = @"
+internal class Test<T> : ICloneable<Test<T?>>
+{
+    public Test<T?> Clone() => new();
+}
+
+internal interface ICloneable<T>
+{
+    T Clone();
+}
+";
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll.WithNullableContextOptions(nullableContextOptions));
+            var method = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("Test").GetMember<MethodSymbol>("Clone").ReturnType;
+            Assert.Equal("T:Test`1", method.GetDocumentationCommentId());
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentIDTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentIDTests.cs
@@ -396,5 +396,25 @@ class A<TA1, TA2>
             var method = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("A").GetMember<NamedTypeSymbol>("B").GetMember<NamedTypeSymbol>("C").GetMember<MethodSymbol>("M");
             Assert.Equal("M:A`2.B`2.C`2.M``2(`0,`1,`2,`3,`4,`5,``0,``1)", method.GetDocumentationCommentId());
         }
+
+        [Theory]
+        [CombinatorialData]
+        public void Generic(NullableContextOptions nullableContextOptions)
+        {
+            var source = @"
+internal class Test<T> : ICloneable<Test<T>>
+{
+    public Test<T> Clone() => new();
+}
+
+internal interface ICloneable<T>
+{
+    T Clone();
+}
+";
+            var comp = CreateCompilation(source, options: TestOptions.DebugDll.WithNullableContextOptions(nullableContextOptions));
+            var method = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("Test").GetMember<MethodSymbol>("Clone").ReturnType;
+            Assert.Equal("T:Test`1", method.GetDocumentationCommentId());
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ClsComplianceTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ClsComplianceTests.cs
@@ -3651,5 +3651,24 @@ namespace N1
     Diagnostic(ErrorCode.WRN_CLS_ModuleMissingCLS).WithLocation(1, 1)
                 );
         }
+
+        [Fact]
+        public void ObjectAndDynamicDifference()
+        {
+            var source = @"
+[assembly: System.CLSCompliant(true)]
+
+public class C<T>
+{
+    protected class N { }
+}
+
+public class D : C<object>
+{
+    protected void M4(C<dynamic>.N n) { }
+}
+";
+            CreateCompilation(source).VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ClsComplianceTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ClsComplianceTests.cs
@@ -1086,8 +1086,9 @@ public interface Bad { }
         }
 
         // From LegacyTest\CSharp\Source\csharp\Source\ClsCompliance\generics\Rule_E_01.cs
-        [Fact]
-        public void WRN_CLS_BadArgType_ConstructedTypeAccessibility()
+        [Theory]
+        [CombinatorialData]
+        public void WRN_CLS_BadArgType_ConstructedTypeAccessibility(NullableContextOptions nullableContextOptions)
         {
             var source = @"
 [assembly: System.CLSCompliant(true)]
@@ -1114,7 +1115,7 @@ public class D : C<long>
 }
 ";
 
-            CreateCompilation(source).VerifyDiagnostics(
+            CreateCompilation(source, options: TestOptions.ReleaseDll.WithNullableContextOptions(nullableContextOptions)).VerifyDiagnostics(
                 // (7,32): warning CS3001: Argument type 'C<int>.N' is not CLS-compliant
                 //     protected void M1(C<int>.N n) { }	// Not CLS-compliant - C<int>.N not 
                 Diagnostic(ErrorCode.WRN_CLS_BadArgType, "n").WithArguments("C<int>.N"),


### PR DESCRIPTION
Fixes #62368
Fixes #58966
Fixes #65428

cc @333fred @jcouv @AlekseyTs 

Keeping draft until the behavior of `ConsiderEverything` (and the fact that we create `ConstructedNamedTypeSymbol` under `#nullable enable`, and `SourceNamedTypeSymbol` otherwise) is confirmed as a correct behavior. Otherwise, the fix will be much more involving.