### PR TITLE
Gracefully handle additional locations in DiagnosticData.Create

### DIFF
--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticData.cs
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 if (location.IsInSource)
                 {
-                    builder.AddIfNotNull(CreateLocation(document.Project.GetRequiredDocument(location.SourceTree), location));
+                    builder.AddIfNotNull(CreateLocation(document.Project.Solution.GetDocument(location.SourceTree), location));
                 }
                 else if (location.Kind == LocationKind.ExternalFile)
                 {


### PR DESCRIPTION
Fixes [AB#1676229](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1676229)
Fixes #65381

Handle additional location in different project from the primary location project as well additional location in a document which was subsequently removed from the solution.

Verified that the added unit test fails prior to the product fix.