### PR TITLE
Consult secondary index to avoid looking in a document for unit-test matches.

### DIFF
--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingSearchHelpers.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingSearchHelpers.cs
@@ -135,6 +135,15 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
             UnitTestingSearchQuery query,
             CancellationToken cancellationToken)
         {
+            // quick check that the symbol name is actually in the bloom-filter index for this document.  Can avoid
+            // checking any of the items in it if so.
+            var syntaxTreeIndex = await SyntaxTreeIndex.GetRequiredIndexAsync(document, cancellationToken).ConfigureAwait(false);
+            if (!syntaxTreeIndex.ProbablyContainsIdentifier(symbolName))
+                return ImmutableArray<UnitTestingDocumentSpan>.Empty;
+
+            // Ok, the symbol name was in this document.  Now go get the declaration-index and look through that to find
+            // the location of a potential matching symbol.
+
             using var _ = ArrayBuilder<UnitTestingDocumentSpan>.GetInstance(out var result);
 
             SyntaxTree? tree = null;


### PR DESCRIPTION
Currently, while we *are* using an index to search for unit-test results, we still check *every* item in that index against what is being searched for.  However, unlike navigate-to (which allows for arbitrary pattern matching of a search-string against a symbol), the search-string is known to always be an exact match.  As such, we can utilize one of our other indices to quickly determine if the document even contains the name in question before looking in it (similar to what FAR does).