### PR TITLE
Add unit test entrypoint to just find a single result

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -254,6 +254,7 @@
     <SystemThreadingChannelsVersion>6.0.0</SystemThreadingChannelsVersion>
     <!-- Note: When updating SystemTextJsonVersion ensure that the version is no higher than what is used by MSBuild. -->
     <SystemTextJsonVersion>6.0.0</SystemTextJsonVersion>
+    <SystemThreadingChannelsVersion>6.0.0</SystemThreadingChannelsVersion>
     <SystemThreadingTasksDataflowVersion>6.0.0</SystemThreadingTasksDataflowVersion>
     <!-- We need System.ValueTuple assembly version at least 4.0.3.0 on net47 to make F5 work against Dev15 - see https://github.com/dotnet/roslyn/issues/29705 -->
     <SystemValueTupleVersion>4.5.0</SystemValueTupleVersion>

--- a/src/EditorFeatures/Test2/UnitTesting/UnitTestingSearchHelpersTests.vb
+++ b/src/EditorFeatures/Test2/UnitTesting/UnitTestingSearchHelpersTests.vb
@@ -28,6 +28,16 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.UnitTesting
 
                 Assert.Equal(expected, actual.DocumentSpan.SourceSpan)
             Next
+
+            Dim actualLocation = Await UnitTestingSearchHelpers.GetSourceLocationAsync(
+                project, query, cancellationToken:=Nothing)
+
+            If actualLocation Is Nothing Then
+                Assert.Empty(expectedLocations)
+            Else
+                Dim expectedLocation = expectedLocations(0)
+                Assert.Equal(expectedLocation, actualLocation.Value.DocumentSpan.SourceSpan)
+            End If
         End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingSearchHelpers.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingSearchHelpers.cs
@@ -135,6 +135,15 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
             UnitTestingSearchQuery query,
             CancellationToken cancellationToken)
         {
+            // quick check that the symbol name is actually in the bloom-filter index for this document.  Can avoid
+            // checking any of the items in it if so.
+            var syntaxTreeIndex = await SyntaxTreeIndex.GetRequiredIndexAsync(document, cancellationToken).ConfigureAwait(false);
+            if (!syntaxTreeIndex.ProbablyContainsIdentifier(symbolName))
+                return ImmutableArray<UnitTestingDocumentSpan>.Empty;
+
+            // Ok, the symbol name was in this document.  Now go get the declaration-index and look through that to find
+            // the location of a potential matching symbol.
+
             using var _ = ArrayBuilder<UnitTestingDocumentSpan>.GetInstance(out var result);
 
             SyntaxTree? tree = null;

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingSearchHelpers.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/API/UnitTestingSearchHelpers.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;
@@ -13,12 +15,36 @@ using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
 {
     internal static class UnitTestingSearchHelpers
     {
         private static readonly char[] s_splitCharacters = { '.', '+' };
+
+        public static async Task<UnitTestingDocumentSpan?> GetSourceLocationAsync(
+            Project project, UnitTestingSearchQuery query, CancellationToken cancellationToken)
+        {
+            if (!project.SupportsCompilation)
+                return null;
+
+            var client = await RemoteHostClient.TryGetClientAsync(project.Solution.Services, cancellationToken).ConfigureAwait(false);
+
+            if (client != null)
+            {
+                var location = await client.TryInvokeAsync<IRemoteUnitTestingSearchService, UnitTestingSourceLocation?>(
+                    project,
+                    (service, solutionChecksum, cancellationToken) => service.GetSourceLocationAsync(solutionChecksum, project.Id, query, cancellationToken),
+                    cancellationToken).ConfigureAwait(false);
+                if (!location.HasValue || location.Value is null)
+                    return null;
+
+                return await location.Value.Value.TryRehydrateAsync(project.Solution, cancellationToken).ConfigureAwait(false);
+            }
+
+            return await GetSourceLocationInProcessAsync(project, query, cancellationToken).ConfigureAwait(false);
+        }
 
         public static async Task<ImmutableArray<UnitTestingDocumentSpan>> GetSourceLocationsAsync(
             Project project, UnitTestingSearchQuery query, CancellationToken cancellationToken)
@@ -112,7 +138,32 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
             }
         }
 
+        private static async Task<UnitTestingDocumentSpan?> GetSourceLocationInProcessAsync(
+            Project project,
+            UnitTestingSearchQuery query,
+            CancellationToken cancellationToken)
+        {
+            // Return the first result we find.
+            await foreach (var item in GetSourceLocationsInProcessWorkerAsync(project, query, cancellationToken).ConfigureAwait(false))
+                return item;
+
+            return null;
+        }
+
         private static async Task<ImmutableArray<UnitTestingDocumentSpan>> GetSourceLocationsInProcessAsync(
+            Project project,
+            UnitTestingSearchQuery query,
+            CancellationToken cancellationToken)
+        {
+            using var _ = ArrayBuilder<UnitTestingDocumentSpan>.GetInstance(out var result);
+
+            await foreach (var item in GetSourceLocationsInProcessWorkerAsync(project, query, cancellationToken).ConfigureAwait(false))
+                result.Add(item);
+
+            return result.ToImmutable();
+        }
+
+        private static IAsyncEnumerable<UnitTestingDocumentSpan> GetSourceLocationsInProcessWorkerAsync(
             Project project,
             UnitTestingSearchQuery query,
             CancellationToken cancellationToken)
@@ -121,30 +172,27 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
             var syntaxFacts = project.GetRequiredLanguageService<ISyntaxFactsService>();
             var comparer = syntaxFacts.StringComparer;
 
-            var tasks = project.Documents.Select(d => GetSourceLocationsInProcessAsync(d, comparer, container, symbolName, symbolArity, query, cancellationToken));
-            var result = await Task.WhenAll(tasks).ConfigureAwait(false);
-            return result.SelectMany(r => r).ToImmutableArray();
+            var streams = project.Documents.SelectAsArray(d => GetSourceLocationsInProcessAsync(d, comparer, container, symbolName, symbolArity, query, cancellationToken));
+            return streams.MergeAsync(cancellationToken);
         }
 
-        private static async Task<ImmutableArray<UnitTestingDocumentSpan>> GetSourceLocationsInProcessAsync(
+        private static async IAsyncEnumerable<UnitTestingDocumentSpan> GetSourceLocationsInProcessAsync(
             Document document,
             StringComparer comparer,
             string container,
             string symbolName,
             int symbolArity,
             UnitTestingSearchQuery query,
-            CancellationToken cancellationToken)
+            [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             // quick check that the symbol name is actually in the bloom-filter index for this document.  Can avoid
             // checking any of the items in it if so.
             var syntaxTreeIndex = await SyntaxTreeIndex.GetRequiredIndexAsync(document, cancellationToken).ConfigureAwait(false);
             if (!syntaxTreeIndex.ProbablyContainsIdentifier(symbolName))
-                return ImmutableArray<UnitTestingDocumentSpan>.Empty;
+                yield break;
 
             // Ok, the symbol name was in this document.  Now go get the declaration-index and look through that to find
             // the location of a potential matching symbol.
-
-            using var _ = ArrayBuilder<UnitTestingDocumentSpan>.GetInstance(out var result);
 
             SyntaxTree? tree = null;
 
@@ -185,10 +233,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.Api
                 tree ??= await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
                 var mappedSpan = tree.GetMappedLineSpan(info.Span, cancellationToken);
 
-                result.Add(new UnitTestingDocumentSpan(new DocumentSpan(document, info.Span), mappedSpan));
+                yield return new UnitTestingDocumentSpan(new DocumentSpan(document, info.Span), mappedSpan);
             }
-
-            return result.ToImmutable();
         }
     }
 }

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/IRemoteUnitTestingSearchService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/IRemoteUnitTestingSearchService.cs
@@ -12,6 +12,8 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting
 {
     internal interface IRemoteUnitTestingSearchService
     {
+        ValueTask<UnitTestingSourceLocation?> GetSourceLocationAsync(
+            Checksum solutionChecksum, ProjectId projectId, UnitTestingSearchQuery query, CancellationToken cancellationToken);
         ValueTask<ImmutableArray<UnitTestingSourceLocation>> GetSourceLocationsAsync(
             Checksum solutionChecksum, ProjectId projectId, UnitTestingSearchQuery query, CancellationToken cancellationToken);
     }

--- a/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="System.Composition" Version="$(SystemCompositionVersion)" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVersion)" />
     <PackageReference Include="System.IO.Pipelines" Version="$(SystemIOPipelinesVersion)" />
+    <PackageReference Include="System.Threading.Channels" Version="$(SystemThreadingChannelsVersion)" />
   </ItemGroup>
   <ItemGroup Label="Linked Files">
     <Compile Remove="Storage\SQLite\**\*.cs" Condition="'$(DotNetBuildFromSource)' == 'true'" />

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IAsyncEnumerableExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IAsyncEnumerableExtensions.cs
@@ -4,7 +4,9 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.PooledObjects;
 
@@ -12,6 +14,18 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 {
     internal static class IAsyncEnumerableExtensions
     {
+        internal static class AsyncEnumerable<T>
+        {
+            public static readonly IAsyncEnumerable<T> Empty = GetEmptyAsync();
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+            private static async IAsyncEnumerable<T> GetEmptyAsync()
+            {
+                yield break;
+            }
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        }
+
         public static async Task<ImmutableArray<T>> ToImmutableArrayAsync<T>(this IAsyncEnumerable<T> values, CancellationToken cancellationToken)
         {
             using var _ = ArrayBuilder<T>.GetInstance(out var result);
@@ -19,6 +33,65 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 result.Add(value);
 
             return result.ToImmutable();
+        }
+
+        /// <summary>
+        /// Takes an array of <see cref="IAsyncEnumerable{T}"/>s and produces a single resultant <see
+        /// cref="IAsyncEnumerable{T}"/> with all their values merged together.  Absolutely no ordering guarantee is
+        /// provided.  It will be expected that the individual values from distinct enumerables will be interleaved
+        /// together.
+        /// </summary>
+        /// <remarks>This helper is useful when doign parallel processing of work where each job returns an <see
+        /// cref="IAsyncEnumerable{T}"/>, but one final stream is desired as the result.</remarks>
+        public static IAsyncEnumerable<T> MergeAsync<T>(this ImmutableArray<IAsyncEnumerable<T>> streams, CancellationToken cancellationToken)
+        {
+            // Code provided by Stephen Toub, but heavily modified after that.
+
+            // 1024 chosen as a way to ensure we don't necessarily create a huge unbounded channel, while also making it
+            // so that we're unlikely to throttle on any stream unless there is truly a huge amount of results in it.
+            var channel = Channel.CreateBounded<T>(1024);
+
+            var tasks = new Task[streams.Length];
+            for (var i = 0; i < streams.Length; i++)
+                tasks[i] = Process(streams[i], channel.Writer, cancellationToken);
+
+            // Complete the channel writer with the result of all the tasks.  If nothing failed, t.Exception will be
+            // null and this will complete successfully.  If anything failed, the exception will propagate out.
+            //
+            // Note: passing CancellationToken.None here is intentional/correct.  We must complete all the channels to
+            // allow reading to complete as well.
+            Task.WhenAll(tasks).CompletesChannel(channel);
+
+            return channel.Reader.ReadAllAsync(cancellationToken);
+
+            static async Task Process(IAsyncEnumerable<T> stream, ChannelWriter<T> writer, CancellationToken cancellationToken)
+            {
+                await foreach (var value in stream)
+                    await writer.WriteAsync(value, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        public static async IAsyncEnumerable<T> ReadAllAsync<T>(
+            this ChannelReader<T> reader, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            while (await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                while (reader.TryRead(out var item))
+                    yield return item;
+            }
+        }
+
+        /// <summary>
+        /// Runs after task completes in any fashion (success, cancellation, faulting) and ensures the channel writer is
+        /// always completed.  If the task faults then the exception from that task will be used to complete the channel
+        /// </summary>
+        public static void CompletesChannel<T>(this Task task, Channel<T> channel)
+        {
+            // Note: using `Complete(task.Exception)` is always fine.  Exception is only produced in the case of
+            // faulting. it is null otherwise.
+            task.ContinueWith(
+                static (task, channel) => ((Channel<T>)channel!).Writer.Complete(task.Exception),
+                channel, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Services/UnitTesting/RemoteUnitTestingSearchService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/UnitTesting/RemoteUnitTestingSearchService.cs
@@ -24,6 +24,28 @@ namespace Microsoft.CodeAnalysis.Remote
         {
         }
 
+        public ValueTask<UnitTestingSourceLocation?> GetSourceLocationAsync(
+            Checksum solutionChecksum,
+            ProjectId projectId,
+            UnitTestingSearchQuery query,
+            CancellationToken cancellationToken)
+        {
+            return RunServiceAsync<UnitTestingSourceLocation?>(solutionChecksum, async solution =>
+            {
+                var project = solution.GetRequiredProject(projectId);
+
+                var resultOpt = await UnitTestingSearchHelpers.GetSourceLocationAsync(project, query, cancellationToken).ConfigureAwait(false);
+                if (resultOpt is null)
+                    return null;
+
+                var result = resultOpt.Value;
+
+                return new UnitTestingSourceLocation(
+                    new DocumentIdSpan(result.DocumentSpan.Document.Id, result.DocumentSpan.SourceSpan),
+                    result.Span);
+            }, cancellationToken);
+        }
+
         public ValueTask<ImmutableArray<UnitTestingSourceLocation>> GetSourceLocationsAsync(
             Checksum solutionChecksum,
             ProjectId projectId,


### PR DESCRIPTION
This allows us to stop searching when we find the first result, as that's all that unit testing needs.