### PR TITLE
Add back -vs-deps to `PublishData.json`

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -127,7 +127,7 @@
       "vsMajorVersion": 17,
       "insertionTitlePrefix": "[d17.4]"
     },
-    "release/dev17.5": {
+    "release/dev17.5-vs-deps": {
       "nugetKind": [
         "Shipping",
         "NonShipping"
@@ -138,6 +138,16 @@
       "insertionTitlePrefix": "[d17.5p1]"
     },
     "main": {
+      "nugetKind": [
+        "Shipping",
+        "NonShipping"
+      ],
+      "vsBranch": "main",
+      "vsMajorVersion": 17,
+      "insertionCreateDraftPR": true,
+      "insertionTitlePrefix": "[Validation]"
+    },
+    "main-vs-deps": {
       "nugetKind": [
         "Shipping",
         "NonShipping"


### PR DESCRIPTION
Cyrus mentioned he will be using main-vs-deps this sprint, so adding back the `PublishData.json` info.