### PR TITLE
Check type parameter index bounds when parsing `DocumentationCommentId`

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SuppressMessageTargetSymbolResolverTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/SuppressMessageTargetSymbolResolverTests.cs
@@ -1237,6 +1237,35 @@ End Class
                 "C`1+D`1.#[blah]M`2(!0,!1,!!0)"); // Invalid calling convention
         }
 
+        [Fact, WorkItem(65396, "https://github.com/dotnet/roslyn/issues/65396")]
+        public void TestNoResolutionForMalformedNames3()
+        {
+            var names = new[]
+            {
+                "C.#M`1(G`2<!1,!!0[]>)", // Wrong class type index
+                "C.#M`1(G`2<!0,!!1[]>)", // Wrong method type index
+            };
+
+            VerifyNoMemberResolution("""
+                class G<T0,T1> { }
+                class C<T3>
+                {
+                    G<int,int> M<T4>(G<T3, T4[]> g) { }
+                }
+                """,
+                LanguageNames.CSharp, false, names);
+
+            VerifyNoMemberResolution("""
+                Class G(Of T0, T1)
+                End Class
+                Class C(Of T3)
+                	Private Function M(Of T4)(g As G(Of T3, T4())) As G(Of Integer, Integer)
+                	End Function
+                End Class
+                """,
+                LanguageNames.VisualBasic, false, names);
+        }
+
         private static void VerifyNamespaceResolution(string markup, string language, bool rootNamespace, params string[] fxCopFullyQualifiedNames)
         {
             string rootNamespaceName = "";

--- a/src/Compilers/Core/CodeAnalysisTest/Symbols/DocumentationCommentIdTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Symbols/DocumentationCommentIdTests.cs
@@ -119,6 +119,41 @@ class C
             Assert.Equal(new[] { symbol }, foundSymbols);
         }
 
+        [Fact, WorkItem(65396, "https://github.com/dotnet/roslyn/issues/65396")]
+        public void InvalidTypeParameterIndex_CSharp()
+        {
+            var comp = CreateCSharpCompilation("""
+                namespace N;
+                class C
+                {
+                    static void Main() { }
+                    public void M<T>(T[] ts) { }
+                }
+                """).VerifyDiagnostics();
+            Assert.NotNull(DocumentationCommentId.GetFirstSymbolForDeclarationId("M:N.C.M``1(``0[])", comp));
+            Assert.Null(DocumentationCommentId.GetFirstSymbolForDeclarationId("M:N.C.M``1(`0[])", comp));
+            Assert.Null(DocumentationCommentId.GetFirstSymbolForDeclarationId("M:N.C.M``1(``1[])", comp));
+        }
+
+        [Fact, WorkItem(65396, "https://github.com/dotnet/roslyn/issues/65396")]
+        public void InvalidTypeParameterIndex_VisualBasic()
+        {
+            var comp = CreateVisualBasicCompilation("""
+                Namespace N
+                    Class C
+                        Shared Sub Main()
+                        End Sub
+
+                        Public Sub M(Of T)(ByVal ts As T())
+                        End Sub
+                    End Class
+                End Namespace
+                """).VerifyDiagnostics();
+            Assert.NotNull(DocumentationCommentId.GetFirstSymbolForDeclarationId("M:N.C.M``1(``0[])", comp));
+            Assert.Null(DocumentationCommentId.GetFirstSymbolForDeclarationId("M:N.C.M``1(`0[])", comp));
+            Assert.Null(DocumentationCommentId.GetFirstSymbolForDeclarationId("M:N.C.M``1(``1[])", comp));
+        }
+
         internal override string VisualizeRealIL(
             IModuleSymbol peModule, CompilationTestData.MethodData methodData, IReadOnlyDictionary<int, string> markers, bool areLocalsZeroed)
             => throw new NotImplementedException();

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.TargetSymbolResolver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/SuppressMessageAttributeState.TargetSymbolResolver.cs
@@ -841,7 +841,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     return GetNthTypeParameter(typeSymbol.ContainingType, n);
                 }
 
-                return typeSymbol.TypeParameters[n - containingTypeParameterCount];
+                var index = n - containingTypeParameterCount;
+                var typeParameters = typeSymbol.TypeParameters;
+                if (index < typeParameters.Length)
+                {
+                    return typeParameters[index];
+                }
+
+                return null;
             }
 
             private static int GetTypeParameterCount(INamedTypeSymbol typeSymbol)

--- a/src/Compilers/Core/Portable/DocumentationCommentId.cs
+++ b/src/Compilers/Core/Portable/DocumentationCommentId.cs
@@ -958,9 +958,9 @@ namespace Microsoft.CodeAnalysis
                     var methodContext = typeParameterContext as IMethodSymbol;
                     var typeContext = methodContext != null ? methodContext.ContainingType : typeParameterContext as INamedTypeSymbol;
 
-                    if (typeContext != null)
+                    if (typeContext != null && GetNthTypeParameter(typeContext, typeParameterIndex) is { } typeParameter)
                     {
-                        results.Add(GetNthTypeParameter(typeContext, typeParameterIndex));
+                        results.Add(typeParameter);
                     }
                 }
             }
@@ -1365,7 +1365,7 @@ namespace Microsoft.CodeAnalysis
                 return parameterType != null && symbol.Type.Equals(parameterType, SymbolEqualityComparer.CLRSignature);
             }
 
-            private static ITypeParameterSymbol GetNthTypeParameter(INamedTypeSymbol typeSymbol, int n)
+            private static ITypeParameterSymbol? GetNthTypeParameter(INamedTypeSymbol typeSymbol, int n)
             {
                 var containingTypeParameterCount = GetTypeParameterCount(typeSymbol.ContainingType);
                 if (n < containingTypeParameterCount)
@@ -1374,7 +1374,12 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 var index = n - containingTypeParameterCount;
-                return typeSymbol.TypeParameters[index];
+                if (index < typeSymbol.TypeParameters.Length)
+                {
+                    return typeSymbol.TypeParameters[index];
+                }
+
+                return null;
             }
 
             private static int GetTypeParameterCount(INamedTypeSymbol typeSymbol)

--- a/src/Compilers/Core/Portable/DocumentationCommentId.cs
+++ b/src/Compilers/Core/Portable/DocumentationCommentId.cs
@@ -1374,9 +1374,10 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 var index = n - containingTypeParameterCount;
-                if (index < typeSymbol.TypeParameters.Length)
+                var typeParameters = typeSymbol.TypeParameters;
+                if (index < typeParameters.Length)
                 {
-                    return typeSymbol.TypeParameters[index];
+                    return typeParameters[index];
                 }
 
                 return null;

--- a/src/Workspaces/CoreTest/UtilityTest/DocumentationCommentIdTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/DocumentationCommentIdTests.cs
@@ -351,5 +351,21 @@ namespace Acme
             CheckReferenceId("System.Int32[]", compilation.CreateArrayTypeSymbol(intType), compilation);
             CheckReferenceId("System.Int32*", compilation.CreatePointerTypeSymbol(intType), compilation);
         }
+
+        [Fact, WorkItem(65396, "https://github.com/dotnet/roslyn/issues/65396")]
+        public void TestInvalidTypeParameterId()
+        {
+            var compilation = CreateCSharpCompilation("""
+                namespace N;
+                class C
+                {
+                    static void Main() { }
+                    public void M<T>(T[] ts) { }
+                }
+                """).VerifyDiagnostics();
+            Assert.NotNull(DocumentationCommentId.GetFirstSymbolForDeclarationId("M:N.C.M``1(``0[])", compilation));
+            Assert.Null(DocumentationCommentId.GetFirstSymbolForDeclarationId("M:N.C.M``1(`0[])", compilation));
+            Assert.Null(DocumentationCommentId.GetFirstSymbolForDeclarationId("M:N.C.M``1(``1[])", compilation));
+        }
     }
 }

--- a/src/Workspaces/CoreTest/UtilityTest/DocumentationCommentIdTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/DocumentationCommentIdTests.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.VisualBasic;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -16,8 +17,14 @@ namespace Microsoft.CodeAnalysis.UnitTests
     {
         private static CSharpCompilation CreateCSharpCompilation(string sourceText)
         {
-            var syntaxTree = SyntaxFactory.ParseSyntaxTree(sourceText);
+            var syntaxTree = CSharp.SyntaxFactory.ParseSyntaxTree(sourceText);
             return CSharpCompilation.Create("goo.exe").AddReferences(TestMetadata.Net451.mscorlib).AddSyntaxTrees(syntaxTree);
+        }
+
+        private static VisualBasicCompilation CreateVisualBasicCompilation(string sourceText)
+        {
+            var syntaxTree = VisualBasic.SyntaxFactory.ParseSyntaxTree(sourceText);
+            return VisualBasicCompilation.Create("goo.exe").AddReferences(TestMetadata.Net451.mscorlib).AddSyntaxTrees(syntaxTree);
         }
 
         private static void CheckDeclarationId(string expectedId, INamespaceOrTypeSymbol symbol, Compilation compilation)
@@ -353,7 +360,7 @@ namespace Acme
         }
 
         [Fact, WorkItem(65396, "https://github.com/dotnet/roslyn/issues/65396")]
-        public void TestInvalidTypeParameterId()
+        public void TestInvalidTypeParameterId_CSharp()
         {
             var compilation = CreateCSharpCompilation("""
                 namespace N;
@@ -362,6 +369,25 @@ namespace Acme
                     static void Main() { }
                     public void M<T>(T[] ts) { }
                 }
+                """).VerifyDiagnostics();
+            Assert.NotNull(DocumentationCommentId.GetFirstSymbolForDeclarationId("M:N.C.M``1(``0[])", compilation));
+            Assert.Null(DocumentationCommentId.GetFirstSymbolForDeclarationId("M:N.C.M``1(`0[])", compilation));
+            Assert.Null(DocumentationCommentId.GetFirstSymbolForDeclarationId("M:N.C.M``1(``1[])", compilation));
+        }
+
+        [Fact, WorkItem(65396, "https://github.com/dotnet/roslyn/issues/65396")]
+        public void TestInvalidTypeParameterId_VisualBasic()
+        {
+            var compilation = CreateVisualBasicCompilation("""
+                Namespace N
+                    Class C
+                        Shared Sub Main()
+                        End Sub
+
+                        Public Sub M(Of T)(ByVal ts As T())
+                        End Sub
+                    End Class
+                End Namespace
                 """).VerifyDiagnostics();
             Assert.NotNull(DocumentationCommentId.GetFirstSymbolForDeclarationId("M:N.C.M``1(``0[])", compilation));
             Assert.Null(DocumentationCommentId.GetFirstSymbolForDeclarationId("M:N.C.M``1(`0[])", compilation));


### PR DESCRIPTION
Fixes #65396.