### PR TITLE
Enable member edit analysis when LSP pull diagnostics is on

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -309,12 +309,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // If we are computing full document diagnostics, and the provided analyzers
                 // support span based analysis, we will attempt to perform incremental
                 // member edit analysis.
-                // This analysis is currently guarded with 'IncrementalMemberEditAnalysisFeatureFlag'
+                // This analysis is currently only enabled with LSP pull diagnostics.
                 var incrementalAnalysis = !span.HasValue
                     && supportsSpanBasedAnalysis
                     && _document is Document sourceDocument
                     && sourceDocument.SupportsSyntaxTree
-                    && _owner.GlobalOptions.GetOption(DiagnosticOptionsStorage.IncrementalMemberEditAnalysisFeatureFlag);
+                    && _owner.GlobalOptions.IsPullDiagnostics(InternalDiagnosticsOptions.NormalDiagnosticMode);
 
                 ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<DiagnosticData>> diagnosticsMap;
                 if (incrementalAnalysis)

--- a/src/Features/LanguageServer/Protocol/Features/Options/DiagnosticOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/DiagnosticOptionsStorage.cs
@@ -19,10 +19,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             FeatureName, nameof(LspPullDiagnosticsFeatureFlag), defaultValue: false,
             new FeatureFlagStorageLocation("Lsp.PullDiagnostics"));
 
-        public static readonly Option2<bool> IncrementalMemberEditAnalysisFeatureFlag = new(
-            FeatureName, nameof(IncrementalMemberEditAnalysisFeatureFlag), defaultValue: false,
-            new FeatureFlagStorageLocation("Roslyn.IncrementalMemberEditAnalysis"));
-
         public static readonly Option2<bool> LogTelemetryForBackgroundAnalyzerExecution = new(
             FeatureName, nameof(LogTelemetryForBackgroundAnalyzerExecution), defaultValue: false,
             new FeatureFlagStorageLocation($"Roslyn.LogTelemetryForBackgroundAnalyzerExecution"));


### PR DESCRIPTION
Instead of having a separate feature flag to manage, we can turn this on with LSP pull diagnostics.  If something goes wrong we still have at least 1 escape hatch

Resolves https://github.com/dotnet/roslyn/issues/63324