### PR TITLE
Trampoline to a base method implementation when deleting an override

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.GenerationVerifier.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueTest.GenerationVerifier.cs
@@ -3,10 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using Microsoft.CodeAnalysis.CSharp.UnitTests;
+using Microsoft.Metadata.Tools;
 using Roslyn.Test.Utilities;
 using static Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests.EditAndContinueTestBase;
 
@@ -104,6 +105,15 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             internal void VerifyIL(string expectedIL)
             {
                 _generationInfo.CompilationDifference!.VerifyIL(expectedIL);
+            }
+
+            internal string Visualize()
+            {
+                using var writer = new StringWriter();
+                var visualizer = new MetadataVisualizer(_readers.ToList(), writer, MetadataVisualizerOptions.NoHeapReferences);
+                visualizer.VisualizeAllGenerations();
+                writer.Flush();
+                return writer.ToString();
             }
         }
     }

--- a/src/Compilers/Core/Portable/CodeGen/ILBuilderEmit.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILBuilderEmit.cs
@@ -63,6 +63,12 @@ namespace Microsoft.CodeAnalysis.CodeGen
             this.GetCurrentWriter().WriteUInt32(token);
         }
 
+        internal void EmitRawToken(uint token)
+        {
+            token |= Cci.MetadataWriter.LiteralMethodDefinitionToken;
+            this.GetCurrentWriter().WriteUInt32(token);
+        }
+
         internal void EmitGreatestMethodToken()
         {
             // A magic value indicates that the token value is to be the literal value of the greatest method definition token.

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeletedMethodBody.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeletedMethodBody.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Emit.EditAndContinue
 
         public StateMachineStatesDebugInfo StateMachineStatesDebugInfo => default;
 
-        private static ImmutableArray<byte> GetIL(IMethodDefinition methodDef, IMethodReference? overriddenMethod, uint overriddenMethodToken, EmitContext context)
+        private static ImmutableArray<byte> GetIL(IMethodDefinition methodDef, IMethodReference overriddenMethod, uint overriddenMethodToken, EmitContext context)
         {
             var missingMethodExceptionStringStringConstructor = context.Module.CommonCompilation.CommonGetWellKnownTypeMember(WellKnownMember.System_MissingMethodException__ctor);
             Debug.Assert(missingMethodExceptionStringStringConstructor is not null);

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeletedMethodDefinition.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeletedMethodDefinition.cs
@@ -13,20 +13,24 @@ namespace Microsoft.CodeAnalysis.Emit.EditAndContinue
     internal sealed class DeletedMethodDefinition : DeletedDefinition<IMethodDefinition>, IMethodDefinition
     {
         private readonly ITypeDefinition _containingTypeDef;
-        private readonly IMethodDefinition? _overriddenMethodDef;
+        private readonly IMethodReference? _overriddenMethodDef;
+        private readonly uint _overriddenMethodToken;
         private readonly ImmutableArray<DeletedParameterDefinition> _parameters;
         private DeletedMethodBody? _body;
 
-        public DeletedMethodDefinition(IMethodDefinition oldMethod, ITypeDefinition containingTypeDef, Dictionary<ITypeDefinition, DeletedTypeDefinition> typesUsedByDeletedMembers, IMethodDefinition? overriddenMethodDef)
+        public DeletedMethodDefinition(IMethodDefinition oldMethod, ITypeDefinition containingTypeDef, Dictionary<ITypeDefinition, DeletedTypeDefinition> typesUsedByDeletedMembers, IMethodReference? overriddenMethodDef, uint token)
             : base(oldMethod, typesUsedByDeletedMembers)
         {
             _containingTypeDef = containingTypeDef;
             _overriddenMethodDef = overriddenMethodDef;
+            _overriddenMethodToken = token;
 
             _parameters = WrapParameters(oldMethod.Parameters);
         }
 
-        public IMethodDefinition? OverriddenMethod => _overriddenMethodDef;
+        public IMethodReference? OverriddenMethod => _overriddenMethodDef;
+
+        public uint OverriddenMethodToken => _overriddenMethodToken;
 
         public IEnumerable<IGenericMethodParameter> GenericParameters
         {

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeletedMethodDefinition.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeletedMethodDefinition.cs
@@ -13,16 +13,20 @@ namespace Microsoft.CodeAnalysis.Emit.EditAndContinue
     internal sealed class DeletedMethodDefinition : DeletedDefinition<IMethodDefinition>, IMethodDefinition
     {
         private readonly ITypeDefinition _containingTypeDef;
+        private readonly IMethodDefinition? _overriddenMethodDef;
         private readonly ImmutableArray<DeletedParameterDefinition> _parameters;
         private DeletedMethodBody? _body;
 
-        public DeletedMethodDefinition(IMethodDefinition oldMethod, ITypeDefinition containingTypeDef, Dictionary<ITypeDefinition, DeletedTypeDefinition> typesUsedByDeletedMembers)
+        public DeletedMethodDefinition(IMethodDefinition oldMethod, ITypeDefinition containingTypeDef, Dictionary<ITypeDefinition, DeletedTypeDefinition> typesUsedByDeletedMembers, IMethodDefinition? overriddenMethodDef)
             : base(oldMethod, typesUsedByDeletedMembers)
         {
             _containingTypeDef = containingTypeDef;
+            _overriddenMethodDef = overriddenMethodDef;
 
             _parameters = WrapParameters(oldMethod.Parameters);
         }
+
+        public IMethodDefinition? OverriddenMethod => _overriddenMethodDef;
 
         public IEnumerable<IGenericMethodParameter> GenericParameters
         {

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -547,8 +547,9 @@ namespace Microsoft.CodeAnalysis.Emit
                 var deletedTypeMembers = ImmutableDictionary.CreateBuilder<IMethodDefinition, DeletedMethodDefinition>(ReferenceEqualityComparer.Instance);
                 foreach (var methodDef in deletedMethods)
                 {
+                    var overriddenMemberDef = _changes.TryGetBaseImplementationDefinition(methodDef) as IMethodDefinition;
                     var oldMethodDef = (IMethodDefinition)methodDef.GetCciAdapter();
-                    deletedTypeMembers.Add(oldMethodDef, new DeletedMethodDefinition(oldMethodDef, typeDef, _typesUsedByDeletedMembers));
+                    deletedTypeMembers.Add(oldMethodDef, new DeletedMethodDefinition(oldMethodDef, typeDef, _typesUsedByDeletedMembers, overriddenMemberDef));
                 }
 
                 _deletedTypeMembers.Add(typeDef, deletedTypeMembers.ToImmutableDictionary());

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/SymbolChanges.cs
@@ -427,8 +427,9 @@ namespace Microsoft.CodeAnalysis.Emit
         /// Gets the base definition for the specified symbol, if there is one, and it has an implementation
         /// that is callable.
         /// </summary>
-        public IDefinition? TryGetBaseImplementationDefinition(ISymbolInternal symbolInternal)
+        public IReference? TryGetBaseImplementationDefinition(ISymbolInternal symbolInternal, out bool isThisAssembly)
         {
+            isThisAssembly = false;
             var symbol = symbolInternal.GetISymbol();
 
             ISymbol? baseSymbol;
@@ -455,7 +456,9 @@ namespace Microsoft.CodeAnalysis.Emit
                 return null;
             }
 
-            return GetISymbolInternalOrNull(baseSymbol)?.GetCciAdapter() as IDefinition;
+            isThisAssembly = baseSymbol.ContainingAssembly == symbol.ContainingAssembly;
+
+            return GetISymbolInternalOrNull(baseSymbol)?.GetCciAdapter();
         }
 
         protected abstract ISymbolInternal? GetISymbolInternalOrNull(ISymbol symbol);

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -3065,6 +3065,14 @@ namespace Microsoft.Cci
         private EntityHandle ResolveEntityHandleFromPseudoToken(int pseudoSymbolToken)
         {
             int index = pseudoSymbolToken;
+
+            // If the token was emitted as a literal token, then it is resolved just by removing the flag, rather
+            // than doing any kind of pseudo token lookup
+            if ((pseudoSymbolToken & LiteralMethodDefinitionToken) == LiteralMethodDefinitionToken)
+            {
+                return MetadataTokens.EntityHandle(pseudoSymbolToken & (int)~LiteralMethodDefinitionToken);
+            }
+
             var entity = _pseudoSymbolTokenToReferenceMap[index];
             if (entity != null)
             {

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -7163,7 +7163,6 @@ class C
         [Theory]
         [InlineData("virtual")]
         [InlineData("abstract")]
-        [InlineData("override")]
         public void Method_Delete_Modifiers(string modifier)
         {
             /* TODO: https://github.com/dotnet/roslyn/issues/59264
@@ -7979,7 +7978,6 @@ class C
         [Theory]
         [InlineData("virtual")]
         [InlineData("abstract")]
-        [InlineData("override")]
         public void Method_Rename_Modifiers(string modifier)
         {
             /* TODO: https://github.com/dotnet/roslyn/issues/59264

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -3364,7 +3364,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         {
             // We don't currently allow deleting virtual or abstract methods, because if those are in the middle of
             // an inheritance chain then throwing a missing method exception is not expected
-            if (symbol.GetSymbolModifiers() is not { IsVirtual: false, IsAbstract: false, IsOverride: false })
+            if (symbol.GetSymbolModifiers() is not { IsVirtual: false, IsAbstract: false })
                 return false;
 
             // Extern methods can't be deleted


### PR DESCRIPTION
Part of #59264

Given:
```
class B
{
    public virtual void M(int x)
    {
    }
}

class C : B
{
    public override void M(int x)
    {
    }
}
```

When deleting `C.M`, instead of emitting `throw new MissingMethodException()` this will now emit `base.M(x);`