### PR TITLE
Reduce tagging work in files without raw strings

### DIFF
--- a/src/Features/CSharp/Portable/StringIndentation/CSharpStringIndentationService.cs
+++ b/src/Features/CSharp/Portable/StringIndentation/CSharpStringIndentationService.cs
@@ -31,6 +31,11 @@ namespace Microsoft.CodeAnalysis.CSharp.StringIndentation
             Document document, TextSpan textSpan, CancellationToken cancellationToken)
         {
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            if (text.IndexOf(@"""""""", textSpan.Start, true) < 0)
+            {
+                return ImmutableArray<StringIndentationRegion>.Empty;
+            }
+
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             using var _ = ArrayBuilder<StringIndentationRegion>.GetInstance(out var result);


### PR DESCRIPTION
Avoid loading the full syntax tree in cases where the text does not contain `"""`, and therefore cannot contain any raw strings.

Fixes [AB#1611109](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1611109)