### PR TITLE
Improve consistency in our parser code.

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -4236,7 +4236,7 @@ parse_member_name:;
                     nodes.Add(token);
                 }
 
-                trailingTrivia = (nodes.Count > 0) ? nodes.ToListNode() : null;
+                trailingTrivia = nodes.ToListNode();
                 return action;
             }
             finally

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -12477,14 +12477,11 @@ tryAgain:
             var openBrace = this.EatToken(SyntaxKind.OpenBraceToken);
             var expressions = _pool.AllocateSeparated<AnonymousObjectMemberDeclaratorSyntax>();
             this.ParseAnonymousTypeMemberInitializers(ref openBrace, ref expressions);
-            var result = _syntaxFactory.AnonymousObjectCreationExpression(
+            return _syntaxFactory.AnonymousObjectCreationExpression(
                 @new,
                 openBrace,
-                expressions,
+                _pool.ToListAndFree(expressions),
                 this.EatToken(SyntaxKind.CloseBraceToken));
-            _pool.Free(expressions);
-
-            return result;
         }
 
         private void ParseAnonymousTypeMemberInitializers(ref SyntaxToken openBrace, ref SeparatedSyntaxListBuilder<AnonymousObjectMemberDeclaratorSyntax> list)


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/65480.

Should be reviewed with whitespace off.

Our parser code is heavily inconsistent from one method to the next.  This makes understanding and maintenance more difficult, and makes it easier for bugs to creep in.  New code doesn't have clear patterns to follow to keep things consistent.   Note that this is not stylistic, but rather patterns that help ensure clarity and correctness.

Comments in-line in the major consistency efforts made in teh code.