### PR TITLE
Fix MEF composition used for the LSIF generator

### DIFF
--- a/src/Features/Lsif/Generator/CompilerInvocation.cs
+++ b/src/Features/Lsif/Generator/CompilerInvocation.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
             // We will use a Workspace to simplify the creation of the compilation, but will be careful not to return the Workspace instance from this class.
             // We will still provide the language services which are used by the generator itself, but we don't tie it to a Workspace object so we can
             // run this as an in-proc source generator if one day desired.
-            var workspace = new AdhocWorkspace(MefHostServices.Create(Generator.MefCompositionAssemblies));
+            var workspace = new AdhocWorkspace(await Composition.CreateHostServicesAsync());
 
             var languageName = GetLanguageName(invocationInfo);
             var languageServices = workspace.Services.GetLanguageServices(languageName).LanguageServices;

--- a/src/Features/Lsif/Generator/CompilerInvocation.cs
+++ b/src/Features/Lsif/Generator/CompilerInvocation.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Newtonsoft.Json;
@@ -44,7 +45,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
             // We will use a Workspace to simplify the creation of the compilation, but will be careful not to return the Workspace instance from this class.
             // We will still provide the language services which are used by the generator itself, but we don't tie it to a Workspace object so we can
             // run this as an in-proc source generator if one day desired.
-            var workspace = new AdhocWorkspace();
+            var workspace = new AdhocWorkspace(MefHostServices.Create(Generator.MefCompositionAssemblies));
 
             var languageName = GetLanguageName(invocationInfo);
             var languageServices = workspace.Services.GetLanguageServices(languageName).LanguageServices;

--- a/src/Features/Lsif/Generator/Composition.cs
+++ b/src/Features/Lsif/Generator/Composition.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
+{
+    internal static class Composition
+    {
+        public static readonly ImmutableArray<Assembly> MefCompositionAssemblies =
+            MSBuildMefHostServices.DefaultAssemblies.Add(typeof(RoslynLanguageServer).Assembly);
+
+        public static async Task<HostServices> CreateHostServicesAsync()
+        {
+            var discovery = new AttributedPartDiscovery(Resolver.DefaultInstance, isNonPublicSupported: true);
+
+            var catalog = ComposableCatalog.Create(Resolver.DefaultInstance)
+                .AddParts(await discovery.CreatePartsAsync(MefCompositionAssemblies))
+                .WithCompositionService(); // Makes an ICompositionService export available to MEF parts to import
+
+            var config = CompositionConfiguration.Create(catalog);
+
+            var exportProvider = config.CreateExportProviderFactory().CreateExportProvider();
+            return VisualStudioMefHostServices.Create(exportProvider);
+        }
+    }
+}

--- a/src/Features/Lsif/Generator/Generator.cs
+++ b/src/Features/Lsif/Generator/Generator.cs
@@ -5,11 +5,15 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph;
 using Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.ResultSetTracking;
@@ -24,6 +28,8 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
 {
     internal sealed class Generator
     {
+        public static readonly ImmutableArray<Assembly> MefCompositionAssemblies = MSBuildMefHostServices.DefaultAssemblies.Add(typeof(RoslynLanguageServer).Assembly);
+
         // LSIF generator capabilities. See https://github.com/microsoft/lsif-node/blob/main/protocol/src/protocol.ts#L925 for details.
         private const bool HoverProvider = true;
         private const bool DeclarationProvider = false;

--- a/src/Features/Lsif/Generator/Generator.cs
+++ b/src/Features/Lsif/Generator/Generator.cs
@@ -28,8 +28,6 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
 {
     internal sealed class Generator
     {
-        public static readonly ImmutableArray<Assembly> MefCompositionAssemblies = MSBuildMefHostServices.DefaultAssemblies.Add(typeof(RoslynLanguageServer).Assembly);
-
         // LSIF generator capabilities. See https://github.com/microsoft/lsif-node/blob/main/protocol/src/protocol.ts#L925 for details.
         private const bool HoverProvider = true;
         private const bool DeclarationProvider = false;

--- a/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
+++ b/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
@@ -53,10 +53,12 @@
 
   <ItemGroup>
     <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\IsExternalInit.cs" Link="Utilities\IsExternalInit.cs" />
+    <Compile Include="..\..\..\Workspaces\Remote\Core\VisualStudioMefHostServices.cs" Link="VisualStudioMefHostServices.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)" />
     <PackageReference Include="MSBuild.StructuredLogger" Version="$(MSBuildStructuredLoggerVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.CommandLine.Experimental" Version="$(SystemCommandLineExperimentalVersion)" />

--- a/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
+++ b/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
@@ -83,9 +83,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Reference to EditorFeatures should be removed once Hover is moved into the Features layer.
-         See https://github.com/dotnet/roslyn/issues/55142 for details -->
-    <ProjectReference Include="..\..\..\EditorFeatures\Core\Microsoft.CodeAnalysis.EditorFeatures.csproj" />
+    <ProjectReference Include="..\..\LanguageServer\Protocol\Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\Core\MSBuild\Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Workspaces.csproj" />
     <ProjectReference Include="..\..\..\Workspaces\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.Workspaces.vbproj" />
@@ -97,7 +95,6 @@
     <ProjectReference Include="..\..\..\Compilers\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.csproj" />
     <ProjectReference Include="..\..\..\Compilers\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.vbproj" />
     <ProjectReference Include="..\..\..\Workspaces\Core\Portable\Microsoft.CodeAnalysis.Workspaces.csproj" />
-    <ProjectReference Include="..\..\LanguageServer\Protocol\Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj" />
     <ProjectReference Include="..\..\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Features.csproj" />
     <ProjectReference Include="..\..\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.Features.vbproj" />
   </ItemGroup>

--- a/src/Features/Lsif/Generator/Program.cs
+++ b/src/Features/Lsif/Generator/Program.cs
@@ -154,7 +154,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
 
             var solutionLoadStopwatch = Stopwatch.StartNew();
 
-            var msbuildWorkspace = MSBuildWorkspace.Create(MefHostServices.Create(Generator.MefCompositionAssemblies));
+            var msbuildWorkspace = MSBuildWorkspace.Create(await Composition.CreateHostServicesAsync());
             msbuildWorkspace.WorkspaceFailed += (s, e) => logFile.WriteLine("Error while loading: " + e.Diagnostic.Message);
 
             var solution = await openAsync(msbuildWorkspace);

--- a/src/Features/Lsif/Generator/Program.cs
+++ b/src/Features/Lsif/Generator/Program.cs
@@ -14,6 +14,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Build.Locator;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing;
 using Microsoft.CodeAnalysis.MSBuild;
 using CompilerInvocationsReader = Microsoft.Build.Logging.StructuredLogger.CompilerInvocationsReader;
@@ -153,7 +154,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
 
             var solutionLoadStopwatch = Stopwatch.StartNew();
 
-            var msbuildWorkspace = MSBuildWorkspace.Create();
+            var msbuildWorkspace = MSBuildWorkspace.Create(MefHostServices.Create(Generator.MefCompositionAssemblies));
             msbuildWorkspace.WorkspaceFailed += (s, e) => logFile.WriteLine("Error while loading: " + e.Diagnostic.Message);
 
             var solution = await openAsync(msbuildWorkspace);

--- a/src/Features/Lsif/GeneratorTest/FoldingRangeTests.vb
+++ b/src/Features/Lsif/GeneratorTest/FoldingRangeTests.vb
@@ -51,7 +51,7 @@ using System.Linq;|}", "imports", "...")>
                                 <%= code %>
                             </Document>
                         </Project>
-                    </Workspace>)
+                    </Workspace>, openDocuments:=False, composition:=TestLsifOutput.TestComposition)
 
                 Dim annotatedLocations = Await AbstractLanguageServerProtocolTests.GetAnnotatedLocationsAsync(workspace, workspace.CurrentSolution)
                 Dim expectedRanges = annotatedLocations("foldingRange").Select(Function(location) CreateFoldingRange(rangeKind, location.Range, collapsedText)).OrderBy(Function(range) range.StartLine).ToArray()

--- a/src/Features/Lsif/GeneratorTest/HoverTests.vb
+++ b/src/Features/Lsif/GeneratorTest/HoverTests.vb
@@ -25,14 +25,13 @@ class C
 }")>
         Public Async Function TestDefinition(code As String) As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
-                TestWorkspace.CreateWorkspace(
-                    <Workspace>
-                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
-                            <Document Name="A.cs" FilePath="Z:\A.cs">
-                                <%= code %>
-                            </Document>
-                        </Project>
-                    </Workspace>))
+                <Workspace>
+                    <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                        <Document Name="A.cs" FilePath="Z:\A.cs">
+                            <%= code %>
+                        </Document>
+                    </Project>
+                </Workspace>)
 
             Dim rangeVertex = Await lsif.GetSelectedRangeAsync()
             Dim resultSetVertex = lsif.GetLinkedVertices(Of Graph.ResultSet)(rangeVertex, "next").Single()
@@ -100,14 +99,13 @@ class C
 }")>
         Public Async Function TestReference(code As String) As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
-                TestWorkspace.CreateWorkspace(
-                    <Workspace>
-                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
-                            <Document Name="A.cs" FilePath="Z:\A.cs">
-                                <%= code %>
-                            </Document>
-                        </Project>
-                    </Workspace>))
+                <Workspace>
+                    <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                        <Document Name="A.cs" FilePath="Z:\A.cs">
+                            <%= code %>
+                        </Document>
+                    </Project>
+                </Workspace>)
 
             Dim rangeVertex = Await lsif.GetSelectedRangeAsync()
             Dim resultSetVertex = lsif.GetLinkedVertices(Of Graph.ResultSet)(rangeVertex, "next").Single()
@@ -167,26 +165,25 @@ void C.M()
         <Fact>
         Public Async Function ToplevelResultsInMultipleFiles() As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
-                TestWorkspace.CreateWorkspace(
-                    <Workspace>
-                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
-                            <Document Name="A.cs" FilePath="Z:\A.cs">
-                                class A { [|string|] s; }
-                            </Document>
-                            <Document Name="B.cs" FilePath="Z:\B.cs">
-                                class B { [|string|] s; }
-                            </Document>
-                            <Document Name="C.cs" FilePath="Z:\C.cs">
-                                class C { [|string|] s; }
-                            </Document>
-                            <Document Name="D.cs" FilePath="Z:\D.cs">
-                                class D { [|string|] s; }
-                            </Document>
-                            <Document Name="E.cs" FilePath="Z:\E.cs">
-                                class E { [|string|] s; }
-                            </Document>
-                        </Project>
-                    </Workspace>))
+                <Workspace>
+                    <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                        <Document Name="A.cs" FilePath="Z:\A.cs">
+                            class A { [|string|] s; }
+                        </Document>
+                        <Document Name="B.cs" FilePath="Z:\B.cs">
+                            class B { [|string|] s; }
+                        </Document>
+                        <Document Name="C.cs" FilePath="Z:\C.cs">
+                            class C { [|string|] s; }
+                        </Document>
+                        <Document Name="D.cs" FilePath="Z:\D.cs">
+                            class D { [|string|] s; }
+                        </Document>
+                        <Document Name="E.cs" FilePath="Z:\E.cs">
+                            class E { [|string|] s; }
+                        </Document>
+                    </Project>
+                </Workspace>)
 
             Dim hoverVertex As Graph.HoverResult = Nothing
             For Each rangeVertex In Await lsif.GetSelectedRangesAsync()

--- a/src/Features/Lsif/GeneratorTest/OutputFormatTests.vb
+++ b/src/Features/Lsif/GeneratorTest/OutputFormatTests.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
                         <Project Language="C#" Name="TestProject" FilePath="Z:\TestProject.csproj">
                             <Document Name="A.cs" FilePath="Z:\A.cs"/>
                         </Project>
-                    </Workspace>), jsonWriter)
+                    </Workspace>, openDocuments:=False, composition:=TestLsifOutput.TestComposition), jsonWriter)
 
             AssertEx.EqualOrDiff(
 "{""hoverProvider"":true,""declarationProvider"":false,""definitionProvider"":true,""referencesProvider"":true,""typeDefinitionProvider"":false,""documentSymbolProvider"":false,""foldingRangeProvider"":true,""diagnosticProvider"":false,""id"":1,""type"":""vertex"",""label"":""capabilities""}
@@ -45,12 +45,12 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
             Using jsonWriter = New JsonModeLsifJsonWriter(stringWriter)
 
                 Await TestLsifOutput.GenerateForWorkspaceAsync(
-                TestWorkspace.CreateWorkspace(
-                    <Workspace>
-                        <Project Language="C#" Name="TestProject" FilePath="Z:\TestProject.csproj">
-                            <Document Name="A.cs" FilePath="Z:\A.cs"/>
-                        </Project>
-                    </Workspace>), jsonWriter)
+                    TestWorkspace.CreateWorkspace(
+                        <Workspace>
+                            <Project Language="C#" Name="TestProject" FilePath="Z:\TestProject.csproj">
+                                <Document Name="A.cs" FilePath="Z:\A.cs"/>
+                            </Project>
+                        </Workspace>, openDocuments:=False, composition:=TestLsifOutput.TestComposition), jsonWriter)
             End Using
 
             AssertEx.EqualOrDiff(

--- a/src/Features/Lsif/GeneratorTest/ProjectStructureTests.vb
+++ b/src/Features/Lsif/GeneratorTest/ProjectStructureTests.vb
@@ -16,13 +16,12 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
         <Fact>
         Public Async Function ProjectContainsDocuments() As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
-                TestWorkspace.CreateWorkspace(
-                    <Workspace>
-                        <Project Language="C#" Name="TestProject" FilePath="Z:\TestProject.csproj">
-                            <Document Name="A.cs" FilePath="Z:\A.cs"/>
-                            <Document Name="B.cs" FilePath="Z:\B.cs"/>
-                        </Project>
-                    </Workspace>))
+                <Workspace>
+                    <Project Language="C#" Name="TestProject" FilePath="Z:\TestProject.csproj">
+                        <Document Name="A.cs" FilePath="Z:\A.cs"/>
+                        <Document Name="B.cs" FilePath="Z:\B.cs"/>
+                    </Project>
+                </Workspace>)
 
             Dim projectVertex = Assert.Single(lsif.Vertices.OfType(Of Graph.LsifProject))
             Dim documentVertices = lsif.GetLinkedVertices(Of Graph.LsifDocument)(projectVertex, "contains")
@@ -41,7 +40,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
                     <Workspace>
                         <Project Language="C#" Name="TestProject" FilePath="Z:\TestProject.csproj" CommonReferences="true">
                         </Project>
-                    </Workspace>)
+                    </Workspace>, openDocuments:=False, composition:=TestLsifOutput.TestComposition)
 
             workspace.OnAnalyzerReferenceAdded(workspace.CurrentSolution.ProjectIds.Single(),
                                                New TestGeneratorReference(New TestSourceGenerator.HelloWorldGenerator()))
@@ -72,7 +71,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
                         <Project Language="C#" Name="TestProject" FilePath="Z:\TestProject.csproj" CommonReferences="true">
                             <DocumentFromSourceGenerator></DocumentFromSourceGenerator>
                         </Project>
-                    </Workspace>)
+                    </Workspace>, openDocuments:=False, composition:=TestLsifOutput.TestComposition)
 
             Dim stringWriter = New StringWriter
             Await TestLsifOutput.GenerateForWorkspaceAsync(workspace, New LineModeLsifJsonWriter(stringWriter))

--- a/src/Features/Lsif/GeneratorTest/RangeResultSetTests.vb
+++ b/src/Features/Lsif/GeneratorTest/RangeResultSetTests.vb
@@ -23,14 +23,13 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
         <InlineData("class C { [|global|]::System.String s; }", "<global namespace>", WellKnownSymbolMonikerSchemes.DotnetNamespace)>
         Public Async Function ReferenceMoniker(code As String, expectedMoniker As String, expectedMonikerScheme As String) As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
-                TestWorkspace.CreateWorkspace(
-                    <Workspace>
-                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
-                            <Document Name="A.cs" FilePath="Z:\A.cs">
-                                <%= code %>
-                            </Document>
-                        </Project>
-                    </Workspace>))
+                <Workspace>
+                    <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                        <Document Name="A.cs" FilePath="Z:\A.cs">
+                            <%= code %>
+                        </Document>
+                    </Project>
+                </Workspace>)
 
             Dim rangeVertex = Await lsif.GetSelectedRangeAsync()
             Dim resultSetVertex = lsif.GetLinkedVertices(Of Graph.ResultSet)(rangeVertex, "next").Single()
@@ -49,16 +48,15 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
         <InlineData("extern alias A;")>
         Public Async Function NoRangesAtAll(code As String) As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
-                TestWorkspace.CreateWorkspace(
-                    <Workspace>
-                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
-                            <Document Name="A.cs" FilePath="Z:\A.cs">
-                                <%= code %>
-                            </Document>
-                            <ProjectReference Alias="A">ReferencedWithAlias</ProjectReference>
-                        </Project>
-                        <Project AssemblyName="ReferencedWithAlias" Language="C#" FilePath="Z:\ReferencedWithAlias.csproj"></Project>
-                    </Workspace>))
+                <Workspace>
+                    <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                        <Document Name="A.cs" FilePath="Z:\A.cs">
+                            <%= code %>
+                        </Document>
+                        <ProjectReference Alias="A">ReferencedWithAlias</ProjectReference>
+                    </Project>
+                    <Project AssemblyName="ReferencedWithAlias" Language="C#" FilePath="Z:\ReferencedWithAlias.csproj"></Project>
+                </Workspace>)
 
             Assert.Empty(lsif.Vertices.OfType(Of Range))
         End Function
@@ -66,14 +64,13 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
         <Fact>
         Public Async Function DefinitionIncludedInDefinitionResult() As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
-                TestWorkspace.CreateWorkspace(
-                    <Workspace>
-                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
-                            <Document Name="A.cs" FilePath="Z:\A.cs">
-                                class [|C|] { }
-                            </Document>
-                        </Project>
-                    </Workspace>))
+                <Workspace>
+                    <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                        <Document Name="A.cs" FilePath="Z:\A.cs">
+                            class [|C|] { }
+                        </Document>
+                    </Project>
+                </Workspace>)
 
             Dim rangeVertex = Await lsif.GetSelectedRangeAsync()
             Dim resultSetVertex = lsif.GetLinkedVertices(Of Graph.ResultSet)(rangeVertex, "next").Single()
@@ -87,14 +84,13 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
         <Fact>
         Public Async Function ReferenceIncludedInReferenceResult() As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
-                TestWorkspace.CreateWorkspace(
-                    <Workspace>
-                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
-                            <Document Name="A.cs" FilePath="Z:\A.cs">
-                                class C { [|string|] s; }
-                            </Document>
-                        </Project>
-                    </Workspace>))
+                <Workspace>
+                    <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                        <Document Name="A.cs" FilePath="Z:\A.cs">
+                            class C { [|string|] s; }
+                        </Document>
+                    </Project>
+                </Workspace>)
 
             Dim rangeVertex = Await lsif.GetSelectedRangeAsync()
             Dim resultSetVertex = lsif.GetLinkedVertices(Of Graph.ResultSet)(rangeVertex, "next").Single()
@@ -108,26 +104,25 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
         <Fact>
         Public Async Function ReferenceIncludedInSameReferenceResultForMultipleFiles() As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
-                TestWorkspace.CreateWorkspace(
-                    <Workspace>
-                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
-                            <Document Name="A.cs" FilePath="Z:\A.cs">
-                                class A { [|string|] s; }
-                            </Document>
-                            <Document Name="B.cs" FilePath="Z:\B.cs">
-                                class B { [|string|] s; }
-                            </Document>
-                            <Document Name="C.cs" FilePath="Z:\C.cs">
-                                class C { [|string|] s; }
-                            </Document>
-                            <Document Name="D.cs" FilePath="Z:\D.cs">
-                                class D { [|string|] s; }
-                            </Document>
-                            <Document Name="E.cs" FilePath="Z:\E.cs">
-                                class E { [|string|] s; }
-                            </Document>
-                        </Project>
-                    </Workspace>))
+                <Workspace>
+                    <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                        <Document Name="A.cs" FilePath="Z:\A.cs">
+                            class A { [|string|] s; }
+                        </Document>
+                        <Document Name="B.cs" FilePath="Z:\B.cs">
+                            class B { [|string|] s; }
+                        </Document>
+                        <Document Name="C.cs" FilePath="Z:\C.cs">
+                            class C { [|string|] s; }
+                        </Document>
+                        <Document Name="D.cs" FilePath="Z:\D.cs">
+                            class D { [|string|] s; }
+                        </Document>
+                        <Document Name="E.cs" FilePath="Z:\E.cs">
+                            class E { [|string|] s; }
+                        </Document>
+                    </Project>
+                </Workspace>)
 
             For Each rangeVertex In Await lsif.GetSelectedRangesAsync()
                 Dim resultSetVertex = lsif.GetLinkedVertices(Of Graph.ResultSet)(rangeVertex, "next").Single()
@@ -149,13 +144,12 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
                     }")> ' case for crefs
         Public Async Function NoCrossDocumentReferencesWithoutAMoniker(file1 As String, file2 As String) As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
-                TestWorkspace.CreateWorkspace(
-                    <Workspace>
-                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
-                            <Document Name="File1.cs" FilePath="Z:\File1.cs"><%= file1 %></Document>
-                            <Document Name="File2.cs" FilePath="Z:\File2.cs"><%= file2 %></Document>
-                        </Project>
-                    </Workspace>))
+                <Workspace>
+                    <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                        <Document Name="File1.cs" FilePath="Z:\File1.cs"><%= file1 %></Document>
+                        <Document Name="File2.cs" FilePath="Z:\File2.cs"><%= file2 %></Document>
+                    </Project>
+                </Workspace>)
 
             ' If we ever emit a result set that doesn't have a moniker, some LSIF importers will make up a moniker
             ' for us when they're importing, which can be based on the first range that they see. This is problematic if
@@ -190,15 +184,14 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
         <Fact>
         Public Async Function InterfaceImplementation() As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
-                TestWorkspace.CreateWorkspace(
-                    <Workspace>
-                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
-                            <Document Name="A.cs" FilePath="Z:\A.cs">
+                <Workspace>
+                    <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                        <Document Name="A.cs" FilePath="Z:\A.cs">
 interface I { void {|Base:M|}(); }
 class C : I { public void {|Implementation:M|}() { } }
-                            </Document>
-                        </Project>
-                    </Workspace>))
+                        </Document>
+                    </Project>
+                </Workspace>)
 
             Await AssertImplementationCorrectlyLinked(lsif)
         End Function
@@ -206,15 +199,14 @@ class C : I { public void {|Implementation:M|}() { } }
         <Fact>
         Public Async Function [Overrides]() As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
-                TestWorkspace.CreateWorkspace(
-                    <Workspace>
-                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
-                            <Document Name="A.cs" FilePath="Z:\A.cs">
+                <Workspace>
+                    <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                        <Document Name="A.cs" FilePath="Z:\A.cs">
 class C { public virtual void {|Base:M|}() { } }
 class D : C { public override void {|Implementation:M|}() { } }
-                            </Document>
-                        </Project>
-                    </Workspace>))
+                        </Document>
+                    </Project>
+                </Workspace>)
 
             Await AssertImplementationCorrectlyLinked(lsif)
         End Function
@@ -222,16 +214,15 @@ class D : C { public override void {|Implementation:M|}() { } }
         <Fact>
         Public Async Function OverridesAlwaysPointsToInitialVirtualMethod() As Task
             Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(
-                TestWorkspace.CreateWorkspace(
-                    <Workspace>
-                        <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
-                            <Document Name="A.cs" FilePath="Z:\A.cs">
+                <Workspace>
+                    <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                        <Document Name="A.cs" FilePath="Z:\A.cs">
 class C { public virtual void {|Base:M|}() { } }
 class D : C { public override void {|Implementation:M|}() { } }
 class E : D { public override void {|Implementation:M|}() { } }
-                            </Document>
-                        </Project>
-                    </Workspace>))
+                        </Document>
+                    </Project>
+                </Workspace>)
 
             Await AssertImplementationCorrectlyLinked(lsif)
         End Function

--- a/src/Features/Lsif/GeneratorTest/Utilities/TestLsifOutput.vb
+++ b/src/Features/Lsif/GeneratorTest/Utilities/TestLsifOutput.vb
@@ -9,16 +9,27 @@ Imports Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Writing
 Imports Microsoft.CodeAnalysis.Text
 Imports LSP = Microsoft.VisualStudio.LanguageServer.Protocol
 Imports Roslyn.Utilities
+Imports Microsoft.CodeAnalysis.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests.Utilities
     Friend Class TestLsifOutput
         Private ReadOnly _testLsifJsonWriter As TestLsifJsonWriter
         Private ReadOnly _workspace As TestWorkspace
 
+        ''' <summary>
+        ''' A MEF composition that matches the exact same MEF composition that will be used in the actual LSIF tool.
+        ''' </summary>
+        Public Shared ReadOnly TestComposition As TestComposition = TestComposition.Empty.AddAssemblies(Generator.MefCompositionAssemblies)
+
         Public Sub New(testLsifJsonWriter As TestLsifJsonWriter, workspace As TestWorkspace)
             _testLsifJsonWriter = testLsifJsonWriter
             _workspace = workspace
         End Sub
+
+        Public Shared Function GenerateForWorkspaceAsync(workspaceElement As XElement) As Task(Of TestLsifOutput)
+            Dim workspace = TestWorkspace.CreateWorkspace(workspaceElement, openDocuments:=False, composition:=TestComposition)
+            Return GenerateForWorkspaceAsync(workspace)
+        End Function
 
         Public Shared Async Function GenerateForWorkspaceAsync(workspace As TestWorkspace) As Task(Of TestLsifOutput)
             Dim testLsifJsonWriter = New TestLsifJsonWriter()
@@ -29,6 +40,10 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests.U
         End Function
 
         Public Shared Async Function GenerateForWorkspaceAsync(workspace As TestWorkspace, jsonWriter As ILsifJsonWriter) As Task
+            ' We always want to assert that we're running with the correct composition, or otherwies the test doesn't reflect the real
+            ' world function of the indexer.
+            Assert.Equal(workspace.Composition, TestComposition)
+
             Dim lsifGenerator = Generator.CreateAndWriteCapabilitiesVertex(jsonWriter)
 
             For Each project In workspace.CurrentSolution.Projects

--- a/src/Features/Lsif/GeneratorTest/Utilities/TestLsifOutput.vb
+++ b/src/Features/Lsif/GeneratorTest/Utilities/TestLsifOutput.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests.U
         ''' <summary>
         ''' A MEF composition that matches the exact same MEF composition that will be used in the actual LSIF tool.
         ''' </summary>
-        Public Shared ReadOnly TestComposition As TestComposition = TestComposition.Empty.AddAssemblies(Generator.MefCompositionAssemblies)
+        Public Shared ReadOnly TestComposition As TestComposition = TestComposition.Empty.AddAssemblies(Composition.MefCompositionAssemblies)
 
         Public Sub New(testLsifJsonWriter As TestLsifJsonWriter, workspace As TestWorkspace)
             _testLsifJsonWriter = testLsifJsonWriter


### PR DESCRIPTION
We were including only the base Workspaces binaries in the MEF composition, but the LSP layer expects that services it exports are also available; when some code was refactored this broke. This also updates the tests to use the same MEF container that the actual tool uses. Even better, this also removes the now unnecessary EditorFeatures reference.

Fixes https://github.com/dotnet/roslyn/issues/65367