### PR TITLE
Only complete () if constructor is accessible

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
@@ -771,7 +771,7 @@ class Program
         }
 
         [Theory]
-        [WorkItem("51629", "https://github.com/dotnet/roslyn/issues/51629")]
+        [WorkItem(51629, "https://github.com/dotnet/roslyn/issues/51629")]
         [InlineData('.')]
         [InlineData(';')]
         public async Task DoNotAddParenthesisWhenContructorIsInaccessible(char commitChar)

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
@@ -769,5 +769,34 @@ class Program
 }";
             await VerifyProviderCommitAsync(markup, "List<int>", expectedMark, commitChar: ';');
         }
+
+        [Theory]
+        [WorkItem("51629", "https://github.com/dotnet/roslyn/issues/51629")]
+        [InlineData('.')]
+        [InlineData(';')]
+        public async Task DoNotAddParenthesisWhenContructorIsInaccessible(char commitChar)
+        {
+            var source = @"
+Outer x = new Out$$
+class Outer
+{
+    private Outer() { }
+
+    public class Inner
+    {
+    }
+}";
+            var expected = $@"
+Outer x = new Outer{commitChar}
+class Outer
+{{
+    private Outer() {{ }}
+
+    public class Inner
+    {{
+    }}
+}}";
+            await VerifyProviderCommitAsync(source, "Outer", expected, commitChar: commitChar);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -11964,6 +11964,36 @@ class C
             await VerifyAnyItemExistsAsync(source);
         }
 
+        [Theory]
+        [WorkItem("51629", "https://github.com/dotnet/roslyn/issues/51629")]
+        [InlineData(';')]
+        [InlineData('.')]
+        public async Task DoNotCompleteParenthesisIfConstructorIsInaccessible(char commitChar)
+        {
+            var source = @"
+var x = new Out$$
+class Outer
+{
+    private Outer() { }
+
+    public class Inner
+    {
+    }
+}";
+            var expected = $@"
+var x = new Outer{commitChar}
+class Outer
+{{
+    private Outer() {{ }}
+
+    public class Inner
+    {{
+    }}
+}}";
+
+            await VerifyProviderCommitAsync(source, "Outer", expected, commitChar);
+        }
+
         private static string MakeMarkup(string source, string languageVersion = "Preview")
         {
             return $$"""

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -11965,7 +11965,7 @@ class C
         }
 
         [Theory]
-        [WorkItem("51629", "https://github.com/dotnet/roslyn/issues/51629")]
+        [WorkItem(51629, "https://github.com/dotnet/roslyn/issues/51629")]
         [InlineData(';')]
         [InlineData('.')]
         public async Task DoNotCompleteParenthesisIfConstructorIsInaccessible(char commitChar)

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -10964,5 +10964,67 @@ public class Bar&lt;T&gt; : ISomeInterface&lt;T&gt;
                 Await state.AssertCompletionItemsContain("SomeExtMethod", displayTextSuffix:="<>")
             End Using
         End Function
+
+        <WpfTheory, WorkItem(51629, "https://github.com/dotnet/roslyn/issues/51629")>
+        <InlineData(";"c)>
+        <InlineData("."c)>
+        Public Async Function DoNotAddParenthesisWhenContructorIsInaccessible1(commitChar As Char) As Task
+
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+using System;
+var x = new $$
+class Bar
+{
+    private Bar() {}
+}
+</Document>, languageVersion:=LanguageVersion.Preview)
+
+                state.SendTypeChars("Bar")
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
+                state.SendTypeChars(commitChar)
+
+                Dim expectedText = $"
+using System;
+var x = new Bar{commitChar}
+class Bar
+{{
+    private Bar() {{}}
+}}
+"
+                Assert.Equal(expectedText, state.GetDocumentText())
+            End Using
+        End Function
+
+        <WpfTheory, WorkItem(51629, "https://github.com/dotnet/roslyn/issues/51629")>
+        <InlineData(";"c)>
+        <InlineData("."c)>
+        Public Async Function DoNotAddParenthesisWhenContructorIsInaccessible2(commitChar As Char) As Task
+
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+using System;
+Bar x = new $$
+class Bar
+{
+    private Bar() {}
+}
+</Document>, languageVersion:=LanguageVersion.Preview)
+
+                state.SendTypeChars("Bar")
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
+                state.SendTypeChars(commitChar)
+
+                Dim expectedText = $"
+using System;
+Bar x = new Bar{commitChar}
+class Bar
+{{
+    private Bar() {{}}
+}}
+"
+                Assert.Equal(expectedText, state.GetDocumentText())
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/CompletionUtilities.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/CompletionUtilities.cs
@@ -183,5 +183,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 return lastStatement.GetLocation().SourceSpan.End;
             }
         }
+
+        public static bool IsConstructorAccessibleAtPosition(int position, INamedTypeSymbol symbol, SemanticModel semanticModel)
+        {
+            foreach (var constructor in symbol.Constructors)
+            {
+                if (semanticModel.IsAccessible(position, constructor))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectCreationCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectCreationCompletionProvider.cs
@@ -15,9 +15,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -148,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         {
             var item = base.CreateItem(completionContext, displayText, displayTextSuffix, insertionText, symbols, context, supportedPlatformData);
             var symbol = symbols[0].Symbol;
-            if (symbol is INamedTypeSymbol or IAliasSymbol { Target.IsType: true })
+            if (symbol is INamedTypeSymbol or IAliasSymbol { Target: INamedTypeSymbol })
             {
                 var namedTypeSymbol = symbol.Kind switch
                 {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     item = SymbolCompletionItem.AddShouldProvideParenthesisCompletion(item);
                 }
             }
-            else if (symbol.IsKind(SymbolKind.NamedType) || symbol is IAliasSymbol aliasSymbol && aliasSymbol.Target.IsType)
+            else if (symbol is INamedTypeSymbol or IAliasSymbol { Target: INamedTypeSymbol })
             {
                 var namedTypeSymbol = symbol.Kind switch
                 {


### PR DESCRIPTION
A fix for https://github.com/dotnet/roslyn/issues/51629
Here we want to have a better completion when the completion item has a nested class when the commit char is `;` or `.`
So only add `()` when the constructor is accessible.
