### PR TITLE
Add more telemetry to Go To Def results from external sources

### DIFF
--- a/src/EditorFeatures/CSharpTest/PdbSourceDocument/NullResultMetadataAsSourceFileProvider.cs
+++ b/src/EditorFeatures/CSharpTest/PdbSourceDocument/NullResultMetadataAsSourceFileProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PdbSourceDocument
         {
         }
 
-        public Task<MetadataAsSourceFile?> GetGeneratedFileAsync(MetadataAsSourceWorkspace metadataWorkspace, Workspace sourceWorkspace, Project sourceProject, ISymbol symbol, bool signaturesOnly, MetadataAsSourceOptions options, string tempPath, CancellationToken cancellationToken)
+        public Task<MetadataAsSourceFile?> GetGeneratedFileAsync(MetadataAsSourceWorkspace metadataWorkspace, Workspace sourceWorkspace, Project sourceProject, ISymbol symbol, bool signaturesOnly, MetadataAsSourceOptions options, string tempPath, TelemetryMessage? telemetry, CancellationToken cancellationToken)
         {
             return Task.FromResult<MetadataAsSourceFile?>(NullResult);
         }

--- a/src/EditorFeatures/CSharpTest/PdbSourceDocument/PdbFileLocatorServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/PdbSourceDocument/PdbFileLocatorServiceTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.UnitTests;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.PdbSourceDocument;
 using Roslyn.Test.Utilities;
 using Xunit;

--- a/src/EditorFeatures/CSharpTest/PdbSourceDocument/PdbSourceDocumentLoaderServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/PdbSourceDocument/PdbSourceDocumentLoaderServiceTests.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.UnitTests;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.PdbSourceDocument;
 using Roslyn.Test.Utilities;
 using Xunit;

--- a/src/Features/Core/Portable/MetadataAsSource/DecompilationMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/DecompilationMetadataAsSourceFileProvider.cs
@@ -66,6 +66,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             bool signaturesOnly,
             MetadataAsSourceOptions options,
             string tempPath,
+            TelemetryMessage? telemetryMessage,
             CancellationToken cancellationToken)
         {
             MetadataAsSourceGeneratedFileInfo fileInfo;
@@ -121,6 +122,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                         if (decompiledSourceService != null)
                         {
                             var decompilationDocument = await decompiledSourceService.AddSourceToAsync(temporaryDocument, compilation, symbol, refInfo.metadataReference, refInfo.assemblyLocation, options.GenerationOptions.CleanupOptions.FormattingOptions, cancellationToken).ConfigureAwait(false);
+                            telemetryMessage?.SetDecompiled(decompilationDocument is not null);
                             if (decompilationDocument is not null)
                             {
                                 temporaryDocument = decompilationDocument;

--- a/src/Features/Core/Portable/MetadataAsSource/IMetadataAsSourceFileProvider.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/IMetadataAsSourceFileProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
         /// Generates a file from metadata. Will be called under a lock to prevent concurrent access.
         /// </summary>
         Task<MetadataAsSourceFile?> GetGeneratedFileAsync(
-            MetadataAsSourceWorkspace metadataWorkspace, Workspace sourceWorkspace, Project sourceProject, ISymbol symbol, bool signaturesOnly, MetadataAsSourceOptions options, string tempPath, CancellationToken cancellationToken);
+            MetadataAsSourceWorkspace metadataWorkspace, Workspace sourceWorkspace, Project sourceProject, ISymbol symbol, bool signaturesOnly, MetadataAsSourceOptions options, string tempPath, TelemetryMessage? telemetryMessage, CancellationToken cancellationToken);
 
         /// <summary>
         /// Called to clean up any state. Will be called under a lock to prevent concurrent access.

--- a/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -98,11 +98,14 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 Contract.ThrowIfNull(_workspace);
                 var tempPath = GetRootPathWithGuid_NoLock();
 
+                // We don't want to track telemetry for signatures only requests, only where we try to show source
+                using var telemetryMessage = signaturesOnly ? null : new TelemetryMessage(cancellationToken);
+
                 foreach (var lazyProvider in _providers)
                 {
                     var provider = lazyProvider.Value;
                     var providerTempPath = Path.Combine(tempPath, provider.GetType().Name);
-                    var result = await provider.GetGeneratedFileAsync(_workspace, sourceWorkspace, sourceProject, symbol, signaturesOnly, options, providerTempPath, cancellationToken).ConfigureAwait(false);
+                    var result = await provider.GetGeneratedFileAsync(_workspace, sourceWorkspace, sourceProject, symbol, signaturesOnly, options, providerTempPath, telemetryMessage, cancellationToken).ConfigureAwait(false);
                     if (result is not null)
                     {
                         return result;

--- a/src/Features/Core/Portable/MetadataAsSource/TelemetryMessage.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/TelemetryMessage.cs
@@ -4,15 +4,19 @@
 
 using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Threading;
 using Microsoft.CodeAnalysis.Internal.Log;
 
-namespace Microsoft.CodeAnalysis.PdbSourceDocument
+namespace Microsoft.CodeAnalysis.MetadataAsSource
 {
     internal class TelemetryMessage : IDisposable
     {
         private string? _pdbSource;
         private string? _sourceFileSource;
+        private string? _referenceAssembly;
+        private string? _dll;
+        private bool? _decompiled;
 
         private readonly IDisposable _logBlock;
 
@@ -32,10 +36,37 @@ namespace Microsoft.CodeAnalysis.PdbSourceDocument
             _sourceFileSource = source;
         }
 
+        public void SetReferenceAssembly(string referenceAssembly)
+        {
+            _referenceAssembly = referenceAssembly;
+        }
+
+        public void SetDll(string dll)
+        {
+            _dll = dll;
+        }
+
+        public void SetDecompiled(bool decompiled)
+        {
+            _decompiled = decompiled;
+        }
+
         private void SetLogProperties(Dictionary<string, object?> properties)
         {
             properties["pdb"] = _pdbSource ?? "none";
             properties["source"] = _sourceFileSource ?? "none";
+            properties["referenceassembly"] = _referenceAssembly ?? "no";
+            if (_dll is not null)
+            {
+                properties["dll"] = new PiiValue(_dll);
+            }
+
+            properties["decompiled"] = _decompiled switch
+            {
+                true => "yes",
+                false => "no",
+                _ => "n/a"
+            };
         }
 
         public void Dispose()

--- a/src/Features/Core/Portable/PdbSourceDocument/IPdbFileLocatorService.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/IPdbFileLocatorService.cs
@@ -4,6 +4,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 
 namespace Microsoft.CodeAnalysis.PdbSourceDocument
 {

--- a/src/Features/Core/Portable/PdbSourceDocument/IPdbSourceDocumentLoaderService.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/IPdbSourceDocumentLoaderService.cs
@@ -5,6 +5,7 @@
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.PdbSourceDocument

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbFileLocatorService.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbFileLocatorService.cs
@@ -10,6 +10,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 

--- a/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentLoaderService.cs
+++ b/src/Features/Core/Portable/PdbSourceDocument/PdbSourceDocumentLoaderService.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Text;
 


### PR DESCRIPTION
Fixes #65427

This lifts the `TelemetryMessage` class we were already using, up to the larger "Metadata as source" level, and passes it into the providers, so we can add telemetry for decompilation. It also adds a couple more properties for info on resolving reference assemblies, and which DLL is being looked for (hashed of course)

For example:

Showing SourceLink because we correctly resolved a reference assembly to its implementation:
<img width="587" alt="image" src="https://user-images.githubusercontent.com/754264/203158729-36d635da-053e-479a-8a67-5d3e335708cc.png">

Showing metadata because no SourceLink info was available, didn't attempt decompilation:
<img width="567" alt="image" src="https://user-images.githubusercontent.com/754264/203158665-8e6cbb96-9f45-4512-aa60-5516ab228b0a.png">

/cc @chuckries 