### PR TITLE
Fix null ref in add-import

### DIFF
--- a/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
+++ b/src/Features/Core/Portable/AddImport/AbstractAddImportFeatureService.cs
@@ -223,6 +223,9 @@ namespace Microsoft.CodeAnalysis.AddImport
 
             foreach (var unreferencedProject in viableUnreferencedProjects)
             {
+                if (!unreferencedProject.SupportsCompilation)
+                    continue;
+
                 // Search in this unreferenced project.  But don't search in any of its'
                 // direct references.  i.e. we don't want to search in its metadata references
                 // or in the projects it references itself. We'll be searching those entities

--- a/src/Features/Core/Portable/AddImport/SearchScopes/ProjectSearchScope.cs
+++ b/src/Features/Core/Portable/AddImport/SearchScopes/ProjectSearchScope.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.Threading;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.AddImport
 {
@@ -21,6 +22,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 CancellationToken cancellationToken)
                 : base(provider, exact, cancellationToken)
             {
+                Contract.ThrowIfFalse(project.SupportsCompilation);
                 _project = project;
             }
 

--- a/src/Features/Core/Portable/AddImport/SearchScopes/SourceSymbolsProjectSearchScope.cs
+++ b/src/Features/Core/Portable/AddImport/SearchScopes/SourceSymbolsProjectSearchScope.cs
@@ -2,14 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.FindSymbols.SymbolTree;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.AddImport
@@ -36,7 +35,7 @@ namespace Microsoft.CodeAnalysis.AddImport
             protected override async Task<ImmutableArray<ISymbol>> FindDeclarationsAsync(
                 SymbolFilter filter, SearchQuery searchQuery)
             {
-                var service = _project.Solution.Services.GetService<ISymbolTreeInfoCacheService>();
+                var service = _project.Solution.Services.GetRequiredService<ISymbolTreeInfoCacheService>();
                 var info = await service.TryGetPotentiallyStaleSourceSymbolTreeInfoAsync(_project, CancellationToken).ConfigureAwait(false);
                 if (info == null)
                 {
@@ -60,7 +59,7 @@ namespace Microsoft.CodeAnalysis.AddImport
                 return new AsyncLazy<IAssemblySymbol>(
                     async c =>
                     {
-                        var compilation = await project.GetCompilationAsync(c).ConfigureAwait(false);
+                        var compilation = await project.GetRequiredCompilationAsync(c).ConfigureAwait(false);
                         return compilation.Assembly;
                     }, cacheResult: true);
             }


### PR DESCRIPTION
VS4Mac has seen an issue with a null ref here in this code. I don't see anything in the code preventing this from happening, so i'm going to add an explicit check to mitigate things.