### PR TITLE
[EnC] Allow reordering of top level statements

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -18503,6 +18503,42 @@ public class B
                 });
         }
 
+        [Fact]
+        public void TopLevelStatements_BlockReorder()
+        {
+            var src1 = @"
+{ int a; }
+{ int b; }
+";
+            var src2 = @"
+{ int b; }
+{ int a; }
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits("Reorder [{ int b; }]@14 -> @2");
+
+            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$")));
+        }
+
+        [Fact]
+        public void TopLevelStatements_Reorder()
+        {
+            var src1 = @"
+System.Console.Write(1);
+System.Console.Write(2);
+";
+            var src2 = @"
+System.Console.Write(2);
+System.Console.Write(1);
+";
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifyEdits("Reorder [System.Console.Write(2);]@28 -> @2");
+
+            edits.VerifySemantics(SemanticEdit(SemanticEditKind.Update, c => c.GetMember("Program.<Main>$")));
+        }
+
         #endregion
     }
 }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -17947,10 +17947,22 @@ Console.WriteLine(""Hello"");
         }
 
         [Fact]
-        public void TopLevelStatements_StackAlloc()
+        public void TopLevelStatements_StackAllocInUnsafeBlock()
         {
             var src1 = @"unsafe { var x = stackalloc int[3]; System.Console.Write(1); }";
             var src2 = @"unsafe { var x = stackalloc int[3]; System.Console.Write(2); }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.StackAllocUpdate, "stackalloc", CSharpFeaturesResources.global_statement));
+        }
+
+        [Fact]
+        public void TopLevelStatements_StackAllocInTopBlock()
+        {
+            var src1 = @"{ var x = stackalloc int[3]; System.Console.Write(1); }";
+            var src2 = @"{ var x = stackalloc int[3]; System.Console.Write(2); }";
 
             var edits = GetTopEdits(src1, src2);
 

--- a/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/SyntaxComparer.cs
@@ -1057,6 +1057,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 case SyntaxKind.Block:
                 case SyntaxKind.LabeledStatement:
+                case SyntaxKind.GlobalStatement:
                     distance = ComputeWeightedBlockDistance(leftBlock, rightBlock);
                     return true;
 


### PR DESCRIPTION
Includes #65557 for the block display name fix, so just review the second commit (or whatever, its not that big)