### PR TITLE
Fix expected number of unsupported diagnostic IDs in a test

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -563,8 +563,8 @@ namespace A
             var expectedNumberOfUnsupportedDiagnosticIds =
                 language switch
                 {
-                    LanguageNames.CSharp => 38,
-                    LanguageNames.VisualBasic => 75,
+                    LanguageNames.CSharp => 39,
+                    LanguageNames.VisualBasic => 76,
                     _ => throw ExceptionUtilities.UnexpectedValue(language),
                 };
 


### PR DESCRIPTION
Fixes #65566.

Not sure how it happened, but CI checks on my PRs started failing today due to these wrong numbers in a test.