### PR TITLE
Add asserts for debug only test failures and fix tests

### DIFF
--- a/src/VisualStudio/Core/Def/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -10,12 +10,10 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Notification;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SolutionCrawler;
@@ -415,6 +413,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
         public void AddNewErrors(ProjectId projectId, DiagnosticData diagnostic)
         {
+            Debug.Assert(diagnostic.IsBuildDiagnostic());
+
             // Capture state that will be processed in background thread.
             var state = GetOrCreateInProgressState();
 
@@ -427,6 +427,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
         public void AddNewErrors(DocumentId documentId, DiagnosticData diagnostic)
         {
+            Debug.Assert(diagnostic.IsBuildDiagnostic());
+
             // Capture state that will be processed in background thread.
             var state = GetOrCreateInProgressState();
 
@@ -440,6 +442,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         public void AddNewErrors(
             ProjectId projectId, HashSet<DiagnosticData> projectErrors, Dictionary<DocumentId, HashSet<DiagnosticData>> documentErrorMap)
         {
+            Debug.Assert(projectErrors.All(d => d.IsBuildDiagnostic()));
+            Debug.Assert(documentErrorMap.SelectMany(kvp => kvp.Value).All(d => d.IsBuildDiagnostic()));
+
             // Capture state that will be processed in background thread
             var state = GetOrCreateInProgressState();
 

--- a/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DiagnosticTableDataSourceTests.vb
@@ -692,7 +692,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                             diagnostic1.IsEnabledByDefault,
                             diagnostic1.WarningLevel,
                             diagnostic1.CustomTags,
-                            diagnostic1.Properties,
+                            diagnostic1.Properties.AddRange(DiagnosticData.PropertiesForBuildDiagnostic),
                             diagnostic1.ProjectId,
                             New DiagnosticDataLocation(
                                 diagnostic1.DataLocation.UnmappedFileSpan,
@@ -716,7 +716,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                             diagnostic2.IsEnabledByDefault,
                             diagnostic2.WarningLevel,
                             diagnostic2.CustomTags,
-                            diagnostic2.Properties,
+                            diagnostic2.Properties.AddRange(DiagnosticData.PropertiesForBuildDiagnostic),
                             diagnostic2.ProjectId,
                             New DiagnosticDataLocation(
                                 diagnostic2.DataLocation.UnmappedFileSpan,

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -196,12 +196,45 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
 
             Using workspace = TestWorkspace.CreateCSharp(String.Empty)
                 Dim project = workspace.CurrentSolution.Projects.First()
+                Dim service = New TestDiagnosticAnalyzerService(workspace.GlobalOptions)
+                Dim waiter = New AsynchronousOperationListener()
+                Using source = New ExternalErrorDiagnosticUpdateSource(
+                    workspace, service, workspace.GetService(Of IGlobalOperationNotificationService), waiter, CancellationToken.None)
 
-                Dim diagnostic = GetDiagnosticData(project.Id, isBuildDiagnostic:=True)
-                Assert.True(diagnostic.IsBuildDiagnostic())
+                    Dim diagnostic = New DiagnosticData(
+                        "id",
+                        category:="Test",
+                        message:="Test Message",
+                        severity:=DiagnosticSeverity.Error,
+                        defaultSeverity:=DiagnosticSeverity.Error,
+                        isEnabledByDefault:=True,
+                        warningLevel:=0,
+                        projectId:=project.Id,
+                        location:=New DiagnosticDataLocation(New FileLinePositionSpan("", Nothing)),
+                        customTags:=ImmutableArray(Of String).Empty,
+                        properties:=DiagnosticData.PropertiesForBuildDiagnostic,
+                        language:=LanguageNames.VisualBasic)
+                    Assert.True(diagnostic.IsBuildDiagnostic())
+                    source.AddNewErrors(project.Id, diagnostic)
 
-                diagnostic = GetDiagnosticData(project.Id, isBuildDiagnostic:=False)
-                Assert.False(diagnostic.IsBuildDiagnostic())
+                    diagnostic = New DiagnosticData(
+                        "id",
+                        category:="Test",
+                        message:="Test Message",
+                        severity:=DiagnosticSeverity.Error,
+                        defaultSeverity:=DiagnosticSeverity.Error,
+                        isEnabledByDefault:=True,
+                        warningLevel:=0,
+                        projectId:=project.Id,
+                        location:=New DiagnosticDataLocation(New FileLinePositionSpan("", Nothing)),
+                        customTags:=ImmutableArray(Of String).Empty,
+                        properties:=ImmutableDictionary(Of String, String).Empty,
+                        language:=LanguageNames.VisualBasic)
+                    Assert.False(diagnostic.IsBuildDiagnostic())
+#If DEBUG Then
+                    Assert.Throws(Of InvalidOperationException)(Sub() source.AddNewErrors(project.Id, diagnostic))
+#End If
+                End Using
             End Using
         End Sub
 
@@ -256,7 +289,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Using source = New ExternalErrorDiagnosticUpdateSource(
                     workspace, service, workspace.GetService(Of IGlobalOperationNotificationService), waiter, CancellationToken.None)
 
-                    Dim diagnostic = GetDiagnosticData(project.Id, isBuildDiagnostic:=True, id:=analyzer.SupportedDiagnostics(0).Id)
+                    Dim diagnostic = GetDiagnosticData(project.Id, id:=analyzer.SupportedDiagnostics(0).Id)
                     source.AddNewErrors(project.Id, diagnostic)
 
                     Dim buildDiagnosticCallbackSeen = False
@@ -308,7 +341,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Using source = New ExternalErrorDiagnosticUpdateSource(
                     workspace, service, workspace.GetService(Of IGlobalOperationNotificationService), waiter, CancellationToken.None)
 
-                    Dim diagnostic = GetDiagnosticData(project.Id, isBuildDiagnostic:=True, id:=analyzer.SupportedDiagnostics(0).Id)
+                    Dim diagnostic = GetDiagnosticData(project.Id, id:=analyzer.SupportedDiagnostics(0).Id)
                     source.AddNewErrors(project.Id, diagnostic)
 
                     AddHandler source.DiagnosticsUpdated, Sub(o, a)
@@ -347,7 +380,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Using source = New ExternalErrorDiagnosticUpdateSource(
                     workspace, service, workspace.GetService(Of IGlobalOperationNotificationService), waiter, CancellationToken.None)
 
-                    Dim diagnostic = GetDiagnosticData(project.Id, isBuildDiagnostic:=True, id:=analyzer.SupportedDiagnostics(0).Id)
+                    Dim diagnostic = GetDiagnosticData(project.Id, id:=analyzer.SupportedDiagnostics(0).Id)
                     source.AddNewErrors(project.Id, diagnostic)
 
                     Dim called = False
@@ -423,18 +456,18 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                     workspace, service, workspace.GetService(Of IGlobalOperationNotificationService), waiter, CancellationToken.None)
 
                     Dim diagnostic = New DiagnosticData(
-                    id:="CS1002",
-                    category:="Test",
-                    message:="Test Message",
-                    severity:=DiagnosticSeverity.Error,
-                    defaultSeverity:=DiagnosticSeverity.Error,
-                    isEnabledByDefault:=True,
-                    warningLevel:=0,
-                    customTags:=ImmutableArray(Of String).Empty,
-                    properties:=ImmutableDictionary(Of String, String).Empty,
-                    project.Id,
-                    location:=New DiagnosticDataLocation(New FileLinePositionSpan("Test.txt", New LinePosition(4, 4), New LinePosition(4, 4)), documentId:=Nothing),
-                    language:=project.Language)
+                        id:="CS1002",
+                        category:="Test",
+                        message:="Test Message",
+                        severity:=DiagnosticSeverity.Error,
+                        defaultSeverity:=DiagnosticSeverity.Error,
+                        isEnabledByDefault:=True,
+                        warningLevel:=0,
+                        customTags:=ImmutableArray(Of String).Empty,
+                        properties:=DiagnosticData.PropertiesForBuildDiagnostic,
+                        project.Id,
+                        location:=New DiagnosticDataLocation(New FileLinePositionSpan("Test.txt", New LinePosition(4, 4), New LinePosition(4, 4)), documentId:=Nothing),
+                        language:=project.Language)
 
                     AddHandler service.DiagnosticsUpdated, Sub(o, args)
                                                                Dim diagnostics = args.GetPushDiagnostics(globalOptions, InternalDiagnosticsOptions.NormalDiagnosticMode)
@@ -582,8 +615,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             End Sub
         End Class
 
-        Private Shared Function GetDiagnosticData(projectId As ProjectId, Optional isBuildDiagnostic As Boolean = False, Optional id As String = "id") As DiagnosticData
-            Dim properties = If(isBuildDiagnostic, DiagnosticData.PropertiesForBuildDiagnostic, ImmutableDictionary(Of String, String).Empty)
+        Private Shared Function GetDiagnosticData(projectId As ProjectId, Optional id As String = "id") As DiagnosticData
             Return New DiagnosticData(
                 id,
                 category:="Test",
@@ -595,7 +627,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 projectId:=projectId,
                 location:=New DiagnosticDataLocation(New FileLinePositionSpan("", Nothing)),
                 customTags:=ImmutableArray(Of String).Empty,
-                properties:=properties,
+                properties:=DiagnosticData.PropertiesForBuildDiagnostic,
                 language:=LanguageNames.VisualBasic)
         End Function
 


### PR DESCRIPTION
Closes #65563
Verified that the added asserts in product source fire for bunch of existings tests ExternalDiagnosticUpdateSourceTests and match the failing assert in #65563 (`diagnostic.IsBuildDiagnostic()`). Fixed the tests to avoid the asserts.