### PR TITLE
Make sure the container syntax node is not GlobalStatements

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertLocalFunctionToMethod/ConvertLocalFunctionToMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertLocalFunctionToMethod/ConvertLocalFunctionToMethodTests.cs
@@ -905,5 +905,18 @@ $@"class C
     }
 }");
         }
+
+        [Fact]
+        public async Task TestTopLevelStatements()
+        {
+            await TestMissingAsync(@"
+Console.WriteLine(""Hello"");
+{
+    public static int [|Add|](int x, int y)
+    {
+        return x + y;
+    }
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/CodeRefactorings/ConvertLocalFunctionToMethod/CSharpConvertLocalFunctionToMethodCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/ConvertLocalFunctionToMethod/CSharpConvertLocalFunctionToMethodCodeRefactoringProvider.cs
@@ -58,13 +58,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ConvertLocalFunctionToM
             }
 
             var container = localFunction.GetAncestor<MemberDeclarationSyntax>();
-            // Top-Level statements is defined as 
-            // compilation_unit
-            //: extern_alias_directive* using_directive*global_attributes ? statement * namespace_member_declaration *
-            //;
             // If the local function is defined in a block within the top-level statements context, then we can't provide the refactoring because
             // there is no class we can put the generated method in.
-            if (container == null || (container.IsKind(SyntaxKind.GlobalStatement) && container.Parent.IsKind(SyntaxKind.CompilationUnit)))
+            if (container == null || container.IsKind(SyntaxKind.GlobalStatement))
             {
                 return;
             }


### PR DESCRIPTION
Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1684866
In top-level statement context, don't provide the refactoring to convert local functions to general methods, because there is no 'container' class of the statements. So we have no where to generate the method.