### PR TITLE
Increase CodeCleanUp test value

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/CodeCleanupTests.cs
@@ -563,8 +563,8 @@ namespace A
             var expectedNumberOfUnsupportedDiagnosticIds =
                 language switch
                 {
-                    LanguageNames.CSharp => 38,
-                    LanguageNames.VisualBasic => 75,
+                    LanguageNames.CSharp => 39,
+                    LanguageNames.VisualBasic => 76,
                     _ => throw ExceptionUtilities.UnexpectedValue(language),
                 };
 


### PR DESCRIPTION
So the whole story is
Cyrus adds two diagnosticsID in https://github.com/dotnet/roslyn/pull/65476 and https://github.com/dotnet/roslyn/pull/65371
And I guess the check of each of the PR is passed, because they are based on the merging into the main.
But after these two PRs are checked in, things get broken.