### PR TITLE
Add capability to request fine grained DiagnosticKinds to diagnostic analyzer service

### DIFF
--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CommonDiagnosticAnalyzers
 Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.Diagnostics.CSharp
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
@@ -1215,7 +1216,7 @@ public class B
                 Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
 
                 Dim diagnostics = (Await diagnosticService.GetDiagnosticsForSpanAsync(document, fullSpan)).
-                    OrderBy(Function(d) d.DataLocation.UnmappedFileSpan.getclampedTextSpan(text).Start).ToArray()
+                    OrderBy(Function(d) d.DataLocation.UnmappedFileSpan.GetClampedTextSpan(text).Start).ToArray()
 
                 Assert.Equal(3, diagnostics.Count)
                 Assert.True(diagnostics.All(Function(d) d.Id = MethodSymbolAnalyzer.Descriptor.Id))
@@ -1379,11 +1380,11 @@ public class B
                 Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
                 Dim text = Await document.GetTextAsync()
                 Dim diagnostics = (Await diagnosticService.GetDiagnosticsForSpanAsync(document, fullSpan)).
-                    OrderBy(Function(d) d.DataLocation.unmappedfilespan.getclampedTextSpan(text).Start).
+                    OrderBy(Function(d) d.DataLocation.UnmappedFileSpan.GetClampedTextSpan(text).Start).
                     ToArray()
 
                 For Each diagnostic In diagnostics
-                    Dim spanAtCaret = New TextSpan(diagnostic.DataLocation.unmappedfilespan.getclampedtextspan(text).Start, 0)
+                    Dim spanAtCaret = New TextSpan(diagnostic.DataLocation.UnmappedFileSpan.GetClampedTextSpan(text).Start, 0)
                     Dim otherDiagnostics = (Await diagnosticService.GetDiagnosticsForSpanAsync(document, spanAtCaret)).ToArray()
 
                     Assert.Equal(1, otherDiagnostics.Length)
@@ -2326,6 +2327,84 @@ class MyClass
 
                 ' Verify only span-based analyzer is invoked with TryAppendDiagnosticsForSpanAsync
                 Assert.Equal(isSpanBasedAnalyzer, analyzer.ReceivedOperationCallback)
+            End Using
+        End Function
+
+        <WpfTheory>
+        <InlineData(DiagnosticKinds.CompilerSyntax)>
+        <InlineData(DiagnosticKinds.CompilerSemantic)>
+        <InlineData(DiagnosticKinds.AnalyzerSyntax)>
+        <InlineData(DiagnosticKinds.AnalyzerSemantic)>
+        <InlineData(DiagnosticKinds.AllCompiler)>
+        <InlineData(DiagnosticKinds.AllAnalyzer)>
+        <InlineData(DiagnosticKinds.AllSyntax)>
+        <InlineData(DiagnosticKinds.AllSemantic)>
+        <InlineData(DiagnosticKinds.All)>
+        Friend Async Function TestGetDiagnosticsForDiagnosticsKindAsync(diagnosticKinds As DiagnosticKinds) As Task
+            Dim test = <Workspace>
+                           <Project Language="C#" CommonReferences="true">
+                               <Document><![CDATA[
+class MyClass
+{
+    private readonly int _field;    // ID0001 (analyzer syntax warning) and ID0002 (analyzer semantic warning)
+
+    void M()
+    {
+        int x = 0;  // CS0219: unused variable (compiler semantic warning)
+        ,           // CS1513: } expected (compiler syntax error)
+    }
+}]]>
+                               </Document>
+                           </Project>
+                       </Workspace>
+
+            Using workspace = TestWorkspace.CreateWorkspace(test, composition:=s_compositionWithMockDiagnosticUpdateSourceRegistrationService)
+                Dim solution = workspace.CurrentSolution
+                Dim project = solution.Projects.Single()
+
+                ' Add syntax and semantic analyzers
+                Dim syntaxAnalyzer = New FieldAnalyzer("ID0001", syntaxTreeAction:=True)
+                Dim semanticAnalyzer = New FieldAnalyzer("ID0002", syntaxTreeAction:=False)
+                Dim compilerAnalyzer = New CSharpCompilerDiagnosticAnalyzer()
+                Dim analyzerReference = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(compilerAnalyzer, syntaxAnalyzer, semanticAnalyzer))
+                project = project.AddAnalyzerReference(analyzerReference)
+
+                Dim mefExportProvider = DirectCast(workspace.Services.HostServices, IMefHostExportProvider)
+                Assert.IsType(Of MockDiagnosticUpdateSourceRegistrationService)(workspace.GetService(Of IDiagnosticUpdateSourceRegistrationService)())
+                Dim diagnosticService = Assert.IsType(Of DiagnosticAnalyzerService)(workspace.GetService(Of IDiagnosticAnalyzerService)())
+                Dim incrementalAnalyzer = diagnosticService.CreateIncrementalAnalyzer(workspace)
+
+                ' Get diagnostics for span for the given DiagnosticKinds
+                Dim document = project.Documents.Single()
+                Dim root = Await document.GetSyntaxRootAsync()
+                Dim diagnostics = Await diagnosticService.GetDiagnosticsForSpanAsync(document, root.FullSpan, diagnosticKinds:=diagnosticKinds)
+
+                Dim expectedCount = 0
+                Dim expectedDiagnosticIds As New HashSet(Of String)
+
+                If (diagnosticKinds And DiagnosticKinds.CompilerSyntax) <> 0 Then
+                    expectedCount += 1
+                    expectedDiagnosticIds.Add("CS1513")
+                End If
+
+                If (diagnosticKinds And DiagnosticKinds.CompilerSemantic) <> 0 Then
+                    expectedCount += 1
+                    expectedDiagnosticIds.Add("CS0219")
+                End If
+
+                If (diagnosticKinds And DiagnosticKinds.AnalyzerSyntax) <> 0 Then
+                    expectedCount += 1
+                    expectedDiagnosticIds.Add("ID0001")
+                End If
+
+                If (diagnosticKinds And DiagnosticKinds.AnalyzerSemantic) <> 0 Then
+                    expectedCount += 1
+                    expectedDiagnosticIds.Add("ID0002")
+                End If
+
+                Assert.Equal(expectedCount, diagnostics.Length)
+                Dim actualDiagnosticIds = diagnostics.Select(Function(d) d.Id).ToHashSet()
+                Assert.Equal(expectedDiagnosticIds, actualDiagnosticIds)
             End Using
         End Function
 

--- a/src/EditorFeatures/TestUtilities/Diagnostics/MockDiagnosticAnalyzerService.cs
+++ b/src/EditorFeatures/TestUtilities/Diagnostics/MockDiagnosticAnalyzerService.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId = null, DocumentId? documentId = null, ImmutableHashSet<string>? diagnosticIds = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(TextDocument document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeCompilerDiagnostics, bool includeSuppressedDiagnostics = true, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default)
+        public Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(TextDocument document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeCompilerDiagnostics, bool includeSuppressedDiagnostics = true, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, DiagnosticKinds diagnosticKinds = DiagnosticKinds.All, CancellationToken cancellationToken = default)
             => !Diagnostics.IsDefault ? Task.FromResult(Diagnostics) : throw new NotImplementedException();
 
         public Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(Solution solution, ProjectId? projectId = null, ImmutableHashSet<string>? diagnosticIds = null, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
         public Task<ImmutableArray<DiagnosticData>> GetSpecificCachedDiagnosticsAsync(Workspace workspace, object id, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
 
-        public Task<(ImmutableArray<DiagnosticData> diagnostics, bool upToDate)> TryGetDiagnosticsForSpanAsync(TextDocument document, TextSpan range, Func<string, bool>? shouldIncludeDiagnostic, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, CancellationToken cancellationToken = default)
+        public Task<(ImmutableArray<DiagnosticData> diagnostics, bool upToDate)> TryGetDiagnosticsForSpanAsync(TextDocument document, TextSpan range, Func<string, bool>? shouldIncludeDiagnostic, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, DiagnosticKinds diagnosticKinds = DiagnosticKinds.All, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticKinds.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticKinds.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Diagnostics;
+
+[Flags]
+internal enum DiagnosticKinds
+{
+    CompilerSyntax = 1 << 0,
+    AnalyzerSyntax = 1 << 1,
+    CompilerSemantic = 1 << 2,
+    AnalyzerSemantic = 1 << 3,
+
+    AllCompiler = CompilerSyntax | CompilerSemantic,
+    AllAnalyzer = AnalyzerSyntax | AnalyzerSemantic,
+    AllSyntax = CompilerSyntax | AnalyzerSyntax,
+    AllSemantic = CompilerSemantic | AnalyzerSemantic,
+    All = AllSyntax | AllSemantic
+}

--- a/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/IDiagnosticAnalyzerService.cs
@@ -74,10 +74,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// This API will only force complete analyzers that support span based analysis, i.e. compiler analyzer and
         /// <see cref="IBuiltInAnalyzer"/>s that support <see cref="DiagnosticAnalyzerCategory.SemanticSpanAnalysis"/>.
         /// For the rest of the analyzers, it will only return diagnostics if the analyzer has already been executed.
-        /// Use <see cref="GetDiagnosticsForSpanAsync(TextDocument, TextSpan?, Func{string, bool}?, bool, bool, CodeActionRequestPriority, Func{string, IDisposable?}?, CancellationToken)"/>
+        /// Use <see cref="GetDiagnosticsForSpanAsync(TextDocument, TextSpan?, Func{string, bool}?, bool, bool, CodeActionRequestPriority, Func{string, IDisposable?}?, DiagnosticKinds, CancellationToken)"/>
         /// if you want to force complete all analyzers and get up-to-date diagnostics for all analyzers for the given span.
         /// </summary>
-        Task<(ImmutableArray<DiagnosticData> diagnostics, bool upToDate)> TryGetDiagnosticsForSpanAsync(TextDocument document, TextSpan range, Func<string, bool>? shouldIncludeDiagnostic, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, CancellationToken cancellationToken = default);
+        Task<(ImmutableArray<DiagnosticData> diagnostics, bool upToDate)> TryGetDiagnosticsForSpanAsync(
+            TextDocument document, TextSpan range, Func<string, bool>? shouldIncludeDiagnostic,
+            bool includeSuppressedDiagnostics = false,
+            CodeActionRequestPriority priority = CodeActionRequestPriority.None,
+            DiagnosticKinds diagnosticKinds = DiagnosticKinds.All,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Return up to date diagnostics for the given span for the document
@@ -87,13 +92,23 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// none of its reported diagnostics should be included in the result.
         /// </para>
         /// </summary>
-        Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(TextDocument document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic, bool includeCompilerDiagnostics, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default);
+        Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(
+            TextDocument document, TextSpan? range, Func<string, bool>? shouldIncludeDiagnostic,
+            bool includeCompilerDiagnostics, bool includeSuppressedDiagnostics = false,
+            CodeActionRequestPriority priority = CodeActionRequestPriority.None,
+            Func<string, IDisposable?>? addOperationScope = null,
+            DiagnosticKinds diagnosticKinds = DiagnosticKinds.All,
+            CancellationToken cancellationToken = default);
     }
 
     internal static class IDiagnosticAnalyzerServiceExtensions
     {
-        public static Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(this IDiagnosticAnalyzerService service, TextDocument document, TextSpan range, string? diagnosticId = null, bool includeSuppressedDiagnostics = false, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default)
-            => service.GetDiagnosticsForSpanAsync(document, range, diagnosticId, includeSuppressedDiagnostics, CodeActionRequestPriority.None, addOperationScope, cancellationToken);
+        public static Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(this IDiagnosticAnalyzerService service,
+            TextDocument document, TextSpan range, string? diagnosticId = null,
+            bool includeSuppressedDiagnostics = false, Func<string, IDisposable?>? addOperationScope = null,
+            DiagnosticKinds diagnosticKinds = DiagnosticKinds.All,
+            CancellationToken cancellationToken = default)
+            => service.GetDiagnosticsForSpanAsync(document, range, diagnosticId, includeSuppressedDiagnostics, CodeActionRequestPriority.None, addOperationScope, diagnosticKinds, cancellationToken);
 
         /// <summary>
         /// Return up to date diagnostics for the given span for the document
@@ -103,11 +118,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// name="diagnosticId"/> value.
         /// </para>
         /// </summary>
-        public static Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(this IDiagnosticAnalyzerService service, TextDocument document, TextSpan? range, string? diagnosticId = null, bool includeSuppressedDiagnostics = false, CodeActionRequestPriority priority = CodeActionRequestPriority.None, Func<string, IDisposable?>? addOperationScope = null, CancellationToken cancellationToken = default)
+        public static Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForSpanAsync(this IDiagnosticAnalyzerService service,
+            TextDocument document, TextSpan? range, string? diagnosticId = null,
+            bool includeSuppressedDiagnostics = false,
+            CodeActionRequestPriority priority = CodeActionRequestPriority.None,
+            Func<string, IDisposable?>? addOperationScope = null,
+            DiagnosticKinds diagnosticKinds = DiagnosticKinds.All,
+            CancellationToken cancellationToken = default)
         {
             Func<string, bool>? shouldIncludeDiagnostic = diagnosticId != null ? id => id == diagnosticId : null;
             return service.GetDiagnosticsForSpanAsync(document, range, shouldIncludeDiagnostic,
-                includeCompilerDiagnostics: true, includeSuppressedDiagnostics, priority: priority, addOperationScope: addOperationScope, cancellationToken: cancellationToken);
+                includeCompilerDiagnostics: true, includeSuppressedDiagnostics, priority,
+                addOperationScope, diagnosticKinds, cancellationToken);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         {
             var (allDiagnostics, upToDate) = await _diagnosticService.TryGetDiagnosticsForSpanAsync(
                 document, range, GetShouldIncludeDiagnosticPredicate(document, priority),
-                includeSuppressedDiagnostics: false, priority, cancellationToken).ConfigureAwait(false);
+                includeSuppressedDiagnostics: false, priority, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             var buildOnlyDiagnosticsService = document.Project.Solution.Services.GetRequiredService<IBuildOnlyDiagnosticsService>();
             allDiagnostics.AddRange(buildOnlyDiagnosticsService.GetBuildOnlyDiagnostics(document.Id));

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/DiagnosticAnalyzerService.cs
@@ -74,6 +74,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             Func<string, bool>? shouldIncludeDiagnostic,
             bool includeSuppressedDiagnostics = false,
             CodeActionRequestPriority priority = CodeActionRequestPriority.None,
+            DiagnosticKinds diagnosticKinds = DiagnosticKinds.All,
             CancellationToken cancellationToken = default)
         {
             if (_map.TryGetValue(document.Project.Solution.Workspace, out var analyzer))
@@ -85,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     var upToDate = await analyzer.TryAppendDiagnosticsForSpanAsync(
                         document, range, diagnostics, shouldIncludeDiagnostic,
                         includeSuppressedDiagnostics, true, priority, blockForData: false,
-                        addOperationScope: null, cancellationToken).ConfigureAwait(false);
+                        addOperationScope: null, diagnosticKinds, cancellationToken).ConfigureAwait(false);
                     return (diagnostics.ToImmutable(), upToDate);
                 }, cancellationToken);
             }
@@ -101,6 +102,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             bool includeSuppressedDiagnostics,
             CodeActionRequestPriority priority,
             Func<string, IDisposable?>? addOperationScope,
+            DiagnosticKinds diagnosticKinds,
             CancellationToken cancellationToken)
         {
             if (_map.TryGetValue(document.Project.Solution.Workspace, out var analyzer))
@@ -108,7 +110,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 // always make sure that analyzer is called on background thread.
                 return Task.Run(() => analyzer.GetDiagnosticsForSpanAsync(
                     document, range, shouldIncludeDiagnostic, includeSuppressedDiagnostics, includeCompilerDiagnostics,
-                    priority, blockForData: true, addOperationScope, cancellationToken), cancellationToken);
+                    priority, blockForData: true, addOperationScope, diagnosticKinds, cancellationToken), cancellationToken);
             }
 
             return SpecializedTasks.EmptyImmutableArray<DiagnosticData>();

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -24,11 +24,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         public async Task<bool> TryAppendDiagnosticsForSpanAsync(
             TextDocument document, TextSpan? range, ArrayBuilder<DiagnosticData> result, Func<string, bool>? shouldIncludeDiagnostic,
             bool includeSuppressedDiagnostics, bool includeCompilerDiagnostics, CodeActionRequestPriority priority, bool blockForData,
-            Func<string, IDisposable?>? addOperationScope, CancellationToken cancellationToken)
+            Func<string, IDisposable?>? addOperationScope, DiagnosticKinds diagnosticKinds, CancellationToken cancellationToken)
         {
             var getter = await LatestDiagnosticsForSpanGetter.CreateAsync(
                 this, document, range, blockForData, addOperationScope, includeSuppressedDiagnostics, includeCompilerDiagnostics,
-                priority, shouldIncludeDiagnostic, cancellationToken).ConfigureAwait(false);
+                priority, shouldIncludeDiagnostic, diagnosticKinds, cancellationToken).ConfigureAwait(false);
             return await getter.TryGetAsync(result, cancellationToken).ConfigureAwait(false);
         }
 
@@ -41,12 +41,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             CodeActionRequestPriority priority,
             bool blockForData,
             Func<string, IDisposable?>? addOperationScope,
+            DiagnosticKinds diagnosticKinds,
             CancellationToken cancellationToken)
         {
             using var _ = ArrayBuilder<DiagnosticData>.GetInstance(out var list);
             var result = await TryAppendDiagnosticsForSpanAsync(
                 document, range, list, shouldIncludeDiagnostic, includeSuppressedDiagnostics, includeCompilerDiagnostics,
-                priority, blockForData, addOperationScope, cancellationToken).ConfigureAwait(false);
+                priority, blockForData, addOperationScope, diagnosticKinds, cancellationToken).ConfigureAwait(false);
             Debug.Assert(result);
             return list.ToImmutable();
         }
@@ -77,6 +78,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             private readonly Func<string, IDisposable?>? _addOperationScope;
             private readonly bool _cacheFullDocumentDiagnostics;
             private readonly bool _logPerformanceInfo;
+            private readonly DiagnosticKinds _diagnosticKinds;
 
             private delegate Task<IEnumerable<DiagnosticData>> DiagnosticsGetterAsync(DiagnosticAnalyzer analyzer, DocumentAnalysisExecutor executor, CancellationToken cancellationToken);
 
@@ -90,6 +92,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                  bool includeCompilerDiagnostics,
                  CodeActionRequestPriority priority,
                  Func<string, bool>? shouldIncludeDiagnostic,
+                 DiagnosticKinds diagnosticKinds,
                  CancellationToken cancellationToken)
             {
                 var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
@@ -111,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 return new LatestDiagnosticsForSpanGetter(
                     owner, compilationWithAnalyzers, document, text, stateSets, shouldIncludeDiagnostic, includeCompilerDiagnostics,
-                    range, blockForData, addOperationScope, includeSuppressedDiagnostics, priority, cacheFullDocumentDiagnostics, logPerformanceInfo);
+                    range, blockForData, addOperationScope, includeSuppressedDiagnostics, priority, cacheFullDocumentDiagnostics, logPerformanceInfo, diagnosticKinds);
             }
 
             private static async Task<CompilationWithAnalyzers?> GetOrCreateCompilationWithAnalyzersAsync(
@@ -154,7 +157,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 bool includeSuppressedDiagnostics,
                 CodeActionRequestPriority priority,
                 bool cacheFullDocumentDiagnostics,
-                bool logPerformanceInfo)
+                bool logPerformanceInfo,
+                DiagnosticKinds diagnosticKinds)
             {
                 _owner = owner;
                 _compilationWithAnalyzers = compilationWithAnalyzers;
@@ -170,6 +174,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 _priority = priority;
                 _cacheFullDocumentDiagnostics = cacheFullDocumentDiagnostics;
                 _logPerformanceInfo = logPerformanceInfo;
+                _diagnosticKinds = diagnosticKinds;
             }
 
             public async Task<bool> TryGetAsync(ArrayBuilder<DiagnosticData> list, CancellationToken cancellationToken)
@@ -182,15 +187,19 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     using var _1 = ArrayBuilder<StateSet>.GetInstance(out var syntaxAnalyzers);
                     using var _2 = ArrayBuilder<StateSet>.GetInstance(out var semanticSpanBasedAnalyzers);
                     using var _3 = ArrayBuilder<StateSet>.GetInstance(out var semanticDocumentBasedAnalyzers);
+                    var seenCompilerAnalyzer = false;
                     foreach (var stateSet in _stateSets)
                     {
                         if (!ShouldIncludeAnalyzer(stateSet.Analyzer, _shouldIncludeDiagnostic, _owner))
                             continue;
 
-                        if (!await TryAddCachedDocumentDiagnosticsAsync(stateSet, AnalysisKind.Syntax, list, cancellationToken).ConfigureAwait(false))
+                        var (includeSyntax, includeSemantic) = ProcessDiagnosticKinds(stateSet.Analyzer, _diagnosticKinds, ref seenCompilerAnalyzer);
+
+                        if (includeSyntax && !await TryAddCachedDocumentDiagnosticsAsync(stateSet, AnalysisKind.Syntax, list, cancellationToken).ConfigureAwait(false))
                             syntaxAnalyzers.Add(stateSet);
 
-                        if (_document is Document &&
+                        if (includeSemantic &&
+                            _document is Document &&
                             !await TryAddCachedDocumentDiagnosticsAsync(stateSet, AnalysisKind.Semantic, list, cancellationToken).ConfigureAwait(false))
                         {
                             // Check whether we want up-to-date document wide semantic diagnostics
@@ -243,6 +252,37 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     }
 
                     return true;
+                }
+
+                static (bool includeSyntax, bool includeSemantic) ProcessDiagnosticKinds(
+                    DiagnosticAnalyzer analyzer,
+                    DiagnosticKinds diagnosticKinds,
+                    ref bool seenCompilerAnalyzer)
+                {
+                    if (diagnosticKinds == DiagnosticKinds.All)
+                    {
+                        return (true, true);
+                    }
+
+                    bool isCompilerAnalyzer;
+                    if (seenCompilerAnalyzer)
+                    {
+                        Debug.Assert(!analyzer.IsCompilerAnalyzer(), "Unexpected duplicate compiler analyzer instances");
+                        isCompilerAnalyzer = false;
+                    }
+                    else
+                    {
+                        isCompilerAnalyzer = analyzer.IsCompilerAnalyzer();
+                        seenCompilerAnalyzer = isCompilerAnalyzer;
+                    }
+
+                    var includeSyntax = isCompilerAnalyzer
+                        ? (diagnosticKinds & DiagnosticKinds.CompilerSyntax) != 0
+                        : (diagnosticKinds & DiagnosticKinds.AnalyzerSyntax) != 0;
+                    var includeSemantic = isCompilerAnalyzer
+                        ? (diagnosticKinds & DiagnosticKinds.CompilerSemantic) != 0
+                        : (diagnosticKinds & DiagnosticKinds.AnalyzerSemantic) != 0;
+                    return (includeSyntax, includeSemantic);
                 }
             }
 

--- a/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/ExternalDiagnosticUpdateSourceTests.vb
@@ -667,7 +667,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Public Sub Reanalyze(workspace As Workspace, Optional projectIds As IEnumerable(Of ProjectId) = Nothing, Optional documentIds As IEnumerable(Of DocumentId) = Nothing, Optional highPriority As Boolean = False) Implements IDiagnosticAnalyzerService.Reanalyze
             End Sub
 
-            Public Function GetDiagnosticsForSpanAsync(document As TextDocument, range As TextSpan?, shouldIncludeDiagnostic As Func(Of String, Boolean), includeCompilerDiagnostics As Boolean, Optional includeSuppressedDiagnostics As Boolean = False, Optional priority As CodeActionRequestPriority = CodeActionRequestPriority.None, Optional addOperationScope As Func(Of String, IDisposable) = Nothing, Optional cancellationToken As CancellationToken = Nothing) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
+            Public Function GetDiagnosticsForSpanAsync(document As TextDocument, range As TextSpan?, shouldIncludeDiagnostic As Func(Of String, Boolean), includeCompilerDiagnostics As Boolean, Optional includeSuppressedDiagnostics As Boolean = False, Optional priority As CodeActionRequestPriority = CodeActionRequestPriority.None, Optional addOperationScope As Func(Of String, IDisposable) = Nothing, Optional diagnosticKinds As DiagnosticKinds = DiagnosticKinds.All, Optional cancellationToken As CancellationToken = Nothing) As Task(Of ImmutableArray(Of DiagnosticData)) Implements IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync
                 Return SpecializedTasks.EmptyImmutableArray(Of DiagnosticData)
             End Function
 
@@ -699,7 +699,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
                 Throw New NotImplementedException()
             End Function
 
-            Public Function TryGetDiagnosticsForSpanAsync(document As TextDocument, range As TextSpan, shouldIncludeDiagnostic As Func(Of String, Boolean), Optional includeSuppressedDiagnostics As Boolean = False, Optional priority As CodeActionRequestPriority = CodeActionRequestPriority.None, Optional cancellationToken As CancellationToken = Nothing) As Task(Of (diagnostics As ImmutableArray(Of DiagnosticData), upToDate As Boolean)) Implements IDiagnosticAnalyzerService.TryGetDiagnosticsForSpanAsync
+            Public Function TryGetDiagnosticsForSpanAsync(document As TextDocument, range As TextSpan, shouldIncludeDiagnostic As Func(Of String, Boolean), Optional includeSuppressedDiagnostics As Boolean = False, Optional priority As CodeActionRequestPriority = CodeActionRequestPriority.None, Optional diagnosticKinds As DiagnosticKinds = DiagnosticKinds.All, Optional cancellationToken As CancellationToken = Nothing) As Task(Of (diagnostics As ImmutableArray(Of DiagnosticData), upToDate As Boolean)) Implements IDiagnosticAnalyzerService.TryGetDiagnosticsForSpanAsync
                 Return Task.FromResult((ImmutableArray(Of DiagnosticData).Empty, False))
             End Function
         End Class


### PR DESCRIPTION
The span based APIs `IDiagnosticAnalyzerService.GetDiagnosticsForSpanAsync` and `IDiagnosticAnalyzerService.TryGetDiagnosticsForSpanAsync` can now request more fine grained diagnostics: compiler syntax, compiler semantic, analyzer syntax, analyzer semantic or any combination of these.

Required by #65547 to move our taggers to LSP pull diagnostics