### PR TITLE
Compress indices before storing in persistence service

### DIFF
--- a/src/Tools/IdeCoreBenchmarks/NavigateToBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/NavigateToBenchmarks.cs
@@ -163,7 +163,12 @@ namespace IdeCoreBenchmarks
                 Console.WriteLine("Successfully got persistent storage instance");
                 var start = DateTime.Now;
                 var tasks = _workspace.CurrentSolution.Projects.SelectMany(p => p.Documents).Select(d => Task.Run(
-                    async () => await SyntaxTreeIndex.GetIndexAsync(d, default))).ToList();
+                    async () =>
+                    {
+                        // var tree = await d.GetSyntaxRootAsync();
+                        await TopLevelSyntaxTreeIndex.GetIndexAsync(d, default);
+                        await SyntaxTreeIndex.GetIndexAsync(d, default);
+                    })).ToList();
                 await Task.WhenAll(tasks);
                 Console.WriteLine("Solution parallel: " + (DateTime.Now - start));
             }

--- a/src/Tools/IdeCoreBenchmarks/NavigateToBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/NavigateToBenchmarks.cs
@@ -24,6 +24,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.CodeAnalysis.NavigateTo;
 using Microsoft.CodeAnalysis.Storage;
+using Roslyn.Utilities;
 
 namespace IdeCoreBenchmarks
 {
@@ -162,14 +163,18 @@ namespace IdeCoreBenchmarks
             {
                 Console.WriteLine("Successfully got persistent storage instance");
                 var start = DateTime.Now;
+                var indexTime = TimeSpan.Zero;
                 var tasks = _workspace.CurrentSolution.Projects.SelectMany(p => p.Documents).Select(d => Task.Run(
                     async () =>
                     {
-                        // var tree = await d.GetSyntaxRootAsync();
+                        var tree = await d.GetSyntaxRootAsync();
+                        var stopwatch = SharedStopwatch.StartNew();
                         await TopLevelSyntaxTreeIndex.GetIndexAsync(d, default);
                         await SyntaxTreeIndex.GetIndexAsync(d, default);
+                        indexTime += stopwatch.Elapsed;
                     })).ToList();
                 await Task.WhenAll(tasks);
+                Console.WriteLine("Indexing time    : " + indexTime);
                 Console.WriteLine("Solution parallel: " + (DateTime.Now - start));
             }
             Console.WriteLine("DB flushed");

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO.Compression;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -65,6 +66,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
                 // attempt to load from persisted state
                 using var stream = await storage.ReadStreamAsync(documentKey, s_persistenceName, checksum, cancellationToken).ConfigureAwait(false);
+                using var gzipStream = new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true);
                 using var reader = ObjectReader.TryGetReader(stream, cancellationToken: cancellationToken);
                 if (reader != null)
                     return read(stringTable, reader, checksum);
@@ -127,15 +129,19 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             {
                 var storage = await persistentStorageService.GetStorageAsync(SolutionKey.ToSolutionKey(solution), cancellationToken).ConfigureAwait(false);
                 await using var _ = storage.ConfigureAwait(false);
-                using var stream = SerializableBytes.CreateWritableStream();
 
-                using (var writer = new ObjectWriter(stream, leaveOpen: true, cancellationToken))
+                using (var stream = SerializableBytes.CreateWritableStream())
                 {
-                    WriteTo(writer);
-                }
+                    using (var gzipStream = new GZipStream(stream, CompressionLevel.Optimal, leaveOpen: true))
+                    using (var writer = new ObjectWriter(gzipStream, leaveOpen: true, cancellationToken))
+                    {
+                        WriteTo(writer);
+                        gzipStream.Flush();
+                    }
 
-                stream.Position = 0;
-                return await storage.WriteStreamAsync(document, s_persistenceName, stream, this.Checksum, cancellationToken).ConfigureAwait(false);
+                    stream.Position = 0;
+                    return await storage.WriteStreamAsync(document, s_persistenceName, stream, this.Checksum, cancellationToken).ConfigureAwait(false);
+                }
             }
             catch (Exception e) when (IOUtilities.IsNormalIOException(e))
             {

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal partial class AbstractSyntaxIndex<TIndex> : IObjectWritable
     {
         private static readonly string s_persistenceName = typeof(TIndex).Name;
-        private static readonly Checksum s_serializationFormatChecksum = Checksum.Create("34");
+        private static readonly Checksum s_serializationFormatChecksum = Checksum.Create("35");
 
         /// <summary>
         /// Cache of ParseOptions to a checksum for the <see cref="ParseOptions.PreprocessorSymbolNames"/> contained

--- a/src/Workspaces/Core/Portable/Shared/Utilities/IOUtilities.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/IOUtilities.cs
@@ -55,7 +55,8 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                    ArgumentException or
                    UnauthorizedAccessException or
                    NotSupportedException or
-                   InvalidOperationException;
+                   InvalidOperationException or
+                   InvalidDataException;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorageConstants.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorageConstants.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
-using Microsoft.CodeAnalysis.Storage;
-
 namespace Microsoft.CodeAnalysis.SQLite.v2
 {
     internal static class SQLitePersistentStorageConstants
@@ -15,10 +12,13 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
         //    and validating checksums without the overhead of reading the full 'value' into
         //    memory.
         // 3. Use an in-memory DB to cache writes before flushing to disk.
-        // 4. Store checksums directly inline (i.e. 20 bytes), instead of usign ObjectWriter serialization (which adds
+        // 4. Store checksums directly inline (i.e. 20 bytes), instead of using ObjectWriter serialization (which adds
         //    more data to the checksum).
         // 5. Use individual columns for primary keys.
-        private const string Version = "5";
+        // 6. Use compression in some features.  Need to move to a different table since the blob
+        //    format will be different and we don't want different VS versions (that do/don't support
+        //    compression constantly stomping on each other.
+        private const string Version = "6";
 
         /// <summary>
         /// Inside the DB we have a table dedicated to storing strings that also provides a unique


### PR DESCRIPTION
Saves 50% of the space on disk (34MB instead of 67MB for initial roslyn nav-to and find-refs  indices), and adds no additional time to compute all that information.