### PR TITLE
Move "Unseal class" codefix to VerifyCS

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/UnsealClass/CSharpUnsealClassCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UnsealClass/CSharpUnsealClassCodeFixProvider.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.UnsealClass;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnsealClass
@@ -18,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnsealClass
         private const string CS0509 = nameof(CS0509); // 'D': cannot derive from sealed type 'C'
 
         [ImportingConstructor]
-        [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CSharpUnsealClassCodeFixProvider()
         {
         }

--- a/src/Analyzers/Core/CodeFixes/UnsealClass/AbstractUnsealClassCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/UnsealClass/AbstractUnsealClassCodeFixProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Linq;
@@ -22,7 +20,7 @@ namespace Microsoft.CodeAnalysis.UnsealClass
     {
         protected abstract string TitleFormat { get; }
 
-        public override FixAllProvider GetFixAllProvider()
+        public override FixAllProvider? GetFixAllProvider()
         {
             // This code fix addresses a very specific compiler error. It's unlikely there will be more than 1 of them at a time.
             return null;
@@ -33,8 +31,8 @@ namespace Microsoft.CodeAnalysis.UnsealClass
             var document = context.Document;
             var cancellationToken = context.CancellationToken;
 
-            var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var syntaxRoot = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
             var node = syntaxRoot.FindNode(context.Span, getInnermostNodeForTie: true);
 
@@ -43,7 +41,7 @@ namespace Microsoft.CodeAnalysis.UnsealClass
             {
                 var definition = await SymbolFinder.FindSourceDefinitionAsync(
                     type, document.Project.Solution, cancellationToken).ConfigureAwait(false);
-                if (definition != null && definition.DeclaringSyntaxReferences.Length > 0)
+                if (definition is not null && definition.DeclaringSyntaxReferences.Length > 0)
                 {
                     var title = string.Format(TitleFormat, type.Name);
                     context.RegisterCodeFix(
@@ -60,10 +58,10 @@ namespace Microsoft.CodeAnalysis.UnsealClass
             Solution solution, ImmutableArray<SyntaxReference> declarationReferences, CancellationToken cancellationToken)
         {
             foreach (var (documentId, syntaxReferences) in
-                declarationReferences.GroupBy(reference => solution.GetDocumentId(reference.SyntaxTree)))
+                declarationReferences.GroupBy(reference => solution.GetDocumentId(reference.SyntaxTree)!))
             {
-                var document = solution.GetDocument(documentId);
-                var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                var document = solution.GetRequiredDocument(documentId);
+                var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
                 var editor = new SyntaxEditor(root, document.Project.Solution.Services);
                 var generator = editor.Generator;


### PR DESCRIPTION
- Moved `Unseal class` to `VerifyCS` test model
- Enabled nullable in the codefix itself