### PR TITLE
Use ILegacyDocumentOptionsProvider if it is available

### DIFF
--- a/src/EditorFeatures/Core/Options/TextBufferOptionProviders.cs
+++ b/src/EditorFeatures/Core/Options/TextBufferOptionProviders.cs
@@ -46,9 +46,17 @@ internal static class TextBufferOptionProviders
     public static SyntaxFormattingOptions GetSyntaxFormattingOptions(this ITextBuffer textBuffer, EditorOptionsService optionsProvider, LanguageServices languageServices, bool explicitFormat)
         => GetSyntaxFormattingOptionsImpl(textBuffer, optionsProvider.Factory.GetOptions(textBuffer), optionsProvider.IndentationManager, optionsProvider.GlobalOptions, languageServices, explicitFormat);
 
+    public static SyntaxFormattingOptions GetSyntaxFormattingOptions(this ITextBuffer textBuffer, AnalyzerConfigOptions configOptions, EditorOptionsService optionsProvider, LanguageServices languageServices, bool explicitFormat)
+        => GetSyntaxFormattingOptionsImpl(textBuffer, configOptions, optionsProvider.Factory.GetOptions(textBuffer), optionsProvider.IndentationManager, optionsProvider.GlobalOptions, languageServices, explicitFormat);
+
     private static SyntaxFormattingOptions GetSyntaxFormattingOptionsImpl(ITextBuffer textBuffer, IEditorOptions editorOptions, IIndentationManagerService indentationManager, IGlobalOptionService globalOptions, LanguageServices languageServices, bool explicitFormat)
     {
         var configOptions = new EditorAnalyzerConfigOptions(editorOptions);
+        return GetSyntaxFormattingOptionsImpl(textBuffer, configOptions, editorOptions, indentationManager, globalOptions, languageServices, explicitFormat);
+    }
+
+    private static SyntaxFormattingOptions GetSyntaxFormattingOptionsImpl(ITextBuffer textBuffer, AnalyzerConfigOptions configOptions, IEditorOptions editorOptions, IIndentationManagerService indentationManager, IGlobalOptionService globalOptions, LanguageServices languageServices, bool explicitFormat)
+    {
         var fallbackOptions = globalOptions.GetSyntaxFormattingOptions(languageServices);
         var options = configOptions.GetSyntaxFormattingOptions(fallbackOptions, languageServices);
         var lineFormattingOptions = GetLineFormattingOptionsImpl(textBuffer, editorOptions, indentationManager, explicitFormat);


### PR DESCRIPTION
## Problem
Visual Studio for Mac was using the `ILegacyDocumentOptionsProvider` to provide editor config options when formatting a document.

It seems in the recent rewrite of the `CSharpFormattingInteractionService` it stopped calling this interface meaning that Visual Studio for Mac was just using the default options every time.

## Solution
Check for the presense of the `ILegacyDocumentOptionsProvider` and call it if it exists, otherwise, call the non-legacy methods.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1591730 Fixes https://developercommunity.visualstudio.com/t/C-NewLine-Formatting-Settings-Not-Worki/10118551