### PR TITLE
Bump mac editor and implement CocoaTextBufferVisibilityTracker

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -28,7 +28,7 @@
     <VisualStudioEditorPackagesVersion>17.4.249</VisualStudioEditorPackagesVersion>
     <!-- This should generally be set to $(VisualStudioEditorPackagesVersion),
          but sometimes EditorFeatures.Cocoa specifically requires a newer editor build. -->
-    <VisualStudioMacEditorPackagesVersion>17.3.133-preview</VisualStudioMacEditorPackagesVersion>
+    <VisualStudioMacEditorPackagesVersion>17.4.265</VisualStudioMacEditorPackagesVersion>
     <ILAsmPackageVersion>5.0.0-alpha1.19409.1</ILAsmPackageVersion>
     <ILDAsmPackageVersion>5.0.0-preview.1.20112.8</ILDAsmPackageVersion>
     <MicrosoftVisualStudioLanguageServerClientPackagesVersion>17.3.3101</MicrosoftVisualStudioLanguageServerClientPackagesVersion>

--- a/src/EditorFeatures/Core.Cocoa/Workspaces/CocoaTextBufferVisibilityTracker.cs
+++ b/src/EditorFeatures/Core.Cocoa/Workspaces/CocoaTextBufferVisibilityTracker.cs
@@ -1,0 +1,225 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.CodeAnalysis.Editor;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Workspaces
+{
+    [Export(typeof(ITextBufferVisibilityTracker))]
+    internal sealed class CocoaTextBufferVisibilityTracker : ITextBufferVisibilityTracker
+    {
+        private readonly ITextBufferAssociatedViewService _associatedViewService;
+        private readonly IThreadingContext _threadingContext;
+
+        private readonly Dictionary<ITextBuffer, VisibleTrackerData> _subjectBufferToCallbacks = new();
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public CocoaTextBufferVisibilityTracker(
+            ITextBufferAssociatedViewService associatedViewService,
+            IThreadingContext threadingContext)
+        {
+            _associatedViewService = associatedViewService;
+            _threadingContext = threadingContext;
+
+            associatedViewService.SubjectBuffersConnected += AssociatedViewService_SubjectBuffersConnected;
+            associatedViewService.SubjectBuffersDisconnected += AssociatedViewService_SubjectBuffersDisconnected;
+        }
+
+        private void AssociatedViewService_SubjectBuffersConnected(object sender, SubjectBuffersConnectedEventArgs e)
+        {
+            _threadingContext.ThrowIfNotOnUIThread();
+            UpdateAllAssociatedViews(e.SubjectBuffers);
+        }
+
+        private void AssociatedViewService_SubjectBuffersDisconnected(object sender, SubjectBuffersConnectedEventArgs e)
+        {
+            _threadingContext.ThrowIfNotOnUIThread();
+            UpdateAllAssociatedViews(e.SubjectBuffers);
+        }
+
+        private void UpdateAllAssociatedViews(ReadOnlyCollection<ITextBuffer> subjectBuffers)
+        {
+            // Whenever views get attached/detached from buffers, make sure we're hooked up to the appropriate events
+            // for them.
+            foreach (var buffer in subjectBuffers)
+            {
+                if (_subjectBufferToCallbacks.TryGetValue(buffer, out var data))
+                    data.UpdateAssociatedViews();
+            }
+        }
+
+        public bool IsVisible(ITextBuffer subjectBuffer)
+        {
+            _threadingContext.ThrowIfNotOnUIThread();
+
+            var views = _associatedViewService.GetAssociatedTextViews(subjectBuffer).ToImmutableArrayOrEmpty();
+
+            // If we don't have any views at all, then assume the buffer is visible.
+            if (views.Length == 0)
+                return true;
+
+            // if any of the views were *not* cocoa text views, assume the buffer is visible.  We don't know how to
+            // determine the visibility of this buffer.  While unlikely to happen, this is possible with VS's
+            // extensibility model, which allows for a plugin to host an ITextBuffer in their own impl of an ITextView.
+            // For those cases, just assume these buffers are visible.
+            if (views.Any(static v => v is not ICocoaTextView))
+                return true;
+
+            return views.OfType<ICocoaTextView>().Any(v => v.IsVisible);
+        }
+
+        public void RegisterForVisibilityChanges(ITextBuffer subjectBuffer, Action callback)
+        {
+            _threadingContext.ThrowIfNotOnUIThread();
+            if (!_subjectBufferToCallbacks.TryGetValue(subjectBuffer, out var data))
+            {
+                data = new VisibleTrackerData(this, subjectBuffer);
+                _subjectBufferToCallbacks.Add(subjectBuffer, data);
+            }
+
+            data.AddCallback(callback);
+        }
+
+        public void UnregisterForVisibilityChanges(ITextBuffer subjectBuffer, Action callback)
+        {
+            _threadingContext.ThrowIfNotOnUIThread();
+
+            // Both of these methods must succeed.  Otherwise we're somehow unregistering something we don't know about.
+            Contract.ThrowIfFalse(_subjectBufferToCallbacks.TryGetValue(subjectBuffer, out var data));
+            Contract.ThrowIfFalse(data.Callbacks.Contains(callback));
+            data.RemoveCallback(callback);
+
+            // If we have nothing that wants to listen to information about this buffer anymore, then disconnect it
+            // from all events and remove our map.
+            if (data.Callbacks.Count == 0)
+            {
+                data.Dispose();
+                _subjectBufferToCallbacks.Remove(subjectBuffer);
+            }
+        }
+
+        public TestAccessor GetTestAccessor()
+            => new TestAccessor(this);
+
+        public readonly struct TestAccessor
+        {
+            private readonly CocoaTextBufferVisibilityTracker _visibilityTracker;
+
+            public TestAccessor(CocoaTextBufferVisibilityTracker visibilityTracker)
+            {
+                _visibilityTracker = visibilityTracker;
+            }
+
+            public void TriggerCallbacks(ITextBuffer subjectBuffer)
+            {
+                var data = _visibilityTracker._subjectBufferToCallbacks[subjectBuffer];
+                data.TriggerCallbacks();
+            }
+        }
+
+        private sealed class VisibleTrackerData : IDisposable
+        {
+            public readonly HashSet<ITextView> TextViews = new();
+
+            private readonly CocoaTextBufferVisibilityTracker _tracker;
+            private readonly ITextBuffer _subjectBuffer;
+
+            /// <summary>
+            /// The callbacks that want to be notified when our <see cref="TextViews"/> change visibility.  Stored as an
+            /// <see cref="ImmutableHashSet{T}"/> so we can enumerate it safely without it changing underneath us.
+            /// </summary>
+            public ImmutableHashSet<Action> Callbacks { get; private set; } = ImmutableHashSet<Action>.Empty;
+
+            public VisibleTrackerData(
+                CocoaTextBufferVisibilityTracker tracker,
+                ITextBuffer subjectBuffer)
+            {
+                _tracker = tracker;
+                _subjectBuffer = subjectBuffer;
+                UpdateAssociatedViews();
+            }
+
+            public void Dispose()
+            {
+                _tracker._threadingContext.ThrowIfNotOnUIThread();
+
+                // Shouldn't be disposing of this if we still have clients that want to hear about visibility changes.
+                Contract.ThrowIfTrue(Callbacks.Count > 0);
+
+                // Clear out all our textviews.  This will disconnect us from any events we have registered with them.
+                UpdateTextViews(Array.Empty<ITextView>());
+
+                Contract.ThrowIfTrue(TextViews.Count > 0);
+            }
+
+            public void AddCallback(Action callback)
+            {
+                _tracker._threadingContext.ThrowIfNotOnUIThread();
+                this.Callbacks = this.Callbacks.Add(callback);
+            }
+
+            public void RemoveCallback(Action callback)
+            {
+                _tracker._threadingContext.ThrowIfNotOnUIThread();
+                this.Callbacks = this.Callbacks.Remove(callback);
+            }
+
+            public void UpdateAssociatedViews()
+            {
+                _tracker._threadingContext.ThrowIfNotOnUIThread();
+
+                // Update us to whatever the currently associated text views are for this buffer.
+                UpdateTextViews(_tracker._associatedViewService.GetAssociatedTextViews(_subjectBuffer));
+            }
+
+            private void UpdateTextViews(IEnumerable<ITextView> associatedTextViews)
+            {
+                var removedViews = TextViews.Except(associatedTextViews);
+                var addedViews = associatedTextViews.Except(TextViews);
+
+                // Disconnect from hearing about visibility changes for any views we're no longer associated with.
+                foreach (var removedView in removedViews)
+                {
+                    if (removedView is ICocoaTextView removedCocoaView)
+                        removedCocoaView.IsVisibleChanged -= VisualElement_IsVisibleChanged;
+                }
+
+                // Connect to hearing about visbility changes for any views we are associated with.
+                foreach (var addedView in addedViews)
+                {
+                    if (addedView is ICocoaTextView addedCocoaView)
+                        addedCocoaView.IsVisibleChanged += VisualElement_IsVisibleChanged;
+                }
+
+                TextViews.Clear();
+                TextViews.AddRange(associatedTextViews);
+            }
+
+            private void VisualElement_IsVisibleChanged(object sender, EventArgs e)
+            {
+                TriggerCallbacks();
+            }
+
+            internal void TriggerCallbacks()
+            {
+                _tracker._threadingContext.ThrowIfNotOnUIThread();
+                foreach (var callback in Callbacks)
+                    callback();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This should help reduce the number classification marks triggering in the editor in VSMac.

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1689011

Backport of https://github.com/dotnet/roslyn/pull/65568 without the refactoring.