### PR TITLE
Bulk read in all the strings-id pairs in the DB.

### DIFF
--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.cs
@@ -190,8 +190,6 @@ $@"create unique index if not exists ""{StringInfoTableName}_{DataColumnName}"" 
             EnsureTables(connection, Database.Main);
             EnsureTables(connection, Database.WriteCache);
 
-            LoadExistingStringIds(connection);
-
             return;
 
             void EnsureTables(SqlConnection connection, Database database)

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.cs
@@ -45,6 +45,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
 
         private readonly string _insert_into_string_table_values_0 = $"insert into {StringInfoTableName}({DataColumnName}) values (?)";
         private readonly string _select_star_from_string_table_where_0_limit_one = $"select * from {StringInfoTableName} where ({DataColumnName} = ?) limit 1";
+        private readonly string _select_star_from_string_table = $"select * from {StringInfoTableName}";
 
         private SQLitePersistentStorage(
             SQLiteConnectionPoolService connectionPoolService,
@@ -188,6 +189,8 @@ $@"create unique index if not exists ""{StringInfoTableName}_{DataColumnName}"" 
             // the same shape.
             EnsureTables(connection, Database.Main);
             EnsureTables(connection, Database.WriteCache);
+
+            LoadExistingStringIds(connection);
 
             return;
 

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.cs
@@ -45,6 +45,7 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
 
         private readonly string _insert_into_string_table_values_0 = $"insert into {StringInfoTableName}({DataColumnName}) values (?)";
         private readonly string _select_star_from_string_table_where_0_limit_one = $"select * from {StringInfoTableName} where ({DataColumnName} = ?) limit 1";
+        private readonly string _select_star_from_string_table = $"select * from {StringInfoTableName}";
 
         private SQLitePersistentStorage(
             SQLiteConnectionPoolService connectionPoolService,

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.cs
@@ -190,6 +190,10 @@ $@"create unique index if not exists ""{StringInfoTableName}_{DataColumnName}"" 
             EnsureTables(connection, Database.Main);
             EnsureTables(connection, Database.WriteCache);
 
+            // Bulk load all the existing string/id pairs in the DB at once.  In a solution like roslyn, there are
+            // roughly 20k of these strings.  Doing it as 20k individual reads adds more than a second of work time
+            // reading in all the data.  This allows for a single query that can efficiently have the DB just stream the
+            // pages from disk and bulk read those in the cursor the query uses.
             LoadExistingStringIds(connection);
 
             return;

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage.cs
@@ -190,6 +190,8 @@ $@"create unique index if not exists ""{StringInfoTableName}_{DataColumnName}"" 
             EnsureTables(connection, Database.Main);
             EnsureTables(connection, Database.WriteCache);
 
+            LoadExistingStringIds(connection);
+
             return;
 
             void EnsureTables(SqlConnection connection, Database database)

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_StringIds.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_StringIds.cs
@@ -170,5 +170,29 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             // So how could we then not find the string in the table?
             throw new InvalidOperationException();
         }
+
+        private void LoadExistingStringIds(SqlConnection connection)
+        {
+            try
+            {
+                using var resettableStatement = connection.GetResettableStatement(_select_star_from_string_table);
+                var statement = resettableStatement.Statement;
+
+                Result stepResult;
+                while ((stepResult = statement.Step()) == Result.ROW)
+                {
+                    var id = statement.GetInt32At(columnIndex: 0);
+                    var value = statement.GetStringAt(columnIndex: 1);
+                    _stringToIdMap.TryAdd(value, id);
+                }
+            }
+            catch (Exception ex)
+            {
+                // If we simply failed to even talk to the DB then we have to bail out.  There's
+                // nothing we can accomplish at this point.
+                StorageDatabaseLogger.LogException(ex);
+                return;
+            }
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_StringIds.cs
+++ b/src/Workspaces/Core/Portable/Storage/SQLite/v2/SQLitePersistentStorage_StringIds.cs
@@ -170,29 +170,5 @@ namespace Microsoft.CodeAnalysis.SQLite.v2
             // So how could we then not find the string in the table?
             throw new InvalidOperationException();
         }
-
-        private void LoadExistingStringIds(SqlConnection connection)
-        {
-            try
-            {
-                using var resettableStatement = connection.GetResettableStatement(_select_star_from_string_table);
-                var statement = resettableStatement.Statement;
-
-                Result stepResult;
-                while ((stepResult = statement.Step()) == Result.ROW)
-                {
-                    var id = statement.GetInt32At(columnIndex: 0);
-                    var value = statement.GetStringAt(columnIndex: 1);
-                    _stringToIdMap.TryAdd(value, id);
-                }
-            }
-            catch (Exception ex)
-            {
-                // If we simply failed to even talk to the DB then we have to bail out.  There's
-                // nothing we can accomplish at this point.
-                StorageDatabaseLogger.LogException(ex);
-                return;
-            }
-        }
     }
 }


### PR DESCRIPTION
Followup to https://github.com/dotnet/roslyn/pull/65646.

This saves time on initial DB load by replacing N chatty reads with one single streaming cursor. In perf testing this saves about a second, which is nice to have the DB data ready as soon as possible after VS load.