### PR TITLE
Add Rename In File Telemetry

### DIFF
--- a/src/EditorFeatures/Core/InlineRename/RenameLogMessage.cs
+++ b/src/EditorFeatures/Core/InlineRename/RenameLogMessage.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         private const string RenameInComments = nameof(RenameInComments);
         private const string RenameInStrings = nameof(RenameInStrings);
         private const string RenameOverloads = nameof(RenameOverloads);
+        private const string RenameFile = nameof(RenameFile);
 
         private const string Committed = nameof(Committed);
         private const string Canceled = nameof(Canceled);
@@ -38,6 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 m[RenameInComments] = options.RenameInComments;
                 m[RenameInStrings] = options.RenameInStrings;
                 m[RenameOverloads] = options.RenameOverloads;
+                m[RenameFile] = options.RenameFile;
 
                 m[Committed] = (outcome & UserActionOutcome.Committed) == UserActionOutcome.Committed;
                 m[Canceled] = (outcome & UserActionOutcome.Canceled) == UserActionOutcome.Canceled;


### PR DESCRIPTION
Found while investigating numbers that this option was missing from telemetry.

![image](https://user-images.githubusercontent.com/475144/204656069-de1b973d-824e-473f-8493-80e968293d4e.png)

