### PR TITLE
Switch to having the IFileChangeWatcher return IDisposable tokens

### DIFF
--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProject.BatchingDocumentCollection.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProject.BatchingDocumentCollection.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     _orderedDocumentsInBatch = _orderedDocumentsInBatch?.Add(documentId);
 
                     _documentPathsToDocumentIds.Add(fullPath, documentId);
-                    _project._documentFileWatchingTokens.Add(documentId, _project._documentFileChangeContext.EnqueueWatchingFile(fullPath));
+                    _project._documentWatchedFiles.Add(documentId, _project._documentFileChangeContext.EnqueueWatchingFile(fullPath));
 
                     if (_project._activeBatchScopes > 0)
                     {
@@ -266,8 +266,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                         throw new ArgumentException($"'{fullPath}' is not a source file of this project.");
                     }
 
-                    _project._documentFileChangeContext.StopWatchingFile(_project._documentFileWatchingTokens[documentId]);
-                    _project._documentFileWatchingTokens.Remove(documentId);
+                    _project._documentWatchedFiles[documentId].Dispose();
+                    _project._documentWatchedFiles.Remove(documentId);
 
                     RemoveFileInternal(documentId, fullPath);
                 }

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProject.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// The file watching tokens for the documents in this project. We get the tokens even when we're in a batch, so the files here
         /// may not be in the actual workspace yet.
         /// </summary>
-        private readonly Dictionary<DocumentId, IFileWatchingToken> _documentFileWatchingTokens = new();
+        private readonly Dictionary<DocumentId, IWatchedFile> _documentWatchedFiles = new();
 
         /// <summary>
         /// A file change context used to watch source files, additional files, and analyzer config files for this project. It's automatically set to watch the user's project

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/FileWatchedPortableExecutableReferenceFactory.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.ProjectSystem
         /// File watching tokens from <see cref="_fileReferenceChangeContext"/> that are watching metadata references. These are only created once we are actually applying a batch because
         /// we don't determine until the batch is applied if the file reference will actually be a file reference or it'll be a converted project reference.
         /// </summary>
-        private readonly Dictionary<PortableExecutableReference, IFileWatchingToken> _metadataReferenceFileWatchingTokens = new();
+        private readonly Dictionary<PortableExecutableReference, IWatchedFile> _metadataReferenceFileWatchingTokens = new();
 
         /// <summary>
         /// <see cref="CancellationTokenSource"/>s for in-flight refreshing of metadata references. When we see a file change, we wait a bit before trying to actually
@@ -74,12 +74,12 @@ namespace Microsoft.CodeAnalysis.ProjectSystem
         {
             lock (_gate)
             {
-                if (!_metadataReferenceFileWatchingTokens.TryGetValue(reference, out var token))
+                if (!_metadataReferenceFileWatchingTokens.TryGetValue(reference, out var watchedFile))
                 {
                     throw new ArgumentException("The reference was already not being watched.");
                 }
 
-                _fileReferenceChangeContext.StopWatchingFile(token);
+                watchedFile.Dispose();
                 _metadataReferenceFileWatchingTokens.Remove(reference);
 
                 // Note we still potentially have an outstanding change that we haven't raised a notification

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IFileChangeWatcher.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IFileChangeWatcher.cs
@@ -66,15 +66,10 @@ namespace Microsoft.CodeAnalysis.ProjectSystem
         /// Starts watching a file but doesn't wait for the file watcher to be registered with the operating system. Good if you know
         /// you'll need a file watched (eventually) but it's not worth blocking yet.
         /// </summary>
-        IFileWatchingToken EnqueueWatchingFile(string filePath);
-
-        void StopWatchingFile(IFileWatchingToken token);
+        IWatchedFile EnqueueWatchingFile(string filePath);
     }
 
-    /// <summary>
-    /// A marker interface for tokens returned from <see cref="IFileChangeContext.EnqueueWatchingFile(string)"/>.
-    /// </summary>
-    public interface IFileWatchingToken
+    public interface IWatchedFile : IDisposable
     {
     }
 }


### PR DESCRIPTION
@CyrusNajmabadi had a good suggestion that rather than returning an interface to represent a watched file you had to hand back to the service, we could just make thta implement IDisposable instead. This cleans up the implementation a bit and makes the special placeholder more explicit.