### PR TITLE
Create DkmCustomUIVisualizerInfo instances with ExtensionPartId field

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -140,7 +140,7 @@
     <MicrosoftVisualStudioComponentModelHostVersion>17.4.248</MicrosoftVisualStudioComponentModelHostVersion>
     <MicrosoftVisualStudioCompositionVersion>16.9.20</MicrosoftVisualStudioCompositionVersion>
     <MicrosoftVisualStudioCoreUtilityVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioCoreUtilityVersion>
-    <MicrosoftVisualStudioDebuggerUIInterfacesVersion>17.5.1120201-preview</MicrosoftVisualStudioDebuggerUIInterfacesVersion>
+    <MicrosoftVisualStudioDebuggerUIInterfacesVersion>17.4.0-beta.22368.1</MicrosoftVisualStudioDebuggerUIInterfacesVersion>
     <MicrosoftVisualStudioDebuggerContractsVersion>17.4.0-beta.22368.1</MicrosoftVisualStudioDebuggerContractsVersion>
     <MicrosoftVisualStudioDebuggerEngineimplementationVersion>17.5.1120201-preview</MicrosoftVisualStudioDebuggerEngineimplementationVersion>
     <MicrosoftVisualStudioDebuggerMetadataimplementationVersion>17.5.1120201-preview</MicrosoftVisualStudioDebuggerMetadataimplementationVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -140,10 +140,10 @@
     <MicrosoftVisualStudioComponentModelHostVersion>17.4.248</MicrosoftVisualStudioComponentModelHostVersion>
     <MicrosoftVisualStudioCompositionVersion>16.9.20</MicrosoftVisualStudioCompositionVersion>
     <MicrosoftVisualStudioCoreUtilityVersion>$(VisualStudioEditorPackagesVersion)</MicrosoftVisualStudioCoreUtilityVersion>
-    <MicrosoftVisualStudioDebuggerUIInterfacesVersion>17.4.0-beta.22368.1</MicrosoftVisualStudioDebuggerUIInterfacesVersion>
+    <MicrosoftVisualStudioDebuggerUIInterfacesVersion>17.5.1120201-preview</MicrosoftVisualStudioDebuggerUIInterfacesVersion>
     <MicrosoftVisualStudioDebuggerContractsVersion>17.4.0-beta.22368.1</MicrosoftVisualStudioDebuggerContractsVersion>
-    <MicrosoftVisualStudioDebuggerEngineimplementationVersion>17.0.1042805-preview</MicrosoftVisualStudioDebuggerEngineimplementationVersion>
-    <MicrosoftVisualStudioDebuggerMetadataimplementationVersion>17.0.1042805-preview</MicrosoftVisualStudioDebuggerMetadataimplementationVersion>
+    <MicrosoftVisualStudioDebuggerEngineimplementationVersion>17.5.1120201-preview</MicrosoftVisualStudioDebuggerEngineimplementationVersion>
+    <MicrosoftVisualStudioDebuggerMetadataimplementationVersion>17.5.1120201-preview</MicrosoftVisualStudioDebuggerMetadataimplementationVersion>
     <MicrosoftVisualStudioDesignerInterfacesVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioDesignerInterfacesVersion>
     <MicrosoftVisualStudioDiagnosticsMeasurementVersion>17.0.0-preview-1-30928-1112</MicrosoftVisualStudioDiagnosticsMeasurementVersion>
     <MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerVisualizerAttributeTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/DebuggerVisualizerAttributeTests.cs
@@ -59,13 +59,15 @@ class Q
                     UISideVisualizerAssemblyName = typeP.Assembly.FullName,
                     UISideVisualizerAssemblyLocation = DkmClrCustomVisualizerAssemblyLocation.Unknown,
                     DebuggeeSideVisualizerTypeName = defaultDebuggeeSideVisualizerTypeName,
-                    DebuggeeSideVisualizerAssemblyName = defaultDebuggeeSideVisualizerAssemblyName},
+                    DebuggeeSideVisualizerAssemblyName = defaultDebuggeeSideVisualizerAssemblyName,
+                    ExtensionPartId = Guid.Empty},
                 new DkmCustomUIVisualizerInfo { Id = 1, Description = "Q Visualizer", MenuName = "Q Visualizer",  Metric = "ClrCustomVisualizerVSHost",
                     UISideVisualizerTypeName = typeQ.FullName,
                     UISideVisualizerAssemblyName = typeQ.Assembly.FullName,
                     UISideVisualizerAssemblyLocation = DkmClrCustomVisualizerAssemblyLocation.Unknown,
                     DebuggeeSideVisualizerTypeName = defaultDebuggeeSideVisualizerTypeName,
-                    DebuggeeSideVisualizerAssemblyName = defaultDebuggeeSideVisualizerAssemblyName}
+                    DebuggeeSideVisualizerAssemblyName = defaultDebuggeeSideVisualizerAssemblyName,
+                    ExtensionPartId = Guid.Empty}
             };
 
             Verify(evalResult,

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/TypeHelpers.cs
@@ -633,7 +633,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                         visualizerAttribute.UISideVisualizerAssemblyName,
                         visualizerAttribute.UISideVisualizerAssemblyLocation,
                         visualizerAttribute.DebuggeeSideVisualizerTypeName,
-                        visualizerAttribute.DebuggeeSideVisualizerAssemblyName));
+                        visualizerAttribute.DebuggeeSideVisualizerAssemblyName,
+                        visualizerAttribute.ExtensionPartId));
                 }
 
                 underlyingType = underlyingType.GetBaseTypeOrNull(appDomain, out type);

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrDebuggerVisualizerAttribute.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrDebuggerVisualizerAttribute.cs
@@ -25,13 +25,15 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
         /// <param name="debuggeeSideVisualizerTypeName">[Required] The full name of the debuggee-side visualizer type</param>
         /// <param name="debuggeeSideVisualizerAssemblyName">[Required] The full name of the debuggee-side visualizer assembly</param>
         /// <param name="visualizerDescription">[Required] The visualizer description</param>
+        /// <param name="extensionPartId">[Required] This is a unique id for visualizers that are installed via the ExtensionPartManager.</param>
         internal DkmClrDebuggerVisualizerAttribute(string targetMember,
             string uiSideVisualizerTypeName,
             string uiSideVisualizerAssemblyName,
             DkmClrCustomVisualizerAssemblyLocation uiSideVisualizerAssemblyLocation,
             string debuggeeSideVisualizerTypeName,
             string debuggeeSideVisualizerAssemblyName,
-            string visualizerDescription) :
+            string visualizerDescription,
+            System.Guid extensionPartId) :
             base(null)
         {
             UISideVisualizerTypeName = uiSideVisualizerTypeName;
@@ -40,6 +42,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
             DebuggeeSideVisualizerTypeName = debuggeeSideVisualizerTypeName;
             DebuggeeSideVisualizerAssemblyName = debuggeeSideVisualizerAssemblyName;
             VisualizerDescription = visualizerDescription;
+            ExtensionPartId = extensionPartId;
         }
 
         public readonly string UISideVisualizerTypeName;
@@ -48,6 +51,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
         public readonly string DebuggeeSideVisualizerTypeName;
         public readonly string DebuggeeSideVisualizerAssemblyName;
         public readonly string VisualizerDescription;
+        public readonly System.Guid ExtensionPartId;
     }
 }
 

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrType.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmClrType.cs
@@ -364,7 +364,8 @@ namespace Microsoft.VisualStudio.Debugger.Clr
                     uiSideVisualizerAssemblyLocation: Evaluation.DkmClrCustomVisualizerAssemblyLocation.Unknown,
                     debuggeeSideVisualizerTypeName: debuggeeSideVisualizerTypeName,
                     debuggeeSideVisualizerAssemblyName: debuggeeSideVisualizerAssemblyName,
-                    visualizerDescription: visualizerDescription));
+                    visualizerDescription: visualizerDescription,
+                    extensionPartId: System.Guid.Empty));
             }
 
             return builder.ToArrayAndFree();

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmCustomUIVisualizerInfo.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Debugger/Engine/DkmCustomUIVisualizerInfo.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation
         public DkmClrCustomVisualizerAssemblyLocation UISideVisualizerAssemblyLocation;
         public string DebuggeeSideVisualizerTypeName;
         public string DebuggeeSideVisualizerAssemblyName;
+        public Guid ExtensionPartId;
 
         public static DkmCustomUIVisualizerInfo Create(uint Id, string MenuName, string Description, string Metric)
         {
@@ -52,6 +53,32 @@ namespace Microsoft.VisualStudio.Debugger.Evaluation
                 UISideVisualizerAssemblyLocation = UISideVisualizerAssemblyLocation,
                 DebuggeeSideVisualizerTypeName = DebuggeeSideVisualizerTypeName,
                 DebuggeeSideVisualizerAssemblyName = DebuggeeSideVisualizerAssemblyName
+            };
+        }
+
+        public static DkmCustomUIVisualizerInfo Create(uint Id,
+            string MenuName,
+            string Description,
+            string Metric,
+            string UISideVisualizerTypeName,
+            string UISideVisualizerAssemblyName,
+            DkmClrCustomVisualizerAssemblyLocation UISideVisualizerAssemblyLocation,
+            string DebuggeeSideVisualizerTypeName,
+            string DebuggeeSideVisualizerAssemblyName,
+            Guid ExtensionPartId)
+        {
+            return new DkmCustomUIVisualizerInfo
+            {
+                Id = Id,
+                MenuName = MenuName,
+                Description = Description,
+                Metric = Metric,
+                UISideVisualizerTypeName = UISideVisualizerTypeName,
+                UISideVisualizerAssemblyName = UISideVisualizerAssemblyName,
+                UISideVisualizerAssemblyLocation = UISideVisualizerAssemblyLocation,
+                DebuggeeSideVisualizerTypeName = DebuggeeSideVisualizerTypeName,
+                DebuggeeSideVisualizerAssemblyName = DebuggeeSideVisualizerAssemblyName,
+                ExtensionPartId = ExtensionPartId
             };
         }
     }

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/ResultProviderTestBase.cs
@@ -553,7 +553,8 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     x.UISideVisualizerAssemblyName == y.UISideVisualizerAssemblyName &&
                     x.UISideVisualizerAssemblyLocation == y.UISideVisualizerAssemblyLocation &&
                     x.DebuggeeSideVisualizerTypeName == y.DebuggeeSideVisualizerTypeName &&
-                    x.DebuggeeSideVisualizerAssemblyName == y.DebuggeeSideVisualizerAssemblyName);
+                    x.DebuggeeSideVisualizerAssemblyName == y.DebuggeeSideVisualizerAssemblyName &&
+                    x.ExtensionPartId == y.ExtensionPartId);
             }
 
             int IEqualityComparer<DkmCustomUIVisualizerInfo>.GetHashCode(DkmCustomUIVisualizerInfo obj)


### PR DESCRIPTION
Debugger Managed Custom Visualizers can now be installed via .VSIX packages into Visual Studio. However, we need a new mechanism to identify them within the new extension manager that processes them. Therefore, visualizers now have a new GUID field for that purpose.

Since the Debugger Component that instantiates visualizers receives its information from the `DkmSuccessEvaluationResult` that the Result Provider from Roslyn provides, we need it to also create the `DkmCustomUIVisualizerInfo` collection that is passes to the `DkmSuccessEvaluationResult` with the new field.

Hence, this change makes sure to create new `DkmCustomUIVisualizerInfo` instances with the new `ExtensionPartId` field.