### PR TITLE
Fix bounds checking for `SyntaxTriviaListBuilder` indexer

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/SyntaxTriviaListBuilder.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTriviaListBuilder.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Syntax
         {
             get
             {
-                if (index < 0 || index > _count)
+                if (index < 0 || index >= _count)
                 {
                     throw new IndexOutOfRangeException();
                 }


### PR DESCRIPTION
FAR is only showing two usages of the indexer, both provide a correct index. So as of now, the change can't be noticed. This is to prevent any possible future bugs.

![image](https://user-images.githubusercontent.com/31348972/205701582-d8609b8e-88c4-44bf-81a3-f87cdf835da2.png)
