### PR TITLE
Fix correctness build

### DIFF
--- a/src/Features/RulesMissingDocumentation.md
+++ b/src/Features/RulesMissingDocumentation.md
@@ -16,6 +16,7 @@ IDE0241 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-r
 IDE0250 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0250> | Make struct 'readonly' |
 IDE0260 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0260> | Use pattern matching |
 IDE0270 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0270> | Use coalesce expression |
+IDE0280 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0280> | Use 'nameof' |
 IDE1007 |  |  |
 IDE2000 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2000> | Avoid multiple blank lines |
 IDE2001 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide2001> | Embedded statements must be on their own line |


### PR DESCRIPTION
https://github.com/dotnet/roslyn/pull/65729 (added a new analyzer) and https://github.com/dotnet/roslyn/pull/62242 (added new rule violated by analyzer) merged independently without CI re-triggering. 

The temporary fix here is to add the new rule to the allow list until documentation can be added (cc @CyrusNajmabadi for tracking that).