### PR TITLE
Make main-vs-deps PRs non-draft

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -154,7 +154,7 @@
       ],
       "vsBranch": "main",
       "vsMajorVersion": 17,
-      "insertionCreateDraftPR": true,
+      "insertionCreateDraftPR": false,
       "insertionTitlePrefix": "[d17.5p3]"
     },
     "dev/jorobich/fix-pr-val": {


### PR DESCRIPTION
VS main is now open for 17.5p3 so we can create these as non-draft