### PR TITLE
Use `dotnet` instead of `.dotnet/dotnet` in VSCode tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -43,7 +43,7 @@
     },
     {
         "label": "build csc",
-        "command": "${workspaceFolder}/.dotnet/dotnet",
+        "command": "dotnet",
         "type": "shell",
         "args": [
           "msbuild",
@@ -57,7 +57,7 @@
     {
         "label": "build current project",
         "type": "shell",
-        "command": "${workspaceFolder}/.dotnet/dotnet",
+        "command": "dotnet",
         "args": [
           "pwsh",
           "${workspaceFolder}/scripts/vscode-build.ps1",
@@ -98,7 +98,7 @@
     },
     {
         "label": "generate compiler code",
-        "command": "${workspaceFolder}/.dotnet/dotnet",
+        "command": "dotnet",
         "type": "shell",
         "args": [
           "pwsh",
@@ -122,7 +122,7 @@
     },
     {
         "label": "run tests in current file (netcoreapp3.1)",
-        "command": "${workspaceFolder}/.dotnet/dotnet",
+        "command": "dotnet",
         "type": "shell",
         "args": [
           "pwsh",
@@ -141,7 +141,7 @@
     },
     {
         "label": "run tests in current project (netcoreapp3.1)",
-        "command": "${workspaceFolder}/.dotnet/dotnet",
+        "command": "dotnet",
         "type": "shell",
         "args": [
           "pwsh",
@@ -158,7 +158,7 @@
     },
     {
         "label": "run tests in current file (all frameworks)",
-        "command": "${workspaceFolder}/.dotnet/dotnet",
+        "command": "dotnet",
         "type": "shell",
         "args": [
           "pwsh",
@@ -173,7 +173,7 @@
     },
     {
         "label": "run tests in current project (all frameworks)",
-        "command": "${workspaceFolder}/.dotnet/dotnet",
+        "command": "dotnet",
         "type": "shell",
         "args": [
           "pwsh",


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/65803