### PR TITLE
Ensure lvalue struct receivers are not copied by value by implicit Range indexer rewrite

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -518,27 +518,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             var receiver = VisitExpression(node.Receiver);
             var rangeArg = node.Argument;
 
-            var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
-            var sideEffectsBuilder = ArrayBuilder<BoundExpression>.GetInstance();
+            BoundExpression? startMakeOffsetInput = null;
+            PatternIndexOffsetLoweringStrategy startStrategy = default;
+            BoundExpression? endMakeOffsetInput = null;
+            PatternIndexOffsetLoweringStrategy endStrategy = default;
+            var rangeExpr = rangeArg as BoundRangeExpression;
+            BoundExpression? rewrittenRangeArg = null;
 
-            // Do not capture receiver if it is a local or parameter and we are evaluating a pattern
-            // If length access is a local, then we are evaluating a pattern
-            if (node.LengthOrCountAccess.Kind is not BoundKind.Local || receiver.Kind is not (BoundKind.Local or BoundKind.Parameter))
-            {
-                // The way this capture is done is likely source of https://github.com/dotnet/roslyn/issues/65586
-                var receiverLocal = F.StoreToTemp(receiver, out var receiverStore);
-
-                localsBuilder.Add(receiverLocal.LocalSymbol);
-                sideEffectsBuilder.Add(receiverStore);
-
-                receiver = receiverLocal;
-            }
-
-            AddPlaceholderReplacement(node.ReceiverPlaceholder, receiver);
-
-            BoundExpression startExpr;
-            BoundExpression rangeSizeExpr;
-            if (rangeArg is BoundRangeExpression rangeExpr)
+            if (rangeExpr is not null)
             {
                 // If we know that the input is a range expression, we can
                 // optimize by pulling it apart inline, so
@@ -552,9 +539,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // int start = start.GetOffset(length)
                 // int rangeSize = end.GetOffset(length) - start
 
-                BoundExpression? startMakeOffsetInput;
-                PatternIndexOffsetLoweringStrategy startStrategy;
-
                 if (rangeExpr.LeftOperandOpt is BoundExpression left)
                 {
                     startMakeOffsetInput = DetermineMakePatternIndexOffsetExpressionStrategy(left, out startStrategy);
@@ -565,9 +549,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     startMakeOffsetInput = null;
                 }
 
-                BoundExpression? endMakeOffsetInput;
-                PatternIndexOffsetLoweringStrategy endStrategy;
-
                 if (rangeExpr.RightOperandOpt is BoundExpression right)
                 {
                     endMakeOffsetInput = DetermineMakePatternIndexOffsetExpressionStrategy(right, out endStrategy);
@@ -577,6 +558,84 @@ namespace Microsoft.CodeAnalysis.CSharp
                     endStrategy = PatternIndexOffsetLoweringStrategy.Length;
                     endMakeOffsetInput = null;
                 }
+            }
+            else
+            {
+                rewrittenRangeArg = VisitExpression(rangeArg);
+            }
+
+            var localsBuilder = ArrayBuilder<LocalSymbol>.GetInstance();
+            var sideEffectsBuilder = ArrayBuilder<BoundExpression>.GetInstance();
+
+            // Do not capture receiver if it is a local or parameter and we are evaluating a pattern
+            // If length access is a local, then we are evaluating a pattern
+            if (node.LengthOrCountAccess.Kind is not BoundKind.Local || receiver.Kind is not (BoundKind.Local or BoundKind.Parameter))
+            {
+                Debug.Assert(receiver.Type is { });
+
+                var receiverLocal = F.StoreToTemp(
+                    receiver,
+                    out var receiverStore,
+                    // Store the receiver as a ref local if it's a value type to ensure side effects are propagated
+                    receiver.Type.IsReferenceType ? RefKind.None : RefKind.Ref);
+
+                localsBuilder.Add(receiverLocal.LocalSymbol);
+
+                if (receiverLocal.LocalSymbol.IsRef &&
+                    CodeGenerator.IsPossibleReferenceTypeReceiverOfConstrainedCall(receiverLocal) &&
+                    !CodeGenerator.ReceiverIsKnownToReferToTempIfReferenceType(receiverLocal))
+                {
+                    var argumentsBuilder = ArrayBuilder<BoundExpression>.GetInstance(2);
+
+                    if (startMakeOffsetInput is not null)
+                    {
+                        argumentsBuilder.Add(startMakeOffsetInput);
+                    }
+
+                    if (endMakeOffsetInput is not null)
+                    {
+                        argumentsBuilder.Add(endMakeOffsetInput);
+                    }
+
+                    if (rewrittenRangeArg is not null)
+                    {
+                        argumentsBuilder.Add(rewrittenRangeArg);
+                    }
+
+                    if (!CodeGenerator.IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(argumentsBuilder.ToImmutableAndFree()))
+                    {
+                        BoundAssignmentOperator? extraRefInitialization;
+                        ReferToTempIfReferenceTypeReceiver(receiverLocal, ref receiverStore, out extraRefInitialization, localsBuilder);
+
+                        if (extraRefInitialization is object)
+                        {
+                            sideEffectsBuilder.Add(extraRefInitialization);
+                        }
+                    }
+                }
+
+                sideEffectsBuilder.Add(receiverStore);
+
+                receiver = receiverLocal;
+            }
+
+            AddPlaceholderReplacement(node.ReceiverPlaceholder, receiver);
+
+            BoundExpression startExpr;
+            BoundExpression rangeSizeExpr;
+            if (rangeExpr is not null)
+            {
+                // If we know that the input is a range expression, we can
+                // optimize by pulling it apart inline, so
+                // 
+                // Range range = argumentExpr;
+                // int start = range.Start.GetOffset(length)
+                // int rangeSize = range.End.GetOffset(length) - start
+                //
+                // is, with `start..end`:
+                //
+                // int start = start.GetOffset(length)
+                // int rangeSize = end.GetOffset(length) - start
 
                 const int captureStartOffset = 1 << 0;
                 const int captureEndOffset = 1 << 1;
@@ -699,7 +758,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                var rangeLocal = F.StoreToTemp(VisitExpression(rangeArg), out var rangeStore);
+                Debug.Assert(rewrittenRangeArg is not null);
+                var rangeLocal = F.StoreToTemp(rewrittenRangeArg, out var rangeStore);
                 localsBuilder.Add(rangeLocal.LocalSymbol);
                 sideEffectsBuilder.Add(rangeStore);
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
@@ -416,37 +416,40 @@ Slice 1
 5");
             verifier.VerifyIL("C.Main", @"
 {
-  // Code size       53 (0x35)
-  .maxstack  4
-  .locals init (int[] V_0, //array
-                S V_1)
-  IL_0000:  ldc.i4.2
-  IL_0001:  newarr     ""int""
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  ldc.i4.1
-  IL_0009:  ldelem.i4
-  IL_000a:  call       ""void System.Console.WriteLine(int)""
-  IL_000f:  ldloc.0
-  IL_0010:  newobj     ""S..ctor(int[])""
-  IL_0015:  stloc.1
-  IL_0016:  ldloca.s   V_1
-  IL_0018:  ldc.i4.1
-  IL_0019:  ldloca.s   V_1
-  IL_001b:  call       ""int S.Length.get""
-  IL_0020:  ldc.i4.1
-  IL_0021:  sub
-  IL_0022:  call       ""ref int S.Slice(int, int)""
-  IL_0027:  dup
-  IL_0028:  ldind.i4
-  IL_0029:  ldc.i4.5
-  IL_002a:  add
-  IL_002b:  stind.i4
-  IL_002c:  ldloc.0
-  IL_002d:  ldc.i4.1
-  IL_002e:  ldelem.i4
-  IL_002f:  call       ""void System.Console.WriteLine(int)""
-  IL_0034:  ret
+  // Code size       55 (0x37)
+      .maxstack  4
+      .locals init (int[] V_0, //array
+                    S V_1, //s
+                    S& V_2)
+      IL_0000:  ldc.i4.2
+      IL_0001:  newarr     ""int""
+      IL_0006:  stloc.0
+      IL_0007:  ldloc.0
+      IL_0008:  ldc.i4.1
+      IL_0009:  ldelem.i4
+      IL_000a:  call       ""void System.Console.WriteLine(int)""
+      IL_000f:  ldloca.s   V_1
+      IL_0011:  ldloc.0
+      IL_0012:  call       ""S..ctor(int[])""
+      IL_0017:  ldloca.s   V_1
+      IL_0019:  stloc.2
+      IL_001a:  ldloc.2
+      IL_001b:  ldc.i4.1
+      IL_001c:  ldloc.2
+      IL_001d:  call       ""int S.Length.get""
+      IL_0022:  ldc.i4.1
+      IL_0023:  sub
+      IL_0024:  call       ""ref int S.Slice(int, int)""
+      IL_0029:  dup
+      IL_002a:  ldind.i4
+      IL_002b:  ldc.i4.5
+      IL_002c:  add
+      IL_002d:  stind.i4
+      IL_002e:  ldloc.0
+      IL_002f:  ldc.i4.1
+      IL_0030:  ldelem.i4
+      IL_0031:  call       ""void System.Console.WriteLine(int)""
+      IL_0036:  ret
 }");
         }
 
@@ -829,46 +832,49 @@ abcd
 abcd");
             verifier.VerifyIL("C.Main", @"
 {
-  // Code size       80 (0x50)
-  .maxstack  4
-  .locals init (string V_0,
-                System.ReadOnlySpan<char> V_1,
-                int V_2,
-                System.ReadOnlySpan<char> V_3)
-  IL_0000:  ldstr      ""abcd""
-  IL_0005:  dup
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  ldc.i4.0
-  IL_0009:  ldloc.0
-  IL_000a:  callvirt   ""int string.Length.get""
-  IL_000f:  callvirt   ""string string.Substring(int, int)""
-  IL_0014:  call       ""void System.Console.WriteLine(string)""
-  IL_0019:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.op_Implicit(string)""
-  IL_001e:  stloc.3
-  IL_001f:  ldloca.s   V_3
-  IL_0021:  ldc.i4.0
-  IL_0022:  ldloca.s   V_3
-  IL_0024:  call       ""int System.ReadOnlySpan<char>.Length.get""
-  IL_0029:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.Slice(int, int)""
-  IL_002e:  stloc.1
-  IL_002f:  ldc.i4.0
-  IL_0030:  stloc.2
-  IL_0031:  br.s       IL_0045
-  IL_0033:  ldloca.s   V_1
-  IL_0035:  ldloc.2
-  IL_0036:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
-  IL_003b:  ldind.u2
-  IL_003c:  call       ""void System.Console.Write(char)""
-  IL_0041:  ldloc.2
-  IL_0042:  ldc.i4.1
-  IL_0043:  add
-  IL_0044:  stloc.2
-  IL_0045:  ldloc.2
-  IL_0046:  ldloca.s   V_1
-  IL_0048:  call       ""int System.ReadOnlySpan<char>.Length.get""
-  IL_004d:  blt.s      IL_0033
-  IL_004f:  ret
+  // Code size       84 (0x54)
+      .maxstack  4
+      .locals init (System.ReadOnlySpan<char> V_0, //span
+                    string V_1,
+                    System.ReadOnlySpan<char> V_2,
+                    int V_3,
+                    System.ReadOnlySpan<char>& V_4)
+      IL_0000:  ldstr      ""abcd""
+      IL_0005:  dup
+      IL_0006:  stloc.1
+      IL_0007:  ldloc.1
+      IL_0008:  ldc.i4.0
+      IL_0009:  ldloc.1
+      IL_000a:  callvirt   ""int string.Length.get""
+      IL_000f:  callvirt   ""string string.Substring(int, int)""
+      IL_0014:  call       ""void System.Console.WriteLine(string)""
+      IL_0019:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.op_Implicit(string)""
+      IL_001e:  stloc.0
+      IL_001f:  ldloca.s   V_0
+      IL_0021:  stloc.s    V_4
+      IL_0023:  ldloc.s    V_4
+      IL_0025:  ldc.i4.0
+      IL_0026:  ldloc.s    V_4
+      IL_0028:  call       ""int System.ReadOnlySpan<char>.Length.get""
+      IL_002d:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.Slice(int, int)""
+      IL_0032:  stloc.2
+      IL_0033:  ldc.i4.0
+      IL_0034:  stloc.3
+      IL_0035:  br.s       IL_0049
+      IL_0037:  ldloca.s   V_2
+      IL_0039:  ldloc.3
+      IL_003a:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
+      IL_003f:  ldind.u2
+      IL_0040:  call       ""void System.Console.Write(char)""
+      IL_0045:  ldloc.3
+      IL_0046:  ldc.i4.1
+      IL_0047:  add
+      IL_0048:  stloc.3
+      IL_0049:  ldloc.3
+      IL_004a:  ldloca.s   V_2
+      IL_004c:  call       ""int System.ReadOnlySpan<char>.Length.get""
+      IL_0051:  blt.s      IL_0037
+      IL_0053:  ret
 }");
 
             var (model, elementAccesses) = GetModelAndAccesses(comp);
@@ -1096,14 +1102,13 @@ f
 g");
             verifier.VerifyIL(@"C.Main", @"
 {
-  // Code size      130 (0x82)
+  // Code size      124 (0x7c)
   .maxstack  4
   .locals init (System.ReadOnlySpan<char> V_0, //s
                 System.Index V_1, //index
                 System.ReadOnlySpan<char>& V_2,
-                System.ReadOnlySpan<char> V_3,
-                int V_4,
-                int V_5)
+                int V_3,
+                int V_4)
   IL_0000:  ldstr      ""abcdefg""
   IL_0005:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.op_Implicit(string)""
   IL_000a:  stloc.0
@@ -1129,33 +1134,31 @@ g");
   IL_003a:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
   IL_003f:  ldind.u2
   IL_0040:  call       ""void System.Console.WriteLine(char)""
-  IL_0045:  ldloc.0
-  IL_0046:  stloc.3
-  IL_0047:  ldloca.s   V_3
-  IL_0049:  call       ""int System.ReadOnlySpan<char>.Length.get""
-  IL_004e:  stloc.s    V_4
-  IL_0050:  ldloc.s    V_4
-  IL_0052:  ldc.i4.2
-  IL_0053:  sub
-  IL_0054:  stloc.s    V_5
-  IL_0056:  ldloca.s   V_3
-  IL_0058:  ldloc.s    V_5
-  IL_005a:  ldloc.s    V_4
-  IL_005c:  ldloc.s    V_5
-  IL_005e:  sub
-  IL_005f:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.Slice(int, int)""
-  IL_0064:  stloc.0
-  IL_0065:  ldloca.s   V_0
-  IL_0067:  ldc.i4.0
-  IL_0068:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
-  IL_006d:  ldind.u2
-  IL_006e:  call       ""void System.Console.WriteLine(char)""
-  IL_0073:  ldloca.s   V_0
-  IL_0075:  ldc.i4.1
-  IL_0076:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
-  IL_007b:  ldind.u2
-  IL_007c:  call       ""void System.Console.WriteLine(char)""
-  IL_0081:  ret
+  IL_0045:  ldloca.s   V_0
+  IL_0047:  dup
+  IL_0048:  call       ""int System.ReadOnlySpan<char>.Length.get""
+  IL_004d:  stloc.3
+  IL_004e:  ldloc.3
+  IL_004f:  ldc.i4.2
+  IL_0050:  sub
+  IL_0051:  stloc.s    V_4
+  IL_0053:  ldloc.s    V_4
+  IL_0055:  ldloc.3
+  IL_0056:  ldloc.s    V_4
+  IL_0058:  sub
+  IL_0059:  call       ""System.ReadOnlySpan<char> System.ReadOnlySpan<char>.Slice(int, int)""
+  IL_005e:  stloc.0
+  IL_005f:  ldloca.s   V_0
+  IL_0061:  ldc.i4.0
+  IL_0062:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
+  IL_0067:  ldind.u2
+  IL_0068:  call       ""void System.Console.WriteLine(char)""
+  IL_006d:  ldloca.s   V_0
+  IL_006f:  ldc.i4.1
+  IL_0070:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
+  IL_0075:  ldind.u2
+  IL_0076:  call       ""void System.Console.WriteLine(char)""
+  IL_007b:  ret
 }
 ");
         }
@@ -1184,70 +1187,67 @@ class C
 6");
             verifier.VerifyIL("C.Main", @"
 {
-  // Code size      142 (0x8e)
-  .maxstack  4
-  .locals init (System.Span<int> V_0, //s
-                System.Index V_1, //index
-                System.Span<int>& V_2,
-                System.Span<int> V_3,
-                int V_4,
-                int V_5)
-  IL_0000:  ldc.i4.4
-  IL_0001:  newarr     ""int""
-  IL_0006:  dup
-  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.B35A10C764778866E34111165FC69660C6171DF0CB0141E39FA0217EF7A97646""
-  IL_000c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
-  IL_0011:  call       ""System.Span<int> System.Span<int>.op_Implicit(int[])""
-  IL_0016:  stloc.0
-  IL_0017:  ldloca.s   V_0
-  IL_0019:  dup
-  IL_001a:  call       ""int System.Span<int>.Length.get""
-  IL_001f:  ldc.i4.2
-  IL_0020:  sub
-  IL_0021:  call       ""ref int System.Span<int>.this[int].get""
-  IL_0026:  ldind.i4
-  IL_0027:  call       ""void System.Console.WriteLine(int)""
-  IL_002c:  ldloca.s   V_1
-  IL_002e:  ldc.i4.1
-  IL_002f:  ldc.i4.1
-  IL_0030:  call       ""System.Index..ctor(int, bool)""
-  IL_0035:  ldloca.s   V_0
-  IL_0037:  stloc.2
-  IL_0038:  ldloc.2
-  IL_0039:  ldloca.s   V_1
-  IL_003b:  ldloc.2
-  IL_003c:  call       ""int System.Span<int>.Length.get""
-  IL_0041:  call       ""int System.Index.GetOffset(int)""
-  IL_0046:  call       ""ref int System.Span<int>.this[int].get""
-  IL_004b:  ldind.i4
-  IL_004c:  call       ""void System.Console.WriteLine(int)""
-  IL_0051:  ldloc.0
-  IL_0052:  stloc.3
-  IL_0053:  ldloca.s   V_3
-  IL_0055:  call       ""int System.Span<int>.Length.get""
-  IL_005a:  stloc.s    V_4
-  IL_005c:  ldloc.s    V_4
-  IL_005e:  ldc.i4.2
-  IL_005f:  sub
-  IL_0060:  stloc.s    V_5
-  IL_0062:  ldloca.s   V_3
-  IL_0064:  ldloc.s    V_5
-  IL_0066:  ldloc.s    V_4
-  IL_0068:  ldloc.s    V_5
-  IL_006a:  sub
-  IL_006b:  call       ""System.Span<int> System.Span<int>.Slice(int, int)""
-  IL_0070:  stloc.0
-  IL_0071:  ldloca.s   V_0
-  IL_0073:  ldc.i4.0
-  IL_0074:  call       ""ref int System.Span<int>.this[int].get""
-  IL_0079:  ldind.i4
-  IL_007a:  call       ""void System.Console.WriteLine(int)""
-  IL_007f:  ldloca.s   V_0
-  IL_0081:  ldc.i4.1
-  IL_0082:  call       ""ref int System.Span<int>.this[int].get""
-  IL_0087:  ldind.i4
-  IL_0088:  call       ""void System.Console.WriteLine(int)""
-  IL_008d:  ret
+  // Code size      136 (0x88)
+      .maxstack  4
+      .locals init (System.Span<int> V_0, //s
+                    System.Index V_1, //index
+                    System.Span<int>& V_2,
+                    int V_3,
+                    int V_4)
+      IL_0000:  ldc.i4.4
+      IL_0001:  newarr     ""int""
+      IL_0006:  dup
+      IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.B35A10C764778866E34111165FC69660C6171DF0CB0141E39FA0217EF7A97646""
+      IL_000c:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+      IL_0011:  call       ""System.Span<int> System.Span<int>.op_Implicit(int[])""
+      IL_0016:  stloc.0
+      IL_0017:  ldloca.s   V_0
+      IL_0019:  dup
+      IL_001a:  call       ""int System.Span<int>.Length.get""
+      IL_001f:  ldc.i4.2
+      IL_0020:  sub
+      IL_0021:  call       ""ref int System.Span<int>.this[int].get""
+      IL_0026:  ldind.i4
+      IL_0027:  call       ""void System.Console.WriteLine(int)""
+      IL_002c:  ldloca.s   V_1
+      IL_002e:  ldc.i4.1
+      IL_002f:  ldc.i4.1
+      IL_0030:  call       ""System.Index..ctor(int, bool)""
+      IL_0035:  ldloca.s   V_0
+      IL_0037:  stloc.2
+      IL_0038:  ldloc.2
+      IL_0039:  ldloca.s   V_1
+      IL_003b:  ldloc.2
+      IL_003c:  call       ""int System.Span<int>.Length.get""
+      IL_0041:  call       ""int System.Index.GetOffset(int)""
+      IL_0046:  call       ""ref int System.Span<int>.this[int].get""
+      IL_004b:  ldind.i4
+      IL_004c:  call       ""void System.Console.WriteLine(int)""
+      IL_0051:  ldloca.s   V_0
+      IL_0053:  dup
+      IL_0054:  call       ""int System.Span<int>.Length.get""
+      IL_0059:  stloc.3
+      IL_005a:  ldloc.3
+      IL_005b:  ldc.i4.2
+      IL_005c:  sub
+      IL_005d:  stloc.s    V_4
+      IL_005f:  ldloc.s    V_4
+      IL_0061:  ldloc.3
+      IL_0062:  ldloc.s    V_4
+      IL_0064:  sub
+      IL_0065:  call       ""System.Span<int> System.Span<int>.Slice(int, int)""
+      IL_006a:  stloc.0
+      IL_006b:  ldloca.s   V_0
+      IL_006d:  ldc.i4.0
+      IL_006e:  call       ""ref int System.Span<int>.this[int].get""
+      IL_0073:  ldind.i4
+      IL_0074:  call       ""void System.Console.WriteLine(int)""
+      IL_0079:  ldloca.s   V_0
+      IL_007b:  ldc.i4.1
+      IL_007c:  call       ""ref int System.Span<int>.this[int].get""
+      IL_0081:  ldind.i4
+      IL_0082:  call       ""void System.Console.WriteLine(int)""
+      IL_0087:  ret
 }
 ");
         }
@@ -3823,22 +3823,19 @@ struct S
     
     public int Length => 10;
 }";
-            var verifier = CompileAndVerifyWithIndexAndRange(src, expectedOutput: "0").VerifyDiagnostics();
+            var verifier = CompileAndVerifyWithIndexAndRange(src, expectedOutput: "1").VerifyDiagnostics();
 
             verifier.VerifyIL("Program.Test",
 @"
 {
-  // Code size       17 (0x11)
+  // Code size       14 (0xe)
   .maxstack  3
-  .locals init (S V_0)
-  IL_0000:  ldsfld     ""S Program.s""
-  IL_0005:  stloc.0
-  IL_0006:  ldloca.s   V_0
-  IL_0008:  ldc.i4.1
-  IL_0009:  ldc.i4.1
-  IL_000a:  call       ""int S.Slice(int, int)""
-  IL_000f:  pop
-  IL_0010:  ret
+  IL_0000:  ldsflda    ""S Program.s""
+  IL_0005:  ldc.i4.1
+  IL_0006:  ldc.i4.1
+  IL_0007:  call       ""int S.Slice(int, int)""
+  IL_000c:  pop
+  IL_000d:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenCallTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenCallTests.cs
@@ -28776,35 +28776,41 @@ Position Slice for item '2'
             verifier.VerifyIL("Program.Shift2<T>",
 @"
 {
-  // Code size       65 (0x41)
+  // Code size       70 (0x46)
   .maxstack  4
-  .locals init (T V_0,
-                int V_1,
-                T V_2)
-  IL_0000:  ldarg.0
-  IL_0001:  stloc.0
-  IL_0002:  ldarga.s   V_0
-  IL_0004:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0009:  stloc.1
-  IL_000a:  ldloca.s   V_0
-  IL_000c:  ldloca.s   V_2
-  IL_000e:  initobj    ""T""
+  .locals init (T& V_0,
+                T V_1,
+                T& V_2,
+                int V_3,
+                T V_4)
+  IL_0000:  ldarga.s   V_0
+  IL_0002:  stloc.2
+  IL_0003:  ldloca.s   V_4
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_4
+  IL_000d:  box        ""T""
+  IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.2
-  IL_0015:  box        ""T""
-  IL_001a:  brtrue.s   IL_0024
-  IL_001c:  ldobj      ""T""
-  IL_0021:  stloc.2
-  IL_0022:  ldloca.s   V_2
-  IL_0024:  ldc.i4.0
-  IL_0025:  ldloca.s   V_0
-  IL_0027:  constrained. ""T""
-  IL_002d:  callvirt   ""int IMoveable.Length.get""
-  IL_0032:  ldloc.1
-  IL_0033:  sub
-  IL_0034:  constrained. ""T""
-  IL_003a:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
-  IL_003f:  pop
-  IL_0040:  ret
+  IL_0015:  ldobj      ""T""
+  IL_001a:  stloc.1
+  IL_001b:  ldloca.s   V_1
+  IL_001d:  br.s       IL_0020
+  IL_001f:  ldloc.2
+  IL_0020:  stloc.0
+  IL_0021:  ldarga.s   V_0
+  IL_0023:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_0028:  stloc.3
+  IL_0029:  ldloc.0
+  IL_002a:  ldc.i4.0
+  IL_002b:  ldloc.0
+  IL_002c:  constrained. ""T""
+  IL_0032:  callvirt   ""int IMoveable.Length.get""
+  IL_0037:  ldloc.3
+  IL_0038:  sub
+  IL_0039:  constrained. ""T""
+  IL_003f:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
+  IL_0044:  pop
+  IL_0045:  ret
 }
 ");
         }
@@ -28872,37 +28878,36 @@ class Program
 }
 ";
 
-            // Wrong output
             var verifier = CompileAndVerify(source, targetFramework: TargetFramework.NetLatest, options: TestOptions.ReleaseExe, expectedOutput: @"
-Position Length for item '1'
-Position Slice for item '1'
-Position Length for item '2'
-Position Slice for item '2'
+Position Length for item '-1'
+Position Slice for item '-1'
+Position Length for item '-2'
+Position Slice for item '-2'
 ").VerifyDiagnostics();
 
             verifier.VerifyIL("Program.Shift1<T>",
 @"
 {
-  // Code size       41 (0x29)
+  // Code size       40 (0x28)
   .maxstack  4
-  .locals init (T V_0,
+  .locals init (T& V_0,
                 int V_1)
-  IL_0000:  ldarg.0
-  IL_0001:  stloc.0
-  IL_0002:  ldarga.s   V_0
-  IL_0004:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0009:  stloc.1
-  IL_000a:  ldloca.s   V_0
+  IL_0000:  ldarga.s   V_0
+  IL_0002:  stloc.0
+  IL_0003:  ldarga.s   V_0
+  IL_0005:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_000a:  stloc.1
+  IL_000b:  ldloc.0
   IL_000c:  ldc.i4.0
-  IL_000d:  ldloca.s   V_0
-  IL_000f:  constrained. ""T""
-  IL_0015:  callvirt   ""int IMoveable.Length.get""
-  IL_001a:  ldloc.1
-  IL_001b:  sub
-  IL_001c:  constrained. ""T""
-  IL_0022:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
-  IL_0027:  pop
-  IL_0028:  ret
+  IL_000d:  ldloc.0
+  IL_000e:  constrained. ""T""
+  IL_0014:  callvirt   ""int IMoveable.Length.get""
+  IL_0019:  ldloc.1
+  IL_001a:  sub
+  IL_001b:  constrained. ""T""
+  IL_0021:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
+  IL_0026:  pop
+  IL_0027:  ret
 }
 ");
         }
@@ -29007,36 +29012,41 @@ Position Slice for item '2'
             verifier.VerifyIL("Program.Shift2<T>",
 @"
 {
-  // Code size       69 (0x45)
+  // Code size       68 (0x44)
   .maxstack  4
-  .locals init (T V_0,
-                int V_1,
-                T V_2)
+  .locals init (T& V_0,
+            T V_1,
+            T& V_2,
+            int V_3,
+            T V_4)
   IL_0000:  ldarg.0
-  IL_0001:  ldobj      ""T""
-  IL_0006:  stloc.0
-  IL_0007:  ldarg.0
-  IL_0008:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_000d:  stloc.1
-  IL_000e:  ldloca.s   V_0
-  IL_0010:  ldloca.s   V_2
-  IL_0012:  initobj    ""T""
-  IL_0018:  ldloc.2
-  IL_0019:  box        ""T""
-  IL_001e:  brtrue.s   IL_0028
-  IL_0020:  ldobj      ""T""
-  IL_0025:  stloc.2
-  IL_0026:  ldloca.s   V_2
+  IL_0001:  stloc.2
+  IL_0002:  ldloca.s   V_4
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_4
+  IL_000c:  box        ""T""
+  IL_0011:  brtrue.s   IL_001e
+  IL_0013:  ldloc.2
+  IL_0014:  ldobj      ""T""
+  IL_0019:  stloc.1
+  IL_001a:  ldloca.s   V_1
+  IL_001c:  br.s       IL_001f
+  IL_001e:  ldloc.2
+  IL_001f:  stloc.0
+  IL_0020:  ldarg.0
+  IL_0021:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_0026:  stloc.3
+  IL_0027:  ldloc.0
   IL_0028:  ldc.i4.0
-  IL_0029:  ldloca.s   V_0
-  IL_002b:  constrained. ""T""
-  IL_0031:  callvirt   ""int IMoveable.Length.get""
-  IL_0036:  ldloc.1
-  IL_0037:  sub
-  IL_0038:  constrained. ""T""
-  IL_003e:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
-  IL_0043:  pop
-  IL_0044:  ret
+  IL_0029:  ldloc.0
+  IL_002a:  constrained. ""T""
+  IL_0030:  callvirt   ""int IMoveable.Length.get""
+  IL_0035:  ldloc.3
+  IL_0036:  sub
+  IL_0037:  constrained. ""T""
+  IL_003d:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
+  IL_0042:  pop
+  IL_0043:  ret
 }
 ");
         }
@@ -29104,38 +29114,36 @@ class Program
 }
 ";
 
-            // Wrong output
             var verifier = CompileAndVerify(source, targetFramework: TargetFramework.NetLatest, options: TestOptions.ReleaseExe, expectedOutput: @"
-Position Length for item '1'
-Position Slice for item '1'
-Position Length for item '2'
-Position Slice for item '2'
+Position Length for item '-1'
+Position Slice for item '-1'
+Position Length for item '-2'
+Position Slice for item '-2'
 ").VerifyDiagnostics();
 
             verifier.VerifyIL("Program.Shift1<T>",
 @"
 {
-  // Code size       45 (0x2d)
+  // Code size       38 (0x26)
   .maxstack  4
-  .locals init (T V_0,
+  .locals init (T& V_0,
                 int V_1)
   IL_0000:  ldarg.0
-  IL_0001:  ldobj      ""T""
-  IL_0006:  stloc.0
-  IL_0007:  ldarg.0
-  IL_0008:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_000d:  stloc.1
-  IL_000e:  ldloca.s   V_0
-  IL_0010:  ldc.i4.0
-  IL_0011:  ldloca.s   V_0
-  IL_0013:  constrained. ""T""
-  IL_0019:  callvirt   ""int IMoveable.Length.get""
-  IL_001e:  ldloc.1
-  IL_001f:  sub
-  IL_0020:  constrained. ""T""
-  IL_0026:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
-  IL_002b:  pop
-  IL_002c:  ret
+  IL_0001:  stloc.0
+  IL_0002:  ldarg.0
+  IL_0003:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_0008:  stloc.1
+  IL_0009:  ldloc.0
+  IL_000a:  ldc.i4.0
+  IL_000b:  ldloc.0
+  IL_000c:  constrained. ""T""
+  IL_0012:  callvirt   ""int IMoveable.Length.get""
+  IL_0017:  ldloc.1
+  IL_0018:  sub
+  IL_0019:  constrained. ""T""
+  IL_001f:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
+  IL_0024:  pop
+  IL_0025:  ret
 }
 ");
         }
@@ -29316,12 +29324,12 @@ Position Slice for item '2'
             verifier.VerifyIL("Program.<Shift2>d__2<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"
 {
-  // Code size      245 (0xf5)
+  // Code size      285 (0x11d)
   .maxstack  4
   .locals init (int V_0,
                 int V_1,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
-                T V_3,
+                T V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
                 System.Exception V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
@@ -29329,92 +29337,105 @@ Position Slice for item '2'
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0058
-    IL_000a:  ldarg.0
-    IL_000b:  ldarg.0
-    IL_000c:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0011:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0016:  ldarg.0
-    IL_0017:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_001c:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0021:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_0026:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_002b:  stloc.2
-    IL_002c:  ldloca.s   V_2
-    IL_002e:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0033:  brtrue.s   IL_0074
-    IL_0035:  ldarg.0
-    IL_0036:  ldc.i4.0
-    IL_0037:  dup
-    IL_0038:  stloc.0
-    IL_0039:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_003e:  ldarg.0
-    IL_003f:  ldloc.2
-    IL_0040:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0008:  brfalse.s  IL_0068
+    IL_000a:  ldloca.s   V_2
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.2
+    IL_0013:  box        ""T""
+    IL_0018:  brtrue.s   IL_0026
+    IL_001a:  ldarg.0
+    IL_001b:  ldarg.0
+    IL_001c:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0021:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0026:  ldarg.0
+    IL_0027:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_002c:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0031:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_0036:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_003b:  stloc.3
+    IL_003c:  ldloca.s   V_3
+    IL_003e:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0043:  brtrue.s   IL_0084
     IL_0045:  ldarg.0
-    IL_0046:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_004b:  ldloca.s   V_2
-    IL_004d:  ldarg.0
-    IL_004e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
-    IL_0053:  leave      IL_00f4
-    IL_0058:  ldarg.0
-    IL_0059:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_005e:  stloc.2
-    IL_005f:  ldarg.0
-    IL_0060:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0065:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_006b:  ldarg.0
-    IL_006c:  ldc.i4.m1
-    IL_006d:  dup
-    IL_006e:  stloc.0
-    IL_006f:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0074:  ldloca.s   V_2
-    IL_0076:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_007b:  stloc.1
-    IL_007c:  ldarg.0
-    IL_007d:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0082:  ldloca.s   V_3
-    IL_0084:  initobj    ""T""
-    IL_008a:  ldloc.3
-    IL_008b:  box        ""T""
-    IL_0090:  brtrue.s   IL_009a
-    IL_0092:  ldobj      ""T""
-    IL_0097:  stloc.3
-    IL_0098:  ldloca.s   V_3
-    IL_009a:  ldc.i4.0
-    IL_009b:  ldarg.0
-    IL_009c:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00a1:  constrained. ""T""
-    IL_00a7:  callvirt   ""int IMoveable.Length.get""
-    IL_00ac:  ldloc.1
-    IL_00ad:  sub
-    IL_00ae:  constrained. ""T""
-    IL_00b4:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
-    IL_00b9:  pop
-    IL_00ba:  ldarg.0
-    IL_00bb:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00c0:  initobj    ""T""
-    IL_00c6:  leave.s    IL_00e1
+    IL_0046:  ldc.i4.0
+    IL_0047:  dup
+    IL_0048:  stloc.0
+    IL_0049:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_004e:  ldarg.0
+    IL_004f:  ldloc.3
+    IL_0050:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0055:  ldarg.0
+    IL_0056:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_005b:  ldloca.s   V_3
+    IL_005d:  ldarg.0
+    IL_005e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
+    IL_0063:  leave      IL_011c
+    IL_0068:  ldarg.0
+    IL_0069:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_006e:  stloc.3
+    IL_006f:  ldarg.0
+    IL_0070:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0075:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_007b:  ldarg.0
+    IL_007c:  ldc.i4.m1
+    IL_007d:  dup
+    IL_007e:  stloc.0
+    IL_007f:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0084:  ldloca.s   V_3
+    IL_0086:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_008b:  stloc.1
+    IL_008c:  ldloca.s   V_2
+    IL_008e:  initobj    ""T""
+    IL_0094:  ldloc.2
+    IL_0095:  box        ""T""
+    IL_009a:  brtrue.s   IL_00a4
+    IL_009c:  ldarg.0
+    IL_009d:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00a2:  br.s       IL_00aa
+    IL_00a4:  ldarg.0
+    IL_00a5:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00aa:  ldc.i4.0
+    IL_00ab:  ldloca.s   V_2
+    IL_00ad:  initobj    ""T""
+    IL_00b3:  ldloc.2
+    IL_00b4:  box        ""T""
+    IL_00b9:  brtrue.s   IL_00c3
+    IL_00bb:  ldarg.0
+    IL_00bc:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00c1:  br.s       IL_00c9
+    IL_00c3:  ldarg.0
+    IL_00c4:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00c9:  constrained. ""T""
+    IL_00cf:  callvirt   ""int IMoveable.Length.get""
+    IL_00d4:  ldloc.1
+    IL_00d5:  sub
+    IL_00d6:  constrained. ""T""
+    IL_00dc:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
+    IL_00e1:  pop
+    IL_00e2:  ldarg.0
+    IL_00e3:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00e8:  initobj    ""T""
+    IL_00ee:  leave.s    IL_0109
   }
   catch System.Exception
   {
-    IL_00c8:  stloc.s    V_4
-    IL_00ca:  ldarg.0
-    IL_00cb:  ldc.i4.s   -2
-    IL_00cd:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00d2:  ldarg.0
-    IL_00d3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_00d8:  ldloc.s    V_4
-    IL_00da:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_00df:  leave.s    IL_00f4
+    IL_00f0:  stloc.s    V_4
+    IL_00f2:  ldarg.0
+    IL_00f3:  ldc.i4.s   -2
+    IL_00f5:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00fa:  ldarg.0
+    IL_00fb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_0100:  ldloc.s    V_4
+    IL_0102:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0107:  leave.s    IL_011c
   }
-  IL_00e1:  ldarg.0
-  IL_00e2:  ldc.i4.s   -2
-  IL_00e4:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-  IL_00e9:  ldarg.0
-  IL_00ea:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-  IL_00ef:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_00f4:  ret
+  IL_0109:  ldarg.0
+  IL_010a:  ldc.i4.s   -2
+  IL_010c:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+  IL_0111:  ldarg.0
+  IL_0112:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+  IL_0117:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_011c:  ret
 }
 ");
         }
@@ -29489,18 +29510,17 @@ class Program
 }
 ";
 
-            // Wrong output
             var verifier = CompileAndVerify(source, targetFramework: TargetFramework.NetLatest, options: TestOptions.ReleaseExe, expectedOutput: @"
-Position Length for item '1'
-Position Slice for item '1'
-Position Length for item '2'
-Position Slice for item '2'
+Position Length for item '-1'
+Position Slice for item '-1'
+Position Length for item '-2'
+Position Slice for item '-2'
 ").VerifyDiagnostics();
 
             verifier.VerifyIL("Program.<Shift1>d__1<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"
 {
-  // Code size      219 (0xdb)
+  // Code size      192 (0xc0)
   .maxstack  4
   .locals init (int V_0,
                 int V_1,
@@ -29512,84 +29532,77 @@ Position Slice for item '2'
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0058
+    IL_0008:  brfalse.s  IL_0049
     IL_000a:  ldarg.0
-    IL_000b:  ldarg.0
-    IL_000c:  ldfld      ""T Program.<Shift1>d__1<T>.item""
-    IL_0011:  stfld      ""T Program.<Shift1>d__1<T>.<>7__wrap1""
-    IL_0016:  ldarg.0
-    IL_0017:  ldflda     ""T Program.<Shift1>d__1<T>.item""
-    IL_001c:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0021:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_0026:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_002b:  stloc.2
-    IL_002c:  ldloca.s   V_2
-    IL_002e:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0033:  brtrue.s   IL_0074
-    IL_0035:  ldarg.0
-    IL_0036:  ldc.i4.0
-    IL_0037:  dup
-    IL_0038:  stloc.0
-    IL_0039:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
-    IL_003e:  ldarg.0
-    IL_003f:  ldloc.2
-    IL_0040:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift1>d__1<T>.<>u__1""
-    IL_0045:  ldarg.0
-    IL_0046:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift1>d__1<T>.<>t__builder""
-    IL_004b:  ldloca.s   V_2
-    IL_004d:  ldarg.0
-    IL_004e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift1>d__1<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift1>d__1<T>)""
-    IL_0053:  leave      IL_00da
-    IL_0058:  ldarg.0
-    IL_0059:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift1>d__1<T>.<>u__1""
-    IL_005e:  stloc.2
-    IL_005f:  ldarg.0
-    IL_0060:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift1>d__1<T>.<>u__1""
-    IL_0065:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_006b:  ldarg.0
-    IL_006c:  ldc.i4.m1
-    IL_006d:  dup
-    IL_006e:  stloc.0
-    IL_006f:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
-    IL_0074:  ldloca.s   V_2
-    IL_0076:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_007b:  stloc.1
-    IL_007c:  ldarg.0
-    IL_007d:  ldflda     ""T Program.<Shift1>d__1<T>.<>7__wrap1""
-    IL_0082:  ldc.i4.0
-    IL_0083:  ldarg.0
-    IL_0084:  ldflda     ""T Program.<Shift1>d__1<T>.<>7__wrap1""
-    IL_0089:  constrained. ""T""
-    IL_008f:  callvirt   ""int IMoveable.Length.get""
-    IL_0094:  ldloc.1
-    IL_0095:  sub
-    IL_0096:  constrained. ""T""
-    IL_009c:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
-    IL_00a1:  pop
-    IL_00a2:  ldarg.0
-    IL_00a3:  ldflda     ""T Program.<Shift1>d__1<T>.<>7__wrap1""
-    IL_00a8:  initobj    ""T""
-    IL_00ae:  leave.s    IL_00c7
+    IL_000b:  ldflda     ""T Program.<Shift1>d__1<T>.item""
+    IL_0010:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0015:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_001a:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_001f:  stloc.2
+    IL_0020:  ldloca.s   V_2
+    IL_0022:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0027:  brtrue.s   IL_0065
+    IL_0029:  ldarg.0
+    IL_002a:  ldc.i4.0
+    IL_002b:  dup
+    IL_002c:  stloc.0
+    IL_002d:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
+    IL_0032:  ldarg.0
+    IL_0033:  ldloc.2
+    IL_0034:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift1>d__1<T>.<>u__1""
+    IL_0039:  ldarg.0
+    IL_003a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift1>d__1<T>.<>t__builder""
+    IL_003f:  ldloca.s   V_2
+    IL_0041:  ldarg.0
+    IL_0042:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift1>d__1<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift1>d__1<T>)""
+    IL_0047:  leave.s    IL_00bf
+    IL_0049:  ldarg.0
+    IL_004a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift1>d__1<T>.<>u__1""
+    IL_004f:  stloc.2
+    IL_0050:  ldarg.0
+    IL_0051:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift1>d__1<T>.<>u__1""
+    IL_0056:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_005c:  ldarg.0
+    IL_005d:  ldc.i4.m1
+    IL_005e:  dup
+    IL_005f:  stloc.0
+    IL_0060:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
+    IL_0065:  ldloca.s   V_2
+    IL_0067:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_006c:  stloc.1
+    IL_006d:  ldarg.0
+    IL_006e:  ldflda     ""T Program.<Shift1>d__1<T>.item""
+    IL_0073:  ldc.i4.0
+    IL_0074:  ldarg.0
+    IL_0075:  ldflda     ""T Program.<Shift1>d__1<T>.item""
+    IL_007a:  constrained. ""T""
+    IL_0080:  callvirt   ""int IMoveable.Length.get""
+    IL_0085:  ldloc.1
+    IL_0086:  sub
+    IL_0087:  constrained. ""T""
+    IL_008d:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
+    IL_0092:  pop
+    IL_0093:  leave.s    IL_00ac
   }
   catch System.Exception
   {
-    IL_00b0:  stloc.3
-    IL_00b1:  ldarg.0
-    IL_00b2:  ldc.i4.s   -2
-    IL_00b4:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
-    IL_00b9:  ldarg.0
-    IL_00ba:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift1>d__1<T>.<>t__builder""
-    IL_00bf:  ldloc.3
-    IL_00c0:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_00c5:  leave.s    IL_00da
+    IL_0095:  stloc.3
+    IL_0096:  ldarg.0
+    IL_0097:  ldc.i4.s   -2
+    IL_0099:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
+    IL_009e:  ldarg.0
+    IL_009f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift1>d__1<T>.<>t__builder""
+    IL_00a4:  ldloc.3
+    IL_00a5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00aa:  leave.s    IL_00bf
   }
-  IL_00c7:  ldarg.0
-  IL_00c8:  ldc.i4.s   -2
-  IL_00ca:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
-  IL_00cf:  ldarg.0
-  IL_00d0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift1>d__1<T>.<>t__builder""
-  IL_00d5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_00da:  ret
+  IL_00ac:  ldarg.0
+  IL_00ad:  ldc.i4.s   -2
+  IL_00af:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
+  IL_00b4:  ldarg.0
+  IL_00b5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift1>d__1<T>.<>t__builder""
+  IL_00ba:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_00bf:  ret
 }
 ");
         }
@@ -29710,46 +29723,58 @@ Position Slice for item '2'
             verifier.VerifyIL("Program.Shift2<T>",
 @"
 {
-  // Code size       81 (0x51)
+  // Code size      111 (0x6f)
   .maxstack  3
   .locals init (T V_0,
-                System.Range V_1,
-                int V_2,
+                T& V_1,
+                System.Range V_2,
                 int V_3,
                 int V_4,
-                System.Index V_5)
-  IL_0000:  ldarg.0
-  IL_0001:  stloc.0
-  IL_0002:  ldarga.s   V_0
-  IL_0004:  call       ""System.Range Program.GetOffset<T>(ref T)""
-  IL_0009:  stloc.1
-  IL_000a:  ldloca.s   V_0
-  IL_000c:  constrained. ""T""
-  IL_0012:  callvirt   ""int IMoveable.Length.get""
-  IL_0017:  stloc.2
-  IL_0018:  ldloca.s   V_1
-  IL_001a:  call       ""System.Index System.Range.Start.get""
-  IL_001f:  stloc.s    V_5
-  IL_0021:  ldloca.s   V_5
-  IL_0023:  ldloc.2
-  IL_0024:  call       ""int System.Index.GetOffset(int)""
-  IL_0029:  stloc.3
-  IL_002a:  ldloca.s   V_1
-  IL_002c:  call       ""System.Index System.Range.End.get""
-  IL_0031:  stloc.s    V_5
-  IL_0033:  ldloca.s   V_5
-  IL_0035:  ldloc.2
-  IL_0036:  call       ""int System.Index.GetOffset(int)""
-  IL_003b:  ldloc.3
-  IL_003c:  sub
-  IL_003d:  stloc.s    V_4
-  IL_003f:  ldloca.s   V_0
-  IL_0041:  ldloc.3
-  IL_0042:  ldloc.s    V_4
-  IL_0044:  constrained. ""T""
-  IL_004a:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
-  IL_004f:  pop
-  IL_0050:  ret
+                int V_5,
+                T V_6,
+                System.Index V_7)
+  IL_0000:  ldarga.s   V_0
+  IL_0002:  stloc.1
+  IL_0003:  ldloca.s   V_6
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_6
+  IL_000d:  box        ""T""
+  IL_0012:  brtrue.s   IL_001f
+  IL_0014:  ldloc.1
+  IL_0015:  ldobj      ""T""
+  IL_001a:  stloc.0
+  IL_001b:  ldloca.s   V_0
+  IL_001d:  br.s       IL_0020
+  IL_001f:  ldloc.1
+  IL_0020:  ldarga.s   V_0
+  IL_0022:  call       ""System.Range Program.GetOffset<T>(ref T)""
+  IL_0027:  stloc.2
+  IL_0028:  dup
+  IL_0029:  constrained. ""T""
+  IL_002f:  callvirt   ""int IMoveable.Length.get""
+  IL_0034:  stloc.3
+  IL_0035:  ldloca.s   V_2
+  IL_0037:  call       ""System.Index System.Range.Start.get""
+  IL_003c:  stloc.s    V_7
+  IL_003e:  ldloca.s   V_7
+  IL_0040:  ldloc.3
+  IL_0041:  call       ""int System.Index.GetOffset(int)""
+  IL_0046:  stloc.s    V_4
+  IL_0048:  ldloca.s   V_2
+  IL_004a:  call       ""System.Index System.Range.End.get""
+  IL_004f:  stloc.s    V_7
+  IL_0051:  ldloca.s   V_7
+  IL_0053:  ldloc.3
+  IL_0054:  call       ""int System.Index.GetOffset(int)""
+  IL_0059:  ldloc.s    V_4
+  IL_005b:  sub
+  IL_005c:  stloc.s    V_5
+  IL_005e:  ldloc.s    V_4
+  IL_0060:  ldloc.s    V_5
+  IL_0062:  constrained. ""T""
+  IL_0068:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
+  IL_006d:  pop
+  IL_006e:  ret
 }
 ");
         }
@@ -29817,57 +29842,53 @@ class Program
 }
 ";
 
-            // Wrong output
             var verifier = CompileAndVerify(source, targetFramework: TargetFramework.NetLatest, options: TestOptions.ReleaseExe, expectedOutput: @"
-Position Length for item '1'
-Position Slice for item '1'
-Position Length for item '2'
-Position Slice for item '2'
+Position Length for item '-1'
+Position Slice for item '-1'
+Position Length for item '-2'
+Position Slice for item '-2'
 ").VerifyDiagnostics();
 
             verifier.VerifyIL("Program.Shift1<T>",
 @"
 {
-  // Code size       81 (0x51)
+  // Code size       76 (0x4c)
   .maxstack  3
-  .locals init (T V_0,
-                System.Range V_1,
+  .locals init (System.Range V_0,
+                int V_1,
                 int V_2,
                 int V_3,
-                int V_4,
-                System.Index V_5)
-  IL_0000:  ldarg.0
-  IL_0001:  stloc.0
+                System.Index V_4)
+  IL_0000:  ldarga.s   V_0
   IL_0002:  ldarga.s   V_0
   IL_0004:  call       ""System.Range Program.GetOffset<T>(ref T)""
-  IL_0009:  stloc.1
-  IL_000a:  ldloca.s   V_0
-  IL_000c:  constrained. ""T""
-  IL_0012:  callvirt   ""int IMoveable.Length.get""
-  IL_0017:  stloc.2
-  IL_0018:  ldloca.s   V_1
-  IL_001a:  call       ""System.Index System.Range.Start.get""
-  IL_001f:  stloc.s    V_5
-  IL_0021:  ldloca.s   V_5
-  IL_0023:  ldloc.2
-  IL_0024:  call       ""int System.Index.GetOffset(int)""
-  IL_0029:  stloc.3
-  IL_002a:  ldloca.s   V_1
-  IL_002c:  call       ""System.Index System.Range.End.get""
-  IL_0031:  stloc.s    V_5
-  IL_0033:  ldloca.s   V_5
-  IL_0035:  ldloc.2
-  IL_0036:  call       ""int System.Index.GetOffset(int)""
-  IL_003b:  ldloc.3
-  IL_003c:  sub
-  IL_003d:  stloc.s    V_4
-  IL_003f:  ldloca.s   V_0
-  IL_0041:  ldloc.3
-  IL_0042:  ldloc.s    V_4
-  IL_0044:  constrained. ""T""
-  IL_004a:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
-  IL_004f:  pop
-  IL_0050:  ret
+  IL_0009:  stloc.0
+  IL_000a:  dup
+  IL_000b:  constrained. ""T""
+  IL_0011:  callvirt   ""int IMoveable.Length.get""
+  IL_0016:  stloc.1
+  IL_0017:  ldloca.s   V_0
+  IL_0019:  call       ""System.Index System.Range.Start.get""
+  IL_001e:  stloc.s    V_4
+  IL_0020:  ldloca.s   V_4
+  IL_0022:  ldloc.1
+  IL_0023:  call       ""int System.Index.GetOffset(int)""
+  IL_0028:  stloc.2
+  IL_0029:  ldloca.s   V_0
+  IL_002b:  call       ""System.Index System.Range.End.get""
+  IL_0030:  stloc.s    V_4
+  IL_0032:  ldloca.s   V_4
+  IL_0034:  ldloc.1
+  IL_0035:  call       ""int System.Index.GetOffset(int)""
+  IL_003a:  ldloc.2
+  IL_003b:  sub
+  IL_003c:  stloc.3
+  IL_003d:  ldloc.2
+  IL_003e:  ldloc.3
+  IL_003f:  constrained. ""T""
+  IL_0045:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
+  IL_004a:  pop
+  IL_004b:  ret
 }
 ");
         }
@@ -29989,47 +30010,58 @@ Position Slice for item '2'
             verifier.VerifyIL("Program.Shift2<T>",
 @"
 {
-  // Code size       85 (0x55)
+  // Code size      109 (0x6d)
   .maxstack  3
   .locals init (T V_0,
-                System.Range V_1,
-                int V_2,
+                T& V_1,
+                System.Range V_2,
                 int V_3,
                 int V_4,
-                System.Index V_5)
+                int V_5,
+                T V_6,
+                System.Index V_7)
   IL_0000:  ldarg.0
-  IL_0001:  ldobj      ""T""
-  IL_0006:  stloc.0
-  IL_0007:  ldarg.0
-  IL_0008:  call       ""System.Range Program.GetOffset<T>(ref T)""
-  IL_000d:  stloc.1
-  IL_000e:  ldloca.s   V_0
-  IL_0010:  constrained. ""T""
-  IL_0016:  callvirt   ""int IMoveable.Length.get""
-  IL_001b:  stloc.2
-  IL_001c:  ldloca.s   V_1
-  IL_001e:  call       ""System.Index System.Range.Start.get""
-  IL_0023:  stloc.s    V_5
-  IL_0025:  ldloca.s   V_5
-  IL_0027:  ldloc.2
-  IL_0028:  call       ""int System.Index.GetOffset(int)""
-  IL_002d:  stloc.3
-  IL_002e:  ldloca.s   V_1
-  IL_0030:  call       ""System.Index System.Range.End.get""
-  IL_0035:  stloc.s    V_5
-  IL_0037:  ldloca.s   V_5
-  IL_0039:  ldloc.2
-  IL_003a:  call       ""int System.Index.GetOffset(int)""
-  IL_003f:  ldloc.3
-  IL_0040:  sub
-  IL_0041:  stloc.s    V_4
-  IL_0043:  ldloca.s   V_0
-  IL_0045:  ldloc.3
-  IL_0046:  ldloc.s    V_4
-  IL_0048:  constrained. ""T""
-  IL_004e:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
-  IL_0053:  pop
-  IL_0054:  ret
+  IL_0001:  stloc.1
+  IL_0002:  ldloca.s   V_6
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_6
+  IL_000c:  box        ""T""
+  IL_0011:  brtrue.s   IL_001e
+  IL_0013:  ldloc.1
+  IL_0014:  ldobj      ""T""
+  IL_0019:  stloc.0
+  IL_001a:  ldloca.s   V_0
+  IL_001c:  br.s       IL_001f
+  IL_001e:  ldloc.1
+  IL_001f:  ldarg.0
+  IL_0020:  call       ""System.Range Program.GetOffset<T>(ref T)""
+  IL_0025:  stloc.2
+  IL_0026:  dup
+  IL_0027:  constrained. ""T""
+  IL_002d:  callvirt   ""int IMoveable.Length.get""
+  IL_0032:  stloc.3
+  IL_0033:  ldloca.s   V_2
+  IL_0035:  call       ""System.Index System.Range.Start.get""
+  IL_003a:  stloc.s    V_7
+  IL_003c:  ldloca.s   V_7
+  IL_003e:  ldloc.3
+  IL_003f:  call       ""int System.Index.GetOffset(int)""
+  IL_0044:  stloc.s    V_4
+  IL_0046:  ldloca.s   V_2
+  IL_0048:  call       ""System.Index System.Range.End.get""
+  IL_004d:  stloc.s    V_7
+  IL_004f:  ldloca.s   V_7
+  IL_0051:  ldloc.3
+  IL_0052:  call       ""int System.Index.GetOffset(int)""
+  IL_0057:  ldloc.s    V_4
+  IL_0059:  sub
+  IL_005a:  stloc.s    V_5
+  IL_005c:  ldloc.s    V_4
+  IL_005e:  ldloc.s    V_5
+  IL_0060:  constrained. ""T""
+  IL_0066:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
+  IL_006b:  pop
+  IL_006c:  ret
 }
 ");
         }
@@ -30097,58 +30129,53 @@ class Program
 }
 ";
 
-            // Wrong output
             var verifier = CompileAndVerify(source, targetFramework: TargetFramework.NetLatest, options: TestOptions.ReleaseExe, expectedOutput: @"
-Position Length for item '1'
-Position Slice for item '1'
-Position Length for item '2'
-Position Slice for item '2'
+Position Length for item '-1'
+Position Slice for item '-1'
+Position Length for item '-2'
+Position Slice for item '-2'
 ").VerifyDiagnostics();
 
             verifier.VerifyIL("Program.Shift1<T>",
 @"
 {
-  // Code size       85 (0x55)
+  // Code size       74 (0x4a)
   .maxstack  3
-  .locals init (T V_0,
-                System.Range V_1,
+  .locals init (System.Range V_0,
+                int V_1,
                 int V_2,
                 int V_3,
-                int V_4,
-                System.Index V_5)
+                System.Index V_4)
   IL_0000:  ldarg.0
-  IL_0001:  ldobj      ""T""
-  IL_0006:  stloc.0
-  IL_0007:  ldarg.0
-  IL_0008:  call       ""System.Range Program.GetOffset<T>(ref T)""
-  IL_000d:  stloc.1
-  IL_000e:  ldloca.s   V_0
-  IL_0010:  constrained. ""T""
-  IL_0016:  callvirt   ""int IMoveable.Length.get""
-  IL_001b:  stloc.2
-  IL_001c:  ldloca.s   V_1
-  IL_001e:  call       ""System.Index System.Range.Start.get""
-  IL_0023:  stloc.s    V_5
-  IL_0025:  ldloca.s   V_5
-  IL_0027:  ldloc.2
-  IL_0028:  call       ""int System.Index.GetOffset(int)""
-  IL_002d:  stloc.3
-  IL_002e:  ldloca.s   V_1
-  IL_0030:  call       ""System.Index System.Range.End.get""
-  IL_0035:  stloc.s    V_5
-  IL_0037:  ldloca.s   V_5
-  IL_0039:  ldloc.2
-  IL_003a:  call       ""int System.Index.GetOffset(int)""
-  IL_003f:  ldloc.3
-  IL_0040:  sub
-  IL_0041:  stloc.s    V_4
-  IL_0043:  ldloca.s   V_0
-  IL_0045:  ldloc.3
-  IL_0046:  ldloc.s    V_4
-  IL_0048:  constrained. ""T""
-  IL_004e:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
-  IL_0053:  pop
-  IL_0054:  ret
+  IL_0001:  ldarg.0
+  IL_0002:  call       ""System.Range Program.GetOffset<T>(ref T)""
+  IL_0007:  stloc.0
+  IL_0008:  dup
+  IL_0009:  constrained. ""T""
+  IL_000f:  callvirt   ""int IMoveable.Length.get""
+  IL_0014:  stloc.1
+  IL_0015:  ldloca.s   V_0
+  IL_0017:  call       ""System.Index System.Range.Start.get""
+  IL_001c:  stloc.s    V_4
+  IL_001e:  ldloca.s   V_4
+  IL_0020:  ldloc.1
+  IL_0021:  call       ""int System.Index.GetOffset(int)""
+  IL_0026:  stloc.2
+  IL_0027:  ldloca.s   V_0
+  IL_0029:  call       ""System.Index System.Range.End.get""
+  IL_002e:  stloc.s    V_4
+  IL_0030:  ldloca.s   V_4
+  IL_0032:  ldloc.1
+  IL_0033:  call       ""int System.Index.GetOffset(int)""
+  IL_0038:  ldloc.2
+  IL_0039:  sub
+  IL_003a:  stloc.3
+  IL_003b:  ldloc.2
+  IL_003c:  ldloc.3
+  IL_003d:  constrained. ""T""
+  IL_0043:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
+  IL_0048:  pop
+  IL_0049:  ret
 }
 ");
         }
@@ -30349,116 +30376,138 @@ Position Slice for item '2'
             verifier.VerifyIL("Program.<Shift2>d__2<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"
 {
-  // Code size      264 (0x108)
+  // Code size      331 (0x14b)
   .maxstack  3
   .locals init (int V_0,
                 System.Range V_1,
                 int V_2,
                 int V_3,
                 int V_4,
-                System.Runtime.CompilerServices.TaskAwaiter<System.Range> V_5,
-                System.Index V_6,
-                System.Exception V_7)
+                T V_5,
+                System.Runtime.CompilerServices.TaskAwaiter<System.Range> V_6,
+                System.Index V_7,
+                System.Exception V_8)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_005a
-    IL_000a:  ldarg.0
-    IL_000b:  ldarg.0
-    IL_000c:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0011:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0016:  ldarg.0
-    IL_0017:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_001c:  call       ""System.Range Program.GetOffset<T>(ref T)""
-    IL_0021:  call       ""System.Threading.Tasks.Task<System.Range> Program.GetOffsetAsync(System.Range)""
-    IL_0026:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> System.Threading.Tasks.Task<System.Range>.GetAwaiter()""
-    IL_002b:  stloc.s    V_5
-    IL_002d:  ldloca.s   V_5
-    IL_002f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<System.Range>.IsCompleted.get""
-    IL_0034:  brtrue.s   IL_0077
-    IL_0036:  ldarg.0
-    IL_0037:  ldc.i4.0
-    IL_0038:  dup
-    IL_0039:  stloc.0
-    IL_003a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_003f:  ldarg.0
-    IL_0040:  ldloc.s    V_5
-    IL_0042:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0008:  brfalse.s  IL_006b
+    IL_000a:  ldloca.s   V_5
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.s    V_5
+    IL_0014:  box        ""T""
+    IL_0019:  brtrue.s   IL_0027
+    IL_001b:  ldarg.0
+    IL_001c:  ldarg.0
+    IL_001d:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0022:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0027:  ldarg.0
+    IL_0028:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_002d:  call       ""System.Range Program.GetOffset<T>(ref T)""
+    IL_0032:  call       ""System.Threading.Tasks.Task<System.Range> Program.GetOffsetAsync(System.Range)""
+    IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> System.Threading.Tasks.Task<System.Range>.GetAwaiter()""
+    IL_003c:  stloc.s    V_6
+    IL_003e:  ldloca.s   V_6
+    IL_0040:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<System.Range>.IsCompleted.get""
+    IL_0045:  brtrue.s   IL_0088
     IL_0047:  ldarg.0
-    IL_0048:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_004d:  ldloca.s   V_5
-    IL_004f:  ldarg.0
-    IL_0050:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<System.Range>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<System.Range>, ref Program.<Shift2>d__2<T>)""
-    IL_0055:  leave      IL_0107
-    IL_005a:  ldarg.0
-    IL_005b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0060:  stloc.s    V_5
-    IL_0062:  ldarg.0
-    IL_0063:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0068:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<System.Range>""
-    IL_006e:  ldarg.0
-    IL_006f:  ldc.i4.m1
-    IL_0070:  dup
-    IL_0071:  stloc.0
-    IL_0072:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0077:  ldloca.s   V_5
-    IL_0079:  call       ""System.Range System.Runtime.CompilerServices.TaskAwaiter<System.Range>.GetResult()""
-    IL_007e:  stloc.1
+    IL_0048:  ldc.i4.0
+    IL_0049:  dup
+    IL_004a:  stloc.0
+    IL_004b:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0050:  ldarg.0
+    IL_0051:  ldloc.s    V_6
+    IL_0053:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0058:  ldarg.0
+    IL_0059:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_005e:  ldloca.s   V_6
+    IL_0060:  ldarg.0
+    IL_0061:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<System.Range>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<System.Range>, ref Program.<Shift2>d__2<T>)""
+    IL_0066:  leave      IL_014a
+    IL_006b:  ldarg.0
+    IL_006c:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0071:  stloc.s    V_6
+    IL_0073:  ldarg.0
+    IL_0074:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0079:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<System.Range>""
     IL_007f:  ldarg.0
-    IL_0080:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0085:  constrained. ""T""
-    IL_008b:  callvirt   ""int IMoveable.Length.get""
-    IL_0090:  stloc.2
-    IL_0091:  ldloca.s   V_1
-    IL_0093:  call       ""System.Index System.Range.Start.get""
-    IL_0098:  stloc.s    V_6
-    IL_009a:  ldloca.s   V_6
-    IL_009c:  ldloc.2
-    IL_009d:  call       ""int System.Index.GetOffset(int)""
-    IL_00a2:  stloc.3
-    IL_00a3:  ldloca.s   V_1
-    IL_00a5:  call       ""System.Index System.Range.End.get""
-    IL_00aa:  stloc.s    V_6
-    IL_00ac:  ldloca.s   V_6
-    IL_00ae:  ldloc.2
-    IL_00af:  call       ""int System.Index.GetOffset(int)""
-    IL_00b4:  ldloc.3
-    IL_00b5:  sub
-    IL_00b6:  stloc.s    V_4
-    IL_00b8:  ldarg.0
-    IL_00b9:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00be:  ldloc.3
-    IL_00bf:  ldloc.s    V_4
-    IL_00c1:  constrained. ""T""
-    IL_00c7:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
-    IL_00cc:  pop
-    IL_00cd:  ldarg.0
-    IL_00ce:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00d3:  initobj    ""T""
-    IL_00d9:  leave.s    IL_00f4
+    IL_0080:  ldc.i4.m1
+    IL_0081:  dup
+    IL_0082:  stloc.0
+    IL_0083:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0088:  ldloca.s   V_6
+    IL_008a:  call       ""System.Range System.Runtime.CompilerServices.TaskAwaiter<System.Range>.GetResult()""
+    IL_008f:  stloc.1
+    IL_0090:  ldloca.s   V_5
+    IL_0092:  initobj    ""T""
+    IL_0098:  ldloc.s    V_5
+    IL_009a:  box        ""T""
+    IL_009f:  brtrue.s   IL_00a9
+    IL_00a1:  ldarg.0
+    IL_00a2:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00a7:  br.s       IL_00af
+    IL_00a9:  ldarg.0
+    IL_00aa:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00af:  constrained. ""T""
+    IL_00b5:  callvirt   ""int IMoveable.Length.get""
+    IL_00ba:  stloc.2
+    IL_00bb:  ldloca.s   V_1
+    IL_00bd:  call       ""System.Index System.Range.Start.get""
+    IL_00c2:  stloc.s    V_7
+    IL_00c4:  ldloca.s   V_7
+    IL_00c6:  ldloc.2
+    IL_00c7:  call       ""int System.Index.GetOffset(int)""
+    IL_00cc:  stloc.3
+    IL_00cd:  ldloca.s   V_1
+    IL_00cf:  call       ""System.Index System.Range.End.get""
+    IL_00d4:  stloc.s    V_7
+    IL_00d6:  ldloca.s   V_7
+    IL_00d8:  ldloc.2
+    IL_00d9:  call       ""int System.Index.GetOffset(int)""
+    IL_00de:  ldloc.3
+    IL_00df:  sub
+    IL_00e0:  stloc.s    V_4
+    IL_00e2:  ldloca.s   V_5
+    IL_00e4:  initobj    ""T""
+    IL_00ea:  ldloc.s    V_5
+    IL_00ec:  box        ""T""
+    IL_00f1:  brtrue.s   IL_00fb
+    IL_00f3:  ldarg.0
+    IL_00f4:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00f9:  br.s       IL_0101
+    IL_00fb:  ldarg.0
+    IL_00fc:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0101:  ldloc.3
+    IL_0102:  ldloc.s    V_4
+    IL_0104:  constrained. ""T""
+    IL_010a:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
+    IL_010f:  pop
+    IL_0110:  ldarg.0
+    IL_0111:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0116:  initobj    ""T""
+    IL_011c:  leave.s    IL_0137
   }
   catch System.Exception
   {
-    IL_00db:  stloc.s    V_7
-    IL_00dd:  ldarg.0
-    IL_00de:  ldc.i4.s   -2
-    IL_00e0:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00e5:  ldarg.0
-    IL_00e6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_00eb:  ldloc.s    V_7
-    IL_00ed:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_00f2:  leave.s    IL_0107
+    IL_011e:  stloc.s    V_8
+    IL_0120:  ldarg.0
+    IL_0121:  ldc.i4.s   -2
+    IL_0123:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0128:  ldarg.0
+    IL_0129:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_012e:  ldloc.s    V_8
+    IL_0130:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0135:  leave.s    IL_014a
   }
-  IL_00f4:  ldarg.0
-  IL_00f5:  ldc.i4.s   -2
-  IL_00f7:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-  IL_00fc:  ldarg.0
-  IL_00fd:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-  IL_0102:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0107:  ret
+  IL_0137:  ldarg.0
+  IL_0138:  ldc.i4.s   -2
+  IL_013a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+  IL_013f:  ldarg.0
+  IL_0140:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+  IL_0145:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_014a:  ret
 }
 ");
         }
@@ -30533,18 +30582,17 @@ class Program
 }
 ";
 
-            // Wrong output
             var verifier = CompileAndVerify(source, targetFramework: TargetFramework.NetLatest, options: TestOptions.ReleaseExe, expectedOutput: @"
-Position Length for item '1'
-Position Slice for item '1'
-Position Length for item '2'
-Position Slice for item '2'
+Position Length for item '-1'
+Position Slice for item '-1'
+Position Length for item '-2'
+Position Slice for item '-2'
 ").VerifyDiagnostics();
 
             verifier.VerifyIL("Program.<Shift1>d__1<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"
 {
-  // Code size      264 (0x108)
+  // Code size      240 (0xf0)
   .maxstack  3
   .locals init (int V_0,
                 System.Range V_1,
@@ -30560,100 +30608,93 @@ Position Slice for item '2'
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_005a
+    IL_0008:  brfalse.s  IL_004e
     IL_000a:  ldarg.0
-    IL_000b:  ldarg.0
-    IL_000c:  ldfld      ""T Program.<Shift1>d__1<T>.item""
-    IL_0011:  stfld      ""T Program.<Shift1>d__1<T>.<>7__wrap1""
-    IL_0016:  ldarg.0
-    IL_0017:  ldflda     ""T Program.<Shift1>d__1<T>.item""
-    IL_001c:  call       ""System.Range Program.GetOffset<T>(ref T)""
-    IL_0021:  call       ""System.Threading.Tasks.Task<System.Range> Program.GetOffsetAsync(System.Range)""
-    IL_0026:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> System.Threading.Tasks.Task<System.Range>.GetAwaiter()""
-    IL_002b:  stloc.s    V_5
-    IL_002d:  ldloca.s   V_5
-    IL_002f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<System.Range>.IsCompleted.get""
-    IL_0034:  brtrue.s   IL_0077
-    IL_0036:  ldarg.0
-    IL_0037:  ldc.i4.0
-    IL_0038:  dup
-    IL_0039:  stloc.0
-    IL_003a:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
-    IL_003f:  ldarg.0
-    IL_0040:  ldloc.s    V_5
-    IL_0042:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> Program.<Shift1>d__1<T>.<>u__1""
-    IL_0047:  ldarg.0
-    IL_0048:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift1>d__1<T>.<>t__builder""
-    IL_004d:  ldloca.s   V_5
-    IL_004f:  ldarg.0
-    IL_0050:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<System.Range>, Program.<Shift1>d__1<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<System.Range>, ref Program.<Shift1>d__1<T>)""
-    IL_0055:  leave      IL_0107
-    IL_005a:  ldarg.0
-    IL_005b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> Program.<Shift1>d__1<T>.<>u__1""
-    IL_0060:  stloc.s    V_5
+    IL_000b:  ldflda     ""T Program.<Shift1>d__1<T>.item""
+    IL_0010:  call       ""System.Range Program.GetOffset<T>(ref T)""
+    IL_0015:  call       ""System.Threading.Tasks.Task<System.Range> Program.GetOffsetAsync(System.Range)""
+    IL_001a:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> System.Threading.Tasks.Task<System.Range>.GetAwaiter()""
+    IL_001f:  stloc.s    V_5
+    IL_0021:  ldloca.s   V_5
+    IL_0023:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<System.Range>.IsCompleted.get""
+    IL_0028:  brtrue.s   IL_006b
+    IL_002a:  ldarg.0
+    IL_002b:  ldc.i4.0
+    IL_002c:  dup
+    IL_002d:  stloc.0
+    IL_002e:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
+    IL_0033:  ldarg.0
+    IL_0034:  ldloc.s    V_5
+    IL_0036:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> Program.<Shift1>d__1<T>.<>u__1""
+    IL_003b:  ldarg.0
+    IL_003c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift1>d__1<T>.<>t__builder""
+    IL_0041:  ldloca.s   V_5
+    IL_0043:  ldarg.0
+    IL_0044:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<System.Range>, Program.<Shift1>d__1<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<System.Range>, ref Program.<Shift1>d__1<T>)""
+    IL_0049:  leave      IL_00ef
+    IL_004e:  ldarg.0
+    IL_004f:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> Program.<Shift1>d__1<T>.<>u__1""
+    IL_0054:  stloc.s    V_5
+    IL_0056:  ldarg.0
+    IL_0057:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> Program.<Shift1>d__1<T>.<>u__1""
+    IL_005c:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<System.Range>""
     IL_0062:  ldarg.0
-    IL_0063:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> Program.<Shift1>d__1<T>.<>u__1""
-    IL_0068:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<System.Range>""
-    IL_006e:  ldarg.0
-    IL_006f:  ldc.i4.m1
-    IL_0070:  dup
-    IL_0071:  stloc.0
-    IL_0072:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
-    IL_0077:  ldloca.s   V_5
-    IL_0079:  call       ""System.Range System.Runtime.CompilerServices.TaskAwaiter<System.Range>.GetResult()""
-    IL_007e:  stloc.1
-    IL_007f:  ldarg.0
-    IL_0080:  ldflda     ""T Program.<Shift1>d__1<T>.<>7__wrap1""
-    IL_0085:  constrained. ""T""
-    IL_008b:  callvirt   ""int IMoveable.Length.get""
-    IL_0090:  stloc.2
-    IL_0091:  ldloca.s   V_1
-    IL_0093:  call       ""System.Index System.Range.Start.get""
-    IL_0098:  stloc.s    V_6
-    IL_009a:  ldloca.s   V_6
-    IL_009c:  ldloc.2
-    IL_009d:  call       ""int System.Index.GetOffset(int)""
-    IL_00a2:  stloc.3
-    IL_00a3:  ldloca.s   V_1
-    IL_00a5:  call       ""System.Index System.Range.End.get""
-    IL_00aa:  stloc.s    V_6
-    IL_00ac:  ldloca.s   V_6
-    IL_00ae:  ldloc.2
-    IL_00af:  call       ""int System.Index.GetOffset(int)""
-    IL_00b4:  ldloc.3
-    IL_00b5:  sub
-    IL_00b6:  stloc.s    V_4
-    IL_00b8:  ldarg.0
-    IL_00b9:  ldflda     ""T Program.<Shift1>d__1<T>.<>7__wrap1""
-    IL_00be:  ldloc.3
-    IL_00bf:  ldloc.s    V_4
-    IL_00c1:  constrained. ""T""
-    IL_00c7:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
-    IL_00cc:  pop
-    IL_00cd:  ldarg.0
-    IL_00ce:  ldflda     ""T Program.<Shift1>d__1<T>.<>7__wrap1""
-    IL_00d3:  initobj    ""T""
-    IL_00d9:  leave.s    IL_00f4
+    IL_0063:  ldc.i4.m1
+    IL_0064:  dup
+    IL_0065:  stloc.0
+    IL_0066:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
+    IL_006b:  ldloca.s   V_5
+    IL_006d:  call       ""System.Range System.Runtime.CompilerServices.TaskAwaiter<System.Range>.GetResult()""
+    IL_0072:  stloc.1
+    IL_0073:  ldarg.0
+    IL_0074:  ldflda     ""T Program.<Shift1>d__1<T>.item""
+    IL_0079:  constrained. ""T""
+    IL_007f:  callvirt   ""int IMoveable.Length.get""
+    IL_0084:  stloc.2
+    IL_0085:  ldloca.s   V_1
+    IL_0087:  call       ""System.Index System.Range.Start.get""
+    IL_008c:  stloc.s    V_6
+    IL_008e:  ldloca.s   V_6
+    IL_0090:  ldloc.2
+    IL_0091:  call       ""int System.Index.GetOffset(int)""
+    IL_0096:  stloc.3
+    IL_0097:  ldloca.s   V_1
+    IL_0099:  call       ""System.Index System.Range.End.get""
+    IL_009e:  stloc.s    V_6
+    IL_00a0:  ldloca.s   V_6
+    IL_00a2:  ldloc.2
+    IL_00a3:  call       ""int System.Index.GetOffset(int)""
+    IL_00a8:  ldloc.3
+    IL_00a9:  sub
+    IL_00aa:  stloc.s    V_4
+    IL_00ac:  ldarg.0
+    IL_00ad:  ldflda     ""T Program.<Shift1>d__1<T>.item""
+    IL_00b2:  ldloc.3
+    IL_00b3:  ldloc.s    V_4
+    IL_00b5:  constrained. ""T""
+    IL_00bb:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
+    IL_00c0:  pop
+    IL_00c1:  leave.s    IL_00dc
   }
   catch System.Exception
   {
-    IL_00db:  stloc.s    V_7
-    IL_00dd:  ldarg.0
-    IL_00de:  ldc.i4.s   -2
-    IL_00e0:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
-    IL_00e5:  ldarg.0
-    IL_00e6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift1>d__1<T>.<>t__builder""
-    IL_00eb:  ldloc.s    V_7
-    IL_00ed:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_00f2:  leave.s    IL_0107
+    IL_00c3:  stloc.s    V_7
+    IL_00c5:  ldarg.0
+    IL_00c6:  ldc.i4.s   -2
+    IL_00c8:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
+    IL_00cd:  ldarg.0
+    IL_00ce:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift1>d__1<T>.<>t__builder""
+    IL_00d3:  ldloc.s    V_7
+    IL_00d5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00da:  leave.s    IL_00ef
   }
-  IL_00f4:  ldarg.0
-  IL_00f5:  ldc.i4.s   -2
-  IL_00f7:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
-  IL_00fc:  ldarg.0
-  IL_00fd:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift1>d__1<T>.<>t__builder""
-  IL_0102:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0107:  ret
+  IL_00dc:  ldarg.0
+  IL_00dd:  ldc.i4.s   -2
+  IL_00df:  stfld      ""int Program.<Shift1>d__1<T>.<>1__state""
+  IL_00e4:  ldarg.0
+  IL_00e5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift1>d__1<T>.<>t__builder""
+  IL_00ea:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_00ef:  ret
 }
 ");
         }


### PR DESCRIPTION
Fixes #65586.
Related to #63221.