### PR TITLE
Cleanup redundant NeitherNull methods

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpDeclarationComparer.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpDeclarationComparer.cs
@@ -298,33 +298,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return result;
         }
 
-        private static bool NeitherNull(object x, object y, out int comparisonResult)
-        {
-            if (x == null && y == null)
-            {
-                comparisonResult = 0;
-                return false;
-            }
-            else if (x == null)
-            {
-                // x == null && y != null
-                comparisonResult = -1;
-                return false;
-            }
-            else if (y == null)
-            {
-                // x != null && y == null
-                comparisonResult = 1;
-                return false;
-            }
-            else
-            {
-                // x != null && y != null
-                comparisonResult = 0;
-                return true;
-            }
-        }
-
         private static bool ContainsToken(SyntaxTokenList list, SyntaxKind kind)
             => list.Contains(token => token.Kind() == kind);
 
@@ -421,24 +394,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         private static bool EqualIdentifierName(SyntaxToken x, SyntaxToken y, out int comparisonResult)
         {
-            if (NeitherNull(x, y, out comparisonResult))
-            {
-                comparisonResult = string.Compare(x.ValueText, y.ValueText, StringComparison.OrdinalIgnoreCase);
-            }
-
+            comparisonResult = string.Compare(x.ValueText, y.ValueText, StringComparison.OrdinalIgnoreCase);
             return comparisonResult == 0;
         }
 
         private static bool EqualOperatorPrecedence(SyntaxToken x, SyntaxToken y, out int comparisonResult)
         {
-            if (NeitherNull(x, y, out comparisonResult))
-            {
-                s_operatorPrecedenceMap.TryGetValue(x.Kind(), out var xPrecedence);
-                s_operatorPrecedenceMap.TryGetValue(y.Kind(), out var yPrecedence);
+            s_operatorPrecedenceMap.TryGetValue(x.Kind(), out var xPrecedence);
+            s_operatorPrecedenceMap.TryGetValue(y.Kind(), out var yPrecedence);
 
-                comparisonResult = xPrecedence - yPrecedence;
-            }
-
+            comparisonResult = xPrecedence - yPrecedence;
             return comparisonResult == 0;
         }
 

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicDeclarationComparer.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicDeclarationComparer.vb
@@ -388,24 +388,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Private Shared Function EqualIdentifierName(x As SyntaxToken, y As SyntaxToken, ByRef comparisonResult As Integer) As Boolean
-            If NeitherNull(x, y, comparisonResult) Then
-                comparisonResult = CaseInsensitiveComparison.Compare(x.ValueText, y.ValueText)
-            End If
-
+            comparisonResult = CaseInsensitiveComparison.Compare(x.ValueText, y.ValueText)
             Return comparisonResult = 0
         End Function
 
         Private Shared Function EqualOperatorPrecedence(x As SyntaxToken, y As SyntaxToken, ByRef comparisonResult As Integer) As Boolean
-            If NeitherNull(x, y, comparisonResult) Then
-                Dim xPrecedence = 0
-                Dim yPrecedence = 0
+            Dim xPrecedence = 0
+            Dim yPrecedence = 0
 
-                s_operatorPrecedenceMap.TryGetValue(x.Kind, xPrecedence)
-                s_operatorPrecedenceMap.TryGetValue(y.Kind, yPrecedence)
+            s_operatorPrecedenceMap.TryGetValue(x.Kind, xPrecedence)
+            s_operatorPrecedenceMap.TryGetValue(y.Kind, yPrecedence)
 
-                comparisonResult = If(xPrecedence = yPrecedence, 0, If(xPrecedence < yPrecedence, -1, 1))
-            End If
-
+            comparisonResult = If(xPrecedence = yPrecedence, 0, If(xPrecedence < yPrecedence, -1, 1))
             Return comparisonResult = 0
         End Function
 


### PR DESCRIPTION
It seems like callers of `NeitherNull` are passing `SyntaxToken` (which is a struct (value type)).

When those `SyntaxToken`s are boxed and compared against null, I think the comparison is always false. This PR cleans that up.