### PR TITLE
Pass non-null SyntaxContext when available

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             if (token.Kind() == SyntaxKind.OpenBracketToken &&
                 token.Parent.IsKind(SyntaxKind.AttributeList) &&
                 this.SyntaxTree.IsTypeDeclarationContext(
-                    token.SpanStart, contextOpt: null, validModifiers: null, validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations, canBePartial: false, cancellationToken: cancellationToken))
+                    token.SpanStart, contextOpt: this, validModifiers: null, validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations, canBePartial: false, cancellationToken: cancellationToken))
             {
                 return true;
             }
@@ -368,7 +368,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 }
 
                 if (SyntaxTree.IsMemberDeclarationContext(
-                    token.SpanStart, contextOpt: null, validModifiers: null, validTypeDeclarations: validTypeDeclarations, canBePartial: false, cancellationToken: cancellationToken))
+                    token.SpanStart, contextOpt: this, validModifiers: null, validTypeDeclarations: validTypeDeclarations, canBePartial: false, cancellationToken: cancellationToken))
                 {
                     return true;
                 }


### PR DESCRIPTION
This avoids re-calculating few things in these methods where we have a context that already calculated them.

Things that are now not re-calculated:

https://github.com/dotnet/roslyn/blob/becd261d8904c4c0b02be1eaeaa8ca30b7c654f0/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs#L247-L249

https://github.com/dotnet/roslyn/blob/becd261d8904c4c0b02be1eaeaa8ca30b7c654f0/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs#L264-L266

https://github.com/dotnet/roslyn/blob/becd261d8904c4c0b02be1eaeaa8ca30b7c654f0/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs#L289

---

https://github.com/dotnet/roslyn/blob/becd261d8904c4c0b02be1eaeaa8ca30b7c654f0/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs#L538-L540

https://github.com/dotnet/roslyn/blob/becd261d8904c4c0b02be1eaeaa8ca30b7c654f0/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs#L553-L555

https://github.com/dotnet/roslyn/blob/becd261d8904c4c0b02be1eaeaa8ca30b7c654f0/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs#L559-L561

https://github.com/dotnet/roslyn/blob/becd261d8904c4c0b02be1eaeaa8ca30b7c654f0/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs#L559-L561