### PR TITLE
Ensure we recompute top level semantic versions, even when making frozen documents

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -201,10 +201,6 @@ namespace Microsoft.CodeAnalysis
                         var oldTree = oldState.GetSyntaxTree(cancellationToken);
 
                         compilationPair = compilationPair.ReplaceSyntaxTree(oldTree, tree);
-
-                        // We're changing the text of this document to something else entirely.  So we need to pass
-                        // `textChanged: true, recalculateDependentVersions: true` so that any interested parties that
-                        // compute anything that is dependent on changed text get the right values.
                         inProgressProject = inProgressProject.UpdateDocument(docState, contentChanged: true);
                     }
                     else

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -201,6 +201,10 @@ namespace Microsoft.CodeAnalysis
                         var oldTree = oldState.GetSyntaxTree(cancellationToken);
 
                         compilationPair = compilationPair.ReplaceSyntaxTree(oldTree, tree);
+
+                        // We're changing the text of this document to something else entirely.  So we need to pass
+                        // `textChanged: true, recalculateDependentVersions: true` so that any interested parties that
+                        // compute anything that is dependent on changed text get the right values.
                         inProgressProject = inProgressProject.UpdateDocument(docState, textChanged: false, recalculateDependentVersions: false);
                     }
                     else

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis
                         // We're changing the text of this document to something else entirely.  So we need to pass
                         // `textChanged: true, recalculateDependentVersions: true` so that any interested parties that
                         // compute anything that is dependent on changed text get the right values.
-                        inProgressProject = inProgressProject.UpdateDocument(docState, textChanged: false, recalculateDependentVersions: false);
+                        inProgressProject = inProgressProject.UpdateDocument(docState, contentChanged: true);
                     }
                     else
                     {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1231,7 +1231,7 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return UpdateDocumentState(oldDocument.UpdateName(name));
+            return UpdateDocumentState(oldDocument.UpdateName(name), contentChanged: false);
         }
 
         /// <summary>
@@ -1246,7 +1246,7 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return UpdateDocumentState(oldDocument.UpdateFolders(folders));
+            return UpdateDocumentState(oldDocument.UpdateFolders(folders), contentChanged: false);
         }
 
         /// <summary>
@@ -1260,7 +1260,7 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return UpdateDocumentState(oldDocument.UpdateFilePath(filePath));
+            return UpdateDocumentState(oldDocument.UpdateFilePath(filePath), contentChanged: false);
         }
 
         /// <summary>
@@ -1275,7 +1275,7 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return UpdateDocumentState(oldDocument.UpdateText(text, mode), textChanged: true);
+            return UpdateDocumentState(oldDocument.UpdateText(text, mode), contentChanged: true);
         }
 
         /// <summary>
@@ -1290,7 +1290,7 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return UpdateAdditionalDocumentState(oldDocument.UpdateText(text, mode), textChanged: true);
+            return UpdateAdditionalDocumentState(oldDocument.UpdateText(text, mode), contentChanged: true);
         }
 
         /// <summary>
@@ -1320,7 +1320,7 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return UpdateDocumentState(oldDocument.UpdateText(textAndVersion, mode), textChanged: true);
+            return UpdateDocumentState(oldDocument.UpdateText(textAndVersion, mode), contentChanged: true);
         }
 
         /// <summary>
@@ -1335,7 +1335,7 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return UpdateAdditionalDocumentState(oldDocument.UpdateText(textAndVersion, mode), textChanged: true);
+            return UpdateAdditionalDocumentState(oldDocument.UpdateText(textAndVersion, mode), contentChanged: true);
         }
 
         /// <summary>
@@ -1367,7 +1367,7 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return UpdateDocumentState(oldDocument.UpdateTree(root, mode), textChanged: true);
+            return UpdateDocumentState(oldDocument.UpdateTree(root, mode), contentChanged: true);
         }
 
         private static async Task<Compilation> UpdateDocumentInCompilationAsync(
@@ -1393,16 +1393,16 @@ namespace Microsoft.CodeAnalysis
                 return this;
             }
 
-            return UpdateDocumentState(oldDocument.UpdateSourceCodeKind(sourceCodeKind), textChanged: true);
+            return UpdateDocumentState(oldDocument.UpdateSourceCodeKind(sourceCodeKind), contentChanged: true);
         }
 
         public SolutionState UpdateDocumentTextLoader(DocumentId documentId, TextLoader loader, PreservationMode mode)
         {
             var oldDocument = GetRequiredDocumentState(documentId);
 
-            // Assumes that text has changed. User could have closed a doc without saving and we are loading text from closed file with
-            // old content. Also this should make sure we don't re-use latest doc version with data associated with opened document.
-            return UpdateDocumentState(oldDocument.UpdateText(loader, mode), textChanged: true, recalculateDependentVersions: true);
+            // Assumes that content has changed. User could have closed a doc without saving and we are loading text
+            // from closed file with old content.
+            return UpdateDocumentState(oldDocument.UpdateText(loader, mode), contentChanged: true);
         }
 
         /// <summary>
@@ -1413,9 +1413,9 @@ namespace Microsoft.CodeAnalysis
         {
             var oldDocument = GetRequiredAdditionalDocumentState(documentId);
 
-            // Assumes that text has changed. User could have closed a doc without saving and we are loading text from closed file with
-            // old content. Also this should make sure we don't re-use latest doc version with data associated with opened document.
-            return UpdateAdditionalDocumentState(oldDocument.UpdateText(loader, mode), textChanged: true, recalculateDependentVersions: true);
+            // Assumes that content has changed. User could have closed a doc without saving and we are loading text
+            // from closed file with old content.
+            return UpdateAdditionalDocumentState(oldDocument.UpdateText(loader, mode), contentChanged: true);
         }
 
         /// <summary>
@@ -1431,10 +1431,10 @@ namespace Microsoft.CodeAnalysis
             return UpdateAnalyzerConfigDocumentState(oldDocument.UpdateText(loader, mode));
         }
 
-        private SolutionState UpdateDocumentState(DocumentState newDocument, bool textChanged = false, bool recalculateDependentVersions = false)
+        private SolutionState UpdateDocumentState(DocumentState newDocument, bool contentChanged)
         {
             var oldProject = GetProjectState(newDocument.Id.ProjectId)!;
-            var newProject = oldProject.UpdateDocument(newDocument, textChanged, recalculateDependentVersions);
+            var newProject = oldProject.UpdateDocument(newDocument, contentChanged);
 
             // This method shouldn't have been called if the document has not changed.
             Debug.Assert(oldProject != newProject);
@@ -1448,10 +1448,10 @@ namespace Microsoft.CodeAnalysis
                 newFilePathToDocumentIdsMap: newFilePathToDocumentIdsMap);
         }
 
-        private SolutionState UpdateAdditionalDocumentState(AdditionalDocumentState newDocument, bool textChanged = false, bool recalculateDependentVersions = false)
+        private SolutionState UpdateAdditionalDocumentState(AdditionalDocumentState newDocument, bool contentChanged)
         {
             var oldProject = GetProjectState(newDocument.Id.ProjectId)!;
-            var newProject = oldProject.UpdateAdditionalDocument(newDocument, textChanged, recalculateDependentVersions);
+            var newProject = oldProject.UpdateAdditionalDocument(newDocument, contentChanged);
 
             // This method shouldn't have been called if the document has not changed.
             Debug.Assert(oldProject != newProject);

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -3030,8 +3030,6 @@ public class C : A {
             Assert.Equal(
                 await documentToFreezeChanged.Project.GetSemanticVersionAsync(),
                 await frozenDocument.Project.GetSemanticVersionAsync());
-
-            GC.KeepAlive(tree);
         }
 
         [Fact]
@@ -3079,8 +3077,6 @@ public class C : A {
             Assert.Equal(
                 await documentToFreezeChanged.Project.GetSemanticVersionAsync(),
                 await frozenDocument.Project.GetSemanticVersionAsync());
-
-            GC.KeepAlive(tree);
         }
 
         [Fact]

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -3003,7 +3003,6 @@ public class C : A {
 
             var frozenDocument = documentToFreezeChanged.WithFrozenPartialSemantics(CancellationToken.None);
 
-            // Because we had no compilation produced yet, we expect that only the DocumentToFreeze is in the compilation
             Assert.NotSame(frozenDocument, documentToFreezeChanged);
 
             // Versions should the same since there wasn't a top level change different
@@ -3049,7 +3048,6 @@ public class C : A {
 
             var frozenDocument = documentToFreezeChanged.WithFrozenPartialSemantics(CancellationToken.None);
 
-            // Because we had no compilation produced yet, we expect that only the DocumentToFreeze is in the compilation
             Assert.NotSame(frozenDocument, documentToFreezeChanged);
 
             // Before/after the change must always result in a top level change.

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -3054,12 +3054,13 @@ public class C : A {
             // Because we had no compilation produced yet, we expect that only the DocumentToFreeze is in the compilation
             Assert.NotSame(frozenDocument, documentToFreezeChanged);
 
-            // Versions should the different since there was a top level change different
+            // Before/after the change must always result in a top level change.
+            // After the change, we should get the same version between the doc and its frozen version.
             Assert.NotEqual(
                 await documentToFreezeOriginal.GetTopLevelChangeTextVersionAsync(),
                 await frozenDocument.GetTopLevelChangeTextVersionAsync());
 
-            Assert.NotEqual(
+            Assert.Equal(
                 await documentToFreezeChanged.GetTopLevelChangeTextVersionAsync(),
                 await frozenDocument.GetTopLevelChangeTextVersionAsync());
 
@@ -3067,7 +3068,7 @@ public class C : A {
                 await documentToFreezeOriginal.Project.GetDependentSemanticVersionAsync(),
                 await frozenDocument.Project.GetDependentSemanticVersionAsync());
 
-            Assert.NotEqual(
+            Assert.Equal(
                 await documentToFreezeChanged.Project.GetDependentSemanticVersionAsync(),
                 await frozenDocument.Project.GetDependentSemanticVersionAsync());
 
@@ -3075,7 +3076,7 @@ public class C : A {
                 await documentToFreezeOriginal.Project.GetSemanticVersionAsync(),
                 await frozenDocument.Project.GetSemanticVersionAsync());
 
-            Assert.NotEqual(
+            Assert.Equal(
                 await documentToFreezeChanged.Project.GetSemanticVersionAsync(),
                 await frozenDocument.Project.GetSemanticVersionAsync());
 

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -2962,7 +2962,7 @@ public class C : A {
         }
 
         [Fact]
-        public async Task TestFrozenPartialProjectHasDifferentSemanticVersions()
+        public async Task TestFrozenPartialProjectHasDifferentSemanticVersions_AddedDoc()
         {
             using var workspace = WorkspaceTestUtilities.CreateWorkspaceWithPartialSemantics();
             var project = workspace.CurrentSolution.AddProject("CSharpProject", "CSharpProject", LanguageNames.CSharp);
@@ -2984,6 +2984,102 @@ public class C : A {
             Assert.NotEqual(
                 await documentToFreeze.Project.GetSemanticVersionAsync(),
                 await frozenDocument.Project.GetSemanticVersionAsync());
+        }
+
+        [Fact]
+        public async Task TestFrozenPartialProjectHasDifferentSemanticVersions_ChangedDoc1()
+        {
+            using var workspace = WorkspaceTestUtilities.CreateWorkspaceWithPartialSemantics();
+            var project = workspace.CurrentSolution.AddProject("CSharpProject", "CSharpProject", LanguageNames.CSharp);
+            project = project.AddDocument("Extra.cs", SourceText.From("class Extra { }")).Project;
+
+            var documentToFreezeOriginal = project.AddDocument("DocumentToFreeze.cs", SourceText.From("class DocumentToFreeze { void M() { } }"));
+            project = documentToFreezeOriginal.Project;
+            var compilation = await project.GetCompilationAsync();
+
+            var solution = project.Solution.WithDocumentText(documentToFreezeOriginal.Id, SourceText.From("class DocumentToFreeze { void M() { /*no top level change*/ } }"));
+            var documentToFreezeChanged = solution.GetDocument(documentToFreezeOriginal.Id);
+            var tree = await documentToFreezeChanged.GetSyntaxTreeAsync();
+
+            var frozenDocument = documentToFreezeChanged.WithFrozenPartialSemantics(CancellationToken.None);
+
+            // Because we had no compilation produced yet, we expect that only the DocumentToFreeze is in the compilation
+            Assert.NotSame(frozenDocument, documentToFreezeChanged);
+
+            // Versions should the same since there wasn't a top level change different
+            Assert.Equal(
+                await documentToFreezeOriginal.GetTopLevelChangeTextVersionAsync(),
+                await frozenDocument.GetTopLevelChangeTextVersionAsync());
+
+            Assert.Equal(
+                await documentToFreezeChanged.GetTopLevelChangeTextVersionAsync(),
+                await frozenDocument.GetTopLevelChangeTextVersionAsync());
+
+            Assert.Equal(
+                await documentToFreezeOriginal.Project.GetDependentSemanticVersionAsync(),
+                await frozenDocument.Project.GetDependentSemanticVersionAsync());
+
+            Assert.Equal(
+                await documentToFreezeChanged.Project.GetDependentSemanticVersionAsync(),
+                await frozenDocument.Project.GetDependentSemanticVersionAsync());
+
+            Assert.Equal(
+                await documentToFreezeOriginal.Project.GetSemanticVersionAsync(),
+                await frozenDocument.Project.GetSemanticVersionAsync());
+
+            Assert.Equal(
+                await documentToFreezeChanged.Project.GetSemanticVersionAsync(),
+                await frozenDocument.Project.GetSemanticVersionAsync());
+
+            GC.KeepAlive(tree);
+        }
+
+        [Fact]
+        public async Task TestFrozenPartialProjectHasDifferentSemanticVersions_ChangedDoc2()
+        {
+            using var workspace = WorkspaceTestUtilities.CreateWorkspaceWithPartialSemantics();
+            var project = workspace.CurrentSolution.AddProject("CSharpProject", "CSharpProject", LanguageNames.CSharp);
+            project = project.AddDocument("Extra.cs", SourceText.From("class Extra { }")).Project;
+
+            var documentToFreezeOriginal = project.AddDocument("DocumentToFreeze.cs", SourceText.From("class DocumentToFreeze { void M() { } }"));
+            project = documentToFreezeOriginal.Project;
+            var compilation = await project.GetCompilationAsync();
+
+            var solution = project.Solution.WithDocumentText(documentToFreezeOriginal.Id, SourceText.From("class DocumentToFreeze { void M() { } public void NewMethod() { } }"));
+            var documentToFreezeChanged = solution.GetDocument(documentToFreezeOriginal.Id);
+            var tree = await documentToFreezeChanged.GetSyntaxTreeAsync();
+
+            var frozenDocument = documentToFreezeChanged.WithFrozenPartialSemantics(CancellationToken.None);
+
+            // Because we had no compilation produced yet, we expect that only the DocumentToFreeze is in the compilation
+            Assert.NotSame(frozenDocument, documentToFreezeChanged);
+
+            // Versions should the different since there was a top level change different
+            Assert.NotEqual(
+                await documentToFreezeOriginal.GetTopLevelChangeTextVersionAsync(),
+                await frozenDocument.GetTopLevelChangeTextVersionAsync());
+
+            Assert.NotEqual(
+                await documentToFreezeChanged.GetTopLevelChangeTextVersionAsync(),
+                await frozenDocument.GetTopLevelChangeTextVersionAsync());
+
+            Assert.NotEqual(
+                await documentToFreezeOriginal.Project.GetDependentSemanticVersionAsync(),
+                await frozenDocument.Project.GetDependentSemanticVersionAsync());
+
+            Assert.NotEqual(
+                await documentToFreezeChanged.Project.GetDependentSemanticVersionAsync(),
+                await frozenDocument.Project.GetDependentSemanticVersionAsync());
+
+            Assert.NotEqual(
+                await documentToFreezeOriginal.Project.GetSemanticVersionAsync(),
+                await frozenDocument.Project.GetSemanticVersionAsync());
+
+            Assert.NotEqual(
+                await documentToFreezeChanged.Project.GetSemanticVersionAsync(),
+                await frozenDocument.Project.GetSemanticVersionAsync());
+
+            GC.KeepAlive(tree);
         }
 
         [Fact]

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -583,5 +583,8 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         // 650-660 for diagnostic/fix related ids.
         Diagnostics_AnalyzerPerformanceInfo = 651,
+
+        // 660-670 for semantic model reuse service.
+        SemanticModelReuseLanguageService_TryGetSpeculativeSemanticModelAsync_Equivalent = 660,
     }
 }


### PR DESCRIPTION
Potential fix for an [NFW](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/1692705) we're seeing in speedometer.  And, even if it doesn't help there, it certainly makes this code saner and properly in line with invariants we expect.