### PR TITLE
Remove code for cloning compilations for skeleton references

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Options/WorkspaceConfigurationOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/WorkspaceConfigurationOptionsStorage.cs
@@ -13,8 +13,7 @@ internal static class WorkspaceConfigurationOptionsStorage
         => new(
             CacheStorage: globalOptions.GetOption(CloudCacheFeatureFlag) ? StorageDatabase.CloudCache : globalOptions.GetOption(Database),
             EnableOpeningSourceGeneratedFiles: globalOptions.GetOption(EnableOpeningSourceGeneratedFilesInWorkspace) ??
-                                               globalOptions.GetOption(EnableOpeningSourceGeneratedFilesInWorkspaceFeatureFlag),
-            DisableCloneWhenProducingSkeletonReferences: globalOptions.GetOption(DisableCloneWhenProducingSkeletonReferences));
+                                               globalOptions.GetOption(EnableOpeningSourceGeneratedFilesInWorkspaceFeatureFlag));
 
     public static readonly Option2<StorageDatabase> Database = new(
         "FeatureManager/Storage", nameof(Database), WorkspaceConfigurationOptions.Default.CacheStorage,
@@ -23,10 +22,6 @@ internal static class WorkspaceConfigurationOptionsStorage
     public static readonly Option2<bool> CloudCacheFeatureFlag = new(
         "FeatureManager/Storage", "CloudCacheFeatureFlag", WorkspaceConfigurationOptions.Default.CacheStorage == StorageDatabase.CloudCache,
         new FeatureFlagStorageLocation("Roslyn.CloudCache3"));
-
-    public static readonly Option2<bool> DisableCloneWhenProducingSkeletonReferences = new(
-        "WorkspaceConfigurationOptions", "DisableCloneWhenProducingSkeletonReferences", WorkspaceConfigurationOptions.Default.DisableCloneWhenProducingSkeletonReferences,
-        new FeatureFlagStorageLocation("Roslyn.DisableCloneWhenProducingSkeletonReferences"));
 
     public static readonly Option2<bool> DisableReferenceManagerRecoverableMetadata = new(
         "WorkspaceConfigurationOptions", "DisableReferenceManagerRecoverableMetadata", WorkspaceConfigurationOptions.Default.DisableReferenceManagerRecoverableMetadata,

--- a/src/Workspaces/Core/Portable/Workspace/IWorkspaceConfigurationService.cs
+++ b/src/Workspaces/Core/Portable/Workspace/IWorkspaceConfigurationService.cs
@@ -25,9 +25,8 @@ namespace Microsoft.CodeAnalysis.Host
     internal readonly record struct WorkspaceConfigurationOptions(
         [property: DataMember(Order = 0)] StorageDatabase CacheStorage = StorageDatabase.SQLite,
         [property: DataMember(Order = 1)] bool EnableOpeningSourceGeneratedFiles = false,
-        [property: DataMember(Order = 2)] bool DisableCloneWhenProducingSkeletonReferences = false,
-        [property: DataMember(Order = 3)] bool DisableReferenceManagerRecoverableMetadata = false,
-        [property: DataMember(Order = 4)] bool DisableBackgroundCompilation = false)
+        [property: DataMember(Order = 2)] bool DisableReferenceManagerRecoverableMetadata = false,
+        [property: DataMember(Order = 3)] bool DisableBackgroundCompilation = false)
     {
         public WorkspaceConfigurationOptions()
             : this(CacheStorage: StorageDatabase.SQLite)
@@ -43,7 +42,6 @@ namespace Microsoft.CodeAnalysis.Host
         public static readonly WorkspaceConfigurationOptions RemoteDefault = new(
             CacheStorage: StorageDatabase.None,
             EnableOpeningSourceGeneratedFiles: false,
-            DisableCloneWhenProducingSkeletonReferences: false,
             DisableReferenceManagerRecoverableMetadata: false,
             DisableBackgroundCompilation: false);
     }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.SkeletonReferenceCache.cs
@@ -241,11 +241,7 @@ internal partial class SolutionState
                 {
                     using var stream = SerializableBytes.CreateWritableStream();
 
-                    var optionsService = workspace.Services.GetService<IWorkspaceConfigurationService>();
-                    var doNotClone = optionsService != null && optionsService.Options.DisableCloneWhenProducingSkeletonReferences;
-
-                    var compilationToEmit = doNotClone ? compilation : compilation.Clone();
-                    var emitResult = compilationToEmit.Emit(stream, options: s_metadataOnlyEmitOptions, cancellationToken: cancellationToken);
+                    var emitResult = compilation.Emit(stream, options: s_metadataOnlyEmitOptions, cancellationToken: cancellationToken);
 
                     if (emitResult.Success)
                     {


### PR DESCRIPTION
This is going into Dev17.6 for maximal runway time.

This was a fine approach prior to SGs as it meant the minor symbolic work we did in the compilation we created for skeleton refs could be thrown away.  With SGs this adds to tanking performance as SGs will have to *fully* run in the cloned compilation, only to be thrown away.  This is a massive amount of work that will be redone whenever the dependent compilation changes.  But we'll already have some features causing that work to happen within that compilation anyways, so we end up duplicating it.

A/B test (>1m  participants) (https://exp.microsoft.com/xCard/?stepId=898ff0b8-a120-485c-a02d-b880d980d87c) shows no issues:

![image](https://user-images.githubusercontent.com/4564579/206280267-611c45ce-08fe-413b-ad48-545b250c4e3a.png)
