### PR TITLE
Switch to non-preview queue to use 17.4.1 instead of 17.4 Preview 5

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -55,7 +55,7 @@ parameters:
 - name: queueName
   displayName: Queue Name
   type: string
-  default: windows.vs2022preview.amd64.open
+  default: windows.vs2022.scout.amd64.open
   values:
   - windows.vs2022.amd64.open
   - windows.vs2022.scout.amd64.open


### PR DESCRIPTION
We can't upgrade to the scouting preview queue (17.5 Preview 1) due to https://github.com/dotnet/arcade/issues/11707

However we can switch to the scouting non-preview queue which is 17.4.1 (better than preview queue which is on 17.4 Preview 5).  This might help with the vsix install issues we've been seeing.

This appears to work (failed one already known flaky test) - https://dev.azure.com/dnceng-public/public/_build/results?buildId=104914&view=results