### PR TITLE
Add ExecuteCommandAsync overloads which accept arguments

### DIFF
--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ShellInProcess.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/InProcess/ShellInProcess.cs
@@ -3,18 +3,21 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.ComponentModel.Design;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Controls;
 using System.Windows.Input;
 using Microsoft.CodeAnalysis.UnitTests;
+using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Utilities;
 using Xunit;
 using IAsyncDisposable = System.IAsyncDisposable;
 
@@ -115,6 +118,35 @@ namespace Microsoft.VisualStudio.Extensibility.Testing
 
             await fileChangeService.Pause();
             return new PauseFileChangesRestorer(fileChangeService);
+        }
+
+        public Task ExecuteCommandAsync(CommandID command, string argument, CancellationToken cancellationToken)
+            => ExecuteCommandAsync(command.Guid, (uint)command.ID, argument, cancellationToken);
+
+        public async Task ExecuteCommandAsync(Guid commandGuid, uint commandId, string argument, CancellationToken cancellationToken)
+        {
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var dispatcher = await TestServices.Shell.GetRequiredGlobalServiceAsync<SUIHostCommandDispatcher, IOleCommandTarget>(cancellationToken);
+
+            var pvaIn = Marshal.AllocHGlobal(Marshal.SizeOf<VARIANT>());
+            try
+            {
+                Marshal.GetNativeVariantForObject(argument, pvaIn);
+                ErrorHandler.ThrowOnFailure(dispatcher.Exec(commandGuid, commandId, (uint)OLECMDEXECOPT.OLECMDEXECOPT_DODEFAULT, pvaIn, IntPtr.Zero));
+            }
+            finally
+            {
+                var variant = Marshal.PtrToStructure<VARIANT>(pvaIn);
+                Marshal.FreeBSTR(variant.bstrVal);
+                Marshal.FreeHGlobal(pvaIn);
+            }
+        }
+
+        public Task ExecuteCommandAsync<TEnum>(TEnum command, string argument, CancellationToken cancellationToken)
+            where TEnum : struct, Enum
+        {
+            return ExecuteCommandAsync(typeof(TEnum).GUID, Convert.ToUInt32(command), argument, cancellationToken);
         }
 
         // This is based on WaitForQuiescenceAsync in the FileChangeService tests


### PR DESCRIPTION
Requested by @dibarbet in #65734.