### PR TITLE
Remove mutable state from rename

### DIFF
--- a/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/CSharpRenameRewriterLanguageService.cs
@@ -52,9 +52,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
             private readonly Solution _solution;
             private readonly string _replacementText;
             private readonly string _originalText;
-            private readonly ICollection<string> _possibleNameConflicts;
-            private readonly Dictionary<TextSpan, RenameLocation> _renameLocations;
-            private readonly ISet<TextSpan> _conflictLocations;
+            private readonly ImmutableArray<string> _possibleNameConflicts;
+            private readonly ImmutableDictionary<TextSpan, RenameLocation> _renameLocations;
+            private readonly ImmutableHashSet<TextSpan> _conflictLocations;
             private readonly SemanticModel _semanticModel;
             private readonly CancellationToken _cancellationToken;
 

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -789,7 +789,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                         // Get all rename locations for the current document.
                         var allTextSpansInSingleSourceTree = renameLocations
                             .Where(l => l.DocumentId == documentId && ShouldIncludeLocation(renameLocations, l))
-                            .ToDictionary(l => l.Location.SourceSpan);
+                            .ToImmutableDictionary(l => l.Location.SourceSpan);
 
                         // All textspan in the document documentId, that requires rename in String or Comment
                         var stringAndCommentTextSpansInSingleSourceTree = renameLocations
@@ -802,7 +802,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
                         var conflictLocationSpans = conflictLocations
                             .Where(t => t.DocumentId == documentId)
                             .Select(t => t.ComplexifiedSpan)
-                            .ToSet();
+                            .ToImmutableHashSet();
 
                         // Annotate all nodes with a RenameLocation annotations to record old locations & old referenced symbols.
                         // Also annotate nodes that should get complexified (nodes for rename locations + conflict locations)

--- a/src/Workspaces/Core/Portable/Rename/RenameRewriterParameters.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameRewriterParameters.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Rename
     internal class RenameRewriterParameters
     {
         internal readonly CancellationToken CancellationToken;
-        internal readonly ISet<TextSpan> ConflictLocationSpans;
+        internal readonly ImmutableHashSet<TextSpan> ConflictLocationSpans;
         internal readonly bool IsRenamingInStrings;
         internal readonly bool IsRenamingInComments;
         internal readonly Solution OriginalSolution;
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Rename
         internal readonly string OriginalText;
         internal readonly ImmutableArray<string> PossibleNameConflicts;
         internal readonly RenameAnnotation RenamedSymbolDeclarationAnnotation;
-        internal readonly Dictionary<TextSpan, RenameLocation> RenameLocations;
+        internal readonly ImmutableDictionary<TextSpan, RenameLocation> RenameLocations;
         internal readonly RenamedSpansTracker RenameSpansTracker;
         internal readonly ISymbol RenameSymbol;
         internal readonly string ReplacementText;
@@ -41,9 +41,9 @@ namespace Microsoft.CodeAnalysis.Rename
             string replacementText,
             string originalText,
             ImmutableArray<string> possibleNameConflicts,
-            Dictionary<TextSpan, RenameLocation> renameLocations,
+            ImmutableDictionary<TextSpan, RenameLocation> renameLocations,
             ImmutableDictionary<TextSpan, ImmutableSortedSet<TextSpan>?> stringAndCommentTextSpans,
-            ISet<TextSpan> conflictLocationSpans,
+            ImmutableHashSet<TextSpan> conflictLocationSpans,
             Solution originalSolution,
             ISymbol renameSymbol,
             bool replacementTextValid,

--- a/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Rename/VisualBasicRenameRewriterLanguageService.vb
@@ -42,9 +42,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Rename
             Private ReadOnly _solution As Solution
             Private ReadOnly _replacementText As String
             Private ReadOnly _originalText As String
-            Private ReadOnly _possibleNameConflicts As ICollection(Of String)
-            Private ReadOnly _renameLocations As Dictionary(Of TextSpan, RenameLocation)
-            Private ReadOnly _conflictLocations As IEnumerable(Of TextSpan)
+            Private ReadOnly _possibleNameConflicts As ImmutableArray(Of String)
+            Private ReadOnly _renameLocations As ImmutableDictionary(Of TextSpan, RenameLocation)
+            Private ReadOnly _conflictLocations As ImmutableHashSet(Of TextSpan)
             Private ReadOnly _semanticModel As SemanticModel
             Private ReadOnly _cancellationToken As CancellationToken
             Private ReadOnly _renamedSymbol As ISymbol


### PR DESCRIPTION
Was finding these mutable fields very confusing for determining what was going on in rename as i work on shared syntax trees.  So pulled out this PR to clean it up.