### PR TITLE
Add support for draft of semantic tokens LSIF spec to LSIF generator

### DIFF
--- a/src/Features/Lsif/Generator/Graph/Capabilities.cs
+++ b/src/Features/Lsif/Generator/Graph/Capabilities.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph
@@ -35,6 +36,9 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph
         [JsonProperty("diagnosticProvider")]
         public bool DiagnosticProvider { get; }
 
+        [JsonProperty("semanticTokensProvider")]
+        public SemanticTokensCapabilities SemanticTokensProvider { get; }
+
         public Capabilities(
             IdFactory idFactory,
             bool hoverProvider,
@@ -44,7 +48,8 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph
             bool typeDefinitionProvider,
             bool documentSymbolProvider,
             bool foldingRangeProvider,
-            bool diagnosticProvider)
+            bool diagnosticProvider,
+            SemanticTokensCapabilities semanticTokensProvider)
             : base(label: "capabilities", idFactory)
         {
             HoverProvider = hoverProvider;
@@ -55,6 +60,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph
             DocumentSymbolProvider = documentSymbolProvider;
             FoldingRangeProvider = foldingRangeProvider;
             DiagnosticProvider = diagnosticProvider;
+            SemanticTokensProvider = semanticTokensProvider;
         }
     }
 }

--- a/src/Features/Lsif/Generator/Graph/SemanticTokensCapabilities.cs
+++ b/src/Features/Lsif/Generator/Graph/SemanticTokensCapabilities.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Newtonsoft.Json;
+
+    internal sealed class SemanticTokensCapabilities
+    {
+        public SemanticTokensCapabilities(
+            IReadOnlyList<string>? tokenTypes,
+            IReadOnlyList<string>? tokenModifiers)
+        {
+            this.TokenTypes = tokenTypes;
+            this.TokenModifiers = tokenModifiers;
+        }
+
+        [JsonProperty("tokenTypes")]
+        public IReadOnlyList<string>? TokenTypes { get; }
+
+        [JsonProperty("tokenModifiers")]
+        public IReadOnlyList<string>? TokenModifiers { get; }
+    }
+}

--- a/src/Features/Lsif/Generator/Graph/SemanticTokensResult.cs
+++ b/src/Features/Lsif/Generator/Graph/SemanticTokensResult.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Newtonsoft.Json;
+
+namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph
+{
+    /// <summary>
+    /// Represents a semantic tokens vertex for serialization. See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokens for further details.
+    /// </summary>
+    internal sealed class SemanticTokensResult : Vertex
+    {
+        [JsonProperty("result")]
+        public SemanticTokens Result { get; }
+
+        public SemanticTokensResult(SemanticTokens result, IdFactory idFactory)
+            : base(label: "semanticTokensResult", idFactory)
+        {
+            Result = result;
+        }
+    }
+}

--- a/src/Features/Lsif/GeneratorTest/OutputFormatTests.vb
+++ b/src/Features/Lsif/GeneratorTest/OutputFormatTests.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
                     </Workspace>, openDocuments:=False, composition:=TestLsifOutput.TestComposition), jsonWriter)
 
             AssertEx.EqualOrDiff(
-"{""hoverProvider"":true,""declarationProvider"":false,""definitionProvider"":true,""referencesProvider"":true,""typeDefinitionProvider"":false,""documentSymbolProvider"":false,""foldingRangeProvider"":true,""diagnosticProvider"":false,""id"":1,""type"":""vertex"",""label"":""capabilities""}
+"{""hoverProvider"":true,""declarationProvider"":false,""definitionProvider"":true,""referencesProvider"":true,""typeDefinitionProvider"":false,""documentSymbolProvider"":false,""foldingRangeProvider"":true,""diagnosticProvider"":false,""semanticTokensProvider"":{""tokenTypes"":[""namespace"",""type"",""class"",""enum"",""interface"",""struct"",""typeParameter"",""parameter"",""variable"",""property"",""enumMember"",""event"",""function"",""method"",""macro"",""keyword"",""modifier"",""comment"",""string"",""number"",""regexp"",""operator"",""class name"",""constant name"",""delegate name"",""enum member name"",""enum name"",""event name"",""excluded code"",""extension method name"",""field name"",""interface name"",""json - array"",""json - comment"",""json - constructor name"",""json - keyword"",""json - number"",""json - object"",""json - operator"",""json - property name"",""json - punctuation"",""json - string"",""json - text"",""keyword - control"",""label name"",""local name"",""method name"",""module name"",""namespace name"",""operator - overloaded"",""parameter name"",""preprocessor keyword"",""preprocessor text"",""property name"",""punctuation"",""record class name"",""record struct name"",""regex - alternation"",""regex - anchor"",""regex - character class"",""regex - comment"",""regex - grouping"",""regex - other escape"",""regex - quantifier"",""regex - self escaped character"",""regex - text"",""string - escape character"",""string - verbatim"",""struct name"",""text"",""type parameter name"",""whitespace"",""xml doc comment - attribute name"",""xml doc comment - attribute quotes"",""xml doc comment - attribute value"",""xml doc comment - cdata section"",""xml doc comment - comment"",""xml doc comment - delimiter"",""xml doc comment - entity reference"",""xml doc comment - name"",""xml doc comment - processing instruction"",""xml doc comment - text"",""xml literal - attribute name"",""xml literal - attribute quotes"",""xml literal - attribute value"",""xml literal - cdata section"",""xml literal - comment"",""xml literal - delimiter"",""xml literal - embedded expression"",""xml literal - entity reference"",""xml literal - name"",""xml literal - processing instruction"",""xml literal - text""],""tokenModifiers"":[""static""]},""id"":1,""type"":""vertex"",""label"":""capabilities""}
 {""kind"":""csharp"",""resource"":""file:///Z:/TestProject.csproj"",""name"":""TestProject"",""id"":2,""type"":""vertex"",""label"":""project""}
 {""kind"":""begin"",""scope"":""project"",""data"":2,""id"":3,""type"":""vertex"",""label"":""$event""}
 {""uri"":""file:///Z:/A.cs"",""languageId"":""csharp"",""id"":4,""type"":""vertex"",""label"":""document""}
@@ -33,9 +33,11 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
 {""outV"":4,""inVs"":[],""id"":6,""type"":""edge"",""label"":""contains""}
 {""result"":[],""id"":7,""type"":""vertex"",""label"":""foldingRangeResult""}
 {""outV"":4,""inV"":7,""id"":8,""type"":""edge"",""label"":""textDocument/foldingRange""}
-{""kind"":""end"",""scope"":""document"",""data"":4,""id"":9,""type"":""vertex"",""label"":""$event""}
-{""outV"":2,""inVs"":[4],""id"":10,""type"":""edge"",""label"":""contains""}
-{""kind"":""end"",""scope"":""project"",""data"":2,""id"":11,""type"":""vertex"",""label"":""$event""}
+{""result"":{""data"":[]},""id"":9,""type"":""vertex"",""label"":""semanticTokensResult""}
+{""outV"":4,""inV"":9,""id"":10,""type"":""edge"",""label"":""textDocument/semanticTokens/full""}
+{""kind"":""end"",""scope"":""document"",""data"":4,""id"":11,""type"":""vertex"",""label"":""$event""}
+{""outV"":2,""inVs"":[4],""id"":12,""type"":""edge"",""label"":""contains""}
+{""kind"":""end"",""scope"":""project"",""data"":2,""id"":13,""type"":""vertex"",""label"":""$event""}
 ", stringWriter.ToString())
         End Function
 
@@ -64,6 +66,106 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
     ""documentSymbolProvider"": false,
     ""foldingRangeProvider"": true,
     ""diagnosticProvider"": false,
+    ""semanticTokensProvider"": {
+      ""tokenTypes"": [
+        ""namespace"",
+        ""type"",
+        ""class"",
+        ""enum"",
+        ""interface"",
+        ""struct"",
+        ""typeParameter"",
+        ""parameter"",
+        ""variable"",
+        ""property"",
+        ""enumMember"",
+        ""event"",
+        ""function"",
+        ""method"",
+        ""macro"",
+        ""keyword"",
+        ""modifier"",
+        ""comment"",
+        ""string"",
+        ""number"",
+        ""regexp"",
+        ""operator"",
+        ""class name"",
+        ""constant name"",
+        ""delegate name"",
+        ""enum member name"",
+        ""enum name"",
+        ""event name"",
+        ""excluded code"",
+        ""extension method name"",
+        ""field name"",
+        ""interface name"",
+        ""json - array"",
+        ""json - comment"",
+        ""json - constructor name"",
+        ""json - keyword"",
+        ""json - number"",
+        ""json - object"",
+        ""json - operator"",
+        ""json - property name"",
+        ""json - punctuation"",
+        ""json - string"",
+        ""json - text"",
+        ""keyword - control"",
+        ""label name"",
+        ""local name"",
+        ""method name"",
+        ""module name"",
+        ""namespace name"",
+        ""operator - overloaded"",
+        ""parameter name"",
+        ""preprocessor keyword"",
+        ""preprocessor text"",
+        ""property name"",
+        ""punctuation"",
+        ""record class name"",
+        ""record struct name"",
+        ""regex - alternation"",
+        ""regex - anchor"",
+        ""regex - character class"",
+        ""regex - comment"",
+        ""regex - grouping"",
+        ""regex - other escape"",
+        ""regex - quantifier"",
+        ""regex - self escaped character"",
+        ""regex - text"",
+        ""string - escape character"",
+        ""string - verbatim"",
+        ""struct name"",
+        ""text"",
+        ""type parameter name"",
+        ""whitespace"",
+        ""xml doc comment - attribute name"",
+        ""xml doc comment - attribute quotes"",
+        ""xml doc comment - attribute value"",
+        ""xml doc comment - cdata section"",
+        ""xml doc comment - comment"",
+        ""xml doc comment - delimiter"",
+        ""xml doc comment - entity reference"",
+        ""xml doc comment - name"",
+        ""xml doc comment - processing instruction"",
+        ""xml doc comment - text"",
+        ""xml literal - attribute name"",
+        ""xml literal - attribute quotes"",
+        ""xml literal - attribute value"",
+        ""xml literal - cdata section"",
+        ""xml literal - comment"",
+        ""xml literal - delimiter"",
+        ""xml literal - embedded expression"",
+        ""xml literal - entity reference"",
+        ""xml literal - name"",
+        ""xml literal - processing instruction"",
+        ""xml literal - text""
+      ],
+      ""tokenModifiers"": [
+        ""static""
+      ]
+    },
     ""id"": 1,
     ""type"": ""vertex"",
     ""label"": ""capabilities""
@@ -120,10 +222,25 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
     ""label"": ""textDocument/foldingRange""
   },
   {
+    ""result"": {
+      ""data"": []
+    },
+    ""id"": 9,
+    ""type"": ""vertex"",
+    ""label"": ""semanticTokensResult""
+  },
+  {
+    ""outV"": 4,
+    ""inV"": 9,
+    ""id"": 10,
+    ""type"": ""edge"",
+    ""label"": ""textDocument/semanticTokens/full""
+  },
+  {
     ""kind"": ""end"",
     ""scope"": ""document"",
     ""data"": 4,
-    ""id"": 9,
+    ""id"": 11,
     ""type"": ""vertex"",
     ""label"": ""$event""
   },
@@ -132,7 +249,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
     ""inVs"": [
       4
     ],
-    ""id"": 10,
+    ""id"": 12,
     ""type"": ""edge"",
     ""label"": ""contains""
   },
@@ -140,7 +257,7 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
     ""kind"": ""end"",
     ""scope"": ""project"",
     ""data"": 2,
-    ""id"": 11,
+    ""id"": 13,
     ""type"": ""vertex"",
     ""label"": ""$event""
   }

--- a/src/Features/Lsif/GeneratorTest/SemanticTokensTests.vb
+++ b/src/Features/Lsif/GeneratorTest/SemanticTokensTests.vb
@@ -1,0 +1,54 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Linq
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.Graph
+Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Newtonsoft.Json
+
+Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests
+
+    <UseExportProvider>
+    Public NotInheritable Class SemanticTokensTests
+        Private Const TestProjectAssemblyName As String = "TestProject"
+
+        <Theory>
+        <InlineData("", "{""data"":[]}")>
+        <InlineData("namespace Foo;", "{""data"":[0,0,9,15,0,0,10,3,48,0,0,3,1,54,0]}")>
+        <InlineData("namespace " & vbCrLf & " Foo {}", "{""data"":[0,0,9,15,0,2,1,3,48,0,0,4,1,54,0,0,1,1,54,0]}")>
+        <InlineData("public class Foo { System.Collections.IList FooList { get; set; } int FooMethod() { int x = 0; return x; } }", "{""data"":[0,0,6,15,0,0,7,5,15,0,0,6,3,22,0,0,4,1,54,0,0,2,6,48,0,0,6,1,21,0,0,1,11,48,0,0,11,1,21,0,0,1,5,31,0,0,6,7,53,0,0,8,1,54,0,0,2,3,15,0,0,3,1,54,0,0,2,3,15,0,0,3,1,54,0,0,2,1,54,0,0,2,3,15,0,0,4,9,46,0,0,9,1,54,0,0,1,1,54,0,0,2,1,54,0,0,2,3,15,0,0,4,1,45,0,0,2,1,21,0,0,2,1,19,0,0,1,1,54,0,0,2,6,43,0,0,7,1,45,0,0,1,1,54,0,0,2,1,54,0,0,2,1,54,0]}")>
+        Public Async Function TestSemanticTokensData(code As String, expectedTokens As String) As Task
+            ' This test performs LSIF specific validation of the semantic tokens output. As of this writing
+            ' this feature is based on the same code path used to generate semantic tokens information in LSP
+            ' so it is assumed that exhaustive test coverage comes from that scenario.
+            '
+            ' LSIF Cases of interest:
+            ' - Empty file - generates empty data
+            ' - Single line
+            ' - Multi-line
+            ' - Roslyn custom token type ('x' in 'int x' uses a Roslyn custom token type).
+            ' - Token in last line with no trailing newline (ensure sufficient range was passed to LSP generator).
+
+            Using semanticTokensWorkspace = TestWorkspace.CreateWorkspace(
+                <Workspace>
+                    <Project Language="C#" AssemblyName=<%= TestProjectAssemblyName %> FilePath="Z:\TestProject.csproj" CommonReferences="true">
+                        <Document Name="A.cs" FilePath="Z:\A.cs">
+                            <%= code %>
+                        </Document>
+                    </Project>
+                </Workspace>, openDocuments:=False, composition:=TestLsifOutput.TestComposition)
+
+                Dim lsif = Await TestLsifOutput.GenerateForWorkspaceAsync(semanticTokensWorkspace)
+                Dim document = semanticTokensWorkspace.CurrentSolution.Projects.Single().Documents.Single()
+
+                Dim tokens = lsif.GetSemanticTokens(document)
+                Dim serializedTokens = JsonConvert.SerializeObject(tokens)
+
+                Assert.Equal(expectedTokens, serializedTokens)
+            End Using
+        End Function
+    End Class
+
+End Namespace

--- a/src/Features/Lsif/GeneratorTest/Utilities/TestLsifOutput.vb
+++ b/src/Features/Lsif/GeneratorTest/Utilities/TestLsifOutput.vb
@@ -124,12 +124,22 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests.U
         End Function
 
         Public Function GetFoldingRanges(document As Document) As LSP.FoldingRange()
-            Dim documentVertex = _testLsifJsonWriter.Vertices _
-                                                        .OfType(Of LsifDocument) _
-                                                        .Where(Function(d) d.Uri.LocalPath = document.FilePath) _
-                                                        .Single()
+            Dim documentVertex = _testLsifJsonWriter.Vertices.
+                                                        OfType(Of LsifDocument).
+                                                        Where(Function(d) d.Uri.LocalPath = document.FilePath).
+                                                        Single()
             Dim foldingRangeVertex = GetLinkedVertices(Of FoldingRangeResult)(documentVertex, "textDocument/foldingRange").Single()
             Return foldingRangeVertex.Result
+        End Function
+
+        Public Function GetSemanticTokens(document As Document) As LSP.SemanticTokens
+            Dim documentVertex = _testLsifJsonWriter.Vertices.
+                OfType(Of LsifDocument).
+                Where(Function(d) d.Uri.LocalPath = document.FilePath).
+                Single()
+
+            Dim semanticTokensVertex = GetLinkedVertices(Of SemanticTokensResult)(documentVertex, "textDocument/semanticTokens/full").Single()
+            Return semanticTokensVertex.Result
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
Adds support for draft of Semantic Tokens LSIF protocol to the LSIF generator.

This adds two additional bits of content to the LSIF output:

- 'semanticTokensProvidier': string[] - a new 'string[]' typed property in the capabilities vertex. Each item in the array represents a unique token type that maps to one or more color, font, and style presentation details.

```json
{
  "hoverProvider": true,
  "declarationProvider": false,
  "definitionProvider": true,
  "referencesProvider": true,
  "typeDefinitionProvider": false,
  "documentSymbolProvider": false,
  "foldingRangeProvider": true,
  "diagnosticProvider": false,
  "semanticTokensProvider": [
    "tokenTypes": [
      "namespace",
      "type",
      "class",
      "enum",
      "interface",
      "struct",
      ...
    ]
  ],
  "id": 1,
  "type": "vertex",
  "label": "capabilities"
}
```

- 'textDocument/semanticTokens/full' - A new single vertex per document off of the document node describing the semantic tokens for the full document. These data are emitted in the exact same format as [LSP semantic tokens](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_semanticTokens).

```json
{
    "outV":4,
    "inV":12,
    "id":15,
    "type":"edge",
    "label":"textDocument/semanticTokens/full"
}

{
    "result":
    {
        "data": [0,0,20,17,0,1,0,5,15,0,0,6,6,48,0,0,6,1,54,0,1,0,5,15,0,0,6,6,48,0,0,6,1,21,0,0,1,10,48,0,0,10,1,54,0,1,0,1,54,0,0,1,8,15,0,0,8,1,54,0,0,2,6,15,0,0,6,2,21,0,0,2,6,48,0,0,6,1,21,0,0,1,7,48,0,0,7,1,21,0,0,1,10,48,0,0,10,1,21,0,0,1,24,22,0,0,24,1,54,0,0,1,30,18,0,0,30,1,54,0,0,2,20,53,0,0,21,1,21,0,0,2,22,18,0,0,22,1,54,0,0,1,1,54,0]
    },
    "id":12,
    "type":"vertex",
    "label": "semanticTokensResult"
}
```

These changes increase the size of the LSIF output by approximately 6.5 percent in my tests generating LSIF on the LSP client repository and increases the generation duration by 15 percent.