### PR TITLE
Share underlying text-loading-abstraction instances across documents.

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AdditionalDocumentState.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis
         public new AdditionalDocumentState UpdateText(TextAndVersion newTextAndVersion, PreservationMode mode)
             => (AdditionalDocumentState)base.UpdateText(newTextAndVersion, mode);
 
-        protected override TextDocumentState UpdateText(ITextAndVersionSource newTextSource, PreservationMode mode, bool incremental)
+        protected sealed override TextDocumentState UpdateText(ITextAndVersionSource newTextSource, PreservationMode mode, bool incremental)
         {
             return new AdditionalDocumentState(
                 this.solutionServices,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/AnalyzerConfigDocumentState.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis
         public new AnalyzerConfigDocumentState UpdateText(TextAndVersion newTextAndVersion, PreservationMode mode)
             => (AnalyzerConfigDocumentState)base.UpdateText(newTextAndVersion, mode);
 
-        protected override TextDocumentState UpdateText(ITextAndVersionSource newTextSource, PreservationMode mode, bool incremental)
+        protected sealed override TextDocumentState UpdateText(ITextAndVersionSource newTextSource, PreservationMode mode, bool incremental)
         {
             return new AnalyzerConfigDocumentState(
                 this.solutionServices,

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -23,8 +23,7 @@ namespace Microsoft.CodeAnalysis
     {
         private static readonly Func<string?, PreservationMode, string> s_fullParseLog = (path, mode) => $"{path} : {mode}";
 
-        private static readonly ConditionalWeakTable<SyntaxTree, DocumentId> s_syntaxTreeToIdMap =
-            new();
+        private static readonly ConditionalWeakTable<SyntaxTree, DocumentId> s_syntaxTreeToIdMap = new();
 
         // properties inherited from the containing project:
         private readonly HostLanguageServices _languageServices;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SourceGeneratedDocumentState.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis
         // The base allows for parse options to be null for non-C#/VB languages, but we'll always have parse options
         public new ParseOptions ParseOptions => base.ParseOptions!;
 
-        protected override TextDocumentState UpdateText(ITextAndVersionSource newTextSource, PreservationMode mode, bool incremental)
+        protected sealed override TextDocumentState UpdateText(ITextAndVersionSource newTextSource, PreservationMode mode, bool incremental)
             => throw new NotSupportedException(WorkspacesResources.The_contents_of_a_SourceGeneratedDocument_may_not_be_changed);
 
         public SourceGeneratedDocumentState WithUpdatedGeneratedContent(SourceText sourceText, ParseOptions parseOptions)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
@@ -205,8 +205,11 @@ namespace Microsoft.CodeAnalysis
 
         public TextDocumentState UpdateText(SourceText newText, PreservationMode mode)
         {
-            var newVersion = GetNewerVersion();
-            var newTextAndVersion = TextAndVersion.Create(newText, newVersion, FilePath);
+            // Intentionally do not hold onto the new version into this TextAndVersion ourselves. While we are making a
+            // fresh TextAndVersion, when we call into UpdateText it might be that we end up pointing at a different
+            // instance corresponding to another file linked with us that shares this same SourceText.  In this fashion,
+            // all files that are linked together will have the same corresponding SourceText and Version.
+            var newTextAndVersion = TextAndVersion.Create(newText, GetNewerVersion(), FilePath);
 
             return UpdateText(newTextAndVersion, mode);
         }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextLoader.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextLoader.cs
@@ -172,6 +172,8 @@ namespace Microsoft.CodeAnalysis
                 Diagnostic.Create(WorkspaceDiagnosticDescriptors.ErrorReadingFileContent, location, new[] { display, message }));
         }
 
+        private static readonly ConditionalWeakTable<SourceText, TextLoader> s_textToLoader = new();
+
         /// <summary>
         /// Creates a new <see cref="TextLoader"/> from an already existing source text and version.
         /// </summary>
@@ -182,7 +184,7 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(textAndVersion));
             }
 
-            return new TextDocumentLoader(textAndVersion);
+            return s_textToLoader.GetValue(textAndVersion.Text, _ => new TextDocumentLoader(textAndVersion));
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -871,25 +871,14 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected internal void OnDocumentTextLoaderChanged(DocumentId documentId, TextLoader loader)
         {
-            //OnAnyDocumentTextChanged(
-            //    documentId,
-            //    newText,
-            //    mode,
-            //    CheckDocumentIsInSolution,
-            //    (solution, docId) => solution.GetRelatedDocumentIds(docId),
-            //    (solution, docId, text, preservationMode) => solution.WithDocumentText(docId, text, preservationMode),
-            //    WorkspaceChangeKind.DocumentChanged,
-            //    isCodeDocument: true);
-
-
-            SetCurrentSolution(
-                oldSolution =>
-                {
-                    CheckDocumentIsInSolution(oldSolution, documentId);
-                    return oldSolution.WithDocumentTextLoader(documentId, loader, PreservationMode.PreserveValue);
-                },
-                WorkspaceChangeKind.DocumentChanged, documentId: documentId,
-                onAfterUpdate: (_, newSolution) => this.OnDocumentTextChanged(newSolution.GetRequiredDocument(documentId)));
+            OnAnyDocumentTextChanged(
+                documentId,
+                loader,
+                CheckDocumentIsInSolution,
+                (solution, docId) => solution.GetRelatedDocumentIds(docId),
+                (solution, docId, loader) => solution.WithDocumentTextLoader(docId, loader, PreservationMode.PreserveValue),
+                WorkspaceChangeKind.DocumentChanged,
+                isCodeDocument: true);
         }
 
         /// <summary>
@@ -897,13 +886,14 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected internal void OnAdditionalDocumentTextLoaderChanged(DocumentId documentId, TextLoader loader)
         {
-            SetCurrentSolution(
-                oldSolution =>
-                {
-                    CheckAdditionalDocumentIsInSolution(oldSolution, documentId);
-                    return oldSolution.WithAdditionalDocumentTextLoader(documentId, loader, PreservationMode.PreserveValue);
-                },
-                WorkspaceChangeKind.AdditionalDocumentChanged, documentId: documentId);
+            OnAnyDocumentTextChanged(
+                documentId,
+                loader,
+                CheckAdditionalDocumentIsInSolution,
+                (solution, docId) => ImmutableArray.Create(docId), // We do not support the concept of linked additional documents
+                (solution, docId, loader) => solution.WithAdditionalDocumentTextLoader(docId, loader, PreservationMode.PreserveValue),
+                WorkspaceChangeKind.AdditionalDocumentChanged,
+                isCodeDocument: false);
         }
 
         /// <summary>
@@ -911,13 +901,14 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         protected internal void OnAnalyzerConfigDocumentTextLoaderChanged(DocumentId documentId, TextLoader loader)
         {
-            SetCurrentSolution(
-                oldSolution =>
-                {
-                    CheckAnalyzerConfigDocumentIsInSolution(oldSolution, documentId);
-                    return oldSolution.WithAnalyzerConfigDocumentTextLoader(documentId, loader, PreservationMode.PreserveValue);
-                },
-                WorkspaceChangeKind.AnalyzerConfigDocumentChanged, documentId: documentId);
+            OnAnyDocumentTextChanged(
+                documentId,
+                loader,
+                CheckAnalyzerConfigDocumentIsInSolution,
+                (solution, docId) => ImmutableArray.Create(docId), // We do not support the concept of linked additional documents
+                (solution, docId, loader) => solution.WithAnalyzerConfigDocumentTextLoader(docId, loader, PreservationMode.PreserveValue),
+                WorkspaceChangeKind.AnalyzerConfigDocumentChanged,
+                isCodeDocument: false);
         }
 
         /// <summary>


### PR DESCRIPTION
This allows us to use the same ITextAndVersionSource for documents backed by teh same SourceText or TextLoader instance.  It also ensures that if we change the TextLoader for one doc, we change it for all linked-docs of it.  We were already doing that for SourceTexts, but not TextLoaders.

This is part of the work to share syntax trees.   By doing this, we can share syntax trees if we see that those documents have the same ITextAndVersionSource.

--

This likely won't work unless we can get the workspace to reuse loaders.