### PR TITLE
Relayer our project system

### DIFF
--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSInputSet.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSInputSet.cs
@@ -45,12 +45,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
             // Some projects like web projects give us just a filename; those aren't really useful (they're just filler) so we'll ignore them for purposes of tracking the path
             if (PathUtilities.IsAbsolute(filename))
             {
-                VisualStudioProject.CompilationOutputAssemblyFilePath = filename;
+                ProjectSystemProject.CompilationOutputAssemblyFilePath = filename;
             }
 
             if (filename != null)
             {
-                VisualStudioProject.AssemblyName = Path.GetFileNameWithoutExtension(filename);
+                ProjectSystemProject.AssemblyName = Path.GetFileNameWithoutExtension(filename);
             }
 
             RefreshBinOutputPath();

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSharpProjectSite.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSharpProjectSite.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
             }
 
             var embedInteropTypes = optionID == CompilerOptions.OPTID_IMPORTSUSINGNOPIA;
-            VisualStudioProject.AddMetadataReference(filename, new MetadataReferenceProperties(embedInteropTypes: embedInteropTypes));
+            ProjectSystemProject.AddMetadataReference(filename, new MetadataReferenceProperties(embedInteropTypes: embedInteropTypes));
 
             return VSConstants.S_OK;
         }
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
         {
             filename = FileUtilities.NormalizeAbsolutePath(filename);
 
-            VisualStudioProject.RemoveMetadataReference(filename, VisualStudioProject.GetPropertiesForMetadataReference(filename).Single());
+            ProjectSystemProject.RemoveMetadataReference(filename, properties: ProjectSystemProject.GetPropertiesForMetadataReference(filename).Single());
         }
 
         public void OnOutputFileChanged(string filename)
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
 
         public int GetValidStartupClasses(IntPtr[] classNames, ref int count)
         {
-            var project = Workspace.CurrentSolution.GetRequiredProject(VisualStudioProject.Id);
+            var project = Workspace.CurrentSolution.GetRequiredProject(ProjectSystemProject.Id);
             var compilation = project.GetRequiredCompilationAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
             var entryPoints = EntryPointFinder.FindEntryPoints(compilation.SourceModule.GlobalNamespace);
 
@@ -164,11 +164,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
 
         public void OnAliasesChanged(string file, string project, int previousAliasesCount, string[] previousAliases, int currentAliasesCount, string[] currentAliases)
         {
-            using (VisualStudioProject.CreateBatchScope())
+            using (ProjectSystemProject.CreateBatchScope())
             {
-                var existingProperties = VisualStudioProject.GetPropertiesForMetadataReference(file).Single();
-                VisualStudioProject.RemoveMetadataReference(file, existingProperties);
-                VisualStudioProject.AddMetadataReference(file, existingProperties.WithAliases(currentAliases));
+                var existingProperties = ProjectSystemProject.GetPropertiesForMetadataReference(file).Single();
+                ProjectSystemProject.RemoveMetadataReference(file, existingProperties);
+                ProjectSystemProject.AddMetadataReference(file, existingProperties.WithAliases(currentAliases));
             }
         }
     }

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSharpVenusProjectSite.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSharpVenusProjectSite.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
         {
             var projectSite = GetProjectSite(project);
 
-            var projectReferencesToRemove = VisualStudioProject.GetProjectReferences().Where(p => p.ProjectId == projectSite.VisualStudioProject.Id).ToList();
+            var projectReferencesToRemove = ProjectSystemProject.GetProjectReferences().Where(p => p.ProjectId == projectSite.ProjectSystemProject.Id).ToList();
 
             if (projectReferencesToRemove.Count == 0)
             {
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
 
             foreach (var projectReferenceToRemove in projectReferencesToRemove)
             {
-                VisualStudioProject.RemoveProjectReference(new ProjectReference(projectSite.VisualStudioProject.Id));
+                ProjectSystemProject.RemoveProjectReference(new ProjectReference(projectSite.ProjectSystemProject.Id));
             }
         }
 
@@ -41,12 +41,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
         {
             var projectSite = GetProjectSite(project);
 
-            using (VisualStudioProject.CreateBatchScope())
+            using (ProjectSystemProject.CreateBatchScope())
             {
-                var existingProjectReference = VisualStudioProject.GetProjectReferences().Single(p => p.ProjectId == projectSite.VisualStudioProject.Id);
+                var existingProjectReference = ProjectSystemProject.GetProjectReferences().Single(p => p.ProjectId == projectSite.ProjectSystemProject.Id);
 
-                VisualStudioProject.RemoveProjectReference(existingProjectReference);
-                VisualStudioProject.AddProjectReference(new ProjectReference(existingProjectReference.ProjectId, ImmutableArray.Create(currentAliases), existingProjectReference.EmbedInteropTypes));
+                ProjectSystemProject.RemoveProjectReference(existingProjectReference);
+                ProjectSystemProject.AddProjectReference(new ProjectReference(existingProjectReference.ProjectId, ImmutableArray.Create(currentAliases), existingProjectReference.EmbedInteropTypes));
             }
         }
 
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
         {
             var projectSite = GetProjectSite(projectRoot);
 
-            VisualStudioProject.AddProjectReference(new ProjectReference(projectSite.VisualStudioProject.Id, embedInteropTypes: optionID == CompilerOptions.OPTID_IMPORTSUSINGNOPIA));
+            ProjectSystemProject.AddProjectReference(new ProjectReference(projectSite.ProjectSystemProject.Id, embedInteropTypes: optionID == CompilerOptions.OPTID_IMPORTSUSINGNOPIA));
         }
 
         /// <summary>

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.OptionsProcessor.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.OptionsProcessor.cs
@@ -9,6 +9,7 @@ using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Roslyn.Utilities;
@@ -19,16 +20,16 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
     {
         private class OptionsProcessor : VisualStudioProjectOptionsProcessor
         {
-            private readonly VisualStudioProject _visualStudioProject;
+            private readonly ProjectSystemProject _projectSystemProject;
 
             private readonly object[] _options = new object[(int)CompilerOptions.LARGEST_OPTION_ID];
             private string? _mainTypeName;
             private OutputKind _outputKind;
 
-            public OptionsProcessor(VisualStudioProject visualStudioProject, SolutionServices workspaceServices)
-                : base(visualStudioProject, workspaceServices)
+            public OptionsProcessor(ProjectSystemProject projectSystemProject, SolutionServices workspaceServices)
+                : base(projectSystemProject, workspaceServices)
             {
-                _visualStudioProject = visualStudioProject;
+                _projectSystemProject = projectSystemProject;
             }
 
             public object this[CompilerOptions compilerOption]
@@ -187,7 +188,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
                     return null;
                 }
 
-                var directory = Path.GetDirectoryName(_visualStudioProject.FilePath);
+                var directory = Path.GetDirectoryName(_projectSystemProject.FilePath);
 
                 if (!string.IsNullOrEmpty(directory))
                 {

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
@@ -66,8 +66,8 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
 
             var componentModel = (IComponentModel)serviceProvider.GetService(typeof(SComponentModel));
 
-            this.ProjectCodeModel = componentModel.GetService<IProjectCodeModelFactory>().CreateProjectCodeModel(VisualStudioProject.Id, this);
-            this.VisualStudioProjectOptionsProcessor = new OptionsProcessor(this.VisualStudioProject, Workspace.Services.SolutionServices);
+            this.ProjectCodeModel = componentModel.GetService<IProjectCodeModelFactory>().CreateProjectCodeModel(ProjectSystemProject.Id, this);
+            this.VisualStudioProjectOptionsProcessor = new OptionsProcessor(this.ProjectSystemProject, Workspace.Services.SolutionServices);
 
             // Ensure the default options are set up
             ResetAllOptions();

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/CSharpCompilerOptionsTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/CSharpCompilerOptionsTests.cs
@@ -111,7 +111,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
             Assert.Equal(initialPath, project.GetOutputFileName());
 
             string getCurrentCompilationOutputAssemblyPath()
-                => environment.Workspace.CurrentSolution.GetRequiredProject(project.Test_VisualStudioProject.Id).CompilationOutputInfo.AssemblyPath;
+                => environment.Workspace.CurrentSolution.GetRequiredProject(project.Test_ProjectSystemProject.Id).CompilationOutputInfo.AssemblyPath;
 
             Assert.Equal(initialPath, getCurrentCompilationOutputAssemblyPath());
 
@@ -144,7 +144,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
             var project = CSharpHelpers.CreateCSharpProject(environment, "Test");
 
             string getCurrentCompilationOutputAssemblyPath()
-                => environment.Workspace.CurrentSolution.GetRequiredProject(project.Test_VisualStudioProject.Id).CompilationOutputInfo.AssemblyPath;
+                => environment.Workspace.CurrentSolution.GetRequiredProject(project.Test_ProjectSystemProject.Id).CompilationOutputInfo.AssemblyPath;
 
             Assert.Null(getCurrentCompilationOutputAssemblyPath());
 

--- a/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/VSTypeScriptVisualStudioProjectWrapper.cs
+++ b/src/VisualStudio/Core/Def/ExternalAccess/VSTypeScript/Api/VSTypeScriptVisualStudioProjectWrapper.cs
@@ -4,13 +4,14 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 
 namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Api
 {
     internal sealed partial class VSTypeScriptVisualStudioProjectWrapper
     {
-        public VSTypeScriptVisualStudioProjectWrapper(VisualStudioProject underlyingObject)
+        public VSTypeScriptVisualStudioProjectWrapper(ProjectSystemProject underlyingObject)
             => Project = underlyingObject;
 
         public ProjectId Id => Project.Id;
@@ -39,6 +40,6 @@ namespace Microsoft.VisualStudio.LanguageServices.ExternalAccess.VSTypeScript.Ap
         public void RemoveFromWorkspace()
             => Project.RemoveFromWorkspace();
 
-        internal VisualStudioProject Project { get; }
+        internal ProjectSystemProject Project { get; }
     }
 }

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsContainedLanguageFactory.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.IVsContainedLanguageFactory.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
@@ -14,7 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 {
     internal abstract partial class AbstractLanguageService<TPackage, TLanguageService> : IVsContainedLanguageFactory
     {
-        private VisualStudioProject FindMatchingProject(IVsHierarchy hierarchy, uint itemid)
+        private ProjectSystemProject FindMatchingProject(IVsHierarchy hierarchy, uint itemid)
         {
             // Here we must determine the project that this file's document is to be a part of.
             // Venus creates a separate Project for a .aspx or .ascx file, and so we must associate

--- a/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.cs
+++ b/src/VisualStudio/Core/Def/LanguageService/AbstractLanguageService`2.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Structure;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
@@ -276,7 +277,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             => this.LanguageDebugInfo = null;
 
         protected virtual IVsContainedLanguage CreateContainedLanguage(
-            IVsTextBufferCoordinator bufferCoordinator, VisualStudioProject project,
+            IVsTextBufferCoordinator bufferCoordinator, ProjectSystemProject project,
             IVsHierarchy hierarchy, uint itemid)
         {
             return new ContainedLanguage(

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -35,7 +35,6 @@
   <ItemGroup Label="PkgDef">
     <PkgDefPackageRegistration Include="{$(RoslynPackageGuid)}" Name="RoslynPackage" Class="Microsoft.VisualStudio.LanguageServices.Setup.RoslynPackage" AllowsBackgroundLoad="true" />
     <None Include="CodeCleanup\readme.md" />
-    <None Include="ProjectSystem\Readme.md" />
     <None Include="PackageRegistration.pkgdef" PkgDefEntry="FileContent" />
     <None Include=".\ColorSchemes\VisualStudio2019.pkgdef" PkgDefEntry="FileContent" />
   </ItemGroup>

--- a/src/VisualStudio/Core/Def/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/AbstractProject.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Venus;
@@ -183,7 +184,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
 #nullable enable
 
-        public VisualStudioProject? VisualStudioProject { get; internal set; }
+        public ProjectSystemProject? VisualStudioProject { get; internal set; }
 
 #nullable disable
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
@@ -29,12 +30,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
     internal abstract partial class AbstractLegacyProject : ForegroundThreadAffinitizedObject
     {
         public IVsHierarchy Hierarchy { get; }
-        protected VisualStudioProject VisualStudioProject { get; }
+        protected ProjectSystemProject ProjectSystemProject { get; }
         internal VisualStudioProjectOptionsProcessor VisualStudioProjectOptionsProcessor { get; set; }
         protected IProjectCodeModel ProjectCodeModel { get; set; }
         protected VisualStudioWorkspace Workspace { get; }
 
-        internal VisualStudioProject Test_VisualStudioProject => VisualStudioProject;
+        internal ProjectSystemProject Test_ProjectSystemProject => ProjectSystemProject;
 
         /// <summary>
         /// The path to the directory of the project. Read-only, since although you can rename
@@ -102,7 +103,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
             }
 
             var projectFactory = componentModel.GetService<VisualStudioProjectFactory>();
-            VisualStudioProject = threadingContext.JoinableTaskFactory.Run(() => projectFactory.CreateAndAddToWorkspaceAsync(
+            ProjectSystemProject = threadingContext.JoinableTaskFactory.Run(() => projectFactory.CreateAndAddToWorkspaceAsync(
                 projectSystemName,
                 language,
                 new VisualStudioProjectCreationInfo
@@ -117,7 +118,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
                 CancellationToken.None));
 
             workspaceImpl.AddProjectRuleSetFileToInternalMaps(
-                VisualStudioProject,
+                ProjectSystemProject,
                 () => VisualStudioProjectOptionsProcessor.EffectiveRuleSetFilePath);
 
             // Right now VB doesn't have the concept of "default namespace". But we conjure one in workspace 
@@ -125,44 +126,44 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
             // use it for their own purpose.
             // In the future, we might consider officially exposing "default namespace" for VB project 
             // (e.g. through a <defaultnamespace> msbuild property)
-            VisualStudioProject.DefaultNamespace = GetRootNamespacePropertyValue(hierarchy);
+            ProjectSystemProject.DefaultNamespace = GetRootNamespacePropertyValue(hierarchy);
 
             if (TryGetPropertyValue(hierarchy, BuildPropertyNames.MaxSupportedLangVersion, out var maxLangVer))
             {
-                VisualStudioProject.MaxLangVersion = maxLangVer;
+                ProjectSystemProject.MaxLangVersion = maxLangVer;
             }
 
             if (TryGetBoolPropertyValue(hierarchy, BuildPropertyNames.RunAnalyzers, out var runAnayzers))
             {
-                VisualStudioProject.RunAnalyzers = runAnayzers;
+                ProjectSystemProject.RunAnalyzers = runAnayzers;
             }
 
             if (TryGetBoolPropertyValue(hierarchy, BuildPropertyNames.RunAnalyzersDuringLiveAnalysis, out var runAnayzersDuringLiveAnalysis))
             {
-                VisualStudioProject.RunAnalyzersDuringLiveAnalysis = runAnayzersDuringLiveAnalysis;
+                ProjectSystemProject.RunAnalyzersDuringLiveAnalysis = runAnayzersDuringLiveAnalysis;
             }
 
             Hierarchy = hierarchy;
             ConnectHierarchyEvents();
             RefreshBinOutputPath();
 
-            _externalErrorReporter = new ProjectExternalErrorReporter(VisualStudioProject.Id, externalErrorReportingPrefix, language, workspaceImpl);
+            _externalErrorReporter = new ProjectExternalErrorReporter(ProjectSystemProject.Id, externalErrorReportingPrefix, language, workspaceImpl);
             _batchScopeCreator = componentModel.GetService<SolutionEventsBatchScopeCreator>();
-            _batchScopeCreator.StartTrackingProject(VisualStudioProject, Hierarchy);
+            _batchScopeCreator.StartTrackingProject(ProjectSystemProject, Hierarchy);
         }
 
-        public string AssemblyName => VisualStudioProject.AssemblyName;
+        public string AssemblyName => ProjectSystemProject.AssemblyName;
 
         public string GetOutputFileName()
-            => VisualStudioProject.CompilationOutputAssemblyFilePath;
+            => ProjectSystemProject.CompilationOutputAssemblyFilePath;
 
         public virtual void Disconnect()
         {
-            _batchScopeCreator.StopTrackingProject(VisualStudioProject);
+            _batchScopeCreator.StopTrackingProject(ProjectSystemProject);
 
             VisualStudioProjectOptionsProcessor?.Dispose();
             ProjectCodeModel.OnProjectClosed();
-            VisualStudioProject.RemoveFromWorkspace();
+            ProjectSystemProject.RemoveFromWorkspace();
 
             // Unsubscribe IVsHierarchyEvents
             DisconnectHierarchyEvents();
@@ -190,7 +191,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
                 folders = GetFolderNamesForDocument(itemid);
             }
 
-            VisualStudioProject.AddSourceFile(filename, sourceCodeKind, folders);
+            ProjectSystemProject.AddSourceFile(filename, sourceCodeKind, folders);
         }
 
         protected void AddFile(
@@ -212,14 +213,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
                 var linkFolderPath = Path.GetDirectoryName(linkMetadata);
                 folders = linkFolderPath.Split(PathSeparatorCharacters, StringSplitOptions.RemoveEmptyEntries).ToImmutableArray();
             }
-            else if (!string.IsNullOrEmpty(VisualStudioProject.FilePath))
+            else if (!string.IsNullOrEmpty(ProjectSystemProject.FilePath))
             {
                 var relativePath = PathUtilities.GetRelativePath(_projectDirectory, filename);
                 var relativePathParts = relativePath.Split(PathSeparatorCharacters);
                 folders = ImmutableArray.Create(relativePathParts, start: 0, length: relativePathParts.Length - 1);
             }
 
-            VisualStudioProject.AddSourceFile(filename, sourceCodeKind, folders);
+            ProjectSystemProject.AddSourceFile(filename, sourceCodeKind, folders);
         }
 
         protected void RemoveFile(string filename)
@@ -232,7 +233,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
                 return;
             }
 
-            VisualStudioProject.RemoveSourceFile(filename);
+            ProjectSystemProject.RemoveSourceFile(filename);
             ProjectCodeModel.OnSourceFileRemoved(filename);
         }
 
@@ -266,12 +267,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
             // web app case
             if (!PathUtilities.IsAbsolute(outputDirectory))
             {
-                if (VisualStudioProject.FilePath == null)
+                if (ProjectSystemProject.FilePath == null)
                 {
                     return;
                 }
 
-                outputDirectory = FileUtilities.ResolveRelativePath(outputDirectory, Path.GetDirectoryName(VisualStudioProject.FilePath));
+                outputDirectory = FileUtilities.ResolveRelativePath(outputDirectory, Path.GetDirectoryName(ProjectSystemProject.FilePath));
             }
 
             if (outputDirectory == null)
@@ -279,15 +280,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
                 return;
             }
 
-            VisualStudioProject.OutputFilePath = FileUtilities.NormalizeAbsolutePath(Path.Combine(outputDirectory, targetFileName));
+            ProjectSystemProject.OutputFilePath = FileUtilities.NormalizeAbsolutePath(Path.Combine(outputDirectory, targetFileName));
 
             if (ErrorHandler.Succeeded(storage.GetPropertyValue("TargetRefPath", null, (uint)_PersistStorageType.PST_PROJECT_FILE, out var targetRefPath)) && !string.IsNullOrEmpty(targetRefPath))
             {
-                VisualStudioProject.OutputRefFilePath = targetRefPath;
+                ProjectSystemProject.OutputRefFilePath = targetRefPath;
             }
             else
             {
-                VisualStudioProject.OutputRefFilePath = null;
+                ProjectSystemProject.OutputRefFilePath = null;
             }
         }
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IAnalyzerConfigFileHost.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IAnalyzerConfigFileHost.cs
@@ -11,9 +11,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
     internal abstract partial class AbstractLegacyProject : IAnalyzerConfigFileHost
     {
         void IAnalyzerConfigFileHost.AddAnalyzerConfigFile(string filePath)
-            => VisualStudioProject.AddAnalyzerConfigFile(filePath);
+            => ProjectSystemProject.AddAnalyzerConfigFile(filePath);
 
         void IAnalyzerConfigFileHost.RemoveAnalyzerConfigFile(string filePath)
-            => VisualStudioProject.RemoveAnalyzerConfigFile(filePath);
+            => ProjectSystemProject.RemoveAnalyzerConfigFile(filePath);
     }
 }

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IAnalyzerHost.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IAnalyzerHost.cs
@@ -13,10 +13,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
     internal abstract partial class AbstractLegacyProject : IAnalyzerHost
     {
         void IAnalyzerHost.AddAnalyzerReference(string analyzerAssemblyFullPath)
-            => VisualStudioProject.AddAnalyzerReference(analyzerAssemblyFullPath);
+            => ProjectSystemProject.AddAnalyzerReference(analyzerAssemblyFullPath);
 
         void IAnalyzerHost.RemoveAnalyzerReference(string analyzerAssemblyFullPath)
-            => VisualStudioProject.RemoveAnalyzerReference(analyzerAssemblyFullPath);
+            => ProjectSystemProject.RemoveAnalyzerReference(analyzerAssemblyFullPath);
 
         void IAnalyzerHost.SetRuleSetFile(string ruleSetFileFullPath)
         {
@@ -36,9 +36,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
         }
 
         void IAnalyzerHost.AddAdditionalFile(string additionalFilePath)
-            => VisualStudioProject.AddAdditionalFile(additionalFilePath);
+            => ProjectSystemProject.AddAdditionalFile(additionalFilePath);
 
         void IAnalyzerHost.RemoveAdditionalFile(string additionalFilePath)
-            => VisualStudioProject.RemoveAdditionalFile(additionalFilePath);
+            => ProjectSystemProject.RemoveAdditionalFile(additionalFilePath);
     }
 }

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IProjectSiteEx.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IProjectSiteEx.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Interop;
 using Roslyn.Utilities;
 
@@ -14,10 +15,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
 {
     internal abstract partial class AbstractLegacyProject : IProjectSiteEx
     {
-        private readonly Stack<VisualStudioProject.BatchScope> _batchScopes = new();
+        private readonly Stack<ProjectSystemProject.BatchScope> _batchScopes = new();
 
         public void StartBatch()
-            => _batchScopes.Push(VisualStudioProject.CreateBatchScope());
+            => _batchScopes.Push(ProjectSystemProject.CreateBatchScope());
 
         public void EndBatch()
         {

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IVsHierarchyEvents.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IVsHierarchyEvents.cs
@@ -65,12 +65,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
 
                 if (filePath != null && File.Exists(filePath))
                 {
-                    VisualStudioProject.FilePath = filePath;
+                    ProjectSystemProject.FilePath = filePath;
                 }
 
                 if (Hierarchy.TryGetName(out var name))
                 {
-                    VisualStudioProject.DisplayName = name;
+                    ProjectSystemProject.DisplayName = name;
                 }
             }
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/SolutionEventsBatchScopeCreator.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/SolutionEventsBatchScopeCreator.cs
@@ -10,6 +10,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Roslyn.Utilities;
@@ -24,7 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
     [Export(typeof(SolutionEventsBatchScopeCreator))]
     internal sealed class SolutionEventsBatchScopeCreator : ForegroundThreadAffinitizedObject
     {
-        private readonly List<(VisualStudioProject project, IVsHierarchy hierarchy, VisualStudioProject.BatchScope batchScope)> _fullSolutionLoadScopes = new List<(VisualStudioProject, IVsHierarchy, VisualStudioProject.BatchScope)>();
+        private readonly List<(ProjectSystemProject project, IVsHierarchy hierarchy, ProjectSystemProject.BatchScope batchScope)> _fullSolutionLoadScopes = new List<(ProjectSystemProject, IVsHierarchy, ProjectSystemProject.BatchScope)>();
 
         private uint? _runningDocumentTableEventsCookie;
 
@@ -41,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
             _serviceProvider = serviceProvider;
         }
 
-        public void StartTrackingProject(VisualStudioProject project, IVsHierarchy hierarchy)
+        public void StartTrackingProject(ProjectSystemProject project, IVsHierarchy hierarchy)
         {
             AssertIsForeground();
 
@@ -55,7 +56,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
             }
         }
 
-        public void StopTrackingProject(VisualStudioProject project)
+        public void StopTrackingProject(ProjectSystemProject project)
         {
             AssertIsForeground();
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectCreationInfo.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectCreationInfo.cs
@@ -4,17 +4,13 @@
 
 using System;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
-    internal sealed class VisualStudioProjectCreationInfo
+    internal sealed class VisualStudioProjectCreationInfo : ProjectSystemProjectCreationInfo
     {
-        public string? AssemblyName { get; set; }
-        public CompilationOptions? CompilationOptions { get; set; }
-        public string? FilePath { get; set; }
-        public ParseOptions? ParseOptions { get; set; }
-
         public IVsHierarchy? Hierarchy { get; set; }
         public Guid ProjectGuid { get; set; }
     }

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioProjectOptionsProcessor.cs
@@ -10,13 +10,14 @@ using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
     internal class VisualStudioProjectOptionsProcessor : IDisposable
     {
-        private readonly VisualStudioProject _project;
+        private readonly ProjectSystemProject _project;
         private readonly SolutionServices _workspaceServices;
         private readonly ICommandLineParserService _commandLineParserService;
         private readonly ITemporaryStorageServiceInternal _temporaryStorageService;
@@ -47,7 +48,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private IReferenceCountedDisposable<ICacheEntry<string, IRuleSetFile>>? _ruleSetFile = null;
 
         public VisualStudioProjectOptionsProcessor(
-            VisualStudioProject project,
+            ProjectSystemProject project,
             SolutionServices workspaceServices)
         {
             _project = project ?? throw new ArgumentNullException(nameof(project));

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.SolutionAnalyzerSetterService.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.SolutionAnalyzerSetterService.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 => _workspace = workspace;
 
             public void SetAnalyzerReferences(ImmutableArray<AnalyzerReference> references)
-                => _workspace.ApplyChangeToWorkspace(w => w.SetCurrentSolution(s => s.WithAnalyzerReferences(references), WorkspaceChangeKind.SolutionChanged));
+                => _workspace.ProjectSystemProjectFactory.ApplyChangeToWorkspace(w => w.SetCurrentSolution(s => s.WithAnalyzerReferences(references), WorkspaceChangeKind.SolutionChanged));
         }
     }
 }

--- a/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -51,6 +51,7 @@ using Task = System.Threading.Tasks.Task;
 using Solution = Microsoft.CodeAnalysis.Solution;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.ProjectSystem;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
@@ -73,11 +74,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private readonly ITextBufferCloneService _textBufferCloneService;
 
         /// <summary>
-        /// The main gate to synchronize updates to this solution.
+        /// Guards any updates to the maps here that aren't updated via interlocked updates.
         /// </summary>
-        /// <remarks>
-        /// See the Readme.md in this directory for further comments about threading in this area.
-        /// </remarks>
         private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
 
         /// <summary>
@@ -88,12 +86,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private ImmutableDictionary<ProjectId, IVsHierarchy?> _projectToHierarchyMap = ImmutableDictionary<ProjectId, IVsHierarchy?>.Empty;
         private ImmutableDictionary<ProjectId, Guid> _projectToGuidMap = ImmutableDictionary<ProjectId, Guid>.Empty;
 
-        /// <remarks>Should be updated with <see cref="ImmutableInterlocked"/>.</remarks>
-        private ImmutableDictionary<ProjectId, string?> _projectToMaxSupportedLangVersionMap = ImmutableDictionary<ProjectId, string?>.Empty;
-
-        /// <remarks>Should be updated with <see cref="ImmutableInterlocked"/>.</remarks>
-        private ImmutableDictionary<ProjectId, string> _projectToDependencyNodeTargetIdentifier = ImmutableDictionary<ProjectId, string>.Empty;
-
         /// <summary>
         /// A map to fetch the path to a rule set file for a project. This right now is only used to implement
         /// <see cref="TryGetRuleSetPathForProject(ProjectId)"/> and any other use is extremely suspicious, since direct use of this is out of
@@ -102,23 +94,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// <remarks>Should be updated with <see cref="ImmutableInterlocked"/>.</remarks>
         private ImmutableDictionary<ProjectId, Func<string?>> _projectToRuleSetFilePath = ImmutableDictionary<ProjectId, Func<string?>>.Empty;
 
-        private readonly Dictionary<string, List<VisualStudioProject>> _projectSystemNameToProjectsMap = new();
+        private readonly Dictionary<string, List<ProjectSystemProject>> _projectSystemNameToProjectsMap = new();
 
         /// <summary>
         /// Only safe to use on the UI thread.
         /// </summary>
         private readonly Dictionary<string, UIContext?> _languageToProjectExistsUIContext = new();
-
-        /// <summary>
-        /// A set of documents that were added by <see cref="VisualStudioProject.AddSourceTextContainer"/>, and aren't otherwise
-        /// tracked for opening/closing.
-        /// </summary>
-        private ImmutableHashSet<DocumentId> _documentsNotFromFiles = ImmutableHashSet<DocumentId>.Empty;
-
-        /// <summary>
-        /// Indicates whether the current solution is closing.
-        /// </summary>
-        private bool _solutionClosing;
 
         [Obsolete("This is a compatibility shim for TypeScript; please do not use it.")]
         internal VisualStudioProjectTracker? _projectTracker;
@@ -127,7 +108,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         private OpenFileTracker? _openFileTracker;
         internal IFileChangeWatcher FileChangeWatcher { get; }
-        internal FileWatchedPortableExecutableReferenceFactory FileWatchedReferenceFactory { get; }
+
+        internal ProjectSystemProjectFactory ProjectSystemProjectFactory { get; }
 
         private readonly Lazy<IProjectCodeModelFactory> _projectCodeModelFactory;
 
@@ -156,12 +138,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _textBufferFactoryService.TextBufferCreated += AddTextBufferCloneServiceToBuffer;
             _projectionBufferFactoryService.ProjectionBufferCreated += AddTextBufferCloneServiceToBuffer;
 
-            _ = Task.Run(() => InitializeUIAffinitizedServicesAsync(asyncServiceProvider));
-
             FileChangeWatcher = exportProvider.GetExportedValue<FileChangeWatcherProvider>().Watcher;
-            FileWatchedReferenceFactory = new FileWatchedPortableExecutableReferenceFactory(this.Services.SolutionServices, FileChangeWatcher);
 
-            FileWatchedReferenceFactory.ReferenceChanged += this.StartRefreshingMetadataReferencesForFile;
+            ProjectSystemProjectFactory = new ProjectSystemProjectFactory(this, FileChangeWatcher, QueueCheckForFilesBeingOpen, RemoveProjectFromMaps);
+
+            _ = Task.Run(() => InitializeUIAffinitizedServicesAsync(asyncServiceProvider));
 
             _lazyExternalErrorDiagnosticUpdateSource = new Lazy<ExternalErrorDiagnosticUpdateSource>(() =>
                 new ExternalErrorDiagnosticUpdateSource(
@@ -229,9 +210,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             var telemetrySession = TelemetryService.DefaultSession;
 
             var solutionClosingContext = UIContext.FromUIContextGuid(VSConstants.UICONTEXT.SolutionClosing_guid);
-            solutionClosingContext.UIContextChanged += (_, e) => _solutionClosing = e.Activated;
+            solutionClosingContext.UIContextChanged += (_, e) => ProjectSystemProjectFactory.SolutionClosing = e.Activated;
 
-            var openFileTracker = await OpenFileTracker.CreateAsync(this, asyncServiceProvider).ConfigureAwait(true);
+            var openFileTracker = await OpenFileTracker.CreateAsync(this, ProjectSystemProjectFactory, asyncServiceProvider).ConfigureAwait(true);
             var memoryListener = await VirtualMemoryNotificationListener.CreateAsync(this, _threadingContext, asyncServiceProvider, _globalOptions, _threadingContext.DisposalToken).ConfigureAwait(true);
 
             // Update our fields first, so any asynchronous work that needs to use these is able to see the service.
@@ -264,31 +245,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         public void ProcessQueuedWorkOnUIThread()
             => _openFileTracker?.ProcessQueuedWorkOnUIThread();
 
-        internal void AddProjectToInternalMaps_NoLock(VisualStudioProject project, IVsHierarchy? hierarchy, Guid guid, string projectSystemName)
+        internal void AddProjectToInternalMaps(ProjectSystemProject project, IVsHierarchy? hierarchy, Guid guid, string projectSystemName)
         {
-            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-            _projectToHierarchyMap = _projectToHierarchyMap.Add(project.Id, hierarchy);
-            _projectToGuidMap = _projectToGuidMap.Add(project.Id, guid);
-            _projectSystemNameToProjectsMap.MultiAdd(projectSystemName, project);
+            using (_gate.DisposableWait())
+            {
+                _projectToHierarchyMap = _projectToHierarchyMap.Add(project.Id, hierarchy);
+                _projectToGuidMap = _projectToGuidMap.Add(project.Id, guid);
+                _projectSystemNameToProjectsMap.MultiAdd(projectSystemName, project);
+            }
         }
 
-        internal void AddProjectRuleSetFileToInternalMaps(VisualStudioProject project, Func<string?> ruleSetFilePathFunc)
+        internal void AddProjectRuleSetFileToInternalMaps(ProjectSystemProject project, Func<string?> ruleSetFilePathFunc)
         {
             Contract.ThrowIfFalse(ImmutableInterlocked.TryAdd(ref _projectToRuleSetFilePath, project.Id, ruleSetFilePathFunc));
-        }
-
-        internal void AddDocumentToDocumentsNotFromFiles_NoLock(DocumentId documentId)
-        {
-            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-            _documentsNotFromFiles = _documentsNotFromFiles.Add(documentId);
-        }
-
-        internal void RemoveDocumentToDocumentsNotFromFiles_NoLock(DocumentId documentId)
-        {
-            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-            _documentsNotFromFiles = _documentsNotFromFiles.Remove(documentId);
         }
 
         [Obsolete("This is a compatibility shim for TypeScript; please do not use it.")]
@@ -308,7 +277,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
-        internal VisualStudioProject? GetProjectWithHierarchyAndName(IVsHierarchy hierarchy, string projectName)
+        internal ProjectSystemProject? GetProjectWithHierarchyAndName(IVsHierarchy hierarchy, string projectName)
         {
             using (_gate.DisposableWait())
             {
@@ -316,7 +285,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
-        private VisualStudioProject? GetProjectWithHierarchyAndName_NoLock(IVsHierarchy hierarchy, string projectName)
+        private ProjectSystemProject? GetProjectWithHierarchyAndName_NoLock(IVsHierarchy hierarchy, string projectName)
         {
             if (_projectSystemNameToProjectsMap.TryGetValue(projectName, out var projects))
             {
@@ -469,7 +438,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public override bool CanApplyParseOptionChange(ParseOptions oldOptions, ParseOptions newOptions, CodeAnalysis.Project project)
         {
-            _projectToMaxSupportedLangVersionMap.TryGetValue(project.Id, out var maxSupportLangVersion);
+            var maxSupportLangVersion = ProjectSystemProjectFactory.TryGetMaxSupportedLanguageVersion(project.Id);
 
             return project.Services.GetRequiredService<IParseOptionsChangingService>().CanApplyChange(oldOptions, newOptions, maxSupportLangVersion);
         }
@@ -1349,9 +1318,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         internal string? TryGetDependencyNodeTargetIdentifier(ProjectId projectId)
         {
-            // This doesn't take a lock since _projectToDependencyNodeTargetIdentifier is immutable
-            _projectToDependencyNodeTargetIdentifier.TryGetValue(projectId, out var identifier);
-            return identifier;
+            return ProjectSystemProjectFactory.TryGetDependencyNodeTargetIdentifier(projectId);
         }
 
         internal override void SetDocumentContext(DocumentId documentId)
@@ -1438,7 +1405,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             {
                 _textBufferFactoryService.TextBufferCreated -= AddTextBufferCloneServiceToBuffer;
                 _projectionBufferFactoryService.ProjectionBufferCreated -= AddTextBufferCloneServiceToBuffer;
-                FileWatchedReferenceFactory.ReferenceChanged -= StartRefreshingMetadataReferencesForFile;
 
                 if (_lazyExternalErrorDiagnosticUpdateSource.IsValueCreated)
                 {
@@ -1553,147 +1519,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return result != (uint)__VSREFERENCEQUERYRESULT.REFERENCE_DENY;
         }
 
-        /// <summary>
-        /// Applies a single operation to the workspace. <paramref name="action"/> should be a call to one of the protected Workspace.On* methods.
-        /// </summary>
-        public void ApplyChangeToWorkspace(Action<Workspace> action)
+        internal void RemoveProjectFromMaps(CodeAnalysis.Project project)
         {
-            using (_gate.DisposableWait())
-            {
-                action(this);
-            }
-        }
-
-        /// <summary>
-        /// Applies a single operation to the workspace. <paramref name="action"/> should be a call to one of the protected Workspace.On* methods.
-        /// </summary>
-        public async ValueTask ApplyChangeToWorkspaceAsync(Action<Workspace> action)
-        {
-            using (await _gate.DisposableWaitAsync().ConfigureAwait(false))
-            {
-                action(this);
-            }
-        }
-
-        /// <summary>
-        /// Applies a single operation to the workspace. <paramref name="action"/> should be a call to one of the protected Workspace.On* methods.
-        /// </summary>
-        public async ValueTask ApplyChangeToWorkspaceMaybeAsync(bool useAsync, Action<Workspace> action)
-        {
-            using (useAsync ? await _gate.DisposableWaitAsync().ConfigureAwait(false) : _gate.DisposableWait())
-            {
-                action(this);
-            }
-        }
-
-        /// <summary>
-        /// Applies a solution transformation to the workspace and triggers workspace changed event for specified <paramref name="projectId"/>.
-        /// The transformation shall only update the project of the solution with the specified <paramref name="projectId"/>.
-        /// </summary>
-        public void ApplyChangeToWorkspace(ProjectId projectId, Func<CodeAnalysis.Solution, CodeAnalysis.Solution> solutionTransformation)
-        {
-            using (_gate.DisposableWait())
-            {
-                SetCurrentSolution(solutionTransformation, WorkspaceChangeKind.ProjectChanged, projectId);
-            }
-        }
-
-        /// <inheritdoc cref="ApplyBatchChangeToWorkspaceMaybeAsync(bool, Action{SolutionChangeAccumulator})"/>
-        public void ApplyBatchChangeToWorkspace(Action<SolutionChangeAccumulator> mutation)
-        {
-            ApplyBatchChangeToWorkspaceMaybeAsync(useAsync: false, mutation).VerifyCompleted();
-        }
-
-        /// <inheritdoc cref="ApplyBatchChangeToWorkspaceMaybeAsync(bool, Action{SolutionChangeAccumulator})"/>
-        public Task ApplyBatchChangeToWorkspaceAsync(Action<SolutionChangeAccumulator> mutation)
-        {
-            return ApplyBatchChangeToWorkspaceMaybeAsync(useAsync: true, mutation);
-        }
-
-        /// <summary>
-        /// Applies a change to the workspace that can do any number of project changes.
-        /// </summary>
-        /// <remarks>This is needed to synchronize with <see cref="ApplyChangeToWorkspace(Action{Workspace})" /> to avoid any races. This
-        /// method could be moved down to the core Workspace layer and then could use the synchronization lock there.</remarks>
-        public async Task ApplyBatchChangeToWorkspaceMaybeAsync(bool useAsync, Action<SolutionChangeAccumulator> mutation)
-        {
-            using (useAsync ? await _gate.DisposableWaitAsync().ConfigureAwait(false) : _gate.DisposableWait())
-            {
-                var solutionChanges = new SolutionChangeAccumulator(CurrentSolution);
-                mutation(solutionChanges);
-
-                ApplyBatchChangeToWorkspace_NoLock(solutionChanges);
-            }
-        }
-
-        private void ApplyBatchChangeToWorkspace_NoLock(SolutionChangeAccumulator solutionChanges)
-        {
-            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-            if (!solutionChanges.HasChange)
-                return;
-
-            this.SetCurrentSolution(
-                _ => solutionChanges.Solution,
-                solutionChanges.WorkspaceChangeKind,
-                solutionChanges.WorkspaceChangeProjectId,
-                solutionChanges.WorkspaceChangeDocumentId,
-                onBeforeUpdate: (_, _) =>
-                {
-                    // Clear out mutable state not associated with the solution snapshot (for example, which documents are
-                    // currently open).
-                    foreach (var documentId in solutionChanges.DocumentIdsRemoved)
-                        this.ClearDocumentData(documentId);
-                });
-        }
-
-        private readonly Dictionary<ProjectId, ProjectReferenceInformation> _projectReferenceInfoMap = new();
-
-        private ProjectReferenceInformation GetReferenceInfo_NoLock(ProjectId projectId)
-        {
-            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-            return _projectReferenceInfoMap.GetOrAdd(projectId, _ => new ProjectReferenceInformation());
-        }
-
-        /// <summary>
-        /// Removes the project from the various maps this type maintains; it's still up to the caller to actually remove
-        /// the project in one way or another.
-        /// </summary>
-        internal void RemoveProjectFromTrackingMaps_NoLock(ProjectId projectId)
-        {
-            string? languageName;
-
-            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-            languageName = CurrentSolution.GetRequiredProject(projectId).Language;
-
-            if (_projectReferenceInfoMap.TryGetValue(projectId, out var projectReferenceInfo))
-            {
-                // If we still had any output paths, we'll want to remove them to cause conversion back to metadata references.
-                // The call below implicitly is modifying the collection we've fetched, so we'll make a copy.
-                var solutionChanges = new SolutionChangeAccumulator(this.CurrentSolution);
-
-                foreach (var outputPath in projectReferenceInfo.OutputPaths.ToList())
-                {
-                    RemoveProjectOutputPath_NoLock(solutionChanges, projectId, outputPath);
-                }
-
-                ApplyBatchChangeToWorkspace_NoLock(solutionChanges);
-
-                _projectReferenceInfoMap.Remove(projectId);
-            }
-
-            _projectToHierarchyMap = _projectToHierarchyMap.Remove(projectId);
-            _projectToGuidMap = _projectToGuidMap.Remove(projectId);
-
-            ImmutableInterlocked.TryRemove<ProjectId, string?>(ref _projectToMaxSupportedLangVersionMap, projectId, out _);
-            ImmutableInterlocked.TryRemove(ref _projectToDependencyNodeTargetIdentifier, projectId, out _);
-            ImmutableInterlocked.TryRemove(ref _projectToRuleSetFilePath, projectId, out _);
-
             foreach (var (projectName, projects) in _projectSystemNameToProjectsMap)
             {
-                if (projects.RemoveAll(p => p.Id == projectId) > 0)
+                if (projects.RemoveAll(p => p.Id == project.Id) > 0)
                 {
                     if (projects.Count == 0)
                     {
@@ -1704,370 +1534,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
             }
 
+            _projectToHierarchyMap = _projectToHierarchyMap.Remove(project.Id);
+            _projectToGuidMap = _projectToGuidMap.Remove(project.Id);
+
+            ImmutableInterlocked.TryRemove(ref _projectToRuleSetFilePath, project.Id, out _);
+
             // Try to update the UI context info.  But cancel that work if we're shutting down.
             _threadingContext.RunWithShutdownBlockAsync(async cancellationToken =>
             {
                 using var asyncToken = _workspaceListener.BeginAsyncOperation(nameof(RefreshProjectExistsUIContextForLanguageAsync));
-                await RefreshProjectExistsUIContextForLanguageAsync(languageName, cancellationToken).ConfigureAwait(false);
+                await RefreshProjectExistsUIContextForLanguageAsync(project.Language, cancellationToken).ConfigureAwait(false);
             });
-        }
-
-        internal void RemoveSolution_NoLock()
-        {
-            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-            // At this point, we should have had RemoveProjectFromTrackingMaps_NoLock called for everything else, so it's just the solution itself
-            // to clean up
-            Contract.ThrowIfFalse(_projectReferenceInfoMap.Count == 0);
-            Contract.ThrowIfFalse(_projectToHierarchyMap.Count == 0);
-            Contract.ThrowIfFalse(_projectToGuidMap.Count == 0);
-            Contract.ThrowIfFalse(_projectToMaxSupportedLangVersionMap.Count == 0);
-            Contract.ThrowIfFalse(_projectToDependencyNodeTargetIdentifier.Count == 0);
-            Contract.ThrowIfFalse(_projectToRuleSetFilePath.Count == 0);
-            Contract.ThrowIfFalse(_projectSystemNameToProjectsMap.Count == 0);
-
-            // Create a new empty solution and set this; we will reuse the same SolutionId and path since components still may have persistence information they still need
-            // to look up by that location; we also keep the existing analyzer references around since those are host-level analyzers that were loaded asynchronously.
-            ClearOpenDocuments();
-
-            SetCurrentSolution(
-                solution => CreateSolution(
-                    SolutionInfo.Create(
-                        SolutionId.CreateNewId(),
-                        VersionStamp.Create(),
-                        analyzerReferences: solution.AnalyzerReferences)),
-                WorkspaceChangeKind.SolutionRemoved);
-        }
-
-        private sealed class ProjectReferenceInformation
-        {
-            public readonly List<string> OutputPaths = new();
-            public readonly List<(string path, ProjectReference projectReference)> ConvertedProjectReferences = new List<(string path, ProjectReference)>();
-        }
-
-        /// <summary>
-        /// A multimap from an output path to the project outputting to it. Ideally, this shouldn't ever
-        /// actually be a true multimap, since we shouldn't have two projects outputting to the same path, but
-        /// any bug by a project adding the wrong output path means we could end up with some duplication.
-        /// In that case, we'll temporarily have two until (hopefully) somebody removes it.
-        /// </summary>
-        private readonly Dictionary<string, List<ProjectId>> _projectsByOutputPath = new(StringComparer.OrdinalIgnoreCase);
-
-        public void AddProjectOutputPath_NoLock(SolutionChangeAccumulator solutionChanges, ProjectId projectId, string outputPath)
-        {
-            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-            var projectReferenceInformation = GetReferenceInfo_NoLock(projectId);
-
-            projectReferenceInformation.OutputPaths.Add(outputPath);
-            _projectsByOutputPath.MultiAdd(outputPath, projectId);
-
-            var projectsForOutputPath = _projectsByOutputPath[outputPath];
-            var distinctProjectsForOutputPath = projectsForOutputPath.Distinct().ToList();
-
-            // If we have exactly one, then we're definitely good to convert
-            if (projectsForOutputPath.Count == 1)
-            {
-                ConvertMetadataReferencesToProjectReferences_NoLock(solutionChanges, projectId, outputPath);
-            }
-            else if (distinctProjectsForOutputPath.Count == 1)
-            {
-                // The same project has multiple output paths that are the same. Any project would have already been converted
-                // by the prior add, so nothing further to do
-            }
-            else
-            {
-                // We have more than one project outputting to the same path. This shouldn't happen but we'll convert back
-                // because now we don't know which project to reference.
-                foreach (var otherProjectId in projectsForOutputPath)
-                {
-                    // We know that since we're adding a path to projectId and we're here that we couldn't have already
-                    // had a converted reference to us, instead we need to convert things that are pointing to the project
-                    // we're colliding with
-                    if (otherProjectId != projectId)
-                    {
-                        ConvertProjectReferencesToMetadataReferences_NoLock(solutionChanges, otherProjectId, outputPath);
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Attempts to convert all metadata references to <paramref name="outputPath"/> to a project reference to <paramref name="projectIdToReference"/>.
-        /// </summary>
-        /// <param name="projectIdToReference">The <see cref="ProjectId"/> of the project that could be referenced in place of the output path.</param>
-        /// <param name="outputPath">The output path to replace.</param>
-        [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/31306",
-            Constraint = "Avoid calling " + nameof(CodeAnalysis.Solution.GetProject) + " to avoid realizing all projects.")]
-        private void ConvertMetadataReferencesToProjectReferences_NoLock(SolutionChangeAccumulator solutionChanges, ProjectId projectIdToReference, string outputPath)
-        {
-            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-            foreach (var projectIdToRetarget in solutionChanges.Solution.ProjectIds)
-            {
-                if (CanConvertMetadataReferenceToProjectReference(solutionChanges.Solution, projectIdToRetarget, referencedProjectId: projectIdToReference))
-                {
-                    // PERF: call GetProjectState instead of GetProject, otherwise creating a new project might force all
-                    // Project instances to get created.
-                    foreach (PortableExecutableReference reference in solutionChanges.Solution.GetProjectState(projectIdToRetarget)!.MetadataReferences)
-                    {
-                        if (string.Equals(reference.FilePath, outputPath, StringComparison.OrdinalIgnoreCase))
-                        {
-                            FileWatchedReferenceFactory.StopWatchingReference(reference);
-
-                            var projectReference = new ProjectReference(projectIdToReference, reference.Properties.Aliases, reference.Properties.EmbedInteropTypes);
-                            var newSolution = solutionChanges.Solution.RemoveMetadataReference(projectIdToRetarget, reference)
-                                                                      .AddProjectReference(projectIdToRetarget, projectReference);
-
-                            solutionChanges.UpdateSolutionForProjectAction(projectIdToRetarget, newSolution);
-
-                            GetReferenceInfo_NoLock(projectIdToRetarget).ConvertedProjectReferences.Add(
-                                (reference.FilePath!, projectReference));
-
-                            // We have converted one, but you could have more than one reference with different aliases
-                            // that we need to convert, so we'll keep going
-                        }
-                    }
-                }
-            }
-        }
-
-        [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/31306",
-            Constraint = "Avoid calling " + nameof(CodeAnalysis.Solution.GetProject) + " to avoid realizing all projects.")]
-        private static bool CanConvertMetadataReferenceToProjectReference(Solution solution, ProjectId projectIdWithMetadataReference, ProjectId referencedProjectId)
-        {
-            // We can never make a project reference ourselves. This isn't a meaningful scenario, but if somebody does this by accident
-            // we do want to throw exceptions.
-            if (projectIdWithMetadataReference == referencedProjectId)
-            {
-                return false;
-            }
-
-            // PERF: call GetProjectState instead of GetProject, otherwise creating a new project might force all
-            // Project instances to get created.
-            var projectWithMetadataReference = solution.GetProjectState(projectIdWithMetadataReference);
-            var referencedProject = solution.GetProjectState(referencedProjectId);
-
-            Contract.ThrowIfNull(projectWithMetadataReference);
-            Contract.ThrowIfNull(referencedProject);
-
-            // We don't want to convert a metadata reference to a project reference if the project being referenced isn't something
-            // we can create a Compilation for. For example, if we have a C# project, and it's referencing a F# project via a metadata reference
-            // everything would be fine if we left it a metadata reference. Converting it to a project reference means we couldn't create a Compilation
-            // anymore in the IDE, since the C# compilation would need to reference an F# compilation. F# projects referencing other F# projects though
-            // do expect this to work, and so we'll always allow references through of the same language.
-            if (projectWithMetadataReference.Language != referencedProject.Language)
-            {
-                if (projectWithMetadataReference.LanguageServices.GetService<ICompilationFactoryService>() != null &&
-                    referencedProject.LanguageServices.GetService<ICompilationFactoryService>() == null)
-                {
-                    // We're referencing something that we can't create a compilation from something that can, so keep the metadata reference
-                    return false;
-                }
-            }
-
-            // If this is going to cause a circular reference, also disallow it
-            if (solution.GetProjectDependencyGraph().GetProjectsThatThisProjectTransitivelyDependsOn(referencedProjectId).Contains(projectIdWithMetadataReference))
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Finds all projects that had a project reference to <paramref name="projectId"/> and convert it back to a metadata reference.
-        /// </summary>
-        /// <param name="projectId">The <see cref="ProjectId"/> of the project being referenced.</param>
-        /// <param name="outputPath">The output path of the given project to remove the link to.</param>
-        [PerformanceSensitive(
-            "https://github.com/dotnet/roslyn/issues/37616",
-            Constraint = "Update ConvertedProjectReferences in place to avoid duplicate list allocations.")]
-        private void ConvertProjectReferencesToMetadataReferences_NoLock(SolutionChangeAccumulator solutionChanges, ProjectId projectId, string outputPath)
-        {
-            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-            foreach (var projectIdToRetarget in solutionChanges.Solution.ProjectIds)
-            {
-                var referenceInfo = GetReferenceInfo_NoLock(projectIdToRetarget);
-
-                // Update ConvertedProjectReferences in place to avoid duplicate list allocations
-                for (var i = 0; i < referenceInfo.ConvertedProjectReferences.Count; i++)
-                {
-                    var convertedReference = referenceInfo.ConvertedProjectReferences[i];
-
-                    if (string.Equals(convertedReference.path, outputPath, StringComparison.OrdinalIgnoreCase) &&
-                        convertedReference.projectReference.ProjectId == projectId)
-                    {
-                        var metadataReference =
-                            FileWatchedReferenceFactory.CreateReferenceAndStartWatchingFile(
-                                convertedReference.path,
-                                new MetadataReferenceProperties(
-                                    aliases: convertedReference.projectReference.Aliases,
-                                    embedInteropTypes: convertedReference.projectReference.EmbedInteropTypes));
-
-                        var newSolution = solutionChanges.Solution.RemoveProjectReference(projectIdToRetarget, convertedReference.projectReference)
-                                                                  .AddMetadataReference(projectIdToRetarget, metadataReference);
-
-                        solutionChanges.UpdateSolutionForProjectAction(projectIdToRetarget, newSolution);
-
-                        referenceInfo.ConvertedProjectReferences.RemoveAt(i);
-
-                        // We have converted one, but you could have more than one reference with different aliases
-                        // that we need to convert, so we'll keep going. Make sure to decrement the index so we don't
-                        // skip any items.
-                        i--;
-                    }
-                }
-            }
-        }
-
-        public ProjectReference? TryCreateConvertedProjectReference_NoLock(ProjectId referencingProject, string path, MetadataReferenceProperties properties)
-        {
-            // Any conversion to or from project references must be done under the global workspace lock,
-            // since that needs to be coordinated with updating all projects simultaneously.
-            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-            if (_projectsByOutputPath.TryGetValue(path, out var ids) && ids.Distinct().Count() == 1)
-            {
-                var projectIdToReference = ids.First();
-
-                if (CanConvertMetadataReferenceToProjectReference(this.CurrentSolution, referencingProject, projectIdToReference))
-                {
-                    var projectReference = new ProjectReference(
-                        projectIdToReference,
-                        aliases: properties.Aliases,
-                        embedInteropTypes: properties.EmbedInteropTypes);
-
-                    GetReferenceInfo_NoLock(referencingProject).ConvertedProjectReferences.Add((path, projectReference));
-
-                    return projectReference;
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        public ProjectReference? TryRemoveConvertedProjectReference_NoLock(ProjectId referencingProject, string path, MetadataReferenceProperties properties)
-        {
-            // Any conversion to or from project references must be done under the global workspace lock,
-            // since that needs to be coordinated with updating all projects simultaneously.
-            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-            var projectReferenceInformation = GetReferenceInfo_NoLock(referencingProject);
-            foreach (var convertedProject in projectReferenceInformation.ConvertedProjectReferences)
-            {
-                if (convertedProject.path == path &&
-                    convertedProject.projectReference.EmbedInteropTypes == properties.EmbedInteropTypes &&
-                    convertedProject.projectReference.Aliases.SequenceEqual(properties.Aliases))
-                {
-                    projectReferenceInformation.ConvertedProjectReferences.Remove(convertedProject);
-                    return convertedProject.projectReference;
-                }
-            }
-
-            return null;
-        }
-
-        public void RemoveProjectOutputPath_NoLock(SolutionChangeAccumulator solutionChanges, ProjectId projectId, string outputPath)
-        {
-            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
-
-            var projectReferenceInformation = GetReferenceInfo_NoLock(projectId);
-            if (!projectReferenceInformation.OutputPaths.Contains(outputPath))
-            {
-                throw new ArgumentException($"Project does not contain output path '{outputPath}'", nameof(outputPath));
-            }
-
-            projectReferenceInformation.OutputPaths.Remove(outputPath);
-            _projectsByOutputPath.MultiRemove(outputPath, projectId);
-
-            // When a project is closed, we may need to convert project references to metadata references (or vice
-            // versa). Failure to convert the references could leave a project in the workspace with a project
-            // reference to a project which is not open.
-            //
-            // For the specific case where the entire solution is closing, we do not need to update the state for
-            // remaining projects as each project closes, because we know those projects will be closed without
-            // further use. Avoiding reference conversion when the solution is closing improves performance for both
-            // IDE close scenarios and solution reload scenarios that occur after complex branch switches.
-            if (!_solutionClosing)
-            {
-                if (_projectsByOutputPath.TryGetValue(outputPath, out var remainingProjectsForOutputPath))
-                {
-                    var distinctRemainingProjects = remainingProjectsForOutputPath.Distinct();
-                    if (distinctRemainingProjects.Count() == 1)
-                    {
-                        // We had more than one project outputting to the same path. Now we're back down to one
-                        // so we can reference that one again
-                        ConvertMetadataReferencesToProjectReferences_NoLock(solutionChanges, distinctRemainingProjects.Single(), outputPath);
-                    }
-                }
-                else
-                {
-                    // No projects left, we need to convert back to metadata references
-                    ConvertProjectReferencesToMetadataReferences_NoLock(solutionChanges, projectId, outputPath);
-                }
-            }
-        }
-
-        private void StartRefreshingMetadataReferencesForFile(object sender, string fullFilePath)
-        {
-            _threadingContext.RunWithShutdownBlockAsync(async cancellationToken =>
-            {
-                using var asyncToken = _workspaceListener.BeginAsyncOperation(nameof(StartRefreshingMetadataReferencesForFile));
-                await ApplyBatchChangeToWorkspaceAsync(solutionChanges =>
-                {
-                    foreach (var project in CurrentSolution.Projects)
-                    {
-                        // Loop to find each reference with the given path. It's possible that there might be multiple references of the same path;
-                        // the project system could concievably add the same reference multiple times but with different aliases. It's also possible
-                        // we might not find the path at all: when we receive the file changed event, we aren't checking if the file is still
-                        // in the workspace at that time; it's possible it might have already been removed.
-                        foreach (var portableExecutableReference in project.MetadataReferences.OfType<PortableExecutableReference>())
-                        {
-                            if (portableExecutableReference.FilePath == fullFilePath)
-                            {
-                                FileWatchedReferenceFactory.StopWatchingReference(portableExecutableReference);
-
-                                var newPortableExecutableReference =
-                                    FileWatchedReferenceFactory.CreateReferenceAndStartWatchingFile(
-                                        portableExecutableReference.FilePath,
-                                        portableExecutableReference.Properties);
-
-                                var newSolution = solutionChanges.Solution.RemoveMetadataReference(project.Id, portableExecutableReference)
-                                                                            .AddMetadataReference(project.Id, newPortableExecutableReference);
-
-                                solutionChanges.UpdateSolutionForProjectAction(project.Id, newSolution);
-
-                            }
-                        }
-                    }
-                }).ConfigureAwait(false);
-            });
-        }
-
-        [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/54137", AllowLocks = false)]
-        internal void SetMaxLanguageVersion(ProjectId projectId, string? maxLanguageVersion)
-        {
-            ImmutableInterlocked.Update(
-                ref _projectToMaxSupportedLangVersionMap,
-                static (map, arg) => map.SetItem(arg.projectId, arg.maxLanguageVersion),
-                (projectId, maxLanguageVersion));
-        }
-
-        [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/54135", AllowLocks = false)]
-        internal void SetDependencyNodeTargetIdentifier(ProjectId projectId, string targetIdentifier)
-        {
-            ImmutableInterlocked.Update(
-                ref _projectToDependencyNodeTargetIdentifier,
-                static (map, arg) => map.SetItem(arg.projectId, arg.targetIdentifier),
-                (projectId, targetIdentifier));
         }
 
         internal async Task RefreshProjectExistsUIContextForLanguageAsync(string language, CancellationToken cancellationToken)

--- a/src/VisualStudio/Core/Def/TaskList/HostDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/TaskList/HostDiagnosticUpdateSource.cs
@@ -127,5 +127,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 RaiseDiagnosticsRemovedForProject(projectId, key);
             }
         }
+
+        public DiagnosticData CreateAnalyzerLoadFailureDiagnostic(AnalyzerLoadFailureEventArgs e, string fullPath, ProjectId projectId, string language)
+        {
+            return DocumentAnalysisExecutor.CreateAnalyzerLoadFailureDiagnostic(e, fullPath, projectId, language);
+        }
     }
 }

--- a/src/VisualStudio/Core/Def/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedDocument.cs
@@ -23,6 +23,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -87,7 +88,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         private readonly HostType _hostType;
         private readonly ReiteratedVersionSnapshotTracker _snapshotTracker;
         private readonly AbstractFormattingRule _vbHelperFormattingRule;
-        private readonly VisualStudioProject _project;
+        private readonly ProjectSystemProject _project;
 
         public bool SupportsRename { get { return _hostType == HostType.Razor; } }
         public bool SupportsSemanticSnippets { get { return false; } }
@@ -105,7 +106,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             ITextBuffer dataBuffer,
             IVsTextBufferCoordinator bufferCoordinator,
             Workspace workspace,
-            VisualStudioProject project,
+            ProjectSystemProject project,
             IComponentModel componentModel,
             AbstractFormattingRule vbHelperFormattingRule)
             : base(threadingContext)

--- a/src/VisualStudio/Core/Def/Venus/ContainedLanguage.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedLanguage.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
@@ -31,7 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         protected readonly Workspace Workspace;
         protected readonly IComponentModel ComponentModel;
 
-        public VisualStudioProject? Project { get; }
+        public ProjectSystemProject? Project { get; }
 
         protected readonly ContainedDocument ContainedDocument;
 
@@ -71,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             IComponentModel componentModel,
             Workspace workspace,
             ProjectId projectId,
-            VisualStudioProject? project,
+            ProjectSystemProject? project,
             Guid languageServiceGuid,
             AbstractFormattingRule? vbHelperFormattingRule = null)
         {

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IProjectCodeModelProvider.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IProjectCodeModelProvider.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
 
             private EnvDTE.ProjectItem GetProjectItem(string filePath)
             {
-                var dteProject = _project._visualStudioWorkspace.TryGetDTEProject(_project._visualStudioProject.Id);
+                var dteProject = _project._visualStudioWorkspace.TryGetDTEProject(_project._projectSystemProject.Id);
                 if (dteProject == null)
                 {
                     return null;

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
@@ -20,7 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
 {
     internal sealed partial class CPSProject : IWorkspaceProjectContext
     {
-        private readonly VisualStudioProject _visualStudioProject;
+        private readonly ProjectSystemProject _projectSystemProject;
 
         /// <summary>
         /// The <see cref="VisualStudioProjectOptionsProcessor"/> we're using to parse command line options. Null if we don't
@@ -32,24 +33,24 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         private readonly IProjectCodeModel _projectCodeModel;
         private readonly Lazy<ProjectExternalErrorReporter?> _externalErrorReporter;
 
-        private readonly ConcurrentQueue<VisualStudioProject.BatchScope> _batchScopes = new();
+        private readonly ConcurrentQueue<ProjectSystemProject.BatchScope> _batchScopes = new();
 
         public string DisplayName
         {
-            get => _visualStudioProject.DisplayName;
-            set => _visualStudioProject.DisplayName = value;
+            get => _projectSystemProject.DisplayName;
+            set => _projectSystemProject.DisplayName = value;
         }
 
         public string? ProjectFilePath
         {
-            get => _visualStudioProject.FilePath;
-            set => _visualStudioProject.FilePath = value;
+            get => _projectSystemProject.FilePath;
+            set => _projectSystemProject.FilePath = value;
         }
 
         public bool IsPrimary
         {
-            get => _visualStudioProject.IsPrimary;
-            set => _visualStudioProject.IsPrimary = value;
+            get => _projectSystemProject.IsPrimary;
+            set => _projectSystemProject.IsPrimary = value;
         }
 
         public Guid Guid
@@ -60,18 +61,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
 
         public bool LastDesignTimeBuildSucceeded
         {
-            get => _visualStudioProject.HasAllInformation;
-            set => _visualStudioProject.HasAllInformation = value;
+            get => _projectSystemProject.HasAllInformation;
+            set => _projectSystemProject.HasAllInformation = value;
         }
 
-        public CPSProject(VisualStudioProject visualStudioProject, VisualStudioWorkspaceImpl visualStudioWorkspace, IProjectCodeModelFactory projectCodeModelFactory, Guid projectGuid)
+        public CPSProject(ProjectSystemProject projectSystemProject, VisualStudioWorkspaceImpl visualStudioWorkspace, IProjectCodeModelFactory projectCodeModelFactory, Guid projectGuid)
         {
-            _visualStudioProject = visualStudioProject;
+            _projectSystemProject = projectSystemProject;
             _visualStudioWorkspace = visualStudioWorkspace;
 
             _externalErrorReporter = new Lazy<ProjectExternalErrorReporter?>(() =>
             {
-                var prefix = visualStudioProject.Language switch
+                var prefix = projectSystemProject.Language switch
                 {
                     LanguageNames.CSharp => "CS",
                     LanguageNames.VisualBasic => "BC",
@@ -79,17 +80,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
                     _ => null
                 };
 
-                return (prefix != null) ? new ProjectExternalErrorReporter(visualStudioProject.Id, prefix, visualStudioProject.Language, visualStudioWorkspace) : null;
+                return (prefix != null) ? new ProjectExternalErrorReporter(projectSystemProject.Id, prefix, projectSystemProject.Language, visualStudioWorkspace) : null;
             });
 
-            _projectCodeModel = projectCodeModelFactory.CreateProjectCodeModel(visualStudioProject.Id, new CPSCodeModelInstanceFactory(this));
+            _projectCodeModel = projectCodeModelFactory.CreateProjectCodeModel(projectSystemProject.Id, new CPSCodeModelInstanceFactory(this));
 
             // If we have a command line parser service for this language, also set up our ability to process options if they come in
-            if (visualStudioWorkspace.Services.GetLanguageServices(visualStudioProject.Language).GetService<ICommandLineParserService>() != null)
+            if (visualStudioWorkspace.Services.GetLanguageServices(projectSystemProject.Language).GetService<ICommandLineParserService>() != null)
             {
-                _visualStudioProjectOptionsProcessor = new VisualStudioProjectOptionsProcessor(_visualStudioProject, visualStudioWorkspace.Services.SolutionServices);
+                _visualStudioProjectOptionsProcessor = new VisualStudioProjectOptionsProcessor(_projectSystemProject, visualStudioWorkspace.Services.SolutionServices);
                 _visualStudioWorkspace.AddProjectRuleSetFileToInternalMaps(
-                    visualStudioProject,
+                    projectSystemProject,
                     () => _visualStudioProjectOptionsProcessor.EffectiveRuleSetFilePath);
             }
 
@@ -98,13 +99,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
 
         public string? BinOutputPath
         {
-            get => _visualStudioProject.OutputFilePath;
+            get => _projectSystemProject.OutputFilePath;
             set
             {
                 // If we don't have a path, always set it to null
                 if (string.IsNullOrEmpty(value))
                 {
-                    _visualStudioProject.OutputFilePath = null;
+                    _projectSystemProject.OutputFilePath = null;
                     return;
                 }
 
@@ -113,26 +114,26 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
                 // can be removed now, but we still have tests asserting it.
                 if (!PathUtilities.IsAbsolute(value))
                 {
-                    var rootDirectory = _visualStudioProject.FilePath != null
-                                        ? Path.GetDirectoryName(_visualStudioProject.FilePath)
+                    var rootDirectory = _projectSystemProject.FilePath != null
+                                        ? Path.GetDirectoryName(_projectSystemProject.FilePath)
                                         : Path.GetTempPath();
 
-                    _visualStudioProject.OutputFilePath = Path.Combine(rootDirectory, value);
+                    _projectSystemProject.OutputFilePath = Path.Combine(rootDirectory, value);
                 }
                 else
                 {
-                    _visualStudioProject.OutputFilePath = value;
+                    _projectSystemProject.OutputFilePath = value;
                 }
             }
         }
 
         internal string? CompilationOutputAssemblyFilePath
         {
-            get => _visualStudioProject.CompilationOutputAssemblyFilePath;
-            set => _visualStudioProject.CompilationOutputAssemblyFilePath = value;
+            get => _projectSystemProject.CompilationOutputAssemblyFilePath;
+            set => _projectSystemProject.CompilationOutputAssemblyFilePath = value;
         }
 
-        public ProjectId Id => _visualStudioProject.Id;
+        public ProjectId Id => _projectSystemProject.Id;
 
         public void SetOptions(string commandLineForOptions)
             => _visualStudioProjectOptionsProcessor?.SetCommandLine(commandLineForOptions);
@@ -149,32 +150,32 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
                 // use it for their own purpose.
                 // In the future, we might consider officially exposing "default namespace" for VB project 
                 // (e.g. through a <defaultnamespace> msbuild property)
-                _visualStudioProject.DefaultNamespace = value;
+                _projectSystemProject.DefaultNamespace = value;
             }
             else if (name == BuildPropertyNames.MaxSupportedLangVersion)
             {
-                _visualStudioProject.MaxLangVersion = value;
+                _projectSystemProject.MaxLangVersion = value;
             }
             else if (name == BuildPropertyNames.RunAnalyzers)
             {
                 var boolValue = bool.TryParse(value, out var parsedBoolValue) ? parsedBoolValue : (bool?)null;
-                _visualStudioProject.RunAnalyzers = boolValue;
+                _projectSystemProject.RunAnalyzers = boolValue;
             }
             else if (name == BuildPropertyNames.RunAnalyzersDuringLiveAnalysis)
             {
                 var boolValue = bool.TryParse(value, out var parsedBoolValue) ? parsedBoolValue : (bool?)null;
-                _visualStudioProject.RunAnalyzersDuringLiveAnalysis = boolValue;
+                _projectSystemProject.RunAnalyzersDuringLiveAnalysis = boolValue;
             }
             else if (name == BuildPropertyNames.TemporaryDependencyNodeTargetIdentifier && !RoslynString.IsNullOrEmpty(value))
             {
-                _visualStudioProject.DependencyNodeTargetIdentifier = value;
+                _projectSystemProject.DependencyNodeTargetIdentifier = value;
             }
             else if (name == BuildPropertyNames.TargetRefPath)
             {
                 // If we don't have a path, always set it to null
                 if (string.IsNullOrEmpty(value))
                 {
-                    _visualStudioProject.OutputRefFilePath = null;
+                    _projectSystemProject.OutputRefFilePath = null;
                 }
                 else
                 {
@@ -183,15 +184,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
                     // can be removed now, but we still have tests asserting it.
                     if (!PathUtilities.IsAbsolute(value))
                     {
-                        var rootDirectory = _visualStudioProject.FilePath != null
-                                            ? Path.GetDirectoryName(_visualStudioProject.FilePath)
+                        var rootDirectory = _projectSystemProject.FilePath != null
+                                            ? Path.GetDirectoryName(_projectSystemProject.FilePath)
                                             : Path.GetTempPath();
 
-                        _visualStudioProject.OutputRefFilePath = Path.Combine(rootDirectory, value);
+                        _projectSystemProject.OutputRefFilePath = Path.Combine(rootDirectory, value);
                     }
                     else
                     {
-                        _visualStudioProject.OutputRefFilePath = value;
+                        _projectSystemProject.OutputRefFilePath = value;
                     }
                 }
             }
@@ -200,64 +201,64 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         public void AddMetadataReference(string referencePath, MetadataReferenceProperties properties)
         {
             referencePath = FileUtilities.NormalizeAbsolutePath(referencePath);
-            _visualStudioProject.AddMetadataReference(referencePath, properties);
+            _projectSystemProject.AddMetadataReference(referencePath, properties);
         }
 
         public void RemoveMetadataReference(string referencePath)
         {
             referencePath = FileUtilities.NormalizeAbsolutePath(referencePath);
-            _visualStudioProject.RemoveMetadataReference(referencePath, _visualStudioProject.GetPropertiesForMetadataReference(referencePath).Single());
+            _projectSystemProject.RemoveMetadataReference(referencePath, _projectSystemProject.GetPropertiesForMetadataReference(referencePath).Single());
         }
 
         public void AddProjectReference(IWorkspaceProjectContext project, MetadataReferenceProperties properties)
         {
-            var otherProjectId = ((CPSProject)project)._visualStudioProject.Id;
-            _visualStudioProject.AddProjectReference(new ProjectReference(otherProjectId, properties.Aliases, properties.EmbedInteropTypes));
+            var otherProjectId = ((CPSProject)project)._projectSystemProject.Id;
+            _projectSystemProject.AddProjectReference(new ProjectReference(otherProjectId, properties.Aliases, properties.EmbedInteropTypes));
         }
 
         public void RemoveProjectReference(IWorkspaceProjectContext project)
         {
-            var otherProjectId = ((CPSProject)project)._visualStudioProject.Id;
-            var otherProjectReference = _visualStudioProject.GetProjectReferences().Single(pr => pr.ProjectId == otherProjectId);
-            _visualStudioProject.RemoveProjectReference(otherProjectReference);
+            var otherProjectId = ((CPSProject)project)._projectSystemProject.Id;
+            var otherProjectReference = _projectSystemProject.GetProjectReferences().Single(pr => pr.ProjectId == otherProjectId);
+            _projectSystemProject.RemoveProjectReference(otherProjectReference);
         }
 
         public void AddSourceFile(string filePath, bool isInCurrentContext = true, IEnumerable<string>? folderNames = null, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
-            => _visualStudioProject.AddSourceFile(filePath, sourceCodeKind, folderNames.AsImmutableOrNull());
+            => _projectSystemProject.AddSourceFile(filePath, sourceCodeKind, folderNames.AsImmutableOrNull());
 
         public void RemoveSourceFile(string filePath)
         {
-            _visualStudioProject.RemoveSourceFile(filePath);
+            _projectSystemProject.RemoveSourceFile(filePath);
             _projectCodeModel.OnSourceFileRemoved(filePath);
         }
 
         public void AddAdditionalFile(string filePath, bool isInCurrentContext = true)
-            => _visualStudioProject.AddAdditionalFile(filePath);
+            => _projectSystemProject.AddAdditionalFile(filePath);
 
         public void Dispose()
         {
             _projectCodeModel?.OnProjectClosed();
             _visualStudioProjectOptionsProcessor?.Dispose();
-            _visualStudioProject.RemoveFromWorkspace();
+            _projectSystemProject.RemoveFromWorkspace();
         }
 
         public void AddAnalyzerReference(string referencePath)
-            => _visualStudioProject.AddAnalyzerReference(referencePath);
+            => _projectSystemProject.AddAnalyzerReference(referencePath);
 
         public void RemoveAnalyzerReference(string referencePath)
-            => _visualStudioProject.RemoveAnalyzerReference(referencePath);
+            => _projectSystemProject.RemoveAnalyzerReference(referencePath);
 
         public void RemoveAdditionalFile(string filePath)
-            => _visualStudioProject.RemoveAdditionalFile(filePath);
+            => _projectSystemProject.RemoveAdditionalFile(filePath);
 
         public void AddDynamicFile(string filePath, IEnumerable<string>? folderNames = null)
-            => _visualStudioProject.AddDynamicSourceFile(filePath, folderNames.ToImmutableArrayOrEmpty());
+            => _projectSystemProject.AddDynamicSourceFile(filePath, folderNames.ToImmutableArrayOrEmpty());
 
         public void RemoveDynamicFile(string filePath)
-            => _visualStudioProject.RemoveDynamicSourceFile(filePath);
+            => _projectSystemProject.RemoveDynamicSourceFile(filePath);
 
         public void StartBatch()
-            => _batchScopes.Enqueue(_visualStudioProject.CreateBatchScope());
+            => _batchScopes.Enqueue(_projectSystemProject.CreateBatchScope());
 
         public ValueTask EndBatchAsync()
         {
@@ -266,17 +267,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         }
 
         public void ReorderSourceFiles(IEnumerable<string>? filePaths)
-            => _visualStudioProject.ReorderSourceFiles(filePaths.ToImmutableArrayOrEmpty());
+            => _projectSystemProject.ReorderSourceFiles(filePaths.ToImmutableArrayOrEmpty());
 
-        internal VisualStudioProject GetProject_TestOnly()
-            => _visualStudioProject;
+        internal ProjectSystemProject GetProject_TestOnly()
+            => _projectSystemProject;
 
         public void AddAnalyzerConfigFile(string filePath)
-            => _visualStudioProject.AddAnalyzerConfigFile(filePath);
+            => _projectSystemProject.AddAnalyzerConfigFile(filePath);
 
         public void RemoveAnalyzerConfigFile(string filePath)
-            => _visualStudioProject.RemoveAnalyzerConfigFile(filePath);
+            => _projectSystemProject.RemoveAnalyzerConfigFile(filePath);
 
-        public IAsyncDisposable CreateBatchScope() => _visualStudioProject.CreateBatchScope();
+        public IAsyncDisposable CreateBatchScope() => _projectSystemProject.CreateBatchScope();
     }
 }

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCompilerOptionsTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCompilerOptionsTests.vb
@@ -212,7 +212,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 project.SetCompilerOptions(compilerOptions)
                 Assert.Equal("C:\test.dll", project.GetOutputFileName())
 
-                Assert.Equal("C:\test.dll", project.Test_VisualStudioProject.CompilationOutputAssemblyFilePath)
+                Assert.Equal("C:\test.dll", project.Test_ProjectSystemProject.CompilationOutputAssemblyFilePath)
 
                 ' Change output folder from command line arguments - verify that objOutputPath changes.
                 Dim newPath = "C:\NewFolder\test.dll"
@@ -222,7 +222,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 project.SetCompilerOptions(compilerOptions)
                 Assert.Equal(newPath, project.GetOutputFileName())
 
-                Assert.Equal("C:\NewFolder\test.dll", project.Test_VisualStudioProject.CompilationOutputAssemblyFilePath)
+                Assert.Equal("C:\NewFolder\test.dll", project.Test_ProjectSystemProject.CompilationOutputAssemblyFilePath)
 
                 ' Change output file name - verify that outputPath changes.
                 newPath = "C:\NewFolder\test2.dll"
@@ -232,7 +232,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 project.SetCompilerOptions(compilerOptions)
                 Assert.Equal(newPath, project.GetOutputFileName())
 
-                Assert.Equal("C:\NewFolder\test2.dll", project.Test_VisualStudioProject.CompilationOutputAssemblyFilePath)
+                Assert.Equal("C:\NewFolder\test2.dll", project.Test_ProjectSystemProject.CompilationOutputAssemblyFilePath)
 
                 ' Change output file name and folder - verify that outputPath changes.
                 newPath = "C:\NewFolder3\test3.dll"
@@ -242,7 +242,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 project.SetCompilerOptions(compilerOptions)
                 Assert.Equal(newPath, project.GetOutputFileName())
 
-                Assert.Equal("C:\NewFolder3\test3.dll", project.Test_VisualStudioProject.CompilationOutputAssemblyFilePath)
+                Assert.Equal("C:\NewFolder3\test3.dll", project.Test_ProjectSystemProject.CompilationOutputAssemblyFilePath)
 
                 ' Relative path - set by VBIntelliProj in VB Web App project
                 compilerOptions = CreateMinimalCompilerOptions(project)
@@ -250,7 +250,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 compilerOptions.wszExeName = "test3.dll"
                 project.SetCompilerOptions(compilerOptions)
                 Assert.Equal(Nothing, project.GetOutputFileName())
-                Assert.Equal(Nothing, project.Test_VisualStudioProject.CompilationOutputAssemblyFilePath)
+                Assert.Equal(Nothing, project.Test_ProjectSystemProject.CompilationOutputAssemblyFilePath)
             End Using
         End Sub
     End Class

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
@@ -11,6 +11,7 @@ Imports Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Test.Utilities
+Imports Microsoft.CodeAnalysis.Workspaces.ProjectSystem
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 Imports Roslyn.Test.Utilities
@@ -34,7 +35,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Dim registrationService = Assert.IsType(Of MockDiagnosticUpdateSourceRegistrationService)(workspace.GetService(Of IDiagnosticUpdateSourceRegistrationService)())
                 Dim hostDiagnosticUpdateSource = New HostDiagnosticUpdateSource(lazyWorkspace, registrationService)
 
-                Using tempRoot = New TempRoot(), analyzer = New VisualStudioAnalyzer(tempRoot.CreateFile().Path, hostDiagnosticUpdateSource, ProjectId.CreateNewId(), LanguageNames.VisualBasic)
+                Using tempRoot = New TempRoot(), analyzer = New ProjectAnalyzerReference(tempRoot.CreateFile().Path, hostDiagnosticUpdateSource, ProjectId.CreateNewId(), LanguageNames.VisualBasic)
                     Dim reference1 = analyzer.GetReference()
                     Dim reference2 = analyzer.GetReference()
 
@@ -59,7 +60,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
                 Dim eventHandler = New EventHandlers(file)
                 AddHandler hostDiagnosticUpdateSource.DiagnosticsUpdated, AddressOf eventHandler.DiagnosticAddedTest
 
-                Using analyzer = New VisualStudioAnalyzer(file, hostDiagnosticUpdateSource, ProjectId.CreateNewId(), LanguageNames.VisualBasic)
+                Using analyzer = New ProjectAnalyzerReference(file, hostDiagnosticUpdateSource, ProjectId.CreateNewId(), LanguageNames.VisualBasic)
                     Dim reference = analyzer.GetReference()
                     reference.GetAnalyzers(LanguageNames.VisualBasic)
 

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicLanguageService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicLanguageService.vb
@@ -5,6 +5,7 @@
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor
+Imports Microsoft.CodeAnalysis.Workspaces.ProjectSystem
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelliSense
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
@@ -73,7 +74,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
 
         Protected Overrides Function CreateContainedLanguage(
             bufferCoordinator As IVsTextBufferCoordinator,
-            project As VisualStudioProject,
+            project As ProjectSystemProject,
             hierarchy As IVsHierarchy,
             itemid As UInteger
         ) As IVsContainedLanguage

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicCodeModelInstanceFactory.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicCodeModelInstanceFactory.vb
@@ -31,7 +31,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                 ' with the correct "parent" object.
                 '
                 ' Because the VB project system lacks these hooks, we simulate the same operations that those hooks perform.
-                Dim document = _project.Workspace.CurrentSolution.GetDocumentIdsWithFilePath(filePath).FirstOrDefault(Function(d) d.ProjectId Is _project.VisualStudioProject.Id)
+                Dim document = _project.Workspace.CurrentSolution.GetDocumentIdsWithFilePath(filePath).FirstOrDefault(Function(d) d.ProjectId Is _project.ProjectSystemProject.Id)
 
                 If document Is Nothing Then
                     Throw New ArgumentException(NameOf(filePath))

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.OptionsProcessor.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.OptionsProcessor.vb
@@ -9,6 +9,7 @@ Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.VisualBasic
+Imports Microsoft.CodeAnalysis.Workspaces.ProjectSystem
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim.Interop
 
@@ -40,7 +41,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
             ''' </summary>
             Private Shared ReadOnly s_importsCache As Dictionary(Of String, GlobalImport) = New Dictionary(Of String, GlobalImport)
 
-            Public Sub New(project As VisualStudioProject, workspaceServices As SolutionServices)
+            Public Sub New(project As ProjectSystemProject, workspaceServices As SolutionServices)
                 MyBase.New(project, workspaceServices)
             End Sub
 

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -48,8 +48,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 
             Dim componentModel = DirectCast(serviceProvider.GetService(GetType(SComponentModel)), IComponentModel)
 
-            ProjectCodeModel = componentModel.GetService(Of IProjectCodeModelFactory).CreateProjectCodeModel(VisualStudioProject.Id, New VisualBasicCodeModelInstanceFactory(Me))
-            VisualStudioProjectOptionsProcessor = New OptionsProcessor(VisualStudioProject, Workspace.Services.SolutionServices)
+            ProjectCodeModel = componentModel.GetService(Of IProjectCodeModelFactory).CreateProjectCodeModel(ProjectSystemProject.Id, New VisualBasicCodeModelInstanceFactory(Me))
+            VisualStudioProjectOptionsProcessor = New OptionsProcessor(ProjectSystemProject, Workspace.Services.SolutionServices)
         End Sub
 
         Private Shadows Property VisualStudioProjectOptionsProcessor As OptionsProcessor
@@ -70,7 +70,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
         End Sub
 
         Public Function AddEmbeddedMetaDataReference(wszFileName As String) As Integer Implements IVbCompilerProject.AddEmbeddedMetaDataReference
-            VisualStudioProject.AddMetadataReference(wszFileName, New MetadataReferenceProperties(embedInteropTypes:=True))
+            ProjectSystemProject.AddMetadataReference(wszFileName, New MetadataReferenceProperties(embedInteropTypes:=True))
             Return VSConstants.S_OK
         End Function
 
@@ -80,7 +80,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                 _explicitlyAddedRuntimeLibraries.Add(wszFileName)
                 Return VSConstants.S_OK
             Else
-                VisualStudioProject.AddMetadataReference(wszFileName, MetadataReferenceProperties.Assembly)
+                ProjectSystemProject.AddMetadataReference(wszFileName, MetadataReferenceProperties.Assembly)
                 Return VSConstants.S_OK
             End If
         End Function
@@ -94,7 +94,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                 Throw New ArgumentException("Unknown type of IVbCompilerProject.", NameOf(pReferencedCompilerProject))
             End If
 
-            VisualStudioProject.AddProjectReference(New ProjectReference(referencedProject.VisualStudioProject.Id, embedInteropTypes:=True))
+            ProjectSystemProject.AddProjectReference(New ProjectReference(referencedProject.ProjectSystemProject.Id, embedInteropTypes:=True))
         End Sub
 
         Public Shadows Sub AddFile(wszFileName As String, itemid As UInteger, fAddDuringOpen As Boolean) Implements IVbCompilerProject.AddFile
@@ -114,7 +114,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                 Throw New ArgumentException("Unknown type of IVbCompilerProject.", NameOf(pReferencedCompilerProject))
             End If
 
-            VisualStudioProject.AddProjectReference(New ProjectReference(referencedProject.VisualStudioProject.Id))
+            ProjectSystemProject.AddProjectReference(New ProjectReference(referencedProject.ProjectSystemProject.Id))
         End Sub
 
         Public Sub AddResourceReference(wszFileName As String, wszName As String, fPublic As Boolean, fEmbed As Boolean) Implements IVbCompilerProject.AddResourceReference
@@ -198,7 +198,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
         End Function
 
         Public Sub GetEntryPointsList(cItems As Integer, strList() As String, ByVal pcActualItems As IntPtr) Implements IVbCompilerProject.GetEntryPointsList
-            Dim project = Workspace.CurrentSolution.GetProject(VisualStudioProject.Id)
+            Dim project = Workspace.CurrentSolution.GetProject(ProjectSystemProject.Id)
             Dim compilation = project.GetCompilationAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None)
 
             GetEntryPointsWorker(compilation, cItems, strList, pcActualItems, findFormsOnly:=False)
@@ -270,7 +270,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                 Return
             End If
 
-            VisualStudioProject.RemoveMetadataReference(wszFileName, VisualStudioProject.GetPropertiesForMetadataReference(wszFileName).Single())
+            ProjectSystemProject.RemoveMetadataReference(wszFileName, ProjectSystemProject.GetPropertiesForMetadataReference(wszFileName).Single())
         End Sub
 
         Public Shadows Sub RemoveProjectReference(pReferencedCompilerProject As IVbCompilerProject) Implements IVbCompilerProject.RemoveProjectReference
@@ -282,8 +282,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                 Throw New ArgumentException("Unknown type of IVbCompilerProject.", NameOf(pReferencedCompilerProject))
             End If
 
-            Dim projectReference = VisualStudioProject.GetProjectReferences().Single(Function(p) p.ProjectId = referencedProject.VisualStudioProject.Id)
-            VisualStudioProject.RemoveProjectReference(projectReference)
+            Dim projectReference = ProjectSystemProject.GetProjectReferences().Single(Function(p) p.ProjectId = referencedProject.ProjectSystemProject.Id)
+            ProjectSystemProject.RemoveProjectReference(projectReference)
         End Sub
 
         Public Sub RenameDefaultNamespace(bstrDefaultNamespace As String) Implements IVbCompilerProject.RenameDefaultNamespace
@@ -315,16 +315,16 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
             VisualStudioProjectOptionsProcessor.SetNewRawOptions(pCompilerOptions)
 
             If Not String.IsNullOrEmpty(pCompilerOptions.wszExeName) Then
-                VisualStudioProject.AssemblyName = Path.GetFileNameWithoutExtension(pCompilerOptions.wszExeName)
+                ProjectSystemProject.AssemblyName = Path.GetFileNameWithoutExtension(pCompilerOptions.wszExeName)
 
                 ' Some legacy projects (e.g. Venus IntelliSense project) set '\' as the wszOutputPath.
                 ' /src/venus/project/vb/vbprj/vbintelliproj.cpp
                 ' Ignore paths that are not absolute.
                 If Not String.IsNullOrEmpty(pCompilerOptions.wszOutputPath) Then
                     If PathUtilities.IsAbsolute(pCompilerOptions.wszOutputPath) Then
-                        VisualStudioProject.CompilationOutputAssemblyFilePath = Path.Combine(pCompilerOptions.wszOutputPath, pCompilerOptions.wszExeName)
+                        ProjectSystemProject.CompilationOutputAssemblyFilePath = Path.Combine(pCompilerOptions.wszOutputPath, pCompilerOptions.wszExeName)
                     Else
-                        VisualStudioProject.CompilationOutputAssemblyFilePath = Nothing
+                        ProjectSystemProject.CompilationOutputAssemblyFilePath = Nothing
                     End If
                 End If
             End If
@@ -334,14 +334,14 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
             _runtimeLibraries = VisualStudioProjectOptionsProcessor.GetRuntimeLibraries(_compilerHost)
 
             If Not _runtimeLibraries.SequenceEqual(oldRuntimeLibraries, StringComparer.Ordinal) Then
-                Using batchScope = VisualStudioProject.CreateBatchScope()
+                Using batchScope = ProjectSystemProject.CreateBatchScope()
                     ' To keep things simple, we'll just remove everything and add everything back in
                     For Each oldRuntimeLibrary In oldRuntimeLibraries
                         ' If this one was added explicitly in addition to our computation, we don't have to remove it 
                         If _explicitlyAddedRuntimeLibraries.Contains(oldRuntimeLibrary) Then
                             _explicitlyAddedRuntimeLibraries.Remove(oldRuntimeLibrary)
                         Else
-                            VisualStudioProject.RemoveMetadataReference(oldRuntimeLibrary, MetadataReferenceProperties.Assembly)
+                            ProjectSystemProject.RemoveMetadataReference(oldRuntimeLibrary, MetadataReferenceProperties.Assembly)
                         End If
                     Next
 
@@ -349,10 +349,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
                         newRuntimeLibrary = FileUtilities.NormalizeAbsolutePath(newRuntimeLibrary)
 
                         ' If we already reference this, just skip it
-                        If VisualStudioProject.ContainsMetadataReference(newRuntimeLibrary, MetadataReferenceProperties.Assembly) Then
+                        If ProjectSystemProject.ContainsMetadataReference(newRuntimeLibrary, MetadataReferenceProperties.Assembly) Then
                             _explicitlyAddedRuntimeLibraries.Add(newRuntimeLibrary)
                         Else
-                            VisualStudioProject.AddMetadataReference(newRuntimeLibrary, MetadataReferenceProperties.Assembly)
+                            ProjectSystemProject.AddMetadataReference(newRuntimeLibrary, MetadataReferenceProperties.Assembly)
                         End If
                     Next
                 End Using

--- a/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.Editor.VisualBasic.Utilities
 Imports Microsoft.CodeAnalysis.Formatting.Rules
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Microsoft.CodeAnalysis.Workspaces.ProjectSystem
 Imports Microsoft.VisualStudio.ComponentModelHost
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Venus
@@ -26,7 +27,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Venus
         <Obsolete("Use the constructor that omits the IVsHierarchy and UInteger parameters instead.", True)>
         Public Sub New(bufferCoordinator As IVsTextBufferCoordinator,
                 componentModel As IComponentModel,
-                project As VisualStudioProject,
+                project As ProjectSystemProject,
                 hierarchy As IVsHierarchy,
                 itemid As UInteger,
                 languageServiceGuid As Guid)
@@ -40,7 +41,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Venus
 
         Public Sub New(bufferCoordinator As IVsTextBufferCoordinator,
                 componentModel As IComponentModel,
-                project As VisualStudioProject,
+                project As ProjectSystemProject,
                 languageServiceGuid As Guid)
 
             MyBase.New(

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlProjectService.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.Editor.Xaml;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.CodeAnalysis.Xaml.Diagnostics.Analyzers;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
@@ -33,7 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
         private readonly VisualStudioProjectFactory _visualStudioProjectFactory;
         private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactory;
         private readonly IThreadingContext _threadingContext;
-        private readonly Dictionary<IVsHierarchy, VisualStudioProject> _xamlProjects = new();
+        private readonly Dictionary<IVsHierarchy, ProjectSystemProject> _xamlProjects = new();
         private readonly ConcurrentDictionary<string, DocumentId> _documentIds = new ConcurrentDictionary<string, DocumentId>(StringComparer.OrdinalIgnoreCase);
 
         private RunningDocumentTable? _rdt;

--- a/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
@@ -148,6 +148,9 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CodeStyle.LegacyTestFramework.UnitTestUtilities" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Workspace\ProjectSystem\Readme.md" />
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Update="WorkspacesResources.resx" GenerateSource="true" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IProjectSystemDiagnosticSource.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IProjectSystemDiagnosticSource.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
         void ClearAllDiagnosticsForProject(ProjectId projectId);
         void ClearAnalyzerReferenceDiagnostics(AnalyzerFileReference fileReference, string language, ProjectId projectId);
         void ClearDiagnosticsForProject(ProjectId projectId, object key);
+        DiagnosticData CreateAnalyzerLoadFailureDiagnostic(AnalyzerLoadFailureEventArgs e, string fullPath, ProjectId projectId, string language);
         void UpdateDiagnosticsForProject(ProjectId projectId, object key, IEnumerable<DiagnosticData> items);
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectCreationInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectCreationInfo.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
+{
+    internal class ProjectSystemProjectCreationInfo
+    {
+        public string? AssemblyName { get; set; }
+        public CompilationOptions? CompilationOptions { get; set; }
+        public string? FilePath { get; set; }
+        public ParseOptions? ParseOptions { get; set; }
+
+        public Guid TelemetryId { get; set; }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -1,0 +1,657 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata.Ecma335;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.ProjectSystem;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
+{
+    internal sealed class ProjectSystemProjectFactory
+    {
+        /// <summary>
+        /// The main gate to synchronize updates to this solution.
+        /// </summary>
+        /// <remarks>
+        /// See the Readme.md in this directory for further comments about threading in this area.
+        /// </remarks>
+        // TODO: we should be able to get rid of this gate in favor of just calling the various workspace methods that acquire the Workspace's
+        // serialization lock and then allow us to update our own state under that lock.
+        private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
+
+        public Workspace Workspace { get; }
+        public IAsynchronousOperationListener WorkspaceListener { get; }
+        public IFileChangeWatcher FileChangeWatcher { get; }
+        public FileWatchedPortableExecutableReferenceFactory FileWatchedReferenceFactory { get; }
+
+        private readonly Action<ImmutableArray<string>> _onDocumentsAdded;
+        private readonly Action<Project> _onProjectRemoved;
+
+        /// <summary>
+        /// A set of documents that were added by <see cref="ProjectSystemProject.AddSourceTextContainer"/>, and aren't otherwise
+        /// tracked for opening/closing.
+        /// </summary>
+        public ImmutableHashSet<DocumentId> DocumentsNotFromFiles { get; private set; } = ImmutableHashSet<DocumentId>.Empty;
+
+        /// <remarks>Should be updated with <see cref="ImmutableInterlocked"/>.</remarks>
+        private ImmutableDictionary<ProjectId, string?> _projectToMaxSupportedLangVersionMap = ImmutableDictionary<ProjectId, string?>.Empty;
+
+        /// <remarks>Should be updated with <see cref="ImmutableInterlocked"/>.</remarks>
+        private ImmutableDictionary<ProjectId, string> _projectToDependencyNodeTargetIdentifier = ImmutableDictionary<ProjectId, string>.Empty;
+
+        /// <summary>
+        /// Set by the host if the solution is currently closing; this can be used to optimize some things there.
+        /// </summary>
+        public bool SolutionClosing { get; set; }
+
+        /// <summary>
+        /// The current path to the solution. Currently this is only used to update the solution path when the first project is added -- we don't have a concept
+        /// of the solution path changing in the middle while a bunch of projects are loaded.
+        /// </summary>
+        public string? SolutionPath { get; set; }
+        public Guid SolutionTelemetryId { get; set; }
+
+        public ProjectSystemProjectFactory(Workspace workspace, IFileChangeWatcher fileChangeWatcher, Action<ImmutableArray<string>> onDocumentsAdded, Action<Project> onProjectRemoved)
+        {
+            Workspace = workspace;
+            WorkspaceListener = workspace.Services.GetRequiredService<IWorkspaceAsynchronousOperationListenerProvider>().GetListener();
+
+            FileChangeWatcher = fileChangeWatcher;
+            FileWatchedReferenceFactory = new FileWatchedPortableExecutableReferenceFactory(workspace.Services.SolutionServices, fileChangeWatcher);
+            FileWatchedReferenceFactory.ReferenceChanged += this.StartRefreshingMetadataReferencesForFile;
+
+            _onDocumentsAdded = onDocumentsAdded;
+            _onProjectRemoved = onProjectRemoved;
+        }
+
+        public async Task<ProjectSystemProject> CreateAndAddToWorkspaceAsync(string projectSystemName, string language, ProjectSystemProjectCreationInfo creationInfo, ProjectSystemHostInfo hostInfo)
+        {
+            var id = ProjectId.CreateNewId(projectSystemName);
+            var assemblyName = creationInfo.AssemblyName ?? projectSystemName;
+
+            // We will use the project system name as the default display name of the project
+            var project = new ProjectSystemProject(
+                this,
+                hostInfo,
+                id,
+                displayName: projectSystemName,
+                language,
+                assemblyName: assemblyName,
+                compilationOptions: creationInfo.CompilationOptions,
+                filePath: creationInfo.FilePath,
+                parseOptions: creationInfo.ParseOptions);
+
+            var versionStamp = creationInfo.FilePath != null ? VersionStamp.Create(File.GetLastWriteTimeUtc(creationInfo.FilePath))
+                                                             : VersionStamp.Create();
+
+            await ApplyChangeToWorkspaceAsync(w =>
+            {
+                var projectInfo = ProjectInfo.Create(
+                    new ProjectInfo.ProjectAttributes(
+                        id,
+                        versionStamp,
+                        name: projectSystemName,
+                        assemblyName: assemblyName,
+                        language: language,
+                        checksumAlgorithm: SourceHashAlgorithms.Default, // will be updated when command line is set
+                        compilationOutputFilePaths: default, // will be updated when command line is set
+                        filePath: creationInfo.FilePath,
+                        telemetryId: creationInfo.TelemetryId),
+                    compilationOptions: creationInfo.CompilationOptions,
+                    parseOptions: creationInfo.ParseOptions);
+
+                // If we don't have any projects and this is our first project being added, then we'll create a new SolutionId
+                // and count this as the solution being added so that event is raised.
+                if (w.CurrentSolution.ProjectIds.Count == 0)
+                {
+                    w.OnSolutionAdded(
+                        SolutionInfo.Create(
+                            SolutionId.CreateNewId(SolutionPath),
+                            VersionStamp.Create(),
+                            SolutionPath,
+                            projects: new[] { projectInfo },
+                            analyzerReferences: w.CurrentSolution.AnalyzerReferences)
+                        .WithTelemetryId(SolutionTelemetryId));
+                }
+                else
+                {
+                    w.OnProjectAdded(projectInfo);
+                }
+            }).ConfigureAwait(false);
+
+            return project;
+        }
+
+        public string? TryGetDependencyNodeTargetIdentifier(ProjectId projectId)
+        {
+            // This doesn't take a lock since _projectToDependencyNodeTargetIdentifier is immutable
+            _projectToDependencyNodeTargetIdentifier.TryGetValue(projectId, out var identifier);
+            return identifier;
+        }
+
+        public string? TryGetMaxSupportedLanguageVersion(ProjectId projectId)
+        {
+            // This doesn't take a lock since _projectToMaxSupportedLangVersionMap is immutable
+            _projectToMaxSupportedLangVersionMap.TryGetValue(projectId, out var identifier);
+            return identifier;
+        }
+
+        internal void AddDocumentToDocumentsNotFromFiles_NoLock(DocumentId documentId)
+        {
+            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
+
+            DocumentsNotFromFiles = DocumentsNotFromFiles.Add(documentId);
+        }
+
+        internal void RemoveDocumentToDocumentsNotFromFiles_NoLock(DocumentId documentId)
+        {
+            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
+            DocumentsNotFromFiles = DocumentsNotFromFiles.Remove(documentId);
+        }
+        /// <summary>
+        /// Applies a single operation to the workspace. <paramref name="action"/> should be a call to one of the protected Workspace.On* methods.
+        /// </summary>
+        public void ApplyChangeToWorkspace(Action<Workspace> action)
+        {
+            using (_gate.DisposableWait())
+            {
+                action(Workspace);
+            }
+        }
+
+        /// <summary>
+        /// Applies a single operation to the workspace. <paramref name="action"/> should be a call to one of the protected Workspace.On* methods.
+        /// </summary>
+        public async ValueTask ApplyChangeToWorkspaceAsync(Action<Workspace> action)
+        {
+            using (await _gate.DisposableWaitAsync().ConfigureAwait(false))
+            {
+                action(Workspace);
+            }
+        }
+
+        /// <summary>
+        /// Applies a single operation to the workspace. <paramref name="action"/> should be a call to one of the protected Workspace.On* methods.
+        /// </summary>
+        public async ValueTask ApplyChangeToWorkspaceMaybeAsync(bool useAsync, Action<Workspace> action)
+        {
+            using (useAsync ? await _gate.DisposableWaitAsync().ConfigureAwait(false) : _gate.DisposableWait())
+            {
+                action(Workspace);
+            }
+        }
+
+        /// <summary>
+        /// Applies a solution transformation to the workspace and triggers workspace changed event for specified <paramref name="projectId"/>.
+        /// The transformation shall only update the project of the solution with the specified <paramref name="projectId"/>.
+        /// </summary>
+        public void ApplyChangeToWorkspace(ProjectId projectId, Func<CodeAnalysis.Solution, CodeAnalysis.Solution> solutionTransformation)
+        {
+            using (_gate.DisposableWait())
+            {
+                Workspace.SetCurrentSolution(solutionTransformation, WorkspaceChangeKind.ProjectChanged, projectId);
+            }
+        }
+
+        /// <inheritdoc cref="ApplyBatchChangeToWorkspaceMaybeAsync(bool, Action{SolutionChangeAccumulator})"/>
+        public void ApplyBatchChangeToWorkspace(Action<SolutionChangeAccumulator> mutation)
+        {
+            ApplyBatchChangeToWorkspaceMaybeAsync(useAsync: false, mutation).VerifyCompleted();
+        }
+
+        /// <inheritdoc cref="ApplyBatchChangeToWorkspaceMaybeAsync(bool, Action{SolutionChangeAccumulator})"/>
+        public Task ApplyBatchChangeToWorkspaceAsync(Action<SolutionChangeAccumulator> mutation)
+        {
+            return ApplyBatchChangeToWorkspaceMaybeAsync(useAsync: true, mutation);
+        }
+
+        /// <summary>
+        /// Applies a change to the workspace that can do any number of project changes.
+        /// </summary>
+        /// <remarks>This is needed to synchronize with <see cref="ApplyChangeToWorkspace(Action{Workspace})" /> to avoid any races. This
+        /// method could be moved down to the core Workspace layer and then could use the synchronization lock there.</remarks>
+        public async Task ApplyBatchChangeToWorkspaceMaybeAsync(bool useAsync, Action<SolutionChangeAccumulator> mutation)
+        {
+            using (useAsync ? await _gate.DisposableWaitAsync().ConfigureAwait(false) : _gate.DisposableWait())
+            {
+                var solutionChanges = new SolutionChangeAccumulator(Workspace.CurrentSolution);
+                mutation(solutionChanges);
+
+                ApplyBatchChangeToWorkspace_NoLock(solutionChanges);
+            }
+        }
+
+        private void ApplyBatchChangeToWorkspace_NoLock(SolutionChangeAccumulator solutionChanges)
+        {
+            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
+
+            if (!solutionChanges.HasChange)
+                return;
+
+            Workspace.SetCurrentSolution(
+                _ => solutionChanges.Solution,
+                solutionChanges.WorkspaceChangeKind,
+                solutionChanges.WorkspaceChangeProjectId,
+                solutionChanges.WorkspaceChangeDocumentId,
+                onBeforeUpdate: (_, _) =>
+                {
+                    // Clear out mutable state not associated with the solution snapshot (for example, which documents are
+                    // currently open).
+                    foreach (var documentId in solutionChanges.DocumentIdsRemoved)
+                        Workspace.ClearDocumentData(documentId);
+                });
+        }
+
+        private readonly Dictionary<ProjectId, ProjectReferenceInformation> _projectReferenceInfoMap = new();
+
+        private ProjectReferenceInformation GetReferenceInfo_NoLock(ProjectId projectId)
+        {
+            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
+
+            return _projectReferenceInfoMap.GetOrAdd(projectId, _ => new ProjectReferenceInformation());
+        }
+
+        /// <summary>
+        /// Removes the project from the various maps this type maintains; it's still up to the caller to actually remove
+        /// the project in one way or another.
+        /// </summary>
+        internal void RemoveProjectFromTrackingMaps_NoLock(ProjectId projectId)
+        {
+            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
+
+            var project = Workspace.CurrentSolution.GetRequiredProject(projectId);
+
+            if (_projectReferenceInfoMap.TryGetValue(projectId, out var projectReferenceInfo))
+            {
+                // If we still had any output paths, we'll want to remove them to cause conversion back to metadata references.
+                // The call below implicitly is modifying the collection we've fetched, so we'll make a copy.
+                var solutionChanges = new SolutionChangeAccumulator(Workspace.CurrentSolution);
+
+                foreach (var outputPath in projectReferenceInfo.OutputPaths.ToList())
+                {
+                    RemoveProjectOutputPath_NoLock(solutionChanges, projectId, outputPath);
+                }
+
+                ApplyBatchChangeToWorkspace_NoLock(solutionChanges);
+
+                _projectReferenceInfoMap.Remove(projectId);
+            }
+
+            ImmutableInterlocked.TryRemove<ProjectId, string?>(ref _projectToMaxSupportedLangVersionMap, projectId, out _);
+            ImmutableInterlocked.TryRemove(ref _projectToDependencyNodeTargetIdentifier, projectId, out _);
+
+            _onProjectRemoved?.Invoke(project);
+        }
+
+        internal void RemoveSolution_NoLock()
+        {
+            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
+
+            // At this point, we should have had RemoveProjectFromTrackingMaps_NoLock called for everything else, so it's just the solution itself
+            // to clean up
+            Contract.ThrowIfFalse(_projectReferenceInfoMap.Count == 0);
+            Contract.ThrowIfFalse(_projectToMaxSupportedLangVersionMap.Count == 0);
+            Contract.ThrowIfFalse(_projectToDependencyNodeTargetIdentifier.Count == 0);
+
+            // Create a new empty solution and set this; we will reuse the same SolutionId and path since components still may have persistence information they still need
+            // to look up by that location; we also keep the existing analyzer references around since those are host-level analyzers that were loaded asynchronously.
+            Workspace.ClearOpenDocuments();
+
+            Workspace.SetCurrentSolution(
+                solution => Workspace.CreateSolution(
+                    SolutionInfo.Create(
+                        SolutionId.CreateNewId(),
+                        VersionStamp.Create(),
+                        analyzerReferences: solution.AnalyzerReferences)),
+                WorkspaceChangeKind.SolutionRemoved);
+        }
+
+        [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/54137", AllowLocks = false)]
+        internal void SetMaxLanguageVersion(ProjectId projectId, string? maxLanguageVersion)
+        {
+            ImmutableInterlocked.Update(
+                ref _projectToMaxSupportedLangVersionMap,
+                static (map, arg) => map.SetItem(arg.projectId, arg.maxLanguageVersion),
+                (projectId, maxLanguageVersion));
+        }
+
+        [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/54135", AllowLocks = false)]
+        internal void SetDependencyNodeTargetIdentifier(ProjectId projectId, string targetIdentifier)
+        {
+            ImmutableInterlocked.Update(
+                ref _projectToDependencyNodeTargetIdentifier,
+                static (map, arg) => map.SetItem(arg.projectId, arg.targetIdentifier),
+                (projectId, targetIdentifier));
+        }
+
+        private sealed class ProjectReferenceInformation
+        {
+            public readonly List<string> OutputPaths = new();
+            public readonly List<(string path, ProjectReference projectReference)> ConvertedProjectReferences = new List<(string path, ProjectReference)>();
+        }
+
+        /// <summary>
+        /// A multimap from an output path to the project outputting to it. Ideally, this shouldn't ever
+        /// actually be a true multimap, since we shouldn't have two projects outputting to the same path, but
+        /// any bug by a project adding the wrong output path means we could end up with some duplication.
+        /// In that case, we'll temporarily have two until (hopefully) somebody removes it.
+        /// </summary>
+        private readonly Dictionary<string, List<ProjectId>> _projectsByOutputPath = new(StringComparer.OrdinalIgnoreCase);
+
+        public void AddProjectOutputPath_NoLock(SolutionChangeAccumulator solutionChanges, ProjectId projectId, string outputPath)
+        {
+            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
+
+            var projectReferenceInformation = GetReferenceInfo_NoLock(projectId);
+
+            projectReferenceInformation.OutputPaths.Add(outputPath);
+            _projectsByOutputPath.MultiAdd(outputPath, projectId);
+
+            var projectsForOutputPath = _projectsByOutputPath[outputPath];
+            var distinctProjectsForOutputPath = projectsForOutputPath.Distinct().ToList();
+
+            // If we have exactly one, then we're definitely good to convert
+            if (projectsForOutputPath.Count == 1)
+            {
+                ConvertMetadataReferencesToProjectReferences_NoLock(solutionChanges, projectId, outputPath);
+            }
+            else if (distinctProjectsForOutputPath.Count == 1)
+            {
+                // The same project has multiple output paths that are the same. Any project would have already been converted
+                // by the prior add, so nothing further to do
+            }
+            else
+            {
+                // We have more than one project outputting to the same path. This shouldn't happen but we'll convert back
+                // because now we don't know which project to reference.
+                foreach (var otherProjectId in projectsForOutputPath)
+                {
+                    // We know that since we're adding a path to projectId and we're here that we couldn't have already
+                    // had a converted reference to us, instead we need to convert things that are pointing to the project
+                    // we're colliding with
+                    if (otherProjectId != projectId)
+                    {
+                        ConvertProjectReferencesToMetadataReferences_NoLock(solutionChanges, otherProjectId, outputPath);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Attempts to convert all metadata references to <paramref name="outputPath"/> to a project reference to <paramref name="projectIdToReference"/>.
+        /// </summary>
+        /// <param name="projectIdToReference">The <see cref="ProjectId"/> of the project that could be referenced in place of the output path.</param>
+        /// <param name="outputPath">The output path to replace.</param>
+        [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/31306",
+            Constraint = "Avoid calling " + nameof(CodeAnalysis.Solution.GetProject) + " to avoid realizing all projects.")]
+        private void ConvertMetadataReferencesToProjectReferences_NoLock(SolutionChangeAccumulator solutionChanges, ProjectId projectIdToReference, string outputPath)
+        {
+            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
+
+            foreach (var projectIdToRetarget in solutionChanges.Solution.ProjectIds)
+            {
+                if (CanConvertMetadataReferenceToProjectReference(solutionChanges.Solution, projectIdToRetarget, referencedProjectId: projectIdToReference))
+                {
+                    // PERF: call GetProjectState instead of GetProject, otherwise creating a new project might force all
+                    // Project instances to get created.
+                    foreach (PortableExecutableReference reference in solutionChanges.Solution.GetProjectState(projectIdToRetarget)!.MetadataReferences)
+                    {
+                        if (string.Equals(reference.FilePath, outputPath, StringComparison.OrdinalIgnoreCase))
+                        {
+                            FileWatchedReferenceFactory.StopWatchingReference(reference);
+
+                            var projectReference = new ProjectReference(projectIdToReference, reference.Properties.Aliases, reference.Properties.EmbedInteropTypes);
+                            var newSolution = solutionChanges.Solution.RemoveMetadataReference(projectIdToRetarget, reference)
+                                                                      .AddProjectReference(projectIdToRetarget, projectReference);
+
+                            solutionChanges.UpdateSolutionForProjectAction(projectIdToRetarget, newSolution);
+
+                            GetReferenceInfo_NoLock(projectIdToRetarget).ConvertedProjectReferences.Add(
+                                (reference.FilePath!, projectReference));
+
+                            // We have converted one, but you could have more than one reference with different aliases
+                            // that we need to convert, so we'll keep going
+                        }
+                    }
+                }
+            }
+        }
+
+        [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/31306",
+            Constraint = "Avoid calling " + nameof(CodeAnalysis.Solution.GetProject) + " to avoid realizing all projects.")]
+        private static bool CanConvertMetadataReferenceToProjectReference(Solution solution, ProjectId projectIdWithMetadataReference, ProjectId referencedProjectId)
+        {
+            // We can never make a project reference ourselves. This isn't a meaningful scenario, but if somebody does this by accident
+            // we do want to throw exceptions.
+            if (projectIdWithMetadataReference == referencedProjectId)
+            {
+                return false;
+            }
+
+            // PERF: call GetProjectState instead of GetProject, otherwise creating a new project might force all
+            // Project instances to get created.
+            var projectWithMetadataReference = solution.GetProjectState(projectIdWithMetadataReference);
+            var referencedProject = solution.GetProjectState(referencedProjectId);
+
+            Contract.ThrowIfNull(projectWithMetadataReference);
+            Contract.ThrowIfNull(referencedProject);
+
+            // We don't want to convert a metadata reference to a project reference if the project being referenced isn't something
+            // we can create a Compilation for. For example, if we have a C# project, and it's referencing a F# project via a metadata reference
+            // everything would be fine if we left it a metadata reference. Converting it to a project reference means we couldn't create a Compilation
+            // anymore in the IDE, since the C# compilation would need to reference an F# compilation. F# projects referencing other F# projects though
+            // do expect this to work, and so we'll always allow references through of the same language.
+            if (projectWithMetadataReference.Language != referencedProject.Language)
+            {
+                if (projectWithMetadataReference.LanguageServices.GetService<ICompilationFactoryService>() != null &&
+                    referencedProject.LanguageServices.GetService<ICompilationFactoryService>() == null)
+                {
+                    // We're referencing something that we can't create a compilation from something that can, so keep the metadata reference
+                    return false;
+                }
+            }
+
+            // If this is going to cause a circular reference, also disallow it
+            if (solution.GetProjectDependencyGraph().GetProjectsThatThisProjectTransitivelyDependsOn(referencedProjectId).Contains(projectIdWithMetadataReference))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Finds all projects that had a project reference to <paramref name="projectId"/> and convert it back to a metadata reference.
+        /// </summary>
+        /// <param name="projectId">The <see cref="ProjectId"/> of the project being referenced.</param>
+        /// <param name="outputPath">The output path of the given project to remove the link to.</param>
+        [PerformanceSensitive(
+            "https://github.com/dotnet/roslyn/issues/37616",
+            Constraint = "Update ConvertedProjectReferences in place to avoid duplicate list allocations.")]
+        private void ConvertProjectReferencesToMetadataReferences_NoLock(SolutionChangeAccumulator solutionChanges, ProjectId projectId, string outputPath)
+        {
+            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
+
+            foreach (var projectIdToRetarget in solutionChanges.Solution.ProjectIds)
+            {
+                var referenceInfo = GetReferenceInfo_NoLock(projectIdToRetarget);
+
+                // Update ConvertedProjectReferences in place to avoid duplicate list allocations
+                for (var i = 0; i < referenceInfo.ConvertedProjectReferences.Count; i++)
+                {
+                    var convertedReference = referenceInfo.ConvertedProjectReferences[i];
+
+                    if (string.Equals(convertedReference.path, outputPath, StringComparison.OrdinalIgnoreCase) &&
+                        convertedReference.projectReference.ProjectId == projectId)
+                    {
+                        var metadataReference =
+                            FileWatchedReferenceFactory.CreateReferenceAndStartWatchingFile(
+                                convertedReference.path,
+                                new MetadataReferenceProperties(
+                                    aliases: convertedReference.projectReference.Aliases,
+                                    embedInteropTypes: convertedReference.projectReference.EmbedInteropTypes));
+
+                        var newSolution = solutionChanges.Solution.RemoveProjectReference(projectIdToRetarget, convertedReference.projectReference)
+                                                                  .AddMetadataReference(projectIdToRetarget, metadataReference);
+
+                        solutionChanges.UpdateSolutionForProjectAction(projectIdToRetarget, newSolution);
+
+                        referenceInfo.ConvertedProjectReferences.RemoveAt(i);
+
+                        // We have converted one, but you could have more than one reference with different aliases
+                        // that we need to convert, so we'll keep going. Make sure to decrement the index so we don't
+                        // skip any items.
+                        i--;
+                    }
+                }
+            }
+        }
+
+        public ProjectReference? TryCreateConvertedProjectReference_NoLock(ProjectId referencingProject, string path, MetadataReferenceProperties properties)
+        {
+            // Any conversion to or from project references must be done under the global workspace lock,
+            // since that needs to be coordinated with updating all projects simultaneously.
+            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
+
+            if (_projectsByOutputPath.TryGetValue(path, out var ids) && ids.Distinct().Count() == 1)
+            {
+                var projectIdToReference = ids.First();
+
+                if (CanConvertMetadataReferenceToProjectReference(Workspace.CurrentSolution, referencingProject, projectIdToReference))
+                {
+                    var projectReference = new ProjectReference(
+                        projectIdToReference,
+                        aliases: properties.Aliases,
+                        embedInteropTypes: properties.EmbedInteropTypes);
+
+                    GetReferenceInfo_NoLock(referencingProject).ConvertedProjectReferences.Add((path, projectReference));
+
+                    return projectReference;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public ProjectReference? TryRemoveConvertedProjectReference_NoLock(ProjectId referencingProject, string path, MetadataReferenceProperties properties)
+        {
+            // Any conversion to or from project references must be done under the global workspace lock,
+            // since that needs to be coordinated with updating all projects simultaneously.
+            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
+
+            var projectReferenceInformation = GetReferenceInfo_NoLock(referencingProject);
+            foreach (var convertedProject in projectReferenceInformation.ConvertedProjectReferences)
+            {
+                if (convertedProject.path == path &&
+                    convertedProject.projectReference.EmbedInteropTypes == properties.EmbedInteropTypes &&
+                    convertedProject.projectReference.Aliases.SequenceEqual(properties.Aliases))
+                {
+                    projectReferenceInformation.ConvertedProjectReferences.Remove(convertedProject);
+                    return convertedProject.projectReference;
+                }
+            }
+
+            return null;
+        }
+
+        public void RemoveProjectOutputPath_NoLock(SolutionChangeAccumulator solutionChanges, ProjectId projectId, string outputPath)
+        {
+            Contract.ThrowIfFalse(_gate.CurrentCount == 0);
+
+            var projectReferenceInformation = GetReferenceInfo_NoLock(projectId);
+            if (!projectReferenceInformation.OutputPaths.Contains(outputPath))
+            {
+                throw new ArgumentException($"Project does not contain output path '{outputPath}'", nameof(outputPath));
+            }
+
+            projectReferenceInformation.OutputPaths.Remove(outputPath);
+            _projectsByOutputPath.MultiRemove(outputPath, projectId);
+
+            // When a project is closed, we may need to convert project references to metadata references (or vice
+            // versa). Failure to convert the references could leave a project in the workspace with a project
+            // reference to a project which is not open.
+            //
+            // For the specific case where the entire solution is closing, we do not need to update the state for
+            // remaining projects as each project closes, because we know those projects will be closed without
+            // further use. Avoiding reference conversion when the solution is closing improves performance for both
+            // IDE close scenarios and solution reload scenarios that occur after complex branch switches.
+            if (!SolutionClosing)
+            {
+                if (_projectsByOutputPath.TryGetValue(outputPath, out var remainingProjectsForOutputPath))
+                {
+                    var distinctRemainingProjects = remainingProjectsForOutputPath.Distinct();
+                    if (distinctRemainingProjects.Count() == 1)
+                    {
+                        // We had more than one project outputting to the same path. Now we're back down to one
+                        // so we can reference that one again
+                        ConvertMetadataReferencesToProjectReferences_NoLock(solutionChanges, distinctRemainingProjects.Single(), outputPath);
+                    }
+                }
+                else
+                {
+                    // No projects left, we need to convert back to metadata references
+                    ConvertProjectReferencesToMetadataReferences_NoLock(solutionChanges, projectId, outputPath);
+                }
+            }
+        }
+
+#pragma warning disable VSTHRD100 // Avoid async void methods
+        private async void StartRefreshingMetadataReferencesForFile(object? sender, string fullFilePath)
+#pragma warning restore VSTHRD100 // Avoid async void methods
+        {
+            using var asyncToken = WorkspaceListener.BeginAsyncOperation(nameof(StartRefreshingMetadataReferencesForFile));
+
+            await ApplyBatchChangeToWorkspaceAsync(solutionChanges =>
+            {
+                foreach (var project in Workspace.CurrentSolution.Projects)
+                {
+                    // Loop to find each reference with the given path. It's possible that there might be multiple references of the same path;
+                    // the project system could concievably add the same reference multiple times but with different aliases. It's also possible
+                    // we might not find the path at all: when we receive the file changed event, we aren't checking if the file is still
+                    // in the workspace at that time; it's possible it might have already been removed.
+                    foreach (var portableExecutableReference in project.MetadataReferences.OfType<PortableExecutableReference>())
+                    {
+                        if (portableExecutableReference.FilePath == fullFilePath)
+                        {
+                            FileWatchedReferenceFactory.StopWatchingReference(portableExecutableReference);
+
+                            var newPortableExecutableReference =
+                                FileWatchedReferenceFactory.CreateReferenceAndStartWatchingFile(
+                                    portableExecutableReference.FilePath,
+                                    portableExecutableReference.Properties);
+
+                            var newSolution = solutionChanges.Solution.RemoveMetadataReference(project.Id, portableExecutableReference)
+                                                                        .AddMetadataReference(project.Id, newPortableExecutableReference);
+
+                            solutionChanges.UpdateSolutionForProjectAction(project.Id, newSolution);
+
+                        }
+                    }
+                }
+            }).ConfigureAwait(false);
+        }
+
+        internal void RaiseOnDocumentsAdded(ImmutableArray<string> filePaths)
+        {
+            _onDocumentsAdded(filePaths);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectHostInfo.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectHostInfo.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
+{
+    internal record ProjectSystemHostInfo(
+        ImmutableArray<Lazy<IDynamicFileInfoProvider, FileExtensionsMetadata>> DynamicFileInfoProviders,
+        IProjectSystemDiagnosticSource DiagnosticSource,
+        IHostDiagnosticAnalyzerProvider HostDiagnosticAnalyzerProvider);
+}

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/Readme.md
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/Readme.md
@@ -2,40 +2,40 @@
 
 There are two core types in this folder, each of which has their own lock.
 
-Each project from the project system is represented by a VisualStudioProject which has as SemaphoreSlim _gate. This lock is taken
+Each project from the project system is represented by a ProjectSystemProject which has as SemaphoreSlim _gate. This lock is taken
 any time a mutation happens to that individual project, to ensure that the type itself is safe to use concurrently. The expectation
 though is that simultaneous use from multiple threads by a project system isn't common, so no real effort has been expended to try
 to make the locking fine-grained there; each function just acquires the _gate and then does what it needs to do.
 
-The workspace (VisualStudioWorkspaceImpl) also has it's own SemaphoreSlim _gate. This is acquired any time a change is being made
+The project factory (ProjectSystemProjectFactory) also has it's own SemaphoreSlim _gate. This is acquired any time a change is being made
 to the workspace. As much as possible, try to acquire this gate in an asynchronous fashion, since during solution load this lock
 will have a lot of things trying to acquire it at once on a bunch of threads, and we may starve off the thread pool if we're not
 careful. Unfortunately however, we still have legacy project systems that aren't async friendly; they still may apply changes or
 batches synchronously so in those cases we still acquire the gate in a synchronous fashion.
 
-There is a strict lock hierarchy: a VisualStudioProject may try to acquire the workspace lock while holding it's lock,
-but to prevent deadlocks a holder of the VisualStudioWorkspaceImpl lock should never call a function on VisualStudioProject that
+There is a strict lock hierarchy: a ProjectSystemProject may try to acquire the workspace lock while holding it's lock,
+but to prevent deadlocks a holder of the ProjectSystemProjectFactory lock should never call a function on ProjectSystemProject that
 would acquire a project lock. To this end, a few bits of information that may seem to be "project specific" are actually stored
-in maps in the VisualStudioWorkspaceImpl; specifically we maintain a list of the output paths of a project which we use to convert
+in maps in the ProjectSystemProjectFactory; specifically we maintain a list of the output paths of a project which we use to convert
 metadata references to project references. This list is maintained in the workspace itself to avoid having to reach back to a
 project and ask it for information which might violate this lock hierarchy.
 
-When a VisualStudioProject needs to make a change to the workspace, there's a number of Apply methods that can be called that
+When a ProjectSystemProject needs to make a change to the workspace, there's a number of Apply methods that can be called that
 acquire the global workspace lock and then call a lambda to do the work that's needed. In some cases there are public methods on
-VisualStudioWorkspaceImpl which are suffixed wtih _NoLock; these exist to be called inside one of these Apply methods; they all
+ProjectSystemProjectFactory which are suffixed wtih _NoLock; these exist to be called inside one of these Apply methods; they all
 assert that the workspace lock is already being held.
 
-There is a nested class of VisualStudioProject called BatchingDocumentCollection which manages all of logic around adding and removing
+There is a nested class of ProjectSystemProject called BatchingDocumentCollection which manages all of logic around adding and removing
 documents, and dealing with changes. The nested class exists simply because each project has multiple sets of documents (regular
 documents, additional files, and .editorconfig files) that all behave the same way, so this allows for a common abstraction
-to reuse most of the logic. A BatchingDocumentCollection does not have a lock of it's own, it just acquires the VisualStudioProject
+to reuse most of the logic. A BatchingDocumentCollection does not have a lock of it's own, it just acquires the ProjectSystemProject
 lock whenever needed.
 
 There's a few ancillary types that also have their own locks:
 
 VisualStudioProjectOptionsTracker is a helper type which takes compiler command line strings and converts it to ParseOptions and
-CompilationOptions. It holds onto a VisualStudioProject, and may call VisualStudioProject methods while holding it's lock. Nothing
-else holds onto a VisualStudioProjectOptionsTracker that has a lock, so we avoid any deadlocks there.
+CompilationOptions. It holds onto a ProjectSystemProject, and may call ProjectSystemProject methods while holding it's lock. Nothing
+else holds onto a ProjectSystemProjectOptionsTracker that has a lock, so we avoid any deadlocks there.
 
 VisualStudioWorkspaceImpl has a nested type OpenFileTracker that has it's own lock to guard it's own fields. It should call nothing
 outside of itself while holding that lock.

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/SolutionChangeAccumulator.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/SolutionChangeAccumulator.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using Microsoft.CodeAnalysis;
 
-namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
 {
     /// <summary>
     /// A little helper type to hold onto the <see cref="Solution"/> being updated in a batch, which also

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/VisualStudioAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/VisualStudioAnalyzer.cs
@@ -5,15 +5,13 @@
 using System;
 using System.Collections.Immutable;
 using System.IO;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 
-namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
 {
     // TODO: Remove. This is only needed to support Solution Explorer Analyzer node population. 
     // Analyzers should not be loaded in devenv process (see https://github.com/dotnet/roslyn/issues/43008).
-    internal sealed class VisualStudioAnalyzer : IDisposable
+    internal sealed class ProjectAnalyzerReference : IDisposable
     {
         // Shadow copy analyzer files coming from packages to avoid locking the files in NuGet cache.
         // NOTE: It is important that we share the same shadow copy assembly loader for all VisualStudioAnalyzer instances.
@@ -30,7 +28,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private AnalyzerReference? _analyzerReference;
         private ImmutableArray<DiagnosticData> _analyzerLoadErrors = ImmutableArray<DiagnosticData>.Empty;
 
-        public VisualStudioAnalyzer(string fullPath, IProjectSystemDiagnosticSource projectSystemDiagnosticSource, ProjectId projectId, string language)
+        public ProjectAnalyzerReference(string fullPath, IProjectSystemDiagnosticSource projectSystemDiagnosticSource, ProjectId projectId, string language)
         {
             FullPath = fullPath;
             _projectSystemDiagnosticSource = projectSystemDiagnosticSource;
@@ -58,9 +56,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
-        private void OnAnalyzerLoadError(object sender, AnalyzerLoadFailureEventArgs e)
+        private void OnAnalyzerLoadError(object? sender, AnalyzerLoadFailureEventArgs e)
         {
-            var data = DocumentAnalysisExecutor.CreateAnalyzerLoadFailureDiagnostic(e, FullPath, _projectId, _language);
+            var data = _projectSystemDiagnosticSource.CreateAnalyzerLoadFailureDiagnostic(e, FullPath, _projectId, _language);
 
             lock (_gate)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal virtual bool CanChangeActiveContextDocument => false;
 
-        private protected void ClearOpenDocuments()
+        internal void ClearOpenDocuments()
         {
             List<DocumentId> docIds;
             using (_stateLock.DisposableWait())


### PR DESCRIPTION
Our existing VisualStudioWorkspace implementation had several interesting bits that weren't actually specific to Visual Studio for Windows. Specifically, it had support for tracking the output files of projects and converting metadata references to project references. It also had support for tracking when we need to add and remove file watches based on various events, as well as batching updates. None of this depends on any specific VS APIs, so this refactors this to allow for better code reuse.

The transformations are:

1. VisualStudioProject was renamed to ProjectSystemProject and moved down. Yes, I hate that name too.
2. VisualStudioProjectFactory got some of it's contents moved to a new ProjectSystemProjectFactory; the VS specific bits now call into this later type.
3. All of the stuff in VisualStudioWorkspaceImpl that dealt with applying the edits to a workspace (batching, project-to-project reference conversion) also moved to ProjectSystemProjectFactory. The ordering of the members was kept in order to make tracking the edit in Git a bit better, although it does need a follow up to fix some of the oddly ordered bits.

Things that need to happen in follow-up commits:

1. Moving a few more types, like the OptionsProcessor.
2. Moving the tests around -- this still has tests for now reusable code still in the VS layer.
3. Removal of the IProjectSystemDiagnosticSource. It's not clear to me why we can't have the implementation of that also moved down but that'll potential require some additional refactoring.
4. Cleaning up of some of the threading gates in ProjectSystemProjectFactory. We recently added better APIs for making solution changes in the workspace while being under the existing locks; we can now hopefully migrate to that.