### PR TITLE
Fix several issues with CreateSpan support

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitArrayInitializer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitArrayInitializer.cs
@@ -54,20 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             {
                 ImmutableArray<byte> data = this.GetRawData(initExprs);
 
-                // Emit the call to RuntimeHelpers.InitializeArray, creating the necessary metadata blob if there isn't
-                // already one for this data.  Note that this specifies an alignment of 1.  This is valid regardless of
-                // the kind of data stored in the array, as it's never accessed directly in the blob; rather, InitializeArray
-                // copies out the data as bytes.  The upside to keeping this as 1 is it means no special alignment is required.
-                // Although the compiler currently always aligns the metadata fields at an 8-byte boundary, the .pack field
-                // is appropriately set to the alignment value, and a rewriter (e.g. illink) may respect that.  If the alignment
-                // value were to be increased to match the actual alignment requirements of the element type, that could cause
-                // such rewritten binaries to regress in size due to the extra padding necessary for aligning.  The downside
-                // to keeping this as 1 is that this data won't unify with any blobs created for spans (e.g. RuntimeHelpers.CreateSpan).
-                // Code typically does directly read from the blobs via spans, and as such alignment there is required to be
-                // at least what the element type requires.  That means if the same data/element type is used with an array
-                // and separately with a span, the data will exist duplicated in two different blobs.  If it turns out that's
-                // very common, this can be revised in the future to specify the element type's alignment.
-                _builder.EmitArrayBlockInitializer(data, alignment: 1, inits.Syntax, _diagnostics.DiagnosticBag);
+                _builder.EmitArrayBlockInitializer(data, inits.Syntax, _diagnostics.DiagnosticBag);
 
                 if (initializationStyle == ArrayInitializerStyle.Mixed)
                 {
@@ -675,7 +662,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // ensure deterministic behavior.
             arrayType = arrayType.WithElementType(TypeWithAnnotations.Create(elementType.EnumUnderlyingTypeOrSelf()));
 
-            ushort alignment = (ushort)specialElementType.SizeInBytes();
             var cachingField = _builder.module.GetArrayCachingFieldForData(data, _module.Translate(arrayType), wrappedExpression.Syntax, _diagnostics.DiagnosticBag);
             var arrayNotNullLabel = new object();
 
@@ -693,7 +679,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             _builder.EmitIntConstant(elementCount);
             _builder.EmitOpCode(ILOpCode.Newarr);
             EmitSymbolToken(arrayType.ElementType, wrappedExpression.Syntax);
-            _builder.EmitArrayBlockInitializer(data, alignment, wrappedExpression.Syntax, _diagnostics.DiagnosticBag);
+            _builder.EmitArrayBlockInitializer(data, wrappedExpression.Syntax, _diagnostics.DiagnosticBag);
             _builder.EmitOpCode(ILOpCode.Dup);
             _builder.EmitOpCode(ILOpCode.Stsfld);
             _builder.EmitToken(cachingField, wrappedExpression.Syntax, _diagnostics.DiagnosticBag);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadOnlySpanConstructionTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadOnlySpanConstructionTest.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -976,29 +977,29 @@ public class Test
             foreach (bool withCtor in new[] { false, true })
             {
                 // A primitive can be used for the type of the blob
-                yield return new object[] { withCtor, "ushort", "1", "short <PrivateImplementationDetails>.47DC540C94CEB704A23875C11273E16BB0B8A87AED84DE911F2133568115F2542" };
-                yield return new object[] { withCtor, "ushort", "1, 2", "int <PrivateImplementationDetails>.7B11C1133330CD161071BF23A0C9B6CE5320A8F3A0F83620035A72BE46DF41042" };
-                yield return new object[] { withCtor, "ushort", "1, 2, 3, 4", "long <PrivateImplementationDetails>.EA99F710D9D0B8BA192295C969A63ED7CE8FC5743DA20D2057FA2B6D2C404BFB2" };
-                yield return new object[] { withCtor, "uint", "1", "int <PrivateImplementationDetails>.67ABDD721024F0FF4E0B3F4C2FC13BC5BAD42D0B7851D456D88D203D15AAA4504" };
-                yield return new object[] { withCtor, "uint", "1, 2", "long <PrivateImplementationDetails>.34FB5C825DE7CA4AEA6E712F19D439C1DA0C92C37B423936C5F618545CA4FA1F4" };
-                yield return new object[] { withCtor, "ulong", "1", "long <PrivateImplementationDetails>.7C9FA136D4413FA6173637E883B6998D32E1D675F88CDDFF9DCBCF331820F4B88" };
+                yield return new object[] { withCtor, "ushort", "1", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=2_Align=2 <PrivateImplementationDetails>.47DC540C94CEB704A23875C11273E16BB0B8A87AED84DE911F2133568115F2542" };
+                yield return new object[] { withCtor, "ushort", "1, 2", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=4_Align=2 <PrivateImplementationDetails>.7B11C1133330CD161071BF23A0C9B6CE5320A8F3A0F83620035A72BE46DF41042" };
+                yield return new object[] { withCtor, "ushort", "1, 2, 3, 4", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=8_Align=2 <PrivateImplementationDetails>.EA99F710D9D0B8BA192295C969A63ED7CE8FC5743DA20D2057FA2B6D2C404BFB2" };
+                yield return new object[] { withCtor, "uint", "1", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=4_Align=4 <PrivateImplementationDetails>.67ABDD721024F0FF4E0B3F4C2FC13BC5BAD42D0B7851D456D88D203D15AAA4504" };
+                yield return new object[] { withCtor, "uint", "1, 2", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=8_Align=4 <PrivateImplementationDetails>.34FB5C825DE7CA4AEA6E712F19D439C1DA0C92C37B423936C5F618545CA4FA1F4" };
+                yield return new object[] { withCtor, "ulong", "1", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=8_Align=8 <PrivateImplementationDetails>.7C9FA136D4413FA6173637E883B6998D32E1D675F88CDDFF9DCBCF331820F4B88" };
 
                 // Require a new type to be synthesized for the blob
-                yield return new object[] { withCtor, "char", "'a', 'b', 'c'", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6 <PrivateImplementationDetails>.13E228567E8249FCE53337F25D7970DE3BD68AB2653424C7B8F9FD05E33CAEDF2" };
-                yield return new object[] { withCtor, "int", "1, 2, 3", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.4636993D3E1DA4E9D6B8F87B79E8F7C6D018580D52661950EABC3845C5897A4D4" };
-                yield return new object[] { withCtor, "uint", "1, 2, 3", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.4636993D3E1DA4E9D6B8F87B79E8F7C6D018580D52661950EABC3845C5897A4D4" };
-                yield return new object[] { withCtor, "short", "1, 2, 3", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6 <PrivateImplementationDetails>.047DBF5366372631BA7E3E02520E651446B899C96C4B64663BAC378A298A7BF72" };
-                yield return new object[] { withCtor, "ushort", "1, 2, 3", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6 <PrivateImplementationDetails>.047DBF5366372631BA7E3E02520E651446B899C96C4B64663BAC378A298A7BF72" };
-                yield return new object[] { withCtor, "long", "1, 2, 3", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=24 <PrivateImplementationDetails>.E2E2033AE7E19D680599D4EB0A1359A2B48EC5BAAC75066C317FBF85159C54EF8" };
-                yield return new object[] { withCtor, "ulong", "1, 2, 3", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=24 <PrivateImplementationDetails>.E2E2033AE7E19D680599D4EB0A1359A2B48EC5BAAC75066C317FBF85159C54EF8" };
-                yield return new object[] { withCtor, "float", "1.0f, 2.0f, 3.0f", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.8E628779E6A74EE0B36991C10158F63CAFEC7D340AD4E075592502C8708524DD4" };
-                yield return new object[] { withCtor, "double", "1.0, 2.0, 3.0", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=24 <PrivateImplementationDetails>.A68DE4B5E96A60C8CEB3C7B7EF93461725BDBBFF3516B136585A743B5C0EC6648" };
-                yield return new object[] { withCtor, "MyColor_Int16", "MyColor_Int16.Red, MyColor_Int16.Blue", "int <PrivateImplementationDetails>.72034DE8A594B12DE51205FEBA7ADE26899D8425E81EAC7F8C296BF974A51C602" };
-                yield return new object[] { withCtor, "MyColor_UInt16", "MyColor_UInt16.Red, MyColor_UInt16.Blue", "int <PrivateImplementationDetails>.72034DE8A594B12DE51205FEBA7ADE26899D8425E81EAC7F8C296BF974A51C602" };
-                yield return new object[] { withCtor, "MyColor_Int32", "MyColor_Int32.Red, MyColor_Int32.Blue", "long <PrivateImplementationDetails>.1B03AB083D0FB41E44D480F48D5BBA181C623C0594BDA1AA8EA71A3B67DBF3B14" };
-                yield return new object[] { withCtor, "MyColor_UInt32", "MyColor_UInt32.Red, MyColor_UInt32.Blue", "long <PrivateImplementationDetails>.1B03AB083D0FB41E44D480F48D5BBA181C623C0594BDA1AA8EA71A3B67DBF3B14" };
-                yield return new object[] { withCtor, "MyColor_Int64", "MyColor_Int64.Red, MyColor_Int64.Blue", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.F7548C023E431138B11357593F5CCEB9DD35EB0B0A2041F0B1560212EEB6F13E8" };
-                yield return new object[] { withCtor, "MyColor_UInt64", "MyColor_UInt64.Red, MyColor_UInt64.Blue", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.F7548C023E431138B11357593F5CCEB9DD35EB0B0A2041F0B1560212EEB6F13E8" };
+                yield return new object[] { withCtor, "char", "'a', 'b', 'c'", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6_Align=2 <PrivateImplementationDetails>.13E228567E8249FCE53337F25D7970DE3BD68AB2653424C7B8F9FD05E33CAEDF2" };
+                yield return new object[] { withCtor, "int", "1, 2, 3", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12_Align=4 <PrivateImplementationDetails>.4636993D3E1DA4E9D6B8F87B79E8F7C6D018580D52661950EABC3845C5897A4D4" };
+                yield return new object[] { withCtor, "uint", "1, 2, 3", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12_Align=4 <PrivateImplementationDetails>.4636993D3E1DA4E9D6B8F87B79E8F7C6D018580D52661950EABC3845C5897A4D4" };
+                yield return new object[] { withCtor, "short", "1, 2, 3", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6_Align=2 <PrivateImplementationDetails>.047DBF5366372631BA7E3E02520E651446B899C96C4B64663BAC378A298A7BF72" };
+                yield return new object[] { withCtor, "ushort", "1, 2, 3", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6_Align=2 <PrivateImplementationDetails>.047DBF5366372631BA7E3E02520E651446B899C96C4B64663BAC378A298A7BF72" };
+                yield return new object[] { withCtor, "long", "1, 2, 3", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=24_Align=8 <PrivateImplementationDetails>.E2E2033AE7E19D680599D4EB0A1359A2B48EC5BAAC75066C317FBF85159C54EF8" };
+                yield return new object[] { withCtor, "ulong", "1, 2, 3", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=24_Align=8 <PrivateImplementationDetails>.E2E2033AE7E19D680599D4EB0A1359A2B48EC5BAAC75066C317FBF85159C54EF8" };
+                yield return new object[] { withCtor, "float", "1.0f, 2.0f, 3.0f", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12_Align=4 <PrivateImplementationDetails>.8E628779E6A74EE0B36991C10158F63CAFEC7D340AD4E075592502C8708524DD4" };
+                yield return new object[] { withCtor, "double", "1.0, 2.0, 3.0", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=24_Align=8 <PrivateImplementationDetails>.A68DE4B5E96A60C8CEB3C7B7EF93461725BDBBFF3516B136585A743B5C0EC6648" };
+                yield return new object[] { withCtor, "MyColor_Int16", "MyColor_Int16.Red, MyColor_Int16.Blue", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=4_Align=2 <PrivateImplementationDetails>.72034DE8A594B12DE51205FEBA7ADE26899D8425E81EAC7F8C296BF974A51C602" };
+                yield return new object[] { withCtor, "MyColor_UInt16", "MyColor_UInt16.Red, MyColor_UInt16.Blue", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=4_Align=2 <PrivateImplementationDetails>.72034DE8A594B12DE51205FEBA7ADE26899D8425E81EAC7F8C296BF974A51C602" };
+                yield return new object[] { withCtor, "MyColor_Int32", "MyColor_Int32.Red, MyColor_Int32.Blue", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=8_Align=4 <PrivateImplementationDetails>.1B03AB083D0FB41E44D480F48D5BBA181C623C0594BDA1AA8EA71A3B67DBF3B14" };
+                yield return new object[] { withCtor, "MyColor_UInt32", "MyColor_UInt32.Red, MyColor_UInt32.Blue", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=8_Align=4 <PrivateImplementationDetails>.1B03AB083D0FB41E44D480F48D5BBA181C623C0594BDA1AA8EA71A3B67DBF3B14" };
+                yield return new object[] { withCtor, "MyColor_Int64", "MyColor_Int64.Red, MyColor_Int64.Blue", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16_Align=8 <PrivateImplementationDetails>.F7548C023E431138B11357593F5CCEB9DD35EB0B0A2041F0B1560212EEB6F13E8" };
+                yield return new object[] { withCtor, "MyColor_UInt64", "MyColor_UInt64.Red, MyColor_UInt64.Blue", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16_Align=8 <PrivateImplementationDetails>.F7548C023E431138B11357593F5CCEB9DD35EB0B0A2041F0B1560212EEB6F13E8" };
             }
         }
 
@@ -1054,7 +1055,7 @@ public class Test
   // Code size       21 (0x15)
   .maxstack  2
   .locals init (System.ReadOnlySpan<int> V_0) //span
-  IL_0000:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.8B4B2444E57AED8C2D05A1293255DA1B048C63224317D4666230760935FA4A184""
+  IL_0000:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32_Align=4 <PrivateImplementationDetails>.8B4B2444E57AED8C2D05A1293255DA1B048C63224317D4666230760935FA4A184""
   IL_0005:  call       ""System.ReadOnlySpan<int> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<int>(System.RuntimeFieldHandle)""
   IL_000a:  stloc.0
   IL_000b:  ldloca.s   V_0
@@ -1094,53 +1095,53 @@ public class Test
             var verifier = CompileAndVerify(compilation, verify: Verification.Skipped);
             verifier.VerifyIL("Test.M", @$"
 {{
-  // Code size       93 (0x5d)
-  .maxstack  3
-  .locals init (System.ReadOnlySpan<int> V_0, //span1
+    // Code size       93 (0x5d)
+    .maxstack  3
+    .locals init (System.ReadOnlySpan<int> V_0, //span1
                 int V_1, //result
                 System.ReadOnlySpan<int> V_2, //span2
                 System.ReadOnlySpan<int> V_3, //span3
                 System.ReadOnlySpan<int> V_4) //span4
-  IL_0000:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.8B4B2444E57AED8C2D05A1293255DA1B048C63224317D4666230760935FA4A184""
-  IL_0005:  call       ""System.ReadOnlySpan<int> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<int>(System.RuntimeFieldHandle)""
-  IL_000a:  stloc.0
-  IL_000b:  ldloca.s   V_0
-  IL_000d:  ldc.i4.1
-  IL_000e:  call       ""ref readonly int System.ReadOnlySpan<int>.this[int].get""
-  IL_0013:  ldind.i4
-  IL_0014:  stloc.1
-  IL_0015:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.71729EA83D1490C8B1B1F870F7CBA7FFBB490C71AF78C9015B49938A22E42F894""
-  IL_001a:  call       ""System.ReadOnlySpan<int> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<int>(System.RuntimeFieldHandle)""
-  IL_001f:  stloc.2
-  IL_0020:  ldloc.1
-  IL_0021:  ldloca.s   V_2
-  IL_0023:  ldc.i4.2
-  IL_0024:  call       ""ref readonly int System.ReadOnlySpan<int>.this[int].get""
-  IL_0029:  ldind.i4
-  IL_002a:  add
-  IL_002b:  stloc.1
-  IL_002c:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.8B4B2444E57AED8C2D05A1293255DA1B048C63224317D4666230760935FA4A184""
-  IL_0031:  call       ""System.ReadOnlySpan<int> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<int>(System.RuntimeFieldHandle)""
-  IL_0036:  stloc.3
-  IL_0037:  ldloc.1
-  IL_0038:  ldloca.s   V_3
-  IL_003a:  ldc.i4.3
-  IL_003b:  call       ""ref readonly int System.ReadOnlySpan<int>.this[int].get""
-  IL_0040:  ldind.i4
-  IL_0041:  add
-  IL_0042:  stloc.1
-  IL_0043:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.71729EA83D1490C8B1B1F870F7CBA7FFBB490C71AF78C9015B49938A22E42F894""
-  IL_0048:  call       ""System.ReadOnlySpan<int> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<int>(System.RuntimeFieldHandle)""
-  IL_004d:  stloc.s    V_4
-  IL_004f:  ldloc.1
-  IL_0050:  ldloca.s   V_4
-  IL_0052:  ldc.i4.4
-  IL_0053:  call       ""ref readonly int System.ReadOnlySpan<int>.this[int].get""
-  IL_0058:  ldind.i4
-  IL_0059:  add
-  IL_005a:  stloc.1
-  IL_005b:  ldloc.1
-  IL_005c:  ret
+    IL_0000:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32_Align=4 <PrivateImplementationDetails>.8B4B2444E57AED8C2D05A1293255DA1B048C63224317D4666230760935FA4A184""
+    IL_0005:  call       ""System.ReadOnlySpan<int> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<int>(System.RuntimeFieldHandle)""
+    IL_000a:  stloc.0
+    IL_000b:  ldloca.s   V_0
+    IL_000d:  ldc.i4.1
+    IL_000e:  call       ""ref readonly int System.ReadOnlySpan<int>.this[int].get""
+    IL_0013:  ldind.i4
+    IL_0014:  stloc.1
+    IL_0015:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32_Align=4 <PrivateImplementationDetails>.71729EA83D1490C8B1B1F870F7CBA7FFBB490C71AF78C9015B49938A22E42F894""
+    IL_001a:  call       ""System.ReadOnlySpan<int> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<int>(System.RuntimeFieldHandle)""
+    IL_001f:  stloc.2
+    IL_0020:  ldloc.1
+    IL_0021:  ldloca.s   V_2
+    IL_0023:  ldc.i4.2
+    IL_0024:  call       ""ref readonly int System.ReadOnlySpan<int>.this[int].get""
+    IL_0029:  ldind.i4
+    IL_002a:  add
+    IL_002b:  stloc.1
+    IL_002c:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32_Align=4 <PrivateImplementationDetails>.8B4B2444E57AED8C2D05A1293255DA1B048C63224317D4666230760935FA4A184""
+    IL_0031:  call       ""System.ReadOnlySpan<int> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<int>(System.RuntimeFieldHandle)""
+    IL_0036:  stloc.3
+    IL_0037:  ldloc.1
+    IL_0038:  ldloca.s   V_3
+    IL_003a:  ldc.i4.3
+    IL_003b:  call       ""ref readonly int System.ReadOnlySpan<int>.this[int].get""
+    IL_0040:  ldind.i4
+    IL_0041:  add
+    IL_0042:  stloc.1
+    IL_0043:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32_Align=4 <PrivateImplementationDetails>.71729EA83D1490C8B1B1F870F7CBA7FFBB490C71AF78C9015B49938A22E42F894""
+    IL_0048:  call       ""System.ReadOnlySpan<int> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<int>(System.RuntimeFieldHandle)""
+    IL_004d:  stloc.s    V_4
+    IL_004f:  ldloc.1
+    IL_0050:  ldloca.s   V_4
+    IL_0052:  ldc.i4.4
+    IL_0053:  call       ""ref readonly int System.ReadOnlySpan<int>.this[int].get""
+    IL_0058:  ldind.i4
+    IL_0059:  add
+    IL_005a:  stloc.1
+    IL_005b:  ldloc.1
+    IL_005c:  ret
 }}
 ");
         }
@@ -1187,7 +1188,7 @@ public class Test
   IL_0009:  ldc.i4.8
   IL_000a:  newarr     ""int""
   IL_000f:  dup
-  IL_0010:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.8B4B2444E57AED8C2D05A1293255DA1B048C63224317D4666230760935FA4A184""
+  IL_0010:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.8B4B2444E57AED8C2D05A1293255DA1B048C63224317D4666230760935FA4A18""
   IL_0015:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_001a:  dup
   IL_001b:  stsfld     ""int[] <PrivateImplementationDetails>.8B4B2444E57AED8C2D05A1293255DA1B048C63224317D4666230760935FA4A18_A6""
@@ -1205,7 +1206,7 @@ public class Test
   IL_0039:  ldc.i4.8
   IL_003a:  newarr     ""int""
   IL_003f:  dup
-  IL_0040:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.71729EA83D1490C8B1B1F870F7CBA7FFBB490C71AF78C9015B49938A22E42F894""
+  IL_0040:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.71729EA83D1490C8B1B1F870F7CBA7FFBB490C71AF78C9015B49938A22E42F89""
   IL_0045:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_004a:  dup
   IL_004b:  stsfld     ""int[] <PrivateImplementationDetails>.71729EA83D1490C8B1B1F870F7CBA7FFBB490C71AF78C9015B49938A22E42F89_A6""
@@ -1225,7 +1226,7 @@ public class Test
   IL_006b:  ldc.i4.8
   IL_006c:  newarr     ""int""
   IL_0071:  dup
-  IL_0072:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.8B4B2444E57AED8C2D05A1293255DA1B048C63224317D4666230760935FA4A184""
+  IL_0072:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.8B4B2444E57AED8C2D05A1293255DA1B048C63224317D4666230760935FA4A18""
   IL_0077:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_007c:  dup
   IL_007d:  stsfld     ""int[] <PrivateImplementationDetails>.8B4B2444E57AED8C2D05A1293255DA1B048C63224317D4666230760935FA4A18_A6""
@@ -1245,7 +1246,7 @@ public class Test
   IL_009d:  ldc.i4.8
   IL_009e:  newarr     ""int""
   IL_00a3:  dup
-  IL_00a4:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.71729EA83D1490C8B1B1F870F7CBA7FFBB490C71AF78C9015B49938A22E42F894""
+  IL_00a4:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.71729EA83D1490C8B1B1F870F7CBA7FFBB490C71AF78C9015B49938A22E42F89""
   IL_00a9:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_00ae:  dup
   IL_00af:  stsfld     ""int[] <PrivateImplementationDetails>.71729EA83D1490C8B1B1F870F7CBA7FFBB490C71AF78C9015B49938A22E42F89_A6""
@@ -1266,32 +1267,32 @@ public class Test
 
         public static IEnumerable<object[]> NonSize1Types_NoCreateSpan_UsesCachedArray_MemberData()
         {
-            yield return new object[] { "ushort", "ushort", "1", 1, "ldind.u2", "short", "<PrivateImplementationDetails>.47DC540C94CEB704A23875C11273E16BB0B8A87AED84DE911F2133568115F254", "2", "_A13" };
-            yield return new object[] { "ushort", "ushort", "1, 2", 2, "ldind.u2", "int", "<PrivateImplementationDetails>.7B11C1133330CD161071BF23A0C9B6CE5320A8F3A0F83620035A72BE46DF4104", "2", "_A13" };
-            yield return new object[] { "ushort", "ushort", "1, 2, 3, 4", 4, "ldind.u2", "long", "<PrivateImplementationDetails>.EA99F710D9D0B8BA192295C969A63ED7CE8FC5743DA20D2057FA2B6D2C404BFB", "2", "_A13" };
-            yield return new object[] { "uint", "uint", "1", 1, "ldind.u4", "int", "<PrivateImplementationDetails>.67ABDD721024F0FF4E0B3F4C2FC13BC5BAD42D0B7851D456D88D203D15AAA450", "4", "_A14" };
-            yield return new object[] { "uint", "uint", "1, 2", 2, "ldind.u4", "long", "<PrivateImplementationDetails>.34FB5C825DE7CA4AEA6E712F19D439C1DA0C92C37B423936C5F618545CA4FA1F", "4", "_A14" };
-            yield return new object[] { "ulong", "ulong", "1", 1, "ldind.i8", "long", "<PrivateImplementationDetails>.7C9FA136D4413FA6173637E883B6998D32E1D675F88CDDFF9DCBCF331820F4B8", "8", "_A15" };
-            yield return new object[] { "char", "char", "'a', 'b', 'c'", 3, "ldind.u2", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6", "<PrivateImplementationDetails>.13E228567E8249FCE53337F25D7970DE3BD68AB2653424C7B8F9FD05E33CAEDF", "2", "_A1" };
-            yield return new object[] { "int", "int", "1, 2, 3", 3, "ldind.i4", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12", "<PrivateImplementationDetails>.4636993D3E1DA4E9D6B8F87B79E8F7C6D018580D52661950EABC3845C5897A4D", "4", "_A6" };
-            yield return new object[] { "uint", "uint", "1, 2, 3", 3, "ldind.u4", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12", "<PrivateImplementationDetails>.4636993D3E1DA4E9D6B8F87B79E8F7C6D018580D52661950EABC3845C5897A4D", "4", "_A14" };
-            yield return new object[] { "short", "short", "1, 2, 3", 3, "ldind.i2", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6", "<PrivateImplementationDetails>.047DBF5366372631BA7E3E02520E651446B899C96C4B64663BAC378A298A7BF7", "2", "_A5" };
-            yield return new object[] { "ushort", "ushort", "1, 2, 3", 3, "ldind.u2", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6", "<PrivateImplementationDetails>.047DBF5366372631BA7E3E02520E651446B899C96C4B64663BAC378A298A7BF7", "2", "_A13" };
-            yield return new object[] { "long", "long", "1, 2, 3", 3, "ldind.i8", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=24", "<PrivateImplementationDetails>.E2E2033AE7E19D680599D4EB0A1359A2B48EC5BAAC75066C317FBF85159C54EF", "8", "_A7" };
-            yield return new object[] { "ulong", "ulong", "1, 2, 3", 3, "ldind.i8", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=24", "<PrivateImplementationDetails>.E2E2033AE7E19D680599D4EB0A1359A2B48EC5BAAC75066C317FBF85159C54EF", "8", "_A15" };
-            yield return new object[] { "float", "float", "1.0f, 2.0f, 3.0f", 3, "ldind.r4", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12", "<PrivateImplementationDetails>.8E628779E6A74EE0B36991C10158F63CAFEC7D340AD4E075592502C8708524DD", "4", "_A3" };
-            yield return new object[] { "double", "double", "1.0, 2.0, 3.0", 3, "ldind.r8", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=24", "<PrivateImplementationDetails>.A68DE4B5E96A60C8CEB3C7B7EF93461725BDBBFF3516B136585A743B5C0EC664", "8", "_A4" };
-            yield return new object[] { "MyColor_Int16", "short", "MyColor_Int16.Red, MyColor_Int16.Blue", 2, "ldind.i2", "int", "<PrivateImplementationDetails>.72034DE8A594B12DE51205FEBA7ADE26899D8425E81EAC7F8C296BF974A51C60", "2", "_A5" };
-            yield return new object[] { "MyColor_UInt16", "ushort", "MyColor_UInt16.Red, MyColor_UInt16.Blue", 2, "ldind.u2", "int", "<PrivateImplementationDetails>.72034DE8A594B12DE51205FEBA7ADE26899D8425E81EAC7F8C296BF974A51C60", "2", "_A13" };
-            yield return new object[] { "MyColor_Int32", "int", "MyColor_Int32.Red, MyColor_Int32.Blue", 2, "ldind.i4", "long", "<PrivateImplementationDetails>.1B03AB083D0FB41E44D480F48D5BBA181C623C0594BDA1AA8EA71A3B67DBF3B1", "4", "_A6" };
-            yield return new object[] { "MyColor_UInt32", "uint", "MyColor_UInt32.Red, MyColor_UInt32.Blue", 2, "ldind.u4", "long", "<PrivateImplementationDetails>.1B03AB083D0FB41E44D480F48D5BBA181C623C0594BDA1AA8EA71A3B67DBF3B1", "4", "_A14" };
-            yield return new object[] { "MyColor_Int64", "long", "MyColor_Int64.Red, MyColor_Int64.Blue", 2, "ldind.i8", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16", "<PrivateImplementationDetails>.F7548C023E431138B11357593F5CCEB9DD35EB0B0A2041F0B1560212EEB6F13E", "8", "_A7" };
-            yield return new object[] { "MyColor_UInt64", "ulong", "MyColor_UInt64.Red, MyColor_UInt64.Blue", 2, "ldind.i8", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16", "<PrivateImplementationDetails>.F7548C023E431138B11357593F5CCEB9DD35EB0B0A2041F0B1560212EEB6F13E", "8", "_A15" };
+            yield return new object[] { "ushort", "ushort", "1", 1, "ldind.u2", "short", "<PrivateImplementationDetails>.47DC540C94CEB704A23875C11273E16BB0B8A87AED84DE911F2133568115F254", "_A13" };
+            yield return new object[] { "ushort", "ushort", "1, 2", 2, "ldind.u2", "int", "<PrivateImplementationDetails>.7B11C1133330CD161071BF23A0C9B6CE5320A8F3A0F83620035A72BE46DF4104", "_A13" };
+            yield return new object[] { "ushort", "ushort", "1, 2, 3, 4", 4, "ldind.u2", "long", "<PrivateImplementationDetails>.EA99F710D9D0B8BA192295C969A63ED7CE8FC5743DA20D2057FA2B6D2C404BFB", "_A13" };
+            yield return new object[] { "uint", "uint", "1", 1, "ldind.u4", "int", "<PrivateImplementationDetails>.67ABDD721024F0FF4E0B3F4C2FC13BC5BAD42D0B7851D456D88D203D15AAA450", "_A14" };
+            yield return new object[] { "uint", "uint", "1, 2", 2, "ldind.u4", "long", "<PrivateImplementationDetails>.34FB5C825DE7CA4AEA6E712F19D439C1DA0C92C37B423936C5F618545CA4FA1F", "_A14" };
+            yield return new object[] { "ulong", "ulong", "1", 1, "ldind.i8", "long", "<PrivateImplementationDetails>.7C9FA136D4413FA6173637E883B6998D32E1D675F88CDDFF9DCBCF331820F4B8", "_A15" };
+            yield return new object[] { "char", "char", "'a', 'b', 'c'", 3, "ldind.u2", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6", "<PrivateImplementationDetails>.13E228567E8249FCE53337F25D7970DE3BD68AB2653424C7B8F9FD05E33CAEDF", "_A1" };
+            yield return new object[] { "int", "int", "1, 2, 3", 3, "ldind.i4", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12", "<PrivateImplementationDetails>.4636993D3E1DA4E9D6B8F87B79E8F7C6D018580D52661950EABC3845C5897A4D", "_A6" };
+            yield return new object[] { "uint", "uint", "1, 2, 3", 3, "ldind.u4", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12", "<PrivateImplementationDetails>.4636993D3E1DA4E9D6B8F87B79E8F7C6D018580D52661950EABC3845C5897A4D", "_A14" };
+            yield return new object[] { "short", "short", "1, 2, 3", 3, "ldind.i2", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6", "<PrivateImplementationDetails>.047DBF5366372631BA7E3E02520E651446B899C96C4B64663BAC378A298A7BF7", "_A5" };
+            yield return new object[] { "ushort", "ushort", "1, 2, 3", 3, "ldind.u2", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=6", "<PrivateImplementationDetails>.047DBF5366372631BA7E3E02520E651446B899C96C4B64663BAC378A298A7BF7", "_A13" };
+            yield return new object[] { "long", "long", "1, 2, 3", 3, "ldind.i8", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=24", "<PrivateImplementationDetails>.E2E2033AE7E19D680599D4EB0A1359A2B48EC5BAAC75066C317FBF85159C54EF", "_A7" };
+            yield return new object[] { "ulong", "ulong", "1, 2, 3", 3, "ldind.i8", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=24", "<PrivateImplementationDetails>.E2E2033AE7E19D680599D4EB0A1359A2B48EC5BAAC75066C317FBF85159C54EF", "_A15" };
+            yield return new object[] { "float", "float", "1.0f, 2.0f, 3.0f", 3, "ldind.r4", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12", "<PrivateImplementationDetails>.8E628779E6A74EE0B36991C10158F63CAFEC7D340AD4E075592502C8708524DD", "_A3" };
+            yield return new object[] { "double", "double", "1.0, 2.0, 3.0", 3, "ldind.r8", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=24", "<PrivateImplementationDetails>.A68DE4B5E96A60C8CEB3C7B7EF93461725BDBBFF3516B136585A743B5C0EC664", "_A4" };
+            yield return new object[] { "MyColor_Int16", "short", "MyColor_Int16.Red, MyColor_Int16.Blue", 2, "ldind.i2", "int", "<PrivateImplementationDetails>.72034DE8A594B12DE51205FEBA7ADE26899D8425E81EAC7F8C296BF974A51C60", "_A5" };
+            yield return new object[] { "MyColor_UInt16", "ushort", "MyColor_UInt16.Red, MyColor_UInt16.Blue", 2, "ldind.u2", "int", "<PrivateImplementationDetails>.72034DE8A594B12DE51205FEBA7ADE26899D8425E81EAC7F8C296BF974A51C60", "_A13" };
+            yield return new object[] { "MyColor_Int32", "int", "MyColor_Int32.Red, MyColor_Int32.Blue", 2, "ldind.i4", "long", "<PrivateImplementationDetails>.1B03AB083D0FB41E44D480F48D5BBA181C623C0594BDA1AA8EA71A3B67DBF3B1", "_A6" };
+            yield return new object[] { "MyColor_UInt32", "uint", "MyColor_UInt32.Red, MyColor_UInt32.Blue", 2, "ldind.u4", "long", "<PrivateImplementationDetails>.1B03AB083D0FB41E44D480F48D5BBA181C623C0594BDA1AA8EA71A3B67DBF3B1", "_A14" };
+            yield return new object[] { "MyColor_Int64", "long", "MyColor_Int64.Red, MyColor_Int64.Blue", 2, "ldind.i8", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16", "<PrivateImplementationDetails>.F7548C023E431138B11357593F5CCEB9DD35EB0B0A2041F0B1560212EEB6F13E", "_A7" };
+            yield return new object[] { "MyColor_UInt64", "ulong", "MyColor_UInt64.Red, MyColor_UInt64.Blue", 2, "ldind.i8", "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16", "<PrivateImplementationDetails>.F7548C023E431138B11357593F5CCEB9DD35EB0B0A2041F0B1560212EEB6F13E", "_A15" };
         }
 
         [Theory]
         [MemberData(nameof(NonSize1Types_NoCreateSpan_UsesCachedArray_MemberData))]
-        public void NonSize1Types_NoCreateSpan_UsesCachedArray(string type, string underlyingType, string args, int length, string ldind, string fieldType, string fieldName, string dataSuffix, string arraySuffix)
+        public void NonSize1Types_NoCreateSpan_UsesCachedArray(string type, string underlyingType, string args, int length, string ldind, string fieldType, string fieldName, string arraySuffix)
         {
             string csharp = @$"
 public enum MyColor_Byte : byte {{ Red, Orange, Yellow, Green, Blue }}
@@ -1326,7 +1327,7 @@ public class Test
   IL_0009:  ldc.i4.{length}
   IL_000a:  newarr     ""{underlyingType}""
   IL_000f:  dup
-  IL_0010:  ldtoken    ""{fieldType} {fieldName}{dataSuffix}""
+  IL_0010:  ldtoken    ""{fieldType} {fieldName}""
   IL_0015:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_001a:  dup
   IL_001b:  stsfld     ""{underlyingType}[] {fieldName}{arraySuffix}""
@@ -1380,7 +1381,7 @@ public class Test
   IL_0009:  ldc.i4.8
   IL_000a:  newarr     ""int""
   IL_000f:  dup
-  IL_0010:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.FF1F6EE5D67458CFAC950F62E93042E21FCB867E2234DCC8721801231064AD404""
+  IL_0010:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.FF1F6EE5D67458CFAC950F62E93042E21FCB867E2234DCC8721801231064AD40""
   IL_0015:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_001a:  dup
   IL_001b:  stsfld     ""int[] <PrivateImplementationDetails>.FF1F6EE5D67458CFAC950F62E93042E21FCB867E2234DCC8721801231064AD40_A6""
@@ -1393,7 +1394,7 @@ public class Test
   IL_002f:  ldc.i4.8
   IL_0030:  newarr     ""int""
   IL_0035:  dup
-  IL_0036:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.FF1F6EE5D67458CFAC950F62E93042E21FCB867E2234DCC8721801231064AD404""
+  IL_0036:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.FF1F6EE5D67458CFAC950F62E93042E21FCB867E2234DCC8721801231064AD40""
   IL_003b:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0040:  dup
   IL_0041:  stsfld     ""int[] <PrivateImplementationDetails>.FF1F6EE5D67458CFAC950F62E93042E21FCB867E2234DCC8721801231064AD40_A6""
@@ -1406,7 +1407,7 @@ public class Test
   IL_0055:  ldc.i4.8
   IL_0056:  newarr     ""int""
   IL_005b:  dup
-  IL_005c:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.FF1F6EE5D67458CFAC950F62E93042E21FCB867E2234DCC8721801231064AD404""
+  IL_005c:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.FF1F6EE5D67458CFAC950F62E93042E21FCB867E2234DCC8721801231064AD40""
   IL_0061:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0066:  dup
   IL_0067:  stsfld     ""int[] <PrivateImplementationDetails>.FF1F6EE5D67458CFAC950F62E93042E21FCB867E2234DCC8721801231064AD40_A6""
@@ -1613,48 +1614,359 @@ public class Test
             compilation.MakeMemberMissing(WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__CreateSpanRuntimeFieldHandle);
             var verifier = CompileAndVerify(compilation, expectedOutput: "340", verify: Verification.Skipped);
             verifier.VerifyIL("Test.Main", @$"{{
-    // Code size      102 (0x66)
-    .maxstack  3
-    .locals init (System.ReadOnlySpan<byte> V_0, //s1
+  // Code size      102 (0x66)
+  .maxstack  3
+  .locals init (System.ReadOnlySpan<byte> V_0, //s1
                 System.ReadOnlySpan<int> V_1, //s2
                 System.ReadOnlySpan<long> V_2) //s3
-    IL_0000:  ldloca.s   V_0
-    IL_0002:  ldsflda    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=3 <PrivateImplementationDetails>.039058C6F2C0CB492C533B0A4D14EF77CC0F78ABCCCED5287D84A1A2011CFB81""
-    IL_0007:  ldc.i4.3
-    IL_0008:  call       ""System.ReadOnlySpan<byte>..ctor(void*, int)""
-    IL_000d:  ldloc.0
-    IL_000e:  call       ""void Test.Print<byte>(System.ReadOnlySpan<byte>)""
-    IL_0013:  ldloca.s   V_0
-    IL_0015:  call       ""bool System.ReadOnlySpan<byte>.IsEmpty.get""
-    IL_001a:  pop
-    IL_001b:  ldsfld     ""int[] <PrivateImplementationDetails>.CF97ADEEDB59E05BFD73A2B4C2A8885708C4F4F70C84C64B27120E72AB733B72_A6""
-    IL_0020:  dup
-    IL_0021:  brtrue.s   IL_003b
-    IL_0023:  pop
-    IL_0024:  ldc.i4.4
-    IL_0025:  newarr     ""int""
-    IL_002a:  dup
-    IL_002b:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.CF97ADEEDB59E05BFD73A2B4C2A8885708C4F4F70C84C64B27120E72AB733B724""
-    IL_0030:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
-    IL_0035:  dup
-    IL_0036:  stsfld     ""int[] <PrivateImplementationDetails>.CF97ADEEDB59E05BFD73A2B4C2A8885708C4F4F70C84C64B27120E72AB733B72_A6""
-    IL_003b:  newobj     ""System.ReadOnlySpan<int>..ctor(int[])""
-    IL_0040:  dup
-    IL_0041:  stloc.1
-    IL_0042:  call       ""void Test.Print<int>(System.ReadOnlySpan<int>)""
-    IL_0047:  ldloca.s   V_1
-    IL_0049:  call       ""bool System.ReadOnlySpan<int>.IsEmpty.get""
-    IL_004e:  pop
-    IL_004f:  ldloca.s   V_2
-    IL_0051:  initobj    ""System.ReadOnlySpan<long>""
-    IL_0057:  ldloc.2
-    IL_0058:  call       ""void Test.Print<long>(System.ReadOnlySpan<long>)""
-    IL_005d:  ldloca.s   V_2
-    IL_005f:  call       ""bool System.ReadOnlySpan<long>.IsEmpty.get""
-    IL_0064:  pop
-    IL_0065:  ret
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldsflda    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=3 <PrivateImplementationDetails>.039058C6F2C0CB492C533B0A4D14EF77CC0F78ABCCCED5287D84A1A2011CFB81""
+  IL_0007:  ldc.i4.3
+  IL_0008:  call       ""System.ReadOnlySpan<byte>..ctor(void*, int)""
+  IL_000d:  ldloc.0
+  IL_000e:  call       ""void Test.Print<byte>(System.ReadOnlySpan<byte>)""
+  IL_0013:  ldloca.s   V_0
+  IL_0015:  call       ""bool System.ReadOnlySpan<byte>.IsEmpty.get""
+  IL_001a:  pop
+  IL_001b:  ldsfld     ""int[] <PrivateImplementationDetails>.CF97ADEEDB59E05BFD73A2B4C2A8885708C4F4F70C84C64B27120E72AB733B72_A6""
+  IL_0020:  dup
+  IL_0021:  brtrue.s   IL_003b
+  IL_0023:  pop
+  IL_0024:  ldc.i4.4
+  IL_0025:  newarr     ""int""
+  IL_002a:  dup
+  IL_002b:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.CF97ADEEDB59E05BFD73A2B4C2A8885708C4F4F70C84C64B27120E72AB733B72""
+  IL_0030:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
+  IL_0035:  dup
+  IL_0036:  stsfld     ""int[] <PrivateImplementationDetails>.CF97ADEEDB59E05BFD73A2B4C2A8885708C4F4F70C84C64B27120E72AB733B72_A6""
+  IL_003b:  newobj     ""System.ReadOnlySpan<int>..ctor(int[])""
+  IL_0040:  dup
+  IL_0041:  stloc.1
+  IL_0042:  call       ""void Test.Print<int>(System.ReadOnlySpan<int>)""
+  IL_0047:  ldloca.s   V_1
+  IL_0049:  call       ""bool System.ReadOnlySpan<int>.IsEmpty.get""
+  IL_004e:  pop
+  IL_004f:  ldloca.s   V_2
+  IL_0051:  initobj    ""System.ReadOnlySpan<long>""
+  IL_0057:  ldloc.2
+  IL_0058:  call       ""void Test.Print<long>(System.ReadOnlySpan<long>)""
+  IL_005d:  ldloca.s   V_2
+  IL_005f:  call       ""bool System.ReadOnlySpan<long>.IsEmpty.get""
+  IL_0064:  pop
+  IL_0065:  ret
 }}
 ");
+        }
+
+        [ConditionalFact(typeof(CoreClrOnly))]
+        public void MultipleNonSize1Types_EqualDataBlobs_HasCreateSpan_EveryAlignmentGetsUniqueTypeAndBlob()
+        {
+            var source = @"
+using System;
+
+class Test
+{
+    public static void Main()
+    {       
+        var s1 = (ReadOnlySpan<sbyte>)new sbyte[] { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+        var s2 = (ReadOnlySpan<byte>)new byte[] { 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255 };
+        var s3 = (ReadOnlySpan<short>)new short[] { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+        var s4 = (ReadOnlySpan<ushort>)new ushort[] { 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF };
+        var s5 = (ReadOnlySpan<int>)new int[] { -1, -1, -1, -1, -1, -1, -1, -1 };
+        var s6 = (ReadOnlySpan<uint>)new uint[] { 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF };
+        var s7 = (ReadOnlySpan<long>)new long[] { -1, -1, -1, -1 };
+        var s8 = (ReadOnlySpan<ulong>)new ulong[] { 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF };
+        var s9 = (ReadOnlySpan<char>)new char[] { '\uFFFF', '\uFFFF', '\uFFFF', '\uFFFF', '\uFFFF', '\uFFFF', '\uFFFF', '\uFFFF', '\uFFFF', '\uFFFF', '\uFFFF', '\uFFFF', '\uFFFF', '\uFFFF', '\uFFFF', '\uFFFF' };
+
+        long sum = 0;
+        foreach (var v1 in s1) sum += v1;
+        foreach (var v2 in s2) sum += v2;
+        foreach (var v3 in s3) sum += v3;
+        foreach (var v4 in s4) sum += v4;
+        foreach (var v5 in s5) sum += v5;
+        foreach (var v6 in s6) sum += v6;
+        foreach (var v7 in s7) sum += v7;
+        foreach (var v8 in s8) sum += (long)v8;
+        foreach (var v9 in s9) sum += v9;
+
+        Console.Write(sum);
+    }
+}
+";
+            CompileAndVerify(source, expectedOutput: "34361843576", verify: Verification.Skipped, targetFramework: TargetFramework.Net70).VerifyIL("Test.Main", @"
+{
+  // Code size      528 (0x210)
+  .maxstack  2
+  .locals init (System.ReadOnlySpan<sbyte> V_0, //s1
+                System.ReadOnlySpan<byte> V_1, //s2
+                System.ReadOnlySpan<short> V_2, //s3
+                System.ReadOnlySpan<ushort> V_3, //s4
+                System.ReadOnlySpan<int> V_4, //s5
+                System.ReadOnlySpan<uint> V_5, //s6
+                System.ReadOnlySpan<long> V_6, //s7
+                System.ReadOnlySpan<ulong> V_7, //s8
+                System.ReadOnlySpan<char> V_8, //s9
+                long V_9, //sum
+                System.ReadOnlySpan<sbyte> V_10,
+                int V_11,
+                sbyte V_12, //v1
+                System.ReadOnlySpan<byte> V_13,
+                byte V_14, //v2
+                System.ReadOnlySpan<short> V_15,
+                short V_16, //v3
+                System.ReadOnlySpan<ushort> V_17,
+                ushort V_18, //v4
+                System.ReadOnlySpan<int> V_19,
+                int V_20, //v5
+                System.ReadOnlySpan<uint> V_21,
+                uint V_22, //v6
+                System.ReadOnlySpan<long> V_23,
+                long V_24, //v7
+                System.ReadOnlySpan<ulong> V_25,
+                ulong V_26, //v8
+                System.ReadOnlySpan<char> V_27,
+                char V_28) //v9
+  IL_0000:  ldsflda    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051""
+  IL_0005:  ldc.i4.s   32
+  IL_0007:  newobj     ""System.ReadOnlySpan<sbyte>..ctor(void*, int)""
+  IL_000c:  stloc.0
+  IL_000d:  ldsflda    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051""
+  IL_0012:  ldc.i4.s   32
+  IL_0014:  newobj     ""System.ReadOnlySpan<byte>..ctor(void*, int)""
+  IL_0019:  stloc.1
+  IL_001a:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32_Align=2 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C40512""
+  IL_001f:  call       ""System.ReadOnlySpan<short> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<short>(System.RuntimeFieldHandle)""
+  IL_0024:  stloc.2
+  IL_0025:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32_Align=2 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C40512""
+  IL_002a:  call       ""System.ReadOnlySpan<ushort> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<ushort>(System.RuntimeFieldHandle)""
+  IL_002f:  stloc.3
+  IL_0030:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32_Align=4 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C40514""
+  IL_0035:  call       ""System.ReadOnlySpan<int> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<int>(System.RuntimeFieldHandle)""
+  IL_003a:  stloc.s    V_4
+  IL_003c:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32_Align=4 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C40514""
+  IL_0041:  call       ""System.ReadOnlySpan<uint> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<uint>(System.RuntimeFieldHandle)""
+  IL_0046:  stloc.s    V_5
+  IL_0048:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32_Align=8 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C40518""
+  IL_004d:  call       ""System.ReadOnlySpan<long> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<long>(System.RuntimeFieldHandle)""
+  IL_0052:  stloc.s    V_6
+  IL_0054:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32_Align=8 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C40518""
+  IL_0059:  call       ""System.ReadOnlySpan<ulong> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<ulong>(System.RuntimeFieldHandle)""
+  IL_005e:  stloc.s    V_7
+  IL_0060:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32_Align=2 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C40512""
+  IL_0065:  call       ""System.ReadOnlySpan<char> System.Runtime.CompilerServices.RuntimeHelpers.CreateSpan<char>(System.RuntimeFieldHandle)""
+  IL_006a:  stloc.s    V_8
+  IL_006c:  ldc.i4.0
+  IL_006d:  conv.i8
+  IL_006e:  stloc.s    V_9
+  IL_0070:  ldloc.0
+  IL_0071:  stloc.s    V_10
+  IL_0073:  ldc.i4.0
+  IL_0074:  stloc.s    V_11
+  IL_0076:  br.s       IL_0092
+  IL_0078:  ldloca.s   V_10
+  IL_007a:  ldloc.s    V_11
+  IL_007c:  call       ""ref readonly sbyte System.ReadOnlySpan<sbyte>.this[int].get""
+  IL_0081:  ldind.i1
+  IL_0082:  stloc.s    V_12
+  IL_0084:  ldloc.s    V_9
+  IL_0086:  ldloc.s    V_12
+  IL_0088:  conv.i8
+  IL_0089:  add
+  IL_008a:  stloc.s    V_9
+  IL_008c:  ldloc.s    V_11
+  IL_008e:  ldc.i4.1
+  IL_008f:  add
+  IL_0090:  stloc.s    V_11
+  IL_0092:  ldloc.s    V_11
+  IL_0094:  ldloca.s   V_10
+  IL_0096:  call       ""int System.ReadOnlySpan<sbyte>.Length.get""
+  IL_009b:  blt.s      IL_0078
+  IL_009d:  ldloc.1
+  IL_009e:  stloc.s    V_13
+  IL_00a0:  ldc.i4.0
+  IL_00a1:  stloc.s    V_11
+  IL_00a3:  br.s       IL_00bf
+  IL_00a5:  ldloca.s   V_13
+  IL_00a7:  ldloc.s    V_11
+  IL_00a9:  call       ""ref readonly byte System.ReadOnlySpan<byte>.this[int].get""
+  IL_00ae:  ldind.u1
+  IL_00af:  stloc.s    V_14
+  IL_00b1:  ldloc.s    V_9
+  IL_00b3:  ldloc.s    V_14
+  IL_00b5:  conv.u8
+  IL_00b6:  add
+  IL_00b7:  stloc.s    V_9
+  IL_00b9:  ldloc.s    V_11
+  IL_00bb:  ldc.i4.1
+  IL_00bc:  add
+  IL_00bd:  stloc.s    V_11
+  IL_00bf:  ldloc.s    V_11
+  IL_00c1:  ldloca.s   V_13
+  IL_00c3:  call       ""int System.ReadOnlySpan<byte>.Length.get""
+  IL_00c8:  blt.s      IL_00a5
+  IL_00ca:  ldloc.2
+  IL_00cb:  stloc.s    V_15
+  IL_00cd:  ldc.i4.0
+  IL_00ce:  stloc.s    V_11
+  IL_00d0:  br.s       IL_00ec
+  IL_00d2:  ldloca.s   V_15
+  IL_00d4:  ldloc.s    V_11
+  IL_00d6:  call       ""ref readonly short System.ReadOnlySpan<short>.this[int].get""
+  IL_00db:  ldind.i2
+  IL_00dc:  stloc.s    V_16
+  IL_00de:  ldloc.s    V_9
+  IL_00e0:  ldloc.s    V_16
+  IL_00e2:  conv.i8
+  IL_00e3:  add
+  IL_00e4:  stloc.s    V_9
+  IL_00e6:  ldloc.s    V_11
+  IL_00e8:  ldc.i4.1
+  IL_00e9:  add
+  IL_00ea:  stloc.s    V_11
+  IL_00ec:  ldloc.s    V_11
+  IL_00ee:  ldloca.s   V_15
+  IL_00f0:  call       ""int System.ReadOnlySpan<short>.Length.get""
+  IL_00f5:  blt.s      IL_00d2
+  IL_00f7:  ldloc.3
+  IL_00f8:  stloc.s    V_17
+  IL_00fa:  ldc.i4.0
+  IL_00fb:  stloc.s    V_11
+  IL_00fd:  br.s       IL_0119
+  IL_00ff:  ldloca.s   V_17
+  IL_0101:  ldloc.s    V_11
+  IL_0103:  call       ""ref readonly ushort System.ReadOnlySpan<ushort>.this[int].get""
+  IL_0108:  ldind.u2
+  IL_0109:  stloc.s    V_18
+  IL_010b:  ldloc.s    V_9
+  IL_010d:  ldloc.s    V_18
+  IL_010f:  conv.u8
+  IL_0110:  add
+  IL_0111:  stloc.s    V_9
+  IL_0113:  ldloc.s    V_11
+  IL_0115:  ldc.i4.1
+  IL_0116:  add
+  IL_0117:  stloc.s    V_11
+  IL_0119:  ldloc.s    V_11
+  IL_011b:  ldloca.s   V_17
+  IL_011d:  call       ""int System.ReadOnlySpan<ushort>.Length.get""
+  IL_0122:  blt.s      IL_00ff
+  IL_0124:  ldloc.s    V_4
+  IL_0126:  stloc.s    V_19
+  IL_0128:  ldc.i4.0
+  IL_0129:  stloc.s    V_11
+  IL_012b:  br.s       IL_0147
+  IL_012d:  ldloca.s   V_19
+  IL_012f:  ldloc.s    V_11
+  IL_0131:  call       ""ref readonly int System.ReadOnlySpan<int>.this[int].get""
+  IL_0136:  ldind.i4
+  IL_0137:  stloc.s    V_20
+  IL_0139:  ldloc.s    V_9
+  IL_013b:  ldloc.s    V_20
+  IL_013d:  conv.i8
+  IL_013e:  add
+  IL_013f:  stloc.s    V_9
+  IL_0141:  ldloc.s    V_11
+  IL_0143:  ldc.i4.1
+  IL_0144:  add
+  IL_0145:  stloc.s    V_11
+  IL_0147:  ldloc.s    V_11
+  IL_0149:  ldloca.s   V_19
+  IL_014b:  call       ""int System.ReadOnlySpan<int>.Length.get""
+  IL_0150:  blt.s      IL_012d
+  IL_0152:  ldloc.s    V_5
+  IL_0154:  stloc.s    V_21
+  IL_0156:  ldc.i4.0
+  IL_0157:  stloc.s    V_11
+  IL_0159:  br.s       IL_0175
+  IL_015b:  ldloca.s   V_21
+  IL_015d:  ldloc.s    V_11
+  IL_015f:  call       ""ref readonly uint System.ReadOnlySpan<uint>.this[int].get""
+  IL_0164:  ldind.u4
+  IL_0165:  stloc.s    V_22
+  IL_0167:  ldloc.s    V_9
+  IL_0169:  ldloc.s    V_22
+  IL_016b:  conv.u8
+  IL_016c:  add
+  IL_016d:  stloc.s    V_9
+  IL_016f:  ldloc.s    V_11
+  IL_0171:  ldc.i4.1
+  IL_0172:  add
+  IL_0173:  stloc.s    V_11
+  IL_0175:  ldloc.s    V_11
+  IL_0177:  ldloca.s   V_21
+  IL_0179:  call       ""int System.ReadOnlySpan<uint>.Length.get""
+  IL_017e:  blt.s      IL_015b
+  IL_0180:  ldloc.s    V_6
+  IL_0182:  stloc.s    V_23
+  IL_0184:  ldc.i4.0
+  IL_0185:  stloc.s    V_11
+  IL_0187:  br.s       IL_01a2
+  IL_0189:  ldloca.s   V_23
+  IL_018b:  ldloc.s    V_11
+  IL_018d:  call       ""ref readonly long System.ReadOnlySpan<long>.this[int].get""
+  IL_0192:  ldind.i8
+  IL_0193:  stloc.s    V_24
+  IL_0195:  ldloc.s    V_9
+  IL_0197:  ldloc.s    V_24
+  IL_0199:  add
+  IL_019a:  stloc.s    V_9
+  IL_019c:  ldloc.s    V_11
+  IL_019e:  ldc.i4.1
+  IL_019f:  add
+  IL_01a0:  stloc.s    V_11
+  IL_01a2:  ldloc.s    V_11
+  IL_01a4:  ldloca.s   V_23
+  IL_01a6:  call       ""int System.ReadOnlySpan<long>.Length.get""
+  IL_01ab:  blt.s      IL_0189
+  IL_01ad:  ldloc.s    V_7
+  IL_01af:  stloc.s    V_25
+  IL_01b1:  ldc.i4.0
+  IL_01b2:  stloc.s    V_11
+  IL_01b4:  br.s       IL_01cf
+  IL_01b6:  ldloca.s   V_25
+  IL_01b8:  ldloc.s    V_11
+  IL_01ba:  call       ""ref readonly ulong System.ReadOnlySpan<ulong>.this[int].get""
+  IL_01bf:  ldind.i8
+  IL_01c0:  stloc.s    V_26
+  IL_01c2:  ldloc.s    V_9
+  IL_01c4:  ldloc.s    V_26
+  IL_01c6:  add
+  IL_01c7:  stloc.s    V_9
+  IL_01c9:  ldloc.s    V_11
+  IL_01cb:  ldc.i4.1
+  IL_01cc:  add
+  IL_01cd:  stloc.s    V_11
+  IL_01cf:  ldloc.s    V_11
+  IL_01d1:  ldloca.s   V_25
+  IL_01d3:  call       ""int System.ReadOnlySpan<ulong>.Length.get""
+  IL_01d8:  blt.s      IL_01b6
+  IL_01da:  ldloc.s    V_8
+  IL_01dc:  stloc.s    V_27
+  IL_01de:  ldc.i4.0
+  IL_01df:  stloc.s    V_11
+  IL_01e1:  br.s       IL_01fd
+  IL_01e3:  ldloca.s   V_27
+  IL_01e5:  ldloc.s    V_11
+  IL_01e7:  call       ""ref readonly char System.ReadOnlySpan<char>.this[int].get""
+  IL_01ec:  ldind.u2
+  IL_01ed:  stloc.s    V_28
+  IL_01ef:  ldloc.s    V_9
+  IL_01f1:  ldloc.s    V_28
+  IL_01f3:  conv.u8
+  IL_01f4:  add
+  IL_01f5:  stloc.s    V_9
+  IL_01f7:  ldloc.s    V_11
+  IL_01f9:  ldc.i4.1
+  IL_01fa:  add
+  IL_01fb:  stloc.s    V_11
+  IL_01fd:  ldloc.s    V_11
+  IL_01ff:  ldloca.s   V_27
+  IL_0201:  call       ""int System.ReadOnlySpan<char>.Length.get""
+  IL_0206:  blt.s      IL_01e3
+  IL_0208:  ldloc.s    V_9
+  IL_020a:  call       ""void System.Console.Write(long)""
+  IL_020f:  ret
+}");
         }
 
         [Fact]
@@ -1742,7 +2054,7 @@ class Test
   IL_0023:  ldc.i4.s   16
   IL_0025:  newarr     ""short""
   IL_002a:  dup
-  IL_002b:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C40512""
+  IL_002b:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051""
   IL_0030:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0035:  dup
   IL_0036:  stsfld     ""short[] <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051_A5""
@@ -1755,7 +2067,7 @@ class Test
   IL_004a:  ldc.i4.s   16
   IL_004c:  newarr     ""ushort""
   IL_0051:  dup
-  IL_0052:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C40512""
+  IL_0052:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051""
   IL_0057:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_005c:  dup
   IL_005d:  stsfld     ""ushort[] <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051_A13""
@@ -1768,7 +2080,7 @@ class Test
   IL_0071:  ldc.i4.8
   IL_0072:  newarr     ""int""
   IL_0077:  dup
-  IL_0078:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C40514""
+  IL_0078:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051""
   IL_007d:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0082:  dup
   IL_0083:  stsfld     ""int[] <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051_A6""
@@ -1781,7 +2093,7 @@ class Test
   IL_0098:  ldc.i4.8
   IL_0099:  newarr     ""uint""
   IL_009e:  dup
-  IL_009f:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C40514""
+  IL_009f:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051""
   IL_00a4:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_00a9:  dup
   IL_00aa:  stsfld     ""uint[] <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051_A14""
@@ -1794,7 +2106,7 @@ class Test
   IL_00bf:  ldc.i4.4
   IL_00c0:  newarr     ""long""
   IL_00c5:  dup
-  IL_00c6:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C40518""
+  IL_00c6:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051""
   IL_00cb:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_00d0:  dup
   IL_00d1:  stsfld     ""long[] <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051_A7""
@@ -1807,7 +2119,7 @@ class Test
   IL_00e6:  ldc.i4.4
   IL_00e7:  newarr     ""ulong""
   IL_00ec:  dup
-  IL_00ed:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C40518""
+  IL_00ed:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051""
   IL_00f2:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_00f7:  dup
   IL_00f8:  stsfld     ""ulong[] <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051_A15""
@@ -1820,7 +2132,7 @@ class Test
   IL_010d:  ldc.i4.s   16
   IL_010f:  newarr     ""char""
   IL_0114:  dup
-  IL_0115:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C40512""
+  IL_0115:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=32 <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051""
   IL_011a:  call       ""void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_011f:  dup
   IL_0120:  stsfld     ""char[] <PrivateImplementationDetails>.AF9613760F72635FBDB44A5A0A63C39F12AF30F950A6EE5C971BE188E89C4051_A1""
@@ -2227,15 +2539,22 @@ public class Test
 
         [Theory]
         [InlineData("byte", 1)]
+        [InlineData("sbyte", 1)]
         [InlineData("short", 2)]
+        [InlineData("ushort", 2)]
         [InlineData("int", 4)]
+        [InlineData("uint", 4)]
+        [InlineData("float", 4)]
         [InlineData("long", 8)]
+        [InlineData("ulong", 8)]
+        [InlineData("double", 8)]
+        [InlineData("System.DayOfWeek", 4)]
         public void Alignment_FieldsAreAlignedAndPackedAccordingToType(string typeName, int expectedAlignment)
         {
             string csharp = RuntimeHelpersCreateSpan + $@"
 public class Test
 {{
-    public static System.ReadOnlySpan<{typeName}> Data => new {typeName}[] {{ 1, 2, 3 }};
+    public static System.ReadOnlySpan<{typeName}> Data => new[] {{ ({typeName})1, ({typeName})2, ({typeName})3 }};
 }}";
 
             var compilation = CreateCompilation(csharp, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.UnsafeReleaseDll);
@@ -2248,6 +2567,56 @@ public class Test
                 Assert.True(m.Success, $"Expected regex to match in {il}");
                 Assert.True(long.TryParse(m.Groups[1].Value, NumberStyles.HexNumber, null, out long rva), $"Expected {m.Value} to parse as hex long.");
                 Assert.True(rva % expectedAlignment == 0, $"Expected RVA {rva:X8} to be {expectedAlignment}-byte aligned.");
+            });
+        }
+
+        [Theory]
+        [InlineData("byte", 1, false)]
+        [InlineData("byte", 2, false)]
+        [InlineData("byte", 3, true)]
+        [InlineData("byte", 4, false)]
+        [InlineData("byte", 8, false)]
+        [InlineData("byte", 9, true)]
+        [InlineData("sbyte", 1, false)]
+        [InlineData("sbyte", 2, false)]
+        [InlineData("sbyte", 4, false)]
+        [InlineData("short", 1, true)]
+        [InlineData("short", 2, true)]
+        [InlineData("short", 3, true)]
+        [InlineData("short", 4, true)]
+        [InlineData("ushort", 1, true)]
+        [InlineData("ushort", 4, true)]
+        [InlineData("int", 1, true)]
+        [InlineData("int", 2, true)]
+        [InlineData("int", 3, true)]
+        [InlineData("int", 4, true)]
+        [InlineData("uint", 1, true)]
+        [InlineData("uint", 2, true)]
+        [InlineData("System.DayOfWeek", 1, true)]
+        [InlineData("System.DayOfWeek", 2, true)]
+        [InlineData("long", 1, true)]
+        [InlineData("long", 2, true)]
+        public void AlignmentImpactsStaticArrayTypeCreation_BuiltInTypesOnlyUsedForSize1Types(string typeName, int numValues, bool shouldGenerateType)
+        {
+            string values = string.Join(", ", Enumerable.Range(1, numValues).Select(i => $"({typeName}){i}"));
+            string csharp = RuntimeHelpersCreateSpan + $@"
+public class Test
+{{
+    public static System.ReadOnlySpan<{typeName}> Data => new[] {{ {values} }};
+}}";
+
+            var compilation = CreateCompilation(csharp, targetFramework: TargetFramework.NetCoreApp, options: TestOptions.UnsafeReleaseDll);
+            var verifier = CompileAndVerify(compilation, verify: Verification.Skipped);
+            verifier.VerifyTypeIL("<PrivateImplementationDetails>", il =>
+            {
+                if (shouldGenerateType)
+                {
+                    Assert.Contains("__StaticArrayInitTypeSize=", il);
+                }
+                else
+                {
+                    Assert.DoesNotContain("__StaticArrayInitTypeSize=", il);
+                }
             });
         }
     }

--- a/src/Compilers/Core/Portable/CodeGen/ILBuilderEmit.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ILBuilderEmit.cs
@@ -80,13 +80,27 @@ namespace Microsoft.CodeAnalysis.CodeGen
             this.GetCurrentWriter().WriteUInt32((module?.GetSourceDocumentIndexForIL(document) ?? 0xFFFF) | Cci.MetadataWriter.SourceDocumentIndex);
         }
 
-        internal void EmitArrayBlockInitializer(ImmutableArray<byte> data, ushort alignment, SyntaxNode syntaxNode, DiagnosticBag diagnostics)
+        internal void EmitArrayBlockInitializer(ImmutableArray<byte> data, SyntaxNode syntaxNode, DiagnosticBag diagnostics)
         {
+            // Emit the call to RuntimeHelpers.InitializeArray, creating the necessary metadata blob if there isn't
+            // already one for this data.  Note that this specifies an alignment of 1.  This is valid regardless of
+            // the kind of data stored in the array, as it's never accessed directly in the blob; rather, InitializeArray
+            // copies out the data as bytes.  The upside to keeping this as 1 is it means no special alignment is required.
+            // Although the compiler currently always aligns the metadata fields at an 8-byte boundary, the .pack field
+            // is appropriately set to the alignment value, and a rewriter (e.g. illink) may respect that.  If the alignment
+            // value were to be increased to match the actual alignment requirements of the element type, that could cause
+            // such rewritten binaries to regress in size due to the extra padding necessary for aligning.  The downside
+            // to keeping this as 1 is that this data won't unify with any blobs created for spans (RuntimeHelpers.CreateSpan).
+            // Code typically does directly read from the blobs via spans, and as such alignment there is required to be
+            // at least what the element type requires.  That means if the same data/element type is used with an array
+            // and separately with a span, the data will exist duplicated in two different blobs.  If it turns out that's
+            // very common, this can be revised in the future to specify the element type's alignment.
+
             // get helpers
             var initializeArray = module.GetInitArrayHelper();
 
             // map a field to the block (that makes it addressable via a token).
-            var field = module.GetFieldForData(data, alignment, syntaxNode, diagnostics);
+            var field = module.GetFieldForData(data, alignment: 1, syntaxNode, diagnostics);
 
             // emit call to the helper
             EmitOpCode(ILOpCode.Dup);       //array

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitArrayInitializer.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitArrayInitializer.vb
@@ -41,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             If initializationStyle = ArrayInitializerStyle.Element Then
                 Me.EmitElementInitializers(arrayType, initExprs, True)
             Else
-                _builder.EmitArrayBlockInitializer(Me.GetRawData(initExprs), 1, inits.Syntax, _diagnostics) ' alignment == 1 as there's no special need for alignment (.pack) here.
+                _builder.EmitArrayBlockInitializer(Me.GetRawData(initExprs), inits.Syntax, _diagnostics)
 
                 If initializationStyle = ArrayInitializerStyle.Mixed Then
                     EmitElementInitializers(arrayType, initExprs, False)


### PR DESCRIPTION
1. It turns out we can't use the system types (short, int, long) for data fields when there's an alignment requirement, as those types have .pack 1 and thus a rewriter (e.g. illink) might not align fields using those types appropriately.

2. We weren't incorporating the alignment into the name of the ExplicitSizeStruct created, so we could end up with two types both for the same size but for different alignments and with the same name.

3. In looking at the code again, I realized we could simplify it so that EmitArrayBlockInitializer doesn't take an alignment at all, since for array purposes, we always want to use alignment 1.  Because it took an alignment, we were unnecessarily specifying one even for the no-CreateSpan fallback.  This was functionally correct but unnecessary and resulting in a bit more complicated IL, especially once (1) above was fixed.

cc: @jcouv
Contributes to https://github.com/dotnet/runtime/issues/79477