### PR TITLE
Avoid inlining ILanguageClientBroker initialization

### DIFF
--- a/src/EditorFeatures/Core/LanguageServer/AlwaysActiveLanguageClientEventListener.cs
+++ b/src/EditorFeatures/Core/LanguageServer/AlwaysActiveLanguageClientEventListener.cs
@@ -60,8 +60,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient
                 using var token = _asynchronousOperationListener.BeginAsyncOperation(nameof(LoadAsync));
 
                 // Explicitly switch to the bg so that if this causes any expensive work (like mef loads) it 
-                // doesn't block the UI thread.
-                await TaskScheduler.Default;
+                // doesn't block the UI thread. Note, we always yield because sometimes our caller starts
+                // on the threadpool thread but is indirectly blocked on by the UI thread.
+                await TaskScheduler.Default.SwitchTo(alwaysYield: true);
 
                 await _languageClientBroker.Value.LoadAsync(new LanguageClientMetadata(new[]
                 {


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1698422

StartListening is called on thread pool, which causes LanguageClientBroker to be initialized inline without yielding and gets indirectly blocked on by the UI thread via a JTF.Run. Instead, yield so that StartListening continues without blocking on the initialization.

Example call stack (note this is two threads stitched together using the background stacks feature):
```
...
mscorlib.dll!System.Lazy`[System.__Canon].CreateValue
mscorlib.dll!System.Lazy`[System.__Canon].LazyInitValue
microsoft.codeanalysis.editorfeatures.dll!Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient.AlwaysActiveLanguageClientEventListener+d__.MoveNext
?!System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start
microsoft.codeanalysis.editorfeatures.dll!Microsoft.CodeAnalysis.Editor.Implementation.LanguageClient.AlwaysActiveLanguageClientEventListener.LoadAsync
microsoft.codeanalysis.workspaces.dll!Microsoft.CodeAnalysis.Host.DefaultWorkspaceEventListenerServiceFactory+Service.EnsureListeners
microsoft.codeanalysis.workspaces.dll!Microsoft.CodeAnalysis.Workspace.GetEventHandlers[System.__Canon]
microsoft.codeanalysis.workspaces.dll!Microsoft.CodeAnalysis.Workspace.RaiseWorkspaceChangedEventAsync
microsoft.codeanalysis.workspaces.dll!Microsoft.CodeAnalysis.Workspace.OnSolutionAdded
microsoft.visualstudio.languageservices.dll!Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.VisualStudioProjectFactory+<>c__DisplayClass_0.b__
microsoft.visualstudio.languageservices.dll!Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.VisualStudioWorkspaceImpl+d__.MoveNext
microsoft.visualstudio.languageservices.dll!System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Start[Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.VisualStudioWorkspaceImpl+d__]
microsoft.visualstudio.languageservices.dll!Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.VisualStudioWorkspaceImpl.ApplyChangeToWorkspaceAsync
microsoft.visualstudio.languageservices.dll!Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.VisualStudioProjectFactory+d__.MoveNext
mscorlib.dll!System.Threading.ExecutionContext.RunInternal
mscorlib.dll!System.Threading.ExecutionContext.Run
mscorlib.dll!System.Runtime.CompilerServices.AsyncMethodBuilderCore+MoveNextRunner.Run
mscorlib.dll!System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem
mscorlib.dll!System.Threading.ThreadPoolWorkQueue.Dispatch
clr.dll!CallDescrWorkerInternal
clr.dll!CallDescrWorkerWithHandler
clr.dll!MethodDescCallSite::CallTargetWorker
clr.dll!QueueUserWorkItemManagedCallback
clr.dll!ManagedThreadBase_DispatchInner
clr.dll!ManagedThreadBase_DispatchMiddle
clr.dll!ManagedThreadBase_DispatchOuter
clr.dll!ManagedThreadBase_FullTransitionWithAD
clr.dll!ManagedPerAppDomainTPCount::DispatchWorkItem
clr.dll!ThreadpoolMgr::ExecuteWorkRequest
clr.dll!ThreadpoolMgr::WorkerThreadStart
clr.dll!Thread::intermediateThreadProc
kernel32.dll!BaseThreadInitThunk
ntdll.dll!RtlUserThreadStart
PSEUDOFRAME!SynchronousWaitOnABackgroundThread <!---  THREAD TRANSITION
kernelbase.dll!WaitForMultipleObjectsEx
kernelbase.dll!WaitForMultipleObjects
microsoft.visualstudio.threading.dll!DomainBoundILStubClass.IL_STUB_PInvoke
microsoft.visualstudio.threading.dll!Microsoft.VisualStudio.Threading.NoMessagePumpSyncContext.Wait
clr.dll!CallDescrWorkerInternal
clr.dll!CallDescrWorkerWithHandler
clr.dll!MethodDescCallSite::CallTargetWorker
clr.dll!Thread::DoSyncContextWait
clr.dll!Thread::DoAppropriateWaitWorker
clr.dll!Thread::DoAppropriateWait
clr.dll!CLREventBase::WaitEx
clr.dll!Thread::Block
clr.dll!SyncBlock::Wait
clr.dll!ObjectNative::WaitTimeout
mscorlib.dll!System.Threading.ManualResetEventSlim.Wait
mscorlib.dll!System.Threading.Tasks.Task.SpinThenBlockingWait
mscorlib.dll!System.Threading.Tasks.Task.InternalWait
mscorlib.dll!System.Threading.Tasks.Task.Wait
mscorlib.dll!System.Threading.Tasks.Task.Wait
microsoft.visualstudio.threading.dll!Microsoft.VisualStudio.Threading.JoinableTaskFactory.WaitSynchronouslyCore
microsoft.visualstudio.threading.dll!Microsoft.VisualStudio.Threading.JoinableTaskFactory.WaitSynchronously
microsoft.visualstudio.threading.dll!Microsoft.VisualStudio.Threading.JoinableTask.CompleteOnCurrentThread
microsoft.visualstudio.threading.dll!Microsoft.VisualStudio.Threading.JoinableTask`[System.__Canon].CompleteOnCurrentThread
microsoft.visualstudio.languageservices.dll!Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Legacy.AbstractLegacyProject..ctor
microsoft.visualstudio.languageservices.csharp.dll!Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim.CSharpProjectShim..ctor
microsoft.visualstudio.languageservices.csharp.dll!Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService.CSharpLanguageService.BindToProject
microsoft.visualstudio.languageservices.csharp.dll!dynamicClass.IL_STUB_COMtoCLR
clr.dll!COMToCLRDispatchHelper
clr.dll!COMToCLRWorker
clr.dll!GenericComCallStub
csproj.dll!CCSharpBuildMgrSite::BindToHost
csproj.dll!CCSharpBuildCompiler::SetupEmptyCompiler
csproj.dll!CLangProject::PrepareCompiler
csproj.dll!CVsProject::PrepareCompiler
csproj.dll!CLangProject::OnAfterCreateProject
csproj.dll!CVsProject::OnAfterCreateProject
csproj.dll!CPrefetchedProject::FinalizeProject
csproj.dll!CVsProjPackage::FinalizeProject
?!dynamicClass.IL_STUB_CLRtoCOM
```