### PR TITLE
Avoid boxing in BoundDagTest.GetHashCode

### DIFF
--- a/eng/config/BannedSymbols.txt
+++ b/eng/config/BannedSymbols.txt
@@ -50,3 +50,4 @@ M:Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree.Create(Microsoft.Code
 M:Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree.Create(Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode,Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions,System.String,System.Text.Encoding); Use VisualBasicSyntaxTree sublass that takes checksum algorithm
 M:Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree.ParseText(System.String,Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions,System.String,System.Text.Encoding,System.Collections.Immutable.ImmutableDictionary{System.String,Microsoft.CodeAnalysis.ReportDiagnostic},System.Threading.CancellationToken); Use overload with SourceText
 M:Microsoft.CodeAnalysis.Workspaces.Workspace.SetCurrentSolution(Microsoft.CodeAnalysis.Solution); Use SetCurrentSolutionEx instead.
+M:System.Enum.GetHashCode(); Cast to integral type to avoid boxing on .NET Framework

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDagTest.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDagTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override int GetHashCode()
         {
-            return Hash.Combine(Kind.GetHashCode(), Input.GetHashCode());
+            return Hash.Combine(((int)Kind).GetHashCode(), Input.GetHashCode());
         }
 
 #if DEBUG

--- a/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
@@ -755,7 +755,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Hash.Combine(GetHashCodeHelper(),
                    Hash.Combine(this.AllowUnsafe,
                    Hash.Combine(Hash.CombineValues(this.Usings, StringComparer.Ordinal),
-                   Hash.Combine(TopLevelBinderFlags.GetHashCode(), this.NullableContextOptions.GetHashCode()))));
+                   Hash.Combine(((uint)TopLevelBinderFlags).GetHashCode(), ((int)this.NullableContextOptions).GetHashCode()))));
         }
 
         internal override Diagnostic? FilterDiagnostic(Diagnostic diagnostic, CancellationToken cancellationToken)

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerMethodSymbol.cs
@@ -755,7 +755,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal int GetHashCodeNoParameters()
-            => Hash.Combine(ReturnType, Hash.Combine(CallingConvention.GetHashCode(), FunctionPointerTypeSymbol.GetRefKindForHashCode(RefKind).GetHashCode()));
+            => Hash.Combine(ReturnType, Hash.Combine(((int)CallingConvention).GetHashCode(), ((int)FunctionPointerTypeSymbol.GetRefKindForHashCode(RefKind)).GetHashCode()));
 
         internal override CallingConvention CallingConvention { get; }
         internal override bool UseUpdatedEscapeRules { get; }

--- a/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FunctionPointers/FunctionPointerParameterSymbol.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal int MethodHashCode()
-            => Hash.Combine(TypeWithAnnotations.GetHashCode(), FunctionPointerTypeSymbol.GetRefKindForHashCode(RefKind).GetHashCode());
+            => Hash.Combine(TypeWithAnnotations.GetHashCode(), ((int)FunctionPointerTypeSymbol.GetRefKindForHashCode(RefKind)).GetHashCode());
 
         public override ImmutableArray<Location> Locations => ImmutableArray<Location>.Empty;
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;

--- a/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SignatureOnlyParameterSymbol.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     Hash.CombineValues(_type.CustomModifiers),
                     Hash.Combine(
                         _isParams.GetHashCode(),
-                        _refKind.GetHashCode())));
+                        ((int)_refKind).GetHashCode())));
         }
     }
 }

--- a/src/Compilers/Core/Portable/CommandLine/SarifDiagnosticComparer.cs
+++ b/src/Compilers/Core/Portable/CommandLine/SarifDiagnosticComparer.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             return Hash.Combine(obj.Category.GetHashCode(),
-                Hash.Combine(obj.DefaultSeverity.GetHashCode(),
+                Hash.Combine(((int)obj.DefaultSeverity).GetHashCode(),
                 Hash.Combine(obj.Description.GetHashCode(),
                 Hash.Combine(obj.HelpLinkUri.GetHashCode(),
                 Hash.Combine(obj.Id.GetHashCode(),

--- a/src/Compilers/Core/Portable/ConstantValue.cs
+++ b/src/Compilers/Core/Portable/ConstantValue.cs
@@ -875,7 +875,7 @@ namespace Microsoft.CodeAnalysis
 
         public override int GetHashCode()
         {
-            return this.Discriminator.GetHashCode();
+            return ((int)this.Discriminator).GetHashCode();
         }
 
         public override bool Equals(object? obj)

--- a/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/DiagnosticDescriptor.cs
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis
         public override int GetHashCode()
         {
             return Hash.Combine(this.Category.GetHashCode(),
-                Hash.Combine(this.DefaultSeverity.GetHashCode(),
+                Hash.Combine(((int)this.DefaultSeverity).GetHashCode(),
                 Hash.Combine(this.Description.GetHashCode(),
                 Hash.Combine(this.HelpLinkUri.GetHashCode(),
                 Hash.Combine(this.Id.GetHashCode(),

--- a/src/Compilers/Core/Portable/MetadataReference/MetadataReferenceProperties.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/MetadataReferenceProperties.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis
 
         public override int GetHashCode()
         {
-            return Hash.Combine(Hash.CombineValues(Aliases), Hash.Combine(_embedInteropTypes, Hash.Combine(HasRecursiveAliases, _kind.GetHashCode())));
+            return Hash.Combine(Hash.CombineValues(Aliases), Hash.Combine(_embedInteropTypes, Hash.Combine(HasRecursiveAliases, ((int)_kind).GetHashCode())));
         }
 
         public static bool operator ==(MetadataReferenceProperties left, MetadataReferenceProperties right)

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeUsageInfo.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeUsageInfo.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis
 
         public override int GetHashCode()
         {
-            return _flags.GetHashCode();
+            return ((int)_flags).GetHashCode();
         }
 
         internal bool HasValidAttributeTargets

--- a/src/Compilers/Core/Portable/Symbols/NullabilityInfo.cs
+++ b/src/Compilers/Core/Portable/Symbols/NullabilityInfo.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis
             other is NullabilityInfo info && Equals(info);
 
         public override int GetHashCode() =>
-            Hash.Combine(Annotation.GetHashCode(), FlowState.GetHashCode());
+            Hash.Combine(((int)Annotation).GetHashCode(), ((int)FlowState).GetHashCode());
 
         public bool Equals(NullabilityInfo other) =>
             Annotation == other.Annotation &&

--- a/src/Compilers/Core/Portable/Text/SourceTextComparer.cs
+++ b/src/Compilers/Core/Portable/Text/SourceTextComparer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Text
 
             return Hash.Combine(obj.Length,
                 Hash.Combine(contentsHash,
-                Hash.Combine(encodingHash, obj.ChecksumAlgorithm.GetHashCode())));
+                Hash.Combine(encodingHash, ((int)obj.ChecksumAlgorithm).GetHashCode())));
         }
     }
 }

--- a/src/Compilers/Test/Core/Diagnostics/DiagnosticDescription.cs
+++ b/src/Compilers/Test/Core/Diagnostics/DiagnosticDescription.cs
@@ -355,9 +355,9 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             if (_startPosition != null)
                 hashCode = Hash.Combine(hashCode, _startPosition.Value.GetHashCode());
             if (_defaultSeverityOpt != null)
-                hashCode = Hash.Combine(hashCode, _defaultSeverityOpt.Value.GetHashCode());
+                hashCode = Hash.Combine(hashCode, ((int)_defaultSeverityOpt.Value).GetHashCode());
             if (_effectiveSeverityOpt != null)
-                hashCode = Hash.Combine(hashCode, _effectiveSeverityOpt.Value.GetHashCode());
+                hashCode = Hash.Combine(hashCode, ((int)_effectiveSeverityOpt.Value).GetHashCode());
             return hashCode;
         }
 

--- a/src/VisualStudio/Core/Def/TableDataSource/DiagnosticTableItem.cs
+++ b/src/VisualStudio/Core/Def/TableDataSource/DiagnosticTableItem.cs
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 return
                     Hash.Combine(location.UnmappedFileSpan.GetHashCode(),
                     Hash.Combine(data.IsSuppressed,
-                    Hash.Combine(data.Id, data.Severity.GetHashCode())));
+                    Hash.Combine(data.Id, ((int)data.Severity).GetHashCode())));
             }
 
             public bool Equals(DiagnosticTableItem left, DiagnosticTableItem right)

--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelEvent.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelEvent.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         }
 
         public override int GetHashCode()
-            => Hash.Combine(Node, Hash.Combine(ParentNode, Type.GetHashCode()));
+            => Hash.Combine(Node, Hash.Combine(ParentNode, ((int)Type).GetHashCode()));
 
         public override bool Equals(object obj)
             => Equals(obj as CodeModelEvent);

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/RelatedLocation.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/RelatedLocation.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
         {
             var hashCode = 928418920;
             hashCode = hashCode * -1521134295 + ConflictCheckSpan.GetHashCode();
-            hashCode = hashCode * -1521134295 + Type.GetHashCode();
+            hashCode = hashCode * -1521134295 + ((int)Type).GetHashCode();
             hashCode = hashCode * -1521134295 + IsReference.GetHashCode();
             hashCode = hashCode * -1521134295 + EqualityComparer<DocumentId>.Default.GetHashCode(DocumentId);
             hashCode = hashCode * -1521134295 + ComplexifiedTargetSpan.GetHashCode();

--- a/src/Workspaces/Core/Portable/Workspace/Solution/LoadTextOptions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/LoadTextOptions.cs
@@ -31,7 +31,7 @@ public readonly struct LoadTextOptions : IEquatable<LoadTextOptions>
         => !(left == right);
 
     public override int GetHashCode()
-        => ChecksumAlgorithm.GetHashCode();
+        => ((int)ChecksumAlgorithm).GetHashCode();
 
     public override string ToString()
         => $"{{ {nameof(ChecksumAlgorithm)}: {ChecksumAlgorithm} }}";

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SymbolUsageInfo.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SymbolUsageInfo.cs
@@ -68,6 +68,6 @@ namespace Microsoft.CodeAnalysis
         }
 
         public override int GetHashCode()
-            => Hash.Combine(ValueUsageInfoOpt?.GetHashCode() ?? 0, TypeOrNamespaceUsageInfoOpt?.GetHashCode() ?? 0);
+            => Hash.Combine(((int?)ValueUsageInfoOpt)?.GetHashCode() ?? 0, ((int?)TypeOrNamespaceUsageInfoOpt)?.GetHashCode() ?? 0);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.GetHashCodeVisitor.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/SymbolEquivalenceComparer.GetHashCodeVisitor.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             }
 
             private int GetNullableAnnotationsHashCode(ITypeSymbol type)
-                => _symbolEquivalenceComparer._ignoreNullableAnnotations ? 0 : type.NullableAnnotation.GetHashCode();
+                => _symbolEquivalenceComparer._ignoreNullableAnnotations ? 0 : ((int)type.NullableAnnotation).GetHashCode();
 
             private int GetHashCodeWorker(ISymbol x, int currentHash)
                 => x.Kind switch


### PR DESCRIPTION
Fixes 28% (9+ GB) of the allocations observed in #65937