### PR TITLE
Simplify how semantic-tokens works with text tokens

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/QuickInfo/IntellisenseQuickInfoBuilder.cs
+++ b/src/EditorFeatures/Core/IntelliSense/QuickInfo/IntellisenseQuickInfoBuilder.cs
@@ -107,7 +107,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
                 var spanSeparatorNeededBefore = false;
                 foreach (var span in quickInfoItem.RelatedSpans)
                 {
-                    var classifiedSpans = await ClassifierHelper.GetClassifiedSpansAsync(document, span, context.ClassificationOptions, cancellationToken).ConfigureAwait(false);
+                    // We don't present additive-spans (like static/reassigned-variable) any differently, so strip them
+                    // out of the classifications we get back.
+                    var classifiedSpans = await ClassifierHelper.GetClassifiedSpansAsync(
+                        document, span, context.ClassificationOptions, includeAdditiveSpans: false, cancellationToken).ConfigureAwait(false);
 
                     var tabSize = document.Project.Solution.Options.GetOption(FormattingOptions.TabSize, document.Project.Language);
                     var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
+++ b/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
                 Dim text = Await document.GetTextAsync()
 
                 Dim spans = Await ClassifierHelper.GetClassifiedSpansAsync(
-                    document, New TextSpan(0, text.Length), ClassificationOptions.Default, CancellationToken.None)
+                    document, New TextSpan(0, text.Length), ClassificationOptions.Default, includeAdditiveSpans:=False, CancellationToken.None)
 
                 Assert.Equal(
 "(text, '<spaces>', [0..26))
@@ -105,7 +105,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
                 Dim text = Await document.GetTextAsync()
 
                 Dim spans = Await ClassifierHelper.GetClassifiedSpansAsync(
-                    document, New TextSpan(0, text.Length), ClassificationOptions.Default, CancellationToken.None)
+                    document, New TextSpan(0, text.Length), ClassificationOptions.Default, includeAdditiveSpans:=False, CancellationToken.None)
 
                 Assert.Equal(
 "(text, '<spaces>', [0..26))

--- a/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpanFactory.cs
+++ b/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpanFactory.cs
@@ -78,12 +78,12 @@ namespace Microsoft.CodeAnalysis.Classification
         private static async Task<ImmutableArray<ClassifiedSpan>> GetClassifiedSpansAsync(
             Document document, TextSpan narrowSpan, TextSpan widenedSpan, ClassificationOptions options, CancellationToken cancellationToken)
         {
+            // We don't present things like static/assigned variables differently.  So pass `includeAdditiveSpans:
+            // false` as we don't need that data.
             var result = await ClassifierHelper.GetClassifiedSpansAsync(
-                document, widenedSpan, options, cancellationToken).ConfigureAwait(false);
+                document, widenedSpan, options, includeAdditiveSpans: false, cancellationToken).ConfigureAwait(false);
             if (!result.IsDefault)
-            {
                 return result;
-            }
 
             // For languages that don't expose a classification service, we show the entire
             // item as plain text. Break the text into three spans so that we can properly

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -121,10 +121,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                 // `fillInClassifiedSpanGaps` includes whitespace in the results, which we don't care about in LSP.
                 // Therefore, we set both optional parameters to false.
                 var spans = await ClassifierHelper.GetClassifiedSpansAsync(
-                    document, textSpan, options, cancellationToken, removeAdditiveSpans: false, fillInClassifiedSpanGaps: false).ConfigureAwait(false);
+                    document, textSpan, options, cancellationToken, removeAdditiveSpans: false).ConfigureAwait(false);
 
-                // The spans returned to us may include some empty spans, which we don't care about.
-                var nonEmptySpans = spans.Where(s => !s.TextSpan.IsEmpty);
+                // The spans returned to us may include some empty spans, which we don't care about. We also don't care
+                // about the 'text' classification.  It's added for everything between real classifications (including
+                // whitespace), and just means 'don't classify this'.  No need for us to actually include that in
+                // semantic tokens as it just wastes space in the result.
+                var nonEmptySpans = spans.Where(s => !s.TextSpan.IsEmpty && s.ClassificationType != ClassificationTypeNames.Text);
                 classifiedSpans.AddRange(nonEmptySpans);
             }
             else

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -117,11 +117,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             // casing: https://github.com/dotnet/razor-tooling/issues/5850
             if (includeSyntacticClassifications)
             {
-                // `removeAdditiveSpans` will remove token modifiers such as 'static', which we want to include in LSP.
-                // `fillInClassifiedSpanGaps` includes whitespace in the results, which we don't care about in LSP.
-                // Therefore, we set both optional parameters to false.
+                // `includeAdditiveSpans` will add token modifiers such as 'static', which we want to include in LSP.
                 var spans = await ClassifierHelper.GetClassifiedSpansAsync(
-                    document, textSpan, options, cancellationToken, removeAdditiveSpans: false).ConfigureAwait(false);
+                    document, textSpan, options, includeAdditiveSpans: true, cancellationToken).ConfigureAwait(false);
 
                 // The spans returned to us may include some empty spans, which we don't care about. We also don't care
                 // about the 'text' classification.  It's added for everything between real classifications (including

--- a/src/VisualStudio/Core/Def/Venus/ContainedDocument.DocumentServiceProvider.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedDocument.DocumentServiceProvider.cs
@@ -194,10 +194,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                             continue;
                         }
 
-                        // we don't have guarantee that pirmary snapshot is from same snapshot as roslyn snapshot. make sure
-                        // we map it to right snapshot
+                        // we don't have guarantee that primary snapshot is from same snapshot as roslyn snapshot. make
+                        // sure we map it to right snapshot
                         var fixedUpSpan = roslynSpan.TranslateTo(roslynSnapshot, SpanTrackingMode.EdgeExclusive);
-                        var classifiedSpans = await ClassifierHelper.GetClassifiedSpansAsync(document, fixedUpSpan.Span.ToTextSpan(), options, cancellationToken).ConfigureAwait(false);
+                        var classifiedSpans = await ClassifierHelper.GetClassifiedSpansAsync(
+                            document, fixedUpSpan.Span.ToTextSpan(), options, includeAdditiveSpans: false, cancellationToken).ConfigureAwait(false);
                         if (classifiedSpans.IsDefault)
                         {
                             continue;

--- a/src/VisualStudio/Core/Def/Venus/ContainedDocument.DocumentServiceProvider.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedDocument.DocumentServiceProvider.cs
@@ -228,6 +228,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                     // the EditorClassifier call above fills all the gaps for the span it is called with, but we are combining
                     // multiple spans with html code, so we need to fill those gaps
                     using var _2 = ArrayBuilder<ClassifiedSpan>.GetInstance(out var builder);
+
+
                     ClassifierHelper.FillInClassifiedSpanGaps(startPositionOnContentSpan, list, builder);
 
                     // add html after roslyn content if there is any

--- a/src/Workspaces/Core/Portable/Classification/ClassifierHelper.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassifierHelper.cs
@@ -27,8 +27,7 @@ namespace Microsoft.CodeAnalysis.Classification
             TextSpan span,
             ClassificationOptions options,
             CancellationToken cancellationToken,
-            bool removeAdditiveSpans = true,
-            bool fillInClassifiedSpanGaps = true)
+            bool removeAdditiveSpans = true)
         {
             var classificationService = document.GetLanguageService<IClassificationService>();
             if (classificationService == null)
@@ -65,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Classification
                 RemoveAdditiveSpans(semanticSpans);
             }
 
-            var classifiedSpans = MergeClassifiedSpans(syntaxSpans, semanticSpans, span, fillInClassifiedSpanGaps);
+            var classifiedSpans = MergeClassifiedSpans(syntaxSpans, semanticSpans, span);
             return classifiedSpans;
         }
 
@@ -82,8 +81,7 @@ namespace Microsoft.CodeAnalysis.Classification
         private static ImmutableArray<ClassifiedSpan> MergeClassifiedSpans(
             ArrayBuilder<ClassifiedSpan> syntaxSpans,
             ArrayBuilder<ClassifiedSpan> semanticSpans,
-            TextSpan widenedSpan,
-            bool fillInClassifiedSpanGaps)
+            TextSpan widenedSpan)
         {
             // The spans produced by the language services may not be ordered
             // (indeed, this happens with semantic classification as different
@@ -111,13 +109,8 @@ namespace Microsoft.CodeAnalysis.Classification
             MergeParts(syntaxSpans, semanticSpans, mergedSpans);
             Order(mergedSpans);
 
-            if (!fillInClassifiedSpanGaps)
-                return mergedSpans.ToImmutable();
-
-            // The classification service will only produce classifications for
-            // things it knows about.  i.e. there will be gaps in what it produces.
-            // Fill in those gaps so we have *all* parts of the span 
-            // classified properly.
+            // The classification service will only produce classifications for things it knows about.  i.e. there will
+            // be gaps in what it produces. Fill in those gaps so we have *all* parts of the span classified properly.
             using var _2 = ArrayBuilder<ClassifiedSpan>.GetInstance(out var filledInSpans);
             FillInClassifiedSpanGaps(widenedSpan.Start, mergedSpans, filledInSpans);
             return filledInSpans.ToImmutable();

--- a/src/Workspaces/Core/Portable/Classification/ClassifierHelper.cs
+++ b/src/Workspaces/Core/Portable/Classification/ClassifierHelper.cs
@@ -17,23 +17,23 @@ namespace Microsoft.CodeAnalysis.Classification
     internal static partial class ClassifierHelper
     {
         /// <summary>
-        /// Classifies the provided <paramref name="span"/> in the given <paramref name="document"/>.
-        /// This will do this using an appropriate <see cref="IClassificationService"/>
-        /// if that can be found.  <see cref="ImmutableArray{T}.IsDefault"/> will be returned if this
-        /// fails.
+        /// Classifies the provided <paramref name="span"/> in the given <paramref name="document"/>. This will do this
+        /// using an appropriate <see cref="IClassificationService"/> if that can be found.  <see
+        /// cref="ImmutableArray{T}.IsDefault"/> will be returned if this fails.
         /// </summary>
+        /// <param name="includeAdditiveSpans">Whether or not 'additive' classification spans are included in the
+        /// results or not.  'Additive' spans are things like 'this variable is static' or 'this variable is
+        /// overwritten'.  i.e. they add additional information to a previous classification.</param>
         public static async Task<ImmutableArray<ClassifiedSpan>> GetClassifiedSpansAsync(
             Document document,
             TextSpan span,
             ClassificationOptions options,
-            CancellationToken cancellationToken,
-            bool removeAdditiveSpans = true)
+            bool includeAdditiveSpans,
+            CancellationToken cancellationToken)
         {
             var classificationService = document.GetLanguageService<IClassificationService>();
             if (classificationService == null)
-            {
                 return default;
-            }
 
             // Call out to the individual language to classify the chunk of text around the
             // reference. We'll get both the syntactic and semantic spans for this region.
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Classification
             // remove additive ClassifiedSpans until we have support for additive classifications
             // in classified spans. https://github.com/dotnet/roslyn/issues/32770
             // The exception to this is LSP, which expects the additive spans.
-            if (removeAdditiveSpans)
+            if (!includeAdditiveSpans)
             {
                 RemoveAdditiveSpans(syntaxSpans);
                 RemoveAdditiveSpans(semanticSpans);


### PR DESCRIPTION
Instead of baking special behavior into the helper, have the caller be responsible.