### PR TITLE
Use newer msbuild versions

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,9 +7,9 @@
   "tools": {
     "dotnet": "7.0.100",
     "vs": {
-      "version": "17.2"
+      "version": "17.4.1"
     },
-    "xcopy-msbuild": "17.2.1"
+    "xcopy-msbuild": "17.4.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.22524.5",


### PR DESCRIPTION
Signed build failing after .net7 upgrade

https://dnceng.visualstudio.com/internal/_build/results?buildId=2065801&view=logs&j=b11b921d-8982-5bb3-754b-b114d42fd804&t=cdcedd1f-8008-523f-9da1-cc35fbfef9a3&l=33