### PR TITLE
Breaking change: Disallow raw-string-literal interpolations at start of line when indentation-whitespace is present.

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -1,5 +1,31 @@
 # This document lists known breaking changes in Roslyn after .NET 6 all the way to .NET 7.
 
+## Raw string interpolations at start of line.
+
+***Introduced in Visual Studio 2022 version 17.5***
+
+In .NET SDK XXX or earlier the following was erroneously allowed:
+
+```csharp
+var x = $"""
+    Hello
+{1 + 1}
+    World
+    """;
+```
+
+This violated the rule that the lines content (including where an interpolation starts) must start with same whitespace as the final `    """;` line.  It is now required that the above be written as:
+
+
+```csharp
+var x = $"""
+    Hello
+    {1 + 1}
+    World
+    """;
+```
+
+
 ## Inferred delegate type for methods includes default parameter values and `params` modifier
 
 ***Introduced in Visual Studio 2022 version 17.5***

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_InterpolatedString.cs
@@ -268,10 +268,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             // Note: We don't need to check
             //
             //      var x = """
-            //   {1 + 1}
+            // <space>{1 + 1}
             //          """
             //
-            // As initial whitespace in text will already be checked in makeContent.  This is only for the case where
+            // as initial whitespace in text will already be checked in makeContent.  This is only for the case where
             // the interpolation is at the start of a line.
 
             SyntaxDiagnosticInfo? getInterpolationIndentationError(

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -4617,23 +4617,6 @@ namespace System
             }
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/16451")]
-        public void RecursiveParameterDefault()
-        {
-            var text = @"
-class C
-{
-    public static void Main(int arg)
-    {
-        int Local(int x = Local()) => 2;
-    }
-}
-";
-            var compilation = CreateCompilationWithMscorlib45(text);
-            compilation.VerifyDiagnostics(
-                );
-        }
-
         [Fact]
         [WorkItem(16757, "https://github.com/dotnet/roslyn/issues/16757")]
         public void LocalFunctionParameterDefaultUsingConst()

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RawInterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RawInterpolationTests.cs
@@ -315,6 +315,58 @@ class Program
                             """""" );
     }
 }";
+        CreateCompilation(source).VerifyDiagnostics(
+            // (12,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(12, 1));
+    }
+
+    [Fact]
+    public void TwoInserts02_A()
+    {
+        string source =
+@"using System;
+class Program
+{
+    static void Main(string[] args)
+    {
+        var hello = ""Hello"";
+        var world = ""world"";
+        Console.WriteLine( $""""""
+                            {
+                                    hello
+                            },
+  {
+                            world }.
+                            """""" );
+    }
+}";
+        CreateCompilation(source).VerifyDiagnostics(
+            // (12,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            //   {
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "  ").WithLocation(12, 1));
+    }
+
+    [Fact]
+    public void TwoInserts02_B()
+    {
+        string source =
+@"using System;
+class Program
+{
+    static void Main(string[] args)
+    {
+        var hello = ""Hello"";
+        var world = ""world"";
+        Console.WriteLine( $""""""
+                            {
+                                    hello
+                            },
+                            {
+                            world }.
+                            """""" );
+    }
+}";
         string expectedOutput = @"Hello,
 world.";
         CompileAndVerify(source, expectedOutput: expectedOutput);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RawInterpolatedStringLiteralCompilingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RawInterpolatedStringLiteralCompilingTests.cs
@@ -1245,6 +1245,23 @@ System.Console.Write(
     """""");",
                 // (5,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal
                 //   {42}
+                Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(5, 1));
+    }
+
+    [Fact]
+    public void MultiLineCase34_A()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+    a
+{42}
+    b
+    {43}
+    c
+    """""");",
+                // (5,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal
+                //   {42}
                 Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "  ").WithLocation(5, 1));
     }
 
@@ -1280,6 +1297,23 @@ System.Console.Write(
                 // (7,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal
                 //   {43}
                 Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "  ").WithLocation(7, 1));
+    }
+
+    [Fact]
+    public void MultiLineCase36_A()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+    a
+    {42}
+    b
+{43}
+    c
+    """""");",
+                // (7,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal
+                //   {43}
+                Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(7, 1));
     }
 
     [Fact]
@@ -1336,6 +1370,24 @@ System.Console.Write(
     }
 
     [Fact]
+    public void MultiLineCase39_A()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+    a
+    {42}
+{42}
+    b
+    {43}
+    c
+    """""");",
+                // (6,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal
+                //   {42}
+                Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(6, 1));
+    }
+
+    [Fact]
     public void MultiLineCase40()
     {
         RenderAndVerify(@"
@@ -1369,6 +1421,24 @@ System.Console.Write(
                 // (8,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal
                 //   {43}
                 Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "  ").WithLocation(8, 1));
+    }
+
+    [Fact]
+    public void MultiLineCase41_A()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+    a
+    {42}
+    b
+    {43}
+{43}
+    c
+    """""");",
+                // (8,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal
+                //   {43}
+                Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(8, 1));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RawInterpolatedStringLiteralCompilingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RawInterpolatedStringLiteralCompilingTests.cs
@@ -1266,6 +1266,23 @@ System.Console.Write(
     }
 
     [Fact]
+    public void MultiLineCase34_B()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $$""""""
+    a
+{{42}}
+    b
+    {43}
+    c
+    """""");",
+                // (5,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal
+                //   {42}
+                Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(5, 1));
+    }
+
+    [Fact]
     public void MultiLineCase35()
     {
         RenderAndVerify(@"

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/RawInterpolatedStringLiteralCompilingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/RawInterpolatedStringLiteralCompilingTests.cs
@@ -1245,7 +1245,7 @@ System.Console.Write(
     """""");",
                 // (5,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal
                 //   {42}
-                Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(5, 1));
+                Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "  ").WithLocation(5, 1));
     }
 
     [Fact]
@@ -1262,7 +1262,7 @@ System.Console.Write(
     """""");",
                 // (5,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal
                 //   {42}
-                Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "  ").WithLocation(5, 1));
+                Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(5, 1));
     }
 
     [Fact]
@@ -1845,6 +1845,267 @@ System.Console.Write(
 ␠␠␠␠␠
     """""");", expectedOutput: @"a
 ␠");
+    }
+
+    [Fact]
+    public void MultiLineCase67()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+{1+1}
+"""""");", expectedOutput: @"2");
+    }
+
+    [Fact]
+    public void MultiLineCase68()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+  {1+1}
+"""""");", expectedOutput: @"  2");
+    }
+
+    [Fact]
+    public void MultiLineCase69()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+  {1+1}  
+"""""");", expectedOutput: @"  2  ");
+    }
+
+    [Fact]
+    public void MultiLineCase70()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+{1+1}  
+"""""");", expectedOutput: @"2  ");
+    }
+
+    [Fact]
+    public void MultiLineCase71()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+{1+1}
+    """""");",
+            // (4,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(4, 1));
+    }
+
+    [Fact]
+    public void MultiLineCase72()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+    a
+{1+1}
+    """""");",
+            // (5,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(5, 1));
+    }
+
+    [Fact]
+    public void MultiLineCase73()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+    a
+    b
+{1+1}
+    """""");",
+            // (6,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(6, 1));
+    }
+
+    [Fact]
+    public void MultiLineCase74()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+    a
+{1+1}
+    b
+    """""");",
+            // (5,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(5, 1));
+    }
+
+    [Fact]
+    public void MultiLineCase75()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+{1+1}
+    a
+    b
+    """""");",
+            // (4,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(4, 1));
+    }
+
+    [Fact]
+    public void MultiLineCase76()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+{1+1}
+    a
+  {1+1}
+    b
+    """""");",
+            // (4,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(4, 1),
+            // (6,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            //   {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "  ").WithLocation(6, 1));
+    }
+
+    [Fact]
+    public void MultiLineCase77()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+{1+1}
+    a
+    b
+  {1+1}
+    """""");",
+            // (4,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(4, 1),
+            // (7,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            //   {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "  ").WithLocation(7, 1));
+    }
+
+    [Fact]
+    public void MultiLineCase78()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+    a
+{1+1}
+    b
+  {1+1}
+    """""");",
+            // (5,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(5, 1),
+            // (7,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            //   {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "  ").WithLocation(7, 1));
+    }
+
+    [Fact]
+    public void MultiLineCase79()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+    a
+    b
+{1+1}
+  {1+1}
+    """""");",
+            // (6,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(6, 1),
+            // (7,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            //   {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "  ").WithLocation(7, 1));
+    }
+
+    [Fact]
+    public void MultiLineCase80()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+{1+1}
+    a
+    b
+{1+1}
+  {1+1}
+    """""");",
+            // (4,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(4, 1),
+            // (7,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(7, 1),
+            // (8,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            //   {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "  ").WithLocation(8, 1));
+    }
+
+    [Fact]
+    public void MultiLineCase81()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+    a
+{1+1}
+    b
+{1+1}
+  {1+1}
+    """""");",
+            // (5,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(5, 1),
+            // (7,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(7, 1),
+            // (8,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            //   {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "  ").WithLocation(8, 1));
+    }
+
+    [Fact]
+    public void MultiLineCase82()
+    {
+        RenderAndVerify(@"
+System.Console.Write(
+    $""""""
+  {1+1}
+    a
+{1+1}
+    b
+{1+1}
+  {1+1}
+    """""");",
+            // (4,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            //   {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "  ").WithLocation(4, 1),
+            // (6,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(6, 1),
+            // (8,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            // {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "{").WithLocation(8, 1),
+            // (9,1): error CS8999: Line does not start with the same whitespace as the closing line of the raw string literal.
+            //   {1+1}
+            Diagnostic(ErrorCode.ERR_LineDoesNotStartWithSameWhitespace, "  ").WithLocation(9, 1));
     }
 
     [Fact]


### PR DESCRIPTION
Dependent on the decision from LDM if we will take this break or not.

Previously, the following was erroneously allowed:

```csharp
var x = $"""
    Hello
{1 + 1}
    World
    """;
```

This violated the rule that the lines content (including where an interpolation starts) must start with same whitespace as the final `    """;` line.  It is now required that the above be written as:


```csharp
var x = $"""
    Hello
    {1 + 1}
    World
    """;
```

[Sharplab](https://sharplab.io/#v2:C4LgTgrgdgPgAgJgIwFgBQcDMACR2DC2A3utmbkgGy4As2AsgIYCWUAFAJTGnm8BujMNj7YAvNgAkAIhk9e87ADMA9srkLyRbEmwBqbdgC+6jdgBGgkxplSA3FdNkHFAJxs+He2l7G0hoA==)