### PR TITLE
Move some of `Roslyn.Utilities` using statements into namespace block

### DIFF
--- a/src/Compilers/Core/Portable/CodeGen/ItemTokenMap.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ItemTokenMap.cs
@@ -5,11 +5,10 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeGen
 {
-    using Roslyn.Utilities;
-
     /// <summary>
     /// Handles storage of items referenced via tokens in metadata. When items are stored 
     /// they are uniquely "associated" with fake tokens, which are basically sequential numbers.
@@ -19,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
     /// </summary>
     internal sealed class ItemTokenMap<T> where T : class
     {
-        private readonly ConcurrentDictionary<T, uint> _itemToToken = new ConcurrentDictionary<T, uint>(ReferenceEqualityComparer.Instance);
+        private readonly ConcurrentDictionary<T, uint> _itemToToken = new ConcurrentDictionary<T, uint>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
         private readonly ArrayBuilder<T> _items = new ArrayBuilder<T>();
 
         public uint GetOrAddTokenFor(T item)

--- a/src/Compilers/Core/Portable/CodeGen/ItemTokenMap.cs
+++ b/src/Compilers/Core/Portable/CodeGen/ItemTokenMap.cs
@@ -5,10 +5,11 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeGen
 {
+    using Roslyn.Utilities;
+
     /// <summary>
     /// Handles storage of items referenced via tokens in metadata. When items are stored 
     /// they are uniquely "associated" with fake tokens, which are basically sequential numbers.

--- a/src/Compilers/Core/Portable/CodeGen/LocalSlotManager.cs
+++ b/src/Compilers/Core/Portable/CodeGen/LocalSlotManager.cs
@@ -10,10 +10,11 @@ using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeGen
 {
+    using Roslyn.Utilities;
+
     /// <summary>
     /// At this level there are two kinds of local variables:
     /// <list type="bullet">

--- a/src/Compilers/Core/Portable/CodeGen/LocalSlotManager.cs
+++ b/src/Compilers/Core/Portable/CodeGen/LocalSlotManager.cs
@@ -10,11 +10,10 @@ using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeGen
 {
-    using Roslyn.Utilities;
-
     /// <summary>
     /// At this level there are two kinds of local variables:
     /// <list type="bullet">
@@ -94,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
                 var map = _localMap;
                 if (map == null)
                 {
-                    map = new Dictionary<ILocalSymbolInternal, LocalDefinition>(ReferenceEqualityComparer.Instance);
+                    map = new Dictionary<ILocalSymbolInternal, LocalDefinition>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
                     _localMap = map;
                 }
 

--- a/src/Compilers/Core/Portable/Collections/IOrderedReadOnlySet.cs
+++ b/src/Compilers/Core/Portable/Collections/IOrderedReadOnlySet.cs
@@ -3,10 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Collections
 {
+    using Roslyn.Utilities;
+
     internal interface IOrderedReadOnlySet<T> : IReadOnlySet<T>, IReadOnlyList<T>
     {
     }

--- a/src/Compilers/Core/Portable/Collections/IOrderedReadOnlySet.cs
+++ b/src/Compilers/Core/Portable/Collections/IOrderedReadOnlySet.cs
@@ -3,12 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Collections
 {
-    using Roslyn.Utilities;
-
-    internal interface IOrderedReadOnlySet<T> : IReadOnlySet<T>, IReadOnlyList<T>
+    internal interface IOrderedReadOnlySet<T> : Roslyn.Utilities.IReadOnlySet<T>, IReadOnlyList<T>
     {
     }
 }

--- a/src/Compilers/Core/Portable/Collections/OrderedSet.cs
+++ b/src/Compilers/Core/Portable/Collections/OrderedSet.cs
@@ -6,10 +6,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Collections
 {
+    using Roslyn.Utilities;
+
     internal sealed class OrderedSet<T> : IEnumerable<T>, IReadOnlySet<T>, IReadOnlyList<T>, IOrderedReadOnlySet<T>
     {
         private readonly HashSet<T> _set;

--- a/src/Compilers/Core/Portable/Collections/OrderedSet.cs
+++ b/src/Compilers/Core/Portable/Collections/OrderedSet.cs
@@ -6,12 +6,11 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Collections
 {
-    using Roslyn.Utilities;
-
-    internal sealed class OrderedSet<T> : IEnumerable<T>, IReadOnlySet<T>, IReadOnlyList<T>, IOrderedReadOnlySet<T>
+    internal sealed class OrderedSet<T> : IEnumerable<T>, Roslyn.Utilities.IReadOnlySet<T>, IReadOnlyList<T>, IOrderedReadOnlySet<T>
     {
         private readonly HashSet<T> _set;
         private readonly ArrayBuilder<T> _list;

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -19,10 +19,11 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
+    using Roslyn.Utilities;
+
     internal readonly struct BuildPaths
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -19,11 +19,10 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
-    using Roslyn.Utilities;
-
     internal readonly struct BuildPaths
     {
         /// <summary>
@@ -82,7 +81,7 @@ namespace Microsoft.CodeAnalysis
         /// The set of source file paths that are in the set of embedded paths.
         /// This is used to prevent reading source files that are embedded twice.
         /// </summary>
-        public IReadOnlySet<string> EmbeddedSourcePaths { get; }
+        public Roslyn.Utilities.IReadOnlySet<string> EmbeddedSourcePaths { get; }
 
         /// <summary>
         /// The <see cref="ICommonCompilerFileSystem"/> used to access the file system inside this instance.
@@ -482,7 +481,7 @@ namespace Microsoft.CodeAnalysis
             OrderedSet<string> embeddedFiles,
             DiagnosticBag diagnostics);
 
-        private static IReadOnlySet<string> GetEmbeddedSourcePaths(CommandLineArguments arguments)
+        private static Roslyn.Utilities.IReadOnlySet<string> GetEmbeddedSourcePaths(CommandLineArguments arguments)
         {
             if (arguments.EmbeddedFiles.IsEmpty)
             {

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -28,10 +28,11 @@ using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
 using Microsoft.DiaSymReader;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
+    using Roslyn.Utilities;
+
     /// <summary>
     /// The compilation object is an immutable representation of a single invocation of the
     /// compiler. Although immutable, a compilation is also on-demand, and will realize and cache

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -28,11 +28,10 @@ using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
 using Microsoft.DiaSymReader;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
-    using Roslyn.Utilities;
-
     /// <summary>
     /// The compilation object is an immutable representation of a single invocation of the
     /// compiler. Although immutable, a compilation is also on-demand, and will realize and cache
@@ -1133,10 +1132,10 @@ namespace Microsoft.CodeAnalysis
         // is that there are maybe a couple dozen analyzers in the solution and each one has
         // ~0-2 unique well-known types, and the chance of hash collision is very low.
         private readonly ConcurrentCache<string, INamedTypeSymbol?> _getTypeCache =
-            new ConcurrentCache<string, INamedTypeSymbol?>(50, ReferenceEqualityComparer.Instance);
+            new ConcurrentCache<string, INamedTypeSymbol?>(50, Roslyn.Utilities.ReferenceEqualityComparer.Instance);
 
         private readonly ConcurrentCache<string, ImmutableArray<INamedTypeSymbol>> _getTypesCache =
-            new ConcurrentCache<string, ImmutableArray<INamedTypeSymbol>>(50, ReferenceEqualityComparer.Instance);
+            new ConcurrentCache<string, ImmutableArray<INamedTypeSymbol>>(50, Roslyn.Utilities.ReferenceEqualityComparer.Instance);
 
         /// <summary>
         /// Gets the type within the compilation's assembly and all referenced assemblies (other than
@@ -1214,7 +1213,7 @@ namespace Microsoft.CodeAnalysis
                 var result = _getTypesCache.TryAdd(fullyQualifiedMetadataName, val);
                 Debug.Assert(result
                     || !_getTypesCache.TryGetValue(fullyQualifiedMetadataName, out var addedArray) // Could fail if the type was already evicted from the cache
-                    || Enumerable.SequenceEqual(addedArray, val, ReferenceEqualityComparer.Instance));
+                    || Enumerable.SequenceEqual(addedArray, val, Roslyn.Utilities.ReferenceEqualityComparer.Instance));
             }
 
             return val;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -16,11 +16,10 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
-    using Roslyn.Utilities;
-
     /// <summary>
     /// Driver to execute diagnostic analyzers for a given compilation.
     /// It uses a <see cref="AsyncQueue{TElement}"/> of <see cref="CompilationEvent"/>s to drive its analysis.
@@ -377,7 +376,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             _severityFilter = severityFilter;
             _hasDiagnosticSuppressors = this.Analyzers.Any(static a => a is DiagnosticSuppressor);
             _programmaticSuppressions = _hasDiagnosticSuppressors ? new ConcurrentSet<Suppression>() : null;
-            _diagnosticsProcessedForProgrammaticSuppressions = _hasDiagnosticSuppressors ? new ConcurrentSet<Diagnostic>(ReferenceEqualityComparer.Instance) : null;
+            _diagnosticsProcessedForProgrammaticSuppressions = _hasDiagnosticSuppressors ? new ConcurrentSet<Diagnostic>(Roslyn.Utilities.ReferenceEqualityComparer.Instance) : null;
             _lazyAnalyzerGateMap = ImmutableSegmentedDictionary<DiagnosticAnalyzer, SemaphoreSlim>.Empty;
         }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -16,10 +16,11 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
+    using Roslyn.Utilities;
+
     /// <summary>
     /// Driver to execute diagnostic analyzers for a given compilation.
     /// It uses a <see cref="AsyncQueue{TElement}"/> of <see cref="CompilationEvent"/>s to drive its analysis.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -139,6 +140,7 @@ namespace Microsoft.CodeAnalysis
         private static void CopyFile(string originalPath, string shadowCopyPath)
         {
             var directory = Path.GetDirectoryName(shadowCopyPath);
+            Debug.Assert(directory != null);
             Directory.CreateDirectory(directory);
 
             File.Copy(originalPath, shadowCopyPath);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis
         private static void CopyFile(string originalPath, string shadowCopyPath)
         {
             var directory = Path.GetDirectoryName(shadowCopyPath);
-            Debug.Assert(directory != null);
+            Debug.Assert(directory is not null);
             Directory.CreateDirectory(directory);
 
             File.Copy(originalPath, shadowCopyPath);

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -17,10 +17,11 @@ using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Emit.NoPia;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Emit
 {
+    using Roslyn.Utilities;
+
     internal abstract class CommonPEModuleBuilder : Cci.IUnit, Cci.IModuleReference
     {
         internal readonly DebugDocumentsBuilder DebugDocumentsBuilder;

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -17,11 +17,10 @@ using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Emit.NoPia;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Emit
 {
-    using Roslyn.Utilities;
-
     internal abstract class CommonPEModuleBuilder : Cci.IUnit, Cci.IModuleReference
     {
         internal readonly DebugDocumentsBuilder DebugDocumentsBuilder;
@@ -68,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Emit
             DebugDocumentsBuilder = new DebugDocumentsBuilder(compilation.Options.SourceReferenceResolver, compilation.IsCaseSensitive);
             OutputKind = outputKind;
             SerializationProperties = serializationProperties;
-            _methodBodyMap = new ConcurrentDictionary<IMethodSymbolInternal, Cci.IMethodBody>(ReferenceEqualityComparer.Instance);
+            _methodBodyMap = new ConcurrentDictionary<IMethodSymbolInternal, Cci.IMethodBody>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
             EmitOptions = emitOptions;
         }
 
@@ -843,7 +842,7 @@ namespace Microsoft.CodeAnalysis.Emit
         }
 
         private readonly ConcurrentDictionary<TNamedTypeSymbol, SynthesizedDefinitions> _synthesizedTypeMembers =
-            new ConcurrentDictionary<TNamedTypeSymbol, SynthesizedDefinitions>(ReferenceEqualityComparer.Instance);
+            new ConcurrentDictionary<TNamedTypeSymbol, SynthesizedDefinitions>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
 
         private ConcurrentDictionary<INamespaceSymbolInternal, ConcurrentQueue<INamespaceOrTypeSymbolInternal>> _lazySynthesizedNamespaceMembers;
 

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -15,10 +15,11 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit.EditAndContinue;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Emit
 {
+    using Roslyn.Utilities;
+
     internal sealed class DeltaMetadataWriter : MetadataWriter
     {
         private readonly EmitBaseline _previousGeneration;

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DeltaMetadataWriter.cs
@@ -15,11 +15,10 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit.EditAndContinue;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Emit
 {
-    using Roslyn.Utilities;
-
     internal sealed class DeltaMetadataWriter : MetadataWriter
     {
         private readonly EmitBaseline _previousGeneration;
@@ -103,8 +102,8 @@ namespace Microsoft.CodeAnalysis.Emit
             var sizes = previousGeneration.TableSizes;
 
             _changedTypeDefs = new List<ITypeDefinition>();
-            _typesUsedByDeletedMembers = new Dictionary<ITypeDefinition, DeletedTypeDefinition>(ReferenceEqualityComparer.Instance);
-            _deletedTypeMembers = new Dictionary<ITypeDefinition, ImmutableDictionary<IMethodDefinition, DeletedMethodDefinition>>(ReferenceEqualityComparer.Instance);
+            _typesUsedByDeletedMembers = new Dictionary<ITypeDefinition, DeletedTypeDefinition>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
+            _deletedTypeMembers = new Dictionary<ITypeDefinition, ImmutableDictionary<IMethodDefinition, DeletedMethodDefinition>>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
             _typeDefs = new DefinitionIndex<ITypeDefinition>(this.TryGetExistingTypeDefIndex, sizes[(int)TableIndex.TypeDef]);
             _eventDefs = new DefinitionIndex<IEventDefinition>(this.TryGetExistingEventDefIndex, sizes[(int)TableIndex.Event]);
             _fieldDefs = new DefinitionIndex<IFieldDefinition>(this.TryGetExistingFieldDefIndex, sizes[(int)TableIndex.Field]);
@@ -121,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Emit
             _customAttributesAdded = new Dictionary<EntityHandle, ImmutableArray<int>>();
 
             _firstParamRowMap = new Dictionary<MethodDefinitionHandle, int>();
-            _existingParameterDefs = new Dictionary<IParameterDefinition, int>(ReferenceEqualityComparer.Instance);
+            _existingParameterDefs = new Dictionary<IParameterDefinition, int>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
 
             _assemblyRefIndex = new HeapOrReferenceIndex<AssemblyIdentity>(this, lastRowId: sizes[(int)TableIndex.AssemblyRef]);
             _moduleRefIndex = new HeapOrReferenceIndex<string>(this, lastRowId: sizes[(int)TableIndex.ModuleRef]);
@@ -545,7 +544,7 @@ namespace Microsoft.CodeAnalysis.Emit
             var deletedMethods = _changes.GetDeletedMethods(typeDef);
             if (deletedMethods.Length > 0)
             {
-                var deletedTypeMembers = ImmutableDictionary.CreateBuilder<IMethodDefinition, DeletedMethodDefinition>(ReferenceEqualityComparer.Instance);
+                var deletedTypeMembers = ImmutableDictionary.CreateBuilder<IMethodDefinition, DeletedMethodDefinition>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
                 foreach (var methodDef in deletedMethods)
                 {
                     var oldMethodDef = (IMethodDefinition)methodDef.GetCciAdapter();
@@ -1435,7 +1434,7 @@ namespace Microsoft.CodeAnalysis.Emit
             private readonly Dictionary<int, T> _map;
 
             public DefinitionIndex(TryGetExistingIndex tryGetExistingIndex, int lastRowId)
-                : base(lastRowId, ReferenceEqualityComparer.Instance)
+                : base(lastRowId, Roslyn.Utilities.ReferenceEqualityComparer.Instance)
             {
                 _tryGetExistingIndex = tryGetExistingIndex;
                 _map = new Dictionary<int, T>();
@@ -1647,7 +1646,7 @@ namespace Microsoft.CodeAnalysis.Emit
         private sealed class GenericParameterIndex : DefinitionIndexBase<IGenericParameter>
         {
             public GenericParameterIndex(int lastRowId)
-                : base(lastRowId, ReferenceEqualityComparer.Instance)
+                : base(lastRowId, Roslyn.Utilities.ReferenceEqualityComparer.Instance)
             {
             }
 

--- a/src/Compilers/Core/Portable/Emit/NoPia/EmbeddedTypesManager.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/EmbeddedTypesManager.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -14,8 +15,6 @@ using Cci = Microsoft.Cci;
 
 namespace Microsoft.CodeAnalysis.Emit.NoPia
 {
-    using Roslyn.Utilities;
-
     internal abstract class CommonEmbeddedTypesManager
     {
         public abstract bool IsFrozen { get; }
@@ -67,11 +66,11 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
     {
         public readonly TPEModuleBuilder ModuleBeingBuilt;
 
-        public readonly ConcurrentDictionary<TNamedTypeSymbol, TEmbeddedType> EmbeddedTypesMap = new ConcurrentDictionary<TNamedTypeSymbol, TEmbeddedType>(ReferenceEqualityComparer.Instance);
-        public readonly ConcurrentDictionary<TFieldSymbol, TEmbeddedField> EmbeddedFieldsMap = new ConcurrentDictionary<TFieldSymbol, TEmbeddedField>(ReferenceEqualityComparer.Instance);
-        public readonly ConcurrentDictionary<TMethodSymbol, TEmbeddedMethod> EmbeddedMethodsMap = new ConcurrentDictionary<TMethodSymbol, TEmbeddedMethod>(ReferenceEqualityComparer.Instance);
-        public readonly ConcurrentDictionary<TPropertySymbol, TEmbeddedProperty> EmbeddedPropertiesMap = new ConcurrentDictionary<TPropertySymbol, TEmbeddedProperty>(ReferenceEqualityComparer.Instance);
-        public readonly ConcurrentDictionary<TEventSymbol, TEmbeddedEvent> EmbeddedEventsMap = new ConcurrentDictionary<TEventSymbol, TEmbeddedEvent>(ReferenceEqualityComparer.Instance);
+        public readonly ConcurrentDictionary<TNamedTypeSymbol, TEmbeddedType> EmbeddedTypesMap = new ConcurrentDictionary<TNamedTypeSymbol, TEmbeddedType>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
+        public readonly ConcurrentDictionary<TFieldSymbol, TEmbeddedField> EmbeddedFieldsMap = new ConcurrentDictionary<TFieldSymbol, TEmbeddedField>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
+        public readonly ConcurrentDictionary<TMethodSymbol, TEmbeddedMethod> EmbeddedMethodsMap = new ConcurrentDictionary<TMethodSymbol, TEmbeddedMethod>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
+        public readonly ConcurrentDictionary<TPropertySymbol, TEmbeddedProperty> EmbeddedPropertiesMap = new ConcurrentDictionary<TPropertySymbol, TEmbeddedProperty>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
+        public readonly ConcurrentDictionary<TEventSymbol, TEmbeddedEvent> EmbeddedEventsMap = new ConcurrentDictionary<TEventSymbol, TEmbeddedEvent>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
 
         private ImmutableArray<TEmbeddedType> _frozen;
 

--- a/src/Compilers/Core/Portable/Emit/NoPia/EmbeddedTypesManager.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/EmbeddedTypesManager.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Roslyn.Utilities;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -15,6 +14,8 @@ using Cci = Microsoft.Cci;
 
 namespace Microsoft.CodeAnalysis.Emit.NoPia
 {
+    using Roslyn.Utilities;
+
     internal abstract class CommonEmbeddedTypesManager
     {
         public abstract bool IsFrozen { get; }

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -18,10 +18,11 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.DiaSymReader;
-using Roslyn.Utilities;
 
 namespace Microsoft.Cci
 {
+    using Roslyn.Utilities;
+
     internal sealed class PdbWriter : IDisposable
     {
         internal const uint Age = 1;

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -18,11 +18,10 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.DiaSymReader;
+using Roslyn.Utilities;
 
 namespace Microsoft.Cci
 {
-    using Roslyn.Utilities;
-
     internal sealed class PdbWriter : IDisposable
     {
         internal const uint Age = 1;
@@ -47,7 +46,7 @@ namespace Microsoft.Cci
             _symWriterFactory = symWriterFactory;
             _hashAlgorithmNameOpt = hashAlgorithmNameOpt;
             _documentIndex = new Dictionary<DebugSourceDocument, int>();
-            _qualifiedNameCache = new Dictionary<object, string>(ReferenceEqualityComparer.Instance);
+            _qualifiedNameCache = new Dictionary<object, string>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
         }
 
         public void WriteTo(Stream stream)

--- a/src/Compilers/Core/Portable/PEWriter/FullMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/FullMetadataWriter.cs
@@ -10,11 +10,12 @@ using System.Reflection.Metadata.Ecma335;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit;
-using Roslyn.Utilities;
 using EmitContext = Microsoft.CodeAnalysis.Emit.EmitContext;
 
 namespace Microsoft.Cci
 {
+    using Roslyn.Utilities;
+
     internal sealed class FullMetadataWriter : MetadataWriter
     {
         private readonly DefinitionIndex<ITypeDefinition> _typeDefs;

--- a/src/Compilers/Core/Portable/PEWriter/FullMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/FullMetadataWriter.cs
@@ -10,12 +10,11 @@ using System.Reflection.Metadata.Ecma335;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit;
+using Roslyn.Utilities;
 using EmitContext = Microsoft.CodeAnalysis.Emit.EmitContext;
 
 namespace Microsoft.Cci
 {
-    using Roslyn.Utilities;
-
     internal sealed class FullMetadataWriter : MetadataWriter
     {
         private readonly DefinitionIndex<ITypeDefinition> _typeDefs;
@@ -99,9 +98,9 @@ namespace Microsoft.Cci
             _parameterDefs = new DefinitionIndex<IParameterDefinition>(numMethods);
             _genericParameters = new DefinitionIndex<IGenericParameter>(0);
 
-            _fieldDefIndex = new Dictionary<ITypeDefinition, int>(numTypeDefsGuess, ReferenceEqualityComparer.Instance);
-            _methodDefIndex = new Dictionary<ITypeDefinition, int>(numTypeDefsGuess, ReferenceEqualityComparer.Instance);
-            _parameterListIndex = new Dictionary<IMethodDefinition, int>(numMethods, ReferenceEqualityComparer.Instance);
+            _fieldDefIndex = new Dictionary<ITypeDefinition, int>(numTypeDefsGuess, Roslyn.Utilities.ReferenceEqualityComparer.Instance);
+            _methodDefIndex = new Dictionary<ITypeDefinition, int>(numTypeDefsGuess, Roslyn.Utilities.ReferenceEqualityComparer.Instance);
+            _parameterListIndex = new Dictionary<IMethodDefinition, int>(numMethods, Roslyn.Utilities.ReferenceEqualityComparer.Instance);
 
             _assemblyRefIndex = new HeapOrReferenceIndex<AssemblyIdentity>(this);
             _moduleRefIndex = new HeapOrReferenceIndex<string>(this);
@@ -435,7 +434,7 @@ namespace Microsoft.Cci
 
             public DefinitionIndex(int capacity)
             {
-                _index = new Dictionary<T, int>(capacity, ReferenceEqualityComparer.Instance);
+                _index = new Dictionary<T, int>(capacity, Roslyn.Utilities.ReferenceEqualityComparer.Instance);
                 _rows = new List<T>(capacity);
             }
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -26,10 +26,11 @@ using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
 using Microsoft.DiaSymReader;
-using Roslyn.Utilities;
 
 namespace Microsoft.Cci
 {
+    using Roslyn.Utilities;
+
     internal abstract partial class MetadataWriter
     {
         internal static readonly Encoding s_utf8Encoding = Encoding.UTF8;

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -26,11 +26,10 @@ using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Symbols;
 using Microsoft.DiaSymReader;
+using Roslyn.Utilities;
 
 namespace Microsoft.Cci
 {
-    using Roslyn.Utilities;
-
     internal abstract partial class MetadataWriter
     {
         internal static readonly Encoding s_utf8Encoding = Encoding.UTF8;
@@ -106,7 +105,7 @@ namespace Microsoft.Cci
 
             // EDMAURER provide some reasonable size estimates for these that will avoid
             // much of the reallocation that would occur when growing these from empty.
-            _signatureIndex = new Dictionary<ISignature, KeyValuePair<BlobHandle, ImmutableArray<byte>>>(module.HintNumberOfMethodDefinitions, ReferenceEqualityComparer.Instance); //ignores field signatures
+            _signatureIndex = new Dictionary<ISignature, KeyValuePair<BlobHandle, ImmutableArray<byte>>>(module.HintNumberOfMethodDefinitions, Roslyn.Utilities.ReferenceEqualityComparer.Instance); //ignores field signatures
 
             this.Context = context;
             this.messageProvider = messageProvider;
@@ -432,17 +431,17 @@ namespace Microsoft.Cci
         private readonly DynamicAnalysisDataWriter _dynamicAnalysisDataWriterOpt;
 
         private readonly Dictionary<ICustomAttribute, BlobHandle> _customAttributeSignatureIndex = new Dictionary<ICustomAttribute, BlobHandle>();
-        private readonly Dictionary<ITypeReference, BlobHandle> _typeSpecSignatureIndex = new Dictionary<ITypeReference, BlobHandle>(ReferenceEqualityComparer.Instance);
+        private readonly Dictionary<ITypeReference, BlobHandle> _typeSpecSignatureIndex = new Dictionary<ITypeReference, BlobHandle>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
         private readonly Dictionary<string, int> _fileRefIndex = new Dictionary<string, int>(32);  // more than enough in most cases, value is a RowId
         private readonly List<IFileReference> _fileRefList = new List<IFileReference>(32);
-        private readonly Dictionary<IFieldReference, BlobHandle> _fieldSignatureIndex = new Dictionary<IFieldReference, BlobHandle>(ReferenceEqualityComparer.Instance);
+        private readonly Dictionary<IFieldReference, BlobHandle> _fieldSignatureIndex = new Dictionary<IFieldReference, BlobHandle>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
 
         // We need to keep track of both the index of the signature and the actual blob to support VB static local naming scheme.
         private readonly Dictionary<ISignature, KeyValuePair<BlobHandle, ImmutableArray<byte>>> _signatureIndex;
 
         private readonly Dictionary<IMarshallingInformation, BlobHandle> _marshallingDescriptorIndex = new Dictionary<IMarshallingInformation, BlobHandle>();
         protected readonly List<MethodImplementation> methodImplList = new List<MethodImplementation>();
-        private readonly Dictionary<IGenericMethodInstanceReference, BlobHandle> _methodInstanceSignatureIndex = new Dictionary<IGenericMethodInstanceReference, BlobHandle>(ReferenceEqualityComparer.Instance);
+        private readonly Dictionary<IGenericMethodInstanceReference, BlobHandle> _methodInstanceSignatureIndex = new Dictionary<IGenericMethodInstanceReference, BlobHandle>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
 
         // Well known dummy cor library types whose refs are used for attaching assembly attributes off within net modules
         // There is no guarantee the types actually exist in a cor library
@@ -4175,7 +4174,7 @@ namespace Microsoft.Cci
             private readonly Dictionary<ITypeReference, int> _index;
 
             public TypeReferenceIndex(MetadataWriter writer, int lastRowId = 0)
-                : this(writer, new Dictionary<ITypeReference, int>(ReferenceEqualityComparer.Instance), lastRowId)
+                : this(writer, new Dictionary<ITypeReference, int>(Roslyn.Utilities.ReferenceEqualityComparer.Instance), lastRowId)
             {
             }
 
@@ -4205,7 +4204,7 @@ namespace Microsoft.Cci
             public InstanceAndStructuralReferenceIndex(MetadataWriter writer, IEqualityComparer<T> structuralComparer, int lastRowId = 0)
                 : base(writer, lastRowId)
             {
-                _instanceIndex = new Dictionary<T, int>(ReferenceEqualityComparer.Instance);
+                _instanceIndex = new Dictionary<T, int>(Roslyn.Utilities.ReferenceEqualityComparer.Instance);
                 _structuralIndex = new Dictionary<T, int>(structuralComparer);
             }
 

--- a/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
@@ -18,6 +18,7 @@ namespace Roslyn.Utilities
 {
     using System.Collections.Immutable;
     using System.Threading.Tasks;
+    using EncodingExtensions = Microsoft.CodeAnalysis.EncodingExtensions;
 #if COMPILERCORE
     using Resources = CodeAnalysisResources;
 #elif CODE_STYLE

--- a/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectWriter.cs
@@ -18,7 +18,6 @@ namespace Roslyn.Utilities
 {
     using System.Collections.Immutable;
     using System.Threading.Tasks;
-    using EncodingExtensions = Microsoft.CodeAnalysis.EncodingExtensions;
 #if COMPILERCORE
     using Resources = CodeAnalysisResources;
 #elif CODE_STYLE
@@ -1281,7 +1280,7 @@ namespace Roslyn.Utilities
             /// Encoding serialized as <see cref="TextEncodingKind"/>.
             /// </summary>
             FirstWellKnownTextEncoding,
-            LastWellKnownTextEncoding = FirstWellKnownTextEncoding + EncodingExtensions.LastTextEncodingKind - EncodingExtensions.FirstTextEncodingKind,
+            LastWellKnownTextEncoding = FirstWellKnownTextEncoding + Microsoft.CodeAnalysis.EncodingExtensions.LastTextEncodingKind - Microsoft.CodeAnalysis.EncodingExtensions.FirstTextEncodingKind,
 
             /// <summary>
             /// Encoding serialized as <see cref="Encoding.CodePage"/>.
@@ -1293,14 +1292,14 @@ namespace Roslyn.Utilities
 
         internal static TypeCode ToTypeCode(TextEncodingKind kind)
         {
-            Debug.Assert(kind is >= EncodingExtensions.FirstTextEncodingKind and <= EncodingExtensions.LastTextEncodingKind);
-            return TypeCode.FirstWellKnownTextEncoding + (byte)(kind - EncodingExtensions.FirstTextEncodingKind);
+            Debug.Assert(kind is >= Microsoft.CodeAnalysis.EncodingExtensions.FirstTextEncodingKind and <= Microsoft.CodeAnalysis.EncodingExtensions.LastTextEncodingKind);
+            return TypeCode.FirstWellKnownTextEncoding + (byte)(kind - Microsoft.CodeAnalysis.EncodingExtensions.FirstTextEncodingKind);
         }
 
         internal static TextEncodingKind ToEncodingKind(TypeCode code)
         {
             Debug.Assert(code is >= TypeCode.FirstWellKnownTextEncoding and <= TypeCode.LastWellKnownTextEncoding);
-            return EncodingExtensions.FirstTextEncodingKind + (byte)(code - TypeCode.FirstWellKnownTextEncoding);
+            return Microsoft.CodeAnalysis.EncodingExtensions.FirstTextEncodingKind + (byte)(code - TypeCode.FirstWellKnownTextEncoding);
         }
     }
 }


### PR DESCRIPTION
Roslyn cannot target net6.0 right now though, according to conclusion in #65905, we can still make preparations for that.
These changes only resolve semantic type conflicts between types in Roslyn projects and `System.Runtime` of net6.0, e.g. `Error CS0104: 'IReadOnlySet<T>' is an ambiguous reference between 'Roslyn.Utilities.IReadOnlySet<T>' and 'System.Collections.Generic.IReadOnlySet<T>'`.