### PR TITLE
Fixes and improvements for Run Code Analysis command

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.AnalysisData.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.AnalysisData.cs
@@ -109,6 +109,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             public DiagnosticAnalysisResult GetResult(DiagnosticAnalyzer analyzer)
                 => GetResultOrEmpty(Result, analyzer, ProjectId, Version);
 
+            public bool TryGetResult(DiagnosticAnalyzer analyzer, out DiagnosticAnalysisResult result)
+                => Result.TryGetValue(analyzer, out result);
+
             public static async Task<ProjectAnalysisData> CreateAsync(Project project, IEnumerable<StateSet> stateSets, bool avoidLoadingData, CancellationToken cancellationToken)
             {
                 VersionStamp? version = null;

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -53,9 +53,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return existingData;
                 }
 
-                // Check whether analyzer is suppressed for project or document and avoid getting diagnostics if suppressed.
-                // Note that we do not return empty DocumentAnalysisData for suppressed analyzer as that would clear the
-                // error list and remove the previously reported diagnostics from "Run Code Analysis" command.
+                // Check whether analyzer is suppressed for project or document.
+                // If so, we set the flag indicating that the client can skip analysis for this document.
+                // Regardless of whether or not the analyzer is suppressed for project or document,
+                // we return null to indicate that no diagnostics are cached for this document for the given version.
                 skipAnalysisForNonCachedDocument = !DocumentAnalysisExecutor.IsAnalyzerEnabledForProject(stateSet.Analyzer, document.Project, GlobalOptions) ||
                     !IsAnalyzerEnabledForDocument(stateSet.Analyzer, existingData, analysisScope, compilerDiagnosticsScope,
                         isActiveDocument, isVisibleDocument, isOpenDocument, isGeneratedRazorDocument);

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         /// <summary>
         /// Return all cached local diagnostics (syntax, semantic) that belong to given document for the given StateSet (analyzer).
         /// Otherwise, return <code>null</code>.
-        /// For the latter case, <paramref name="skipAnalysisForNonCachedDocument"/> indicates if the analyzer is suppressed
+        /// For the latter case, <paramref name="isAnalyzerSuppressed"/> indicates if the analyzer is suppressed
         /// for the given document/project. If suppressed, the caller does not need to compute the diagnostics for the given
         /// analyzer. Otherwise, diagnostics need to be computed.
         /// </summary>
@@ -37,11 +37,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             bool isActiveDocument, bool isVisibleDocument,
             bool isOpenDocument, bool isGeneratedRazorDocument,
             CancellationToken cancellationToken,
-            out bool skipAnalysisForNonCachedDocument)
+            out bool isAnalyzerSuppressed)
         {
             Debug.Assert(isActiveDocument || isOpenDocument || isGeneratedRazorDocument);
 
-            skipAnalysisForNonCachedDocument = false;
+            isAnalyzerSuppressed = false;
 
             try
             {
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // If so, we set the flag indicating that the client can skip analysis for this document.
                 // Regardless of whether or not the analyzer is suppressed for project or document,
                 // we return null to indicate that no diagnostics are cached for this document for the given version.
-                skipAnalysisForNonCachedDocument = !DocumentAnalysisExecutor.IsAnalyzerEnabledForProject(stateSet.Analyzer, document.Project, GlobalOptions) ||
+                isAnalyzerSuppressed = !DocumentAnalysisExecutor.IsAnalyzerEnabledForProject(stateSet.Analyzer, document.Project, GlobalOptions) ||
                     !IsAnalyzerEnabledForDocument(stateSet.Analyzer, existingData, analysisScope, compilerDiagnosticsScope,
                         isActiveDocument, isVisibleDocument, isOpenDocument, isGeneratedRazorDocument);
                 return null;

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -73,12 +73,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 {
                     var data = TryGetCachedDocumentAnalysisData(document, stateSet, kind, version,
                         backgroundAnalysisScope, compilerDiagnosticsScope, isActiveDocument, isVisibleDocument,
-                        isOpenDocument, isGeneratedRazorDocument, cancellationToken, out var skipAnalysisForNonCachedDocument);
+                        isOpenDocument, isGeneratedRazorDocument, cancellationToken, out var isAnalyzerSuppressed);
                     if (data.HasValue)
                     {
                         PersistAndRaiseDiagnosticsIfNeeded(data.Value, stateSet);
                     }
-                    else if (!skipAnalysisForNonCachedDocument)
+                    else if (!isAnalyzerSuppressed)
                     {
                         nonCachedStateSets.Add(stateSet);
                     }

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -73,13 +73,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 {
                     var data = TryGetCachedDocumentAnalysisData(document, stateSet, kind, version,
                         backgroundAnalysisScope, compilerDiagnosticsScope, isActiveDocument, isVisibleDocument,
-                        isOpenDocument, isGeneratedRazorDocument, cancellationToken);
+                        isOpenDocument, isGeneratedRazorDocument, cancellationToken, out var skipAnalysisForNonCachedDocument);
                     if (data.HasValue)
                     {
-                        // We need to persist and raise diagnostics for suppressed analyzer.
                         PersistAndRaiseDiagnosticsIfNeeded(data.Value, stateSet);
                     }
-                    else
+                    else if (!skipAnalysisForNonCachedDocument)
                     {
                         nonCachedStateSets.Add(stateSet);
                     }
@@ -156,23 +155,25 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
 
                 var result = await GetProjectAnalysisDataAsync(compilationWithAnalyzers, project, ideOptions, stateSets, forceAnalyzerRun, cancellationToken).ConfigureAwait(false);
-                if (result.OldResult == null)
-                {
-                    RaiseProjectDiagnosticsIfNeeded(project, stateSets, result.Result);
-                    return;
-                }
 
                 // no cancellation after this point.
-                // any analyzer that doesn't have result will be treated as returned empty set
-                // which means we will remove those from error list
+                using var _ = ArrayBuilder<StateSet>.GetInstance(out var analyzedStateSetsBuilder);
                 foreach (var stateSet in stateSets)
                 {
                     var state = stateSet.GetOrCreateProjectState(project.Id);
 
-                    await state.SaveToInMemoryStorageAsync(project, result.GetResult(stateSet.Analyzer)).ConfigureAwait(false);
+                    if (result.TryGetResult(stateSet.Analyzer, out var analyzerResult))
+                    {
+                        await state.SaveToInMemoryStorageAsync(project, analyzerResult).ConfigureAwait(false);
+                        analyzedStateSetsBuilder.Add(stateSet);
+                    }
                 }
 
-                RaiseProjectDiagnosticsIfNeeded(project, stateSets, result.OldResult, result.Result);
+                if (analyzedStateSetsBuilder.Count > 0)
+                {
+                    var oldResult = result.OldResult ?? ImmutableDictionary<DiagnosticAnalyzer, DiagnosticAnalysisResult>.Empty;
+                    RaiseProjectDiagnosticsIfNeeded(project, analyzedStateSetsBuilder.ToImmutable(), oldResult, result.Result);
+                }
             }
             catch (Exception e) when (FatalError.ReportAndPropagateUnlessCanceled(e, cancellationToken))
             {

--- a/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Diagnostics/VisualStudioDiagnosticAnalyzerService.cs
@@ -307,6 +307,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
             var solution = _workspace.CurrentSolution;
             var projectOrSolutionName = project?.Name ?? PathUtilities.GetFileName(solution.FilePath);
 
+            // Handle multi-tfm projects - we want to run code analysis for all tfm flavors of the project.
+            ImmutableArray<Project> otherProjectsForMultiTfmProject;
+            if (project != null)
+            {
+                otherProjectsForMultiTfmProject = solution.Projects.Where(
+                    p => p != project && p.FilePath == project.FilePath && p.State.NameAndFlavor.name == project.State.NameAndFlavor.name).ToImmutableArray();
+                if (!otherProjectsForMultiTfmProject.IsEmpty)
+                    projectOrSolutionName = project.State.NameAndFlavor.name;
+            }
+            else
+            {
+                otherProjectsForMultiTfmProject = ImmutableArray<Project>.Empty;
+            }
+
             bool isAnalysisDisabled;
             if (project != null)
             {
@@ -323,9 +337,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
             // Add a message to VS status bar that we are running code analysis.
             var statusBar = _serviceProvider?.GetService(typeof(SVsStatusbar)) as IVsStatusbar;
-            var totalProjectCount = project != null ? 1 : (uint)solution.ProjectIds.Count;
+            var totalProjectCount = project != null ? (1 + otherProjectsForMultiTfmProject.Length) : solution.ProjectIds.Count;
             var statusBarUpdater = statusBar != null
-                ? new StatusBarUpdater(statusBar, _threadingContext, projectOrSolutionName, totalProjectCount)
+                ? new StatusBarUpdater(statusBar, _threadingContext, projectOrSolutionName, (uint)totalProjectCount)
                 : null;
 
             // Force complete analyzer execution in background.
@@ -336,6 +350,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 {
                     var onProjectAnalyzed = statusBarUpdater != null ? statusBarUpdater.OnProjectAnalyzed : (Action<Project>)((Project _) => { });
                     await _diagnosticService.ForceAnalyzeAsync(solution, onProjectAnalyzed, project?.Id, CancellationToken.None).ConfigureAwait(false);
+
+                    foreach (var otherProject in otherProjectsForMultiTfmProject)
+                        await _diagnosticService.ForceAnalyzeAsync(solution, onProjectAnalyzed, otherProject.Id, CancellationToken.None).ConfigureAwait(false);
 
                     // If user has disabled live analyzer execution for any project(s), i.e. set RunAnalyzersDuringLiveAnalysis = false,
                     // then ForceAnalyzeAsync will not cause analyzers to execute.
@@ -355,7 +372,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 RoslynDebug.Assert(solution != null);
 
                 // First clear all special host diagostics for all involved projects.
-                var projects = project != null ? SpecializedCollections.SingletonEnumerable(project) : solution.Projects;
+                var projects = project != null ? otherProjectsForMultiTfmProject.Add(project) : solution.Projects;
                 foreach (var project in projects)
                 {
                     _hostDiagnosticUpdateSource.ClearDiagnosticsForProject(project.Id, key: this);


### PR DESCRIPTION
Fixes #26817
Fixes [AB#1698190](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1698190)

This PR fixes the regression where in diagnostics reported for a project/solution after executing `Run Code Analysis` command were getting cleared out after editing source files and/or switching active file tabs.

While fixing the above, I also enhanced the `Run Code Analysis` to handle multi-tfm projects so that now we run analysis for all tfm flavors of a multi-tfm project instead of just the current tfm.