### PR TITLE
Mimick `.await` completions as snippets

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AwaitCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AwaitCompletionProviderTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
         private async Task VerifyKeywordAsync(string code, LanguageVersion languageVersion = LanguageVersion.Default, string? inlineDescription = null, bool dotAwait = false, bool dotAwaitf = false)
         {
             var expectedDescription = dotAwait
-                ? GetDescription(CompletionDisplayTextAwait, FeaturesResources.Await_the_preceding_expression)
+                ? FeaturesResources.Await_the_preceding_expression
                 : GetDescription(CompletionDisplayTextAwait, FeaturesResources.Asynchronously_waits_for_the_task_to_finish);
             await VerifyItemExistsAsync(GetMarkup(code, languageVersion), CompletionDisplayTextAwait, glyph: (int)(dotAwait ? Glyph.Snippet : Glyph.Keyword), expectedDescriptionOrNull: expectedDescription, inlineDescription: inlineDescription);
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AwaitCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AwaitCompletionProviderTests.cs
@@ -44,12 +44,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
             var expectedDescription = dotAwait
                 ? GetDescription(CompletionDisplayTextAwait, FeaturesResources.Await_the_preceding_expression)
                 : GetDescription(CompletionDisplayTextAwait, FeaturesResources.Asynchronously_waits_for_the_task_to_finish);
-            await VerifyItemExistsAsync(GetMarkup(code, languageVersion), CompletionDisplayTextAwait, glyph: (int)Glyph.Keyword, expectedDescriptionOrNull: expectedDescription, inlineDescription: inlineDescription);
+            await VerifyItemExistsAsync(GetMarkup(code, languageVersion), CompletionDisplayTextAwait, glyph: (int)(dotAwait ? Glyph.Snippet : Glyph.Keyword), expectedDescriptionOrNull: expectedDescription, inlineDescription: inlineDescription);
 
             if (dotAwaitf)
             {
                 expectedDescription = string.Format(FeaturesResources.Await_the_preceding_expression_and_add_ConfigureAwait_0, "false");
-                await VerifyItemExistsAsync(GetMarkup(code, languageVersion), CompletionDisplayTextAwaitAndConfigureAwait, glyph: (int)Glyph.Keyword, expectedDescriptionOrNull: expectedDescription, inlineDescription: inlineDescription);
+                await VerifyItemExistsAsync(GetMarkup(code, languageVersion), CompletionDisplayTextAwaitAndConfigureAwait, glyph: (int)Glyph.Snippet, expectedDescriptionOrNull: expectedDescription, inlineDescription: inlineDescription);
             }
             else
             {

--- a/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
@@ -121,6 +119,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 context.AddItem(CreateCompletionItem(
                     properties, _awaitKeyword, _awaitKeyword,
                     FeaturesResources.Await_the_preceding_expression,
+                    isDotAwait: true,
                     isComplexTextEdit: true));
 
                 if (dotAwaitContext == DotAwaitContext.AwaitAndConfigureAwait)
@@ -130,6 +129,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     context.AddItem(CreateCompletionItem(
                         properties, _awaitfDisplayText, _awaitfFilterText,
                         string.Format(FeaturesResources.Await_the_preceding_expression_and_add_ConfigureAwait_0, _falseKeyword),
+                        isDotAwait: true,
                         isComplexTextEdit: true));
                 }
             }
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return;
 
             static CompletionItem CreateCompletionItem(
-                ImmutableDictionary<string, string> completionProperties, string displayText, string filterText, string tooltip, bool isComplexTextEdit)
+                ImmutableDictionary<string, string> completionProperties, string displayText, string filterText, string tooltip, bool isComplexTextEdit, bool isDotAwait = false)
             {
                 var appendConfigureAwait = completionProperties.ContainsKey(AppendConfigureAwait);
 
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     displayTextSuffix: "",
                     filterText: filterText,
                     rules: CompletionItemRules.Default,
-                    glyph: Glyph.Keyword,
+                    glyph: isDotAwait ? Glyph.Snippet : Glyph.Keyword,
                     description: description,
                     isComplexTextEdit: isComplexTextEdit,
                     properties: completionProperties);

--- a/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             {
                 var appendConfigureAwait = completionProperties.ContainsKey(AppendConfigureAwait);
 
-                var description = appendConfigureAwait
+                var description = appendConfigureAwait || isDotAwait
                     ? ImmutableArray.Create(new SymbolDisplayPart(SymbolDisplayPartKind.Text, null, tooltip))
                     : RecommendedKeyword.CreateDisplayParts(displayText, tooltip);
 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractAwaitCompletionProvider.cs
@@ -119,8 +119,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 context.AddItem(CreateCompletionItem(
                     properties, _awaitKeyword, _awaitKeyword,
                     FeaturesResources.Await_the_preceding_expression,
-                    isDotAwait: true,
-                    isComplexTextEdit: true));
+                    isComplexTextEdit: true,
+                    isDotAwait: true));
 
                 if (dotAwaitContext == DotAwaitContext.AwaitAndConfigureAwait)
                 {
@@ -129,8 +129,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     context.AddItem(CreateCompletionItem(
                         properties, _awaitfDisplayText, _awaitfFilterText,
                         string.Format(FeaturesResources.Await_the_preceding_expression_and_add_ConfigureAwait_0, _falseKeyword),
-                        isDotAwait: true,
-                        isComplexTextEdit: true));
+                        isComplexTextEdit: true,
+                        isDotAwait: true));
                 }
             }
 


### PR DESCRIPTION
`.await` and `.awaitf`are _really_ useful completions. However, in such form they behave a lot more like snippets rather than just a keyword completions. So I made tiny visual changes to them:
1. Change icon to snippet when in a postfix form
2. Do not add `'await' keyword` to the tooltip of `await` completion when in postfix form

Looks like this:
![devenv_7MW32WCwl7](https://user-images.githubusercontent.com/70431552/207700156-d78aef79-6961-43f1-8dad-26e5d13edc41.png)

I think it makes more sense to display them this way. As a user I expect keyword completions to just insert a keyword and maybe do some slight change, e.g. add an `async` to the declaration. But not flip the whole expression.