### PR TITLE
Support Go To Definition in Object Browser for metadata references

### DIFF
--- a/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/SymbolListItem.cs
+++ b/src/VisualStudio/Core/Def/Library/ObjectBrowser/Lists/SymbolListItem.cs
@@ -32,10 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             _fullNameText = fullNameText;
             _searchText = searchText;
 
-            _supportsGoToDefinition = symbol.Kind != SymbolKind.Namespace
-                ? symbol.Locations.Any(static l => l.IsInSource)
-                : false;
-
+            _supportsGoToDefinition = symbol.Kind != SymbolKind.Namespace;
             _supportsFindAllReferences = symbol.Kind != SymbolKind.Namespace;
         }
 


### PR DESCRIPTION
The code that populates Object Browser and Class View currently disables Go To Definition for symbols that don't come from source. However, in Current Year, we can still go to these definitions through Source Link, embedded source, or decompilation. The code was already hooked up to the standard go-to-def path, so this condition is arbitrary.

I cannot find any tests for this, but I suppose I could figure something out if that's desired.

Closes #36120