### PR TITLE
Correctly parse local function with several async modifiers

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -9787,11 +9787,10 @@ tryAgain:
                         return true;
                     }
                 }
-                // If the next token is an identifier with some contextual kind, it might be a modifier.
-                // We want to treat current token as modifier if the next token is a modifier, so we need to check that.
+                // If current token might be a contextual modifier we need to check ahead the next token after it
+                // If the next token appears to be a modifier, we treat current token as a modifier as well
                 // This allows to correctly parse things like local functions with several `async` modifiers
-                while (this.CurrentToken.Kind == SyntaxKind.IdentifierToken &&
-                       this.CurrentToken.ContextualKind != SyntaxKind.IdentifierToken);
+                while (IsAdditionalLocalFunctionModifier(this.CurrentToken.ContextualKind));
 
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -9778,11 +9778,15 @@ tryAgain:
                 {
                     this.EatToken();
 
+                    if (IsDeclarationModifier(this.CurrentToken.Kind) ||
+                        IsAdditionalLocalFunctionModifier(this.CurrentToken.Kind))
+                    {
+                        return true;
+                    }
+
                     using var _2 = this.GetDisposableResetPoint(resetOnDispose: true);
 
-                    if (IsDeclarationModifier(this.CurrentToken.Kind) ||
-                        IsAdditionalLocalFunctionModifier(this.CurrentToken.Kind) ||
-                        (ScanType() != ScanTypeFlags.NotType && this.CurrentToken.Kind == SyntaxKind.IdentifierToken))
+                    if (ScanType() != ScanTypeFlags.NotType && this.CurrentToken.Kind == SyntaxKind.IdentifierToken)
                     {
                         return true;
                     }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
@@ -2111,120 +2111,36 @@ class c
         }
 
         [Fact, WorkItem(32106, "https://github.com/dotnet/roslyn/issues/32106")]
-        public void DuplicateAsyncs()
+        public void DuplicateAsyncs1()
         {
             const string text = """
                 class Program
                 {
                     void M()
                     {
-                        async async void F1() { }
-                        async async async void F2() { }
-                        async async async async void F3() { }
-                        async async async async async void F4() { }
+                        async async void F() { }
                     }
                 }
                 """;
 
             CreateCompilation(text).VerifyDiagnostics(
                 // (5,15): error CS1031: Type expected
-                //         async async void F1() { }
+                //         async async void F() { }
                 Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
                 // (5,15): error CS1004: Duplicate 'async' modifier
-                //         async async void F1() { }
+                //         async async void F() { }
                 Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(5, 15),
                 // (5,26): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
-                //         async async void F1() { }
-                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F1").WithLocation(5, 26),
-                // (5,26): warning CS8321: The local function 'F1' is declared but never used
-                //         async async void F1() { }
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F1").WithArguments("F1").WithLocation(5, 26),
-                // (6,15): error CS1031: Type expected
-                //         async async async void F2() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 15),
-                // (6,15): error CS1004: Duplicate 'async' modifier
-                //         async async async void F2() { }
-                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(6, 15),
-                // (6,21): error CS1031: Type expected
-                //         async async async void F2() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 21),
-                // (6,32): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
-                //         async async async void F2() { }
-                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F2").WithLocation(6, 32),
-                // (6,32): warning CS8321: The local function 'F2' is declared but never used
-                //         async async async void F2() { }
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F2").WithArguments("F2").WithLocation(6, 32),
-                // (7,15): error CS1031: Type expected
-                //         async async async async void F3() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(7, 15),
-                // (7,15): error CS1004: Duplicate 'async' modifier
-                //         async async async async void F3() { }
-                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(7, 15),
-                // (7,21): error CS1031: Type expected
-                //         async async async async void F3() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(7, 21),
-                // (7,27): error CS1031: Type expected
-                //         async async async async void F3() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(7, 27),
-                // (7,38): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
-                //         async async async async void F3() { }
-                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F3").WithLocation(7, 38),
-                // (7,38): warning CS8321: The local function 'F3' is declared but never used
-                //         async async async async void F3() { }
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F3").WithArguments("F3").WithLocation(7, 38),
-                // (8,15): error CS1031: Type expected
-                //         async async async async async void F4() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 15),
-                // (8,15): error CS1004: Duplicate 'async' modifier
-                //         async async async async async void F4() { }
-                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(8, 15),
-                // (8,21): error CS1031: Type expected
-                //         async async async async async void F4() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 21),
-                // (8,27): error CS1031: Type expected
-                //         async async async async async void F4() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 27),
-                // (8,33): error CS1031: Type expected
-                //         async async async async async void F4() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 33),
-                // (8,44): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
-                //         async async async async async void F4() { }
-                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F4").WithLocation(8, 44),
-                // (8,44): warning CS8321: The local function 'F4' is declared but never used
-                //         async async async async async void F4() { }
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F4").WithArguments("F4").WithLocation(8, 44));
+                //         async async void F() { }
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F").WithLocation(5, 26),
+                // (5,26): warning CS8321: The local function 'F' is declared but never used
+                //         async async void F() { }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F").WithArguments("F").WithLocation(5, 26));
 
             UsingDeclaration(text, options: TestOptions.Regular9,
                 // (5,15): error CS1031: Type expected
-                //         async async void F1() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
-                // (6,15): error CS1031: Type expected
-                //         async async async void F2() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 15),
-                // (6,21): error CS1031: Type expected
-                //         async async async void F2() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 21),
-                // (7,15): error CS1031: Type expected
-                //         async async async async void F3() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(7, 15),
-                // (7,21): error CS1031: Type expected
-                //         async async async async void F3() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(7, 21),
-                // (7,27): error CS1031: Type expected
-                //         async async async async void F3() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(7, 27),
-                // (8,15): error CS1031: Type expected
-                //         async async async async async void F4() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 15),
-                // (8,21): error CS1031: Type expected
-                //         async async async async async void F4() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 21),
-                // (8,27): error CS1031: Type expected
-                //         async async async async async void F4() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 27),
-                // (8,33): error CS1031: Type expected
-                //         async async async async async void F4() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 33));
+                //         async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15));
             checkNodes();
 
             void checkNodes()
@@ -2254,7 +2170,7 @@ class c
                                     N(SyntaxKind.AsyncKeyword);
                                     N(SyntaxKind.PredefinedType);
                                     N(SyntaxKind.VoidKeyword);
-                                    N(SyntaxKind.IdentifierToken, "F1");
+                                    N(SyntaxKind.IdentifierToken, "F");
                                     N(SyntaxKind.ParameterList);
                                     {
                                         N(SyntaxKind.OpenParenToken);
@@ -2266,6 +2182,76 @@ class c
                                         N(SyntaxKind.CloseBraceToken);
                                     }
                                 }
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                EOF();
+            }
+        }
+
+        [Fact, WorkItem(32106, "https://github.com/dotnet/roslyn/issues/32106")]
+        public void DuplicateAsyncs2()
+        {
+            const string text = """
+                class Program
+                {
+                    void M()
+                    {
+                        async async async void F() { }
+                    }
+                }
+                """;
+
+            CreateCompilation(text).VerifyDiagnostics(
+                // (5,15): error CS1031: Type expected
+                //         async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
+                // (5,15): error CS1004: Duplicate 'async' modifier
+                //         async async async void F() { }
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(5, 15),
+                // (5,21): error CS1031: Type expected
+                //         async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 21),
+                // (5,32): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //         async async async void F() { }
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F").WithLocation(5, 32),
+                // (5,32): warning CS8321: The local function 'F' is declared but never used
+                //         async async async void F() { }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F").WithArguments("F").WithLocation(5, 32));
+
+            UsingDeclaration(text, options: TestOptions.Regular9,
+                // (5,15): error CS1031: Type expected
+                //         async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
+                // (5,21): error CS1031: Type expected
+                //         async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 21));
+            checkNodes();
+
+            void checkNodes()
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "Program");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        N(SyntaxKind.VoidKeyword);
+                        {
+                            N(SyntaxKind.IdentifierToken, "M");
+                            N(SyntaxKind.ParameterList);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
                                 N(SyntaxKind.LocalFunctionStatement);
                                 {
                                     N(SyntaxKind.AsyncKeyword);
@@ -2273,7 +2259,7 @@ class c
                                     N(SyntaxKind.AsyncKeyword);
                                     N(SyntaxKind.PredefinedType);
                                     N(SyntaxKind.VoidKeyword);
-                                    N(SyntaxKind.IdentifierToken, "F2");
+                                    N(SyntaxKind.IdentifierToken, "F");
                                     N(SyntaxKind.ParameterList);
                                     {
                                         N(SyntaxKind.OpenParenToken);
@@ -2285,6 +2271,82 @@ class c
                                         N(SyntaxKind.CloseBraceToken);
                                     }
                                 }
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                EOF();
+            }
+        }
+
+        [Fact, WorkItem(32106, "https://github.com/dotnet/roslyn/issues/32106")]
+        public void DuplicateAsyncs3()
+        {
+            const string text = """
+                class Program
+                {
+                    void M()
+                    {
+                        async async async async void F() { }
+                    }
+                }
+                """;
+
+            CreateCompilation(text).VerifyDiagnostics(
+                // (5,15): error CS1031: Type expected
+                //         async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
+                // (5,15): error CS1004: Duplicate 'async' modifier
+                //         async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(5, 15),
+                // (5,21): error CS1031: Type expected
+                //         async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 21),
+                // (5,27): error CS1031: Type expected
+                //         async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 27),
+                // (5,38): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //         async async async async void F() { }
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F").WithLocation(5, 38),
+                // (5,38): warning CS8321: The local function 'F' is declared but never used
+                //         async async async async void F() { }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F").WithArguments("F").WithLocation(5, 38));
+
+            UsingDeclaration(text, options: TestOptions.Regular9,
+                // (5,15): error CS1031: Type expected
+                //         async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
+                // (5,21): error CS1031: Type expected
+                //         async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 21),
+                // (5,27): error CS1031: Type expected
+                //         async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 27));
+            checkNodes();
+
+            void checkNodes()
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "Program");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        N(SyntaxKind.VoidKeyword);
+                        {
+                            N(SyntaxKind.IdentifierToken, "M");
+                            N(SyntaxKind.ParameterList);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
                                 N(SyntaxKind.LocalFunctionStatement);
                                 {
                                     N(SyntaxKind.AsyncKeyword);
@@ -2293,7 +2355,7 @@ class c
                                     N(SyntaxKind.AsyncKeyword);
                                     N(SyntaxKind.PredefinedType);
                                     N(SyntaxKind.VoidKeyword);
-                                    N(SyntaxKind.IdentifierToken, "F3");
+                                    N(SyntaxKind.IdentifierToken, "F");
                                     N(SyntaxKind.ParameterList);
                                     {
                                         N(SyntaxKind.OpenParenToken);
@@ -2305,6 +2367,88 @@ class c
                                         N(SyntaxKind.CloseBraceToken);
                                     }
                                 }
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                EOF();
+            }
+        }
+
+        [Fact, WorkItem(32106, "https://github.com/dotnet/roslyn/issues/32106")]
+        public void DuplicateAsyncs4()
+        {
+            const string text = """
+                class Program
+                {
+                    void M()
+                    {
+                        async async async async async void F() { }
+                    }
+                }
+                """;
+
+            CreateCompilation(text).VerifyDiagnostics(
+                // (5,15): error CS1031: Type expected
+                //         async async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
+                // (5,15): error CS1004: Duplicate 'async' modifier
+                //         async async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(5, 15),
+                // (5,21): error CS1031: Type expected
+                //         async async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 21),
+                // (5,27): error CS1031: Type expected
+                //         async async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 27),
+                // (5,33): error CS1031: Type expected
+                //         async async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 33),
+                // (5,44): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //         async async async async async void F() { }
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F").WithLocation(5, 44),
+                // (5,44): warning CS8321: The local function 'F' is declared but never used
+                //         async async async async async void F() { }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F").WithArguments("F").WithLocation(5, 44));
+
+            UsingDeclaration(text, options: TestOptions.Regular9,
+                // (5,15): error CS1031: Type expected
+                //         async async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
+                // (5,21): error CS1031: Type expected
+                //         async async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 21),
+                // (5,27): error CS1031: Type expected
+                //         async async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 27),
+                // (5,33): error CS1031: Type expected
+                //         async async async async async void F() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 33));
+            checkNodes();
+
+            void checkNodes()
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "Program");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        N(SyntaxKind.VoidKeyword);
+                        {
+                            N(SyntaxKind.IdentifierToken, "M");
+                            N(SyntaxKind.ParameterList);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
                                 N(SyntaxKind.LocalFunctionStatement);
                                 {
                                     N(SyntaxKind.AsyncKeyword);
@@ -2314,7 +2458,7 @@ class c
                                     N(SyntaxKind.AsyncKeyword);
                                     N(SyntaxKind.PredefinedType);
                                     N(SyntaxKind.VoidKeyword);
-                                    N(SyntaxKind.IdentifierToken, "F4");
+                                    N(SyntaxKind.IdentifierToken, "F");
                                     N(SyntaxKind.ParameterList);
                                     {
                                         N(SyntaxKind.OpenParenToken);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
@@ -4,11 +4,11 @@
 
 #nullable disable
 
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
-using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -2089,6 +2089,232 @@ class c
                                     N(SyntaxKind.PredefinedType);
                                     N(SyntaxKind.VoidKeyword);
                                     N(SyntaxKind.IdentifierToken, "F2");
+                                    N(SyntaxKind.ParameterList);
+                                    {
+                                        N(SyntaxKind.OpenParenToken);
+                                        N(SyntaxKind.CloseParenToken);
+                                    }
+                                    N(SyntaxKind.Block);
+                                    {
+                                        N(SyntaxKind.OpenBraceToken);
+                                        N(SyntaxKind.CloseBraceToken);
+                                    }
+                                }
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+                EOF();
+            }
+        }
+
+        [Fact, WorkItem(32106, "https://github.com/dotnet/roslyn/issues/32106")]
+        public void DuplicateAsyncs()
+        {
+            const string text = """
+                class Program
+                {
+                    void M()
+                    {
+                        async async void F1() { }
+                        async async async void F2() { }
+                        async async async async void F3() { }
+                        async async async async async void F4() { }
+                    }
+                }
+                """;
+
+            CreateCompilation(text).VerifyDiagnostics(
+                // (5,15): error CS1031: Type expected
+                //         async async void F1() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
+                // (5,15): error CS1004: Duplicate 'async' modifier
+                //         async async void F1() { }
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(5, 15),
+                // (5,26): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //         async async void F1() { }
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F1").WithLocation(5, 26),
+                // (5,26): warning CS8321: The local function 'F1' is declared but never used
+                //         async async void F1() { }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F1").WithArguments("F1").WithLocation(5, 26),
+                // (6,15): error CS1031: Type expected
+                //         async async async void F2() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 15),
+                // (6,15): error CS1004: Duplicate 'async' modifier
+                //         async async async void F2() { }
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(6, 15),
+                // (6,21): error CS1031: Type expected
+                //         async async async void F2() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 21),
+                // (6,32): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //         async async async void F2() { }
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F2").WithLocation(6, 32),
+                // (6,32): warning CS8321: The local function 'F2' is declared but never used
+                //         async async async void F2() { }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F2").WithArguments("F2").WithLocation(6, 32),
+                // (7,15): error CS1031: Type expected
+                //         async async async async void F3() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(7, 15),
+                // (7,15): error CS1004: Duplicate 'async' modifier
+                //         async async async async void F3() { }
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(7, 15),
+                // (7,21): error CS1031: Type expected
+                //         async async async async void F3() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(7, 21),
+                // (7,27): error CS1031: Type expected
+                //         async async async async void F3() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(7, 27),
+                // (7,38): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //         async async async async void F3() { }
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F3").WithLocation(7, 38),
+                // (7,38): warning CS8321: The local function 'F3' is declared but never used
+                //         async async async async void F3() { }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F3").WithArguments("F3").WithLocation(7, 38),
+                // (8,15): error CS1031: Type expected
+                //         async async async async async void F4() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 15),
+                // (8,15): error CS1004: Duplicate 'async' modifier
+                //         async async async async async void F4() { }
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(8, 15),
+                // (8,21): error CS1031: Type expected
+                //         async async async async async void F4() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 21),
+                // (8,27): error CS1031: Type expected
+                //         async async async async async void F4() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 27),
+                // (8,33): error CS1031: Type expected
+                //         async async async async async void F4() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 33),
+                // (8,44): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+                //         async async async async async void F4() { }
+                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F4").WithLocation(8, 44),
+                // (8,44): warning CS8321: The local function 'F4' is declared but never used
+                //         async async async async async void F4() { }
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F4").WithArguments("F4").WithLocation(8, 44));
+
+            UsingDeclaration(text, options: TestOptions.Regular9,
+                // (5,15): error CS1031: Type expected
+                //         async async void F1() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
+                // (6,15): error CS1031: Type expected
+                //         async async async void F2() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 15),
+                // (6,21): error CS1031: Type expected
+                //         async async async void F2() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 21),
+                // (7,15): error CS1031: Type expected
+                //         async async async async void F3() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(7, 15),
+                // (7,21): error CS1031: Type expected
+                //         async async async async void F3() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(7, 21),
+                // (7,27): error CS1031: Type expected
+                //         async async async async void F3() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(7, 27),
+                // (8,15): error CS1031: Type expected
+                //         async async async async async void F4() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 15),
+                // (8,21): error CS1031: Type expected
+                //         async async async async async void F4() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 21),
+                // (8,27): error CS1031: Type expected
+                //         async async async async async void F4() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 27),
+                // (8,33): error CS1031: Type expected
+                //         async async async async async void F4() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(8, 33));
+            checkNodes();
+
+            void checkNodes()
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken, "Program");
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        N(SyntaxKind.VoidKeyword);
+                        {
+                            N(SyntaxKind.IdentifierToken, "M");
+                            N(SyntaxKind.ParameterList);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.LocalFunctionStatement);
+                                {
+                                    N(SyntaxKind.AsyncKeyword);
+                                    N(SyntaxKind.AsyncKeyword);
+                                    N(SyntaxKind.PredefinedType);
+                                    N(SyntaxKind.VoidKeyword);
+                                    N(SyntaxKind.IdentifierToken, "F1");
+                                    N(SyntaxKind.ParameterList);
+                                    {
+                                        N(SyntaxKind.OpenParenToken);
+                                        N(SyntaxKind.CloseParenToken);
+                                    }
+                                    N(SyntaxKind.Block);
+                                    {
+                                        N(SyntaxKind.OpenBraceToken);
+                                        N(SyntaxKind.CloseBraceToken);
+                                    }
+                                }
+                                N(SyntaxKind.LocalFunctionStatement);
+                                {
+                                    N(SyntaxKind.AsyncKeyword);
+                                    N(SyntaxKind.AsyncKeyword);
+                                    N(SyntaxKind.AsyncKeyword);
+                                    N(SyntaxKind.PredefinedType);
+                                    N(SyntaxKind.VoidKeyword);
+                                    N(SyntaxKind.IdentifierToken, "F2");
+                                    N(SyntaxKind.ParameterList);
+                                    {
+                                        N(SyntaxKind.OpenParenToken);
+                                        N(SyntaxKind.CloseParenToken);
+                                    }
+                                    N(SyntaxKind.Block);
+                                    {
+                                        N(SyntaxKind.OpenBraceToken);
+                                        N(SyntaxKind.CloseBraceToken);
+                                    }
+                                }
+                                N(SyntaxKind.LocalFunctionStatement);
+                                {
+                                    N(SyntaxKind.AsyncKeyword);
+                                    N(SyntaxKind.AsyncKeyword);
+                                    N(SyntaxKind.AsyncKeyword);
+                                    N(SyntaxKind.AsyncKeyword);
+                                    N(SyntaxKind.PredefinedType);
+                                    N(SyntaxKind.VoidKeyword);
+                                    N(SyntaxKind.IdentifierToken, "F3");
+                                    N(SyntaxKind.ParameterList);
+                                    {
+                                        N(SyntaxKind.OpenParenToken);
+                                        N(SyntaxKind.CloseParenToken);
+                                    }
+                                    N(SyntaxKind.Block);
+                                    {
+                                        N(SyntaxKind.OpenBraceToken);
+                                        N(SyntaxKind.CloseBraceToken);
+                                    }
+                                }
+                                N(SyntaxKind.LocalFunctionStatement);
+                                {
+                                    N(SyntaxKind.AsyncKeyword);
+                                    N(SyntaxKind.AsyncKeyword);
+                                    N(SyntaxKind.AsyncKeyword);
+                                    N(SyntaxKind.AsyncKeyword);
+                                    N(SyntaxKind.AsyncKeyword);
+                                    N(SyntaxKind.PredefinedType);
+                                    N(SyntaxKind.VoidKeyword);
+                                    N(SyntaxKind.IdentifierToken, "F4");
                                     N(SyntaxKind.ParameterList);
                                     {
                                         N(SyntaxKind.OpenParenToken);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
@@ -2118,29 +2118,24 @@ class c
                 {
                     void M()
                     {
+                        #pragma warning disable 1998, 8321
                         async async void F() { }
                     }
                 }
                 """;
 
             CreateCompilation(text).VerifyDiagnostics(
-                // (5,15): error CS1031: Type expected
+                // (6,15): error CS1031: Type expected
                 //         async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
-                // (5,15): error CS1004: Duplicate 'async' modifier
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 15),
+                // (6,15): error CS1004: Duplicate 'async' modifier
                 //         async async void F() { }
-                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(5, 15),
-                // (5,26): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
-                //         async async void F() { }
-                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F").WithLocation(5, 26),
-                // (5,26): warning CS8321: The local function 'F' is declared but never used
-                //         async async void F() { }
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F").WithArguments("F").WithLocation(5, 26));
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(6, 15));
 
             UsingDeclaration(text, options: TestOptions.Regular9,
-                // (5,15): error CS1031: Type expected
+                // (6,15): error CS1031: Type expected
                 //         async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15));
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 15));
             checkNodes();
 
             void checkNodes()
@@ -2200,35 +2195,30 @@ class c
                 {
                     void M()
                     {
+                        #pragma warning disable 1998, 8321
                         async async async void F() { }
                     }
                 }
                 """;
 
             CreateCompilation(text).VerifyDiagnostics(
-                // (5,15): error CS1031: Type expected
+                // (6,15): error CS1031: Type expected
                 //         async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
-                // (5,15): error CS1004: Duplicate 'async' modifier
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 15),
+                // (6,15): error CS1004: Duplicate 'async' modifier
                 //         async async async void F() { }
-                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(5, 15),
-                // (5,21): error CS1031: Type expected
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(6, 15),
+                // (6,21): error CS1031: Type expected
                 //         async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 21),
-                // (5,32): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
-                //         async async async void F() { }
-                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F").WithLocation(5, 32),
-                // (5,32): warning CS8321: The local function 'F' is declared but never used
-                //         async async async void F() { }
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F").WithArguments("F").WithLocation(5, 32));
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 21));
 
             UsingDeclaration(text, options: TestOptions.Regular9,
-                // (5,15): error CS1031: Type expected
+                // (6,15): error CS1031: Type expected
                 //         async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
-                // (5,21): error CS1031: Type expected
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 15),
+                // (6,21): error CS1031: Type expected
                 //         async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 21));
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 21));
             checkNodes();
 
             void checkNodes()
@@ -2289,41 +2279,36 @@ class c
                 {
                     void M()
                     {
+                        #pragma warning disable 1998, 8321
                         async async async async void F() { }
                     }
                 }
                 """;
 
             CreateCompilation(text).VerifyDiagnostics(
-                // (5,15): error CS1031: Type expected
+                // (6,15): error CS1031: Type expected
                 //         async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
-                // (5,15): error CS1004: Duplicate 'async' modifier
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 15),
+                // (6,15): error CS1004: Duplicate 'async' modifier
                 //         async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(5, 15),
-                // (5,21): error CS1031: Type expected
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(6, 15),
+                // (6,21): error CS1031: Type expected
                 //         async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 21),
-                // (5,27): error CS1031: Type expected
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 21),
+                // (6,27): error CS1031: Type expected
                 //         async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 27),
-                // (5,38): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
-                //         async async async async void F() { }
-                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F").WithLocation(5, 38),
-                // (5,38): warning CS8321: The local function 'F' is declared but never used
-                //         async async async async void F() { }
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F").WithArguments("F").WithLocation(5, 38));
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 27));
 
             UsingDeclaration(text, options: TestOptions.Regular9,
-                // (5,15): error CS1031: Type expected
+                // (6,15): error CS1031: Type expected
                 //         async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
-                // (5,21): error CS1031: Type expected
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 15),
+                // (6,21): error CS1031: Type expected
                 //         async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 21),
-                // (5,27): error CS1031: Type expected
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 21),
+                // (6,27): error CS1031: Type expected
                 //         async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 27));
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 27));
             checkNodes();
 
             void checkNodes()
@@ -2385,47 +2370,42 @@ class c
                 {
                     void M()
                     {
+                        #pragma warning disable 1998, 8321
                         async async async async async void F() { }
                     }
                 }
                 """;
 
             CreateCompilation(text).VerifyDiagnostics(
-                // (5,15): error CS1031: Type expected
+                // (6,15): error CS1031: Type expected
                 //         async async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
-                // (5,15): error CS1004: Duplicate 'async' modifier
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 15),
+                // (6,15): error CS1004: Duplicate 'async' modifier
                 //         async async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(5, 15),
-                // (5,21): error CS1031: Type expected
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "async").WithArguments("async").WithLocation(6, 15),
+                // (6,21): error CS1031: Type expected
                 //         async async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 21),
-                // (5,27): error CS1031: Type expected
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 21),
+                // (6,27): error CS1031: Type expected
                 //         async async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 27),
-                // (5,33): error CS1031: Type expected
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 27),
+                // (6,33): error CS1031: Type expected
                 //         async async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 33),
-                // (5,44): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
-                //         async async async async async void F() { }
-                Diagnostic(ErrorCode.WRN_AsyncLacksAwaits, "F").WithLocation(5, 44),
-                // (5,44): warning CS8321: The local function 'F' is declared but never used
-                //         async async async async async void F() { }
-                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "F").WithArguments("F").WithLocation(5, 44));
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 33));
 
             UsingDeclaration(text, options: TestOptions.Regular9,
-                // (5,15): error CS1031: Type expected
+                // (6,15): error CS1031: Type expected
                 //         async async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 15),
-                // (5,21): error CS1031: Type expected
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 15),
+                // (6,21): error CS1031: Type expected
                 //         async async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 21),
-                // (5,27): error CS1031: Type expected
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 21),
+                // (6,27): error CS1031: Type expected
                 //         async async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 27),
-                // (5,33): error CS1031: Type expected
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 27),
+                // (6,33): error CS1031: Type expected
                 //         async async async async async void F() { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(5, 33));
+                Diagnostic(ErrorCode.ERR_TypeExpected, "async").WithLocation(6, 33));
             checkNodes();
 
             void checkNodes()


### PR DESCRIPTION
Part of https://github.com/dotnet/roslyn/issues/32106

This fixes the folowing case:
```cs
class Program
{
    static void M()
    {
        async async void F() { }
    }
}
```
In the currentl implementation `async async` is parsed as a variable declaration and `void F() { }` as a local function. This creates a bunch of pretty useless errors. You can observe current behaviour in details at the following [sharplab](https://sharplab.io/#v2:EYLgtghglgdgNAFxBAzguATEBqAPgAQCYACfARgHYBYAKAG9binSyA2UgFmIFkAKASkbMGNZmNIAOSZ2IAxAcTrEAvkKaqayoA==).

This PR changes current behaviour to parse `async async void F() { }` as a single local function with multiple `async` modifiers. This significantly improves error messages by providing these 2 errors now: `CS1031: Type expected` and `CS1004: Duplicate 'async' modifier`

The final goal of the issue is to just have `CS1004: Duplicate '{0}' modifier` error, but I preffer to do it by parts, so let's take this one first.