### PR TITLE
Additional perf improvements for document highlights

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.BidirectionalSymbolSet.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.BidirectionalSymbolSet.cs
@@ -27,15 +27,18 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             /// add a new symbol to it we'll continue to cascade in both directions looking for more.
             /// </summary>
             private readonly MetadataUnifyingSymbolHashSet _allSymbols = new();
+            private readonly bool _includeImplementationsThroughDerivedTypes;
 
             public BidirectionalSymbolSet(
                 FindReferencesSearchEngine engine,
                 MetadataUnifyingSymbolHashSet initialSymbols,
-                MetadataUnifyingSymbolHashSet upSymbols)
+                MetadataUnifyingSymbolHashSet upSymbols,
+                bool includeImplementationsThroughDerivedTypes)
                 : base(engine)
             {
                 _allSymbols.AddRange(initialSymbols);
                 _allSymbols.AddRange(upSymbols);
+                _includeImplementationsThroughDerivedTypes = includeImplementationsThroughDerivedTypes;
             }
 
             public override ImmutableArray<ISymbol> GetAllSymbols()
@@ -57,7 +60,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                     // new symbols in this project.  As long as we keep finding symbols, we'll keep searching from them
                     // in both directions.
                     await AddDownSymbolsAsync(this.Engine, current, _allSymbols, workQueue, projects, cancellationToken).ConfigureAwait(false);
-                    await AddUpSymbolsAsync(this.Engine, current, _allSymbols, workQueue, projects, cancellationToken).ConfigureAwait(false);
+                    await AddUpSymbolsAsync(this.Engine, current, _allSymbols, workQueue, projects, _includeImplementationsThroughDerivedTypes, cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine.cs
@@ -82,7 +82,8 @@ namespace Microsoft.CodeAnalysis.FindSymbols
 
                 // Create the initial set of symbols to search for.  As we walk the appropriate projects in the solution
                 // we'll expand this set as we discover new symbols to search for in each project.
-                var symbolSet = await SymbolSet.CreateAsync(this, unifiedSymbols, cancellationToken).ConfigureAwait(false);
+                var symbolSet = await SymbolSet.CreateAsync(
+                    this, unifiedSymbols, includeImplementationsThroughDerivedTypes: true, cancellationToken).ConfigureAwait(false);
 
                 // Report the initial set of symbols to the caller.
                 var allSymbols = symbolSet.GetAllSymbols();

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/FindReferencesSearchEngine_FindReferencesInDocuments.cs
@@ -180,16 +180,20 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 if (await SymbolFinder.OriginalSymbolsMatchAsync(_solution, searchSymbol, candidate, cancellationToken).ConfigureAwait(false))
                     return false;
 
-                // walk up the original symbol's inheritance hierarchy to see if we hit the candidate.
-                var searchSymbolUpSet = await SymbolSet.CreateAsync(this, new() { searchSymbol }, cancellationToken).ConfigureAwait(false);
+                // walk up the original symbol's inheritance hierarchy to see if we hit the candidate. Don't walk down
+                // derived types here.  The point of this algorithm is to only walk upwards looking for matches.
+                var searchSymbolUpSet = await SymbolSet.CreateAsync(
+                    this, new() { searchSymbol }, includeImplementationsThroughDerivedTypes: false, cancellationToken).ConfigureAwait(false);
                 foreach (var symbolUp in searchSymbolUpSet.GetAllSymbols())
                 {
                     if (await SymbolFinder.OriginalSymbolsMatchAsync(_solution, symbolUp, candidate, cancellationToken).ConfigureAwait(false))
                         return true;
                 }
 
-                // walk up the candidate's inheritance hierarchy to see if we hit the original symbol.
-                var candidateSymbolUpSet = await SymbolSet.CreateAsync(this, new() { candidate }, cancellationToken).ConfigureAwait(false);
+                // walk up the candidate's inheritance hierarchy to see if we hit the original symbol. Don't walk down
+                // derived types here.  The point of this algorithm is to only walk upwards looking for matches.
+                var candidateSymbolUpSet = await SymbolSet.CreateAsync(
+                    this, new() { candidate }, includeImplementationsThroughDerivedTypes: false, cancellationToken).ConfigureAwait(false);
                 foreach (var candidateUp in candidateSymbolUpSet.GetAllSymbols())
                 {
                     if (await SymbolFinder.OriginalSymbolsMatchAsync(_solution, searchSymbol, candidateUp, cancellationToken).ConfigureAwait(false))


### PR DESCRIPTION
This saves about 8 seconds of CPU time producing a solution-wide acceleration index used for understanding symbol (including metadata symbols) hierarchies, used for inheritance checking.   This index is rebuilt after any top level change and helps global operations like find-refs.  However, it's super overkill for document-highlights, which is only checking results in a single file.

This takes us down to subsecond to build our indices and do a highlight-refs in a document, even for something with a big set of items in the inheritance hierarchy (think Object.ToString, or IDisposable.Dispose).  