### PR TITLE
Only examine a PEReference once when walking projects to produce inheritance tree

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -220,21 +220,15 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                                 break;
                             case SpecialType.System_ValueType:
                                 await AddMatchingTypesAsync(
-                                    projectIndex.ValueTypes,
-                                    tempBuffer,
-                                    predicateOpt: null).ConfigureAwait(false);
+                                    projectIndex.ValueTypes, tempBuffer, predicateOpt: null).ConfigureAwait(false);
                                 break;
                             case SpecialType.System_Enum:
                                 await AddMatchingTypesAsync(
-                                    projectIndex.Enums,
-                                    tempBuffer,
-                                    predicateOpt: null).ConfigureAwait(false);
+                                    projectIndex.Enums, tempBuffer, predicateOpt: null).ConfigureAwait(false);
                                 break;
                             case SpecialType.System_MulticastDelegate:
                                 await AddMatchingTypesAsync(
-                                    projectIndex.Delegates,
-                                    tempBuffer,
-                                    predicateOpt: null).ConfigureAwait(false);
+                                    projectIndex.Delegates, tempBuffer, predicateOpt: null).ConfigureAwait(false);
                                 break;
                         }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -324,6 +324,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                         result, typesToSearchFor, tempBuffer, transitive, shouldContinueSearching);
                 }
 
+                // Mark all these references as having been seen.  We don't need to examine it in future projects.
                 seenPEReferences.AddRange(compilation.References.OfType<PortableExecutableReference>());
             }
 

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/DependentTypeFinder.cs
@@ -42,9 +42,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private static readonly Func<Location, bool> s_isInMetadata = static loc => loc.IsInMetadata;
         private static readonly Func<Location, bool> s_isInSource = static loc => loc.IsInSource;
 
-        private static readonly Func<INamedTypeSymbol, bool> s_isInterface = t => t?.TypeKind == TypeKind.Interface;
-        private static readonly Func<INamedTypeSymbol, bool> s_isNonSealedClass = t => t?.TypeKind == TypeKind.Class && !t.IsSealed;
-        private static readonly Func<INamedTypeSymbol, bool> s_isInterfaceOrNonSealedClass = t => s_isInterface(t) || s_isNonSealedClass(t);
+        private static readonly Func<INamedTypeSymbol, bool> s_isInterface = static t => t is { TypeKind: TypeKind.Interface };
+        private static readonly Func<INamedTypeSymbol, bool> s_isNonSealedClass = static t => t is { TypeKind: TypeKind.Class, IsSealed: false };
+        private static readonly Func<INamedTypeSymbol, bool> s_isInterfaceOrNonSealedClass = static t => s_isInterface(t) || s_isNonSealedClass(t);
 
         private static readonly ObjectPool<PooledHashSet<INamedTypeSymbol>> s_symbolSetPool = PooledHashSet<INamedTypeSymbol>.CreatePool(SymbolEquivalenceComparer.Instance);
 


### PR DESCRIPTION
This PR should be reviewed commit by commit.  The first commit updates the logic so we only ever look at a metadata-reference once when producing the inheritance tree for PE-references.  The later ones simply our helpers by making them local functions to avoid having to pass around so much redundant state.  