### PR TITLE
Fix crash while deserializing DiagnosticDataLocation

### DIFF
--- a/src/EditorFeatures/Test/EditAndContinue/EmitSolutionUpdateResultsTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EmitSolutionUpdateResultsTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 customTags: ImmutableArray.Create("Test3"),
                 properties: ImmutableDictionary<string, string?>.Empty,
                 document.Project.Id,
-                new DiagnosticDataLocation(new(sourcePath, new(0, 1), new(0, 5)), document.Id, mappedFileSpan: null),
+                new DiagnosticDataLocation(new(sourcePath, new(0, 1), new(0, 5)), document.Id),
                 language: "C#",
                 title: "title",
                 description: "description",

--- a/src/VisualStudio/Core/Def/TableDataSource/Suppression/VisualStudioDiagnosticListSuppressionStateService.cs
+++ b/src/VisualStudio/Core/Def/TableDataSource/Suppression/VisualStudioDiagnosticListSuppressionStateService.cs
@@ -304,7 +304,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                         var linePosition = new LinePosition(line, 0);
                         var linePositionSpan = new LinePositionSpan(start: linePosition, end: linePosition);
                         var location = new DiagnosticDataLocation(
-                            new FileLinePositionSpan(filePath, linePositionSpan), document.Id, mappedFileSpan: null);
+                            new FileLinePositionSpan(filePath, linePositionSpan), document.Id);
 
                         Contract.ThrowIfNull(project);
 

--- a/src/VisualStudio/Core/Def/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/TaskList/ProjectExternalErrorReporter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -275,8 +275,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 projectId: projectId,
                 location: new DiagnosticDataLocation(
                     unmappedSpan,
-                    documentId,
-                    mappedFileSpan: null),
+                    documentId),
                 language: language);
         }
 

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataLocation.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticDataLocation.cs
@@ -38,9 +38,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public DiagnosticDataLocation(
             FileLinePositionSpan unmappedFileSpan,
-            DocumentId? documentId = null,
-            FileLinePositionSpan? mappedFileSpan = null)
+            DocumentId? documentId,
+            FileLinePositionSpan mappedFileSpan)
             : this(unmappedFileSpan, documentId, mappedFileSpan, forceMappedPath: false)
+        {
+            // This constructor is used for deserialization, so the arguments must have the same exact order and type
+            // as the fields with the [DataMember] attribute.
+        }
+
+        public DiagnosticDataLocation(
+            FileLinePositionSpan unmappedFileSpan,
+            DocumentId? documentId = null)
+            : this(unmappedFileSpan, documentId, null, forceMappedPath: false)
         {
         }
 


### PR DESCRIPTION
The arguments of the constructor used by MessagePack to deserialize instances of DiagnosticDataLocation did not match the fields, and that caused a crash.

The problem was with the MappedFileSpan field, which is of type FileLinePositionSpan, but in the constructor it was a Nullable<FileLinePositionSpan>, since it was declared as an optional argument.

The solution is to change the constructor to match the field types, and add a new constructor for the case when mappedFileSpan doesn't need to be provided.