### PR TITLE
 Add unique color scheme for high contrast mode

### DIFF
--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Whitespace/View/WhitespaceBoolSettingView.xaml
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Whitespace/View/WhitespaceBoolSettingView.xaml
@@ -4,11 +4,147 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:vsshell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
-             Resources="{StaticResource {x:Static vsshell:VsResourceKeys.ThemedDialogDefaultStylesKey}}"
+             xmlns:vs="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              mc:Ignorable="d" 
              x:ClassModifier="internal">
+    <UserControl.Resources>
+        <Style x:Key="FocusVisualStyleKey">
+            <Setter Property="Control.Template">
+                <Setter.Value>
+                    <ControlTemplate>
+                        <Rectangle
+                        SnapsToDevicePixels="true"
+                        Margin="0"
+                        Stroke="{DynamicResource {x:Static vs:CommonControlsColors.FocusVisualTextBrushKey}}"
+                        StrokeDashArray="1 2" StrokeThickness="1"/>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+
     <CheckBox x:Name="RootCheckBox"
               IsChecked="{Binding IsChecked}"
               ToolTip="{Binding ToolTip}"
-              AutomationProperties.Name="{Binding AutomationName}" />
+              AutomationProperties.Name="{Binding AutomationName}"
+              FocusVisualStyle="{DynamicResource FocusVisualStyleKey}">
+        <CheckBox.Style>
+            <Style TargetType="{x:Type CheckBox}">
+                <Setter Property="Tag" Value="{DynamicResource {x:Static SystemParameters.HighContrastKey}}"/>
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxTextBrushKey}}" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type CheckBox}">
+                            <Grid x:Name="TemplateRoot">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid SnapsToDevicePixels="true" Width="16" Height="16" HorizontalAlignment="Left" VerticalAlignment="Center">
+                                    <Border x:Name="CheckMarkBorder"
+                                            Background="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxBackgroundBrushKey}}"
+                                            BorderBrush="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxBorderBrushKey}}"
+                                            BorderThickness="1"/>
+                                    <Grid x:Name="MarkGrid">
+                                        <Path x:Name="CheckMark"
+                                              Data="M 6.22,11.02 C6.22,11.02 2.50,7.24 2.50,7.24 2.50,7.24 4.05,5.71 4.05,5.71 4.05,5.71 5.97,7.65 5.97,7.65 5.97,7.65 10.52,1.38 10.52,1.38 10.52,1.38 13.19,1.38 13.19,1.38 13.19,1.38 6.22,11.02 6.22,11.02 6.22,11.02 6.22,11.02 6.22,11.02 z"
+                                              Stretch="Uniform"
+                                              Margin="3,1,2,2"
+                                              Visibility="Collapsed"
+                                              Width="9"
+                                              Height="8"
+                                              Fill="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxGlyphBrushKey}}"/>
+                                        <Rectangle x:Name="IndeterminateMark"
+                                                   Fill="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxGlyphBrushKey}}"
+                                                   Margin="3"
+                                                   Visibility="Hidden"/>
+                                    </Grid>
+                                </Grid>
+                                <ContentPresenter x:Uid="CheckBoxContent" 
+                                          x:Name="CheckBoxContent" 
+                                          Grid.Column="1" 
+                                          Focusable="False"
+                                          Margin="{TemplateBinding Padding}"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          RecognizesAccessKey="True" />
+                            </Grid>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="HasContent" Value="true">
+                                    <Setter Property="Padding" Value="6,1,0,0"/>
+                                </Trigger>
+                                <Trigger Property="IsChecked" Value="true">
+                                    <Setter Property="Visibility" TargetName="CheckMark" Value="Visible"/>
+                                </Trigger>
+                                <Trigger Property="IsChecked" Value="{x:Null}">
+                                    <Setter Property="Visibility" TargetName="IndeterminateMark" Value="Visible"/>
+                                </Trigger>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" Value="false"/>
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsEnabled}" Value="false" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Background" TargetName="CheckMarkBorder" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxBackgroundDisabledBrushKey}}"/>
+                                    <Setter Property="BorderBrush" TargetName="CheckMarkBorder" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxBorderDisabledBrushKey}}"/>
+                                    <Setter Property="Fill" TargetName="CheckMark" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxGlyphDisabledBrushKey}}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxTextDisabledBrushKey}}"/>
+                                </MultiDataTrigger>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" Value="false"/>
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsFocused}" Value="true" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Background" TargetName="CheckMarkBorder" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxBackgroundFocusedBrushKey}}"/>
+                                    <Setter Property="BorderBrush" TargetName="CheckMarkBorder" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxBorderFocusedBrushKey}}"/>
+                                    <Setter Property="Fill" TargetName="CheckMark" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxGlyphFocusedBrushKey}}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxTextFocusedBrushKey}}"/>
+                                </MultiDataTrigger>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" Value="true"/>
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsFocused}" Value="true" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Background" TargetName="CheckMarkBorder" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxTextBrushKey}}"/>
+                                    <Setter Property="BorderBrush" TargetName="CheckMarkBorder" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxBackgroundBrushKey}}"/>
+                                    <Setter Property="Fill" TargetName="CheckMark" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxGlyphFocusedBrushKey}}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxTextFocusedBrushKey}}"/>
+                                </MultiDataTrigger>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" Value="false"/>
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsMouseOver}" Value="true" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Background" TargetName="CheckMarkBorder" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxBackgroundHoverBrushKey}}"/>
+                                    <Setter Property="BorderBrush" TargetName="CheckMarkBorder" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxBorderHoverBrushKey}}"/>
+                                    <Setter Property="Fill" TargetName="CheckMark" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxGlyphHoverBrushKey}}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxTextHoverBrushKey}}"/>
+                                </MultiDataTrigger>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" Value="true"/>
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsMouseOver}" Value="true" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Background" TargetName="CheckMarkBorder" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxTextBrushKey}}"/>
+                                    <Setter Property="BorderBrush" TargetName="CheckMarkBorder" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxBackgroundBrushKey}}"/>
+                                    <Setter Property="Fill" TargetName="CheckMark" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxGlyphFocusedBrushKey}}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxTextFocusedBrushKey}}"/>
+                                </MultiDataTrigger>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=Tag}" Value="false"/>
+                                        <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsPressed}" Value="true" />
+                                    </MultiDataTrigger.Conditions>
+                                    <Setter Property="Background" TargetName="CheckMarkBorder" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxBackgroundPressedBrushKey}}"/>
+                                    <Setter Property="BorderBrush" TargetName="CheckMarkBorder" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxBorderPressedBrushKey}}"/>
+                                    <Setter Property="Fill" TargetName="CheckMark" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxGlyphPressedBrushKey}}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static vs:CommonControlsColors.CheckBoxTextPressedBrushKey}}"/>
+                                </MultiDataTrigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </CheckBox.Style>
+    </CheckBox>
 </UserControl>


### PR DESCRIPTION
In high contrast mode the default VS Color scheme does not meet accessibility requirements. 

Fixes:
- [#AB1642931](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1642931/)

| Current | With Fix |
|---------|----------|
| ![repro-unchecked](https://user-images.githubusercontent.com/9797472/209249158-4bb47bcb-4a96-404b-bb08-59fda0f5096f.png) | ![fixed-unchecked](https://user-images.githubusercontent.com/9797472/209249190-a022a73d-350e-4e73-a0d2-0c6e5b9bf4fd.png) |
| ![repro-checked](https://user-images.githubusercontent.com/9797472/209249216-eb0cccd6-a844-415a-bbac-bfe4b77e28ac.png) | ![fixed-checked](https://user-images.githubusercontent.com/9797472/209249235-2ca5944b-82cc-4d86-96fc-b7b43d07344b.png) |
