### PR TITLE
Account for SpecificDiagnosticOptions in analyzer driver checks for enabling a disabled by default rule

### DIFF
--- a/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -4022,7 +4022,7 @@ public record A(int X, int Y);";
 
             var compilation = CreateCompilation(new[] { source1, source2, source3 });
 
-            var options = compilation.Options;
+            CSharpCompilationOptions options;
             if (treeBasedOptions)
             {
                 // Enable disabled by default analyzer for first source file with analyzer config options.

--- a/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -4010,19 +4010,40 @@ public record A(int X, int Y);";
                      Diagnostic("MyDiagnostic", @"public record A(int X, int Y);").WithLocation(2, 1));
         }
 
-        [Fact, WorkItem(64771, "https://github.com/dotnet/roslyn/issues/64771")]
-        public void TestDisabledByDefaultAnalyzerEnabledForSingleFile()
+        [Theory, CombinatorialData]
+        [WorkItem(64771, "https://github.com/dotnet/roslyn/issues/64771")]
+        [WorkItem(66085, "https://github.com/dotnet/roslyn/issues/66085")]
+        public void TestDisabledByDefaultAnalyzerEnabledForSingleFile(bool treeBasedOptions)
         {
             var source1 = "class C1 { }";
             var source2 = "class C2 { }";
             var source3 = "class C3 { }";
             var analyzer = new AnalyzerWithDisabledRules();
 
-            // Enable disabled by default analyzer for first source file with analyzer config options.
             var compilation = CreateCompilation(new[] { source1, source2, source3 });
-            var tree1 = compilation.SyntaxTrees[0];
-            var options = compilation.Options.WithSyntaxTreeOptionsProvider(
-                new TestSyntaxTreeOptionsProvider(tree1, (AnalyzerWithDisabledRules.Rule.Id, ReportDiagnostic.Warn)));
+
+            var options = compilation.Options;
+            if (treeBasedOptions)
+            {
+                // Enable disabled by default analyzer for first source file with analyzer config options.
+                var tree1 = compilation.SyntaxTrees[0];
+                options = compilation.Options.WithSyntaxTreeOptionsProvider(
+                    new TestSyntaxTreeOptionsProvider(tree1, (AnalyzerWithDisabledRules.Rule.Id, ReportDiagnostic.Warn)));
+            }
+            else
+            {
+                // Enable disabled by default analyzer for entire compilation with SpecificDiagnosticOptions
+                // and disable the analyzer for second and third source file with analyzer config options.
+                // So, effectively the analyzer is enabled only for first source file.
+                var tree2 = compilation.SyntaxTrees[1];
+                var tree3 = compilation.SyntaxTrees[2];
+                options = compilation.Options
+                    .WithSpecificDiagnosticOptions(ImmutableDictionary<string, ReportDiagnostic>.Empty.Add(AnalyzerWithDisabledRules.Rule.Id, ReportDiagnostic.Warn))
+                    .WithSyntaxTreeOptionsProvider(new TestSyntaxTreeOptionsProvider(
+                        (tree2, new[] { (AnalyzerWithDisabledRules.Rule.Id, ReportDiagnostic.Suppress) }),
+                        (tree3, new[] { (AnalyzerWithDisabledRules.Rule.Id, ReportDiagnostic.Suppress) })));
+            }
+
             compilation = compilation.WithOptions(options);
 
             // Verify single analyzer diagnostic reported in the compilation.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1333,10 +1333,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 var hasUnsuppressedDiagnostic = false;
                 foreach (var descriptor in descriptors)
                 {
-                    _ = options.TryGetGlobalDiagnosticValue(descriptor.Id, AnalyzerExecutor.CancellationToken, out var configuredSeverity);
-                    if (options.TryGetDiagnosticValue(tree, descriptor.Id, AnalyzerExecutor.CancellationToken, out var diagnosticSeverity))
+                    var configuredSeverity = descriptor.GetEffectiveSeverity(AnalyzerExecutor.Compilation.Options);
+                    if (options.TryGetDiagnosticValue(tree, descriptor.Id, AnalyzerExecutor.CancellationToken, out var severityFromOptions) ||
+                        options.TryGetGlobalDiagnosticValue(descriptor.Id, AnalyzerExecutor.CancellationToken, out severityFromOptions))
                     {
-                        configuredSeverity = diagnosticSeverity;
+                        configuredSeverity = severityFromOptions;
                     }
 
                     // Disabled by default descriptor with default configured severity is equivalent to suppressed.


### PR DESCRIPTION
Fixes #66085

Ensure that the code in analyzer driver that checks if disabled by default analyzer is enabled for a specific tree checks for configuration through `CompilationOptions.SpecificDiagnosticOptions`. These options can be set through ruleset file or via API in test scenarios, so we need to ensure they are respected. This regressed in #64772 where we respect configuration checks through globalconfig and editorconfig options, but did not account for `CompilationOptions.SpecificDiagnosticOptions` - `Descriptor.GetEffectiveSeverity(CompilationOptions)` gets the effective severity accounting for `SpecificDiagnosticOptions`.

Verified that the modified unit test fails prior to the product fix when executed with `treeBasedOptions = false`