### PR TITLE
Qualify `Task.FromResult` when removing `async` modifier

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveAsyncModifier/RemoveAsyncModifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveAsyncModifier/RemoveAsyncModifierTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing;

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveAsyncModifier/RemoveAsyncModifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveAsyncModifier/RemoveAsyncModifierTests.cs
@@ -7,6 +7,7 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.RemoveAsyncModifier
@@ -1030,6 +1031,34 @@ class C
         return System.Threading.Tasks.Task.FromResult(2);
     }
 }");
+        }
+
+        [Fact, WorkItem(65536, "https://github.com/dotnet/roslyn/issues/65536")]
+        public async Task Method_TaskOfT_BlockBody_QualifyTaskFromResultType()
+        {
+            await VerifyCS.VerifyCodeFixAsync("""
+                using System.Threading.Tasks;
+                using System.Collections.Generic;
+
+                class C
+                {
+                    public async Task<IReadOnlyCollection<int>> {|CS1998:M|}()
+                    {
+                        return new int[0];
+                    }
+                }
+                """, """
+                using System.Threading.Tasks;
+                using System.Collections.Generic;
+                
+                class C
+                {
+                    public Task<IReadOnlyCollection<int>> M()
+                    {
+                        return Task.FromResult<IReadOnlyCollection<int>>(new int[0]);
+                    }
+                }
+                """);
         }
 
         [Fact]

--- a/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodAsynchronous/CSharpMakeMethodAsynchronousCodeFixProvider.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
             {
                 if (!keepVoid)
                 {
-                    newReturnType = knownTypes._taskType.GenerateTypeSyntax();
+                    newReturnType = knownTypes.TaskType.GenerateTypeSyntax();
                 }
             }
             else
@@ -114,15 +114,15 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
                 var returnType = methodSymbol.ReturnType;
                 if (IsIEnumerable(returnType, knownTypes) && IsIterator(methodSymbol, cancellationToken))
                 {
-                    newReturnType = knownTypes._iAsyncEnumerableOfTTypeOpt is null
+                    newReturnType = knownTypes.IAsyncEnumerableOfTTypeOpt is null
                         ? MakeGenericType(nameof(IAsyncEnumerable<int>), methodSymbol.ReturnType)
-                        : knownTypes._iAsyncEnumerableOfTTypeOpt.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();
+                        : knownTypes.IAsyncEnumerableOfTTypeOpt.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();
                 }
                 else if (IsIEnumerator(returnType, knownTypes) && IsIterator(methodSymbol, cancellationToken))
                 {
-                    newReturnType = knownTypes._iAsyncEnumeratorOfTTypeOpt is null
+                    newReturnType = knownTypes.IAsyncEnumeratorOfTTypeOpt is null
                         ? MakeGenericType(nameof(IAsyncEnumerator<int>), methodSymbol.ReturnType)
-                        : knownTypes._iAsyncEnumeratorOfTTypeOpt.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();
+                        : knownTypes.IAsyncEnumeratorOfTTypeOpt.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();
                 }
                 else if (IsIAsyncEnumerableOrEnumerator(returnType, knownTypes))
                 {
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
                 {
                     // If it's not already Task-like, then wrap the existing return type
                     // in Task<>.
-                    newReturnType = knownTypes._taskOfTType.Construct(methodSymbol.ReturnType).GenerateTypeSyntax();
+                    newReturnType = knownTypes.TaskOfTType.Construct(methodSymbol.ReturnType).GenerateTypeSyntax();
                 }
             }
 
@@ -151,14 +151,14 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodAsynchronous
             => method.Locations.Any(static (loc, cancellationToken) => loc.FindNode(cancellationToken).ContainsYield(), cancellationToken);
 
         private static bool IsIAsyncEnumerableOrEnumerator(ITypeSymbol returnType, KnownTypes knownTypes)
-            => returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumerableOfTTypeOpt) ||
-                returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumeratorOfTTypeOpt);
+            => returnType.OriginalDefinition.Equals(knownTypes.IAsyncEnumerableOfTTypeOpt) ||
+                returnType.OriginalDefinition.Equals(knownTypes.IAsyncEnumeratorOfTTypeOpt);
 
         private static bool IsIEnumerable(ITypeSymbol returnType, KnownTypes knownTypes)
-            => returnType.OriginalDefinition.Equals(knownTypes._iEnumerableOfTType);
+            => returnType.OriginalDefinition.Equals(knownTypes.IEnumerableOfTType);
 
         private static bool IsIEnumerator(ITypeSymbol returnType, KnownTypes knownTypes)
-            => returnType.OriginalDefinition.Equals(knownTypes._iEnumeratorOfTType);
+            => returnType.OriginalDefinition.Equals(knownTypes.IEnumeratorOfTType);
 
         private static SyntaxTokenList AddAsyncModifierWithCorrectedTrivia(SyntaxTokenList modifiers, ref TypeSyntax newReturnType)
         {

--- a/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/MakeMethodSynchronous/CSharpMakeMethodSynchronousCodeFixProvider.cs
@@ -62,25 +62,25 @@ namespace Microsoft.CodeAnalysis.CSharp.MakeMethodSynchronous
             var newReturnType = returnTypeSyntax;
 
             var returnType = methodSymbol.ReturnType;
-            if (returnType.OriginalDefinition.Equals(knownTypes._taskType))
+            if (returnType.OriginalDefinition.Equals(knownTypes.TaskType))
             {
                 // If the return type is Task, then make the new return type "void".
                 newReturnType = SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)).WithTriviaFrom(returnTypeSyntax);
             }
-            else if (returnType.OriginalDefinition.Equals(knownTypes._taskOfTType))
+            else if (returnType.OriginalDefinition.Equals(knownTypes.TaskOfTType))
             {
                 // If the return type is Task<T>, then make the new return type "T".
                 newReturnType = returnType.GetTypeArguments()[0].GenerateTypeSyntax().WithTriviaFrom(returnTypeSyntax);
             }
-            else if (returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumerableOfTTypeOpt))
+            else if (returnType.OriginalDefinition.Equals(knownTypes.IAsyncEnumerableOfTTypeOpt))
             {
                 // If the return type is IAsyncEnumerable<T>, then make the new return type IEnumerable<T>.
-                newReturnType = knownTypes._iEnumerableOfTType.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();
+                newReturnType = knownTypes.IEnumerableOfTType.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();
             }
-            else if (returnType.OriginalDefinition.Equals(knownTypes._iAsyncEnumeratorOfTTypeOpt))
+            else if (returnType.OriginalDefinition.Equals(knownTypes.IAsyncEnumeratorOfTTypeOpt))
             {
                 // If the return type is IAsyncEnumerator<T>, then make the new return type IEnumerator<T>.
-                newReturnType = knownTypes._iEnumeratorOfTType.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();
+                newReturnType = knownTypes.IEnumeratorOfTType.Construct(methodSymbol.ReturnType.GetTypeArguments()[0]).GenerateTypeSyntax();
             }
 
             return newReturnType;

--- a/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.KnownTypes.cs
+++ b/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.KnownTypes.cs
@@ -12,29 +12,29 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
     {
         internal readonly struct KnownTypes
         {
-            public readonly INamedTypeSymbol _taskType;
-            public readonly INamedTypeSymbol _taskOfTType;
-            public readonly INamedTypeSymbol _valueTaskType;
-            public readonly INamedTypeSymbol _valueTaskOfTTypeOpt;
+            public readonly INamedTypeSymbol TaskType;
+            public readonly INamedTypeSymbol TaskOfTType;
+            public readonly INamedTypeSymbol ValueTaskType;
+            public readonly INamedTypeSymbol ValueTaskOfTTypeOpt;
 
-            public readonly INamedTypeSymbol _iEnumerableOfTType;
-            public readonly INamedTypeSymbol _iEnumeratorOfTType;
+            public readonly INamedTypeSymbol IEnumerableOfTType;
+            public readonly INamedTypeSymbol IEnumeratorOfTType;
 
-            public readonly INamedTypeSymbol _iAsyncEnumerableOfTTypeOpt;
-            public readonly INamedTypeSymbol _iAsyncEnumeratorOfTTypeOpt;
+            public readonly INamedTypeSymbol IAsyncEnumerableOfTTypeOpt;
+            public readonly INamedTypeSymbol IAsyncEnumeratorOfTTypeOpt;
 
             internal KnownTypes(Compilation compilation)
             {
-                _taskType = compilation.TaskType();
-                _taskOfTType = compilation.TaskOfTType();
-                _valueTaskType = compilation.ValueTaskType();
-                _valueTaskOfTTypeOpt = compilation.ValueTaskOfTType();
+                TaskType = compilation.TaskType();
+                TaskOfTType = compilation.TaskOfTType();
+                ValueTaskType = compilation.ValueTaskType();
+                ValueTaskOfTTypeOpt = compilation.ValueTaskOfTType();
 
-                _iEnumerableOfTType = compilation.IEnumerableOfTType();
-                _iEnumeratorOfTType = compilation.IEnumeratorOfTType();
+                IEnumerableOfTType = compilation.IEnumerableOfTType();
+                IEnumeratorOfTType = compilation.IEnumeratorOfTType();
 
-                _iAsyncEnumerableOfTTypeOpt = compilation.IAsyncEnumerableOfTType();
-                _iAsyncEnumeratorOfTTypeOpt = compilation.IAsyncEnumeratorOfTType();
+                IAsyncEnumerableOfTTypeOpt = compilation.IAsyncEnumerableOfTType();
+                IAsyncEnumeratorOfTTypeOpt = compilation.IAsyncEnumeratorOfTType();
             }
         }
     }

--- a/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
             // if our member is already Task-Like, and that functionality recognizes
             // ValueTask if it is available, but does not care if it is not.
             var knownTypes = new KnownTypes(compilation);
-            if (knownTypes._taskType == null || knownTypes._taskOfTType == null)
+            if (knownTypes.TaskType == null || knownTypes.TaskOfTType == null)
             {
                 return;
             }
@@ -206,22 +206,22 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
 
         protected static bool IsTaskLike(ITypeSymbol returnType, KnownTypes knownTypes)
         {
-            if (returnType.Equals(knownTypes._taskType))
+            if (returnType.Equals(knownTypes.TaskType))
             {
                 return true;
             }
 
-            if (returnType.Equals(knownTypes._valueTaskType))
+            if (returnType.Equals(knownTypes.ValueTaskType))
             {
                 return true;
             }
 
-            if (returnType.OriginalDefinition.Equals(knownTypes._taskOfTType))
+            if (returnType.OriginalDefinition.Equals(knownTypes.TaskOfTType))
             {
                 return true;
             }
 
-            if (returnType.OriginalDefinition.Equals(knownTypes._valueTaskOfTTypeOpt))
+            if (returnType.OriginalDefinition.Equals(knownTypes.ValueTaskOfTTypeOpt))
             {
                 return true;
             }

--- a/src/Features/Core/Portable/RemoveAsyncModifier/AbstractRemoveAsyncModifierCodeFixProvider.cs
+++ b/src/Features/Core/Portable/RemoveAsyncModifier/AbstractRemoveAsyncModifierCodeFixProvider.cs
@@ -103,12 +103,12 @@ namespace Microsoft.CodeAnalysis.RemoveAsyncModifier
 
         private static bool ShouldOfferFix(ITypeSymbol returnType, KnownTypes knownTypes)
             => IsTaskType(returnType, knownTypes)
-                || returnType.OriginalDefinition.Equals(knownTypes._taskOfTType)
-                || returnType.OriginalDefinition.Equals(knownTypes._valueTaskOfTTypeOpt);
+                || returnType.OriginalDefinition.Equals(knownTypes.TaskOfTType)
+                || returnType.OriginalDefinition.Equals(knownTypes.ValueTaskOfTTypeOpt);
 
         private static bool IsTaskType(ITypeSymbol returnType, KnownTypes knownTypes)
-            => returnType.OriginalDefinition.Equals(knownTypes._taskType)
-                || returnType.OriginalDefinition.Equals(knownTypes._valueTaskType);
+            => returnType.OriginalDefinition.Equals(knownTypes.TaskType)
+                || returnType.OriginalDefinition.Equals(knownTypes.ValueTaskType);
 
         private SyntaxNode RemoveAsyncModifier(SyntaxGenerator generator, SyntaxNode node, ITypeSymbol returnType, KnownTypes knownTypes, bool needsReturnStatementAdded)
         {
@@ -199,14 +199,14 @@ namespace Microsoft.CodeAnalysis.RemoveAsyncModifier
         private static SyntaxNode GetReturnTaskCompletedTaskStatement(SyntaxGenerator generator, ITypeSymbol returnType, KnownTypes knownTypes)
         {
             SyntaxNode invocation;
-            if (returnType.OriginalDefinition.Equals(knownTypes._taskType))
+            if (returnType.OriginalDefinition.Equals(knownTypes.TaskType))
             {
-                var taskTypeExpression = TypeExpressionForStaticMemberAccess(generator, knownTypes._taskType);
+                var taskTypeExpression = TypeExpressionForStaticMemberAccess(generator, knownTypes.TaskType);
                 invocation = generator.MemberAccessExpression(taskTypeExpression, nameof(Task.CompletedTask));
             }
             else
             {
-                invocation = generator.ObjectCreationExpression(knownTypes._valueTaskType);
+                invocation = generator.ObjectCreationExpression(knownTypes.ValueTaskType);
             }
 
             var statement = generator.ReturnStatement(invocation);
@@ -215,9 +215,9 @@ namespace Microsoft.CodeAnalysis.RemoveAsyncModifier
 
         private static SyntaxNode WrapExpressionWithTaskFromResult(SyntaxGenerator generator, SyntaxNode expression, ITypeSymbol returnType, KnownTypes knownTypes)
         {
-            if (returnType.OriginalDefinition.Equals(knownTypes._taskOfTType))
+            if (returnType.OriginalDefinition.Equals(knownTypes.TaskOfTType))
             {
-                var taskTypeExpression = TypeExpressionForStaticMemberAccess(generator, knownTypes._taskType);
+                var taskTypeExpression = TypeExpressionForStaticMemberAccess(generator, knownTypes.TaskType);
                 var unwrappedReturnType = returnType.GetTypeArguments()[0];
                 var memberName = generator.GenericName(nameof(Task.FromResult), unwrappedReturnType);
                 var taskFromResult = generator.MemberAccessExpression(taskTypeExpression, memberName);

--- a/src/Features/Core/Portable/RemoveAsyncModifier/AbstractRemoveAsyncModifierCodeFixProvider.cs
+++ b/src/Features/Core/Portable/RemoveAsyncModifier/AbstractRemoveAsyncModifierCodeFixProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
@@ -219,7 +218,9 @@ namespace Microsoft.CodeAnalysis.RemoveAsyncModifier
             if (returnType.OriginalDefinition.Equals(knownTypes._taskOfTType))
             {
                 var taskTypeExpression = TypeExpressionForStaticMemberAccess(generator, knownTypes._taskType);
-                var taskFromResult = generator.MemberAccessExpression(taskTypeExpression, nameof(Task.FromResult));
+                var unwrappedReturnType = returnType.GetTypeArguments()[0];
+                var memberName = generator.GenericName(nameof(Task.FromResult), unwrappedReturnType);
+                var taskFromResult = generator.MemberAccessExpression(taskTypeExpression, memberName);
                 return generator.InvocationExpression(taskFromResult, expression.WithoutTrivia()).WithTriviaFrom(expression);
             }
             else

--- a/src/Features/VisualBasic/Portable/MakeMethodAsynchronous/VisualBasicMakeMethodAsynchronousCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/MakeMethodAsynchronous/VisualBasicMakeMethodAsynchronousCodeFixProvider.vb
@@ -69,7 +69,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodAsynchronous
 
                 Return FixMultiLineLambdaExpression(DirectCast(node, MultiLineLambdaExpressionSyntax))
             ElseIf node.IsKind(SyntaxKind.SubBlock) Then
-                Return FixSubBlock(keepVoid, DirectCast(node, MethodBlockSyntax), knownTypes._taskType)
+                Return FixSubBlock(keepVoid, DirectCast(node, MethodBlockSyntax), knownTypes.TaskType)
             Else
                 Return FixFunctionBlock(
                     methodSymbolOpt, DirectCast(node, MethodBlockSyntax), knownTypes)
@@ -82,7 +82,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodAsynchronous
 
             If Not IsTaskLike(methodSymbol.ReturnType, knownTypes) Then
                 ' if the current return type is not already task-list, then wrap it in Task(of ...)
-                Dim returnType = knownTypes._taskOfTType.Construct(methodSymbol.ReturnType).GenerateTypeSyntax().WithAdditionalAnnotations(Simplifier.AddImportsAnnotation)
+                Dim returnType = knownTypes.TaskOfTType.Construct(methodSymbol.ReturnType).GenerateTypeSyntax().WithAdditionalAnnotations(Simplifier.AddImportsAnnotation)
                 newFunctionStatement = newFunctionStatement.WithAsClause(
                 newFunctionStatement.AsClause.WithType(returnType))
             End If

--- a/src/Features/VisualBasic/Portable/MakeMethodSynchronous/VisualBasicMakeMethodSynchronousCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/MakeMethodSynchronous/VisualBasicMakeMethodSynchronousCodeFixProvider.vb
@@ -56,12 +56,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodSynchronous
 
             ' if this returns Task(of T), then we want to convert this to a T returning function.
             ' if this returns Task, then we want to convert it to a Sub method.
-            If methodSymbol.ReturnType.OriginalDefinition.Equals(knownTypes._taskOfTType) Then
+            If methodSymbol.ReturnType.OriginalDefinition.Equals(knownTypes.TaskOfTType) Then
                 Dim newAsClause = functionStatement.AsClause.WithType(methodSymbol.ReturnType.GetTypeArguments()(0).GenerateTypeSyntax())
                 Dim newFunctionStatement = functionStatement.WithAsClause(newAsClause)
                 newFunctionStatement = RemoveAsyncModifierHelpers.RemoveAsyncKeyword(newFunctionStatement)
                 Return node.WithSubOrFunctionStatement(newFunctionStatement)
-            ElseIf Equals(methodSymbol.ReturnType.OriginalDefinition, knownTypes._taskType) Then
+            ElseIf Equals(methodSymbol.ReturnType.OriginalDefinition, knownTypes.TaskType) Then
                 ' Convert this to a 'Sub' method.
                 Dim subStatement = SyntaxFactory.SubStatement(
                     functionStatement.AttributeLists,


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/65536

Review commit by commit:
1. Frist commit fixes the issue (actual fix + test)
2. Second commit removes `#nullable disable` in test file
3. Third commit renames public fields of `KnownTypes` from `_fieldStyle` to `FieldStyle`. Having public members with `_style` naming seems very confusing to me. We can always revert this if there was some underlying logic there