### PR TITLE
Fix for `return new …` statement differs between `Task` and `ValueTask` methods

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectCreationCompletionProviderTests.cs
@@ -100,6 +100,23 @@ class Program
         }
 
         [Fact]
+        public async Task InAsyncMethodReturnValueTask()
+        {
+            var markup =
+@"using System;
+using System.Threading.Tasks;
+
+class Program
+{
+    async ValueTask&lt;string&gt; M2Async()
+    {
+        return new $$;
+    }
+}";
+            await VerifyItemExistsAsync(MakeMarkup(markup), "string");
+        }
+
+        [Fact]
         public async Task IsCommitCharacterTest()
         {
             const string markup = @"
@@ -768,6 +785,19 @@ class Program
     private List<int> o = new List<int>();
 }";
             await VerifyProviderCommitAsync(markup, "List<int>", expectedMark, commitChar: ';');
+        }
+
+        private static string MakeMarkup(string source, string languageVersion = "Preview")
+        {
+            return $$"""
+<Workspace>
+    <Project Language="C#" AssemblyName="Assembly" CommonReferencesNet6="true" LanguageVersion="{{languageVersion}}">
+        <Document FilePath="Test.cs">
+{{source}}
+        </Document>
+    </Project>
+</Workspace>
+""";
         }
     }
 }

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -11066,5 +11066,25 @@ public class Bar&lt;T&gt; : ISomeInterface&lt;T&gt;
                 Await state.AssertCompletionItemsContain("SomeExtMethod", displayTextSuffix:="<>")
             End Using
         End Function
+
+        <WpfFact, WorkItem(64862, "https://github.com/dotnet/roslyn/issues/64862")>
+        Public Async Function TestAsyncMethodReturningValueTask() As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+using System.Threading.Tasks;
+
+class Program
+{
+    async ValueTask&lt;string&gt; M2Async()
+    {
+        return new $$;
+    }
+}
+                </Document>)
+
+                state.SendInvokeCompletionList()
+                Await state.AssertCompletionItemsContain("string", displayTextSuffix:="")
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -2026,13 +2026,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (isAsync)
                 {
-                    if (type.OriginalDefinition.Equals(this.Compilation.TaskOfTType()))
+                    if (type.OriginalDefinition.Equals(this.Compilation.TaskOfTType()) || type.OriginalDefinition.Equals(this.Compilation.ValueTaskOfTType()))
                     {
                         var namedTypeSymbol = (INamedTypeSymbol)type;
                         return namedTypeSymbol.TypeArguments[0];
                     }
 
-                    if (type.OriginalDefinition.Equals(this.Compilation.TaskType()))
+                    if (type.OriginalDefinition.Equals(this.Compilation.TaskType()) || type.OriginalDefinition.Equals(this.Compilation.ValueTaskType()))
                     {
                         return this.Compilation.GetSpecialType(SpecialType.System_Void);
                     }


### PR DESCRIPTION
Fixes #64862