### PR TITLE
Fix state for pattern declarations on subsequent iterations

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesVsPatterns.cs
@@ -2856,5 +2856,400 @@ public class Class2
                 Diagnostic(ErrorCode.ERR_PropertyLacksGet, "Method").WithArguments("Method").WithLocation(14, 25)
                 );
         }
+
+        [Fact, WorkItem(65976, "https://github.com/dotnet/roslyn/issues/65976")]
+        public void LoopWithPatternDeclaration()
+        {
+            var source = """
+#nullable enable
+using System.Collections.Generic;
+
+class C
+{
+    void M()
+    {
+        string? s = "";
+
+        for (var x = 0; x < 10; x++)
+        {
+            var a = Infer(s);
+            if (a[0] is var z)
+            {
+                z.ToString();
+            }
+
+            s = null;
+        }
+    }
+
+    List<T> Infer<T>(T t) => new() { t };
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (15,17): warning CS8602: Dereference of a possibly null reference.
+                //                 z.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(15, 17)
+                );
+        }
+
+        [Fact, WorkItem(65976, "https://github.com/dotnet/roslyn/issues/65976")]
+        public void LoopWithPatternDeclaration_Tuple()
+        {
+            var source = """
+#nullable enable
+using System.Collections.Generic;
+
+class C
+{
+    void M()
+    {
+        string? s = "";
+
+        for (var x = 0; x < 10; x++)
+        {
+            var a = Infer(s);
+            if ((a[0], 1) is (var z, var z2))
+            {
+                z.ToString();
+            }
+
+            s = null;
+        }
+    }
+
+    List<T> Infer<T>(T t) => new() { t };
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (15,17): warning CS8602: Dereference of a possibly null reference.
+                //                 z.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(15, 17)
+                );
+        }
+
+        [Fact, WorkItem(65976, "https://github.com/dotnet/roslyn/issues/65976")]
+        public void LoopWithPatternDeclaration_ListPattern()
+        {
+            var source = """
+#nullable enable
+using System.Collections.Generic;
+
+string? s = "";
+
+for (var x = 0; x < 10; x++)
+{
+    var a = Infer(s);
+    if (a is [var z])
+    {
+        z.ToString();
+    }
+
+    s = null;
+}
+
+List<T> Infer<T>(T t) => new() { t };
+""";
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics(
+                // (11,9): warning CS8602: Dereference of a possibly null reference.
+                //         z.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(11, 9)
+                );
+        }
+
+        [Fact, WorkItem(65976, "https://github.com/dotnet/roslyn/issues/65976")]
+        public void LoopWithPatternDeclaration_ListPattern_Inline()
+        {
+            var source = """
+#nullable enable
+using System.Collections.Generic;
+
+string? s = "";
+
+for (var x = 0; x < 10; x++)
+{
+    if (Infer(s) is [var z])
+    {
+        z.ToString();
+    }
+
+    s = null;
+}
+
+List<T> Infer<T>(T t) => new() { t };
+""";
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics(
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
+                //         z.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(10, 9)
+                );
+        }
+
+        [Fact, WorkItem(65976, "https://github.com/dotnet/roslyn/issues/65976")]
+        public void LoopWithPatternDeclaration_SlicePattern()
+        {
+            var source = """
+#nullable enable
+
+string? s = "";
+
+for (var x = 0; x < 10; x++)
+{
+    var a = Infer(s);
+    if (a is [_, .. var z, _])
+    {
+        z.ToString();
+    }
+
+    s = null;
+}
+
+Collection<T> Infer<T>(T t) => throw null!;
+
+class Collection<T>
+{
+    public int Length => throw null!;
+    public T this[System.Index i] => throw null!;
+    public T this[System.Range r] => throw null!;
+}
+""";
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics();
+            // Slice is assumed to be never null
+        }
+
+        [Fact, WorkItem(65976, "https://github.com/dotnet/roslyn/issues/65976")]
+        public void LoopWithDeconstructionPattern()
+        {
+            var source = """
+#nullable enable
+
+string? s = "";
+
+for (var x = 0; x < 10; x++)
+{
+    if (Infer(s) is (var z, var z2))
+    {
+        z.ToString(); // 1
+    }
+
+    s = null;
+}
+
+s = "";
+if (Infer(s) is (var y, var y2))
+{
+    y.ToString();
+}
+
+s = null;
+if (Infer(s) is (var w, var w2))
+{
+    w.ToString(); // 2
+}
+
+Container<T> Infer<T>(T t) => throw null!;
+
+class Container<T>
+{
+    public void Deconstruct(out T t1, out T t2) => throw null!;
+}
+""";
+            // Need to re-infer Deconstruct method https://github.com/dotnet/roslyn/issues/34232
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem(65976, "https://github.com/dotnet/roslyn/issues/65976")]
+        public void LoopWithFieldPattern()
+        {
+            var source = """
+#nullable enable
+
+string? s = "";
+
+for (var x = 0; x < 10; x++)
+{
+    var a = Infer(s);
+    if (a is { field: var z })
+    {
+        z.ToString(); // 1
+    }
+
+    s = null;
+}
+
+
+Container<T> Infer<T>(T t) => throw null!;
+
+class Container<T>
+{
+    public T field = default!;
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
+                //         z.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(10, 9)
+                );
+        }
+
+        [Fact, WorkItem(65976, "https://github.com/dotnet/roslyn/issues/65976")]
+        public void LoopWithFieldPattern_Inline()
+        {
+            var source = """
+#nullable enable
+
+string? s = "";
+
+for (var x = 0; x < 10; x++)
+{
+    if (Infer(s) is { field: var z })
+    {
+        z.ToString(); // 1
+    }
+
+    s = null;
+}
+
+
+Container<T> Infer<T>(T t) => throw null!;
+
+class Container<T>
+{
+    public T field = default!;
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (9,9): warning CS8602: Dereference of a possibly null reference.
+                //         z.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(9, 9)
+                );
+        }
+
+        [Fact, WorkItem(65976, "https://github.com/dotnet/roslyn/issues/65976")]
+        public void LoopWithPropertyPattern()
+        {
+            var source = """
+#nullable enable
+
+string? s = "";
+
+for (var x = 0; x < 10; x++)
+{
+    var a = Infer(s);
+    if (a is { field: var z })
+    {
+        z.ToString(); // 1
+    }
+
+    s = null;
+}
+
+
+Container<T> Infer<T>(T t) => throw null!;
+
+class Container<T>
+{
+    public T field => default!;
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (10,9): warning CS8602: Dereference of a possibly null reference.
+                //         z.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(10, 9)
+                );
+        }
+
+        [Fact, WorkItem(65976, "https://github.com/dotnet/roslyn/issues/65976")]
+        public void LoopWithLocalDeclaration()
+        {
+            var source = """
+#nullable enable
+using System.Collections.Generic;
+
+string? s = "";
+
+for (var x = 0; x < 10; x++)
+{
+    var z = Infer(s)[0];
+    z.ToString();
+
+    s = null;
+}
+
+List<T> Infer<T>(T t) => new() { t };
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (9,5): warning CS8602: Dereference of a possibly null reference.
+                //     z.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(9, 5)
+                );
+        }
+
+        [Fact, WorkItem(65976, "https://github.com/dotnet/roslyn/issues/65976")]
+        public void LoopWithDeconstructionDeclaration()
+        {
+            var source = """
+#nullable enable
+using System.Collections.Generic;
+
+string? s = "";
+
+for (var x = 0; x < 10; x++)
+{
+    (var z, var z2) = (Infer(s)[0], 1);
+    z.ToString();
+
+    s = null;
+}
+
+List<T> Infer<T>(T t) => new() { t };
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (9,5): warning CS8602: Dereference of a possibly null reference.
+                //     z.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(9, 5)
+                );
+        }
+
+        [Fact, WorkItem(65976, "https://github.com/dotnet/roslyn/issues/65976")]
+        public void LoopWithDeconstructionDeclaration_CustomType()
+        {
+            var source = """
+#nullable enable
+
+string? s = "";
+
+for (var x = 0; x < 10; x++)
+{
+    (var z, var z2) = Infer(s);
+    z.ToString();
+
+    s = null;
+}
+
+Container<T> Infer<T>(T t) => throw null!;
+
+class Container<T>
+{
+    public void Deconstruct(out T t1, out T t2) => throw null!;
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (8,5): warning CS8602: Dereference of a possibly null reference.
+                //     z.ToString();
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "z").WithLocation(8, 5)
+                );
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/65976

## Example to illustrate the problem with regular declaration pattern

The DAG for `a[0] is var z` is:
 ```
[0]: when <true> ? [1] : <unreachable>
[1]: leaf <isPatternSuccess> `var z`
```

The nullability analysis of the `when` clause in `DAG` is responsible for handling assignments from bindings (see line 616 in `LearnFromDecisionDag`). In this case, we have an assignment `z = t0`. The problem was that we hadn't properly set the state of `t0` (the input variable for the DAG).

In cases without loops, this problem doesn't manifest because the logic to create the slot for `t0` will use the correct state to derive the type of `t0` and so it will get the right initial/default state.
The problem occurs once we're in a loop. On the second iteration, we'd re-use the state of `t0` from the first iteration instead of setting it.

## Example with list pattern

The DAG for `a is [var z]` is:
```
[0]: t0 != null ? [1] : [6]
[1]: t1 = t0.Count; [2]
[2]: t1 == 1 ? [3] : [6]
[3]: t2 = t0[0]; [4]
[4]: when <true> ? [5] : <unreachable>
[5]: leaf <isPatternSuccess> `[var z]`
[6]: leaf <isPatternFailure> `[var z]`
```

The logic in `case BoundDagIndexerEvaluation e:` similarly just grabbed a slot, but didn't explicitly assign to it. So on second iteration, it would re-use the state from `t2` from first iteration.