### PR TITLE
Correct initial state for nested method nullability analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -61,7 +61,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             internal VariableState(VariablesSnapshot variables, LocalStateSnapshot variableNullableStates)
             {
                 Debug.Assert(variables.Id == variableNullableStates.Id);
-                Debug.Assert((variables.VariableSlot.Count() + 1) * 2 == variableNullableStates.State.Capacity);
                 Variables = variables;
                 VariableNullableStates = variableNullableStates;
             }
@@ -1735,7 +1734,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (initialState.HasValue)
                 {
                     Debug.Assert(walker._variables.Id == initialState.Value.Id);
-                    Debug.Assert(initialState.Value.Capacity == walker._variables.NextAvailableIndex);
                 }
 #endif
                 bool badRegion = false;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -11344,7 +11344,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return state;
             }
 
-            public int Capacity => _state.Capacity / 2;
+            private int Capacity => _state.Capacity / 2;
 
             private void EnsureCapacity(int capacity)
             {

--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -127,7 +127,7 @@ namespace RunTests
                 executable: _options.DotnetFilePath,
                 arguments: "build helix-tmp.csproj",
                 captureOutput: true,
-                onOutputDataReceived: (e) => ConsoleUtil.WriteLine(e.Data),
+                onOutputDataReceived: (e) => { Debug.Assert(e.Data is not null); ConsoleUtil.WriteLine(e.Data); },
                 cancellationToken: cancellationToken);
             var result = await process.Result;
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/61516
Fixes https://github.com/dotnet/roslyn/issues/61964

Using the snippet from https://github.com/dotnet/roslyn/issues/61516 (included as first test in this PR), at some point during the analysis (which takes many steps due to lambda inference, method re-inference and lambda conversion) we would visit the property access (`plan. Schedule`). We'd check the slot for the property (see `if (this.State.HasValue(slot))` in  `VisitMemberAccess`) and we'd find that it had value (`NotNull`, ie. false-false in the BitVector).
That value was never set explicitly. Instead, it resulted from an incorrect initialization (too large) of the state/BitVector.

I'm not exactly sure why this problem resulted in the observed behavior (addition of unrelated code affecting nullability analysis).

As part of my investigation and understanding how we track slots for nested methods, I added some assertions that tighten the relationship between `Variables` and `LocalState`. Namely, their `Id` and sizes should match.