### PR TITLE
Fix Extract Base When Class Has Base

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
@@ -2545,6 +2545,29 @@ class C
         }
 
         [Fact]
+        [WorkItem(55610, "https://github.com/dotnet/roslyn/issues/55610")]
+        public async Task TestClassSelected_WithTypeContainingBaseClass()
+        {
+            var code = """
+                class Base
+                {
+                }
+
+                class $$Derived : Base
+                {
+                    public void M() { }
+                    public void N() { }
+                }
+                """;
+
+            await new Test()
+            {
+                TestCode = code,
+                FixedCode = code
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task TestMultipleMethodsSelected_HighlightedMembersAreSelected()
         {
             var code = """

--- a/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
@@ -2604,7 +2604,8 @@ class C
                         expected1,
                         expected2
                     }
-                }
+                },
+                FileName = "Test1.cs"
             }.RunAsync();
         }
 

--- a/src/Features/Core/Portable/ExtractClass/AbstractExtractClassRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ExtractClass/AbstractExtractClassRefactoringProvider.cs
@@ -46,10 +46,14 @@ namespace Microsoft.CodeAnalysis.ExtractClass
                 return;
             }
 
-            // If we register the action on a class node, no need to find selected members. Just allow
-            // the action to be invoked with the dialog and no selected members
-            var action = await TryGetClassActionAsync(context, optionsService).ConfigureAwait(false)
-                ?? await TryGetMemberActionAsync(context, optionsService).ConfigureAwait(false);
+            var (action, hasBaseType) = await TryGetMemberActionAsync(context, optionsService).ConfigureAwait(false);
+
+            // If the action was not offered because we know the containing type
+            // already has a base class, no need to do extra work to see if just a class is selected
+            if (action is null && !hasBaseType)
+            {
+                action = await TryGetClassActionAsync(context, optionsService).ConfigureAwait(false);
+            }
 
             if (action != null)
             {
@@ -57,12 +61,12 @@ namespace Microsoft.CodeAnalysis.ExtractClass
             }
         }
 
-        private async Task<ExtractClassWithDialogCodeAction?> TryGetMemberActionAsync(CodeRefactoringContext context, IExtractClassOptionsService optionsService)
+        private async Task<(ExtractClassWithDialogCodeAction? action, bool hasBaseType)> TryGetMemberActionAsync(CodeRefactoringContext context, IExtractClassOptionsService optionsService)
         {
             var selectedMemberNodes = await GetSelectedNodesAsync(context).ConfigureAwait(false);
             if (selectedMemberNodes.IsEmpty)
             {
-                return null;
+                return (null, false);
             }
 
             var (document, span, cancellationToken) = context;
@@ -75,7 +79,7 @@ namespace Microsoft.CodeAnalysis.ExtractClass
 
             if (memberNodeSymbolPairs.IsEmpty)
             {
-                return null;
+                return (null, false);
             }
 
             var selectedMembers = memberNodeSymbolPairs.SelectAsArray(pair => pair.symbol);
@@ -90,12 +94,9 @@ namespace Microsoft.CodeAnalysis.ExtractClass
                 memberNodeSymbolPairs.First().node.FullSpan.Start,
                 memberNodeSymbolPairs.Last().node.FullSpan.End);
 
-            // Can't extract to a new type if there's already a base. Maybe
-            // in the future we could inject a new type inbetween base and
-            // current
-            if (containingType.BaseType?.SpecialType != SpecialType.System_Object)
+            if (HasBaseType(containingType))
             {
-                return null;
+                return (null, true);
             }
 
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
@@ -104,32 +105,45 @@ namespace Microsoft.CodeAnalysis.ExtractClass
             {
                 // If the containing type node isn't found exit. This could be malformed code that we don't know
                 // how to correctly handle
-                return null;
+                return (null, false);
             }
 
             if (selectedMemberNodes.Any(m => m.FirstAncestorOrSelf<SyntaxNode>(syntaxFacts.IsTypeDeclaration) != containingTypeDeclarationNode))
             {
-                return null;
+                return (null, false);
             }
 
-            return new ExtractClassWithDialogCodeAction(
+            var action = new ExtractClassWithDialogCodeAction(
                 document, memberSpan, optionsService, containingType, containingTypeDeclarationNode, context.Options, selectedMembers);
+
+            return (action, false);
         }
 
         private async Task<ExtractClassWithDialogCodeAction?> TryGetClassActionAsync(CodeRefactoringContext context, IExtractClassOptionsService optionsService)
         {
             var selectedClassNode = await GetSelectedClassDeclarationAsync(context).ConfigureAwait(false);
             if (selectedClassNode is null)
+            {
                 return null;
+            }
 
             var (document, span, cancellationToken) = context;
 
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            if (semanticModel.GetDeclaredSymbol(selectedClassNode, cancellationToken) is not INamedTypeSymbol originalType)
+            if (semanticModel.GetDeclaredSymbol(selectedClassNode, cancellationToken) is not INamedTypeSymbol selectedType)
+            {
                 return null;
+            }
+
+            if (HasBaseType(selectedType))
+            {
+                return null;
+            }
 
             return new ExtractClassWithDialogCodeAction(
-                document, span, optionsService, originalType, selectedClassNode, context.Options, selectedMembers: ImmutableArray<ISymbol>.Empty);
+                document, span, optionsService, selectedType, selectedClassNode, context.Options, selectedMembers: ImmutableArray<ISymbol>.Empty);
         }
+
+        private static bool HasBaseType(INamedTypeSymbol containingType) => containingType.BaseType?.SpecialType != SpecialType.System_Object;
     }
 }


### PR DESCRIPTION
When the class already has a base, make sure not to offer the refactoring. 

Also fix so that if members are highlighted, we prefer to have them selected by default instead of doing the class only offering. 

Fixes #55610