### PR TITLE
Prefer default over starred item

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
@@ -81,8 +81,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
                 // We prefer using the original snapshot, which should always be available from items provided by Roslyn's CompletionSource.
                 // Only use data.Snapshot in the theoretically possible but rare case when all items we are handling are from some non-Roslyn CompletionSource.
-                var snapshotForDocument = TryGetInitialTriggerLocation(_snapshotData, out var intialTriggerLocation)
-                    ? intialTriggerLocation.Snapshot
+                var snapshotForDocument = TryGetInitialTriggerLocation(_snapshotData, out var initialTriggerLocation)
+                    ? initialTriggerLocation.Snapshot
                     : _snapshotData.Snapshot;
 
                 _document = snapshotForDocument?.TextBuffer.AsTextContainer().GetOpenDocumentInCurrentContext();
@@ -95,8 +95,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     // We can change this if get requests from partner teams.
                     _completionHelper = CompletionHelper.GetHelper(_document);
                     _filterMethod = _completionService == null
-                        ? ((matchResults, text, filtereditemsBuilder) => CompletionService.FilterItems(_completionHelper, matchResults, text, filtereditemsBuilder))
-                        : ((matchResults, text, filtereditemsBuilder) => _completionService.FilterItems(_document, matchResults, text, filtereditemsBuilder));
+                        ? ((matchResults, text, filteredItemsBuilder) => CompletionService.FilterItems(_completionHelper, matchResults, text, filteredItemsBuilder))
+                        : ((matchResults, text, filteredItemsBuilder) => _completionService.FilterItems(_document, matchResults, text, filteredItemsBuilder));
 
                     // Nothing to highlight if user hasn't typed anything yet.
                     _highlightMatchingPortions = _filterText.Length > 0
@@ -250,7 +250,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
                     if (CompletionItemData.TryGetData(item, out var itemData))
                     {
-                        // currentIndex is used to track the index of the VS CompletionItem in the intial sorted list to maintain a map from Roslyn itemt o VS item.
+                        // currentIndex is used to track the index of the VS CompletionItem in the initial sorted list to maintain a map from Roslyn item to VS item.
                         // It's also used to sort the items by pattern matching results while preserving the original alphabetical order for items with
                         // same pattern match score since `List<T>.Sort` isn't stable.
                         if (CompletionHelper.TryCreateMatchResult(_completionHelper, itemData.RoslynItem, _filterText,
@@ -577,7 +577,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             }
 
             /// <summary>
-            /// Given multiple possible chosen completion items, pick the one using the following perferences (in order):
+            /// Given multiple possible chosen completion items, pick the one using the following preferences (in order):
             ///     1. Most recently used item is our top preference
             ///     2. IntelliCode item over non-IntelliCode item
             ///     3. Higher MatchPriority
@@ -645,18 +645,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return bestResult;
             }
 
-            private static bool TryGetInitialTriggerLocation(AsyncCompletionSessionDataSnapshot data, out SnapshotPoint intialTriggerLocation)
+            private static bool TryGetInitialTriggerLocation(AsyncCompletionSessionDataSnapshot data, out SnapshotPoint initialTriggerLocation)
             {
                 foreach (var item in data.InitialSortedItemList)
                 {
                     if (CompletionItemData.TryGetData(item, out var itemData) && itemData.TriggerLocation.HasValue)
                     {
-                        intialTriggerLocation = itemData.TriggerLocation.Value;
+                        initialTriggerLocation = itemData.TriggerLocation.Value;
                         return true;
                     }
                 }
 
-                intialTriggerLocation = default;
+                initialTriggerLocation = default;
                 return false;
             }
 
@@ -775,7 +775,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             /// If the suggested default is no worse than current selected item (in a case-sensitive manner,) use the suggested default. Otherwise use the original selection.
             /// For example, if user typed "C", roslyn might select "CancellationToken", but with suggested default "Console" we will end up selecting "Console" instead.
             /// </summary>
-            private ItemSelection GetDefaultsMatch(IReadOnlyList<MatchResult> items, ItemSelection intialSelection, CancellationToken cancellationToken)
+            private ItemSelection GetDefaultsMatch(IReadOnlyList<MatchResult> items, ItemSelection initialSelection, CancellationToken cancellationToken)
             {
                 // Because the items are already sorted based on pattern-matching score, try to limit the range for the items we compare default with
                 // by searching for the first "inferior" item, so we can avoid always going through the entire list.
@@ -787,18 +787,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 }
                 else
                 {
-                    var selectedItemMatch = items[intialSelection.SelectedItemIndex].PatternMatch;
+                    var selectedItemMatch = items[initialSelection.SelectedItemIndex].PatternMatch;
 
                     // It's possible that an item doesn't match filter text but still ended up being selected, this is because we just always keep all the
                     // items in the list in some cases. For example, user brought up completion with ctrl-j or through deletion.
                     // Don't bother changing the selection in such cases (since there's no match to the filter text in the list)
                     if (!selectedItemMatch.HasValue)
-                        return intialSelection;
+                        return initialSelection;
 
                     // Because the items are sorted based on pattern-matching score, the selectedIndex is in the middle of a range of
                     // -- as far as the pattern matcher is concerned -- equivalent items (items with identical PatternMatch.Kind and IsCaseSensitive).
                     // Find the last items in the range and use that to limit the items searched for from the defaults list.     
-                    inferiorItemIndex = intialSelection.SelectedItemIndex;
+                    inferiorItemIndex = initialSelection.SelectedItemIndex;
                     while (++inferiorItemIndex < items.Count)
                     {
                         var itemMatch = items[inferiorItemIndex].PatternMatch;
@@ -823,14 +823,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                         {
                             // If user hasn't typed anything, we'd like to hard select the default item.
                             // This way, they can easily commit the default item which matches what WLC shows.
-                            var selectionHint = _filterText.Length == 0 ? UpdateSelectionHint.Selected : intialSelection.SelectionHint;
-                            return intialSelection with { SelectedItemIndex = i, SelectionHint = selectionHint };
+                            var selectionHint = _filterText.Length == 0 ? UpdateSelectionHint.Selected : initialSelection.SelectionHint;
+                            return initialSelection with { SelectedItemIndex = i, SelectionHint = selectionHint };
                         }
                     }
                 }
 
                 // Don't change the original selection since there's no match to the defaults provided.
-                return intialSelection;
+                return initialSelection;
             }
 
             private sealed class FilterStateHelper

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
@@ -756,9 +756,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 if (_snapshotData.Defaults.IsDefaultOrEmpty || itemSelection.SelectedItemIndex == SuggestionItemIndex)
                     return itemSelection;
 
-                // "Preselect" is only used when we have high confidence with the selection, so don't override it.
+                // "Preselect" is only used when we have high confidence with the selection, so don't override it;
+                // unless it's an IntelliCode item, in which case the default item wins.
                 var selectedItem = items[itemSelection.SelectedItemIndex].CompletionItem;
-                if (selectedItem.Rules.MatchPriority >= MatchPriority.Preselect)
+                if (selectedItem.Rules.MatchPriority >= MatchPriority.Preselect && !selectedItem.IsPreferredItem())
                     return itemSelection;
 
                 var tick = Environment.TickCount;
@@ -818,7 +819,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     // so we just need to search for the first item that matches the suggested default.
                     for (var i = 0; i < inferiorItemIndex; ++i)
                     {
-                        if (items[i].CompletionItem.DisplayText == defaultText)
+                        if (items[i].CompletionItem.FilterText == defaultText)
                         {
                             // If user hasn't typed anything, we'd like to hard select the default item.
                             // This way, they can easily commit the default item which matches what WLC shows.

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.cs
@@ -20,8 +20,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 {
     internal sealed partial class ItemManager : IAsyncCompletionItemManager2
     {
-        public const string AggressiveDefaultsMatchingOptionName = "AggressiveDefaultsMatchingOption";
-
         private readonly RecentItemsManager _recentItemsManager;
         private readonly IGlobalOptionService _globalOptions;
 
@@ -37,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             CancellationToken cancellationToken)
         {
             var stopwatch = SharedStopwatch.StartNew();
-            var items = SortCompletionitems(data, cancellationToken).ToImmutableArray();
+            var items = SortCompletionItems(data, cancellationToken).ToImmutableArray();
 
             AsyncCompletionLogger.LogItemManagerSortTicksDataPoint(stopwatch.Elapsed);
             return Task.FromResult(items);
@@ -49,13 +47,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             CancellationToken cancellationToken)
         {
             var stopwatch = SharedStopwatch.StartNew();
-            var itemList = session.CreateCompletionList(SortCompletionitems(data, cancellationToken));
+            var itemList = session.CreateCompletionList(SortCompletionItems(data, cancellationToken));
 
             AsyncCompletionLogger.LogItemManagerSortTicksDataPoint(stopwatch.Elapsed);
             return Task.FromResult(itemList);
         }
 
-        private static SegmentedList<VSCompletionItem> SortCompletionitems(AsyncCompletionSessionInitialDataSnapshot data, CancellationToken cancellationToken)
+        private static SegmentedList<VSCompletionItem> SortCompletionItems(AsyncCompletionSessionInitialDataSnapshot data, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var items = new SegmentedList<VSCompletionItem>(data.InitialItemList.Count);

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
@@ -127,7 +127,7 @@ class My
             End Using
         End Function
 
-        <WpfFact, CombinatorialData>
+        <WpfFact>
         Public Async Function DoNotChangeIfPreselection() As Task
             Using state = CreateTestStateWithAdditionalDocument(
                               <Document>

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
@@ -17,8 +17,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
     <Trait(Traits.Feature, Traits.Features.Completion)>
     Public Class CSharpCompletionCommandHandlerTests_DefaultsSource
 
-        <WpfTheory, CombinatorialData>
-        Public Async Function TestNoItemMatchesDefaults(isAggressive As Boolean) As Task
+        <WpfFact>
+        Public Async Function TestNoItemMatchesDefaults() As Task
             ' We are not adding the additional file which contains type MyAB and MyA
             ' the the suggestion from default source doesn't match anything in the completion list.
             Using state = TestStateFactory.CreateCSharpTestState(
@@ -32,10 +32,6 @@ class C
 }
                               </Document>,
                               extraExportedTypes:={GetType(MockDefaultSource)}.ToList())
-
-                If isAggressive Then
-                    state.TextView.Options.SetOptionValue(ItemManager.AggressiveDefaultsMatchingOptionName, True)
-                End If
 
                 state.SendInvokeCompletionList()
 
@@ -131,8 +127,8 @@ class My
             End Using
         End Function
 
-        <WpfTheory, CombinatorialData>
-        Public Async Function DoNotChangeIfPreselection(isAggressive As Boolean) As Task
+        <WpfFact, CombinatorialData>
+        Public Async Function DoNotChangeIfPreselection() As Task
             Using state = CreateTestStateWithAdditionalDocument(
                               <Document>
 using NS1;
@@ -144,9 +140,6 @@ class C
     }
 }
                               </Document>)
-                If isAggressive Then
-                    state.TextView.Options.SetOptionValue(ItemManager.AggressiveDefaultsMatchingOptionName, True)
-                End If
 
                 state.SendInvokeCompletionList()
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
@@ -3,8 +3,12 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Collections.Immutable
+Imports System.Composition
+Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion
 Imports Microsoft.VisualStudio.Text.Editor
 
@@ -154,6 +158,7 @@ class C
         End Function
 
         Private Shared Function CreateTestStateWithAdditionalDocument(documentElement As XElement) As TestState
+            MockDefaultSource.Defaults = ImmutableArray.Create("MyAB", "MyA")
             Return TestStateFactory.CreateTestStateFromWorkspace(
                 <Workspace>
                     <Project Language="C#" LanguageVersion="Preview" CommonReferences="true">
@@ -186,14 +191,112 @@ namespace NS1
         Private Class MockDefaultSource
             Implements IAsyncCompletionDefaultsSource
 
+            Public Shared Defaults As ImmutableArray(Of String) = ImmutableArray(Of String).Empty
+
             <ComponentModel.Composition.ImportingConstructor>
             <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
             Public Sub New()
             End Sub
 
             Public Function GetSessionDefaultsAsync(session As IAsyncCompletionSession) As Task(Of ImmutableArray(Of String)) Implements IAsyncCompletionDefaultsSource.GetSessionDefaultsAsync
-                Return Task.FromResult(ImmutableArray.Create("MyAB", "MyA"))
+                Return Task.FromResult(Defaults)
             End Function
         End Class
+
+        <WpfFact>
+        Public Async Function SelectDefaultItemOverStarredItem() As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+class MyClass 
+{                          
+    public bool FirstStarred()  => true;
+    public bool SecondStarred() => true;
+    public bool FirstDefault()  => true;
+}
+class Test
+{
+    void M(MyClass c)
+    {
+        c$$
+    }
+}
+                </Document>,
+                extraExportedTypes:={GetType(IntelliCodeMockProvider), GetType(MockDefaultSource)}.ToList())
+
+                MockDefaultSource.Defaults = ImmutableArray.Create("FirstDefault")
+                state.SendTypeChars(".")
+
+                Await state.AssertCompletionItemsContainAll("★ FirstStarred", "★ SecondStarred", "FirstStarred", "SecondStarred", "FirstDefault")
+                Await state.AssertSelectedCompletionItem("FirstDefault", isHardSelected:=True)
+
+                state.SendTypeChars("First")
+                Await state.AssertCompletionItemsContainAll("★ FirstStarred", "FirstStarred", "FirstDefault")
+                Await state.AssertSelectedCompletionItem("FirstDefault", isHardSelected:=True)
+
+                state.SendTypeChars("S")
+                Await state.AssertSelectedCompletionItem("★ FirstStarred", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact>
+        Public Async Function SelectStarredItemInDefaultList() As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+class MyClass 
+{                          
+    public bool FirstStarred()  => true;
+    public bool SecondStarred() => true;
+    public bool FirstDefault()  => true;
+}
+class Test
+{
+    void M(MyClass c)
+    {
+        c$$
+    }
+}
+                </Document>,
+                extraExportedTypes:={GetType(IntelliCodeMockProvider), GetType(MockDefaultSource)}.ToList())
+
+                MockDefaultSource.Defaults = ImmutableArray.Create("SecondStarred")
+                state.SendTypeChars(".")
+
+                Await state.AssertCompletionItemsContainAll("★ FirstStarred", "★ SecondStarred", "FirstStarred", "SecondStarred", "FirstDefault")
+                Await state.AssertSelectedCompletionItem("★ SecondStarred", isHardSelected:=True)
+
+                state.SendTypeChars("starred")
+                Await state.AssertCompletionItemsContainAll("★ FirstStarred", "FirstStarred", "★ SecondStarred", "SecondStarred")
+                Await state.AssertSelectedCompletionItem("★ SecondStarred", isHardSelected:=True)
+            End Using
+        End Function
+
+        <ExportCompletionProvider(NameOf(IntelliCodeMockProvider), LanguageNames.CSharp)>
+        <[Shared]>
+        <PartNotDiscoverable>
+        Private Class IntelliCodeMockProvider
+            Inherits CompletionProvider
+
+            <ImportingConstructor>
+            <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+            Public Sub New()
+            End Sub
+
+            Public Overrides Function ProvideCompletionsAsync(context As CompletionContext) As Task
+                Dim rules = CompletionItemRules.Default.WithSelectionBehavior(CompletionItemSelectionBehavior.HardSelection).WithMatchPriority(MatchPriority.Preselect)
+                context.AddItem(CompletionItem.Create(displayText:="★ FirstStarred", filterText:="FirstStarred", sortText:=GetSortText(1), rules:=rules))
+                context.AddItem(CompletionItem.Create(displayText:="★ SecondStarred", filterText:="SecondStarred", sortText:=GetSortText(2), rules:=rules))
+                Return Task.CompletedTask
+            End Function
+
+            ' This is what Pythia uses to sort starred items to the top of completion list
+            Private Shared Function GetSortText(index As Integer) As String
+                Return "!" + index.ToString("D10")
+            End Function
+
+            Public Overrides Function ShouldTriggerCompletion(text As SourceText, caretPosition As Integer, trigger As CompletionTrigger, options As OptionSet) As Boolean
+                Return True
+            End Function
+        End Class
+
     End Class
 End Namespace


### PR DESCRIPTION
Address #65982, but instead of `if the gray text matches something elsewhere in the completion list, star that item and place in the starred section`, this PR only selects the non-starred item without promoting it. This is mainly because IntelliCode does more than adding a star for items it provides (e.g. custom SortText) which would impact the behavior of completion. I'd prefer to move those implementation details to a unified helper layer rather than duplicate logic.

The relevant change is in 23672708a58a7f0589034715c853b5cfb3801d37, everything else is just clean-ups

FYI @dpugh