### PR TITLE
Add tests for extract on keyword

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractClass/ExtractClassTests.cs
@@ -2521,6 +2521,45 @@ class C
             }.RunAsync();
         }
 
+        [Fact]
+        [WorkItem(55402, "https://github.com/dotnet/roslyn/issues/55402")]
+        public async Task TestMemberKeyword()
+        {
+            var code = """
+                class C
+                {
+                    $$public void M() { }
+                }
+                """;
+
+            var expected1 = """
+                class C : MyBase
+                {
+                }
+                """;
+
+            var expected2 = """
+                internal class MyBase
+                {
+                    public void M() { }
+                }
+                """;
+
+            await new Test
+            {
+                TestCode = code,
+                FixedState =
+                {
+                    Sources =
+                    {
+                        expected1,
+                        expected2
+                    }
+                },
+                FileName = "Test1.cs",
+            }.RunAsync();
+        }
+
         private static IEnumerable<(string name, bool makeAbstract)> MakeAbstractSelection(params string[] memberNames)
             => memberNames.Select(m => (m, true));
 

--- a/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
+++ b/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
@@ -61,123 +61,135 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task TestNoRefactoringProvidedWhenNoOptionsService()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-    }
+            var testText = """
 
-    public class TestClass : IInterface
-    {
-        public void TestM[||]ethod()
-        {
-            System.Console.WriteLine(""Hello World"");
-        }
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                    }
+
+                    public class TestClass : IInterface
+                    {
+                        public void TestM[||]ethod()
+                        {
+                            System.Console.WriteLine("Hello World");
+                        }
+                    }
+                }
+                """;
             await TestActionCountAsync(testText, 0);
         }
 
         [Fact]
         public async Task TestNoRefactoringProvidedWhenPullFieldInInterfaceViaQuickAction()
         {
-            var testText = @"
-namespace PushUpTest
-{
-    public interface ITestInterface
-    {
-    }
+            var testText = """
 
-    public class TestClass : ITestInterface
-    {
-        public int yo[||]u = 10086;
-    }
-}";
+                namespace PushUpTest
+                {
+                    public interface ITestInterface
+                    {
+                    }
+
+                    public class TestClass : ITestInterface
+                    {
+                        public int yo[||]u = 10086;
+                    }
+                }
+                """;
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact]
         public async Task TestNoRefactoringProvidedWhenMethodDeclarationAlreadyExistsInInterfaceViaQuickAction()
         {
-            var methodTest = @"
-namespace PushUpTest
-{
-    public interface ITestInterface
-    {
-        void TestMethod();
-    }
+            var methodTest = """
 
-    public class TestClass : ITestInterface
-    {
-        public void TestM[||]ethod()
-        {
-            System.Console.WriteLine(""Hello World"");
-        }
-    }
-}";
+                namespace PushUpTest
+                {
+                    public interface ITestInterface
+                    {
+                        void TestMethod();
+                    }
+
+                    public class TestClass : ITestInterface
+                    {
+                        public void TestM[||]ethod()
+                        {
+                            System.Console.WriteLine("Hello World");
+                        }
+                    }
+                }
+                """;
             await TestQuickActionNotProvidedAsync(methodTest);
         }
 
         [Fact]
         public async Task TestNoRefactoringProvidedWhenPropertyDeclarationAlreadyExistsInInterfaceViaQuickAction()
         {
-            var propertyTest1 = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-        int TestProperty { get; }
-    }
+            var propertyTest1 = """
 
-    public class TestClass : IInterface
-    {
-        public int TestPr[||]operty { get; private set; }
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                        int TestProperty { get; }
+                    }
+
+                    public class TestClass : IInterface
+                    {
+                        public int TestPr[||]operty { get; private set; }
+                    }
+                }
+                """;
             await TestQuickActionNotProvidedAsync(propertyTest1);
         }
 
         [Fact]
         public async Task TestNoRefactoringProvidedWhenEventDeclarationAlreadyExistsToInterfaceViaQuickAction()
         {
-            var eventTest = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-        event EventHandler Event2;
-    }
+            var eventTest = """
 
-    public class TestClass : IInterface
-    {
-        public event EventHandler Event1, Eve[||]nt2, Event3;
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                        event EventHandler Event2;
+                    }
+
+                    public class TestClass : IInterface
+                    {
+                        public event EventHandler Event1, Eve[||]nt2, Event3;
+                    }
+                }
+                """;
             await TestQuickActionNotProvidedAsync(eventTest);
         }
 
         [Fact]
         public async Task TestNoRefactoringProvidedInNestedTypesViaQuickAction()
         {
-            var input = @"
-namespace PushUpTest
-{
-    public interface ITestInterface
-    {
-        void Foobar();
-    }
+            var input = """
 
-    public class TestClass : ITestInterface
-    {
-        public class N[||]estedClass
-        {
-        }
-    }
-}";
+                namespace PushUpTest
+                {
+                    public interface ITestInterface
+                    {
+                        void Foobar();
+                    }
+
+                    public class TestClass : ITestInterface
+                    {
+                        public class N[||]estedClass
+                        {
+                        }
+                    }
+                }
+                """;
 
             await TestQuickActionNotProvidedAsync(input);
         }
@@ -185,2836 +197,3040 @@ namespace PushUpTest
         [Fact]
         public async Task TestPullMethodUpToInterfaceViaQuickAction()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-    }
+            var testText = """
 
-    public class TestClass : IInterface
-    {
-        public void TestM[||]ethod()
-        {
-            System.Console.WriteLine(""Hello World"");
-        }
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-        void TestMethod();
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                    }
 
-    public class TestClass : IInterface
-    {
-        public void TestMethod()
-        {
-            System.Console.WriteLine(""Hello World"");
-        }
-    }
-}";
+                    public class TestClass : IInterface
+                    {
+                        public void TestM[||]ethod()
+                        {
+                            System.Console.WriteLine("Hello World");
+                        }
+                    }
+                }
+                """;
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                        void TestMethod();
+                    }
+
+                    public class TestClass : IInterface
+                    {
+                        public void TestMethod()
+                        {
+                            System.Console.WriteLine("Hello World");
+                        }
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullAbstractMethodToInterfaceViaQuickAction()
         {
-            var testText = @"
-namespace PushUpTest
-{
-    public interface IInterface
-    {
-    }
+            var testText = """
 
-    public abstract class TestClass : IInterface
-    {
-        public abstract void TestMeth[||]od();
-    }
-}";
+                namespace PushUpTest
+                {
+                    public interface IInterface
+                    {
+                    }
 
-            var expected = @"
-namespace PushUpTest
-{
-    public interface IInterface
-    {
-        void TestMethod();
-    }
+                    public abstract class TestClass : IInterface
+                    {
+                        public abstract void TestMeth[||]od();
+                    }
+                }
+                """;
 
-    public abstract class TestClass : IInterface
-    {
-        public abstract void TestMethod();
-    }
-}";
+            var expected = """
+
+                namespace PushUpTest
+                {
+                    public interface IInterface
+                    {
+                        void TestMethod();
+                    }
+
+                    public abstract class TestClass : IInterface
+                    {
+                        public abstract void TestMethod();
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullGenericsUpToInterfaceViaQuickAction()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    public interface IInterface
-    {
-    }
+            var testText = """
 
-    public class TestClass : IInterface
-    {
-        public void TestMeth[||]od<T>() where T : IDisposable
-        {
-        }
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    public interface IInterface
+                    {
+                    }
 
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    public interface IInterface
-    {
-        void TestMethod<T>() where T : IDisposable;
-    }
+                    public class TestClass : IInterface
+                    {
+                        public void TestMeth[||]od<T>() where T : IDisposable
+                        {
+                        }
+                    }
+                }
+                """;
 
-    public class TestClass : IInterface
-    {
-        public void TestMeth[||]od<T>() where T : IDisposable
-        {
-        }
-    }
-}";
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public interface IInterface
+                    {
+                        void TestMethod<T>() where T : IDisposable;
+                    }
+
+                    public class TestClass : IInterface
+                    {
+                        public void TestMeth[||]od<T>() where T : IDisposable
+                        {
+                        }
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullSingleEventToInterfaceViaQuickAction()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-    }
+            var testText = """
 
-    public class TestClass : IInterface
-    {
-        public event EventHandler Eve[||]nt1
-        {
-            add
-            {
-                System.Console.Writeline(""This is add"");
-            }
-            remove
-            {
-                System.Console.Writeline(""This is remove"");
-            }
-        }
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                    }
 
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-        event EventHandler Event1;
-    }
+                    public class TestClass : IInterface
+                    {
+                        public event EventHandler Eve[||]nt1
+                        {
+                            add
+                            {
+                                System.Console.Writeline("This is add");
+                            }
+                            remove
+                            {
+                                System.Console.Writeline("This is remove");
+                            }
+                        }
+                    }
+                }
+                """;
 
-    public class TestClass : IInterface
-    {
-        public event EventHandler Event1
-        {
-            add
-            {
-                System.Console.Writeline(""This is add"");
-            }
-            remove
-            {
-                System.Console.Writeline(""This is remove"");
-            }
-        }
-    }
-}";
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                        event EventHandler Event1;
+                    }
+
+                    public class TestClass : IInterface
+                    {
+                        public event EventHandler Event1
+                        {
+                            add
+                            {
+                                System.Console.Writeline("This is add");
+                            }
+                            remove
+                            {
+                                System.Console.Writeline("This is remove");
+                            }
+                        }
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullOneEventFromMultipleEventsToInterfaceViaQuickAction()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-    }
+            var testText = """
 
-    public class TestClass : IInterface
-    {
-        public event EventHandler Event1, Eve[||]nt2, Event3;
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                    }
 
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-        event EventHandler Event2;
-    }
+                    public class TestClass : IInterface
+                    {
+                        public event EventHandler Event1, Eve[||]nt2, Event3;
+                    }
+                }
+                """;
 
-    public class TestClass : IInterface
-    {
-        public event EventHandler Event1, Event2, Event3;
-    }
-}";
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                        event EventHandler Event2;
+                    }
+
+                    public class TestClass : IInterface
+                    {
+                        public event EventHandler Event1, Event2, Event3;
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullPublicEventWithAccessorsToInterfaceViaQuickAction()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-    }
+            var testText = """
 
-    public class TestClass : IInterface
-    {
-        public event EventHandler Eve[||]nt2
-        {
-            add
-            {
-                System.Console.Writeln(""This is add in event1"");
-            }
-            remove
-            {
-                System.Console.Writeln(""This is remove in event2"");
-            }
-        }
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                    }
 
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-        event EventHandler Event2;
-    }
+                    public class TestClass : IInterface
+                    {
+                        public event EventHandler Eve[||]nt2
+                        {
+                            add
+                            {
+                                System.Console.Writeln("This is add in event1");
+                            }
+                            remove
+                            {
+                                System.Console.Writeln("This is remove in event2");
+                            }
+                        }
+                    }
+                }
+                """;
 
-    public class TestClass : IInterface
-    {
-        public event EventHandler Event2
-        {
-            add
-            {
-                System.Console.Writeln(""This is add in event1"");
-            }
-            remove
-            {
-                System.Console.Writeln(""This is remove in event2"");
-            }
-        }
-    }
-}";
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                        event EventHandler Event2;
+                    }
+
+                    public class TestClass : IInterface
+                    {
+                        public event EventHandler Event2
+                        {
+                            add
+                            {
+                                System.Console.Writeln("This is add in event1");
+                            }
+                            remove
+                            {
+                                System.Console.Writeln("This is remove in event2");
+                            }
+                        }
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullPropertyWithPrivateSetterToInterfaceViaQuickAction()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-    }
+            var testText = """
 
-    public class TestClass : IInterface
-    {
-        public int TestPr[||]operty { get; private set; }
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                    }
 
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-        int TestProperty { get; }
-    }
+                    public class TestClass : IInterface
+                    {
+                        public int TestPr[||]operty { get; private set; }
+                    }
+                }
+                """;
 
-    public class TestClass : IInterface
-    {
-        public int TestProperty { get; private set; }
-    }
-}";
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                        int TestProperty { get; }
+                    }
+
+                    public class TestClass : IInterface
+                    {
+                        public int TestProperty { get; private set; }
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullPropertyWithPrivateGetterToInterfaceViaQuickAction()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-    }
+            var testText = """
 
-    public class TestClass : IInterface
-    {
-        public int TestProperty[||]{ private get; set; }
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                    }
 
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-        int TestProperty { set; }
-    }
+                    public class TestClass : IInterface
+                    {
+                        public int TestProperty[||]{ private get; set; }
+                    }
+                }
+                """;
 
-    public class TestClass : IInterface
-    {
-        public int TestProperty{ private get; set; }
-    }
-}";
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                        int TestProperty { set; }
+                    }
+
+                    public class TestClass : IInterface
+                    {
+                        public int TestProperty{ private get; set; }
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullMemberFromInterfaceToInterfaceViaQuickAction()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-    }
+            var testText = """
 
-    interface FooInterface : IInterface
-    {
-        int TestPr[||]operty { set; }
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                    }
 
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-        int TestProperty { set; }
-    }
+                    interface FooInterface : IInterface
+                    {
+                        int TestPr[||]operty { set; }
+                    }
+                }
+                """;
 
-    interface FooInterface : IInterface
-    {
-    }
-}";
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                        int TestProperty { set; }
+                    }
+
+                    interface FooInterface : IInterface
+                    {
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullIndexerWithOnlySetterToInterfaceViaQuickAction()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-    }
+            var testText = """
 
-    public class TestClass : IInterface
-    {
-        private int j;
-        public int th[||]is[int i]
-        {
-           set => j = value;
-        }
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-        int this[int i] { set; }
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                    }
 
-    public class TestClass : IInterface
-    {
-        private int j;
-        public int this[int i]
-        {
-           set => j = value;
-        }
-    }
-}";
+                    public class TestClass : IInterface
+                    {
+                        private int j;
+                        public int th[||]is[int i]
+                        {
+                           set => j = value;
+                        }
+                    }
+                }
+                """;
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                        int this[int i] { set; }
+                    }
+
+                    public class TestClass : IInterface
+                    {
+                        private int j;
+                        public int this[int i]
+                        {
+                           set => j = value;
+                        }
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullIndexerWithOnlyGetterToInterfaceViaQuickAction()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-    }
+            var testText = """
 
-    public class TestClass : IInterface
-    {
-        private int j;
-        public int th[||]is[int i]
-        {
-           get => j = value;
-        }
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-        int this[int i] { get; }
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                    }
 
-    public class TestClass : IInterface
-    {
-        private int j;
-        public int this[int i]
-        {
-           get => j = value;
-        }
-    }
-}";
+                    public class TestClass : IInterface
+                    {
+                        private int j;
+                        public int th[||]is[int i]
+                        {
+                           get => j = value;
+                        }
+                    }
+                }
+                """;
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                        int this[int i] { get; }
+                    }
+
+                    public class TestClass : IInterface
+                    {
+                        private int j;
+                        public int this[int i]
+                        {
+                           get => j = value;
+                        }
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullPropertyToInterfaceWithAddUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public interface IBase
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+            var testText = """
 
-public class Derived : IBase
-{
-    public Uri En[||]dpoint { get; set; }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public interface IBase
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public interface IBase
-{
-    Uri Endpoint { get; set; }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                public class Derived : IBase
+                {
+                    public Uri En[||]dpoint { get; set; }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : IBase
-{
-    public Uri Endpoint { get; set; }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
+
+                public interface IBase
+                {
+                    Uri Endpoint { get; set; }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : IBase
+                {
+                    public Uri Endpoint { get; set; }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToInterfaceWithoutAddUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public interface IBase
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+            var testText = """
 
-public class Derived : IBase
-{
-    public bool Test[||]Method()
-    {
-        var endpoint1 = new Uri(""http://localhost"");
-        var endpoint2 = new Uri(""http://localhost"");
-        return endpoint1.Equals(endpoint2);
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public interface IBase
-{
-    bool TestMethod();
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public interface IBase
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public class Derived : IBase
-{
-    public bool Test[||]Method()
-    {
-        var endpoint1 = new Uri(""http://localhost"");
-        var endpoint2 = new Uri(""http://localhost"");
-        return endpoint1.Equals(endpoint2);
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                public class Derived : IBase
+                {
+                    public bool Test[||]Method()
+                    {
+                        var endpoint1 = new Uri("http://localhost");
+                        var endpoint2 = new Uri("http://localhost");
+                        return endpoint1.Equals(endpoint2);
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public interface IBase
+                {
+                    bool TestMethod();
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : IBase
+                {
+                    public bool Test[||]Method()
+                    {
+                        var endpoint1 = new Uri("http://localhost");
+                        var endpoint2 = new Uri("http://localhost");
+                        return endpoint1.Equals(endpoint2);
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodWithNewReturnTypeToInterfaceWithAddUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public interface IBase
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+            var testText = """
 
-public class Derived : IBase
-{
-    public Uri Test[||]Method()
-    {
-        return new Uri(""http://localhost"");
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public interface IBase
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public interface IBase
-{
-    Uri TestMethod();
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                public class Derived : IBase
+                {
+                    public Uri Test[||]Method()
+                    {
+                        return new Uri("http://localhost");
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : IBase
-{
-    public Uri TestMethod()
-    {
-        return new Uri(""http://localhost"");
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
+
+                public interface IBase
+                {
+                    Uri TestMethod();
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : IBase
+                {
+                    public Uri TestMethod()
+                    {
+                        return new Uri("http://localhost");
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodWithNewParamTypeToInterfaceWithAddUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public interface IBase
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+            var testText = """
 
-public class Derived : IBase
-{
-    public bool Test[||]Method(Uri endpoint)
-    {
-        var localHost = new Uri(""http://localhost"");
-        return endpoint.Equals(localhost);
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public interface IBase
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public interface IBase
-{
-    bool TestMethod(Uri endpoint);
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                public class Derived : IBase
+                {
+                    public bool Test[||]Method(Uri endpoint)
+                    {
+                        var localHost = new Uri("http://localhost");
+                        return endpoint.Equals(localhost);
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : IBase
-{
-    public bool TestMethod(Uri endpoint)
-    {
-        var localHost = new Uri(""http://localhost"");
-        return endpoint.Equals(localhost);
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
+
+                public interface IBase
+                {
+                    bool TestMethod(Uri endpoint);
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : IBase
+                {
+                    public bool TestMethod(Uri endpoint)
+                    {
+                        var localHost = new Uri("http://localhost");
+                        return endpoint.Equals(localhost);
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullEventToInterfaceWithAddUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public interface IBase
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+            var testText = """
 
-public class Derived : IBase
-{
-    public event EventHandler Test[||]Event
-    {
-        add
-        {
-            Console.WriteLine(""adding event..."");
-        }
-        remove
-        {
-            Console.WriteLine(""removing event..."");
-        }
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public interface IBase
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public interface IBase
-{
-    event EventHandler TestEvent;
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                public class Derived : IBase
+                {
+                    public event EventHandler Test[||]Event
+                    {
+                        add
+                        {
+                            Console.WriteLine("adding event...");
+                        }
+                        remove
+                        {
+                            Console.WriteLine("removing event...");
+                        }
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : IBase
-{
-    public event EventHandler TestEvent
-    {
-        add
-        {
-            Console.WriteLine(""adding event..."");
-        }
-        remove
-        {
-            Console.WriteLine(""removing event..."");
-        }
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
+
+                public interface IBase
+                {
+                    event EventHandler TestEvent;
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : IBase
+                {
+                    public event EventHandler TestEvent
+                    {
+                        add
+                        {
+                            Console.WriteLine("adding event...");
+                        }
+                        remove
+                        {
+                            Console.WriteLine("removing event...");
+                        }
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullPropertyToClassWithAddUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+            var testText = """
 
-public class Derived : Base
-{
-    public Uri En[||]dpoint { get; set; }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public class Base
-{
-    public Uri Endpoint { get; set; }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                public class Derived : Base
+                {
+                    public Uri En[||]dpoint { get; set; }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using System;
+
+                public class Base
+                {
+                    public Uri Endpoint { get; set; }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullPropertyToClassWithAddUsingsViaQuickAction2()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">public class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+            var testText = """
 
-public class Derived : Base
-{
-    public Uri En[||]dpoint { get; set; }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using System;
-public class Base
-{
-    public Uri Endpoint { get; set; }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">public class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                public class Derived : Base
+                {
+                    public Uri En[||]dpoint { get; set; }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using System;
+                public class Base
+                {
+                    public Uri Endpoint { get; set; }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullPropertyToClassWithoutDuplicatingUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
+            var testText = """
 
-public class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
 
-public class Derived : Base
-{
-    public Uri En[||]dpoint { get; set; }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
+                public class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public class Base
-{
-    public Uri Endpoint { get; set; }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                public class Derived : Base
+                {
+                    public Uri En[||]dpoint { get; set; }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
+
+                public class Base
+                {
+                    public Uri Endpoint { get; set; }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullPropertyWithNewBodyTypeToClassWithAddUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+            var testText = """
 
-public class Derived : Base
-{
-    public bool Test[||]Property
-    {
-        get
-        {
-            var endpoint1 = new Uri(""http://localhost"");
-            var endpoint2 = new Uri(""http://localhost"");
-            return endpoint1.Equals(endpoint2);
-        }
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public class Base
-{
-    public bool TestProperty
-    {
-        get
-        {
-            var endpoint1 = new Uri(""http://localhost"");
-            var endpoint2 = new Uri(""http://localhost"");
-            return endpoint1.Equals(endpoint2);
-        }
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                public class Derived : Base
+                {
+                    public bool Test[||]Property
+                    {
+                        get
+                        {
+                            var endpoint1 = new Uri("http://localhost");
+                            var endpoint2 = new Uri("http://localhost");
+                            return endpoint1.Equals(endpoint2);
+                        }
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using System;
+
+                public class Base
+                {
+                    public bool TestProperty
+                    {
+                        get
+                        {
+                            var endpoint1 = new Uri("http://localhost");
+                            var endpoint2 = new Uri("http://localhost");
+                            return endpoint1.Equals(endpoint2);
+                        }
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodWithNewNonDeclaredBodyTypeToClassWithAddUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System.Linq;
+            var testText = """
 
-public class Derived : Base
-{
-    public int Test[||]Method()
-    {
-        return Enumerable.Range(0, 5).Sum();
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using System.Linq;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System.Linq;
 
-public class Base
-{
-    public int Test[||]Method()
-    {
-        return Enumerable.Range(0, 5).Sum();
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System.Linq;
+                public class Derived : Base
+                {
+                    public int Test[||]Method()
+                    {
+                        return Enumerable.Range(0, 5).Sum();
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using System.Linq;
+
+                public class Base
+                {
+                    public int Test[||]Method()
+                    {
+                        return Enumerable.Range(0, 5).Sum();
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System.Linq;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithOverlappingUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
-using System.Threading.Tasks;
+            var testText = """
 
-public class Base
-{
-    public Uri Endpoint{ get; set; }
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
+                using System.Threading.Tasks;
 
-    public async Task&lt;int&gt; Get5Async()
-    {
-        return 5;
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System.Linq;
-using System.Threading.Tasks;
+                public class Base
+                {
+                    public Uri Endpoint{ get; set; }
 
-public class Derived : Base
-{
-    public async Task&lt;int&gt; Test[||]Method()
-    {
-        return Enumerable.Range(0, 5).Sum();
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
-using System.Linq;
-using System.Threading.Tasks;
+                    public async Task&lt;int&gt; Get5Async()
+                    {
+                        return 5;
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System.Linq;
+                using System.Threading.Tasks;
 
-public class Base
-{
-    public Uri Endpoint{ get; set; }
+                public class Derived : Base
+                {
+                    public async Task&lt;int&gt; Test[||]Method()
+                    {
+                        return Enumerable.Range(0, 5).Sum();
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-    public async Task&lt;int&gt; Get5Async()
-    {
-        return 5;
-    }
-    public async Task&lt;int&gt; Test[||]Method()
-    {
-        return Enumerable.Range(0, 5).Sum();
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System.Linq;
-using System.Threading.Tasks;
+                """;
+            var expected = """
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
+                using System.Linq;
+                using System.Threading.Tasks;
+
+                public class Base
+                {
+                    public Uri Endpoint{ get; set; }
+
+                    public async Task&lt;int&gt; Get5Async()
+                    {
+                        return 5;
+                    }
+                    public async Task&lt;int&gt; Test[||]Method()
+                    {
+                        return Enumerable.Range(0, 5).Sum();
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System.Linq;
+                using System.Threading.Tasks;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithUnnecessaryFirstUsingViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
+            var testText = """
 
-using System.Threading.Tasks;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
 
-public class Base
-{
-    public async Task&lt;int&gt; Get5Async()
-    {
-        return 5;
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
-using System.Linq;
-using System.Threading.Tasks;
+                using System.Threading.Tasks;
 
-public class Derived : Base
-{
-    public async Task&lt;int&gt; Test[||]Method()
-    {
-        return Enumerable.Range(0, 5).Sum();
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using System.Linq;
-using System.Threading.Tasks;
+                public class Base
+                {
+                    public async Task&lt;int&gt; Get5Async()
+                    {
+                        return 5;
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+                using System.Linq;
+                using System.Threading.Tasks;
 
-public class Base
-{
-    public async Task&lt;int&gt; Get5Async()
-    {
-        return 5;
-    }
-    public async Task&lt;int&gt; Test[||]Method()
-    {
-        return Enumerable.Range(0, 5).Sum();
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
-using System.Linq;
-using System.Threading.Tasks;
+                public class Derived : Base
+                {
+                    public async Task&lt;int&gt; Test[||]Method()
+                    {
+                        return Enumerable.Range(0, 5).Sum();
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using System.Linq;
+                using System.Threading.Tasks;
+
+                public class Base
+                {
+                    public async Task&lt;int&gt; Get5Async()
+                    {
+                        return 5;
+                    }
+                    public async Task&lt;int&gt; Test[||]Method()
+                    {
+                        return Enumerable.Range(0, 5).Sum();
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+                using System.Linq;
+                using System.Threading.Tasks;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithUnusedBaseUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
-using System.Threading.Tasks;
+            var testText = """
 
-public class Base
-{
-    public Uri Endpoint{ get; set; }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System.Linq;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
+                using System.Threading.Tasks;
 
-public class Derived : Base
-{
-    public int Test[||]Method()
-    {
-        return Enumerable.Range(0, 5).Sum();
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
-using System.Linq;
-using System.Threading.Tasks;
+                public class Base
+                {
+                    public Uri Endpoint{ get; set; }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System.Linq;
 
-public class Base
-{
-    public Uri Endpoint{ get; set; }
-    public int TestMethod()
-    {
-        return Enumerable.Range(0, 5).Sum();
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System.Linq;
+                public class Derived : Base
+                {
+                    public int Test[||]Method()
+                    {
+                        return Enumerable.Range(0, 5).Sum();
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
+                using System.Linq;
+                using System.Threading.Tasks;
+
+                public class Base
+                {
+                    public Uri Endpoint{ get; set; }
+                    public int TestMethod()
+                    {
+                        return Enumerable.Range(0, 5).Sum();
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System.Linq;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithRetainCommentsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-// blah blah
+            var testText = """
 
-public class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System.Linq;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                // blah blah
 
-public class Derived : Base
-{
-    public int Test[||]Method()
-    {
-        return 5;
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-// blah blah
+                public class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System.Linq;
 
-public class Base
-{
-    public int TestMethod()
-    {
-        return 5;
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System.Linq;
+                public class Derived : Base
+                {
+                    public int Test[||]Method()
+                    {
+                        return 5;
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                // blah blah
+
+                public class Base
+                {
+                    public int TestMethod()
+                    {
+                        return 5;
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System.Linq;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithRetainPreImportCommentsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-// blah blah
-using System.Linq;
+            var testText = """
 
-public class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                // blah blah
+                using System.Linq;
 
-public class Derived : Base
-{
-    public Uri End[||]point { get; set; }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-// blah blah
-using System;
-using System.Linq;
+                public class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public class Base
-{
-    public Uri Endpoint { get; set; }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                public class Derived : Base
+                {
+                    public Uri End[||]point { get; set; }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                // blah blah
+                using System;
+                using System.Linq;
+
+                public class Base
+                {
+                    public Uri Endpoint { get; set; }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithRetainPostImportCommentsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System.Linq;
+            var testText = """
 
-// blah blah
-public class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System.Linq;
 
-public class Derived : Base
-{
-    public Uri End[||]point { get; set; }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
-using System.Linq;
+                // blah blah
+                public class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-// blah blah
-public class Base
-{
-    public Uri Endpoint { get; set; }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                public class Derived : Base
+                {
+                    public Uri End[||]point { get; set; }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
+                using System.Linq;
+
+                // blah blah
+                public class Base
+                {
+                    public Uri Endpoint { get; set; }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithLambdaUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
-using System.Linq;
+            var testText = """
 
-public class Derived : Base
-{
-    public int Test[||]Method()
-    {
-        return Enumerable.Range(0, 5).
-            Select((n) => new Uri(""http://"" + n)).
-            Count((uri) => uri != null);
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using System;
-using System.Linq;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+                using System.Linq;
 
-public class Base
-{
-    public int TestMethod()
-    {
-        return Enumerable.Range(0, 5).
-            Select((n) => new Uri(""http://"" + n)).
-            Count((uri) => uri != null);
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
-using System.Linq;
+                public class Derived : Base
+                {
+                    public int Test[||]Method()
+                    {
+                        return Enumerable.Range(0, 5).
+                            Select((n) => new Uri("http://" + n)).
+                            Count((uri) => uri != null);
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using System;
+                using System.Linq;
+
+                public class Base
+                {
+                    public int TestMethod()
+                    {
+                        return Enumerable.Range(0, 5).
+                            Select((n) => new Uri("http://" + n)).
+                            Count((uri) => uri != null);
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+                using System.Linq;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithUnusedUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
+            var testText = """
 
-public class Base
-{
-    public Uri Endpoint{ get; set; }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System.Linq;
-using System.Threading.Tasks;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
 
-public class Derived : Base
-{
-    public int Test[||]Method()
-    {
-        return Enumerable.Range(0, 5).Sum();
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
-using System.Linq;
+                public class Base
+                {
+                    public Uri Endpoint{ get; set; }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System.Linq;
+                using System.Threading.Tasks;
 
-public class Base
-{
-    public Uri Endpoint{ get; set; }
-    public int TestMethod()
-    {
-        return Enumerable.Range(0, 5).Sum();
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System.Linq;
-using System.Threading.Tasks;
+                public class Derived : Base
+                {
+                    public int Test[||]Method()
+                    {
+                        return Enumerable.Range(0, 5).Sum();
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
+                using System.Linq;
+
+                public class Base
+                {
+                    public Uri Endpoint{ get; set; }
+                    public int TestMethod()
+                    {
+                        return Enumerable.Range(0, 5).Sum();
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System.Linq;
+                using System.Threading.Tasks;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassKeepSystemFirstViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace TestNs1
-{
-    using System;
+            var testText = """
 
-    public class Base
-    {
-        public Uri Endpoint{ get; set; }
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-namespace A_TestNs2
-{
-    using TestNs1;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace TestNs1
+                {
+                    using System;
 
-    public class Derived : Base
-    {
-        public Foo Test[||]Method()
-        {
-            return null;
-        }
-    }
+                    public class Base
+                    {
+                        public Uri Endpoint{ get; set; }
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                namespace A_TestNs2
+                {
+                    using TestNs1;
 
-    public class Foo
-    {
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace TestNs1
-{
-    using System;
-    using A_TestNs2;
+                    public class Derived : Base
+                    {
+                        public Foo Test[||]Method()
+                        {
+                            return null;
+                        }
+                    }
 
-    public class Base
-    {
-        public Uri Endpoint{ get; set; }
-        public Foo TestMethod()
-        {
-            return null;
-        }
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-namespace A_TestNs2
-{
-    using TestNs1;
+                    public class Foo
+                    {
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-    public class Derived : Base
-    {
-    }
+                """;
+            var expected = """
 
-    public class Foo
-    {
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace TestNs1
+                {
+                    using System;
+                    using A_TestNs2;
+
+                    public class Base
+                    {
+                        public Uri Endpoint{ get; set; }
+                        public Foo TestMethod()
+                        {
+                            return null;
+                        }
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                namespace A_TestNs2
+                {
+                    using TestNs1;
+
+                    public class Derived : Base
+                    {
+                    }
+
+                    public class Foo
+                    {
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassKeepSystemFirstViaQuickAction2()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace TestNs1
-{
-    public class Base
-    {
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-namespace A_TestNs2
-{
-    using System;
-    using TestNs1;
+            var testText = """
 
-    public class Derived : Base
-    {
-        public Foo Test[||]Method()
-        {
-            var uri = new Uri(""http://localhost"");
-            return null;
-        }
-    }
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace TestNs1
+                {
+                    public class Base
+                    {
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                namespace A_TestNs2
+                {
+                    using System;
+                    using TestNs1;
 
-    public class Foo
-    {
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using System;
-using A_TestNs2;
+                    public class Derived : Base
+                    {
+                        public Foo Test[||]Method()
+                        {
+                            var uri = new Uri("http://localhost");
+                            return null;
+                        }
+                    }
 
-namespace TestNs1
-{
-    public class Base
-    {
-        public Foo TestMethod()
-        {
-            var uri = new Uri(""http://localhost"");
-            return null;
-        }
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-namespace A_TestNs2
-{
-    using System;
-    using TestNs1;
+                    public class Foo
+                    {
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-    public class Derived : Base
-    {
-    }
+                """;
+            var expected = """
 
-    public class Foo
-    {
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using System;
+                using A_TestNs2;
+
+                namespace TestNs1
+                {
+                    public class Base
+                    {
+                        public Foo TestMethod()
+                        {
+                            var uri = new Uri("http://localhost");
+                            return null;
+                        }
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                namespace A_TestNs2
+                {
+                    using System;
+                    using TestNs1;
+
+                    public class Derived : Base
+                    {
+                    }
+
+                    public class Foo
+                    {
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithExtensionViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace TestNs1
-{
-    public class Base
-    {
-    }
+            var testText = """
 
-    public class Foo
-    {
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-namespace TestNs2
-{
-    using TestNs1;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace TestNs1
+                {
+                    public class Base
+                    {
+                    }
 
-    public class Derived : Base
-    {
-        public int Test[||]Method()
-        {
-            var foo = new Foo();
-            return foo.FooBar();
-        }
-    }
+                    public class Foo
+                    {
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                namespace TestNs2
+                {
+                    using TestNs1;
 
-    public static class FooExtensions
-    {
-        public static int FooBar(this Foo foo) 
-        {
-            return 5;
-        }
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using TestNs2;
+                    public class Derived : Base
+                    {
+                        public int Test[||]Method()
+                        {
+                            var foo = new Foo();
+                            return foo.FooBar();
+                        }
+                    }
 
-namespace TestNs1
-{
-    public class Base
-    {
-        public int TestMethod()
-        {
-            var foo = new Foo();
-            return foo.FooBar();
-        }
-    }
+                    public static class FooExtensions
+                    {
+                        public static int FooBar(this Foo foo) 
+                        {
+                            return 5;
+                        }
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-    public class Foo
-    {
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-namespace TestNs2
-{
-    using TestNs1;
+                """;
+            var expected = """
 
-    public class Derived : Base
-    {
-    }
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using TestNs2;
 
-    public static class FooExtensions
-    {
-        public static int FooBar(this Foo foo) 
-        {
-            return 5;
-        }
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                namespace TestNs1
+                {
+                    public class Base
+                    {
+                        public int TestMethod()
+                        {
+                            var foo = new Foo();
+                            return foo.FooBar();
+                        }
+                    }
+
+                    public class Foo
+                    {
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                namespace TestNs2
+                {
+                    using TestNs1;
+
+                    public class Derived : Base
+                    {
+                    }
+
+                    public static class FooExtensions
+                    {
+                        public static int FooBar(this Foo foo) 
+                        {
+                            return 5;
+                        }
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithExtensionViaQuickAction2()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace TestNs1
-{
-    public class Base
-    {
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using TestNs1;
-using TestNs3;
-using TestNs4;
+            var testText = """
 
-namespace TestNs2
-{
-    public class Derived : Base
-    {
-        public int Test[||]Method()
-        {
-            var foo = new Foo();
-            return foo.FooBar();
-        }
-    }
-}
-        </Document>
-        <Document FilePath = ""File3.cs"">
-namespace TestNs3
-{
-    public class Foo
-    {
-    }
-}
-        </Document>
-        <Document FilePath = ""File4.cs"">
-using TestNs3;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace TestNs1
+                {
+                    public class Base
+                    {
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using TestNs1;
+                using TestNs3;
+                using TestNs4;
 
-namespace TestNs4
-{
-    public static class FooExtensions
-    {
-        public static int FooBar(this Foo foo) 
-        {
-            return 5;
-        }
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using TestNs3;
-using TestNs4;
+                namespace TestNs2
+                {
+                    public class Derived : Base
+                    {
+                        public int Test[||]Method()
+                        {
+                            var foo = new Foo();
+                            return foo.FooBar();
+                        }
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File3.cs">
+                namespace TestNs3
+                {
+                    public class Foo
+                    {
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File4.cs">
+                using TestNs3;
 
-namespace TestNs1
-{
-    public class Base
-    {
-        public int TestMethod()
-        {
-            var foo = new Foo();
-            return foo.FooBar();
-        }
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using TestNs1;
-using TestNs3;
-using TestNs4;
+                namespace TestNs4
+                {
+                    public static class FooExtensions
+                    {
+                        public static int FooBar(this Foo foo) 
+                        {
+                            return 5;
+                        }
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-namespace TestNs2
-{
-    public class Derived : Base
-    {
-    }
-}
-        </Document>
-        <Document FilePath = ""File3.cs"">
-namespace TestNs3
-{
-    public class Foo
-    {
-    }
-}
-        </Document>
-        <Document FilePath = ""File4.cs"">
-using TestNs3;
+                """;
+            var expected = """
 
-namespace TestNs4
-{
-    public static class FooExtensions
-    {
-        public static int FooBar(this Foo foo) 
-        {
-            return 5;
-        }
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using TestNs3;
+                using TestNs4;
+
+                namespace TestNs1
+                {
+                    public class Base
+                    {
+                        public int TestMethod()
+                        {
+                            var foo = new Foo();
+                            return foo.FooBar();
+                        }
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using TestNs1;
+                using TestNs3;
+                using TestNs4;
+
+                namespace TestNs2
+                {
+                    public class Derived : Base
+                    {
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File3.cs">
+                namespace TestNs3
+                {
+                    public class Foo
+                    {
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File4.cs">
+                using TestNs3;
+
+                namespace TestNs4
+                {
+                    public static class FooExtensions
+                    {
+                        public static int FooBar(this Foo foo) 
+                        {
+                            return 5;
+                        }
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithAliasUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
+            var testText = """
 
-public class Base
-{
-    public Uri Endpoint{ get; set; }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using Enumer = System.Linq.Enumerable;
-using Sys = System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
 
-public class Derived : Base
-{
-    public void Test[||]Method()
-    {
-        Sys.Console.WriteLine(Enumer.Range(0, 5).Sum());
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
-using Enumer = System.Linq.Enumerable;
-using Sys = System;
+                public class Base
+                {
+                    public Uri Endpoint{ get; set; }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using Enumer = System.Linq.Enumerable;
+                using Sys = System;
 
-public class Base
-{
-    public Uri Endpoint{ get; set; }
-    public void TestMethod()
-    {
-        Sys.Console.WriteLine(Enumer.Range(0, 5).Sum());
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using Enumer = System.Linq.Enumerable;
-using Sys = System;
+                public class Derived : Base
+                {
+                    public void Test[||]Method()
+                    {
+                        Sys.Console.WriteLine(Enumer.Range(0, 5).Sum());
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
+                using Enumer = System.Linq.Enumerable;
+                using Sys = System;
+
+                public class Base
+                {
+                    public Uri Endpoint{ get; set; }
+                    public void TestMethod()
+                    {
+                        Sys.Console.WriteLine(Enumer.Range(0, 5).Sum());
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using Enumer = System.Linq.Enumerable;
+                using Sys = System;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullPropertyToClassWithBaseAliasUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using Enumer = System.Linq.Enumerable;
+            var testText = """
 
-public class Base
-{
-    public void TestMethod()
-    {
-        System.Console.WriteLine(Enumer.Range(0, 5).Sum());
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using Enumer = System.Linq.Enumerable;
 
-public class Derived : Base
-{
-    public Uri End[||]point{ get; set; }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-using System;
-using Enumer = System.Linq.Enumerable;
+                public class Base
+                {
+                    public void TestMethod()
+                    {
+                        System.Console.WriteLine(Enumer.Range(0, 5).Sum());
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public class Base
-{
-    public Uri Endpoint{ get; set; }
-    public void TestMethod()
-    {
-        System.Console.WriteLine(Enumer.Range(0, 5).Sum());
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                public class Derived : Base
+                {
+                    public Uri End[||]point{ get; set; }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                using System;
+                using Enumer = System.Linq.Enumerable;
+
+                public class Base
+                {
+                    public Uri Endpoint{ get; set; }
+                    public void TestMethod()
+                    {
+                        System.Console.WriteLine(Enumer.Range(0, 5).Sum());
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithMultipleNamespacedUsingsViaQuickAction()
         {
-            var testText = @"
-namespace TestNs1
-{
-    using System;
+            var testText = """
 
-    public class Base
-    {
-        public Uri Endpoint{ get; set; }
-    }
-}
-namespace TestNs2
-{
-    using System.Linq;
-    using TestNs1;
+                namespace TestNs1
+                {
+                    using System;
 
-    public class Derived : Base
-    {
-        public int Test[||]Method()
-        {
-            return Enumerable.Range(0, 5).Sum();
-        }
-    }
-}
-";
-            var expected = @"
-namespace TestNs1
-{
-    using System;
-    using System.Linq;
+                    public class Base
+                    {
+                        public Uri Endpoint{ get; set; }
+                    }
+                }
+                namespace TestNs2
+                {
+                    using System.Linq;
+                    using TestNs1;
 
-    public class Base
-    {
-        public Uri Endpoint{ get; set; }
-        public int TestMethod()
-        {
-            return Enumerable.Range(0, 5).Sum();
-        }
-    }
-}
-namespace TestNs2
-{
-    using System.Linq;
-    using TestNs1;
+                    public class Derived : Base
+                    {
+                        public int Test[||]Method()
+                        {
+                            return Enumerable.Range(0, 5).Sum();
+                        }
+                    }
+                }
 
-    public class Derived : Base
-    {
-    }
-}
-";
+                """;
+            var expected = """
+
+                namespace TestNs1
+                {
+                    using System;
+                    using System.Linq;
+
+                    public class Base
+                    {
+                        public Uri Endpoint{ get; set; }
+                        public int TestMethod()
+                        {
+                            return Enumerable.Range(0, 5).Sum();
+                        }
+                    }
+                }
+                namespace TestNs2
+                {
+                    using System.Linq;
+                    using TestNs1;
+
+                    public class Derived : Base
+                    {
+                    }
+                }
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithNestedNamespacedUsingsViaQuickAction()
         {
-            var testText = @"
-namespace TestNs1
-{
-    namespace InnerNs1
-    {
-        using System;
+            var testText = """
 
-        public class Base
-        {
-            public Uri Endpoint { get; set; }
-        }
-    }
-}
-namespace TestNs2
-{
-    namespace InnerNs2
-    {
-        using System.Linq;
-        using TestNs1.InnerNs1;
+                namespace TestNs1
+                {
+                    namespace InnerNs1
+                    {
+                        using System;
 
-        public class Derived : Base
-        {
-            public int Test[||]Method()
-            {
-                return Foo.Bar(Enumerable.Range(0, 5).Sum());
-            }
-        }
+                        public class Base
+                        {
+                            public Uri Endpoint { get; set; }
+                        }
+                    }
+                }
+                namespace TestNs2
+                {
+                    namespace InnerNs2
+                    {
+                        using System.Linq;
+                        using TestNs1.InnerNs1;
 
-        public class Foo
-        {
-            public static int Bar(int num)
-            {
-                return num + 1;
-            }
-        }
-    }
-}
-";
-            var expected = @"
-namespace TestNs1
-{
-    namespace InnerNs1
-    {
-        using System;
-        using System.Linq;
-        using TestNs2.InnerNs2;
+                        public class Derived : Base
+                        {
+                            public int Test[||]Method()
+                            {
+                                return Foo.Bar(Enumerable.Range(0, 5).Sum());
+                            }
+                        }
 
-        public class Base
-        {
-            public Uri Endpoint { get; set; }
-            public int TestMethod()
-            {
-                return Foo.Bar(Enumerable.Range(0, 5).Sum());
-            }
-        }
-    }
-}
-namespace TestNs2
-{
-    namespace InnerNs2
-    {
-        using System.Linq;
-        using TestNs1.InnerNs1;
+                        public class Foo
+                        {
+                            public static int Bar(int num)
+                            {
+                                return num + 1;
+                            }
+                        }
+                    }
+                }
 
-        public class Derived : Base
-        {
-        }
+                """;
+            var expected = """
 
-        public class Foo
-        {
-            public static int Bar(int num)
-            {
-                return num + 1;
-            }
-        }
-    }
-}
-";
+                namespace TestNs1
+                {
+                    namespace InnerNs1
+                    {
+                        using System;
+                        using System.Linq;
+                        using TestNs2.InnerNs2;
+
+                        public class Base
+                        {
+                            public Uri Endpoint { get; set; }
+                            public int TestMethod()
+                            {
+                                return Foo.Bar(Enumerable.Range(0, 5).Sum());
+                            }
+                        }
+                    }
+                }
+                namespace TestNs2
+                {
+                    namespace InnerNs2
+                    {
+                        using System.Linq;
+                        using TestNs1.InnerNs1;
+
+                        public class Derived : Base
+                        {
+                        }
+
+                        public class Foo
+                        {
+                            public static int Bar(int num)
+                            {
+                                return num + 1;
+                            }
+                        }
+                    }
+                }
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithNewNamespaceUsingViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace A.B
-{
-    class Base
-    {
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-namespace X.Y
-{
-    class Derived : A.B.Base
-    {
-        public Other Get[||]Other() => null;
-    }
+            var testText = """
 
-    class Other
-    {
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using X.Y;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace A.B
+                {
+                    class Base
+                    {
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                namespace X.Y
+                {
+                    class Derived : A.B.Base
+                    {
+                        public Other Get[||]Other() => null;
+                    }
 
-namespace A.B
-{
-    class Base
-    {
-        public Other GetOther() => null;
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-namespace X.Y
-{
-    class Derived : A.B.Base
-    {
-    }
+                    class Other
+                    {
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-    class Other
-    {
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using X.Y;
+
+                namespace A.B
+                {
+                    class Base
+                    {
+                        public Other GetOther() => null;
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                namespace X.Y
+                {
+                    class Derived : A.B.Base
+                    {
+                    }
+
+                    class Other
+                    {
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithFileNamespaceUsingViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace A.B;
+            var testText = """
 
-class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-namespace X.Y;
-class Derived : A.B.Base
-{
-    public Other Get[||]Other() => null;
-}
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace A.B;
 
-class Other
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using X.Y;
+                class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                namespace X.Y;
+                class Derived : A.B.Base
+                {
+                    public Other Get[||]Other() => null;
+                }
 
-namespace A.B;
+                class Other
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-class Base
-{
-    public Other GetOther() => null;
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-namespace X.Y;
-class Derived : A.B.Base
-{
-}
+                """;
+            var expected = """
 
-class Other
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using X.Y;
+
+                namespace A.B;
+
+                class Base
+                {
+                    public Other GetOther() => null;
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                namespace X.Y;
+                class Derived : A.B.Base
+                {
+                }
+
+                class Other
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithUnusedNamespaceUsingViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace A.B
-{
-    class Base
-    {
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-namespace X.Y
-{
-    class Derived : A.B.Base
-    {
-        public int Get[||]Five() => 5;
-    }
+            var testText = """
 
-    class Other
-    {
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace A.B
-{
-    class Base
-    {
-        public int GetFive() => 5;
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-namespace X.Y
-{
-    class Derived : A.B.Base
-    {
-    }
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace A.B
+                {
+                    class Base
+                    {
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                namespace X.Y
+                {
+                    class Derived : A.B.Base
+                    {
+                        public int Get[||]Five() => 5;
+                    }
 
-    class Other
-    {
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                    class Other
+                    {
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace A.B
+                {
+                    class Base
+                    {
+                        public int GetFive() => 5;
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                namespace X.Y
+                {
+                    class Derived : A.B.Base
+                    {
+                    }
+
+                    class Other
+                    {
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithMultipleNamespacesAndCommentsViaQuickAction()
         {
-            var testText = @"
-// comment 1
+            var testText = """
 
-namespace TestNs1
-{
-    // comment 2
+                // comment 1
 
-    // comment 3 
-    public class Base
-    {
-    }
-}
-namespace TestNs2
-{
-    // comment 4
-    using System.Linq;
-    using TestNs1;
+                namespace TestNs1
+                {
+                    // comment 2
 
-    public class Derived : Base
-    {
-        public int Test[||]Method()
-        {
-            return 5;
-        }
-    }
-}
-";
-            var expected = @"
-// comment 1
+                    // comment 3 
+                    public class Base
+                    {
+                    }
+                }
+                namespace TestNs2
+                {
+                    // comment 4
+                    using System.Linq;
+                    using TestNs1;
 
-namespace TestNs1
-{
-    // comment 2
+                    public class Derived : Base
+                    {
+                        public int Test[||]Method()
+                        {
+                            return 5;
+                        }
+                    }
+                }
 
-    // comment 3 
-    public class Base
-    {
-        public int TestMethod()
-        {
-            return 5;
-        }
-    }
-}
-namespace TestNs2
-{
-    // comment 4
-    using System.Linq;
-    using TestNs1;
+                """;
+            var expected = """
 
-    public class Derived : Base
-    {
-    }
-}
-";
+                // comment 1
+
+                namespace TestNs1
+                {
+                    // comment 2
+
+                    // comment 3 
+                    public class Base
+                    {
+                        public int TestMethod()
+                        {
+                            return 5;
+                        }
+                    }
+                }
+                namespace TestNs2
+                {
+                    // comment 4
+                    using System.Linq;
+                    using TestNs1;
+
+                    public class Derived : Base
+                    {
+                    }
+                }
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithMultipleNamespacedUsingsAndCommentsViaQuickAction()
         {
-            var testText = @"
-// comment 1
+            var testText = """
 
-namespace TestNs1
-{
-    // comment 2
-    using System;
+                // comment 1
 
-    // comment 3 
-    public class Base
-    {
-    }
-}
-namespace TestNs2
-{
-    // comment 4
-    using System.Linq;
-    using TestNs1;
+                namespace TestNs1
+                {
+                    // comment 2
+                    using System;
 
-    public class Derived : Base
-    {
-        public int Test[||]Method()
-        {
-            return Enumerable.Range(0, 5).Sum();
-        }
-    }
-}
-";
-            var expected = @"
-// comment 1
+                    // comment 3 
+                    public class Base
+                    {
+                    }
+                }
+                namespace TestNs2
+                {
+                    // comment 4
+                    using System.Linq;
+                    using TestNs1;
 
-namespace TestNs1
-{
-    // comment 2
-    using System;
-    using System.Linq;
+                    public class Derived : Base
+                    {
+                        public int Test[||]Method()
+                        {
+                            return Enumerable.Range(0, 5).Sum();
+                        }
+                    }
+                }
 
-    // comment 3 
-    public class Base
-    {
-        public int TestMethod()
-        {
-            return Enumerable.Range(0, 5).Sum();
-        }
-    }
-}
-namespace TestNs2
-{
-    // comment 4
-    using System.Linq;
-    using TestNs1;
+                """;
+            var expected = """
 
-    public class Derived : Base
-    {
-    }
-}
-";
+                // comment 1
+
+                namespace TestNs1
+                {
+                    // comment 2
+                    using System;
+                    using System.Linq;
+
+                    // comment 3 
+                    public class Base
+                    {
+                        public int TestMethod()
+                        {
+                            return Enumerable.Range(0, 5).Sum();
+                        }
+                    }
+                }
+                namespace TestNs2
+                {
+                    // comment 4
+                    using System.Linq;
+                    using TestNs1;
+
+                    public class Derived : Base
+                    {
+                    }
+                }
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithNamespacedUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace ClassLibrary1
-{
-    using System;
+            var testText = """
 
-    public class Base
-    {
-        public Uri Endpoint{ get; set; }
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-namespace ClassLibrary1
-{
-    using System.Linq;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace ClassLibrary1
+                {
+                    using System;
 
-    public class Derived : Base
-    {
-        public int Test[||]Method()
-        {
-            return Enumerable.Range(0, 5).Sum();
-        }
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace ClassLibrary1
-{
-    using System;
-    using System.Linq;
+                    public class Base
+                    {
+                        public Uri Endpoint{ get; set; }
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                namespace ClassLibrary1
+                {
+                    using System.Linq;
 
-    public class Base
-    {
-        public Uri Endpoint{ get; set; }
-        public int Test[||]Method()
-        {
-            return Enumerable.Range(0, 5).Sum();
-        }
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-namespace ClassLibrary1
-{
-    using System.Linq;
+                    public class Derived : Base
+                    {
+                        public int Test[||]Method()
+                        {
+                            return Enumerable.Range(0, 5).Sum();
+                        }
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-    public class Derived : Base
-    {
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace ClassLibrary1
+                {
+                    using System;
+                    using System.Linq;
+
+                    public class Base
+                    {
+                        public Uri Endpoint{ get; set; }
+                        public int Test[||]Method()
+                        {
+                            return Enumerable.Range(0, 5).Sum();
+                        }
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                namespace ClassLibrary1
+                {
+                    using System.Linq;
+
+                    public class Derived : Base
+                    {
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithDuplicateNamespacedUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace ClassLibrary1
-{
-    using System;
+            var testText = """
 
-    public class Base
-    {
-        public Uri Endpoint{ get; set; }
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System.Linq;
-namespace ClassLibrary1
-{
-    using System.Linq;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace ClassLibrary1
+                {
+                    using System;
 
-    public class Derived : Base
-    {
-        public int Test[||]Method()
-        {
-            return Enumerable.Range(0, 5).Sum();
-        }
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace ClassLibrary1
-{
-    using System;
-    using System.Linq;
+                    public class Base
+                    {
+                        public Uri Endpoint{ get; set; }
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System.Linq;
+                namespace ClassLibrary1
+                {
+                    using System.Linq;
 
-    public class Base
-    {
-        public Uri Endpoint{ get; set; }
-        public int Test[||]Method()
-        {
-            return Enumerable.Range(0, 5).Sum();
-        }
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System.Linq;
-namespace ClassLibrary1
-{
-    using System.Linq;
+                    public class Derived : Base
+                    {
+                        public int Test[||]Method()
+                        {
+                            return Enumerable.Range(0, 5).Sum();
+                        }
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-    public class Derived : Base
-    {
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace ClassLibrary1
+                {
+                    using System;
+                    using System.Linq;
+
+                    public class Base
+                    {
+                        public Uri Endpoint{ get; set; }
+                        public int Test[||]Method()
+                        {
+                            return Enumerable.Range(0, 5).Sum();
+                        }
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System.Linq;
+                namespace ClassLibrary1
+                {
+                    using System.Linq;
+
+                    public class Derived : Base
+                    {
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodWithNewReturnTypeToClassWithAddUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+            var testText = """
 
-public class Derived : Base
-{
-    public Uri En[||]dpoint()
-    {
-        return new Uri(""http://localhost"");
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public class Base
-{
-    public Uri Endpoint()
-    {
-        return new Uri(""http://localhost"");
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                public class Derived : Base
+                {
+                    public Uri En[||]dpoint()
+                    {
+                        return new Uri("http://localhost");
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using System;
+
+                public class Base
+                {
+                    public Uri Endpoint()
+                    {
+                        return new Uri("http://localhost");
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodWithNewParamTypeToClassWithAddUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+            var testText = """
 
-public class Derived : Base
-{
-    public bool Test[||]Method(Uri endpoint)
-    {
-        var localHost = new Uri(""http://localhost"");
-        return endpoint.Equals(localhost);
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public class Base
-{
-    public bool TestMethod(Uri endpoint)
-    {
-        var localHost = new Uri(""http://localhost"");
-        return endpoint.Equals(localhost);
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                public class Derived : Base
+                {
+                    public bool Test[||]Method(Uri endpoint)
+                    {
+                        var localHost = new Uri("http://localhost");
+                        return endpoint.Equals(localhost);
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using System;
+
+                public class Base
+                {
+                    public bool TestMethod(Uri endpoint)
+                    {
+                        var localHost = new Uri("http://localhost");
+                        return endpoint.Equals(localhost);
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodWithNewBodyTypeToClassWithAddUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+            var testText = """
 
-public class Derived : Base
-{
-    public bool Test[||]Method()
-    {
-        var endpoint1 = new Uri(""http://localhost"");
-        var endpoint2 = new Uri(""http://localhost"");
-        return endpoint1.Equals(endpoint2);
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public class Base
-{
-    public bool TestMethod()
-    {
-        var endpoint1 = new Uri(""http://localhost"");
-        var endpoint2 = new Uri(""http://localhost"");
-        return endpoint1.Equals(endpoint2);
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                public class Derived : Base
+                {
+                    public bool Test[||]Method()
+                    {
+                        var endpoint1 = new Uri("http://localhost");
+                        var endpoint2 = new Uri("http://localhost");
+                        return endpoint1.Equals(endpoint2);
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using System;
+
+                public class Base
+                {
+                    public bool TestMethod()
+                    {
+                        var endpoint1 = new Uri("http://localhost");
+                        var endpoint2 = new Uri("http://localhost");
+                        return endpoint1.Equals(endpoint2);
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullEventToClassWithAddUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+            var testText = """
 
-public class Derived : Base
-{
-    public event EventHandler Test[||]Event
-    {
-        add
-        {
-            Console.WriteLine(""adding event..."");
-        }
-        remove
-        {
-            Console.WriteLine(""removing event..."");
-        }
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public class Base
-{
-    public event EventHandler Test[||]Event
-    {
-        add
-        {
-            Console.WriteLine(""adding event..."");
-        }
-        remove
-        {
-            Console.WriteLine(""removing event..."");
-        }
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                public class Derived : Base
+                {
+                    public event EventHandler Test[||]Event
+                    {
+                        add
+                        {
+                            Console.WriteLine("adding event...");
+                        }
+                        remove
+                        {
+                            Console.WriteLine("removing event...");
+                        }
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using System;
+
+                public class Base
+                {
+                    public event EventHandler Test[||]Event
+                    {
+                        add
+                        {
+                            Console.WriteLine("adding event...");
+                        }
+                        remove
+                        {
+                            Console.WriteLine("removing event...");
+                        }
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullFieldToClassWithAddUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+            var testText = """
 
-public class Derived : Base
-{
-    public var en[||]dpoint = new Uri(""http://localhost"");
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-public class Base
-{
-    public var endpoint = new Uri(""http://localhost"");
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                public class Derived : Base
+                {
+                    public var en[||]dpoint = new Uri("http://localhost");
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using System;
+
+                public class Base
+                {
+                    public var endpoint = new Uri("http://localhost");
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullFieldToClassNoConstructorWithAddUsingsViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-public class Base
-{
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System.Linq;
+            var testText = """
 
-public class Derived : Base
-{
-    public var ran[||]ge = Enumerable.Range(0, 5);
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using System.Linq;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                public class Base
+                {
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System.Linq;
 
-public class Base
-{
-    public var range = Enumerable.Range(0, 5);
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System.Linq;
+                public class Derived : Base
+                {
+                    public var ran[||]ge = Enumerable.Range(0, 5);
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-public class Derived : Base
-{
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using System.Linq;
+
+                public class Base
+                {
+                    public var range = Enumerable.Range(0, 5);
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System.Linq;
+
+                public class Derived : Base
+                {
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestNoRefactoringProvidedWhenPullOverrideMethodUpToClassViaQuickAction()
         {
-            var methodTest = @"
-namespace PushUpTest
-{
-    public class Base
-    {
-        public virtual void TestMethod() => System.Console.WriteLine(""foo bar bar foo"");
-    }
+            var methodTest = """
 
-    public class TestClass : Base
-    {
-        public override void TestMeth[||]od()
-        {
-            System.Console.WriteLine(""Hello World"");
-        }
-    }
-}";
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                        public virtual void TestMethod() => System.Console.WriteLine("foo bar bar foo");
+                    }
+
+                    public class TestClass : Base
+                    {
+                        public override void TestMeth[||]od()
+                        {
+                            System.Console.WriteLine("Hello World");
+                        }
+                    }
+                }
+                """;
             await TestQuickActionNotProvidedAsync(methodTest);
         }
 
         [Fact]
         public async Task TestNoRefactoringProvidedWhenPullOverridePropertyUpToClassViaQuickAction()
         {
-            var propertyTest = @"
-using System;
-namespace PushUpTest
-{
-    public class Base
-    {
-        public virtual int TestProperty { get => 111; private set; }
-    }
+            var propertyTest = """
 
-    public class TestClass : Base
-    {
-        public override int TestPr[||]operty { get; private set; }
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                        public virtual int TestProperty { get => 111; private set; }
+                    }
+
+                    public class TestClass : Base
+                    {
+                        public override int TestPr[||]operty { get; private set; }
+                    }
+                }
+                """;
 
             await TestQuickActionNotProvidedAsync(propertyTest);
         }
@@ -3022,41 +3238,43 @@ namespace PushUpTest
         [Fact]
         public async Task TestNoRefactoringProvidedWhenPullOverrideEventUpToClassViaQuickAction()
         {
-            var eventTest = @"
-using System;
+            var eventTest = """
 
-namespace PushUpTest
-{
-    public class Base2
-    {
-        protected virtual event EventHandler Event3
-        {
-            add
-            {
-                System.Console.WriteLine(""Hello"");
-            }
-            remove
-            {
-                System.Console.WriteLine(""World"");
-            }
-        };
-    }
+                using System;
 
-    public class TestClass2 : Base2
-    {
-        protected override event EventHandler E[||]vent3
-        {
-            add
-            {
-                System.Console.WriteLine(""foo"");
-            }
-            remove
-            {
-                System.Console.WriteLine(""bar"");
-            }
-        };
-    }
-}";
+                namespace PushUpTest
+                {
+                    public class Base2
+                    {
+                        protected virtual event EventHandler Event3
+                        {
+                            add
+                            {
+                                System.Console.WriteLine("Hello");
+                            }
+                            remove
+                            {
+                                System.Console.WriteLine("World");
+                            }
+                        };
+                    }
+
+                    public class TestClass2 : Base2
+                    {
+                        protected override event EventHandler E[||]vent3
+                        {
+                            add
+                            {
+                                System.Console.WriteLine("foo");
+                            }
+                            remove
+                            {
+                                System.Console.WriteLine("bar");
+                            }
+                        };
+                    }
+                }
+                """;
             await TestQuickActionNotProvidedAsync(eventTest);
         }
 
@@ -3065,560 +3283,614 @@ namespace PushUpTest
         {
             // Fields share the same name will be thought as 'override', since it will cause error
             // if two same name fields exist in one class
-            var fieldTest = @"
-namespace PushUpTest
-{
-    public class Base
-    {
-        public int you = -100000;
-    }
+            var fieldTest = """
 
-    public class TestClass : Base
-    {
-        public int y[||]ou = 10086;
-    }
-}";
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                        public int you = -100000;
+                    }
+
+                    public class TestClass : Base
+                    {
+                        public int y[||]ou = 10086;
+                    }
+                }
+                """;
             await TestQuickActionNotProvidedAsync(fieldTest);
         }
 
         [Fact]
         public async Task TestPullMethodToOrdinaryClassViaQuickAction()
         {
-            var testText = @"
-namespace PushUpTest
-{
-    public class Base
-    {
-    }
+            var testText = """
 
-    public class TestClass : Base
-    {
-        public void TestMeth[||]od()
-        {
-            System.Console.WriteLine(""Hello World"");
-        }
-    }
-}";
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                    }
 
-            var expected = @"
-namespace PushUpTest
-{
-    public class Base
-    {
-        public void TestMethod()
-        {
-            System.Console.WriteLine(""Hello World"");
-        }
-    }
+                    public class TestClass : Base
+                    {
+                        public void TestMeth[||]od()
+                        {
+                            System.Console.WriteLine("Hello World");
+                        }
+                    }
+                }
+                """;
 
-    public class TestClass : Base
-    {
-    }
-}";
+            var expected = """
+
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                        public void TestMethod()
+                        {
+                            System.Console.WriteLine("Hello World");
+                        }
+                    }
+
+                    public class TestClass : Base
+                    {
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullOneFieldsToClassViaQuickAction()
         {
-            var testText = @"
-namespace PushUpTest
-{
-    public class Base
-    {
-    }
+            var testText = """
 
-    public class TestClass : Base
-    {
-        public int you[||]= 10086;
-    }
-}";
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                    }
 
-            var expected = @"
-namespace PushUpTest
-{
-    public class Base
-    {
-        public int you = 10086;
-    }
+                    public class TestClass : Base
+                    {
+                        public int you[||]= 10086;
+                    }
+                }
+                """;
 
-    public class TestClass : Base
-    {
-    }
-}";
+            var expected = """
+
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                        public int you = 10086;
+                    }
+
+                    public class TestClass : Base
+                    {
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullGenericsUpToClassViaQuickAction()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    public class BaseClass
-    {
-    }
+            var testText = """
 
-    public class TestClass : BaseClass
-    {
-        public void TestMeth[||]od<T>() where T : IDisposable
-        {
-        }
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    public class BaseClass
+                    {
+                    }
 
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    public class BaseClass
-    {
-        public void TestMethod<T>() where T : IDisposable
-        {
-        }
-    }
+                    public class TestClass : BaseClass
+                    {
+                        public void TestMeth[||]od<T>() where T : IDisposable
+                        {
+                        }
+                    }
+                }
+                """;
 
-    public class TestClass : BaseClass
-    {
-    }
-}";
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public class BaseClass
+                    {
+                        public void TestMethod<T>() where T : IDisposable
+                        {
+                        }
+                    }
+
+                    public class TestClass : BaseClass
+                    {
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullOneFieldFromMultipleFieldsToClassViaQuickAction()
         {
-            var testText = @"
-namespace PushUpTest
-{
-    public class Base
-    {
-    }
+            var testText = """
 
-    public class TestClass : Base
-    {
-        public int you, a[||]nd, someone = 10086;
-    }
-}";
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                    }
 
-            var expected = @"
-namespace PushUpTest
-{
-    public class Base
-    {
-        public int and;
-    }
+                    public class TestClass : Base
+                    {
+                        public int you, a[||]nd, someone = 10086;
+                    }
+                }
+                """;
 
-    public class TestClass : Base
-    {
-        public int you, someone = 10086;
-    }
-}";
+            var expected = """
+
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                        public int and;
+                    }
+
+                    public class TestClass : Base
+                    {
+                        public int you, someone = 10086;
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullMiddleFieldWithValueToClassViaQuickAction()
         {
-            var testText = @"
-namespace PushUpTest
-{
-    public class Base
-    {
-    }
+            var testText = """
 
-    public class TestClass : Base
-    {
-        public int you, a[||]nd = 4000, someone = 10086;
-    }
-}";
-            var expected = @"
-namespace PushUpTest
-{
-    public class Base
-    {
-        public int and = 4000;
-    }
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                    }
 
-    public class TestClass : Base
-    {
-        public int you, someone = 10086;
-    }
-}";
+                    public class TestClass : Base
+                    {
+                        public int you, a[||]nd = 4000, someone = 10086;
+                    }
+                }
+                """;
+            var expected = """
+
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                        public int and = 4000;
+                    }
+
+                    public class TestClass : Base
+                    {
+                        public int you, someone = 10086;
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullOneEventFromMultipleToClassViaQuickAction()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    public class Base2
-    {
-    }
+                using System;
 
-    public class Testclass2 : Base2
-    {
-        private static event EventHandler Event1, Eve[||]nt3, Event4;
-    }
-}";
-            var expected = @"
-using System;
+                namespace PushUpTest
+                {
+                    public class Base2
+                    {
+                    }
 
-namespace PushUpTest
-{
-    public class Base2
-    {
-        private static event EventHandler Event3;
-    }
+                    public class Testclass2 : Base2
+                    {
+                        private static event EventHandler Event1, Eve[||]nt3, Event4;
+                    }
+                }
+                """;
+            var expected = """
 
-    public class Testclass2 : Base2
-    {
-        private static event EventHandler Event1, Event4;
-    }
-}";
+                using System;
+
+                namespace PushUpTest
+                {
+                    public class Base2
+                    {
+                        private static event EventHandler Event3;
+                    }
+
+                    public class Testclass2 : Base2
+                    {
+                        private static event EventHandler Event1, Event4;
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullEventToClassViaQuickAction()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    public class Base2
-    {
-    }
+                using System;
 
-    public class TestClass2 : Base2
-    {
-        private static event EventHandler Eve[||]nt3;
-    }
-}";
-            var expected = @"
-using System;
+                namespace PushUpTest
+                {
+                    public class Base2
+                    {
+                    }
 
-namespace PushUpTest
-{
-    public class Base2
-    {
-        private static event EventHandler Event3;
-    }
+                    public class TestClass2 : Base2
+                    {
+                        private static event EventHandler Eve[||]nt3;
+                    }
+                }
+                """;
+            var expected = """
 
-    public class TestClass2 : Base2
-    {
-    }
-}";
+                using System;
+
+                namespace PushUpTest
+                {
+                    public class Base2
+                    {
+                        private static event EventHandler Event3;
+                    }
+
+                    public class TestClass2 : Base2
+                    {
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullEventWithBodyToClassViaQuickAction()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    public class Base2
-    {
-    }
+                using System;
 
-    public class TestClass2 : Base2
-    {
-        private static event EventHandler Eve[||]nt3
-        {
-            add
-            {
-                System.Console.Writeln(""Hello"");
-            }
-            remove
-            {
-                System.Console.Writeln(""World"");
-            }
-        };
-    }
-}";
-            var expected = @"
-using System;
+                namespace PushUpTest
+                {
+                    public class Base2
+                    {
+                    }
 
-namespace PushUpTest
-{
-    public class Base2
-    {
-        private static event EventHandler Event3
-        {
-            add
-            {
-                System.Console.Writeln(""Hello"");
-            }
-            remove
-            {
-                System.Console.Writeln(""World"");
-            }
-        };
-    }
+                    public class TestClass2 : Base2
+                    {
+                        private static event EventHandler Eve[||]nt3
+                        {
+                            add
+                            {
+                                System.Console.Writeln("Hello");
+                            }
+                            remove
+                            {
+                                System.Console.Writeln("World");
+                            }
+                        };
+                    }
+                }
+                """;
+            var expected = """
 
-    public class TestClass2 : Base2
-    {
-    }
-}";
+                using System;
+
+                namespace PushUpTest
+                {
+                    public class Base2
+                    {
+                        private static event EventHandler Event3
+                        {
+                            add
+                            {
+                                System.Console.Writeln("Hello");
+                            }
+                            remove
+                            {
+                                System.Console.Writeln("World");
+                            }
+                        };
+                    }
+
+                    public class TestClass2 : Base2
+                    {
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullPropertyToClassViaQuickAction()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    public class Base
-    {
-    }
+            var testText = """
 
-    public class TestClass : Base
-    {
-        public int TestPr[||]operty { get; private set; }
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                    }
 
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    public class Base
-    {
-        public int TestProperty { get; private set; }
-    }
+                    public class TestClass : Base
+                    {
+                        public int TestPr[||]operty { get; private set; }
+                    }
+                }
+                """;
 
-    public class TestClass : Base
-    {
-    }
-}";
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                        public int TestProperty { get; private set; }
+                    }
+
+                    public class TestClass : Base
+                    {
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullIndexerToClassViaQuickAction()
         {
-            var testText = @"
-namespace PushUpTest
-{
-    public class Base 
-    {
-    }
+            var testText = """
 
-    public class TestClass : Base
-    {
-        private int j;
-        public int th[||]is[int i]
-        {
-            get => j;
-            set => j = value;
-        }
-    }
-}";
+                namespace PushUpTest
+                {
+                    public class Base 
+                    {
+                    }
 
-            var expected = @"
-namespace PushUpTest
-{
-    public class Base
-    {
-        public int this[int i]
-        {
-            get => j;
-            set => j = value;
-        }
-    }
+                    public class TestClass : Base
+                    {
+                        private int j;
+                        public int th[||]is[int i]
+                        {
+                            get => j;
+                            set => j = value;
+                        }
+                    }
+                }
+                """;
 
-    public class TestClass : Base
-    {
-        private int j;
-    }
-}";
+            var expected = """
+
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                        public int this[int i]
+                        {
+                            get => j;
+                            set => j = value;
+                        }
+                    }
+
+                    public class TestClass : Base
+                    {
+                        private int j;
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullMethodUpAcrossProjectViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""CSAssembly1"" CommonReferences=""true"">
-        <ProjectReference>CSAssembly2</ProjectReference>
-        <Document>
-using Destination;
-public class TestClass : IInterface
-{
-    public int Bar[||]Bar()
-    {
-        return 12345;
-    }
-}
-        </Document>
-  </Project>
-  <Project Language=""C#"" AssemblyName=""CSAssembly2"" CommonReferences=""true"">
-        <Document>
-namespace Destination
-{
-    public interface IInterface
-    {
-    }
-}
-        </Document>
-  </Project>
-</Workspace>";
+            var testText = """
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""CSAssembly1"" CommonReferences=""true"">
-        <ProjectReference>CSAssembly2</ProjectReference>
-        <Document>
-using Destination;
-public class TestClass : IInterface
-{
-    public int Bar[||]Bar()
-    {
-        return 12345;
-    }
-}
-        </Document>
-  </Project>
-  <Project Language=""C#"" AssemblyName=""CSAssembly2"" CommonReferences=""true"">
-        <Document>
-namespace Destination
-{
-    public interface IInterface
-    {
-        int BarBar();
-    }
-}
-        </Document>
-  </Project>
-</Workspace>";
+                <Workspace>
+                    <Project Language="C#" AssemblyName="CSAssembly1" CommonReferences="true">
+                        <ProjectReference>CSAssembly2</ProjectReference>
+                        <Document>
+                using Destination;
+                public class TestClass : IInterface
+                {
+                    public int Bar[||]Bar()
+                    {
+                        return 12345;
+                    }
+                }
+                        </Document>
+                  </Project>
+                  <Project Language="C#" AssemblyName="CSAssembly2" CommonReferences="true">
+                        <Document>
+                namespace Destination
+                {
+                    public interface IInterface
+                    {
+                    }
+                }
+                        </Document>
+                  </Project>
+                </Workspace>
+                """;
+
+            var expected = """
+
+                <Workspace>
+                    <Project Language="C#" AssemblyName="CSAssembly1" CommonReferences="true">
+                        <ProjectReference>CSAssembly2</ProjectReference>
+                        <Document>
+                using Destination;
+                public class TestClass : IInterface
+                {
+                    public int Bar[||]Bar()
+                    {
+                        return 12345;
+                    }
+                }
+                        </Document>
+                  </Project>
+                  <Project Language="C#" AssemblyName="CSAssembly2" CommonReferences="true">
+                        <Document>
+                namespace Destination
+                {
+                    public interface IInterface
+                    {
+                        int BarBar();
+                    }
+                }
+                        </Document>
+                  </Project>
+                </Workspace>
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullPropertyUpAcrossProjectViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""CSAssembly1"" CommonReferences=""true"">
-        <ProjectReference>CSAssembly2</ProjectReference>
-        <Document>
-using Destination;
-public class TestClass : IInterface
-{
-    public int F[||]oo
-    {
-        get;
-        set;
-    }
-}
-        </Document>
-  </Project>
-  <Project Language=""C#"" AssemblyName=""CSAssembly2"" CommonReferences=""true"">
-        <Document>
-namespace Destination
-{
-    public interface IInterface
-    {
-    }
-}
-        </Document>
-  </Project>
-</Workspace>";
+            var testText = """
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""CSAssembly1"" CommonReferences=""true"">
-        <ProjectReference>CSAssembly2</ProjectReference>
-        <Document>
-using Destination;
-public class TestClass : IInterface
-{
-    public int Foo
-    {
-        get;
-        set;
-    }
-}
-        </Document>
-  </Project>
-  <Project Language=""C#"" AssemblyName=""CSAssembly2"" CommonReferences=""true"">
-        <Document>
-namespace Destination
-{
-    public interface IInterface
-    {
-        int Foo { get; set; }
-    }
-}
-        </Document>
-  </Project>
-</Workspace>";
+                <Workspace>
+                    <Project Language="C#" AssemblyName="CSAssembly1" CommonReferences="true">
+                        <ProjectReference>CSAssembly2</ProjectReference>
+                        <Document>
+                using Destination;
+                public class TestClass : IInterface
+                {
+                    public int F[||]oo
+                    {
+                        get;
+                        set;
+                    }
+                }
+                        </Document>
+                  </Project>
+                  <Project Language="C#" AssemblyName="CSAssembly2" CommonReferences="true">
+                        <Document>
+                namespace Destination
+                {
+                    public interface IInterface
+                    {
+                    }
+                }
+                        </Document>
+                  </Project>
+                </Workspace>
+                """;
+
+            var expected = """
+
+                <Workspace>
+                    <Project Language="C#" AssemblyName="CSAssembly1" CommonReferences="true">
+                        <ProjectReference>CSAssembly2</ProjectReference>
+                        <Document>
+                using Destination;
+                public class TestClass : IInterface
+                {
+                    public int Foo
+                    {
+                        get;
+                        set;
+                    }
+                }
+                        </Document>
+                  </Project>
+                  <Project Language="C#" AssemblyName="CSAssembly2" CommonReferences="true">
+                        <Document>
+                namespace Destination
+                {
+                    public interface IInterface
+                    {
+                        int Foo { get; set; }
+                    }
+                }
+                        </Document>
+                  </Project>
+                </Workspace>
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullFieldUpAcrossProjectViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""CSAssembly1"" CommonReferences=""true"">
-        <ProjectReference>CSAssembly2</ProjectReference>
-        <Document>
-using Destination;
-public class TestClass : BaseClass
-{
-    private int i, j, [||]k = 10;
-}
-        </Document>
-  </Project>
-  <Project Language=""C#"" AssemblyName=""CSAssembly2"" CommonReferences=""true"">
-        <Document>
-namespace Destination
-{
-    public class BaseClass
-    {
-    }
-}
-        </Document>
-  </Project>
-</Workspace>";
+            var testText = """
 
-            var expected = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""CSAssembly1"" CommonReferences=""true"">
-        <ProjectReference>CSAssembly2</ProjectReference>
-        <Document>
-using Destination;
-public class TestClass : BaseClass
-{
-    private int i, j;
-}
-        </Document>
-  </Project>
-  <Project Language=""C#"" AssemblyName=""CSAssembly2"" CommonReferences=""true"">
-        <Document>
-namespace Destination
-{
-    public class BaseClass
-    {
-        private int k = 10;
-    }
-}
-        </Document>
-  </Project>
-</Workspace>";
+                <Workspace>
+                    <Project Language="C#" AssemblyName="CSAssembly1" CommonReferences="true">
+                        <ProjectReference>CSAssembly2</ProjectReference>
+                        <Document>
+                using Destination;
+                public class TestClass : BaseClass
+                {
+                    private int i, j, [||]k = 10;
+                }
+                        </Document>
+                  </Project>
+                  <Project Language="C#" AssemblyName="CSAssembly2" CommonReferences="true">
+                        <Document>
+                namespace Destination
+                {
+                    public class BaseClass
+                    {
+                    }
+                }
+                        </Document>
+                  </Project>
+                </Workspace>
+                """;
+
+            var expected = """
+
+                <Workspace>
+                    <Project Language="C#" AssemblyName="CSAssembly1" CommonReferences="true">
+                        <ProjectReference>CSAssembly2</ProjectReference>
+                        <Document>
+                using Destination;
+                public class TestClass : BaseClass
+                {
+                    private int i, j;
+                }
+                        </Document>
+                  </Project>
+                  <Project Language="C#" AssemblyName="CSAssembly2" CommonReferences="true">
+                        <Document>
+                namespace Destination
+                {
+                    public class BaseClass
+                    {
+                        private int k = 10;
+                    }
+                }
+                        </Document>
+                  </Project>
+                </Workspace>
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
@@ -3627,81 +3899,87 @@ namespace Destination
         {
             // Moving member from C# to Visual Basic is not supported currently since the FindMostRelevantDeclarationAsync method in
             // AbstractCodeGenerationService will return null.
-            var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
-        <ProjectReference>VBAssembly</ProjectReference>
-        <Document>
-            using VBAssembly;
-            public class TestClass : VBClass
-            {
-                public int Bar[||]bar()
-                {
-                    return 12345;
-                }
-            }
-        </Document>
-  </Project>
-  <Project Language=""Visual Basic"" AssemblyName=""VBAssembly"" CommonReferences=""true"">
-        <Document>
-            Public Class VBClass
-            End Class
-        </Document>
-  </Project>
-</Workspace>";
+            var input = """
+
+                <Workspace>
+                    <Project Language="C#" AssemblyName="CSAssembly" CommonReferences="true">
+                        <ProjectReference>VBAssembly</ProjectReference>
+                        <Document>
+                            using VBAssembly;
+                            public class TestClass : VBClass
+                            {
+                                public int Bar[||]bar()
+                                {
+                                    return 12345;
+                                }
+                            }
+                        </Document>
+                  </Project>
+                  <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
+                        <Document>
+                            Public Class VBClass
+                            End Class
+                        </Document>
+                  </Project>
+                </Workspace>
+                """;
             await TestQuickActionNotProvidedAsync(input);
         }
 
         [Fact]
         public async Task TestPullMethodUpToVBInterfaceViaQuickAction()
         {
-            var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
-    <ProjectReference>VBAssembly</ProjectReference>
-    <Document>
-        public class TestClass : VBInterface
-        {
-            public int Bar[||]bar()
-            {
-                return 12345;
-            }
-        }
-    </Document>
-  </Project>
-    <Project Language=""Visual Basic"" AssemblyName=""VBAssembly"" CommonReferences=""true"">
-        <Document>
-            Public Interface VBInterface
-            End Interface
-        </Document>
-    </Project>
-</Workspace>
-";
+            var input = """
+
+                <Workspace>
+                    <Project Language="C#" AssemblyName="CSAssembly" CommonReferences="true">
+                    <ProjectReference>VBAssembly</ProjectReference>
+                    <Document>
+                        public class TestClass : VBInterface
+                        {
+                            public int Bar[||]bar()
+                            {
+                                return 12345;
+                            }
+                        }
+                    </Document>
+                  </Project>
+                    <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
+                        <Document>
+                            Public Interface VBInterface
+                            End Interface
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestQuickActionNotProvidedAsync(input);
         }
 
         [Fact]
         public async Task TestPullFieldUpToVBClassViaQuickAction()
         {
-            var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
-        <ProjectReference>VBAssembly</ProjectReference>
-        <Document>
-            using VBAssembly;
-            public class TestClass : VBClass
-            {
-                public int fo[||]obar = 0;
-            }
-        </Document>
-  </Project>
-    <Project Language=""Visual Basic"" AssemblyName=""VBAssembly"" CommonReferences=""true"">
-    <Document>
-        Public Class VBClass
-        End Class
-    </Document>
-    </Project>
-</Workspace>";
+            var input = """
+
+                <Workspace>
+                    <Project Language="C#" AssemblyName="CSAssembly" CommonReferences="true">
+                        <ProjectReference>VBAssembly</ProjectReference>
+                        <Document>
+                            using VBAssembly;
+                            public class TestClass : VBClass
+                            {
+                                public int fo[||]obar = 0;
+                            }
+                        </Document>
+                  </Project>
+                    <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
+                    <Document>
+                        Public Class VBClass
+                        End Class
+                    </Document>
+                    </Project>
+                </Workspace>
+                """;
 
             await TestQuickActionNotProvidedAsync(input);
         }
@@ -3709,171 +3987,183 @@ namespace Destination
         [Fact]
         public async Task TestPullPropertyUpToVBClassViaQuickAction()
         {
-            var input = @"
-<Workspace>
-  <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
-    <ProjectReference>VBAssembly</ProjectReference>
-    <Document>
-using VBAssembly;
-public class TestClass : VBClass
-{
-    public int foo[||]bar
-    {
-        get;
-        set;
-    }
-}</Document>
-  </Project>
-  <Project Language=""Visual Basic"" AssemblyName=""VBAssembly"" CommonReferences=""true"">
-    <Document>
-        Public Class VBClass
-        End Class
-    </Document>
-  </Project>
-</Workspace>
-";
+            var input = """
+
+                <Workspace>
+                  <Project Language="C#" AssemblyName="CSAssembly" CommonReferences="true">
+                    <ProjectReference>VBAssembly</ProjectReference>
+                    <Document>
+                using VBAssembly;
+                public class TestClass : VBClass
+                {
+                    public int foo[||]bar
+                    {
+                        get;
+                        set;
+                    }
+                }</Document>
+                  </Project>
+                  <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
+                    <Document>
+                        Public Class VBClass
+                        End Class
+                    </Document>
+                  </Project>
+                </Workspace>
+
+                """;
             await TestQuickActionNotProvidedAsync(input);
         }
 
         [Fact]
         public async Task TestPullPropertyUpToVBInterfaceViaQuickAction()
         {
-            var input = @"<Workspace>
-    <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
-        <ProjectReference>VBAssembly</ProjectReference>
-        <Document>
-using VBAssembly;
-public class TestClass : VBInterface
-        {
-            public int foo[||]bar
-            {
-                get;
-                set;
-            }
-        }
-        </Document>
-  </Project>
-    <Project Language = ""Visual Basic"" AssemblyName=""VBAssembly"" CommonReferences=""true"">
-        <Document>
-            Public Interface VBInterface
-            End Interface
-        </Document>
-    </Project>
-</Workspace>";
+            var input = """
+                <Workspace>
+                    <Project Language="C#" AssemblyName="CSAssembly" CommonReferences="true">
+                        <ProjectReference>VBAssembly</ProjectReference>
+                        <Document>
+                using VBAssembly;
+                public class TestClass : VBInterface
+                        {
+                            public int foo[||]bar
+                            {
+                                get;
+                                set;
+                            }
+                        }
+                        </Document>
+                  </Project>
+                    <Project Language = "Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
+                        <Document>
+                            Public Interface VBInterface
+                            End Interface
+                        </Document>
+                    </Project>
+                </Workspace>
+                """;
             await TestQuickActionNotProvidedAsync(input);
         }
 
         [Fact]
         public async Task TestPullEventUpToVBClassViaQuickAction()
         {
-            var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
-        <ProjectReference>VBAssembly</ProjectReference>
-            <Document>
-            using VBAssembly;
-            public class TestClass : VBClass
-            {
-                public event EventHandler BarEve[||]nt;
-            }
-            </Document>
-    </Project>
-    <Project Language=""Visual Basic"" AssemblyName=""VBAssembly"" CommonReferences=""true"">
-        <Document>
-            Public Class VBClass
-            End Class
-        </Document>
-    </Project>
-</Workspace>";
+            var input = """
+
+                <Workspace>
+                    <Project Language="C#" AssemblyName="CSAssembly" CommonReferences="true">
+                        <ProjectReference>VBAssembly</ProjectReference>
+                            <Document>
+                            using VBAssembly;
+                            public class TestClass : VBClass
+                            {
+                                public event EventHandler BarEve[||]nt;
+                            }
+                            </Document>
+                    </Project>
+                    <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
+                        <Document>
+                            Public Class VBClass
+                            End Class
+                        </Document>
+                    </Project>
+                </Workspace>
+                """;
             await TestQuickActionNotProvidedAsync(input);
         }
 
         [Fact]
         public async Task TestPullEventUpToVBInterfaceViaQuickAction()
         {
-            var input = @"
-<Workspace>
-    <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
-    <ProjectReference>VBAssembly</ProjectReference>
-    <Document>
-        using VBAssembly;
-        public class TestClass : VBInterface
-        {
-            public event EventHandler BarEve[||]nt;
-        }
-    </Document>
-    </Project>
-    <Project Language=""Visual Basic"" AssemblyName=""VBAssembly"" CommonReferences=""true"">
-    <Document>
-        Public Interface VBInterface
-        End Interface
-    </Document>
-    </Project>
-</Workspace>";
+            var input = """
+
+                <Workspace>
+                    <Project Language="C#" AssemblyName="CSAssembly" CommonReferences="true">
+                    <ProjectReference>VBAssembly</ProjectReference>
+                    <Document>
+                        using VBAssembly;
+                        public class TestClass : VBInterface
+                        {
+                            public event EventHandler BarEve[||]nt;
+                        }
+                    </Document>
+                    </Project>
+                    <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
+                    <Document>
+                        Public Interface VBInterface
+                        End Interface
+                    </Document>
+                    </Project>
+                </Workspace>
+                """;
             await TestQuickActionNotProvidedAsync(input);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/55746")]
         public async Task TestPullMethodWithToClassWithAddUsingsInsideNamespaceViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace N
-{
-    public class Base
-    {
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+            var testText = """
 
-namespace N
-{
-    public class Derived : Base
-    {
-        public Uri En[||]dpoint()
-        {
-            return new Uri(""http://localhost"");
-        }
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace N
-{
-    using System;
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace N
+                {
+                    public class Base
+                    {
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
 
-    public class Base
-    {
-        public Uri Endpoint()
-        {
-            return new Uri(""http://localhost"");
-        }
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
+                namespace N
+                {
+                    public class Derived : Base
+                    {
+                        public Uri En[||]dpoint()
+                        {
+                            return new Uri("http://localhost");
+                        }
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-namespace N
-{
-    public class Derived : Base
-    {
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                """;
+            var expected = """
+
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace N
+                {
+                    using System;
+
+                    public class Base
+                    {
+                        public Uri Endpoint()
+                        {
+                            return new Uri("http://localhost");
+                        }
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+
+                namespace N
+                {
+                    public class Derived : Base
+                    {
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(
                 testText,
                 expected,
@@ -3883,86 +4173,90 @@ namespace N
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/55746")]
         public async Task TestPullMethodWithToClassWithAddUsingsSystemUsingsLastViaQuickAction()
         {
-            var testText = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">
-namespace N1
-{
-    public class Base
-    {
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
-using N2;
+            var testText = """
 
-namespace N1
-{
-    public class Derived : Base
-    {
-        public Goo Ge[||]tGoo()
-        {
-            return new Goo(String.Empty);
-        }
-    }
-}
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">
+                namespace N1
+                {
+                    public class Base
+                    {
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+                using N2;
 
-namespace N2
-{
-    public class Goo
-    {
-        public Goo(String s)
-        {
-        }
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
-            var expected = @"
-<Workspace>
-    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
-        <Document FilePath = ""File1.cs"">using N2;
-using System;
+                namespace N1
+                {
+                    public class Derived : Base
+                    {
+                        public Goo Ge[||]tGoo()
+                        {
+                            return new Goo(String.Empty);
+                        }
+                    }
+                }
 
-namespace N1
-{
-    public class Base
-    {
-        public Goo GetGoo()
-        {
-            return new Goo(String.Empty);
-        }
-    }
-}
-        </Document>
-        <Document FilePath = ""File2.cs"">
-using System;
-using N2;
+                namespace N2
+                {
+                    public class Goo
+                    {
+                        public Goo(String s)
+                        {
+                        }
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
 
-namespace N1
-{
-    public class Derived : Base
-    {
-    }
-}
+                """;
+            var expected = """
 
-namespace N2
-{
-    public class Goo
-    {
-        public Goo(String s)
-        {
-        }
-    }
-}
-        </Document>
-    </Project>
-</Workspace>
-";
+                <Workspace>
+                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
+                        <Document FilePath = "File1.cs">using N2;
+                using System;
+
+                namespace N1
+                {
+                    public class Base
+                    {
+                        public Goo GetGoo()
+                        {
+                            return new Goo(String.Empty);
+                        }
+                    }
+                }
+                        </Document>
+                        <Document FilePath = "File2.cs">
+                using System;
+                using N2;
+
+                namespace N1
+                {
+                    public class Derived : Base
+                    {
+                    }
+                }
+
+                namespace N2
+                {
+                    public class Goo
+                    {
+                        public Goo(String s)
+                        {
+                        }
+                    }
+                }
+                        </Document>
+                    </Project>
+                </Workspace>
+
+                """;
             await TestWithPullMemberDialogAsync(
                 testText,
                 expected,
@@ -3975,242 +4269,302 @@ namespace N2
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullMethodToClassWithDirective()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    #region Hello
-    public void G[||]oo() { }
-    #endregion
-}";
-            var expected = @"
-public class BaseClass
-{
-    public void Goo() { }
-}
+                public class BaseClass
+                {
+                }
 
-public class Bar : BaseClass
-{
+                public class Bar : BaseClass
+                {
+                    #region Hello
+                    public void G[||]oo() { }
+                    #endregion
+                }
+                """;
+            var expected = """
 
-    #region Hello
-    #endregion
-}";
+                public class BaseClass
+                {
+                    public void Goo() { }
+                }
+
+                public class Bar : BaseClass
+                {
+
+                    #region Hello
+                    #endregion
+                }
+                """;
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullMethodToClassBeforeDirective()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    public void H[||]ello() { }
-    #region Hello
-    public void Goo() { }
-    #endregion
-}";
-            var expected = @"
-public class BaseClass
-{
-    public void Hello() { }
-}
+                public class BaseClass
+                {
+                }
 
-public class Bar : BaseClass
-{
-    #region Hello
-    public void Goo() { }
-    #endregion
-}";
+                public class Bar : BaseClass
+                {
+                    public void H[||]ello() { }
+                    #region Hello
+                    public void Goo() { }
+                    #endregion
+                }
+                """;
+            var expected = """
+
+                public class BaseClass
+                {
+                    public void Hello() { }
+                }
+
+                public class Bar : BaseClass
+                {
+                    #region Hello
+                    public void Goo() { }
+                    #endregion
+                }
+                """;
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullMethodToClassBeforeDirective2()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    public void Hello() { }
+                public class BaseClass
+                {
+                }
 
-    #region Hello
-    public void G[||]oo() { }
-    #endregion
-}";
-            var expected = @"
-public class BaseClass
-{
+                public class Bar : BaseClass
+                {
+                    public void Hello() { }
 
-    public void Goo() { }
-}
+                    #region Hello
+                    public void G[||]oo() { }
+                    #endregion
+                }
+                """;
+            var expected = """
 
-public class Bar : BaseClass
-{
-    public void Hello() { }
+                public class BaseClass
+                {
 
-    #region Hello
-    #endregion
-}";
+                    public void Goo() { }
+                }
+
+                public class Bar : BaseClass
+                {
+                    public void Hello() { }
+
+                    #region Hello
+                    #endregion
+                }
+                """;
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullFieldToClassBeforeDirective1()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    public int ba[||]r = 10;
-    #region Hello
-    public int Goo = 10;
-    #endregion
-}";
-            var expected = @"
-public class BaseClass
-{
-    public int bar = 10;
-}
+                public class BaseClass
+                {
+                }
 
-public class Bar : BaseClass
-{
-    #region Hello
-    public int Goo = 10;
-    #endregion
-}";
+                public class Bar : BaseClass
+                {
+                    public int ba[||]r = 10;
+                    #region Hello
+                    public int Goo = 10;
+                    #endregion
+                }
+                """;
+            var expected = """
+
+                public class BaseClass
+                {
+                    public int bar = 10;
+                }
+
+                public class Bar : BaseClass
+                {
+                    #region Hello
+                    public int Goo = 10;
+                    #endregion
+                }
+                """;
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullFieldToClassBeforeDirective2()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    public int bar = 10;
-    #region Hello
-    public int Go[||]o = 10;
-    #endregion
-}";
-            var expected = @"
-public class BaseClass
-{
-    public int Goo = 10;
-}
+                public class BaseClass
+                {
+                }
 
-public class Bar : BaseClass
-{
-    public int bar = 10;
+                public class Bar : BaseClass
+                {
+                    public int bar = 10;
+                    #region Hello
+                    public int Go[||]o = 10;
+                    #endregion
+                }
+                """;
+            var expected = """
 
-    #region Hello
-    #endregion
-}";
+                public class BaseClass
+                {
+                    public int Goo = 10;
+                }
+
+                public class Bar : BaseClass
+                {
+                    public int bar = 10;
+
+                    #region Hello
+                    #endregion
+                }
+                """;
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullFieldToClassBeforeDirective()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    #region Hello
-    public int G[||]oo = 100, Hoo;
-    #endregion
-}";
-            var expected = @"
-public class BaseClass
-{
-    public int Goo = 100;
-}
+                public class BaseClass
+                {
+                }
 
-public class Bar : BaseClass
-{
-    #region Hello
-    public int Hoo;
-    #endregion
-}";
+                public class Bar : BaseClass
+                {
+                    #region Hello
+                    public int G[||]oo = 100, Hoo;
+                    #endregion
+                }
+                """;
+            var expected = """
+
+                public class BaseClass
+                {
+                    public int Goo = 100;
+                }
+
+                public class Bar : BaseClass
+                {
+                    #region Hello
+                    public int Hoo;
+                    #endregion
+                }
+                """;
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullEventToClassBeforeDirective()
         {
-            var text = @"
-using System;
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    #region Hello
-    public event EventHandler e[||]1;
-    #endregion
-}";
-            var expected = @"
-using System;
-public class BaseClass
-{
-    public event EventHandler e1;
-}
+                using System;
+                public class BaseClass
+                {
+                }
 
-public class Bar : BaseClass
-{
+                public class Bar : BaseClass
+                {
+                    #region Hello
+                    public event EventHandler e[||]1;
+                    #endregion
+                }
+                """;
+            var expected = """
 
-    #region Hello
-    #endregion
-}";
+                using System;
+                public class BaseClass
+                {
+                    public event EventHandler e1;
+                }
+
+                public class Bar : BaseClass
+                {
+
+                    #region Hello
+                    #endregion
+                }
+                """;
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullPropertyToClassBeforeDirective()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    #region Hello
-    public int Go[||]o => 1;
-    #endregion
-}";
-            var expected = @"
-public class BaseClass
-{
-    public int Goo => 1;
-}
+                public class BaseClass
+                {
+                }
 
-public class Bar : BaseClass
-{
+                public class Bar : BaseClass
+                {
+                    #region Hello
+                    public int Go[||]o => 1;
+                    #endregion
+                }
+                """;
+            var expected = """
 
-    #region Hello
-    #endregion
-}";
+                public class BaseClass
+                {
+                    public int Goo => 1;
+                }
+
+                public class Bar : BaseClass
+                {
+
+                    #region Hello
+                    #endregion
+                }
+                """;
+            return TestWithPullMemberDialogAsync(text, expected);
+        }
+
+        [Fact, WorkItem(55402, "https://github.com/dotnet/roslyn/issues/55402")]
+        public Task TestPullPropertyToClassOnKeyword()
+        {
+            var text = """
+                public class BaseClass
+                {
+                }
+
+                public class Derived : BaseClass
+                {
+                    $$public int I => 1;
+                }
+                """;
+
+            var expected = """
+                public class BaseClass
+                {
+                    $$public int I => 1;
+                }
+                
+                public class Derived : BaseClass
+                {
+                }
+                """;
+
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
@@ -4237,53 +4591,57 @@ public class Bar : BaseClass
         [Fact]
         public async Task PullPartialMethodUpToInterfaceViaDialog()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    partial interface IInterface
-    {
-    }
+            var testText = """
 
-    public partial class TestClass : IInterface
-    {
-        partial void Bar[||]Bar()
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    partial interface IInterface
+                    {
+                    }
 
-    public partial class TestClass
-    {
-        partial void BarBar()
-        {}
-    }
+                    public partial class TestClass : IInterface
+                    {
+                        partial void Bar[||]Bar()
+                    }
 
-    partial interface IInterface
-    {
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    partial interface IInterface
-    {
-        void BarBar();
-    }
+                    public partial class TestClass
+                    {
+                        partial void BarBar()
+                        {}
+                    }
 
-    public partial class TestClass : IInterface
-    {
-        void BarBar()
-    }
+                    partial interface IInterface
+                    {
+                    }
+                }
+                """;
+            var expected = """
 
-    public partial class TestClass
-    {
-        partial void BarBar()
-        {}
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    partial interface IInterface
+                    {
+                        void BarBar();
+                    }
 
-    partial interface IInterface
-    {
-    }
-}";
+                    public partial class TestClass : IInterface
+                    {
+                        void BarBar()
+                    }
+
+                    public partial class TestClass
+                    {
+                        partial void BarBar()
+                        {}
+                    }
+
+                    partial interface IInterface
+                    {
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -4291,53 +4649,57 @@ namespace PushUpTest
         [Fact]
         public async Task PullExtendedPartialMethodUpToInterfaceViaDialog()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    partial interface IInterface
-    {
-    }
+            var testText = """
 
-    public partial class TestClass : IInterface
-    {
-        public partial void Bar[||]Bar()
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    partial interface IInterface
+                    {
+                    }
 
-    public partial class TestClass
-    {
-        public partial void BarBar()
-        {}
-    }
+                    public partial class TestClass : IInterface
+                    {
+                        public partial void Bar[||]Bar()
+                    }
 
-    partial interface IInterface
-    {
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    partial interface IInterface
-    {
-        void BarBar();
-    }
+                    public partial class TestClass
+                    {
+                        public partial void BarBar()
+                        {}
+                    }
 
-    public partial class TestClass : IInterface
-    {
-        public partial void BarBar()
-    }
+                    partial interface IInterface
+                    {
+                    }
+                }
+                """;
+            var expected = """
 
-    public partial class TestClass
-    {
-        public partial void BarBar()
-        {}
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    partial interface IInterface
+                    {
+                        void BarBar();
+                    }
 
-    partial interface IInterface
-    {
-    }
-}";
+                    public partial class TestClass : IInterface
+                    {
+                        public partial void BarBar()
+                    }
+
+                    public partial class TestClass
+                    {
+                        public partial void BarBar()
+                        {}
+                    }
+
+                    partial interface IInterface
+                    {
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -4345,130 +4707,142 @@ namespace PushUpTest
         [Fact]
         public async Task PullMultipleNonPublicMethodsToInterfaceViaDialog()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-    }
+            var testText = """
 
-    public class TestClass : IInterface
-    {
-        public void TestMethod()
-        {
-            System.Console.WriteLine(""Hello World"");
-        }
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                    }
 
-        protected void F[||]oo(int i)
-        {
-            // do awesome things
-        }
+                    public class TestClass : IInterface
+                    {
+                        public void TestMethod()
+                        {
+                            System.Console.WriteLine("Hello World");
+                        }
 
-        private static string Bar(string x)
-        {}
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-        string Bar(string x);
-        void Foo(int i);
-        void TestMethod();
-    }
+                        protected void F[||]oo(int i)
+                        {
+                            // do awesome things
+                        }
 
-    public class TestClass : IInterface
-    {
-        public void TestMethod()
-        {
-            System.Console.WriteLine(""Hello World"");
-        }
+                        private static string Bar(string x)
+                        {}
+                    }
+                }
+                """;
+            var expected = """
 
-        public void Foo(int i)
-        {
-            // do awesome things
-        }
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                        string Bar(string x);
+                        void Foo(int i);
+                        void TestMethod();
+                    }
 
-        public string Bar(string x)
-        {}
-    }
-}";
+                    public class TestClass : IInterface
+                    {
+                        public void TestMethod()
+                        {
+                            System.Console.WriteLine("Hello World");
+                        }
+
+                        public void Foo(int i)
+                        {
+                            // do awesome things
+                        }
+
+                        public string Bar(string x)
+                        {}
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task PullMultipleNonPublicEventsToInterface()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-    }
+            var testText = """
 
-    public class TestClass : IInterface
-    {
-        private event EventHandler Event1, Eve[||]nt2, Event3;
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                    }
 
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-        event EventHandler Event1;
-        event EventHandler Event2;
-        event EventHandler Event3;
-    }
+                    public class TestClass : IInterface
+                    {
+                        private event EventHandler Event1, Eve[||]nt2, Event3;
+                    }
+                }
+                """;
 
-    public class TestClass : IInterface
-    {
-        public event EventHandler Event1;
-        public event EventHandler Event2;
-        public event EventHandler Event3;
-    }
-}";
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                        event EventHandler Event1;
+                        event EventHandler Event2;
+                        event EventHandler Event3;
+                    }
+
+                    public class TestClass : IInterface
+                    {
+                        public event EventHandler Event1;
+                        public event EventHandler Event2;
+                        public event EventHandler Event3;
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task PullMethodToInnerInterfaceViaDialog()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    public class TestClass : TestClass.IInterface
-    {
-        private void Bar[||]Bar()
-        {
-        }
-        interface IInterface
-        {
-        }
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    public class TestClass : TestClass.IInterface
-    {
-        public void BarBar()
-        {
-        }
-        interface IInterface
-        {
-            void BarBar();
-        }
-    }
-}";
+            var testText = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public class TestClass : TestClass.IInterface
+                    {
+                        private void Bar[||]Bar()
+                        {
+                        }
+                        interface IInterface
+                        {
+                        }
+                    }
+                }
+                """;
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public class TestClass : TestClass.IInterface
+                    {
+                        public void BarBar()
+                        {
+                        }
+                        interface IInterface
+                        {
+                            void BarBar();
+                        }
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -4476,280 +4850,308 @@ namespace PushUpTest
         [Fact]
         public async Task PullDifferentMembersFromClassToPartialInterfaceViaDialog()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    partial interface IInterface
-    {
-    }
+            var testText = """
 
-    public class TestClass : IInterface
-    {
-        public int th[||]is[int i]
-        {
-            get => j = value;
-        }
+                using System;
+                namespace PushUpTest
+                {
+                    partial interface IInterface
+                    {
+                    }
 
-        private static void BarBar()
-        {}
-        
-        protected static event EventHandler event1, event2;
+                    public class TestClass : IInterface
+                    {
+                        public int th[||]is[int i]
+                        {
+                            get => j = value;
+                        }
 
-        internal static int Foo
-        {
-            get; set;
-        }
-    }
-    partial interface IInterface
-    {
-    }
-}";
+                        private static void BarBar()
+                        {}
+                        
+                        protected static event EventHandler event1, event2;
 
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    partial interface IInterface
-    {
-        int this[int i] { get; }
+                        internal static int Foo
+                        {
+                            get; set;
+                        }
+                    }
+                    partial interface IInterface
+                    {
+                    }
+                }
+                """;
 
-        int Foo { get; set; }
+            var expected = """
 
-        event EventHandler event1;
-        event EventHandler event2;
+                using System;
+                namespace PushUpTest
+                {
+                    partial interface IInterface
+                    {
+                        int this[int i] { get; }
 
-        void BarBar();
-    }
+                        int Foo { get; set; }
 
-    public class TestClass : IInterface
-    {
-        public int this[int i]
-        {
-            get => j = value;
-        }
+                        event EventHandler event1;
+                        event EventHandler event2;
 
-        public void BarBar()
-        {}
+                        void BarBar();
+                    }
 
-        public event EventHandler event1;
-        public event EventHandler event2;
+                    public class TestClass : IInterface
+                    {
+                        public int this[int i]
+                        {
+                            get => j = value;
+                        }
 
-        public int Foo
-        {
-            get; set;
-        }
-    }
-    partial interface IInterface
-    {
-    }
-}";
+                        public void BarBar()
+                        {}
+
+                        public event EventHandler event1;
+                        public event EventHandler event2;
+
+                        public int Foo
+                        {
+                            get; set;
+                        }
+                    }
+                    partial interface IInterface
+                    {
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected, index: 1);
         }
 
         [Fact]
         public async Task TestPullAsyncMethod()
         {
-            var testText = @"
-using System.Threading.Tasks;
+            var testText = """
 
-internal interface IPullUp { }
+                using System.Threading.Tasks;
 
-internal class PullUp : IPullUp
-{
-    internal async Task PullU[||]pAsync()
-    {
-        await Task.Delay(1000);
-    }
-}";
-            var expectedText = @"
-using System.Threading.Tasks;
+                internal interface IPullUp { }
 
-internal interface IPullUp
-{
-    Task PullUpAsync();
-}
+                internal class PullUp : IPullUp
+                {
+                    internal async Task PullU[||]pAsync()
+                    {
+                        await Task.Delay(1000);
+                    }
+                }
+                """;
+            var expectedText = """
 
-internal class PullUp : IPullUp
-{
-    public async Task PullUpAsync()
-    {
-        await Task.Delay(1000);
-    }
-}";
+                using System.Threading.Tasks;
+
+                internal interface IPullUp
+                {
+                    Task PullUpAsync();
+                }
+
+                internal class PullUp : IPullUp
+                {
+                    public async Task PullUpAsync()
+                    {
+                        await Task.Delay(1000);
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expectedText);
         }
 
         [Fact]
         public async Task PullMethodWithAbstractOptionToClassViaDialog()
         {
-            var testText = @"
-namespace PushUpTest
-{
-    public class Base
-    {
-    }
+            var testText = """
 
-    public class TestClass : Base
-    {
-        public void TestMeth[||]od()
-        {
-            System.Console.WriteLine(""Hello World"");
-        }
-    }
-}";
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                    }
 
-            var expected = @"
-namespace PushUpTest
-{
-    public abstract class Base
-    {
-        public abstract void TestMethod();
-    }
+                    public class TestClass : Base
+                    {
+                        public void TestMeth[||]od()
+                        {
+                            System.Console.WriteLine("Hello World");
+                        }
+                    }
+                }
+                """;
 
-    public class TestClass : Base
-    {
-        public override void TestMeth[||]od()
-        {
-            System.Console.WriteLine(""Hello World"");
-        }
-    }
-}";
+            var expected = """
+
+                namespace PushUpTest
+                {
+                    public abstract class Base
+                    {
+                        public abstract void TestMethod();
+                    }
+
+                    public class TestClass : Base
+                    {
+                        public override void TestMeth[||]od()
+                        {
+                            System.Console.WriteLine("Hello World");
+                        }
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("TestMethod", true) }, index: 1);
         }
 
         [Fact]
         public async Task PullAbstractMethodToClassViaDialog()
         {
-            var testText = @"
-namespace PushUpTest
-{
-    public class Base
-    {
-    }
+            var testText = """
 
-    public abstract class TestClass : Base
-    {
-        public abstract void TestMeth[||]od();
-    }
-}";
+                namespace PushUpTest
+                {
+                    public class Base
+                    {
+                    }
 
-            var expected = @"
-namespace PushUpTest
-{
-    public abstract class Base
-    {
-        public abstract void TestMethod();
-    }
+                    public abstract class TestClass : Base
+                    {
+                        public abstract void TestMeth[||]od();
+                    }
+                }
+                """;
 
-    public abstract class TestClass : Base
-    {
-    }
-}";
+            var expected = """
+
+                namespace PushUpTest
+                {
+                    public abstract class Base
+                    {
+                        public abstract void TestMethod();
+                    }
+
+                    public abstract class TestClass : Base
+                    {
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("TestMethod", true) }, index: 0);
         }
 
         [Fact]
         public async Task PullMultipleEventsToClassViaDialog()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    public class Base2
-    {
-    }
+            var testText = """
 
-    public class Testclass2 : Base2
-    {
-        private static event EventHandler Event1, Eve[||]nt3, Event4;
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    public class Base2
-    {
-        private static event EventHandler Event1;
-        private static event EventHandler Event3;
-        private static event EventHandler Event4;
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    public class Base2
+                    {
+                    }
 
-    public class Testclass2 : Base2
-    {
-    }
-}";
+                    public class Testclass2 : Base2
+                    {
+                        private static event EventHandler Event1, Eve[||]nt3, Event4;
+                    }
+                }
+                """;
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public class Base2
+                    {
+                        private static event EventHandler Event1;
+                        private static event EventHandler Event3;
+                        private static event EventHandler Event4;
+                    }
+
+                    public class Testclass2 : Base2
+                    {
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected, index: 1);
         }
 
         [Fact]
         public async Task PullMultipleAbstractEventsToInterfaceViaDialog()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    public interface ITest 
-    {
-    }
+            var testText = """
 
-    public abstract class Testclass2 : ITest
-    {
-        protected abstract event EventHandler Event1, Eve[||]nt3, Event4;
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    public interface ITest
-    {
-        event EventHandler Event1;
-        event EventHandler Event3;
-        event EventHandler Event4;
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    public interface ITest 
+                    {
+                    }
 
-    public abstract class Testclass2 : ITest
-    {
-        public abstract event EventHandler Event1;
-        public abstract event EventHandler Event3;
-        public abstract event EventHandler Event4;
-    }
-}";
+                    public abstract class Testclass2 : ITest
+                    {
+                        protected abstract event EventHandler Event1, Eve[||]nt3, Event4;
+                    }
+                }
+                """;
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public interface ITest
+                    {
+                        event EventHandler Event1;
+                        event EventHandler Event3;
+                        event EventHandler Event4;
+                    }
+
+                    public abstract class Testclass2 : ITest
+                    {
+                        public abstract event EventHandler Event1;
+                        public abstract event EventHandler Event3;
+                        public abstract event EventHandler Event4;
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task PullAbstractEventToClassViaDialog()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    public class Base2
-    {
-    }
+            var testText = """
 
-    public abstract class Testclass2 : Base2
-    {
-        private static abstract event EventHandler Event1, Eve[||]nt3, Event4;
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    public class Base2
-    {
-        private static event EventHandler Event3;
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    public class Base2
+                    {
+                    }
 
-    public abstract class Testclass2 : Base2
-    {
-        private static abstract event EventHandler Event1, Event4;
-    }
-}";
+                    public abstract class Testclass2 : Base2
+                    {
+                        private static abstract event EventHandler Event1, Eve[||]nt3, Event4;
+                    }
+                }
+                """;
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public class Base2
+                    {
+                        private static event EventHandler Event3;
+                    }
+
+                    public abstract class Testclass2 : Base2
+                    {
+                        private static abstract event EventHandler Event1, Event4;
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("Event3", false) });
         }
@@ -4757,33 +5159,37 @@ namespace PushUpTest
         [Fact]
         public async Task PullNonPublicEventToInterfaceViaDialog()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    public interface ITest
-    {
-    }
+            var testText = """
 
-    public class Testclass2 : ITest
-    {
-        private event EventHandler Eve[||]nt3;
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    public interface ITest
-    {
-        event EventHandler Event3;
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    public interface ITest
+                    {
+                    }
 
-    public class Testclass2 : ITest
-    {
-        public event EventHandler Event3;
-    }
-}";
+                    public class Testclass2 : ITest
+                    {
+                        private event EventHandler Eve[||]nt3;
+                    }
+                }
+                """;
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public interface ITest
+                    {
+                        event EventHandler Event3;
+                    }
+
+                    public class Testclass2 : ITest
+                    {
+                        public event EventHandler Event3;
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("Event3", false) });
         }
@@ -4791,33 +5197,37 @@ namespace PushUpTest
         [Fact]
         public async Task PullSingleNonPublicEventToInterfaceViaDialog()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    public interface ITest
-    {
-    }
+            var testText = """
 
-    public abstract class TestClass2 : ITest
-    {
-        protected event EventHandler Eve[||]nt3;
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    public interface ITest
-    {
-        event EventHandler Event3;
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    public interface ITest
+                    {
+                    }
 
-    public abstract class TestClass2 : ITest
-    {
-        public event EventHandler Event3;
-    }
-}";
+                    public abstract class TestClass2 : ITest
+                    {
+                        protected event EventHandler Eve[||]nt3;
+                    }
+                }
+                """;
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public interface ITest
+                    {
+                        event EventHandler Event3;
+                    }
+
+                    public abstract class TestClass2 : ITest
+                    {
+                        public event EventHandler Event3;
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("Event3", false) });
         }
@@ -4825,54 +5235,58 @@ namespace PushUpTest
         [Fact]
         public async Task TestPullNonPublicEventWithAddAndRemoveMethodToInterfaceViaDialog()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-    }
+            var testText = """
 
-    public class TestClass : IInterface
-    {
-        private event EventHandler Eve[||]nt1
-        {
-            add
-            {
-                System.Console.Writeline(""This is add"");
-            }
-            remove
-            {
-                System.Console.Writeline(""This is remove"");
-            }
-        }
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                    }
 
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    interface IInterface
-    {
-        event EventHandler Event1;
-    }
+                    public class TestClass : IInterface
+                    {
+                        private event EventHandler Eve[||]nt1
+                        {
+                            add
+                            {
+                                System.Console.Writeline("This is add");
+                            }
+                            remove
+                            {
+                                System.Console.Writeline("This is remove");
+                            }
+                        }
+                    }
+                }
+                """;
 
-    public class TestClass : IInterface
-    {
-        public event EventHandler Event1
-        {
-            add
-            {
-                System.Console.Writeline(""This is add"");
-            }
-            remove
-            {
-                System.Console.Writeline(""This is remove"");
-            }
-        }
-    }
-}";
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    interface IInterface
+                    {
+                        event EventHandler Event1;
+                    }
+
+                    public class TestClass : IInterface
+                    {
+                        public event EventHandler Event1
+                        {
+                            add
+                            {
+                                System.Console.Writeline("This is add");
+                            }
+                            remove
+                            {
+                                System.Console.Writeline("This is remove");
+                            }
+                        }
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("Event1", false) });
         }
@@ -4880,34 +5294,38 @@ namespace PushUpTest
         [Fact]
         public async Task PullFieldsToClassViaDialog()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    public class Base2
-    {
-    }
+            var testText = """
 
-    public class Testclass2 : Base2
-    {
-        public int i, [||]j = 10, k = 100;
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    public class Base2
-    {
-        public int i;
-        public int j = 10;
-        public int k = 100;
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    public class Base2
+                    {
+                    }
 
-    public class Testclass2 : Base2
-    {
-    }
-}";
+                    public class Testclass2 : Base2
+                    {
+                        public int i, [||]j = 10, k = 100;
+                    }
+                }
+                """;
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public class Base2
+                    {
+                        public int i;
+                        public int j = 10;
+                        public int k = 100;
+                    }
+
+                    public class Testclass2 : Base2
+                    {
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected, index: 1);
         }
@@ -4915,33 +5333,37 @@ namespace PushUpTest
         [Fact]
         public async Task PullNonPublicPropertyWithArrowToInterfaceViaDialog()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    public interface ITest
-    {
-    }
+            var testText = """
 
-    public class Testclass2 : ITest
-    {
-        private double Test[||]Property => 2.717;
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    public interface ITest
-    {
-        double TestProperty { get; }
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    public interface ITest
+                    {
+                    }
 
-    public class Testclass2 : ITest
-    {
-        public readonly double TestProperty => 2.717;
-    }
-}";
+                    public class Testclass2 : ITest
+                    {
+                        private double Test[||]Property => 2.717;
+                    }
+                }
+                """;
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public interface ITest
+                    {
+                        double TestProperty { get; }
+                    }
+
+                    public class Testclass2 : ITest
+                    {
+                        public readonly double TestProperty => 2.717;
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -4949,41 +5371,45 @@ namespace PushUpTest
         [Fact]
         public async Task PullNonPublicPropertyToInterfaceViaDialog()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    public interface ITest
-    {
-    }
+            var testText = """
 
-    public class Testclass2 : ITest
-    {
-        private double Test[||]Property
-        {
-            get;
-            set;
-        }
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    public interface ITest
-    {
-        double TestProperty { get; set; }
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    public interface ITest
+                    {
+                    }
 
-    public class Testclass2 : ITest
-    {
-        public double TestProperty
-        {
-            get;
-            set;
-        }
-    }
-}";
+                    public class Testclass2 : ITest
+                    {
+                        private double Test[||]Property
+                        {
+                            get;
+                            set;
+                        }
+                    }
+                }
+                """;
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public interface ITest
+                    {
+                        double TestProperty { get; set; }
+                    }
+
+                    public class Testclass2 : ITest
+                    {
+                        public double TestProperty
+                        {
+                            get;
+                            set;
+                        }
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -4991,39 +5417,43 @@ namespace PushUpTest
         [Fact]
         public async Task PullNonPublicPropertyWithSingleAccessorToInterfaceViaDialog()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    public interface ITest
-    {
-    }
+            var testText = """
 
-    public class Testclass2 : ITest
-    {
-        private static double Test[||]Property
-        {
-            set;
-        }
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    public interface ITest
-    {
-        double TestProperty { set; }
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    public interface ITest
+                    {
+                    }
 
-    public class Testclass2 : ITest
-    {
-        public double Test[||]Property
-        {
-            set;
-        }
-    }
-}";
+                    public class Testclass2 : ITest
+                    {
+                        private static double Test[||]Property
+                        {
+                            set;
+                        }
+                    }
+                }
+                """;
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public interface ITest
+                    {
+                        double TestProperty { set; }
+                    }
+
+                    public class Testclass2 : ITest
+                    {
+                        public double Test[||]Property
+                        {
+                            set;
+                        }
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5031,112 +5461,124 @@ namespace PushUpTest
         [Fact, WorkItem(34268, "https://github.com/dotnet/roslyn/issues/34268")]
         public async Task TestPullPropertyToAbstractClassViaDialogWithMakeAbstractOption()
         {
-            var testText = @"
-abstract class B
-{
-}
+            var testText = """
 
-class D : B
-{
-    int [||]X => 7;
-}";
-            var expected = @"
-abstract class B
-{
-    private abstract int X { get; }
-}
+                abstract class B
+                {
+                }
 
-class D : B
-{
-    override int X => 7;
-}";
+                class D : B
+                {
+                    int [||]X => 7;
+                }
+                """;
+            var expected = """
+
+                abstract class B
+                {
+                    private abstract int X { get; }
+                }
+
+                class D : B
+                {
+                    override int X => 7;
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected, selection: new[] { ("X", true) }, index: 1);
         }
 
         [Fact]
         public async Task PullEventUpToAbstractClassViaDialogWithMakeAbstractOption()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    public class Base2
-    {
-    }
+            var testText = """
 
-    public class Testclass2 : Base2
-    {
-        private event EventHandler Event1, Eve[||]nt3, Event4;
-    }
-}";
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    public abstract class Base2
-    {
-        private abstract event EventHandler Event3;
-    }
+                using System;
+                namespace PushUpTest
+                {
+                    public class Base2
+                    {
+                    }
 
-    public class Testclass2 : Base2
-    {
-        private event EventHandler Event1, Eve[||]nt3, Event4;
-    }
-}";
+                    public class Testclass2 : Base2
+                    {
+                        private event EventHandler Event1, Eve[||]nt3, Event4;
+                    }
+                }
+                """;
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public abstract class Base2
+                    {
+                        private abstract event EventHandler Event3;
+                    }
+
+                    public class Testclass2 : Base2
+                    {
+                        private event EventHandler Event1, Eve[||]nt3, Event4;
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(testText, expected, selection: new[] { ("Event3", true) }, index: 1);
         }
 
         [Fact]
         public async Task TestPullEventWithAddAndRemoveMethodToClassViaDialogWithMakeAbstractOption()
         {
-            var testText = @"
-using System;
-namespace PushUpTest
-{
-    public class BaseClass
-    {
-    }
+            var testText = """
 
-    public class TestClass : BaseClass
-    {
-        public event EventHandler Eve[||]nt1
-        {
-            add
-            {
-                System.Console.Writeline(""This is add"");
-            }
-            remove
-            {
-                System.Console.Writeline(""This is remove"");
-            }
-        }
-    }
-}";
+                using System;
+                namespace PushUpTest
+                {
+                    public class BaseClass
+                    {
+                    }
 
-            var expected = @"
-using System;
-namespace PushUpTest
-{
-    public abstract class BaseClass
-    {
-        public abstract event EventHandler Event1;
-    }
+                    public class TestClass : BaseClass
+                    {
+                        public event EventHandler Eve[||]nt1
+                        {
+                            add
+                            {
+                                System.Console.Writeline("This is add");
+                            }
+                            remove
+                            {
+                                System.Console.Writeline("This is remove");
+                            }
+                        }
+                    }
+                }
+                """;
 
-    public class TestClass : BaseClass
-    {
-        public override event EventHandler Event1
-        {
-            add
-            {
-                System.Console.Writeline(""This is add"");
-            }
-            remove
-            {
-                System.Console.Writeline(""This is remove"");
-            }
-        }
-    }
-}";
+            var expected = """
+
+                using System;
+                namespace PushUpTest
+                {
+                    public abstract class BaseClass
+                    {
+                        public abstract event EventHandler Event1;
+                    }
+
+                    public class TestClass : BaseClass
+                    {
+                        public override event EventHandler Event1
+                        {
+                            add
+                            {
+                                System.Console.Writeline("This is add");
+                            }
+                            remove
+                            {
+                                System.Console.Writeline("This is remove");
+                            }
+                        }
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("Event1", true) }, index: 1);
         }
@@ -5147,46 +5589,50 @@ namespace PushUpTest
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestArgsIsPartOfHeader()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    class Test2Attribute : Attribute { }
-    public class A
-    {
-    }
+                using System;
 
-    public class B : A
-    {
-        [Test]
-        [Test2]
-        void C([||])
-        {
-        }
-    }
-}";
-            var expected = @"
-using System;
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    class Test2Attribute : Attribute { }
+                    public class A
+                    {
+                    }
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    class Test2Attribute : Attribute { }
-    public class A
-    {
-        [Test]
-        [Test2]
-        void C()
-        {
-        }
-    }
+                    public class B : A
+                    {
+                        [Test]
+                        [Test2]
+                        void C([||])
+                        {
+                        }
+                    }
+                }
+                """;
+            var expected = """
 
-    public class B : A
-    {
-    }
-}";
+                using System;
+
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    class Test2Attribute : Attribute { }
+                    public class A
+                    {
+                        [Test]
+                        [Test2]
+                        void C()
+                        {
+                        }
+                    }
+
+                    public class B : A
+                    {
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5194,46 +5640,50 @@ namespace PushUpTest
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringCaretBeforeAttributes()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    class Test2Attribute : Attribute { }
-    public class A
-    {
-    }
+                using System;
 
-    public class B : A
-    {
-        [||][Test]
-        [Test2]
-        void C()
-        {
-        }
-    }
-}";
-            var expected = @"
-using System;
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    class Test2Attribute : Attribute { }
+                    public class A
+                    {
+                    }
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    class Test2Attribute : Attribute { }
-    public class A
-    {
-        [Test]
-        [Test2]
-        void C()
-        {
-        }
-    }
+                    public class B : A
+                    {
+                        [||][Test]
+                        [Test2]
+                        void C()
+                        {
+                        }
+                    }
+                }
+                """;
+            var expected = """
 
-    public class B : A
-    {
-    }
-}";
+                using System;
+
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    class Test2Attribute : Attribute { }
+                    public class A
+                    {
+                        [Test]
+                        [Test2]
+                        void C()
+                        {
+                        }
+                    }
+
+                    public class B : A
+                    {
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5241,68 +5691,74 @@ namespace PushUpTest
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestMissingRefactoringCaretBetweenAttributes()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    class Test2Attribute : Attribute { }
-    public class A
-    {
-    }
+                using System;
 
-    public class B : A
-    {
-        [Test]
-        [||][Test2]
-        void C()
-        {
-        }
-    }
-}";
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    class Test2Attribute : Attribute { }
+                    public class A
+                    {
+                    }
+
+                    public class B : A
+                    {
+                        [Test]
+                        [||][Test2]
+                        void C()
+                        {
+                        }
+                    }
+                }
+                """;
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringSelectionWithAttributes1()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    public class A
-    {
-    }
+                using System;
 
-    public class B : A
-    {
-        [Test]
-        [|void C()
-        {
-        }|]
-    }
-}";
-            var expected = @"
-using System;
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    public class A
+                    {
+                    }
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    public class A
-    {
-        [Test]
-        void C()
-        {
-        }
-    }
+                    public class B : A
+                    {
+                        [Test]
+                        [|void C()
+                        {
+                        }|]
+                    }
+                }
+                """;
+            var expected = """
 
-    public class B : A
-    {
-    }
-}";
+                using System;
+
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    public class A
+                    {
+                        [Test]
+                        void C()
+                        {
+                        }
+                    }
+
+                    public class B : A
+                    {
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5310,42 +5766,46 @@ namespace PushUpTest
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringSelectionWithAttributes2()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    public class A
-    {
-    }
+                using System;
 
-    public class B : A
-    {
-        [|[Test]
-        void C()
-        {
-        }|]
-    }
-}";
-            var expected = @"
-using System;
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    public class A
+                    {
+                    }
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    public class A
-    {
-        [Test]
-        void C()
-        {
-        }
-    }
+                    public class B : A
+                    {
+                        [|[Test]
+                        void C()
+                        {
+                        }|]
+                    }
+                }
+                """;
+            var expected = """
 
-    public class B : A
-    {
-    }
-}";
+                using System;
+
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    public class A
+                    {
+                        [Test]
+                        void C()
+                        {
+                        }
+                    }
+
+                    public class B : A
+                    {
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5353,43 +5813,47 @@ namespace PushUpTest
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringSelectionWithAttributes3()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    public class A
-    {
-    }
+                using System;
 
-    public class B : A
-    {
-        [Test][|
-        void C()
-        {
-        }
-        |]
-    }
-}";
-            var expected = @"
-using System;
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    public class A
+                    {
+                    }
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    public class A
-    {
-        [Test]
-        void C()
-        {
-        }
-    }
+                    public class B : A
+                    {
+                        [Test][|
+                        void C()
+                        {
+                        }
+                        |]
+                    }
+                }
+                """;
+            var expected = """
 
-    public class B : A
-    {
-    }
-}";
+                using System;
+
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    public class A
+                    {
+                        [Test]
+                        void C()
+                        {
+                        }
+                    }
+
+                    public class B : A
+                    {
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5397,194 +5861,210 @@ namespace PushUpTest
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestMissingRefactoringInAttributeList()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    public class A
-    {
-    }
+                using System;
 
-    public class B : A
-    {
-        [[||]Test]
-        void C()
-        {
-        }
-    }
-}";
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    public class A
+                    {
+                    }
+
+                    public class B : A
+                    {
+                        [[||]Test]
+                        void C()
+                        {
+                        }
+                    }
+                }
+                """;
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestMissingRefactoringSelectionAttributeList()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    class Test2Attribute : Attribute { }
-    public class A
-    {
-    }
+                using System;
 
-    public class B : A
-    {
-        [|[Test]
-        [Test2]|]
-        void C()
-        {
-        }
-    }
-}";
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    class Test2Attribute : Attribute { }
+                    public class A
+                    {
+                    }
+
+                    public class B : A
+                    {
+                        [|[Test]
+                        [Test2]|]
+                        void C()
+                        {
+                        }
+                    }
+                }
+                """;
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestMissingRefactoringCaretInAttributeList()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    class Test2Attribute : Attribute { }
-    public class A
-    {
-    }
+                using System;
 
-    public class B : A
-    {
-        [[||]Test]
-        [Test2]
-        void C()
-        {
-        }
-    }
-}";
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    class Test2Attribute : Attribute { }
+                    public class A
+                    {
+                    }
+
+                    public class B : A
+                    {
+                        [[||]Test]
+                        [Test2]
+                        void C()
+                        {
+                        }
+                    }
+                }
+                """;
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestMissingRefactoringCaretBetweenAttributeLists()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    class Test2Attribute : Attribute { }
-    public class A
-    {
-    }
+                using System;
 
-    public class B : A
-    {
-        [Test]
-        [||][Test2]
-        void C()
-        {
-        }
-    }
-}";
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    class Test2Attribute : Attribute { }
+                    public class A
+                    {
+                    }
+
+                    public class B : A
+                    {
+                        [Test]
+                        [||][Test2]
+                        void C()
+                        {
+                        }
+                    }
+                }
+                """;
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestMissingRefactoringSelectionAttributeList2()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    class Test2Attribute : Attribute { }
-    public class A
-    {
-    }
+                using System;
 
-    public class B : A
-    {
-        [|[Test]|]
-        [Test2]
-        void C()
-        {
-        }
-    }
-}";
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    class Test2Attribute : Attribute { }
+                    public class A
+                    {
+                    }
+
+                    public class B : A
+                    {
+                        [|[Test]|]
+                        [Test2]
+                        void C()
+                        {
+                        }
+                    }
+                }
+                """;
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestMissingRefactoringSelectAttributeList()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    public class A
-    {
-    }
+                using System;
 
-    public class B : A
-    {
-        [|[Test]|]
-        void C()
-        {
-        }
-    }
-}";
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    public class A
+                    {
+                    }
+
+                    public class B : A
+                    {
+                        [|[Test]|]
+                        void C()
+                        {
+                        }
+                    }
+                }
+                """;
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringCaretLocAfterAttributes1()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    public class A
-    {
-    }
+                using System;
 
-    public class B : A
-    {
-        [Test]
-        [||]void C()
-        {
-        }
-    }
-}";
-            var expected = @"
-using System;
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    public class A
+                    {
+                    }
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    public class A
-    {
-        [Test]
-        void C()
-        {
-        }
-    }
+                    public class B : A
+                    {
+                        [Test]
+                        [||]void C()
+                        {
+                        }
+                    }
+                }
+                """;
+            var expected = """
 
-    public class B : A
-    {
-    }
-}";
+                using System;
+
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    public class A
+                    {
+                        [Test]
+                        void C()
+                        {
+                        }
+                    }
+
+                    public class B : A
+                    {
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5592,50 +6072,54 @@ namespace PushUpTest
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringCaretLocAfterAttributes2()
         {
-            var testText = @"
-using System;
+            var testText = """
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    class Test2Attribute : Attribute { }
-    public class A
-    {
-    }
+                using System;
 
-    public class B : A
-    {
-        [Test]
-        // Comment1
-        [Test2]
-        // Comment2
-        [||]void C()
-        {
-        }
-    }
-}";
-            var expected = @"
-using System;
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    class Test2Attribute : Attribute { }
+                    public class A
+                    {
+                    }
 
-namespace PushUpTest
-{
-    class TestAttribute : Attribute { }
-    class Test2Attribute : Attribute { }
-    public class A
-    {
-        [Test]
-        // Comment1
-        [Test2]
-        // Comment2
-        void C()
-        {
-        }
-    }
+                    public class B : A
+                    {
+                        [Test]
+                        // Comment1
+                        [Test2]
+                        // Comment2
+                        [||]void C()
+                        {
+                        }
+                    }
+                }
+                """;
+            var expected = """
 
-    public class B : A
-    {
-    }
-}";
+                using System;
+
+                namespace PushUpTest
+                {
+                    class TestAttribute : Attribute { }
+                    class Test2Attribute : Attribute { }
+                    public class A
+                    {
+                        [Test]
+                        // Comment1
+                        [Test2]
+                        // Comment2
+                        void C()
+                        {
+                        }
+                    }
+
+                    public class B : A
+                    {
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5643,34 +6127,38 @@ namespace PushUpTest
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringCaretLoc1()
         {
-            var testText = @"
-namespace PushUpTest
-{
-    public class A
-    {
-    }
+            var testText = """
 
-    public class B : A
-    {
-        [||]void C()
-        {
-        }
-    }
-}";
-            var expected = @"
-namespace PushUpTest
-{
-    public class A
-    {
-        void C()
-        {
-        }
-    }
+                namespace PushUpTest
+                {
+                    public class A
+                    {
+                    }
 
-    public class B : A
-    {
-    }
-}";
+                    public class B : A
+                    {
+                        [||]void C()
+                        {
+                        }
+                    }
+                }
+                """;
+            var expected = """
+
+                namespace PushUpTest
+                {
+                    public class A
+                    {
+                        void C()
+                        {
+                        }
+                    }
+
+                    public class B : A
+                    {
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5678,34 +6166,38 @@ namespace PushUpTest
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringSelection()
         {
-            var testText = @"
-namespace PushUpTest
-{
-    public class A
-    {
-    }
+            var testText = """
 
-    public class B : A
-    {
-        [|void C()
-        {
-        }|]
-    }
-}";
-            var expected = @"
-namespace PushUpTest
-{
-    public class A
-    {
-        void C()
-        {
-        }
-    }
+                namespace PushUpTest
+                {
+                    public class A
+                    {
+                    }
 
-    public class B : A
-    {
-    }
-}";
+                    public class B : A
+                    {
+                        [|void C()
+                        {
+                        }|]
+                    }
+                }
+                """;
+            var expected = """
+
+                namespace PushUpTest
+                {
+                    public class A
+                    {
+                        void C()
+                        {
+                        }
+                    }
+
+                    public class B : A
+                    {
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5713,36 +6205,40 @@ namespace PushUpTest
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringSelectionComments()
         {
-            var testText = @"
-namespace PushUpTest
-{
-    public class A
-    {
-    }
+            var testText = """
 
-    public class B : A
-    {  [|
-        // Comment1
-        void C()
-        {
-        }|]
-    }
-}";
-            var expected = @"
-namespace PushUpTest
-{
-    public class A
-    {
-        // Comment1
-        void C()
-        {
-        }
-    }
+                namespace PushUpTest
+                {
+                    public class A
+                    {
+                    }
 
-    public class B : A
-    {
-    }
-}";
+                    public class B : A
+                    {  [|
+                        // Comment1
+                        void C()
+                        {
+                        }|]
+                    }
+                }
+                """;
+            var expected = """
+
+                namespace PushUpTest
+                {
+                    public class A
+                    {
+                        // Comment1
+                        void C()
+                        {
+                        }
+                    }
+
+                    public class B : A
+                    {
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5750,40 +6246,44 @@ namespace PushUpTest
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringSelectionComments2()
         {
-            var testText = @"
-namespace PushUpTest
-{
-    public class A
-    {
-    }
+            var testText = """
 
-    public class B : A
-    {  
-        [|/// <summary>
-        /// Test
-        /// </summary>
-        void C()
-        {
-        }|]
-    }
-}";
-            var expected = @"
-namespace PushUpTest
-{
-    public class A
-    {
-        /// <summary>
-        /// Test
-        /// </summary>
-        void C()
-        {
-        }
-    }
+                namespace PushUpTest
+                {
+                    public class A
+                    {
+                    }
 
-    public class B : A
-    {
-    }
-}";
+                    public class B : A
+                    {  
+                        [|/// <summary>
+                        /// Test
+                        /// </summary>
+                        void C()
+                        {
+                        }|]
+                    }
+                }
+                """;
+            var expected = """
+
+                namespace PushUpTest
+                {
+                    public class A
+                    {
+                        /// <summary>
+                        /// Test
+                        /// </summary>
+                        void C()
+                        {
+                        }
+                    }
+
+                    public class B : A
+                    {
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5791,40 +6291,44 @@ namespace PushUpTest
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringSelectionComments3()
         {
-            var testText = @"
-namespace PushUpTest
-{
-    public class A
-    {
-    }
+            var testText = """
 
-    public class B : A
-    {  
-        /// <summary>
-        [|/// Test
-        /// </summary>
-        void C()
-        {
-        }|]
-    }
-}";
-            var expected = @"
-namespace PushUpTest
-{
-    public class A
-    {
-        /// <summary>
-        /// Test
-        /// </summary>
-        void C()
-        {
-        }
-    }
+                namespace PushUpTest
+                {
+                    public class A
+                    {
+                    }
 
-    public class B : A
-    {
-    }
-}";
+                    public class B : A
+                    {  
+                        /// <summary>
+                        [|/// Test
+                        /// </summary>
+                        void C()
+                        {
+                        }|]
+                    }
+                }
+                """;
+            var expected = """
+
+                namespace PushUpTest
+                {
+                    public class A
+                    {
+                        /// <summary>
+                        /// Test
+                        /// </summary>
+                        void C()
+                        {
+                        }
+                    }
+
+                    public class B : A
+                    {
+                    }
+                }
+                """;
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5832,197 +6336,227 @@ namespace PushUpTest
         [Fact]
         public async Task TestRefactoringSelectionFieldKeyword1_NoAction()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    pub[|l|]ic int Goo = 10;
-}";
+                public class BaseClass
+                {
+                }
+
+                public class Bar : BaseClass
+                {
+                    pub[|l|]ic int Goo = 10;
+                }
+                """;
             await TestQuickActionNotProvidedAsync(text);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionFieldKeyword2()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    pub[||]lic int Goo = 10;
-}";
-            var expected = @"
-public class BaseClass
-{
-    public int Goo = 10;
-}
+                public class BaseClass
+                {
+                }
 
-public class Bar : BaseClass
-{
-}";
+                public class Bar : BaseClass
+                {
+                    pub[||]lic int Goo = 10;
+                }
+                """;
+            var expected = """
+
+                public class BaseClass
+                {
+                    public int Goo = 10;
+                }
+
+                public class Bar : BaseClass
+                {
+                }
+                """;
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionFieldAfterSemicolon()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    public int Goo = 10;[||]
-}";
-            var expected = @"
-public class BaseClass
-{
-    public int Goo = 10;
-}
+                public class BaseClass
+                {
+                }
 
-public class Bar : BaseClass
-{
-}";
+                public class Bar : BaseClass
+                {
+                    public int Goo = 10;[||]
+                }
+                """;
+            var expected = """
+
+                public class BaseClass
+                {
+                    public int Goo = 10;
+                }
+
+                public class Bar : BaseClass
+                {
+                }
+                """;
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionFieldEntireDeclaration()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    [|public int Goo = 10;|]
-}";
-            var expected = @"
-public class BaseClass
-{
-    public int Goo = 10;
-}
+                public class BaseClass
+                {
+                }
 
-public class Bar : BaseClass
-{
-}";
+                public class Bar : BaseClass
+                {
+                    [|public int Goo = 10;|]
+                }
+                """;
+            var expected = """
+
+                public class BaseClass
+                {
+                    public int Goo = 10;
+                }
+
+                public class Bar : BaseClass
+                {
+                }
+                """;
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionMultipleFieldsInDeclaration1()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    [|public int Goo = 10, Foo = 9;|]
-}";
-            var expected = @"
-public class BaseClass
-{
-    public int Goo = 10;
-    public int Foo = 9;
-}
+                public class BaseClass
+                {
+                }
 
-public class Bar : BaseClass
-{
-}";
+                public class Bar : BaseClass
+                {
+                    [|public int Goo = 10, Foo = 9;|]
+                }
+                """;
+            var expected = """
+
+                public class BaseClass
+                {
+                    public int Goo = 10;
+                    public int Foo = 9;
+                }
+
+                public class Bar : BaseClass
+                {
+                }
+                """;
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionMultipleFieldsInDeclaration2()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    public int Go[||]o = 10, Foo = 9;
-}";
-            var expected = @"
-public class BaseClass
-{
-    public int Goo = 10;
-}
+                public class BaseClass
+                {
+                }
 
-public class Bar : BaseClass
-{
-    public int Foo = 9;
-}";
+                public class Bar : BaseClass
+                {
+                    public int Go[||]o = 10, Foo = 9;
+                }
+                """;
+            var expected = """
+
+                public class BaseClass
+                {
+                    public int Goo = 10;
+                }
+
+                public class Bar : BaseClass
+                {
+                    public int Foo = 9;
+                }
+                """;
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionMultipleFieldsInDeclaration3()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    public int Goo = 10, [||]Foo = 9;
-}";
-            var expected = @"
-public class BaseClass
-{
-    public int Foo = 9;
-}
+                public class BaseClass
+                {
+                }
 
-public class Bar : BaseClass
-{
-    public int Goo = 10;
-}";
+                public class Bar : BaseClass
+                {
+                    public int Goo = 10, [||]Foo = 9;
+                }
+                """;
+            var expected = """
+
+                public class BaseClass
+                {
+                    public int Foo = 9;
+                }
+
+                public class Bar : BaseClass
+                {
+                    public int Goo = 10;
+                }
+                """;
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionMultipleMembers1()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    [|public int Goo = 10, Foo = 9;
+                public class BaseClass
+                {
+                }
 
-    public int DoSomething()
-    {
-        return 5;
-    }|]
-}";
-            var expected = @"
-public class BaseClass
-{
-    public int Goo = 10;
-    public int Foo = 9;
+                public class Bar : BaseClass
+                {
+                    [|public int Goo = 10, Foo = 9;
 
-    public int DoSomething()
-    {
-        return 5;
-    }
-}
+                    public int DoSomething()
+                    {
+                        return 5;
+                    }|]
+                }
+                """;
+            var expected = """
 
-public class Bar : BaseClass
-{
-}";
+                public class BaseClass
+                {
+                    public int Goo = 10;
+                    public int Foo = 9;
+
+                    public int DoSomething()
+                    {
+                        return 5;
+                    }
+                }
+
+                public class Bar : BaseClass
+                {
+                }
+                """;
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
@@ -6030,130 +6564,144 @@ public class Bar : BaseClass
         [Fact]
         public async Task TestRefactoringSelectionMultipleMembers2()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    public int DoSomething()
-    {
-        [|return 5;
-    }
+                public class BaseClass
+                {
+                }
 
-
-    public int Goo = 10, Foo = 9;|]
-}";
-            var expected = @"
-public class BaseClass
-{
+                public class Bar : BaseClass
+                {
+                    public int DoSomething()
+                    {
+                        [|return 5;
+                    }
 
 
-    public int Goo = 10;
+                    public int Goo = 10, Foo = 9;|]
+                }
+                """;
+            var expected = """
+
+                public class BaseClass
+                {
 
 
-    public int Foo = 9;
-}
+                    public int Goo = 10;
 
-public class Bar : BaseClass
-{
-    public int DoSomething()
-    {
-        return 5;
-    }
-}";
+
+                    public int Foo = 9;
+                }
+
+                public class Bar : BaseClass
+                {
+                    public int DoSomething()
+                    {
+                        return 5;
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionMultipleMembers3()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    public int DoSom[|ething()
-    {
-        return 5;
-    }
+                public class BaseClass
+                {
+                }
 
-
-    public int Go|]o = 10, Foo = 9;
-}";
-            var expected = @"
-public class BaseClass
-{
+                public class Bar : BaseClass
+                {
+                    public int DoSom[|ething()
+                    {
+                        return 5;
+                    }
 
 
-    public int Goo = 10;
-    public int DoSomething()
-    {
-        return 5;
-    }
-}
+                    public int Go|]o = 10, Foo = 9;
+                }
+                """;
+            var expected = """
 
-public class Bar : BaseClass
-{
-    public int Foo = 9;
-}";
+                public class BaseClass
+                {
+
+
+                    public int Goo = 10;
+                    public int DoSomething()
+                    {
+                        return 5;
+                    }
+                }
+
+                public class Bar : BaseClass
+                {
+                    public int Foo = 9;
+                }
+                """;
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionMultipleMembers4()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    public int DoSomething()[|
-    {
-        return 5;
-    }
+                public class BaseClass
+                {
+                }
 
-
-    public int Goo = 10, F|]oo = 9;
-}";
-            var expected = @"
-public class BaseClass
-{
+                public class Bar : BaseClass
+                {
+                    public int DoSomething()[|
+                    {
+                        return 5;
+                    }
 
 
-    public int Goo = 10;
+                    public int Goo = 10, F|]oo = 9;
+                }
+                """;
+            var expected = """
+
+                public class BaseClass
+                {
 
 
-    public int Foo = 9;
-}
+                    public int Goo = 10;
 
-public class Bar : BaseClass
-{
-    public int DoSomething()
-    {
-        return 5;
-    }
-}";
+
+                    public int Foo = 9;
+                }
+
+                public class Bar : BaseClass
+                {
+                    public int DoSomething()
+                    {
+                        return 5;
+                    }
+                }
+                """;
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionIncompleteField_NoAction1()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    publ[||] int Goo = 10;
-}";
+                public class BaseClass
+                {
+                }
+
+                public class Bar : BaseClass
+                {
+                    publ[||] int Goo = 10;
+                }
+                """;
             // we expect a diagnostic/error, but also we shouldn't provide the refactoring
             await TestQuickActionNotProvidedAsync(text);
         }
@@ -6161,15 +6709,17 @@ public class Bar : BaseClass
         [Fact]
         public async Task TestRefactoringSelectionIncompleteField_NoAction2()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    [|publicc int Goo = 10;|]
-}";
+                public class BaseClass
+                {
+                }
+
+                public class Bar : BaseClass
+                {
+                    [|publicc int Goo = 10;|]
+                }
+                """;
             // we expect a diagnostic/error, but also we shouldn't provide the refactoring
             await TestQuickActionNotProvidedAsync(text);
         }
@@ -6177,17 +6727,19 @@ public class Bar : BaseClass
         [Fact]
         public async Task TestRefactoringSelectionIncompleteMethod_NoAction()
         {
-            var text = @"
-public class BaseClass
-{
-}
+            var text = """
 
-public class Bar : BaseClass
-{
-    publ[||] int DoSomething() {
-        return 5;
-    }
-}";
+                public class BaseClass
+                {
+                }
+
+                public class Bar : BaseClass
+                {
+                    publ[||] int DoSomething() {
+                        return 5;
+                    }
+                }
+                """;
             // we expect a diagnostic/error, but also we shouldn't provide the refactoring
             await TestQuickActionNotProvidedAsync(text);
         }

--- a/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
+++ b/src/EditorFeatures/CSharpTest/PullMemberUp/CSharpPullMemberUpTests.cs
@@ -61,135 +61,123 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task TestNoRefactoringProvidedWhenNoOptionsService()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                    }
-
-                    public class TestClass : IInterface
-                    {
-                        public void TestM[||]ethod()
-                        {
-                            System.Console.WriteLine("Hello World");
-                        }
-                    }
-                }
-                """;
+    public class TestClass : IInterface
+    {
+        public void TestM[||]ethod()
+        {
+            System.Console.WriteLine(""Hello World"");
+        }
+    }
+}";
             await TestActionCountAsync(testText, 0);
         }
 
         [Fact]
         public async Task TestNoRefactoringProvidedWhenPullFieldInInterfaceViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+namespace PushUpTest
+{
+    public interface ITestInterface
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public interface ITestInterface
-                    {
-                    }
-
-                    public class TestClass : ITestInterface
-                    {
-                        public int yo[||]u = 10086;
-                    }
-                }
-                """;
+    public class TestClass : ITestInterface
+    {
+        public int yo[||]u = 10086;
+    }
+}";
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact]
         public async Task TestNoRefactoringProvidedWhenMethodDeclarationAlreadyExistsInInterfaceViaQuickAction()
         {
-            var methodTest = """
+            var methodTest = @"
+namespace PushUpTest
+{
+    public interface ITestInterface
+    {
+        void TestMethod();
+    }
 
-                namespace PushUpTest
-                {
-                    public interface ITestInterface
-                    {
-                        void TestMethod();
-                    }
-
-                    public class TestClass : ITestInterface
-                    {
-                        public void TestM[||]ethod()
-                        {
-                            System.Console.WriteLine("Hello World");
-                        }
-                    }
-                }
-                """;
+    public class TestClass : ITestInterface
+    {
+        public void TestM[||]ethod()
+        {
+            System.Console.WriteLine(""Hello World"");
+        }
+    }
+}";
             await TestQuickActionNotProvidedAsync(methodTest);
         }
 
         [Fact]
         public async Task TestNoRefactoringProvidedWhenPropertyDeclarationAlreadyExistsInInterfaceViaQuickAction()
         {
-            var propertyTest1 = """
+            var propertyTest1 = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+        int TestProperty { get; }
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                        int TestProperty { get; }
-                    }
-
-                    public class TestClass : IInterface
-                    {
-                        public int TestPr[||]operty { get; private set; }
-                    }
-                }
-                """;
+    public class TestClass : IInterface
+    {
+        public int TestPr[||]operty { get; private set; }
+    }
+}";
             await TestQuickActionNotProvidedAsync(propertyTest1);
         }
 
         [Fact]
         public async Task TestNoRefactoringProvidedWhenEventDeclarationAlreadyExistsToInterfaceViaQuickAction()
         {
-            var eventTest = """
+            var eventTest = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+        event EventHandler Event2;
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                        event EventHandler Event2;
-                    }
-
-                    public class TestClass : IInterface
-                    {
-                        public event EventHandler Event1, Eve[||]nt2, Event3;
-                    }
-                }
-                """;
+    public class TestClass : IInterface
+    {
+        public event EventHandler Event1, Eve[||]nt2, Event3;
+    }
+}";
             await TestQuickActionNotProvidedAsync(eventTest);
         }
 
         [Fact]
         public async Task TestNoRefactoringProvidedInNestedTypesViaQuickAction()
         {
-            var input = """
+            var input = @"
+namespace PushUpTest
+{
+    public interface ITestInterface
+    {
+        void Foobar();
+    }
 
-                namespace PushUpTest
-                {
-                    public interface ITestInterface
-                    {
-                        void Foobar();
-                    }
-
-                    public class TestClass : ITestInterface
-                    {
-                        public class N[||]estedClass
-                        {
-                        }
-                    }
-                }
-                """;
+    public class TestClass : ITestInterface
+    {
+        public class N[||]estedClass
+        {
+        }
+    }
+}";
 
             await TestQuickActionNotProvidedAsync(input);
         }
@@ -197,3040 +185,2836 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task TestPullMethodUpToInterfaceViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                    }
+    public class TestClass : IInterface
+    {
+        public void TestM[||]ethod()
+        {
+            System.Console.WriteLine(""Hello World"");
+        }
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+        void TestMethod();
+    }
 
-                    public class TestClass : IInterface
-                    {
-                        public void TestM[||]ethod()
-                        {
-                            System.Console.WriteLine("Hello World");
-                        }
-                    }
-                }
-                """;
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                        void TestMethod();
-                    }
-
-                    public class TestClass : IInterface
-                    {
-                        public void TestMethod()
-                        {
-                            System.Console.WriteLine("Hello World");
-                        }
-                    }
-                }
-                """;
+    public class TestClass : IInterface
+    {
+        public void TestMethod()
+        {
+            System.Console.WriteLine(""Hello World"");
+        }
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullAbstractMethodToInterfaceViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+namespace PushUpTest
+{
+    public interface IInterface
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public interface IInterface
-                    {
-                    }
+    public abstract class TestClass : IInterface
+    {
+        public abstract void TestMeth[||]od();
+    }
+}";
 
-                    public abstract class TestClass : IInterface
-                    {
-                        public abstract void TestMeth[||]od();
-                    }
-                }
-                """;
+            var expected = @"
+namespace PushUpTest
+{
+    public interface IInterface
+    {
+        void TestMethod();
+    }
 
-            var expected = """
-
-                namespace PushUpTest
-                {
-                    public interface IInterface
-                    {
-                        void TestMethod();
-                    }
-
-                    public abstract class TestClass : IInterface
-                    {
-                        public abstract void TestMethod();
-                    }
-                }
-                """;
+    public abstract class TestClass : IInterface
+    {
+        public abstract void TestMethod();
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullGenericsUpToInterfaceViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    public interface IInterface
-                    {
-                    }
+    public class TestClass : IInterface
+    {
+        public void TestMeth[||]od<T>() where T : IDisposable
+        {
+        }
+    }
+}";
 
-                    public class TestClass : IInterface
-                    {
-                        public void TestMeth[||]od<T>() where T : IDisposable
-                        {
-                        }
-                    }
-                }
-                """;
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public interface IInterface
+    {
+        void TestMethod<T>() where T : IDisposable;
+    }
 
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public interface IInterface
-                    {
-                        void TestMethod<T>() where T : IDisposable;
-                    }
-
-                    public class TestClass : IInterface
-                    {
-                        public void TestMeth[||]od<T>() where T : IDisposable
-                        {
-                        }
-                    }
-                }
-                """;
+    public class TestClass : IInterface
+    {
+        public void TestMeth[||]od<T>() where T : IDisposable
+        {
+        }
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullSingleEventToInterfaceViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                    }
+    public class TestClass : IInterface
+    {
+        public event EventHandler Eve[||]nt1
+        {
+            add
+            {
+                System.Console.Writeline(""This is add"");
+            }
+            remove
+            {
+                System.Console.Writeline(""This is remove"");
+            }
+        }
+    }
+}";
 
-                    public class TestClass : IInterface
-                    {
-                        public event EventHandler Eve[||]nt1
-                        {
-                            add
-                            {
-                                System.Console.Writeline("This is add");
-                            }
-                            remove
-                            {
-                                System.Console.Writeline("This is remove");
-                            }
-                        }
-                    }
-                }
-                """;
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+        event EventHandler Event1;
+    }
 
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                        event EventHandler Event1;
-                    }
-
-                    public class TestClass : IInterface
-                    {
-                        public event EventHandler Event1
-                        {
-                            add
-                            {
-                                System.Console.Writeline("This is add");
-                            }
-                            remove
-                            {
-                                System.Console.Writeline("This is remove");
-                            }
-                        }
-                    }
-                }
-                """;
+    public class TestClass : IInterface
+    {
+        public event EventHandler Event1
+        {
+            add
+            {
+                System.Console.Writeline(""This is add"");
+            }
+            remove
+            {
+                System.Console.Writeline(""This is remove"");
+            }
+        }
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullOneEventFromMultipleEventsToInterfaceViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                    }
+    public class TestClass : IInterface
+    {
+        public event EventHandler Event1, Eve[||]nt2, Event3;
+    }
+}";
 
-                    public class TestClass : IInterface
-                    {
-                        public event EventHandler Event1, Eve[||]nt2, Event3;
-                    }
-                }
-                """;
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+        event EventHandler Event2;
+    }
 
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                        event EventHandler Event2;
-                    }
-
-                    public class TestClass : IInterface
-                    {
-                        public event EventHandler Event1, Event2, Event3;
-                    }
-                }
-                """;
+    public class TestClass : IInterface
+    {
+        public event EventHandler Event1, Event2, Event3;
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullPublicEventWithAccessorsToInterfaceViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                    }
+    public class TestClass : IInterface
+    {
+        public event EventHandler Eve[||]nt2
+        {
+            add
+            {
+                System.Console.Writeln(""This is add in event1"");
+            }
+            remove
+            {
+                System.Console.Writeln(""This is remove in event2"");
+            }
+        }
+    }
+}";
 
-                    public class TestClass : IInterface
-                    {
-                        public event EventHandler Eve[||]nt2
-                        {
-                            add
-                            {
-                                System.Console.Writeln("This is add in event1");
-                            }
-                            remove
-                            {
-                                System.Console.Writeln("This is remove in event2");
-                            }
-                        }
-                    }
-                }
-                """;
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+        event EventHandler Event2;
+    }
 
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                        event EventHandler Event2;
-                    }
-
-                    public class TestClass : IInterface
-                    {
-                        public event EventHandler Event2
-                        {
-                            add
-                            {
-                                System.Console.Writeln("This is add in event1");
-                            }
-                            remove
-                            {
-                                System.Console.Writeln("This is remove in event2");
-                            }
-                        }
-                    }
-                }
-                """;
+    public class TestClass : IInterface
+    {
+        public event EventHandler Event2
+        {
+            add
+            {
+                System.Console.Writeln(""This is add in event1"");
+            }
+            remove
+            {
+                System.Console.Writeln(""This is remove in event2"");
+            }
+        }
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullPropertyWithPrivateSetterToInterfaceViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                    }
+    public class TestClass : IInterface
+    {
+        public int TestPr[||]operty { get; private set; }
+    }
+}";
 
-                    public class TestClass : IInterface
-                    {
-                        public int TestPr[||]operty { get; private set; }
-                    }
-                }
-                """;
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+        int TestProperty { get; }
+    }
 
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                        int TestProperty { get; }
-                    }
-
-                    public class TestClass : IInterface
-                    {
-                        public int TestProperty { get; private set; }
-                    }
-                }
-                """;
+    public class TestClass : IInterface
+    {
+        public int TestProperty { get; private set; }
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullPropertyWithPrivateGetterToInterfaceViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                    }
+    public class TestClass : IInterface
+    {
+        public int TestProperty[||]{ private get; set; }
+    }
+}";
 
-                    public class TestClass : IInterface
-                    {
-                        public int TestProperty[||]{ private get; set; }
-                    }
-                }
-                """;
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+        int TestProperty { set; }
+    }
 
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                        int TestProperty { set; }
-                    }
-
-                    public class TestClass : IInterface
-                    {
-                        public int TestProperty{ private get; set; }
-                    }
-                }
-                """;
+    public class TestClass : IInterface
+    {
+        public int TestProperty{ private get; set; }
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullMemberFromInterfaceToInterfaceViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                    }
+    interface FooInterface : IInterface
+    {
+        int TestPr[||]operty { set; }
+    }
+}";
 
-                    interface FooInterface : IInterface
-                    {
-                        int TestPr[||]operty { set; }
-                    }
-                }
-                """;
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+        int TestProperty { set; }
+    }
 
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                        int TestProperty { set; }
-                    }
-
-                    interface FooInterface : IInterface
-                    {
-                    }
-                }
-                """;
+    interface FooInterface : IInterface
+    {
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullIndexerWithOnlySetterToInterfaceViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                    }
+    public class TestClass : IInterface
+    {
+        private int j;
+        public int th[||]is[int i]
+        {
+           set => j = value;
+        }
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+        int this[int i] { set; }
+    }
 
-                    public class TestClass : IInterface
-                    {
-                        private int j;
-                        public int th[||]is[int i]
-                        {
-                           set => j = value;
-                        }
-                    }
-                }
-                """;
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                        int this[int i] { set; }
-                    }
-
-                    public class TestClass : IInterface
-                    {
-                        private int j;
-                        public int this[int i]
-                        {
-                           set => j = value;
-                        }
-                    }
-                }
-                """;
+    public class TestClass : IInterface
+    {
+        private int j;
+        public int this[int i]
+        {
+           set => j = value;
+        }
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullIndexerWithOnlyGetterToInterfaceViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                    }
+    public class TestClass : IInterface
+    {
+        private int j;
+        public int th[||]is[int i]
+        {
+           get => j = value;
+        }
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+        int this[int i] { get; }
+    }
 
-                    public class TestClass : IInterface
-                    {
-                        private int j;
-                        public int th[||]is[int i]
-                        {
-                           get => j = value;
-                        }
-                    }
-                }
-                """;
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                        int this[int i] { get; }
-                    }
-
-                    public class TestClass : IInterface
-                    {
-                        private int j;
-                        public int this[int i]
-                        {
-                           get => j = value;
-                        }
-                    }
-                }
-                """;
+    public class TestClass : IInterface
+    {
+        private int j;
+        public int this[int i]
+        {
+           get => j = value;
+        }
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullPropertyToInterfaceWithAddUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public interface IBase
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public interface IBase
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : IBase
+{
+    public Uri En[||]dpoint { get; set; }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
 
-                public class Derived : IBase
-                {
-                    public Uri En[||]dpoint { get; set; }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public interface IBase
+{
+    Uri Endpoint { get; set; }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
-
-                public interface IBase
-                {
-                    Uri Endpoint { get; set; }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : IBase
-                {
-                    public Uri Endpoint { get; set; }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : IBase
+{
+    public Uri Endpoint { get; set; }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToInterfaceWithoutAddUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public interface IBase
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public interface IBase
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : IBase
+{
+    public bool Test[||]Method()
+    {
+        var endpoint1 = new Uri(""http://localhost"");
+        var endpoint2 = new Uri(""http://localhost"");
+        return endpoint1.Equals(endpoint2);
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public interface IBase
+{
+    bool TestMethod();
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                public class Derived : IBase
-                {
-                    public bool Test[||]Method()
-                    {
-                        var endpoint1 = new Uri("http://localhost");
-                        var endpoint2 = new Uri("http://localhost");
-                        return endpoint1.Equals(endpoint2);
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public interface IBase
-                {
-                    bool TestMethod();
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : IBase
-                {
-                    public bool Test[||]Method()
-                    {
-                        var endpoint1 = new Uri("http://localhost");
-                        var endpoint2 = new Uri("http://localhost");
-                        return endpoint1.Equals(endpoint2);
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : IBase
+{
+    public bool Test[||]Method()
+    {
+        var endpoint1 = new Uri(""http://localhost"");
+        var endpoint2 = new Uri(""http://localhost"");
+        return endpoint1.Equals(endpoint2);
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodWithNewReturnTypeToInterfaceWithAddUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public interface IBase
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public interface IBase
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : IBase
+{
+    public Uri Test[||]Method()
+    {
+        return new Uri(""http://localhost"");
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
 
-                public class Derived : IBase
-                {
-                    public Uri Test[||]Method()
-                    {
-                        return new Uri("http://localhost");
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public interface IBase
+{
+    Uri TestMethod();
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
-
-                public interface IBase
-                {
-                    Uri TestMethod();
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : IBase
-                {
-                    public Uri TestMethod()
-                    {
-                        return new Uri("http://localhost");
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : IBase
+{
+    public Uri TestMethod()
+    {
+        return new Uri(""http://localhost"");
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodWithNewParamTypeToInterfaceWithAddUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public interface IBase
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public interface IBase
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : IBase
+{
+    public bool Test[||]Method(Uri endpoint)
+    {
+        var localHost = new Uri(""http://localhost"");
+        return endpoint.Equals(localhost);
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
 
-                public class Derived : IBase
-                {
-                    public bool Test[||]Method(Uri endpoint)
-                    {
-                        var localHost = new Uri("http://localhost");
-                        return endpoint.Equals(localhost);
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public interface IBase
+{
+    bool TestMethod(Uri endpoint);
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
-
-                public interface IBase
-                {
-                    bool TestMethod(Uri endpoint);
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : IBase
-                {
-                    public bool TestMethod(Uri endpoint)
-                    {
-                        var localHost = new Uri("http://localhost");
-                        return endpoint.Equals(localhost);
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : IBase
+{
+    public bool TestMethod(Uri endpoint)
+    {
+        var localHost = new Uri(""http://localhost"");
+        return endpoint.Equals(localhost);
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullEventToInterfaceWithAddUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public interface IBase
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public interface IBase
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : IBase
+{
+    public event EventHandler Test[||]Event
+    {
+        add
+        {
+            Console.WriteLine(""adding event..."");
+        }
+        remove
+        {
+            Console.WriteLine(""removing event..."");
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
 
-                public class Derived : IBase
-                {
-                    public event EventHandler Test[||]Event
-                    {
-                        add
-                        {
-                            Console.WriteLine("adding event...");
-                        }
-                        remove
-                        {
-                            Console.WriteLine("removing event...");
-                        }
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public interface IBase
+{
+    event EventHandler TestEvent;
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
-
-                public interface IBase
-                {
-                    event EventHandler TestEvent;
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : IBase
-                {
-                    public event EventHandler TestEvent
-                    {
-                        add
-                        {
-                            Console.WriteLine("adding event...");
-                        }
-                        remove
-                        {
-                            Console.WriteLine("removing event...");
-                        }
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : IBase
+{
+    public event EventHandler TestEvent
+    {
+        add
+        {
+            Console.WriteLine(""adding event..."");
+        }
+        remove
+        {
+            Console.WriteLine(""removing event..."");
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullPropertyToClassWithAddUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : Base
+{
+    public Uri En[||]dpoint { get; set; }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using System;
 
-                public class Derived : Base
-                {
-                    public Uri En[||]dpoint { get; set; }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public Uri Endpoint { get; set; }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using System;
-
-                public class Base
-                {
-                    public Uri Endpoint { get; set; }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullPropertyToClassWithAddUsingsViaQuickAction2()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">public class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">public class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : Base
+{
+    public Uri En[||]dpoint { get; set; }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using System;
+public class Base
+{
+    public Uri Endpoint { get; set; }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                public class Derived : Base
-                {
-                    public Uri En[||]dpoint { get; set; }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using System;
-                public class Base
-                {
-                    public Uri Endpoint { get; set; }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullPropertyToClassWithoutDuplicatingUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
+public class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                public class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : Base
+{
+    public Uri En[||]dpoint { get; set; }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
 
-                public class Derived : Base
-                {
-                    public Uri En[||]dpoint { get; set; }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public Uri Endpoint { get; set; }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
-
-                public class Base
-                {
-                    public Uri Endpoint { get; set; }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullPropertyWithNewBodyTypeToClassWithAddUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : Base
+{
+    public bool Test[||]Property
+    {
+        get
+        {
+            var endpoint1 = new Uri(""http://localhost"");
+            var endpoint2 = new Uri(""http://localhost"");
+            return endpoint1.Equals(endpoint2);
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using System;
 
-                public class Derived : Base
-                {
-                    public bool Test[||]Property
-                    {
-                        get
-                        {
-                            var endpoint1 = new Uri("http://localhost");
-                            var endpoint2 = new Uri("http://localhost");
-                            return endpoint1.Equals(endpoint2);
-                        }
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public bool TestProperty
+    {
+        get
+        {
+            var endpoint1 = new Uri(""http://localhost"");
+            var endpoint2 = new Uri(""http://localhost"");
+            return endpoint1.Equals(endpoint2);
+        }
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using System;
-
-                public class Base
-                {
-                    public bool TestProperty
-                    {
-                        get
-                        {
-                            var endpoint1 = new Uri("http://localhost");
-                            var endpoint2 = new Uri("http://localhost");
-                            return endpoint1.Equals(endpoint2);
-                        }
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodWithNewNonDeclaredBodyTypeToClassWithAddUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System.Linq;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System.Linq;
+public class Derived : Base
+{
+    public int Test[||]Method()
+    {
+        return Enumerable.Range(0, 5).Sum();
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using System.Linq;
 
-                public class Derived : Base
-                {
-                    public int Test[||]Method()
-                    {
-                        return Enumerable.Range(0, 5).Sum();
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public int Test[||]Method()
+    {
+        return Enumerable.Range(0, 5).Sum();
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System.Linq;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using System.Linq;
-
-                public class Base
-                {
-                    public int Test[||]Method()
-                    {
-                        return Enumerable.Range(0, 5).Sum();
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System.Linq;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithOverlappingUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
+using System.Threading.Tasks;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
-                using System.Threading.Tasks;
+public class Base
+{
+    public Uri Endpoint{ get; set; }
 
-                public class Base
-                {
-                    public Uri Endpoint{ get; set; }
+    public async Task&lt;int&gt; Get5Async()
+    {
+        return 5;
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System.Linq;
+using System.Threading.Tasks;
 
-                    public async Task&lt;int&gt; Get5Async()
-                    {
-                        return 5;
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System.Linq;
-                using System.Threading.Tasks;
+public class Derived : Base
+{
+    public async Task&lt;int&gt; Test[||]Method()
+    {
+        return Enumerable.Range(0, 5).Sum();
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 
-                public class Derived : Base
-                {
-                    public async Task&lt;int&gt; Test[||]Method()
-                    {
-                        return Enumerable.Range(0, 5).Sum();
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public Uri Endpoint{ get; set; }
 
-                """;
-            var expected = """
+    public async Task&lt;int&gt; Get5Async()
+    {
+        return 5;
+    }
+    public async Task&lt;int&gt; Test[||]Method()
+    {
+        return Enumerable.Range(0, 5).Sum();
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System.Linq;
+using System.Threading.Tasks;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
-                using System.Linq;
-                using System.Threading.Tasks;
-
-                public class Base
-                {
-                    public Uri Endpoint{ get; set; }
-
-                    public async Task&lt;int&gt; Get5Async()
-                    {
-                        return 5;
-                    }
-                    public async Task&lt;int&gt; Test[||]Method()
-                    {
-                        return Enumerable.Range(0, 5).Sum();
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System.Linq;
-                using System.Threading.Tasks;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithUnnecessaryFirstUsingViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
+using System.Threading.Tasks;
 
-                using System.Threading.Tasks;
+public class Base
+{
+    public async Task&lt;int&gt; Get5Async()
+    {
+        return 5;
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 
-                public class Base
-                {
-                    public async Task&lt;int&gt; Get5Async()
-                    {
-                        return 5;
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-                using System.Linq;
-                using System.Threading.Tasks;
+public class Derived : Base
+{
+    public async Task&lt;int&gt; Test[||]Method()
+    {
+        return Enumerable.Range(0, 5).Sum();
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using System.Linq;
+using System.Threading.Tasks;
 
-                public class Derived : Base
-                {
-                    public async Task&lt;int&gt; Test[||]Method()
-                    {
-                        return Enumerable.Range(0, 5).Sum();
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public async Task&lt;int&gt; Get5Async()
+    {
+        return 5;
+    }
+    public async Task&lt;int&gt; Test[||]Method()
+    {
+        return Enumerable.Range(0, 5).Sum();
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using System.Linq;
-                using System.Threading.Tasks;
-
-                public class Base
-                {
-                    public async Task&lt;int&gt; Get5Async()
-                    {
-                        return 5;
-                    }
-                    public async Task&lt;int&gt; Test[||]Method()
-                    {
-                        return Enumerable.Range(0, 5).Sum();
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-                using System.Linq;
-                using System.Threading.Tasks;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithUnusedBaseUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
+using System.Threading.Tasks;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
-                using System.Threading.Tasks;
+public class Base
+{
+    public Uri Endpoint{ get; set; }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System.Linq;
 
-                public class Base
-                {
-                    public Uri Endpoint{ get; set; }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System.Linq;
+public class Derived : Base
+{
+    public int Test[||]Method()
+    {
+        return Enumerable.Range(0, 5).Sum();
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 
-                public class Derived : Base
-                {
-                    public int Test[||]Method()
-                    {
-                        return Enumerable.Range(0, 5).Sum();
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public Uri Endpoint{ get; set; }
+    public int TestMethod()
+    {
+        return Enumerable.Range(0, 5).Sum();
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System.Linq;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
-                using System.Linq;
-                using System.Threading.Tasks;
-
-                public class Base
-                {
-                    public Uri Endpoint{ get; set; }
-                    public int TestMethod()
-                    {
-                        return Enumerable.Range(0, 5).Sum();
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System.Linq;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithRetainCommentsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+// blah blah
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                // blah blah
+public class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System.Linq;
 
-                public class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System.Linq;
+public class Derived : Base
+{
+    public int Test[||]Method()
+    {
+        return 5;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+// blah blah
 
-                public class Derived : Base
-                {
-                    public int Test[||]Method()
-                    {
-                        return 5;
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public int TestMethod()
+    {
+        return 5;
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System.Linq;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                // blah blah
-
-                public class Base
-                {
-                    public int TestMethod()
-                    {
-                        return 5;
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System.Linq;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithRetainPreImportCommentsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+// blah blah
+using System.Linq;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                // blah blah
-                using System.Linq;
+public class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                public class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : Base
+{
+    public Uri End[||]point { get; set; }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+// blah blah
+using System;
+using System.Linq;
 
-                public class Derived : Base
-                {
-                    public Uri End[||]point { get; set; }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public Uri Endpoint { get; set; }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                // blah blah
-                using System;
-                using System.Linq;
-
-                public class Base
-                {
-                    public Uri Endpoint { get; set; }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithRetainPostImportCommentsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System.Linq;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System.Linq;
+// blah blah
+public class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                // blah blah
-                public class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : Base
+{
+    public Uri End[||]point { get; set; }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
+using System.Linq;
 
-                public class Derived : Base
-                {
-                    public Uri End[||]point { get; set; }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+// blah blah
+public class Base
+{
+    public Uri Endpoint { get; set; }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
-                using System.Linq;
-
-                // blah blah
-                public class Base
-                {
-                    public Uri Endpoint { get; set; }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithLambdaUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
+using System.Linq;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-                using System.Linq;
+public class Derived : Base
+{
+    public int Test[||]Method()
+    {
+        return Enumerable.Range(0, 5).
+            Select((n) => new Uri(""http://"" + n)).
+            Count((uri) => uri != null);
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using System;
+using System.Linq;
 
-                public class Derived : Base
-                {
-                    public int Test[||]Method()
-                    {
-                        return Enumerable.Range(0, 5).
-                            Select((n) => new Uri("http://" + n)).
-                            Count((uri) => uri != null);
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public int TestMethod()
+    {
+        return Enumerable.Range(0, 5).
+            Select((n) => new Uri(""http://"" + n)).
+            Count((uri) => uri != null);
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
+using System.Linq;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using System;
-                using System.Linq;
-
-                public class Base
-                {
-                    public int TestMethod()
-                    {
-                        return Enumerable.Range(0, 5).
-                            Select((n) => new Uri("http://" + n)).
-                            Count((uri) => uri != null);
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-                using System.Linq;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithUnusedUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
+public class Base
+{
+    public Uri Endpoint{ get; set; }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System.Linq;
+using System.Threading.Tasks;
 
-                public class Base
-                {
-                    public Uri Endpoint{ get; set; }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System.Linq;
-                using System.Threading.Tasks;
+public class Derived : Base
+{
+    public int Test[||]Method()
+    {
+        return Enumerable.Range(0, 5).Sum();
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
+using System.Linq;
 
-                public class Derived : Base
-                {
-                    public int Test[||]Method()
-                    {
-                        return Enumerable.Range(0, 5).Sum();
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public Uri Endpoint{ get; set; }
+    public int TestMethod()
+    {
+        return Enumerable.Range(0, 5).Sum();
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System.Linq;
+using System.Threading.Tasks;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
-                using System.Linq;
-
-                public class Base
-                {
-                    public Uri Endpoint{ get; set; }
-                    public int TestMethod()
-                    {
-                        return Enumerable.Range(0, 5).Sum();
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System.Linq;
-                using System.Threading.Tasks;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassKeepSystemFirstViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace TestNs1
+{
+    using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace TestNs1
-                {
-                    using System;
+    public class Base
+    {
+        public Uri Endpoint{ get; set; }
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+namespace A_TestNs2
+{
+    using TestNs1;
 
-                    public class Base
-                    {
-                        public Uri Endpoint{ get; set; }
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                namespace A_TestNs2
-                {
-                    using TestNs1;
+    public class Derived : Base
+    {
+        public Foo Test[||]Method()
+        {
+            return null;
+        }
+    }
 
-                    public class Derived : Base
-                    {
-                        public Foo Test[||]Method()
-                        {
-                            return null;
-                        }
-                    }
+    public class Foo
+    {
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace TestNs1
+{
+    using System;
+    using A_TestNs2;
 
-                    public class Foo
-                    {
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+    public class Base
+    {
+        public Uri Endpoint{ get; set; }
+        public Foo TestMethod()
+        {
+            return null;
+        }
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+namespace A_TestNs2
+{
+    using TestNs1;
 
-                """;
-            var expected = """
+    public class Derived : Base
+    {
+    }
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace TestNs1
-                {
-                    using System;
-                    using A_TestNs2;
-
-                    public class Base
-                    {
-                        public Uri Endpoint{ get; set; }
-                        public Foo TestMethod()
-                        {
-                            return null;
-                        }
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                namespace A_TestNs2
-                {
-                    using TestNs1;
-
-                    public class Derived : Base
-                    {
-                    }
-
-                    public class Foo
-                    {
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+    public class Foo
+    {
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassKeepSystemFirstViaQuickAction2()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace TestNs1
+{
+    public class Base
+    {
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+namespace A_TestNs2
+{
+    using System;
+    using TestNs1;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace TestNs1
-                {
-                    public class Base
-                    {
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                namespace A_TestNs2
-                {
-                    using System;
-                    using TestNs1;
+    public class Derived : Base
+    {
+        public Foo Test[||]Method()
+        {
+            var uri = new Uri(""http://localhost"");
+            return null;
+        }
+    }
 
-                    public class Derived : Base
-                    {
-                        public Foo Test[||]Method()
-                        {
-                            var uri = new Uri("http://localhost");
-                            return null;
-                        }
-                    }
+    public class Foo
+    {
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using System;
+using A_TestNs2;
 
-                    public class Foo
-                    {
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+namespace TestNs1
+{
+    public class Base
+    {
+        public Foo TestMethod()
+        {
+            var uri = new Uri(""http://localhost"");
+            return null;
+        }
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+namespace A_TestNs2
+{
+    using System;
+    using TestNs1;
 
-                """;
-            var expected = """
+    public class Derived : Base
+    {
+    }
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using System;
-                using A_TestNs2;
-
-                namespace TestNs1
-                {
-                    public class Base
-                    {
-                        public Foo TestMethod()
-                        {
-                            var uri = new Uri("http://localhost");
-                            return null;
-                        }
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                namespace A_TestNs2
-                {
-                    using System;
-                    using TestNs1;
-
-                    public class Derived : Base
-                    {
-                    }
-
-                    public class Foo
-                    {
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+    public class Foo
+    {
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithExtensionViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace TestNs1
+{
+    public class Base
+    {
+    }
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace TestNs1
-                {
-                    public class Base
-                    {
-                    }
+    public class Foo
+    {
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+namespace TestNs2
+{
+    using TestNs1;
 
-                    public class Foo
-                    {
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                namespace TestNs2
-                {
-                    using TestNs1;
+    public class Derived : Base
+    {
+        public int Test[||]Method()
+        {
+            var foo = new Foo();
+            return foo.FooBar();
+        }
+    }
 
-                    public class Derived : Base
-                    {
-                        public int Test[||]Method()
-                        {
-                            var foo = new Foo();
-                            return foo.FooBar();
-                        }
-                    }
+    public static class FooExtensions
+    {
+        public static int FooBar(this Foo foo) 
+        {
+            return 5;
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using TestNs2;
 
-                    public static class FooExtensions
-                    {
-                        public static int FooBar(this Foo foo) 
-                        {
-                            return 5;
-                        }
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+namespace TestNs1
+{
+    public class Base
+    {
+        public int TestMethod()
+        {
+            var foo = new Foo();
+            return foo.FooBar();
+        }
+    }
 
-                """;
-            var expected = """
+    public class Foo
+    {
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+namespace TestNs2
+{
+    using TestNs1;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using TestNs2;
+    public class Derived : Base
+    {
+    }
 
-                namespace TestNs1
-                {
-                    public class Base
-                    {
-                        public int TestMethod()
-                        {
-                            var foo = new Foo();
-                            return foo.FooBar();
-                        }
-                    }
-
-                    public class Foo
-                    {
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                namespace TestNs2
-                {
-                    using TestNs1;
-
-                    public class Derived : Base
-                    {
-                    }
-
-                    public static class FooExtensions
-                    {
-                        public static int FooBar(this Foo foo) 
-                        {
-                            return 5;
-                        }
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+    public static class FooExtensions
+    {
+        public static int FooBar(this Foo foo) 
+        {
+            return 5;
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithExtensionViaQuickAction2()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace TestNs1
+{
+    public class Base
+    {
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using TestNs1;
+using TestNs3;
+using TestNs4;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace TestNs1
-                {
-                    public class Base
-                    {
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using TestNs1;
-                using TestNs3;
-                using TestNs4;
+namespace TestNs2
+{
+    public class Derived : Base
+    {
+        public int Test[||]Method()
+        {
+            var foo = new Foo();
+            return foo.FooBar();
+        }
+    }
+}
+        </Document>
+        <Document FilePath = ""File3.cs"">
+namespace TestNs3
+{
+    public class Foo
+    {
+    }
+}
+        </Document>
+        <Document FilePath = ""File4.cs"">
+using TestNs3;
 
-                namespace TestNs2
-                {
-                    public class Derived : Base
-                    {
-                        public int Test[||]Method()
-                        {
-                            var foo = new Foo();
-                            return foo.FooBar();
-                        }
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File3.cs">
-                namespace TestNs3
-                {
-                    public class Foo
-                    {
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File4.cs">
-                using TestNs3;
+namespace TestNs4
+{
+    public static class FooExtensions
+    {
+        public static int FooBar(this Foo foo) 
+        {
+            return 5;
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using TestNs3;
+using TestNs4;
 
-                namespace TestNs4
-                {
-                    public static class FooExtensions
-                    {
-                        public static int FooBar(this Foo foo) 
-                        {
-                            return 5;
-                        }
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+namespace TestNs1
+{
+    public class Base
+    {
+        public int TestMethod()
+        {
+            var foo = new Foo();
+            return foo.FooBar();
+        }
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using TestNs1;
+using TestNs3;
+using TestNs4;
 
-                """;
-            var expected = """
+namespace TestNs2
+{
+    public class Derived : Base
+    {
+    }
+}
+        </Document>
+        <Document FilePath = ""File3.cs"">
+namespace TestNs3
+{
+    public class Foo
+    {
+    }
+}
+        </Document>
+        <Document FilePath = ""File4.cs"">
+using TestNs3;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using TestNs3;
-                using TestNs4;
-
-                namespace TestNs1
-                {
-                    public class Base
-                    {
-                        public int TestMethod()
-                        {
-                            var foo = new Foo();
-                            return foo.FooBar();
-                        }
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using TestNs1;
-                using TestNs3;
-                using TestNs4;
-
-                namespace TestNs2
-                {
-                    public class Derived : Base
-                    {
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File3.cs">
-                namespace TestNs3
-                {
-                    public class Foo
-                    {
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File4.cs">
-                using TestNs3;
-
-                namespace TestNs4
-                {
-                    public static class FooExtensions
-                    {
-                        public static int FooBar(this Foo foo) 
-                        {
-                            return 5;
-                        }
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+namespace TestNs4
+{
+    public static class FooExtensions
+    {
+        public static int FooBar(this Foo foo) 
+        {
+            return 5;
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithAliasUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
+public class Base
+{
+    public Uri Endpoint{ get; set; }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using Enumer = System.Linq.Enumerable;
+using Sys = System;
 
-                public class Base
-                {
-                    public Uri Endpoint{ get; set; }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using Enumer = System.Linq.Enumerable;
-                using Sys = System;
+public class Derived : Base
+{
+    public void Test[||]Method()
+    {
+        Sys.Console.WriteLine(Enumer.Range(0, 5).Sum());
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
+using Enumer = System.Linq.Enumerable;
+using Sys = System;
 
-                public class Derived : Base
-                {
-                    public void Test[||]Method()
-                    {
-                        Sys.Console.WriteLine(Enumer.Range(0, 5).Sum());
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public Uri Endpoint{ get; set; }
+    public void TestMethod()
+    {
+        Sys.Console.WriteLine(Enumer.Range(0, 5).Sum());
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using Enumer = System.Linq.Enumerable;
+using Sys = System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
-                using Enumer = System.Linq.Enumerable;
-                using Sys = System;
-
-                public class Base
-                {
-                    public Uri Endpoint{ get; set; }
-                    public void TestMethod()
-                    {
-                        Sys.Console.WriteLine(Enumer.Range(0, 5).Sum());
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using Enumer = System.Linq.Enumerable;
-                using Sys = System;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullPropertyToClassWithBaseAliasUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using Enumer = System.Linq.Enumerable;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using Enumer = System.Linq.Enumerable;
+public class Base
+{
+    public void TestMethod()
+    {
+        System.Console.WriteLine(Enumer.Range(0, 5).Sum());
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                public class Base
-                {
-                    public void TestMethod()
-                    {
-                        System.Console.WriteLine(Enumer.Range(0, 5).Sum());
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : Base
+{
+    public Uri End[||]point{ get; set; }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+using System;
+using Enumer = System.Linq.Enumerable;
 
-                public class Derived : Base
-                {
-                    public Uri End[||]point{ get; set; }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public Uri Endpoint{ get; set; }
+    public void TestMethod()
+    {
+        System.Console.WriteLine(Enumer.Range(0, 5).Sum());
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                using System;
-                using Enumer = System.Linq.Enumerable;
-
-                public class Base
-                {
-                    public Uri Endpoint{ get; set; }
-                    public void TestMethod()
-                    {
-                        System.Console.WriteLine(Enumer.Range(0, 5).Sum());
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithMultipleNamespacedUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+namespace TestNs1
+{
+    using System;
 
-                namespace TestNs1
-                {
-                    using System;
+    public class Base
+    {
+        public Uri Endpoint{ get; set; }
+    }
+}
+namespace TestNs2
+{
+    using System.Linq;
+    using TestNs1;
 
-                    public class Base
-                    {
-                        public Uri Endpoint{ get; set; }
-                    }
-                }
-                namespace TestNs2
-                {
-                    using System.Linq;
-                    using TestNs1;
+    public class Derived : Base
+    {
+        public int Test[||]Method()
+        {
+            return Enumerable.Range(0, 5).Sum();
+        }
+    }
+}
+";
+            var expected = @"
+namespace TestNs1
+{
+    using System;
+    using System.Linq;
 
-                    public class Derived : Base
-                    {
-                        public int Test[||]Method()
-                        {
-                            return Enumerable.Range(0, 5).Sum();
-                        }
-                    }
-                }
+    public class Base
+    {
+        public Uri Endpoint{ get; set; }
+        public int TestMethod()
+        {
+            return Enumerable.Range(0, 5).Sum();
+        }
+    }
+}
+namespace TestNs2
+{
+    using System.Linq;
+    using TestNs1;
 
-                """;
-            var expected = """
-
-                namespace TestNs1
-                {
-                    using System;
-                    using System.Linq;
-
-                    public class Base
-                    {
-                        public Uri Endpoint{ get; set; }
-                        public int TestMethod()
-                        {
-                            return Enumerable.Range(0, 5).Sum();
-                        }
-                    }
-                }
-                namespace TestNs2
-                {
-                    using System.Linq;
-                    using TestNs1;
-
-                    public class Derived : Base
-                    {
-                    }
-                }
-
-                """;
+    public class Derived : Base
+    {
+    }
+}
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithNestedNamespacedUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+namespace TestNs1
+{
+    namespace InnerNs1
+    {
+        using System;
 
-                namespace TestNs1
-                {
-                    namespace InnerNs1
-                    {
-                        using System;
+        public class Base
+        {
+            public Uri Endpoint { get; set; }
+        }
+    }
+}
+namespace TestNs2
+{
+    namespace InnerNs2
+    {
+        using System.Linq;
+        using TestNs1.InnerNs1;
 
-                        public class Base
-                        {
-                            public Uri Endpoint { get; set; }
-                        }
-                    }
-                }
-                namespace TestNs2
-                {
-                    namespace InnerNs2
-                    {
-                        using System.Linq;
-                        using TestNs1.InnerNs1;
+        public class Derived : Base
+        {
+            public int Test[||]Method()
+            {
+                return Foo.Bar(Enumerable.Range(0, 5).Sum());
+            }
+        }
 
-                        public class Derived : Base
-                        {
-                            public int Test[||]Method()
-                            {
-                                return Foo.Bar(Enumerable.Range(0, 5).Sum());
-                            }
-                        }
+        public class Foo
+        {
+            public static int Bar(int num)
+            {
+                return num + 1;
+            }
+        }
+    }
+}
+";
+            var expected = @"
+namespace TestNs1
+{
+    namespace InnerNs1
+    {
+        using System;
+        using System.Linq;
+        using TestNs2.InnerNs2;
 
-                        public class Foo
-                        {
-                            public static int Bar(int num)
-                            {
-                                return num + 1;
-                            }
-                        }
-                    }
-                }
+        public class Base
+        {
+            public Uri Endpoint { get; set; }
+            public int TestMethod()
+            {
+                return Foo.Bar(Enumerable.Range(0, 5).Sum());
+            }
+        }
+    }
+}
+namespace TestNs2
+{
+    namespace InnerNs2
+    {
+        using System.Linq;
+        using TestNs1.InnerNs1;
 
-                """;
-            var expected = """
+        public class Derived : Base
+        {
+        }
 
-                namespace TestNs1
-                {
-                    namespace InnerNs1
-                    {
-                        using System;
-                        using System.Linq;
-                        using TestNs2.InnerNs2;
-
-                        public class Base
-                        {
-                            public Uri Endpoint { get; set; }
-                            public int TestMethod()
-                            {
-                                return Foo.Bar(Enumerable.Range(0, 5).Sum());
-                            }
-                        }
-                    }
-                }
-                namespace TestNs2
-                {
-                    namespace InnerNs2
-                    {
-                        using System.Linq;
-                        using TestNs1.InnerNs1;
-
-                        public class Derived : Base
-                        {
-                        }
-
-                        public class Foo
-                        {
-                            public static int Bar(int num)
-                            {
-                                return num + 1;
-                            }
-                        }
-                    }
-                }
-
-                """;
+        public class Foo
+        {
+            public static int Bar(int num)
+            {
+                return num + 1;
+            }
+        }
+    }
+}
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithNewNamespaceUsingViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace A.B
+{
+    class Base
+    {
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+namespace X.Y
+{
+    class Derived : A.B.Base
+    {
+        public Other Get[||]Other() => null;
+    }
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace A.B
-                {
-                    class Base
-                    {
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                namespace X.Y
-                {
-                    class Derived : A.B.Base
-                    {
-                        public Other Get[||]Other() => null;
-                    }
+    class Other
+    {
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using X.Y;
 
-                    class Other
-                    {
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+namespace A.B
+{
+    class Base
+    {
+        public Other GetOther() => null;
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+namespace X.Y
+{
+    class Derived : A.B.Base
+    {
+    }
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using X.Y;
-
-                namespace A.B
-                {
-                    class Base
-                    {
-                        public Other GetOther() => null;
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                namespace X.Y
-                {
-                    class Derived : A.B.Base
-                    {
-                    }
-
-                    class Other
-                    {
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+    class Other
+    {
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithFileNamespaceUsingViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace A.B;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace A.B;
+class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+namespace X.Y;
+class Derived : A.B.Base
+{
+    public Other Get[||]Other() => null;
+}
 
-                class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                namespace X.Y;
-                class Derived : A.B.Base
-                {
-                    public Other Get[||]Other() => null;
-                }
+class Other
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using X.Y;
 
-                class Other
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+namespace A.B;
 
-                """;
-            var expected = """
+class Base
+{
+    public Other GetOther() => null;
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+namespace X.Y;
+class Derived : A.B.Base
+{
+}
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using X.Y;
-
-                namespace A.B;
-
-                class Base
-                {
-                    public Other GetOther() => null;
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                namespace X.Y;
-                class Derived : A.B.Base
-                {
-                }
-
-                class Other
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+class Other
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithUnusedNamespaceUsingViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace A.B
+{
+    class Base
+    {
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+namespace X.Y
+{
+    class Derived : A.B.Base
+    {
+        public int Get[||]Five() => 5;
+    }
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace A.B
-                {
-                    class Base
-                    {
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                namespace X.Y
-                {
-                    class Derived : A.B.Base
-                    {
-                        public int Get[||]Five() => 5;
-                    }
+    class Other
+    {
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace A.B
+{
+    class Base
+    {
+        public int GetFive() => 5;
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+namespace X.Y
+{
+    class Derived : A.B.Base
+    {
+    }
 
-                    class Other
-                    {
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace A.B
-                {
-                    class Base
-                    {
-                        public int GetFive() => 5;
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                namespace X.Y
-                {
-                    class Derived : A.B.Base
-                    {
-                    }
-
-                    class Other
-                    {
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+    class Other
+    {
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithMultipleNamespacesAndCommentsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+// comment 1
 
-                // comment 1
+namespace TestNs1
+{
+    // comment 2
 
-                namespace TestNs1
-                {
-                    // comment 2
+    // comment 3 
+    public class Base
+    {
+    }
+}
+namespace TestNs2
+{
+    // comment 4
+    using System.Linq;
+    using TestNs1;
 
-                    // comment 3 
-                    public class Base
-                    {
-                    }
-                }
-                namespace TestNs2
-                {
-                    // comment 4
-                    using System.Linq;
-                    using TestNs1;
+    public class Derived : Base
+    {
+        public int Test[||]Method()
+        {
+            return 5;
+        }
+    }
+}
+";
+            var expected = @"
+// comment 1
 
-                    public class Derived : Base
-                    {
-                        public int Test[||]Method()
-                        {
-                            return 5;
-                        }
-                    }
-                }
+namespace TestNs1
+{
+    // comment 2
 
-                """;
-            var expected = """
+    // comment 3 
+    public class Base
+    {
+        public int TestMethod()
+        {
+            return 5;
+        }
+    }
+}
+namespace TestNs2
+{
+    // comment 4
+    using System.Linq;
+    using TestNs1;
 
-                // comment 1
-
-                namespace TestNs1
-                {
-                    // comment 2
-
-                    // comment 3 
-                    public class Base
-                    {
-                        public int TestMethod()
-                        {
-                            return 5;
-                        }
-                    }
-                }
-                namespace TestNs2
-                {
-                    // comment 4
-                    using System.Linq;
-                    using TestNs1;
-
-                    public class Derived : Base
-                    {
-                    }
-                }
-
-                """;
+    public class Derived : Base
+    {
+    }
+}
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithMultipleNamespacedUsingsAndCommentsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+// comment 1
 
-                // comment 1
+namespace TestNs1
+{
+    // comment 2
+    using System;
 
-                namespace TestNs1
-                {
-                    // comment 2
-                    using System;
+    // comment 3 
+    public class Base
+    {
+    }
+}
+namespace TestNs2
+{
+    // comment 4
+    using System.Linq;
+    using TestNs1;
 
-                    // comment 3 
-                    public class Base
-                    {
-                    }
-                }
-                namespace TestNs2
-                {
-                    // comment 4
-                    using System.Linq;
-                    using TestNs1;
+    public class Derived : Base
+    {
+        public int Test[||]Method()
+        {
+            return Enumerable.Range(0, 5).Sum();
+        }
+    }
+}
+";
+            var expected = @"
+// comment 1
 
-                    public class Derived : Base
-                    {
-                        public int Test[||]Method()
-                        {
-                            return Enumerable.Range(0, 5).Sum();
-                        }
-                    }
-                }
+namespace TestNs1
+{
+    // comment 2
+    using System;
+    using System.Linq;
 
-                """;
-            var expected = """
+    // comment 3 
+    public class Base
+    {
+        public int TestMethod()
+        {
+            return Enumerable.Range(0, 5).Sum();
+        }
+    }
+}
+namespace TestNs2
+{
+    // comment 4
+    using System.Linq;
+    using TestNs1;
 
-                // comment 1
-
-                namespace TestNs1
-                {
-                    // comment 2
-                    using System;
-                    using System.Linq;
-
-                    // comment 3 
-                    public class Base
-                    {
-                        public int TestMethod()
-                        {
-                            return Enumerable.Range(0, 5).Sum();
-                        }
-                    }
-                }
-                namespace TestNs2
-                {
-                    // comment 4
-                    using System.Linq;
-                    using TestNs1;
-
-                    public class Derived : Base
-                    {
-                    }
-                }
-
-                """;
+    public class Derived : Base
+    {
+    }
+}
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithNamespacedUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace ClassLibrary1
+{
+    using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace ClassLibrary1
-                {
-                    using System;
+    public class Base
+    {
+        public Uri Endpoint{ get; set; }
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+namespace ClassLibrary1
+{
+    using System.Linq;
 
-                    public class Base
-                    {
-                        public Uri Endpoint{ get; set; }
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                namespace ClassLibrary1
-                {
-                    using System.Linq;
+    public class Derived : Base
+    {
+        public int Test[||]Method()
+        {
+            return Enumerable.Range(0, 5).Sum();
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace ClassLibrary1
+{
+    using System;
+    using System.Linq;
 
-                    public class Derived : Base
-                    {
-                        public int Test[||]Method()
-                        {
-                            return Enumerable.Range(0, 5).Sum();
-                        }
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+    public class Base
+    {
+        public Uri Endpoint{ get; set; }
+        public int Test[||]Method()
+        {
+            return Enumerable.Range(0, 5).Sum();
+        }
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+namespace ClassLibrary1
+{
+    using System.Linq;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace ClassLibrary1
-                {
-                    using System;
-                    using System.Linq;
-
-                    public class Base
-                    {
-                        public Uri Endpoint{ get; set; }
-                        public int Test[||]Method()
-                        {
-                            return Enumerable.Range(0, 5).Sum();
-                        }
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                namespace ClassLibrary1
-                {
-                    using System.Linq;
-
-                    public class Derived : Base
-                    {
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+    public class Derived : Base
+    {
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodToClassWithDuplicateNamespacedUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace ClassLibrary1
+{
+    using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace ClassLibrary1
-                {
-                    using System;
+    public class Base
+    {
+        public Uri Endpoint{ get; set; }
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System.Linq;
+namespace ClassLibrary1
+{
+    using System.Linq;
 
-                    public class Base
-                    {
-                        public Uri Endpoint{ get; set; }
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System.Linq;
-                namespace ClassLibrary1
-                {
-                    using System.Linq;
+    public class Derived : Base
+    {
+        public int Test[||]Method()
+        {
+            return Enumerable.Range(0, 5).Sum();
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace ClassLibrary1
+{
+    using System;
+    using System.Linq;
 
-                    public class Derived : Base
-                    {
-                        public int Test[||]Method()
-                        {
-                            return Enumerable.Range(0, 5).Sum();
-                        }
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+    public class Base
+    {
+        public Uri Endpoint{ get; set; }
+        public int Test[||]Method()
+        {
+            return Enumerable.Range(0, 5).Sum();
+        }
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System.Linq;
+namespace ClassLibrary1
+{
+    using System.Linq;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace ClassLibrary1
-                {
-                    using System;
-                    using System.Linq;
-
-                    public class Base
-                    {
-                        public Uri Endpoint{ get; set; }
-                        public int Test[||]Method()
-                        {
-                            return Enumerable.Range(0, 5).Sum();
-                        }
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System.Linq;
-                namespace ClassLibrary1
-                {
-                    using System.Linq;
-
-                    public class Derived : Base
-                    {
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+    public class Derived : Base
+    {
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodWithNewReturnTypeToClassWithAddUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : Base
+{
+    public Uri En[||]dpoint()
+    {
+        return new Uri(""http://localhost"");
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using System;
 
-                public class Derived : Base
-                {
-                    public Uri En[||]dpoint()
-                    {
-                        return new Uri("http://localhost");
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public Uri Endpoint()
+    {
+        return new Uri(""http://localhost"");
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using System;
-
-                public class Base
-                {
-                    public Uri Endpoint()
-                    {
-                        return new Uri("http://localhost");
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodWithNewParamTypeToClassWithAddUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : Base
+{
+    public bool Test[||]Method(Uri endpoint)
+    {
+        var localHost = new Uri(""http://localhost"");
+        return endpoint.Equals(localhost);
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using System;
 
-                public class Derived : Base
-                {
-                    public bool Test[||]Method(Uri endpoint)
-                    {
-                        var localHost = new Uri("http://localhost");
-                        return endpoint.Equals(localhost);
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public bool TestMethod(Uri endpoint)
+    {
+        var localHost = new Uri(""http://localhost"");
+        return endpoint.Equals(localhost);
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using System;
-
-                public class Base
-                {
-                    public bool TestMethod(Uri endpoint)
-                    {
-                        var localHost = new Uri("http://localhost");
-                        return endpoint.Equals(localhost);
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullMethodWithNewBodyTypeToClassWithAddUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : Base
+{
+    public bool Test[||]Method()
+    {
+        var endpoint1 = new Uri(""http://localhost"");
+        var endpoint2 = new Uri(""http://localhost"");
+        return endpoint1.Equals(endpoint2);
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using System;
 
-                public class Derived : Base
-                {
-                    public bool Test[||]Method()
-                    {
-                        var endpoint1 = new Uri("http://localhost");
-                        var endpoint2 = new Uri("http://localhost");
-                        return endpoint1.Equals(endpoint2);
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public bool TestMethod()
+    {
+        var endpoint1 = new Uri(""http://localhost"");
+        var endpoint2 = new Uri(""http://localhost"");
+        return endpoint1.Equals(endpoint2);
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using System;
-
-                public class Base
-                {
-                    public bool TestMethod()
-                    {
-                        var endpoint1 = new Uri("http://localhost");
-                        var endpoint2 = new Uri("http://localhost");
-                        return endpoint1.Equals(endpoint2);
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullEventToClassWithAddUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : Base
+{
+    public event EventHandler Test[||]Event
+    {
+        add
+        {
+            Console.WriteLine(""adding event..."");
+        }
+        remove
+        {
+            Console.WriteLine(""removing event..."");
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using System;
 
-                public class Derived : Base
-                {
-                    public event EventHandler Test[||]Event
-                    {
-                        add
-                        {
-                            Console.WriteLine("adding event...");
-                        }
-                        remove
-                        {
-                            Console.WriteLine("removing event...");
-                        }
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public event EventHandler Test[||]Event
+    {
+        add
+        {
+            Console.WriteLine(""adding event..."");
+        }
+        remove
+        {
+            Console.WriteLine(""removing event..."");
+        }
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using System;
-
-                public class Base
-                {
-                    public event EventHandler Test[||]Event
-                    {
-                        add
-                        {
-                            Console.WriteLine("adding event...");
-                        }
-                        remove
-                        {
-                            Console.WriteLine("removing event...");
-                        }
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullFieldToClassWithAddUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+public class Derived : Base
+{
+    public var en[||]dpoint = new Uri(""http://localhost"");
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using System;
 
-                public class Derived : Base
-                {
-                    public var en[||]dpoint = new Uri("http://localhost");
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public var endpoint = new Uri(""http://localhost"");
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using System;
-
-                public class Base
-                {
-                    public var endpoint = new Uri("http://localhost");
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact, WorkItem(46010, "https://github.com/dotnet/roslyn/issues/46010")]
         public async Task TestPullFieldToClassNoConstructorWithAddUsingsViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+public class Base
+{
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System.Linq;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                public class Base
-                {
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System.Linq;
+public class Derived : Base
+{
+    public var ran[||]ge = Enumerable.Range(0, 5);
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using System.Linq;
 
-                public class Derived : Base
-                {
-                    public var ran[||]ge = Enumerable.Range(0, 5);
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+public class Base
+{
+    public var range = Enumerable.Range(0, 5);
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System.Linq;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using System.Linq;
-
-                public class Base
-                {
-                    public var range = Enumerable.Range(0, 5);
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System.Linq;
-
-                public class Derived : Base
-                {
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+public class Derived : Base
+{
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestNoRefactoringProvidedWhenPullOverrideMethodUpToClassViaQuickAction()
         {
-            var methodTest = """
+            var methodTest = @"
+namespace PushUpTest
+{
+    public class Base
+    {
+        public virtual void TestMethod() => System.Console.WriteLine(""foo bar bar foo"");
+    }
 
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                        public virtual void TestMethod() => System.Console.WriteLine("foo bar bar foo");
-                    }
-
-                    public class TestClass : Base
-                    {
-                        public override void TestMeth[||]od()
-                        {
-                            System.Console.WriteLine("Hello World");
-                        }
-                    }
-                }
-                """;
+    public class TestClass : Base
+    {
+        public override void TestMeth[||]od()
+        {
+            System.Console.WriteLine(""Hello World"");
+        }
+    }
+}";
             await TestQuickActionNotProvidedAsync(methodTest);
         }
 
         [Fact]
         public async Task TestNoRefactoringProvidedWhenPullOverridePropertyUpToClassViaQuickAction()
         {
-            var propertyTest = """
+            var propertyTest = @"
+using System;
+namespace PushUpTest
+{
+    public class Base
+    {
+        public virtual int TestProperty { get => 111; private set; }
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                        public virtual int TestProperty { get => 111; private set; }
-                    }
-
-                    public class TestClass : Base
-                    {
-                        public override int TestPr[||]operty { get; private set; }
-                    }
-                }
-                """;
+    public class TestClass : Base
+    {
+        public override int TestPr[||]operty { get; private set; }
+    }
+}";
 
             await TestQuickActionNotProvidedAsync(propertyTest);
         }
@@ -3238,43 +3022,41 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task TestNoRefactoringProvidedWhenPullOverrideEventUpToClassViaQuickAction()
         {
-            var eventTest = """
+            var eventTest = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    public class Base2
+    {
+        protected virtual event EventHandler Event3
+        {
+            add
+            {
+                System.Console.WriteLine(""Hello"");
+            }
+            remove
+            {
+                System.Console.WriteLine(""World"");
+            }
+        };
+    }
 
-                namespace PushUpTest
-                {
-                    public class Base2
-                    {
-                        protected virtual event EventHandler Event3
-                        {
-                            add
-                            {
-                                System.Console.WriteLine("Hello");
-                            }
-                            remove
-                            {
-                                System.Console.WriteLine("World");
-                            }
-                        };
-                    }
-
-                    public class TestClass2 : Base2
-                    {
-                        protected override event EventHandler E[||]vent3
-                        {
-                            add
-                            {
-                                System.Console.WriteLine("foo");
-                            }
-                            remove
-                            {
-                                System.Console.WriteLine("bar");
-                            }
-                        };
-                    }
-                }
-                """;
+    public class TestClass2 : Base2
+    {
+        protected override event EventHandler E[||]vent3
+        {
+            add
+            {
+                System.Console.WriteLine(""foo"");
+            }
+            remove
+            {
+                System.Console.WriteLine(""bar"");
+            }
+        };
+    }
+}";
             await TestQuickActionNotProvidedAsync(eventTest);
         }
 
@@ -3283,614 +3065,560 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         {
             // Fields share the same name will be thought as 'override', since it will cause error
             // if two same name fields exist in one class
-            var fieldTest = """
+            var fieldTest = @"
+namespace PushUpTest
+{
+    public class Base
+    {
+        public int you = -100000;
+    }
 
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                        public int you = -100000;
-                    }
-
-                    public class TestClass : Base
-                    {
-                        public int y[||]ou = 10086;
-                    }
-                }
-                """;
+    public class TestClass : Base
+    {
+        public int y[||]ou = 10086;
+    }
+}";
             await TestQuickActionNotProvidedAsync(fieldTest);
         }
 
         [Fact]
         public async Task TestPullMethodToOrdinaryClassViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+namespace PushUpTest
+{
+    public class Base
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                    }
+    public class TestClass : Base
+    {
+        public void TestMeth[||]od()
+        {
+            System.Console.WriteLine(""Hello World"");
+        }
+    }
+}";
 
-                    public class TestClass : Base
-                    {
-                        public void TestMeth[||]od()
-                        {
-                            System.Console.WriteLine("Hello World");
-                        }
-                    }
-                }
-                """;
+            var expected = @"
+namespace PushUpTest
+{
+    public class Base
+    {
+        public void TestMethod()
+        {
+            System.Console.WriteLine(""Hello World"");
+        }
+    }
 
-            var expected = """
-
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                        public void TestMethod()
-                        {
-                            System.Console.WriteLine("Hello World");
-                        }
-                    }
-
-                    public class TestClass : Base
-                    {
-                    }
-                }
-                """;
+    public class TestClass : Base
+    {
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullOneFieldsToClassViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+namespace PushUpTest
+{
+    public class Base
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                    }
+    public class TestClass : Base
+    {
+        public int you[||]= 10086;
+    }
+}";
 
-                    public class TestClass : Base
-                    {
-                        public int you[||]= 10086;
-                    }
-                }
-                """;
+            var expected = @"
+namespace PushUpTest
+{
+    public class Base
+    {
+        public int you = 10086;
+    }
 
-            var expected = """
-
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                        public int you = 10086;
-                    }
-
-                    public class TestClass : Base
-                    {
-                    }
-                }
-                """;
+    public class TestClass : Base
+    {
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullGenericsUpToClassViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public class BaseClass
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    public class BaseClass
-                    {
-                    }
+    public class TestClass : BaseClass
+    {
+        public void TestMeth[||]od<T>() where T : IDisposable
+        {
+        }
+    }
+}";
 
-                    public class TestClass : BaseClass
-                    {
-                        public void TestMeth[||]od<T>() where T : IDisposable
-                        {
-                        }
-                    }
-                }
-                """;
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public class BaseClass
+    {
+        public void TestMethod<T>() where T : IDisposable
+        {
+        }
+    }
 
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public class BaseClass
-                    {
-                        public void TestMethod<T>() where T : IDisposable
-                        {
-                        }
-                    }
-
-                    public class TestClass : BaseClass
-                    {
-                    }
-                }
-                """;
+    public class TestClass : BaseClass
+    {
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullOneFieldFromMultipleFieldsToClassViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+namespace PushUpTest
+{
+    public class Base
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                    }
+    public class TestClass : Base
+    {
+        public int you, a[||]nd, someone = 10086;
+    }
+}";
 
-                    public class TestClass : Base
-                    {
-                        public int you, a[||]nd, someone = 10086;
-                    }
-                }
-                """;
+            var expected = @"
+namespace PushUpTest
+{
+    public class Base
+    {
+        public int and;
+    }
 
-            var expected = """
-
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                        public int and;
-                    }
-
-                    public class TestClass : Base
-                    {
-                        public int you, someone = 10086;
-                    }
-                }
-                """;
+    public class TestClass : Base
+    {
+        public int you, someone = 10086;
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullMiddleFieldWithValueToClassViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+namespace PushUpTest
+{
+    public class Base
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                    }
+    public class TestClass : Base
+    {
+        public int you, a[||]nd = 4000, someone = 10086;
+    }
+}";
+            var expected = @"
+namespace PushUpTest
+{
+    public class Base
+    {
+        public int and = 4000;
+    }
 
-                    public class TestClass : Base
-                    {
-                        public int you, a[||]nd = 4000, someone = 10086;
-                    }
-                }
-                """;
-            var expected = """
-
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                        public int and = 4000;
-                    }
-
-                    public class TestClass : Base
-                    {
-                        public int you, someone = 10086;
-                    }
-                }
-                """;
+    public class TestClass : Base
+    {
+        public int you, someone = 10086;
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullOneEventFromMultipleToClassViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    public class Base2
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public class Base2
-                    {
-                    }
+    public class Testclass2 : Base2
+    {
+        private static event EventHandler Event1, Eve[||]nt3, Event4;
+    }
+}";
+            var expected = @"
+using System;
 
-                    public class Testclass2 : Base2
-                    {
-                        private static event EventHandler Event1, Eve[||]nt3, Event4;
-                    }
-                }
-                """;
-            var expected = """
+namespace PushUpTest
+{
+    public class Base2
+    {
+        private static event EventHandler Event3;
+    }
 
-                using System;
-
-                namespace PushUpTest
-                {
-                    public class Base2
-                    {
-                        private static event EventHandler Event3;
-                    }
-
-                    public class Testclass2 : Base2
-                    {
-                        private static event EventHandler Event1, Event4;
-                    }
-                }
-                """;
+    public class Testclass2 : Base2
+    {
+        private static event EventHandler Event1, Event4;
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullEventToClassViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    public class Base2
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public class Base2
-                    {
-                    }
+    public class TestClass2 : Base2
+    {
+        private static event EventHandler Eve[||]nt3;
+    }
+}";
+            var expected = @"
+using System;
 
-                    public class TestClass2 : Base2
-                    {
-                        private static event EventHandler Eve[||]nt3;
-                    }
-                }
-                """;
-            var expected = """
+namespace PushUpTest
+{
+    public class Base2
+    {
+        private static event EventHandler Event3;
+    }
 
-                using System;
-
-                namespace PushUpTest
-                {
-                    public class Base2
-                    {
-                        private static event EventHandler Event3;
-                    }
-
-                    public class TestClass2 : Base2
-                    {
-                    }
-                }
-                """;
+    public class TestClass2 : Base2
+    {
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullEventWithBodyToClassViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    public class Base2
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public class Base2
-                    {
-                    }
+    public class TestClass2 : Base2
+    {
+        private static event EventHandler Eve[||]nt3
+        {
+            add
+            {
+                System.Console.Writeln(""Hello"");
+            }
+            remove
+            {
+                System.Console.Writeln(""World"");
+            }
+        };
+    }
+}";
+            var expected = @"
+using System;
 
-                    public class TestClass2 : Base2
-                    {
-                        private static event EventHandler Eve[||]nt3
-                        {
-                            add
-                            {
-                                System.Console.Writeln("Hello");
-                            }
-                            remove
-                            {
-                                System.Console.Writeln("World");
-                            }
-                        };
-                    }
-                }
-                """;
-            var expected = """
+namespace PushUpTest
+{
+    public class Base2
+    {
+        private static event EventHandler Event3
+        {
+            add
+            {
+                System.Console.Writeln(""Hello"");
+            }
+            remove
+            {
+                System.Console.Writeln(""World"");
+            }
+        };
+    }
 
-                using System;
-
-                namespace PushUpTest
-                {
-                    public class Base2
-                    {
-                        private static event EventHandler Event3
-                        {
-                            add
-                            {
-                                System.Console.Writeln("Hello");
-                            }
-                            remove
-                            {
-                                System.Console.Writeln("World");
-                            }
-                        };
-                    }
-
-                    public class TestClass2 : Base2
-                    {
-                    }
-                }
-                """;
+    public class TestClass2 : Base2
+    {
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullPropertyToClassViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public class Base
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                    }
+    public class TestClass : Base
+    {
+        public int TestPr[||]operty { get; private set; }
+    }
+}";
 
-                    public class TestClass : Base
-                    {
-                        public int TestPr[||]operty { get; private set; }
-                    }
-                }
-                """;
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public class Base
+    {
+        public int TestProperty { get; private set; }
+    }
 
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                        public int TestProperty { get; private set; }
-                    }
-
-                    public class TestClass : Base
-                    {
-                    }
-                }
-                """;
+    public class TestClass : Base
+    {
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullIndexerToClassViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+namespace PushUpTest
+{
+    public class Base 
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public class Base 
-                    {
-                    }
+    public class TestClass : Base
+    {
+        private int j;
+        public int th[||]is[int i]
+        {
+            get => j;
+            set => j = value;
+        }
+    }
+}";
 
-                    public class TestClass : Base
-                    {
-                        private int j;
-                        public int th[||]is[int i]
-                        {
-                            get => j;
-                            set => j = value;
-                        }
-                    }
-                }
-                """;
+            var expected = @"
+namespace PushUpTest
+{
+    public class Base
+    {
+        public int this[int i]
+        {
+            get => j;
+            set => j = value;
+        }
+    }
 
-            var expected = """
-
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                        public int this[int i]
-                        {
-                            get => j;
-                            set => j = value;
-                        }
-                    }
-
-                    public class TestClass : Base
-                    {
-                        private int j;
-                    }
-                }
-                """;
+    public class TestClass : Base
+    {
+        private int j;
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullMethodUpAcrossProjectViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSAssembly1"" CommonReferences=""true"">
+        <ProjectReference>CSAssembly2</ProjectReference>
+        <Document>
+using Destination;
+public class TestClass : IInterface
+{
+    public int Bar[||]Bar()
+    {
+        return 12345;
+    }
+}
+        </Document>
+  </Project>
+  <Project Language=""C#"" AssemblyName=""CSAssembly2"" CommonReferences=""true"">
+        <Document>
+namespace Destination
+{
+    public interface IInterface
+    {
+    }
+}
+        </Document>
+  </Project>
+</Workspace>";
 
-                <Workspace>
-                    <Project Language="C#" AssemblyName="CSAssembly1" CommonReferences="true">
-                        <ProjectReference>CSAssembly2</ProjectReference>
-                        <Document>
-                using Destination;
-                public class TestClass : IInterface
-                {
-                    public int Bar[||]Bar()
-                    {
-                        return 12345;
-                    }
-                }
-                        </Document>
-                  </Project>
-                  <Project Language="C#" AssemblyName="CSAssembly2" CommonReferences="true">
-                        <Document>
-                namespace Destination
-                {
-                    public interface IInterface
-                    {
-                    }
-                }
-                        </Document>
-                  </Project>
-                </Workspace>
-                """;
-
-            var expected = """
-
-                <Workspace>
-                    <Project Language="C#" AssemblyName="CSAssembly1" CommonReferences="true">
-                        <ProjectReference>CSAssembly2</ProjectReference>
-                        <Document>
-                using Destination;
-                public class TestClass : IInterface
-                {
-                    public int Bar[||]Bar()
-                    {
-                        return 12345;
-                    }
-                }
-                        </Document>
-                  </Project>
-                  <Project Language="C#" AssemblyName="CSAssembly2" CommonReferences="true">
-                        <Document>
-                namespace Destination
-                {
-                    public interface IInterface
-                    {
-                        int BarBar();
-                    }
-                }
-                        </Document>
-                  </Project>
-                </Workspace>
-                """;
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSAssembly1"" CommonReferences=""true"">
+        <ProjectReference>CSAssembly2</ProjectReference>
+        <Document>
+using Destination;
+public class TestClass : IInterface
+{
+    public int Bar[||]Bar()
+    {
+        return 12345;
+    }
+}
+        </Document>
+  </Project>
+  <Project Language=""C#"" AssemblyName=""CSAssembly2"" CommonReferences=""true"">
+        <Document>
+namespace Destination
+{
+    public interface IInterface
+    {
+        int BarBar();
+    }
+}
+        </Document>
+  </Project>
+</Workspace>";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullPropertyUpAcrossProjectViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSAssembly1"" CommonReferences=""true"">
+        <ProjectReference>CSAssembly2</ProjectReference>
+        <Document>
+using Destination;
+public class TestClass : IInterface
+{
+    public int F[||]oo
+    {
+        get;
+        set;
+    }
+}
+        </Document>
+  </Project>
+  <Project Language=""C#"" AssemblyName=""CSAssembly2"" CommonReferences=""true"">
+        <Document>
+namespace Destination
+{
+    public interface IInterface
+    {
+    }
+}
+        </Document>
+  </Project>
+</Workspace>";
 
-                <Workspace>
-                    <Project Language="C#" AssemblyName="CSAssembly1" CommonReferences="true">
-                        <ProjectReference>CSAssembly2</ProjectReference>
-                        <Document>
-                using Destination;
-                public class TestClass : IInterface
-                {
-                    public int F[||]oo
-                    {
-                        get;
-                        set;
-                    }
-                }
-                        </Document>
-                  </Project>
-                  <Project Language="C#" AssemblyName="CSAssembly2" CommonReferences="true">
-                        <Document>
-                namespace Destination
-                {
-                    public interface IInterface
-                    {
-                    }
-                }
-                        </Document>
-                  </Project>
-                </Workspace>
-                """;
-
-            var expected = """
-
-                <Workspace>
-                    <Project Language="C#" AssemblyName="CSAssembly1" CommonReferences="true">
-                        <ProjectReference>CSAssembly2</ProjectReference>
-                        <Document>
-                using Destination;
-                public class TestClass : IInterface
-                {
-                    public int Foo
-                    {
-                        get;
-                        set;
-                    }
-                }
-                        </Document>
-                  </Project>
-                  <Project Language="C#" AssemblyName="CSAssembly2" CommonReferences="true">
-                        <Document>
-                namespace Destination
-                {
-                    public interface IInterface
-                    {
-                        int Foo { get; set; }
-                    }
-                }
-                        </Document>
-                  </Project>
-                </Workspace>
-                """;
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSAssembly1"" CommonReferences=""true"">
+        <ProjectReference>CSAssembly2</ProjectReference>
+        <Document>
+using Destination;
+public class TestClass : IInterface
+{
+    public int Foo
+    {
+        get;
+        set;
+    }
+}
+        </Document>
+  </Project>
+  <Project Language=""C#"" AssemblyName=""CSAssembly2"" CommonReferences=""true"">
+        <Document>
+namespace Destination
+{
+    public interface IInterface
+    {
+        int Foo { get; set; }
+    }
+}
+        </Document>
+  </Project>
+</Workspace>";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task TestPullFieldUpAcrossProjectViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSAssembly1"" CommonReferences=""true"">
+        <ProjectReference>CSAssembly2</ProjectReference>
+        <Document>
+using Destination;
+public class TestClass : BaseClass
+{
+    private int i, j, [||]k = 10;
+}
+        </Document>
+  </Project>
+  <Project Language=""C#"" AssemblyName=""CSAssembly2"" CommonReferences=""true"">
+        <Document>
+namespace Destination
+{
+    public class BaseClass
+    {
+    }
+}
+        </Document>
+  </Project>
+</Workspace>";
 
-                <Workspace>
-                    <Project Language="C#" AssemblyName="CSAssembly1" CommonReferences="true">
-                        <ProjectReference>CSAssembly2</ProjectReference>
-                        <Document>
-                using Destination;
-                public class TestClass : BaseClass
-                {
-                    private int i, j, [||]k = 10;
-                }
-                        </Document>
-                  </Project>
-                  <Project Language="C#" AssemblyName="CSAssembly2" CommonReferences="true">
-                        <Document>
-                namespace Destination
-                {
-                    public class BaseClass
-                    {
-                    }
-                }
-                        </Document>
-                  </Project>
-                </Workspace>
-                """;
-
-            var expected = """
-
-                <Workspace>
-                    <Project Language="C#" AssemblyName="CSAssembly1" CommonReferences="true">
-                        <ProjectReference>CSAssembly2</ProjectReference>
-                        <Document>
-                using Destination;
-                public class TestClass : BaseClass
-                {
-                    private int i, j;
-                }
-                        </Document>
-                  </Project>
-                  <Project Language="C#" AssemblyName="CSAssembly2" CommonReferences="true">
-                        <Document>
-                namespace Destination
-                {
-                    public class BaseClass
-                    {
-                        private int k = 10;
-                    }
-                }
-                        </Document>
-                  </Project>
-                </Workspace>
-                """;
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSAssembly1"" CommonReferences=""true"">
+        <ProjectReference>CSAssembly2</ProjectReference>
+        <Document>
+using Destination;
+public class TestClass : BaseClass
+{
+    private int i, j;
+}
+        </Document>
+  </Project>
+  <Project Language=""C#"" AssemblyName=""CSAssembly2"" CommonReferences=""true"">
+        <Document>
+namespace Destination
+{
+    public class BaseClass
+    {
+        private int k = 10;
+    }
+}
+        </Document>
+  </Project>
+</Workspace>";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
@@ -3899,87 +3627,81 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         {
             // Moving member from C# to Visual Basic is not supported currently since the FindMostRelevantDeclarationAsync method in
             // AbstractCodeGenerationService will return null.
-            var input = """
-
-                <Workspace>
-                    <Project Language="C#" AssemblyName="CSAssembly" CommonReferences="true">
-                        <ProjectReference>VBAssembly</ProjectReference>
-                        <Document>
-                            using VBAssembly;
-                            public class TestClass : VBClass
-                            {
-                                public int Bar[||]bar()
-                                {
-                                    return 12345;
-                                }
-                            }
-                        </Document>
-                  </Project>
-                  <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
-                        <Document>
-                            Public Class VBClass
-                            End Class
-                        </Document>
-                  </Project>
-                </Workspace>
-                """;
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
+        <ProjectReference>VBAssembly</ProjectReference>
+        <Document>
+            using VBAssembly;
+            public class TestClass : VBClass
+            {
+                public int Bar[||]bar()
+                {
+                    return 12345;
+                }
+            }
+        </Document>
+  </Project>
+  <Project Language=""Visual Basic"" AssemblyName=""VBAssembly"" CommonReferences=""true"">
+        <Document>
+            Public Class VBClass
+            End Class
+        </Document>
+  </Project>
+</Workspace>";
             await TestQuickActionNotProvidedAsync(input);
         }
 
         [Fact]
         public async Task TestPullMethodUpToVBInterfaceViaQuickAction()
         {
-            var input = """
-
-                <Workspace>
-                    <Project Language="C#" AssemblyName="CSAssembly" CommonReferences="true">
-                    <ProjectReference>VBAssembly</ProjectReference>
-                    <Document>
-                        public class TestClass : VBInterface
-                        {
-                            public int Bar[||]bar()
-                            {
-                                return 12345;
-                            }
-                        }
-                    </Document>
-                  </Project>
-                    <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
-                        <Document>
-                            Public Interface VBInterface
-                            End Interface
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
+    <ProjectReference>VBAssembly</ProjectReference>
+    <Document>
+        public class TestClass : VBInterface
+        {
+            public int Bar[||]bar()
+            {
+                return 12345;
+            }
+        }
+    </Document>
+  </Project>
+    <Project Language=""Visual Basic"" AssemblyName=""VBAssembly"" CommonReferences=""true"">
+        <Document>
+            Public Interface VBInterface
+            End Interface
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestQuickActionNotProvidedAsync(input);
         }
 
         [Fact]
         public async Task TestPullFieldUpToVBClassViaQuickAction()
         {
-            var input = """
-
-                <Workspace>
-                    <Project Language="C#" AssemblyName="CSAssembly" CommonReferences="true">
-                        <ProjectReference>VBAssembly</ProjectReference>
-                        <Document>
-                            using VBAssembly;
-                            public class TestClass : VBClass
-                            {
-                                public int fo[||]obar = 0;
-                            }
-                        </Document>
-                  </Project>
-                    <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
-                    <Document>
-                        Public Class VBClass
-                        End Class
-                    </Document>
-                    </Project>
-                </Workspace>
-                """;
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
+        <ProjectReference>VBAssembly</ProjectReference>
+        <Document>
+            using VBAssembly;
+            public class TestClass : VBClass
+            {
+                public int fo[||]obar = 0;
+            }
+        </Document>
+  </Project>
+    <Project Language=""Visual Basic"" AssemblyName=""VBAssembly"" CommonReferences=""true"">
+    <Document>
+        Public Class VBClass
+        End Class
+    </Document>
+    </Project>
+</Workspace>";
 
             await TestQuickActionNotProvidedAsync(input);
         }
@@ -3987,183 +3709,171 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task TestPullPropertyUpToVBClassViaQuickAction()
         {
-            var input = """
-
-                <Workspace>
-                  <Project Language="C#" AssemblyName="CSAssembly" CommonReferences="true">
-                    <ProjectReference>VBAssembly</ProjectReference>
-                    <Document>
-                using VBAssembly;
-                public class TestClass : VBClass
-                {
-                    public int foo[||]bar
-                    {
-                        get;
-                        set;
-                    }
-                }</Document>
-                  </Project>
-                  <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
-                    <Document>
-                        Public Class VBClass
-                        End Class
-                    </Document>
-                  </Project>
-                </Workspace>
-
-                """;
+            var input = @"
+<Workspace>
+  <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
+    <ProjectReference>VBAssembly</ProjectReference>
+    <Document>
+using VBAssembly;
+public class TestClass : VBClass
+{
+    public int foo[||]bar
+    {
+        get;
+        set;
+    }
+}</Document>
+  </Project>
+  <Project Language=""Visual Basic"" AssemblyName=""VBAssembly"" CommonReferences=""true"">
+    <Document>
+        Public Class VBClass
+        End Class
+    </Document>
+  </Project>
+</Workspace>
+";
             await TestQuickActionNotProvidedAsync(input);
         }
 
         [Fact]
         public async Task TestPullPropertyUpToVBInterfaceViaQuickAction()
         {
-            var input = """
-                <Workspace>
-                    <Project Language="C#" AssemblyName="CSAssembly" CommonReferences="true">
-                        <ProjectReference>VBAssembly</ProjectReference>
-                        <Document>
-                using VBAssembly;
-                public class TestClass : VBInterface
-                        {
-                            public int foo[||]bar
-                            {
-                                get;
-                                set;
-                            }
-                        }
-                        </Document>
-                  </Project>
-                    <Project Language = "Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
-                        <Document>
-                            Public Interface VBInterface
-                            End Interface
-                        </Document>
-                    </Project>
-                </Workspace>
-                """;
+            var input = @"<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
+        <ProjectReference>VBAssembly</ProjectReference>
+        <Document>
+using VBAssembly;
+public class TestClass : VBInterface
+        {
+            public int foo[||]bar
+            {
+                get;
+                set;
+            }
+        }
+        </Document>
+  </Project>
+    <Project Language = ""Visual Basic"" AssemblyName=""VBAssembly"" CommonReferences=""true"">
+        <Document>
+            Public Interface VBInterface
+            End Interface
+        </Document>
+    </Project>
+</Workspace>";
             await TestQuickActionNotProvidedAsync(input);
         }
 
         [Fact]
         public async Task TestPullEventUpToVBClassViaQuickAction()
         {
-            var input = """
-
-                <Workspace>
-                    <Project Language="C#" AssemblyName="CSAssembly" CommonReferences="true">
-                        <ProjectReference>VBAssembly</ProjectReference>
-                            <Document>
-                            using VBAssembly;
-                            public class TestClass : VBClass
-                            {
-                                public event EventHandler BarEve[||]nt;
-                            }
-                            </Document>
-                    </Project>
-                    <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
-                        <Document>
-                            Public Class VBClass
-                            End Class
-                        </Document>
-                    </Project>
-                </Workspace>
-                """;
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
+        <ProjectReference>VBAssembly</ProjectReference>
+            <Document>
+            using VBAssembly;
+            public class TestClass : VBClass
+            {
+                public event EventHandler BarEve[||]nt;
+            }
+            </Document>
+    </Project>
+    <Project Language=""Visual Basic"" AssemblyName=""VBAssembly"" CommonReferences=""true"">
+        <Document>
+            Public Class VBClass
+            End Class
+        </Document>
+    </Project>
+</Workspace>";
             await TestQuickActionNotProvidedAsync(input);
         }
 
         [Fact]
         public async Task TestPullEventUpToVBInterfaceViaQuickAction()
         {
-            var input = """
-
-                <Workspace>
-                    <Project Language="C#" AssemblyName="CSAssembly" CommonReferences="true">
-                    <ProjectReference>VBAssembly</ProjectReference>
-                    <Document>
-                        using VBAssembly;
-                        public class TestClass : VBInterface
-                        {
-                            public event EventHandler BarEve[||]nt;
-                        }
-                    </Document>
-                    </Project>
-                    <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
-                    <Document>
-                        Public Interface VBInterface
-                        End Interface
-                    </Document>
-                    </Project>
-                </Workspace>
-                """;
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""CSAssembly"" CommonReferences=""true"">
+    <ProjectReference>VBAssembly</ProjectReference>
+    <Document>
+        using VBAssembly;
+        public class TestClass : VBInterface
+        {
+            public event EventHandler BarEve[||]nt;
+        }
+    </Document>
+    </Project>
+    <Project Language=""Visual Basic"" AssemblyName=""VBAssembly"" CommonReferences=""true"">
+    <Document>
+        Public Interface VBInterface
+        End Interface
+    </Document>
+    </Project>
+</Workspace>";
             await TestQuickActionNotProvidedAsync(input);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/55746")]
         public async Task TestPullMethodWithToClassWithAddUsingsInsideNamespaceViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace N
+{
+    public class Base
+    {
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace N
-                {
-                    public class Base
-                    {
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
+namespace N
+{
+    public class Derived : Base
+    {
+        public Uri En[||]dpoint()
+        {
+            return new Uri(""http://localhost"");
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace N
+{
+    using System;
 
-                namespace N
-                {
-                    public class Derived : Base
-                    {
-                        public Uri En[||]dpoint()
-                        {
-                            return new Uri("http://localhost");
-                        }
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+    public class Base
+    {
+        public Uri Endpoint()
+        {
+            return new Uri(""http://localhost"");
+        }
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
 
-                """;
-            var expected = """
-
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace N
-                {
-                    using System;
-
-                    public class Base
-                    {
-                        public Uri Endpoint()
-                        {
-                            return new Uri("http://localhost");
-                        }
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-
-                namespace N
-                {
-                    public class Derived : Base
-                    {
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+namespace N
+{
+    public class Derived : Base
+    {
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(
                 testText,
                 expected,
@@ -4173,90 +3883,86 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/55746")]
         public async Task TestPullMethodWithToClassWithAddUsingsSystemUsingsLastViaQuickAction()
         {
-            var testText = """
+            var testText = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">
+namespace N1
+{
+    public class Base
+    {
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
+using N2;
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">
-                namespace N1
-                {
-                    public class Base
-                    {
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-                using N2;
+namespace N1
+{
+    public class Derived : Base
+    {
+        public Goo Ge[||]tGoo()
+        {
+            return new Goo(String.Empty);
+        }
+    }
+}
 
-                namespace N1
-                {
-                    public class Derived : Base
-                    {
-                        public Goo Ge[||]tGoo()
-                        {
-                            return new Goo(String.Empty);
-                        }
-                    }
-                }
+namespace N2
+{
+    public class Goo
+    {
+        public Goo(String s)
+        {
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
+            var expected = @"
+<Workspace>
+    <Project Language = ""C#""  LanguageVersion=""preview"" CommonReferences=""true"">
+        <Document FilePath = ""File1.cs"">using N2;
+using System;
 
-                namespace N2
-                {
-                    public class Goo
-                    {
-                        public Goo(String s)
-                        {
-                        }
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
+namespace N1
+{
+    public class Base
+    {
+        public Goo GetGoo()
+        {
+            return new Goo(String.Empty);
+        }
+    }
+}
+        </Document>
+        <Document FilePath = ""File2.cs"">
+using System;
+using N2;
 
-                """;
-            var expected = """
+namespace N1
+{
+    public class Derived : Base
+    {
+    }
+}
 
-                <Workspace>
-                    <Project Language = "C#"  LanguageVersion="preview" CommonReferences="true">
-                        <Document FilePath = "File1.cs">using N2;
-                using System;
-
-                namespace N1
-                {
-                    public class Base
-                    {
-                        public Goo GetGoo()
-                        {
-                            return new Goo(String.Empty);
-                        }
-                    }
-                }
-                        </Document>
-                        <Document FilePath = "File2.cs">
-                using System;
-                using N2;
-
-                namespace N1
-                {
-                    public class Derived : Base
-                    {
-                    }
-                }
-
-                namespace N2
-                {
-                    public class Goo
-                    {
-                        public Goo(String s)
-                        {
-                        }
-                    }
-                }
-                        </Document>
-                    </Project>
-                </Workspace>
-
-                """;
+namespace N2
+{
+    public class Goo
+    {
+        public Goo(String s)
+        {
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+";
             await TestWithPullMemberDialogAsync(
                 testText,
                 expected,
@@ -4269,274 +3975,242 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullMethodToClassWithDirective()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
+public class Bar : BaseClass
+{
+    #region Hello
+    public void G[||]oo() { }
+    #endregion
+}";
+            var expected = @"
+public class BaseClass
+{
+    public void Goo() { }
+}
 
-                public class Bar : BaseClass
-                {
-                    #region Hello
-                    public void G[||]oo() { }
-                    #endregion
-                }
-                """;
-            var expected = """
+public class Bar : BaseClass
+{
 
-                public class BaseClass
-                {
-                    public void Goo() { }
-                }
-
-                public class Bar : BaseClass
-                {
-
-                    #region Hello
-                    #endregion
-                }
-                """;
+    #region Hello
+    #endregion
+}";
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullMethodToClassBeforeDirective()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
+public class Bar : BaseClass
+{
+    public void H[||]ello() { }
+    #region Hello
+    public void Goo() { }
+    #endregion
+}";
+            var expected = @"
+public class BaseClass
+{
+    public void Hello() { }
+}
 
-                public class Bar : BaseClass
-                {
-                    public void H[||]ello() { }
-                    #region Hello
-                    public void Goo() { }
-                    #endregion
-                }
-                """;
-            var expected = """
-
-                public class BaseClass
-                {
-                    public void Hello() { }
-                }
-
-                public class Bar : BaseClass
-                {
-                    #region Hello
-                    public void Goo() { }
-                    #endregion
-                }
-                """;
+public class Bar : BaseClass
+{
+    #region Hello
+    public void Goo() { }
+    #endregion
+}";
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullMethodToClassBeforeDirective2()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
+public class Bar : BaseClass
+{
+    public void Hello() { }
 
-                public class Bar : BaseClass
-                {
-                    public void Hello() { }
+    #region Hello
+    public void G[||]oo() { }
+    #endregion
+}";
+            var expected = @"
+public class BaseClass
+{
 
-                    #region Hello
-                    public void G[||]oo() { }
-                    #endregion
-                }
-                """;
-            var expected = """
+    public void Goo() { }
+}
 
-                public class BaseClass
-                {
+public class Bar : BaseClass
+{
+    public void Hello() { }
 
-                    public void Goo() { }
-                }
-
-                public class Bar : BaseClass
-                {
-                    public void Hello() { }
-
-                    #region Hello
-                    #endregion
-                }
-                """;
+    #region Hello
+    #endregion
+}";
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullFieldToClassBeforeDirective1()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
+public class Bar : BaseClass
+{
+    public int ba[||]r = 10;
+    #region Hello
+    public int Goo = 10;
+    #endregion
+}";
+            var expected = @"
+public class BaseClass
+{
+    public int bar = 10;
+}
 
-                public class Bar : BaseClass
-                {
-                    public int ba[||]r = 10;
-                    #region Hello
-                    public int Goo = 10;
-                    #endregion
-                }
-                """;
-            var expected = """
-
-                public class BaseClass
-                {
-                    public int bar = 10;
-                }
-
-                public class Bar : BaseClass
-                {
-                    #region Hello
-                    public int Goo = 10;
-                    #endregion
-                }
-                """;
+public class Bar : BaseClass
+{
+    #region Hello
+    public int Goo = 10;
+    #endregion
+}";
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullFieldToClassBeforeDirective2()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
+public class Bar : BaseClass
+{
+    public int bar = 10;
+    #region Hello
+    public int Go[||]o = 10;
+    #endregion
+}";
+            var expected = @"
+public class BaseClass
+{
+    public int Goo = 10;
+}
 
-                public class Bar : BaseClass
-                {
-                    public int bar = 10;
-                    #region Hello
-                    public int Go[||]o = 10;
-                    #endregion
-                }
-                """;
-            var expected = """
+public class Bar : BaseClass
+{
+    public int bar = 10;
 
-                public class BaseClass
-                {
-                    public int Goo = 10;
-                }
-
-                public class Bar : BaseClass
-                {
-                    public int bar = 10;
-
-                    #region Hello
-                    #endregion
-                }
-                """;
+    #region Hello
+    #endregion
+}";
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullFieldToClassBeforeDirective()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
+public class Bar : BaseClass
+{
+    #region Hello
+    public int G[||]oo = 100, Hoo;
+    #endregion
+}";
+            var expected = @"
+public class BaseClass
+{
+    public int Goo = 100;
+}
 
-                public class Bar : BaseClass
-                {
-                    #region Hello
-                    public int G[||]oo = 100, Hoo;
-                    #endregion
-                }
-                """;
-            var expected = """
-
-                public class BaseClass
-                {
-                    public int Goo = 100;
-                }
-
-                public class Bar : BaseClass
-                {
-                    #region Hello
-                    public int Hoo;
-                    #endregion
-                }
-                """;
+public class Bar : BaseClass
+{
+    #region Hello
+    public int Hoo;
+    #endregion
+}";
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullEventToClassBeforeDirective()
         {
-            var text = """
+            var text = @"
+using System;
+public class BaseClass
+{
+}
 
-                using System;
-                public class BaseClass
-                {
-                }
+public class Bar : BaseClass
+{
+    #region Hello
+    public event EventHandler e[||]1;
+    #endregion
+}";
+            var expected = @"
+using System;
+public class BaseClass
+{
+    public event EventHandler e1;
+}
 
-                public class Bar : BaseClass
-                {
-                    #region Hello
-                    public event EventHandler e[||]1;
-                    #endregion
-                }
-                """;
-            var expected = """
+public class Bar : BaseClass
+{
 
-                using System;
-                public class BaseClass
-                {
-                    public event EventHandler e1;
-                }
-
-                public class Bar : BaseClass
-                {
-
-                    #region Hello
-                    #endregion
-                }
-                """;
+    #region Hello
+    #endregion
+}";
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact, WorkItem(55746, "https://github.com/dotnet/roslyn/issues/51531")]
         public Task TestPullPropertyToClassBeforeDirective()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
+public class Bar : BaseClass
+{
+    #region Hello
+    public int Go[||]o => 1;
+    #endregion
+}";
+            var expected = @"
+public class BaseClass
+{
+    public int Goo => 1;
+}
 
-                public class Bar : BaseClass
-                {
-                    #region Hello
-                    public int Go[||]o => 1;
-                    #endregion
-                }
-                """;
-            var expected = """
+public class Bar : BaseClass
+{
 
-                public class BaseClass
-                {
-                    public int Goo => 1;
-                }
-
-                public class Bar : BaseClass
-                {
-
-                    #region Hello
-                    #endregion
-                }
-                """;
+    #region Hello
+    #endregion
+}";
             return TestWithPullMemberDialogAsync(text, expected);
         }
 
@@ -4591,57 +4265,53 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task PullPartialMethodUpToInterfaceViaDialog()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    partial interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    partial interface IInterface
-                    {
-                    }
+    public partial class TestClass : IInterface
+    {
+        partial void Bar[||]Bar()
+    }
 
-                    public partial class TestClass : IInterface
-                    {
-                        partial void Bar[||]Bar()
-                    }
+    public partial class TestClass
+    {
+        partial void BarBar()
+        {}
+    }
 
-                    public partial class TestClass
-                    {
-                        partial void BarBar()
-                        {}
-                    }
+    partial interface IInterface
+    {
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    partial interface IInterface
+    {
+        void BarBar();
+    }
 
-                    partial interface IInterface
-                    {
-                    }
-                }
-                """;
-            var expected = """
+    public partial class TestClass : IInterface
+    {
+        void BarBar()
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    partial interface IInterface
-                    {
-                        void BarBar();
-                    }
+    public partial class TestClass
+    {
+        partial void BarBar()
+        {}
+    }
 
-                    public partial class TestClass : IInterface
-                    {
-                        void BarBar()
-                    }
-
-                    public partial class TestClass
-                    {
-                        partial void BarBar()
-                        {}
-                    }
-
-                    partial interface IInterface
-                    {
-                    }
-                }
-                """;
+    partial interface IInterface
+    {
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -4649,57 +4319,53 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task PullExtendedPartialMethodUpToInterfaceViaDialog()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    partial interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    partial interface IInterface
-                    {
-                    }
+    public partial class TestClass : IInterface
+    {
+        public partial void Bar[||]Bar()
+    }
 
-                    public partial class TestClass : IInterface
-                    {
-                        public partial void Bar[||]Bar()
-                    }
+    public partial class TestClass
+    {
+        public partial void BarBar()
+        {}
+    }
 
-                    public partial class TestClass
-                    {
-                        public partial void BarBar()
-                        {}
-                    }
+    partial interface IInterface
+    {
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    partial interface IInterface
+    {
+        void BarBar();
+    }
 
-                    partial interface IInterface
-                    {
-                    }
-                }
-                """;
-            var expected = """
+    public partial class TestClass : IInterface
+    {
+        public partial void BarBar()
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    partial interface IInterface
-                    {
-                        void BarBar();
-                    }
+    public partial class TestClass
+    {
+        public partial void BarBar()
+        {}
+    }
 
-                    public partial class TestClass : IInterface
-                    {
-                        public partial void BarBar()
-                    }
-
-                    public partial class TestClass
-                    {
-                        public partial void BarBar()
-                        {}
-                    }
-
-                    partial interface IInterface
-                    {
-                    }
-                }
-                """;
+    partial interface IInterface
+    {
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -4707,142 +4373,130 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task PullMultipleNonPublicMethodsToInterfaceViaDialog()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                    }
+    public class TestClass : IInterface
+    {
+        public void TestMethod()
+        {
+            System.Console.WriteLine(""Hello World"");
+        }
 
-                    public class TestClass : IInterface
-                    {
-                        public void TestMethod()
-                        {
-                            System.Console.WriteLine("Hello World");
-                        }
+        protected void F[||]oo(int i)
+        {
+            // do awesome things
+        }
 
-                        protected void F[||]oo(int i)
-                        {
-                            // do awesome things
-                        }
+        private static string Bar(string x)
+        {}
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+        string Bar(string x);
+        void Foo(int i);
+        void TestMethod();
+    }
 
-                        private static string Bar(string x)
-                        {}
-                    }
-                }
-                """;
-            var expected = """
+    public class TestClass : IInterface
+    {
+        public void TestMethod()
+        {
+            System.Console.WriteLine(""Hello World"");
+        }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                        string Bar(string x);
-                        void Foo(int i);
-                        void TestMethod();
-                    }
+        public void Foo(int i)
+        {
+            // do awesome things
+        }
 
-                    public class TestClass : IInterface
-                    {
-                        public void TestMethod()
-                        {
-                            System.Console.WriteLine("Hello World");
-                        }
-
-                        public void Foo(int i)
-                        {
-                            // do awesome things
-                        }
-
-                        public string Bar(string x)
-                        {}
-                    }
-                }
-                """;
+        public string Bar(string x)
+        {}
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task PullMultipleNonPublicEventsToInterface()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                    }
+    public class TestClass : IInterface
+    {
+        private event EventHandler Event1, Eve[||]nt2, Event3;
+    }
+}";
 
-                    public class TestClass : IInterface
-                    {
-                        private event EventHandler Event1, Eve[||]nt2, Event3;
-                    }
-                }
-                """;
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+        event EventHandler Event1;
+        event EventHandler Event2;
+        event EventHandler Event3;
+    }
 
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                        event EventHandler Event1;
-                        event EventHandler Event2;
-                        event EventHandler Event3;
-                    }
-
-                    public class TestClass : IInterface
-                    {
-                        public event EventHandler Event1;
-                        public event EventHandler Event2;
-                        public event EventHandler Event3;
-                    }
-                }
-                """;
+    public class TestClass : IInterface
+    {
+        public event EventHandler Event1;
+        public event EventHandler Event2;
+        public event EventHandler Event3;
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task PullMethodToInnerInterfaceViaDialog()
         {
-            var testText = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public class TestClass : TestClass.IInterface
-                    {
-                        private void Bar[||]Bar()
-                        {
-                        }
-                        interface IInterface
-                        {
-                        }
-                    }
-                }
-                """;
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public class TestClass : TestClass.IInterface
-                    {
-                        public void BarBar()
-                        {
-                        }
-                        interface IInterface
-                        {
-                            void BarBar();
-                        }
-                    }
-                }
-                """;
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public class TestClass : TestClass.IInterface
+    {
+        private void Bar[||]Bar()
+        {
+        }
+        interface IInterface
+        {
+        }
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public class TestClass : TestClass.IInterface
+    {
+        public void BarBar()
+        {
+        }
+        interface IInterface
+        {
+            void BarBar();
+        }
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -4850,308 +4504,280 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task PullDifferentMembersFromClassToPartialInterfaceViaDialog()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    partial interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    partial interface IInterface
-                    {
-                    }
+    public class TestClass : IInterface
+    {
+        public int th[||]is[int i]
+        {
+            get => j = value;
+        }
 
-                    public class TestClass : IInterface
-                    {
-                        public int th[||]is[int i]
-                        {
-                            get => j = value;
-                        }
+        private static void BarBar()
+        {}
+        
+        protected static event EventHandler event1, event2;
 
-                        private static void BarBar()
-                        {}
-                        
-                        protected static event EventHandler event1, event2;
+        internal static int Foo
+        {
+            get; set;
+        }
+    }
+    partial interface IInterface
+    {
+    }
+}";
 
-                        internal static int Foo
-                        {
-                            get; set;
-                        }
-                    }
-                    partial interface IInterface
-                    {
-                    }
-                }
-                """;
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    partial interface IInterface
+    {
+        int this[int i] { get; }
 
-            var expected = """
+        int Foo { get; set; }
 
-                using System;
-                namespace PushUpTest
-                {
-                    partial interface IInterface
-                    {
-                        int this[int i] { get; }
+        event EventHandler event1;
+        event EventHandler event2;
 
-                        int Foo { get; set; }
+        void BarBar();
+    }
 
-                        event EventHandler event1;
-                        event EventHandler event2;
+    public class TestClass : IInterface
+    {
+        public int this[int i]
+        {
+            get => j = value;
+        }
 
-                        void BarBar();
-                    }
+        public void BarBar()
+        {}
 
-                    public class TestClass : IInterface
-                    {
-                        public int this[int i]
-                        {
-                            get => j = value;
-                        }
+        public event EventHandler event1;
+        public event EventHandler event2;
 
-                        public void BarBar()
-                        {}
-
-                        public event EventHandler event1;
-                        public event EventHandler event2;
-
-                        public int Foo
-                        {
-                            get; set;
-                        }
-                    }
-                    partial interface IInterface
-                    {
-                    }
-                }
-                """;
+        public int Foo
+        {
+            get; set;
+        }
+    }
+    partial interface IInterface
+    {
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected, index: 1);
         }
 
         [Fact]
         public async Task TestPullAsyncMethod()
         {
-            var testText = """
+            var testText = @"
+using System.Threading.Tasks;
 
-                using System.Threading.Tasks;
+internal interface IPullUp { }
 
-                internal interface IPullUp { }
+internal class PullUp : IPullUp
+{
+    internal async Task PullU[||]pAsync()
+    {
+        await Task.Delay(1000);
+    }
+}";
+            var expectedText = @"
+using System.Threading.Tasks;
 
-                internal class PullUp : IPullUp
-                {
-                    internal async Task PullU[||]pAsync()
-                    {
-                        await Task.Delay(1000);
-                    }
-                }
-                """;
-            var expectedText = """
+internal interface IPullUp
+{
+    Task PullUpAsync();
+}
 
-                using System.Threading.Tasks;
-
-                internal interface IPullUp
-                {
-                    Task PullUpAsync();
-                }
-
-                internal class PullUp : IPullUp
-                {
-                    public async Task PullUpAsync()
-                    {
-                        await Task.Delay(1000);
-                    }
-                }
-                """;
+internal class PullUp : IPullUp
+{
+    public async Task PullUpAsync()
+    {
+        await Task.Delay(1000);
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expectedText);
         }
 
         [Fact]
         public async Task PullMethodWithAbstractOptionToClassViaDialog()
         {
-            var testText = """
+            var testText = @"
+namespace PushUpTest
+{
+    public class Base
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                    }
+    public class TestClass : Base
+    {
+        public void TestMeth[||]od()
+        {
+            System.Console.WriteLine(""Hello World"");
+        }
+    }
+}";
 
-                    public class TestClass : Base
-                    {
-                        public void TestMeth[||]od()
-                        {
-                            System.Console.WriteLine("Hello World");
-                        }
-                    }
-                }
-                """;
+            var expected = @"
+namespace PushUpTest
+{
+    public abstract class Base
+    {
+        public abstract void TestMethod();
+    }
 
-            var expected = """
-
-                namespace PushUpTest
-                {
-                    public abstract class Base
-                    {
-                        public abstract void TestMethod();
-                    }
-
-                    public class TestClass : Base
-                    {
-                        public override void TestMeth[||]od()
-                        {
-                            System.Console.WriteLine("Hello World");
-                        }
-                    }
-                }
-                """;
+    public class TestClass : Base
+    {
+        public override void TestMeth[||]od()
+        {
+            System.Console.WriteLine(""Hello World"");
+        }
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("TestMethod", true) }, index: 1);
         }
 
         [Fact]
         public async Task PullAbstractMethodToClassViaDialog()
         {
-            var testText = """
+            var testText = @"
+namespace PushUpTest
+{
+    public class Base
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public class Base
-                    {
-                    }
+    public abstract class TestClass : Base
+    {
+        public abstract void TestMeth[||]od();
+    }
+}";
 
-                    public abstract class TestClass : Base
-                    {
-                        public abstract void TestMeth[||]od();
-                    }
-                }
-                """;
+            var expected = @"
+namespace PushUpTest
+{
+    public abstract class Base
+    {
+        public abstract void TestMethod();
+    }
 
-            var expected = """
-
-                namespace PushUpTest
-                {
-                    public abstract class Base
-                    {
-                        public abstract void TestMethod();
-                    }
-
-                    public abstract class TestClass : Base
-                    {
-                    }
-                }
-                """;
+    public abstract class TestClass : Base
+    {
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("TestMethod", true) }, index: 0);
         }
 
         [Fact]
         public async Task PullMultipleEventsToClassViaDialog()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public class Base2
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    public class Base2
-                    {
-                    }
+    public class Testclass2 : Base2
+    {
+        private static event EventHandler Event1, Eve[||]nt3, Event4;
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public class Base2
+    {
+        private static event EventHandler Event1;
+        private static event EventHandler Event3;
+        private static event EventHandler Event4;
+    }
 
-                    public class Testclass2 : Base2
-                    {
-                        private static event EventHandler Event1, Eve[||]nt3, Event4;
-                    }
-                }
-                """;
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public class Base2
-                    {
-                        private static event EventHandler Event1;
-                        private static event EventHandler Event3;
-                        private static event EventHandler Event4;
-                    }
-
-                    public class Testclass2 : Base2
-                    {
-                    }
-                }
-                """;
+    public class Testclass2 : Base2
+    {
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected, index: 1);
         }
 
         [Fact]
         public async Task PullMultipleAbstractEventsToInterfaceViaDialog()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public interface ITest 
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    public interface ITest 
-                    {
-                    }
+    public abstract class Testclass2 : ITest
+    {
+        protected abstract event EventHandler Event1, Eve[||]nt3, Event4;
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public interface ITest
+    {
+        event EventHandler Event1;
+        event EventHandler Event3;
+        event EventHandler Event4;
+    }
 
-                    public abstract class Testclass2 : ITest
-                    {
-                        protected abstract event EventHandler Event1, Eve[||]nt3, Event4;
-                    }
-                }
-                """;
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public interface ITest
-                    {
-                        event EventHandler Event1;
-                        event EventHandler Event3;
-                        event EventHandler Event4;
-                    }
-
-                    public abstract class Testclass2 : ITest
-                    {
-                        public abstract event EventHandler Event1;
-                        public abstract event EventHandler Event3;
-                        public abstract event EventHandler Event4;
-                    }
-                }
-                """;
+    public abstract class Testclass2 : ITest
+    {
+        public abstract event EventHandler Event1;
+        public abstract event EventHandler Event3;
+        public abstract event EventHandler Event4;
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected);
         }
 
         [Fact]
         public async Task PullAbstractEventToClassViaDialog()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public class Base2
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    public class Base2
-                    {
-                    }
+    public abstract class Testclass2 : Base2
+    {
+        private static abstract event EventHandler Event1, Eve[||]nt3, Event4;
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public class Base2
+    {
+        private static event EventHandler Event3;
+    }
 
-                    public abstract class Testclass2 : Base2
-                    {
-                        private static abstract event EventHandler Event1, Eve[||]nt3, Event4;
-                    }
-                }
-                """;
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public class Base2
-                    {
-                        private static event EventHandler Event3;
-                    }
-
-                    public abstract class Testclass2 : Base2
-                    {
-                        private static abstract event EventHandler Event1, Event4;
-                    }
-                }
-                """;
+    public abstract class Testclass2 : Base2
+    {
+        private static abstract event EventHandler Event1, Event4;
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("Event3", false) });
         }
@@ -5159,37 +4785,33 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task PullNonPublicEventToInterfaceViaDialog()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public interface ITest
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    public interface ITest
-                    {
-                    }
+    public class Testclass2 : ITest
+    {
+        private event EventHandler Eve[||]nt3;
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public interface ITest
+    {
+        event EventHandler Event3;
+    }
 
-                    public class Testclass2 : ITest
-                    {
-                        private event EventHandler Eve[||]nt3;
-                    }
-                }
-                """;
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public interface ITest
-                    {
-                        event EventHandler Event3;
-                    }
-
-                    public class Testclass2 : ITest
-                    {
-                        public event EventHandler Event3;
-                    }
-                }
-                """;
+    public class Testclass2 : ITest
+    {
+        public event EventHandler Event3;
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("Event3", false) });
         }
@@ -5197,37 +4819,33 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task PullSingleNonPublicEventToInterfaceViaDialog()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public interface ITest
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    public interface ITest
-                    {
-                    }
+    public abstract class TestClass2 : ITest
+    {
+        protected event EventHandler Eve[||]nt3;
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public interface ITest
+    {
+        event EventHandler Event3;
+    }
 
-                    public abstract class TestClass2 : ITest
-                    {
-                        protected event EventHandler Eve[||]nt3;
-                    }
-                }
-                """;
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public interface ITest
-                    {
-                        event EventHandler Event3;
-                    }
-
-                    public abstract class TestClass2 : ITest
-                    {
-                        public event EventHandler Event3;
-                    }
-                }
-                """;
+    public abstract class TestClass2 : ITest
+    {
+        public event EventHandler Event3;
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("Event3", false) });
         }
@@ -5235,58 +4853,54 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task TestPullNonPublicEventWithAddAndRemoveMethodToInterfaceViaDialog()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                    }
+    public class TestClass : IInterface
+    {
+        private event EventHandler Eve[||]nt1
+        {
+            add
+            {
+                System.Console.Writeline(""This is add"");
+            }
+            remove
+            {
+                System.Console.Writeline(""This is remove"");
+            }
+        }
+    }
+}";
 
-                    public class TestClass : IInterface
-                    {
-                        private event EventHandler Eve[||]nt1
-                        {
-                            add
-                            {
-                                System.Console.Writeline("This is add");
-                            }
-                            remove
-                            {
-                                System.Console.Writeline("This is remove");
-                            }
-                        }
-                    }
-                }
-                """;
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    interface IInterface
+    {
+        event EventHandler Event1;
+    }
 
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    interface IInterface
-                    {
-                        event EventHandler Event1;
-                    }
-
-                    public class TestClass : IInterface
-                    {
-                        public event EventHandler Event1
-                        {
-                            add
-                            {
-                                System.Console.Writeline("This is add");
-                            }
-                            remove
-                            {
-                                System.Console.Writeline("This is remove");
-                            }
-                        }
-                    }
-                }
-                """;
+    public class TestClass : IInterface
+    {
+        public event EventHandler Event1
+        {
+            add
+            {
+                System.Console.Writeline(""This is add"");
+            }
+            remove
+            {
+                System.Console.Writeline(""This is remove"");
+            }
+        }
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("Event1", false) });
         }
@@ -5294,38 +4908,34 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task PullFieldsToClassViaDialog()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public class Base2
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    public class Base2
-                    {
-                    }
+    public class Testclass2 : Base2
+    {
+        public int i, [||]j = 10, k = 100;
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public class Base2
+    {
+        public int i;
+        public int j = 10;
+        public int k = 100;
+    }
 
-                    public class Testclass2 : Base2
-                    {
-                        public int i, [||]j = 10, k = 100;
-                    }
-                }
-                """;
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public class Base2
-                    {
-                        public int i;
-                        public int j = 10;
-                        public int k = 100;
-                    }
-
-                    public class Testclass2 : Base2
-                    {
-                    }
-                }
-                """;
+    public class Testclass2 : Base2
+    {
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected, index: 1);
         }
@@ -5333,37 +4943,33 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task PullNonPublicPropertyWithArrowToInterfaceViaDialog()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public interface ITest
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    public interface ITest
-                    {
-                    }
+    public class Testclass2 : ITest
+    {
+        private double Test[||]Property => 2.717;
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public interface ITest
+    {
+        double TestProperty { get; }
+    }
 
-                    public class Testclass2 : ITest
-                    {
-                        private double Test[||]Property => 2.717;
-                    }
-                }
-                """;
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public interface ITest
-                    {
-                        double TestProperty { get; }
-                    }
-
-                    public class Testclass2 : ITest
-                    {
-                        public readonly double TestProperty => 2.717;
-                    }
-                }
-                """;
+    public class Testclass2 : ITest
+    {
+        public readonly double TestProperty => 2.717;
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5371,45 +4977,41 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task PullNonPublicPropertyToInterfaceViaDialog()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public interface ITest
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    public interface ITest
-                    {
-                    }
+    public class Testclass2 : ITest
+    {
+        private double Test[||]Property
+        {
+            get;
+            set;
+        }
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public interface ITest
+    {
+        double TestProperty { get; set; }
+    }
 
-                    public class Testclass2 : ITest
-                    {
-                        private double Test[||]Property
-                        {
-                            get;
-                            set;
-                        }
-                    }
-                }
-                """;
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public interface ITest
-                    {
-                        double TestProperty { get; set; }
-                    }
-
-                    public class Testclass2 : ITest
-                    {
-                        public double TestProperty
-                        {
-                            get;
-                            set;
-                        }
-                    }
-                }
-                """;
+    public class Testclass2 : ITest
+    {
+        public double TestProperty
+        {
+            get;
+            set;
+        }
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5417,43 +5019,39 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task PullNonPublicPropertyWithSingleAccessorToInterfaceViaDialog()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public interface ITest
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    public interface ITest
-                    {
-                    }
+    public class Testclass2 : ITest
+    {
+        private static double Test[||]Property
+        {
+            set;
+        }
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public interface ITest
+    {
+        double TestProperty { set; }
+    }
 
-                    public class Testclass2 : ITest
-                    {
-                        private static double Test[||]Property
-                        {
-                            set;
-                        }
-                    }
-                }
-                """;
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public interface ITest
-                    {
-                        double TestProperty { set; }
-                    }
-
-                    public class Testclass2 : ITest
-                    {
-                        public double Test[||]Property
-                        {
-                            set;
-                        }
-                    }
-                }
-                """;
+    public class Testclass2 : ITest
+    {
+        public double Test[||]Property
+        {
+            set;
+        }
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5461,124 +5059,112 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact, WorkItem(34268, "https://github.com/dotnet/roslyn/issues/34268")]
         public async Task TestPullPropertyToAbstractClassViaDialogWithMakeAbstractOption()
         {
-            var testText = """
+            var testText = @"
+abstract class B
+{
+}
 
-                abstract class B
-                {
-                }
+class D : B
+{
+    int [||]X => 7;
+}";
+            var expected = @"
+abstract class B
+{
+    private abstract int X { get; }
+}
 
-                class D : B
-                {
-                    int [||]X => 7;
-                }
-                """;
-            var expected = """
-
-                abstract class B
-                {
-                    private abstract int X { get; }
-                }
-
-                class D : B
-                {
-                    override int X => 7;
-                }
-                """;
+class D : B
+{
+    override int X => 7;
+}";
             await TestWithPullMemberDialogAsync(testText, expected, selection: new[] { ("X", true) }, index: 1);
         }
 
         [Fact]
         public async Task PullEventUpToAbstractClassViaDialogWithMakeAbstractOption()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public class Base2
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    public class Base2
-                    {
-                    }
+    public class Testclass2 : Base2
+    {
+        private event EventHandler Event1, Eve[||]nt3, Event4;
+    }
+}";
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public abstract class Base2
+    {
+        private abstract event EventHandler Event3;
+    }
 
-                    public class Testclass2 : Base2
-                    {
-                        private event EventHandler Event1, Eve[||]nt3, Event4;
-                    }
-                }
-                """;
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public abstract class Base2
-                    {
-                        private abstract event EventHandler Event3;
-                    }
-
-                    public class Testclass2 : Base2
-                    {
-                        private event EventHandler Event1, Eve[||]nt3, Event4;
-                    }
-                }
-                """;
+    public class Testclass2 : Base2
+    {
+        private event EventHandler Event1, Eve[||]nt3, Event4;
+    }
+}";
             await TestWithPullMemberDialogAsync(testText, expected, selection: new[] { ("Event3", true) }, index: 1);
         }
 
         [Fact]
         public async Task TestPullEventWithAddAndRemoveMethodToClassViaDialogWithMakeAbstractOption()
         {
-            var testText = """
+            var testText = @"
+using System;
+namespace PushUpTest
+{
+    public class BaseClass
+    {
+    }
 
-                using System;
-                namespace PushUpTest
-                {
-                    public class BaseClass
-                    {
-                    }
+    public class TestClass : BaseClass
+    {
+        public event EventHandler Eve[||]nt1
+        {
+            add
+            {
+                System.Console.Writeline(""This is add"");
+            }
+            remove
+            {
+                System.Console.Writeline(""This is remove"");
+            }
+        }
+    }
+}";
 
-                    public class TestClass : BaseClass
-                    {
-                        public event EventHandler Eve[||]nt1
-                        {
-                            add
-                            {
-                                System.Console.Writeline("This is add");
-                            }
-                            remove
-                            {
-                                System.Console.Writeline("This is remove");
-                            }
-                        }
-                    }
-                }
-                """;
+            var expected = @"
+using System;
+namespace PushUpTest
+{
+    public abstract class BaseClass
+    {
+        public abstract event EventHandler Event1;
+    }
 
-            var expected = """
-
-                using System;
-                namespace PushUpTest
-                {
-                    public abstract class BaseClass
-                    {
-                        public abstract event EventHandler Event1;
-                    }
-
-                    public class TestClass : BaseClass
-                    {
-                        public override event EventHandler Event1
-                        {
-                            add
-                            {
-                                System.Console.Writeline("This is add");
-                            }
-                            remove
-                            {
-                                System.Console.Writeline("This is remove");
-                            }
-                        }
-                    }
-                }
-                """;
+    public class TestClass : BaseClass
+    {
+        public override event EventHandler Event1
+        {
+            add
+            {
+                System.Console.Writeline(""This is add"");
+            }
+            remove
+            {
+                System.Console.Writeline(""This is remove"");
+            }
+        }
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected, new (string, bool)[] { ("Event1", true) }, index: 1);
         }
@@ -5589,50 +5175,46 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestArgsIsPartOfHeader()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    class Test2Attribute : Attribute { }
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    class Test2Attribute : Attribute { }
-                    public class A
-                    {
-                    }
+    public class B : A
+    {
+        [Test]
+        [Test2]
+        void C([||])
+        {
+        }
+    }
+}";
+            var expected = @"
+using System;
 
-                    public class B : A
-                    {
-                        [Test]
-                        [Test2]
-                        void C([||])
-                        {
-                        }
-                    }
-                }
-                """;
-            var expected = """
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    class Test2Attribute : Attribute { }
+    public class A
+    {
+        [Test]
+        [Test2]
+        void C()
+        {
+        }
+    }
 
-                using System;
-
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    class Test2Attribute : Attribute { }
-                    public class A
-                    {
-                        [Test]
-                        [Test2]
-                        void C()
-                        {
-                        }
-                    }
-
-                    public class B : A
-                    {
-                    }
-                }
-                """;
+    public class B : A
+    {
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5640,50 +5222,46 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringCaretBeforeAttributes()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    class Test2Attribute : Attribute { }
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    class Test2Attribute : Attribute { }
-                    public class A
-                    {
-                    }
+    public class B : A
+    {
+        [||][Test]
+        [Test2]
+        void C()
+        {
+        }
+    }
+}";
+            var expected = @"
+using System;
 
-                    public class B : A
-                    {
-                        [||][Test]
-                        [Test2]
-                        void C()
-                        {
-                        }
-                    }
-                }
-                """;
-            var expected = """
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    class Test2Attribute : Attribute { }
+    public class A
+    {
+        [Test]
+        [Test2]
+        void C()
+        {
+        }
+    }
 
-                using System;
-
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    class Test2Attribute : Attribute { }
-                    public class A
-                    {
-                        [Test]
-                        [Test2]
-                        void C()
-                        {
-                        }
-                    }
-
-                    public class B : A
-                    {
-                    }
-                }
-                """;
+    public class B : A
+    {
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5691,74 +5269,68 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestMissingRefactoringCaretBetweenAttributes()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    class Test2Attribute : Attribute { }
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    class Test2Attribute : Attribute { }
-                    public class A
-                    {
-                    }
-
-                    public class B : A
-                    {
-                        [Test]
-                        [||][Test2]
-                        void C()
-                        {
-                        }
-                    }
-                }
-                """;
+    public class B : A
+    {
+        [Test]
+        [||][Test2]
+        void C()
+        {
+        }
+    }
+}";
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringSelectionWithAttributes1()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    public class A
-                    {
-                    }
+    public class B : A
+    {
+        [Test]
+        [|void C()
+        {
+        }|]
+    }
+}";
+            var expected = @"
+using System;
 
-                    public class B : A
-                    {
-                        [Test]
-                        [|void C()
-                        {
-                        }|]
-                    }
-                }
-                """;
-            var expected = """
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    public class A
+    {
+        [Test]
+        void C()
+        {
+        }
+    }
 
-                using System;
-
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    public class A
-                    {
-                        [Test]
-                        void C()
-                        {
-                        }
-                    }
-
-                    public class B : A
-                    {
-                    }
-                }
-                """;
+    public class B : A
+    {
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5766,46 +5338,42 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringSelectionWithAttributes2()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    public class A
-                    {
-                    }
+    public class B : A
+    {
+        [|[Test]
+        void C()
+        {
+        }|]
+    }
+}";
+            var expected = @"
+using System;
 
-                    public class B : A
-                    {
-                        [|[Test]
-                        void C()
-                        {
-                        }|]
-                    }
-                }
-                """;
-            var expected = """
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    public class A
+    {
+        [Test]
+        void C()
+        {
+        }
+    }
 
-                using System;
-
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    public class A
-                    {
-                        [Test]
-                        void C()
-                        {
-                        }
-                    }
-
-                    public class B : A
-                    {
-                    }
-                }
-                """;
+    public class B : A
+    {
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5813,47 +5381,43 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringSelectionWithAttributes3()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    public class A
-                    {
-                    }
+    public class B : A
+    {
+        [Test][|
+        void C()
+        {
+        }
+        |]
+    }
+}";
+            var expected = @"
+using System;
 
-                    public class B : A
-                    {
-                        [Test][|
-                        void C()
-                        {
-                        }
-                        |]
-                    }
-                }
-                """;
-            var expected = """
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    public class A
+    {
+        [Test]
+        void C()
+        {
+        }
+    }
 
-                using System;
-
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    public class A
-                    {
-                        [Test]
-                        void C()
-                        {
-                        }
-                    }
-
-                    public class B : A
-                    {
-                    }
-                }
-                """;
+    public class B : A
+    {
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -5861,210 +5425,194 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestMissingRefactoringInAttributeList()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    public class A
-                    {
-                    }
-
-                    public class B : A
-                    {
-                        [[||]Test]
-                        void C()
-                        {
-                        }
-                    }
-                }
-                """;
+    public class B : A
+    {
+        [[||]Test]
+        void C()
+        {
+        }
+    }
+}";
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestMissingRefactoringSelectionAttributeList()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    class Test2Attribute : Attribute { }
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    class Test2Attribute : Attribute { }
-                    public class A
-                    {
-                    }
-
-                    public class B : A
-                    {
-                        [|[Test]
-                        [Test2]|]
-                        void C()
-                        {
-                        }
-                    }
-                }
-                """;
+    public class B : A
+    {
+        [|[Test]
+        [Test2]|]
+        void C()
+        {
+        }
+    }
+}";
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestMissingRefactoringCaretInAttributeList()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    class Test2Attribute : Attribute { }
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    class Test2Attribute : Attribute { }
-                    public class A
-                    {
-                    }
-
-                    public class B : A
-                    {
-                        [[||]Test]
-                        [Test2]
-                        void C()
-                        {
-                        }
-                    }
-                }
-                """;
+    public class B : A
+    {
+        [[||]Test]
+        [Test2]
+        void C()
+        {
+        }
+    }
+}";
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestMissingRefactoringCaretBetweenAttributeLists()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    class Test2Attribute : Attribute { }
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    class Test2Attribute : Attribute { }
-                    public class A
-                    {
-                    }
-
-                    public class B : A
-                    {
-                        [Test]
-                        [||][Test2]
-                        void C()
-                        {
-                        }
-                    }
-                }
-                """;
+    public class B : A
+    {
+        [Test]
+        [||][Test2]
+        void C()
+        {
+        }
+    }
+}";
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestMissingRefactoringSelectionAttributeList2()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    class Test2Attribute : Attribute { }
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    class Test2Attribute : Attribute { }
-                    public class A
-                    {
-                    }
-
-                    public class B : A
-                    {
-                        [|[Test]|]
-                        [Test2]
-                        void C()
-                        {
-                        }
-                    }
-                }
-                """;
+    public class B : A
+    {
+        [|[Test]|]
+        [Test2]
+        void C()
+        {
+        }
+    }
+}";
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestMissingRefactoringSelectAttributeList()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    public class A
-                    {
-                    }
-
-                    public class B : A
-                    {
-                        [|[Test]|]
-                        void C()
-                        {
-                        }
-                    }
-                }
-                """;
+    public class B : A
+    {
+        [|[Test]|]
+        void C()
+        {
+        }
+    }
+}";
             await TestQuickActionNotProvidedAsync(testText);
         }
 
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringCaretLocAfterAttributes1()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    public class A
-                    {
-                    }
+    public class B : A
+    {
+        [Test]
+        [||]void C()
+        {
+        }
+    }
+}";
+            var expected = @"
+using System;
 
-                    public class B : A
-                    {
-                        [Test]
-                        [||]void C()
-                        {
-                        }
-                    }
-                }
-                """;
-            var expected = """
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    public class A
+    {
+        [Test]
+        void C()
+        {
+        }
+    }
 
-                using System;
-
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    public class A
-                    {
-                        [Test]
-                        void C()
-                        {
-                        }
-                    }
-
-                    public class B : A
-                    {
-                    }
-                }
-                """;
+    public class B : A
+    {
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -6072,54 +5620,50 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringCaretLocAfterAttributes2()
         {
-            var testText = """
+            var testText = @"
+using System;
 
-                using System;
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    class Test2Attribute : Attribute { }
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    class Test2Attribute : Attribute { }
-                    public class A
-                    {
-                    }
+    public class B : A
+    {
+        [Test]
+        // Comment1
+        [Test2]
+        // Comment2
+        [||]void C()
+        {
+        }
+    }
+}";
+            var expected = @"
+using System;
 
-                    public class B : A
-                    {
-                        [Test]
-                        // Comment1
-                        [Test2]
-                        // Comment2
-                        [||]void C()
-                        {
-                        }
-                    }
-                }
-                """;
-            var expected = """
+namespace PushUpTest
+{
+    class TestAttribute : Attribute { }
+    class Test2Attribute : Attribute { }
+    public class A
+    {
+        [Test]
+        // Comment1
+        [Test2]
+        // Comment2
+        void C()
+        {
+        }
+    }
 
-                using System;
-
-                namespace PushUpTest
-                {
-                    class TestAttribute : Attribute { }
-                    class Test2Attribute : Attribute { }
-                    public class A
-                    {
-                        [Test]
-                        // Comment1
-                        [Test2]
-                        // Comment2
-                        void C()
-                        {
-                        }
-                    }
-
-                    public class B : A
-                    {
-                    }
-                }
-                """;
+    public class B : A
+    {
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -6127,38 +5671,34 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringCaretLoc1()
         {
-            var testText = """
+            var testText = @"
+namespace PushUpTest
+{
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public class A
-                    {
-                    }
+    public class B : A
+    {
+        [||]void C()
+        {
+        }
+    }
+}";
+            var expected = @"
+namespace PushUpTest
+{
+    public class A
+    {
+        void C()
+        {
+        }
+    }
 
-                    public class B : A
-                    {
-                        [||]void C()
-                        {
-                        }
-                    }
-                }
-                """;
-            var expected = """
-
-                namespace PushUpTest
-                {
-                    public class A
-                    {
-                        void C()
-                        {
-                        }
-                    }
-
-                    public class B : A
-                    {
-                    }
-                }
-                """;
+    public class B : A
+    {
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -6166,38 +5706,34 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringSelection()
         {
-            var testText = """
+            var testText = @"
+namespace PushUpTest
+{
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public class A
-                    {
-                    }
+    public class B : A
+    {
+        [|void C()
+        {
+        }|]
+    }
+}";
+            var expected = @"
+namespace PushUpTest
+{
+    public class A
+    {
+        void C()
+        {
+        }
+    }
 
-                    public class B : A
-                    {
-                        [|void C()
-                        {
-                        }|]
-                    }
-                }
-                """;
-            var expected = """
-
-                namespace PushUpTest
-                {
-                    public class A
-                    {
-                        void C()
-                        {
-                        }
-                    }
-
-                    public class B : A
-                    {
-                    }
-                }
-                """;
+    public class B : A
+    {
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -6205,40 +5741,36 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringSelectionComments()
         {
-            var testText = """
+            var testText = @"
+namespace PushUpTest
+{
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public class A
-                    {
-                    }
+    public class B : A
+    {  [|
+        // Comment1
+        void C()
+        {
+        }|]
+    }
+}";
+            var expected = @"
+namespace PushUpTest
+{
+    public class A
+    {
+        // Comment1
+        void C()
+        {
+        }
+    }
 
-                    public class B : A
-                    {  [|
-                        // Comment1
-                        void C()
-                        {
-                        }|]
-                    }
-                }
-                """;
-            var expected = """
-
-                namespace PushUpTest
-                {
-                    public class A
-                    {
-                        // Comment1
-                        void C()
-                        {
-                        }
-                    }
-
-                    public class B : A
-                    {
-                    }
-                }
-                """;
+    public class B : A
+    {
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -6246,44 +5778,40 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringSelectionComments2()
         {
-            var testText = """
+            var testText = @"
+namespace PushUpTest
+{
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public class A
-                    {
-                    }
+    public class B : A
+    {  
+        [|/// <summary>
+        /// Test
+        /// </summary>
+        void C()
+        {
+        }|]
+    }
+}";
+            var expected = @"
+namespace PushUpTest
+{
+    public class A
+    {
+        /// <summary>
+        /// Test
+        /// </summary>
+        void C()
+        {
+        }
+    }
 
-                    public class B : A
-                    {  
-                        [|/// <summary>
-                        /// Test
-                        /// </summary>
-                        void C()
-                        {
-                        }|]
-                    }
-                }
-                """;
-            var expected = """
-
-                namespace PushUpTest
-                {
-                    public class A
-                    {
-                        /// <summary>
-                        /// Test
-                        /// </summary>
-                        void C()
-                        {
-                        }
-                    }
-
-                    public class B : A
-                    {
-                    }
-                }
-                """;
+    public class B : A
+    {
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -6291,44 +5819,40 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact, WorkItem(35180, "https://github.com/dotnet/roslyn/issues/35180")]
         public async Task TestRefactoringSelectionComments3()
         {
-            var testText = """
+            var testText = @"
+namespace PushUpTest
+{
+    public class A
+    {
+    }
 
-                namespace PushUpTest
-                {
-                    public class A
-                    {
-                    }
+    public class B : A
+    {  
+        /// <summary>
+        [|/// Test
+        /// </summary>
+        void C()
+        {
+        }|]
+    }
+}";
+            var expected = @"
+namespace PushUpTest
+{
+    public class A
+    {
+        /// <summary>
+        /// Test
+        /// </summary>
+        void C()
+        {
+        }
+    }
 
-                    public class B : A
-                    {  
-                        /// <summary>
-                        [|/// Test
-                        /// </summary>
-                        void C()
-                        {
-                        }|]
-                    }
-                }
-                """;
-            var expected = """
-
-                namespace PushUpTest
-                {
-                    public class A
-                    {
-                        /// <summary>
-                        /// Test
-                        /// </summary>
-                        void C()
-                        {
-                        }
-                    }
-
-                    public class B : A
-                    {
-                    }
-                }
-                """;
+    public class B : A
+    {
+    }
+}";
 
             await TestWithPullMemberDialogAsync(testText, expected);
         }
@@ -6336,227 +5860,197 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task TestRefactoringSelectionFieldKeyword1_NoAction()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
-
-                public class Bar : BaseClass
-                {
-                    pub[|l|]ic int Goo = 10;
-                }
-                """;
+public class Bar : BaseClass
+{
+    pub[|l|]ic int Goo = 10;
+}";
             await TestQuickActionNotProvidedAsync(text);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionFieldKeyword2()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
+public class Bar : BaseClass
+{
+    pub[||]lic int Goo = 10;
+}";
+            var expected = @"
+public class BaseClass
+{
+    public int Goo = 10;
+}
 
-                public class Bar : BaseClass
-                {
-                    pub[||]lic int Goo = 10;
-                }
-                """;
-            var expected = """
-
-                public class BaseClass
-                {
-                    public int Goo = 10;
-                }
-
-                public class Bar : BaseClass
-                {
-                }
-                """;
+public class Bar : BaseClass
+{
+}";
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionFieldAfterSemicolon()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
+public class Bar : BaseClass
+{
+    public int Goo = 10;[||]
+}";
+            var expected = @"
+public class BaseClass
+{
+    public int Goo = 10;
+}
 
-                public class Bar : BaseClass
-                {
-                    public int Goo = 10;[||]
-                }
-                """;
-            var expected = """
-
-                public class BaseClass
-                {
-                    public int Goo = 10;
-                }
-
-                public class Bar : BaseClass
-                {
-                }
-                """;
+public class Bar : BaseClass
+{
+}";
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionFieldEntireDeclaration()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
+public class Bar : BaseClass
+{
+    [|public int Goo = 10;|]
+}";
+            var expected = @"
+public class BaseClass
+{
+    public int Goo = 10;
+}
 
-                public class Bar : BaseClass
-                {
-                    [|public int Goo = 10;|]
-                }
-                """;
-            var expected = """
-
-                public class BaseClass
-                {
-                    public int Goo = 10;
-                }
-
-                public class Bar : BaseClass
-                {
-                }
-                """;
+public class Bar : BaseClass
+{
+}";
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionMultipleFieldsInDeclaration1()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
+public class Bar : BaseClass
+{
+    [|public int Goo = 10, Foo = 9;|]
+}";
+            var expected = @"
+public class BaseClass
+{
+    public int Goo = 10;
+    public int Foo = 9;
+}
 
-                public class Bar : BaseClass
-                {
-                    [|public int Goo = 10, Foo = 9;|]
-                }
-                """;
-            var expected = """
-
-                public class BaseClass
-                {
-                    public int Goo = 10;
-                    public int Foo = 9;
-                }
-
-                public class Bar : BaseClass
-                {
-                }
-                """;
+public class Bar : BaseClass
+{
+}";
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionMultipleFieldsInDeclaration2()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
+public class Bar : BaseClass
+{
+    public int Go[||]o = 10, Foo = 9;
+}";
+            var expected = @"
+public class BaseClass
+{
+    public int Goo = 10;
+}
 
-                public class Bar : BaseClass
-                {
-                    public int Go[||]o = 10, Foo = 9;
-                }
-                """;
-            var expected = """
-
-                public class BaseClass
-                {
-                    public int Goo = 10;
-                }
-
-                public class Bar : BaseClass
-                {
-                    public int Foo = 9;
-                }
-                """;
+public class Bar : BaseClass
+{
+    public int Foo = 9;
+}";
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionMultipleFieldsInDeclaration3()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
+public class Bar : BaseClass
+{
+    public int Goo = 10, [||]Foo = 9;
+}";
+            var expected = @"
+public class BaseClass
+{
+    public int Foo = 9;
+}
 
-                public class Bar : BaseClass
-                {
-                    public int Goo = 10, [||]Foo = 9;
-                }
-                """;
-            var expected = """
-
-                public class BaseClass
-                {
-                    public int Foo = 9;
-                }
-
-                public class Bar : BaseClass
-                {
-                    public int Goo = 10;
-                }
-                """;
+public class Bar : BaseClass
+{
+    public int Goo = 10;
+}";
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionMultipleMembers1()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
+public class Bar : BaseClass
+{
+    [|public int Goo = 10, Foo = 9;
 
-                public class Bar : BaseClass
-                {
-                    [|public int Goo = 10, Foo = 9;
+    public int DoSomething()
+    {
+        return 5;
+    }|]
+}";
+            var expected = @"
+public class BaseClass
+{
+    public int Goo = 10;
+    public int Foo = 9;
 
-                    public int DoSomething()
-                    {
-                        return 5;
-                    }|]
-                }
-                """;
-            var expected = """
+    public int DoSomething()
+    {
+        return 5;
+    }
+}
 
-                public class BaseClass
-                {
-                    public int Goo = 10;
-                    public int Foo = 9;
-
-                    public int DoSomething()
-                    {
-                        return 5;
-                    }
-                }
-
-                public class Bar : BaseClass
-                {
-                }
-                """;
+public class Bar : BaseClass
+{
+}";
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
@@ -6564,144 +6058,130 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task TestRefactoringSelectionMultipleMembers2()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
-
-                public class Bar : BaseClass
-                {
-                    public int DoSomething()
-                    {
-                        [|return 5;
-                    }
-
-
-                    public int Goo = 10, Foo = 9;|]
-                }
-                """;
-            var expected = """
-
-                public class BaseClass
-                {
+public class Bar : BaseClass
+{
+    public int DoSomething()
+    {
+        [|return 5;
+    }
 
 
-                    public int Goo = 10;
+    public int Goo = 10, Foo = 9;|]
+}";
+            var expected = @"
+public class BaseClass
+{
 
 
-                    public int Foo = 9;
-                }
+    public int Goo = 10;
 
-                public class Bar : BaseClass
-                {
-                    public int DoSomething()
-                    {
-                        return 5;
-                    }
-                }
-                """;
+
+    public int Foo = 9;
+}
+
+public class Bar : BaseClass
+{
+    public int DoSomething()
+    {
+        return 5;
+    }
+}";
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionMultipleMembers3()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
-
-                public class Bar : BaseClass
-                {
-                    public int DoSom[|ething()
-                    {
-                        return 5;
-                    }
-
-
-                    public int Go|]o = 10, Foo = 9;
-                }
-                """;
-            var expected = """
-
-                public class BaseClass
-                {
+public class Bar : BaseClass
+{
+    public int DoSom[|ething()
+    {
+        return 5;
+    }
 
 
-                    public int Goo = 10;
-                    public int DoSomething()
-                    {
-                        return 5;
-                    }
-                }
+    public int Go|]o = 10, Foo = 9;
+}";
+            var expected = @"
+public class BaseClass
+{
 
-                public class Bar : BaseClass
-                {
-                    public int Foo = 9;
-                }
-                """;
+
+    public int Goo = 10;
+    public int DoSomething()
+    {
+        return 5;
+    }
+}
+
+public class Bar : BaseClass
+{
+    public int Foo = 9;
+}";
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionMultipleMembers4()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
-
-                public class Bar : BaseClass
-                {
-                    public int DoSomething()[|
-                    {
-                        return 5;
-                    }
-
-
-                    public int Goo = 10, F|]oo = 9;
-                }
-                """;
-            var expected = """
-
-                public class BaseClass
-                {
+public class Bar : BaseClass
+{
+    public int DoSomething()[|
+    {
+        return 5;
+    }
 
 
-                    public int Goo = 10;
+    public int Goo = 10, F|]oo = 9;
+}";
+            var expected = @"
+public class BaseClass
+{
 
 
-                    public int Foo = 9;
-                }
+    public int Goo = 10;
 
-                public class Bar : BaseClass
-                {
-                    public int DoSomething()
-                    {
-                        return 5;
-                    }
-                }
-                """;
+
+    public int Foo = 9;
+}
+
+public class Bar : BaseClass
+{
+    public int DoSomething()
+    {
+        return 5;
+    }
+}";
             await TestWithPullMemberDialogAsync(text, expected);
         }
 
         [Fact]
         public async Task TestRefactoringSelectionIncompleteField_NoAction1()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
-
-                public class Bar : BaseClass
-                {
-                    publ[||] int Goo = 10;
-                }
-                """;
+public class Bar : BaseClass
+{
+    publ[||] int Goo = 10;
+}";
             // we expect a diagnostic/error, but also we shouldn't provide the refactoring
             await TestQuickActionNotProvidedAsync(text);
         }
@@ -6709,17 +6189,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task TestRefactoringSelectionIncompleteField_NoAction2()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
-
-                public class Bar : BaseClass
-                {
-                    [|publicc int Goo = 10;|]
-                }
-                """;
+public class Bar : BaseClass
+{
+    [|publicc int Goo = 10;|]
+}";
             // we expect a diagnostic/error, but also we shouldn't provide the refactoring
             await TestQuickActionNotProvidedAsync(text);
         }
@@ -6727,19 +6205,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.PullMemberUp
         [Fact]
         public async Task TestRefactoringSelectionIncompleteMethod_NoAction()
         {
-            var text = """
+            var text = @"
+public class BaseClass
+{
+}
 
-                public class BaseClass
-                {
-                }
-
-                public class Bar : BaseClass
-                {
-                    publ[||] int DoSomething() {
-                        return 5;
-                    }
-                }
-                """;
+public class Bar : BaseClass
+{
+    publ[||] int DoSomething() {
+        return 5;
+    }
+}";
             // we expect a diagnostic/error, but also we shouldn't provide the refactoring
             await TestQuickActionNotProvidedAsync(text);
         }


### PR DESCRIPTION
Add tests showing #55402 does not repro

This is a nuanced because if the cursor position with no selection is on a keyword then it works. However, it looks intentional that if it's on a keyword with a selection then it shouldn't work. 

See https://github.com/dotnet/roslyn/blob/main/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SelectedMembers/AbstractSelectedMembers.cs#L146 