### PR TITLE
Keep using statement in extract method

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.cs
@@ -2012,5 +2012,61 @@ class C
 
             await TestExtractMethodAsync(code, expected);
         }
+
+        [Fact, WorkItem(39329, "https://github.com/dotnet/roslyn/issues/39329")]
+        public Task SimpleUsingStatement()
+        {
+            var code = """
+                public class Goo : IDisposable
+                {
+                    void M2() { }
+                    void M3() { }
+                    string S => "S";
+
+                    void M()
+                    {
+                        using Goo g = [|new Goo();
+                        var s = g.S;
+                        g.M2();
+                        g.M3();|]
+                    }
+
+                    public void Dispose()
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+                """;
+
+            var expected = """
+                public class Goo : IDisposable
+                {
+                    void M2() { }
+                    void M3() { }
+                    string S => "S";
+                
+                    void M()
+                    {
+                        using Goo g = NewMethod();
+                    }
+
+                    private static Goo NewMethod()
+                    {
+                        Goo g = new Goo();
+                        var s = g.S;
+                        g.M2();
+                        g.M3();
+                        return g;
+                    }
+                
+                    public void Dispose()
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+                """;
+
+            return TestExtractMethodAsync(code, expected);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -661,7 +661,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 var typeNode = type.GenerateTypeSyntax();
 
                 var originalIdentifierToken = variable.GetOriginalIdentifierToken(cancellationToken);
-                var usingKeyword = originalIdentifierToken.GetAncestor<LocalDeclarationStatementSyntax>() is LocalDeclarationStatementSyntax { UsingKeyword.FullSpan.IsEmpty: false }
+
+                // Hierarchy being checked for to see if a using keyword is needed is
+                // Token -> VariableDeclarator -> VariableDeclaration -> LocalDeclaration
+                var usingKeyword = originalIdentifierToken.Parent?.Parent?.Parent is LocalDeclarationStatementSyntax { UsingKeyword.FullSpan.IsEmpty: false }
                     ? SyntaxFactory.Token(SyntaxKind.UsingKeyword)
                     : default;
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -660,11 +660,18 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 var type = variable.GetVariableType();
                 var typeNode = type.GenerateTypeSyntax();
 
+                var originalIdentifierToken = variable.GetOriginalIdentifierToken(cancellationToken);
+                var usingKeyword = originalIdentifierToken.GetAncestor<LocalDeclarationStatementSyntax>() is LocalDeclarationStatementSyntax { UsingKeyword.FullSpan.IsEmpty: false }
+                    ? SyntaxFactory.Token(SyntaxKind.UsingKeyword)
+                    : default;
+
                 var equalsValueClause = initialValue == null ? null : SyntaxFactory.EqualsValueClause(value: initialValue);
 
                 return SyntaxFactory.LocalDeclarationStatement(
                     SyntaxFactory.VariableDeclaration(typeNode)
-                          .AddVariables(SyntaxFactory.VariableDeclarator(SyntaxFactory.Identifier(variable.Name)).WithInitializer(equalsValueClause)));
+                          .AddVariables(SyntaxFactory.VariableDeclarator(SyntaxFactory.Identifier(variable.Name))
+                          .WithInitializer(equalsValueClause)))
+                    .WithUsingKeyword(usingKeyword);
             }
 
             protected override async Task<GeneratedCode> CreateGeneratedCodeAsync(OperationStatus status, SemanticDocument newDocument, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
@@ -248,6 +248,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 
                     var declarationStatement = CreateDeclarationStatement(
                         variable, CreateCallSignature(), cancellationToken);
+
                     declarationStatement = declarationStatement.WithAdditionalAnnotations(CallSiteAnnotation);
 
                     return statements.Concat(declarationStatement);

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.CodeGenerator.cs
@@ -248,7 +248,6 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
 
                     var declarationStatement = CreateDeclarationStatement(
                         variable, CreateCallSignature(), cancellationToken);
-
                     declarationStatement = declarationStatement.WithAdditionalAnnotations(CallSiteAnnotation);
 
                     return statements.Concat(declarationStatement);

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableInfo.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableInfo.cs
@@ -130,6 +130,8 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             public SyntaxToken GetIdentifierTokenAtDeclaration(SyntaxNode node)
                 => node.GetAnnotatedTokens(_variableSymbol.IdentifierTokenAnnotation).SingleOrDefault();
 
+            public SyntaxToken GetOriginalIdentifierToken(CancellationToken cancellationToken) => _variableSymbol.GetOriginalIdentifierToken(cancellationToken);
+
             public static void SortVariables(Compilation compilation, ArrayBuilder<VariableInfo> variables)
             {
                 var cancellationTokenType = compilation.GetTypeByMetadataName(typeof(CancellationToken).FullName);

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableSymbol.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableSymbol.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             }
 
             public override SyntaxToken GetOriginalIdentifierToken(CancellationToken cancellationToken)
-                => throw ExceptionUtilities.Unreachable();
+                => default;
 
             public override SyntaxAnnotation IdentifierTokenAnnotation => throw ExceptionUtilities.Unreachable();
 


### PR DESCRIPTION
When a variable declaration syntax had a using, make sure to keep that using in the new variable declaration syntax.

Part of the needed fixes for #39329
