### PR TITLE
Don't rely on unset values from BitVector in nullable state

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -9,7 +9,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Net.NetworkInformation;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.CodeAnalysis.Collections;
@@ -11352,9 +11351,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 static BitVector createBitVectorWithNotNulls(int capacity, bool reachable)
                 {
-                    if (capacity < 1)
-                        capacity = 1;
-
                     BitVector state = BitVector.Create(capacity * 2);
                     state[0] = reachable;
 
@@ -11424,7 +11420,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (!hasValue(ref this, slot))
                     Normalize(walker, variables, useNotNullsAsDefault);
 
-                bool hasValue(ref LocalState state, int slot)
+                static bool hasValue(ref LocalState state, int slot)
                 {
                     if (slot <= 0)
                     {
@@ -11434,7 +11430,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return hasValueCore(ref state, id, index);
                 }
 
-                bool hasValueCore(ref LocalState state, int id, int index)
+                static bool hasValueCore(ref LocalState state, int id, int index)
                 {
                     if (state.Id != id)
                     {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -9,6 +9,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Net.NetworkInformation;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.CodeAnalysis.Collections;
@@ -744,7 +745,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return;
                 }
 
-                var memberState = state[slot];
+                var memberState = GetState(ref state, slot);
                 var badState = symbolType.Type.IsPossiblyNullableReferenceTypeTypeParameter() && (annotations & FlowAnalysisAnnotations.NotNull) == 0
                     ? NullableFlowState.MaybeDefault
                     : NullableFlowState.MaybeNull;
@@ -846,7 +847,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (getSlotForFieldOrPropertyOrEvent(member) is int memberSlot &&
                             memberSlot > 0)
                         {
-                            var parameterState = state[memberSlot];
+                            var parameterState = GetState(ref state, memberSlot);
                             return !parameterState.IsNotNull();
                         }
                         else
@@ -906,7 +907,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 var type = memberToInitialize.GetTypeOrReturnType();
                                 if (!type.NullableAnnotation.IsOblivious())
                                 {
-                                    this.State[memberSlot] = type.Type.IsPossiblyNullableReferenceTypeTypeParameter() ? NullableFlowState.MaybeDefault : NullableFlowState.MaybeNull;
+                                    SetState(ref this.State, memberSlot, type.Type.IsPossiblyNullableReferenceTypeTypeParameter() ? NullableFlowState.MaybeDefault : NullableFlowState.MaybeNull);
                                 }
                             }
                         }
@@ -1060,7 +1061,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (getSlotForFieldOrPropertyOrEvent(member) is int memberSlot &&
                         memberSlot > 0)
                     {
-                        this.State[memberSlot] = NullableFlowState.MaybeNull;
+                        SetState(ref this.State, memberSlot, NullableFlowState.MaybeNull);
                     }
                 }
             }
@@ -1124,7 +1125,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     foreach (var parameter in parameters)
                     {
                         // For non-constant values, only complain if we were able to analyze a difference for this parameter between two branches
-                        if (GetOrCreateSlot(parameter) is > 0 and var slot && pendingReturn.StateWhenTrue[slot] != pendingReturn.StateWhenFalse[slot])
+                        if (GetOrCreateSlot(parameter) is > 0 and var slot && GetState(ref pendingReturn.StateWhenTrue, slot) != GetState(ref pendingReturn.StateWhenFalse, slot))
                         {
                             ReportParameterIfBadConditionalState(returnStatement.Syntax, parameter, sense: true, stateWhen: pendingReturn.StateWhenTrue);
                             ReportParameterIfBadConditionalState(returnStatement.Syntax, parameter, sense: false, stateWhen: pendingReturn.StateWhenFalse);
@@ -1157,7 +1158,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 var annotations = parameter.FlowAnalysisAnnotations;
                 var hasNotNull = (annotations & FlowAnalysisAnnotations.NotNull) == FlowAnalysisAnnotations.NotNull;
-                var parameterState = state[slot];
+                var parameterState = GetState(ref state, slot);
                 if (hasNotNull && parameterState.MayBeNull())
                 {
                     Location location;
@@ -1213,7 +1214,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var slot = GetOrCreateSlot(parameter);
                 if (slot > 0)
                 {
-                    var parameterState = stateWhen[slot];
+                    var parameterState = GetState(ref stateWhen, slot);
 
                     // On a parameter marked with MaybeNullWhen, we would have not reported an assignment warning.
                     // We should only check if an assignment warning would have been warranted ignoring the MaybeNullWhen.
@@ -1251,7 +1252,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (inputParamNames.Contains(inputParam.Name)
                     && GetOrCreateSlot(inputParam) is > 0 and int inputSlot
-                    && state[inputSlot].IsNotNull())
+                    && GetState(ref state, inputSlot).IsNotNull())
                 {
                     var location = syntaxOpt?.GetLocation() ?? methodMainNode.Syntax.GetLastToken().GetLocation();
                     if (outputParam is object)
@@ -1814,6 +1815,29 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 _snapshotBuilderOpt.SetUpdatedSymbol(node, originalSymbol, updatedSymbol);
             }
+        }
+
+        private NullableFlowState GetState(ref LocalState state, int slot)
+        {
+            if (!state.Reachable)
+                return NullableFlowState.NotNull;
+
+            NormalizeIfNeeded(ref state, slot, useNotNullsAsDefault: false);
+            return state[slot];
+        }
+
+        private void SetState(ref LocalState state, int slot, NullableFlowState value, bool useNotNullsAsDefault = false)
+        {
+            if (!state.Reachable)
+                return;
+
+            NormalizeIfNeeded(ref state, slot, useNotNullsAsDefault);
+            state[slot] = value;
+        }
+
+        private void NormalizeIfNeeded(ref LocalState state, int slot, bool useNotNullsAsDefault)
+        {
+            state.NormalizeIfNeeded(slot, this, _variables, useNotNullsAsDefault);
         }
 
         protected override void Normalize(ref LocalState state)
@@ -2423,8 +2447,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return;
                 }
 
-                if (!this.State.HasValue(targetSlot)) Normalize(ref this.State);
-
                 var newState = valueType.State;
                 SetStateAndTrackForFinally(ref this.State, targetSlot, newState);
                 InheritDefaultState(targetType.Type, targetSlot);
@@ -2535,8 +2557,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             return;
                         }
-                        value = this.State.HasValue(valueMemberSlot) ?
-                            this.State[valueMemberSlot] :
+                        value = valueMemberSlot > 0 ?
+                            GetState(ref this.State, valueMemberSlot) :
                             NullableFlowState.NotNull;
                     }
 
@@ -2575,13 +2597,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private void SetStateAndTrackForFinally(ref LocalState state, int slot, NullableFlowState newState)
         {
-            state[slot] = newState;
+            Debug.Assert(slot > 0);
+            SetState(ref state, slot, newState);
             if (newState != NullableFlowState.NotNull && NonMonotonicState.HasValue)
             {
                 var tryState = NonMonotonicState.Value;
                 if (tryState.HasVariable(slot))
                 {
-                    tryState[slot] = newState.Join(tryState[slot]);
+                    SetState(ref tryState, slot, newState.Join(GetState(ref tryState, slot)), useNotNullsAsDefault: true);
                     NonMonotonicState = tryState;
                 }
             }
@@ -2644,7 +2667,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override LocalState ReachableBottomState()
         {
             // Create a reachable state in which all variables are known to be non-null.
-            return LocalState.ReachableState(_variables);
+            return LocalState.ReachableStateWithNotNulls(_variables);
         }
 
         private void EnterParameters()
@@ -2704,7 +2727,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (slot > 0)
                 {
                     var state = GetParameterState(parameterType, parameter.FlowAnalysisAnnotations).State;
-                    this.State[slot] = state;
+                    SetState(ref this.State, slot, state);
                     if (EmptyStructTypeCache.IsTrackableStructType(parameterType.Type))
                     {
                         InheritNullableStateOfTrackableStruct(
@@ -2983,7 +3006,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var symbol = variables[variables.RootSlot(slot)].Symbol;
                     if (Symbol.IsCaptured(symbol, localFunc))
                     {
-                        state[slot] = startingState[slot];
+                        SetState(ref state, slot, GetState(ref startingState, slot));
                     }
                 },
                 _variables);
@@ -3202,7 +3225,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int slot = GetOrCreateSlot(local);
                 if (slot > 0)
                 {
-                    this.State[slot] = GetDefaultState(ref this.State, slot);
+                    SetState(ref this.State, slot, GetDefaultState(ref this.State, slot));
                     InheritDefaultState(GetDeclaredLocalResult(local).Type, slot);
                 }
             }
@@ -3565,7 +3588,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                         }
 
-                        this.State[slot] = resultState;
+                        SetState(ref this.State, slot, resultState);
                     }
                 }
 
@@ -3782,7 +3805,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (slot >= 0 && !initializer.Initializers.IsEmpty)
                 {
-                    if (!initializer.Type.IsValueType && State[slot].MayBeNull())
+                    if (!initializer.Type.IsValueType && GetState(ref State, slot).MayBeNull())
                     {
                         ReportDiagnostic(ErrorCode.WRN_NullReferenceInitializer, initializer.Syntax, symbol);
                     }
@@ -3881,7 +3904,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(TypeSymbol.Equals(containingType, receiverResult.VisitResult.RValueType.Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
                 Debug.Assert(TypeSymbol.Equals(containingType, receiverResult.LValueType.Type, TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
             }
-#endif 
+#endif
 
             return setUpdatedSymbol(node, containingType, reinferredMethod, argumentResults, visitArgumentsCompletion, delayCompletionForType);
 
@@ -4901,11 +4924,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static bool PossiblyNullableType([NotNullWhen(true)] TypeSymbol? operandType) => operandType?.CanContainNull() == true;
 
-        private static void MarkSlotsAsNotNull(ArrayBuilder<int> slots, ref LocalState stateToUpdate)
+        private void MarkSlotsAsNotNull(ArrayBuilder<int> slots, ref LocalState stateToUpdate)
         {
             foreach (int slot in slots)
             {
-                stateToUpdate[slot] = NullableFlowState.NotNull;
+                SetState(ref stateToUpdate, slot, NullableFlowState.NotNull);
             }
         }
 
@@ -4934,7 +4957,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void LearnFromNonNullTest(int slot, ref LocalState state)
         {
-            state[slot] = NullableFlowState.NotNull;
+            SetState(ref state, slot, NullableFlowState.NotNull);
         }
 
         private void LearnFromNullTest(BoundExpression expression, ref LocalState state)
@@ -4959,10 +4982,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (slot > 0 && PossiblyNullableType(expressionType))
             {
-                if (state[slot] == NullableFlowState.NotNull)
+                if (GetState(ref state, slot) == NullableFlowState.NotNull)
                 {
                     // Note: We leave a MaybeDefault state as-is
-                    state[slot] = NullableFlowState.MaybeNull;
+                    SetState(ref state, slot, NullableFlowState.MaybeNull);
                 }
 
                 if (markDependentSlotsNotNull)
@@ -4991,7 +5014,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     int childSlot = GetOrCreateSlot(member, slot, forceSlotEvenIfEmpty: true, createIfMissing: false);
                     if (childSlot > 0)
                     {
-                        state[childSlot] = NullableFlowState.NotNull;
+                        SetState(ref state, childSlot, NullableFlowState.NotNull);
                         MarkDependentSlotsNotNull(childSlot, member.GetTypeOrReturnType().Type, ref state, depth - 1);
                     }
                 }
@@ -5876,7 +5899,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (compareExchangeInfo.Arguments.Length != 3)
             {
                 // This can occur if CompareExchange has optional arguments.
-                // Since none of the main runtimes have optional arguments, 
+                // Since none of the main runtimes have optional arguments,
                 // we bail to avoid an exception but don't bother actually calculating the FlowState.
                 return NullableFlowState.NotNull;
             }
@@ -6407,7 +6430,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             if (GetOrCreateSlot(member, receiverSlot) is int memberSlot &&
                                 memberSlot > 0)
                             {
-                                state[memberSlot] = NullableFlowState.NotNull;
+                                SetState(ref state, memberSlot, NullableFlowState.NotNull);
                             }
                             break;
                         case SymbolKind.Event:
@@ -7275,9 +7298,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private TypeWithState GetAdjustedResult(TypeWithState type, int slot)
         {
-            if (this.State.HasValue(slot))
+            if (slot > 0)
             {
-                NullableFlowState state = this.State[slot];
+                NullableFlowState state = GetState(ref this.State, slot);
                 return TypeWithState.Create(type.Type, state);
             }
 
@@ -7549,7 +7572,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int slot = GetOrCreatePlaceholderSlot(node);
                 if (slot > 0)
                 {
-                    this.State[slot] = NullableFlowState.NotNull;
+                    SetState(ref this.State, slot, NullableFlowState.NotNull);
                     TrackNullableStateOfTupleElements(slot, tupleOpt, arguments, elementTypes, argsToParamsOpt: default, useRestField: false);
                 }
 
@@ -7683,7 +7706,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             int targetFieldSlot = GetOrCreateSlot(targetField, slot);
                             if (targetFieldSlot > 0)
                             {
-                                this.State[targetFieldSlot] = NullableFlowState.NotNull;
+                                SetState(ref this.State, targetFieldSlot, NullableFlowState.NotNull);
                                 int valueFieldSlot = GetOrCreateSlot(valueField, valueSlot);
                                 if (valueFieldSlot > 0)
                                 {
@@ -7700,7 +7723,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             int targetFieldSlot = GetOrCreateSlot(targetField, slot);
                             if (targetFieldSlot > 0)
                             {
-                                this.State[targetFieldSlot] = NullableFlowState.NotNull;
+                                SetState(ref this.State, targetFieldSlot, NullableFlowState.NotNull);
                                 int valueFieldSlot = GetOrCreateSlot(valueField, valueSlot);
                                 if (valueFieldSlot > 0)
                                 {
@@ -7727,7 +7750,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             int targetFieldSlot = GetOrCreateSlot(targetField, slot);
                             if (targetFieldSlot > 0)
                             {
-                                this.State[targetFieldSlot] = convertedType.State;
+                                SetState(ref this.State, targetFieldSlot, convertedType.State);
                             }
                         }
                         break;
@@ -8394,7 +8417,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 VisitRvalue(handlerData.Construction);
 #if DEBUG
                 _completingTargetTypedExpression = save_completingTargetTypedExpression;
-#endif 
+#endif
             }
         }
 
@@ -9859,9 +9882,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (PossiblyNullableType(resultType.Type))
             {
                 int slot = MakeMemberSlot(receiverOpt, member);
-                if (this.State.HasValue(slot))
+                if (slot > 0)
                 {
-                    var state = this.State[slot];
+                    var state = GetState(ref this.State, slot);
                     resultType = TypeWithState.Create(resultType.Type, state);
                 }
             }
@@ -9873,7 +9896,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (containingSlot > 0)
                 {
                     Split();
-                    this.StateWhenTrue[containingSlot] = NullableFlowState.NotNull;
+                    SetState(ref this.StateWhenTrue, containingSlot, NullableFlowState.NotNull);
                 }
             }
 
@@ -9942,7 +9965,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             //    6. The target framework's System.String doesn't implement IEnumerable. This is a compat case: System.String normally
             //       does implement IEnumerable, but there are certain target frameworks where this isn't the case. The compiler will
             //       still emit code for foreach in these scenarios.
-            //    7. The collection type implements the GetEnumerator pattern via an extension GetEnumerator. For this, there will be 
+            //    7. The collection type implements the GetEnumerator pattern via an extension GetEnumerator. For this, there will be
             //       conversion to the parameter of the extension method.
             //    8. Some binding error occurred, and some other error has already been reported. Usually this doesn't have any kind
             //       of conversion on top, but if there was an explicit conversion in code then we could get past the initial check
@@ -10193,7 +10216,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     int slot = GetOrCreateSlot(iterationVariable);
                     if (slot > 0)
                     {
-                        this.State[slot] = state;
+                        SetState(ref this.State, slot, state);
                     }
                 }
 
@@ -10533,7 +10556,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int slot = GetOrCreatePlaceholderSlot(node);
                 if (slot > 0)
                 {
-                    this.State[slot] = NullableFlowState.NotNull;
+                    SetState(ref this.State, slot, NullableFlowState.NotNull);
                     InheritNullableStateOfTrackableStruct(type, slot, valueSlot: -1, isDefaultValue: true);
                 }
             }
@@ -10741,9 +10764,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node.Argument.ConstantValue?.IsNull != true
                 && MakeMemberSlot(receiverOpt, @event) is > 0 and var memberSlot)
             {
-                this.State[memberSlot] = node.IsAddition
-                    ? this.State[memberSlot].Meet(ResultType.State)
-                    : NullableFlowState.MaybeNull;
+                SetState(ref this.State, memberSlot,
+                    node.IsAddition ? GetState(ref this.State, memberSlot).Meet(ResultType.State) : NullableFlowState.MaybeNull);
             }
             SetNotNullResult(node); // https://github.com/dotnet/roslyn/issues/29969 Review whether this is the correct result
             return null;
@@ -11057,7 +11079,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     int slot = GetOrCreateSlot(local);
                     if (slot > 0)
-                        this.State[slot] = NullableFlowState.NotNull;
+                        SetState(ref this.State, slot, NullableFlowState.NotNull);
                 }
             }
 
@@ -11319,27 +11341,51 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return CreateReachableOrUnreachableState(variables, reachable: false);
             }
 
+            public static LocalState ReachableStateWithNotNulls(Variables variables)
+            {
+                var container = variables.Container is null ?
+                    null :
+                    new Boxed(ReachableStateWithNotNulls(variables.Container));
+
+                int capacity = variables.NextAvailableIndex;
+                return new LocalState(variables.Id, container, createBitVectorWithNotNulls(capacity, reachable: true));
+
+                static BitVector createBitVectorWithNotNulls(int capacity, bool reachable)
+                {
+                    if (capacity < 1)
+                        capacity = 1;
+
+                    BitVector state = BitVector.Create(capacity * 2);
+                    state[0] = reachable;
+
+                    for (int i = 1; i < capacity; i++)
+                    {
+                        var index = i * 2;
+                        state[index] = true;
+                        state[index + 1] = true;
+                    }
+                    return state;
+                }
+            }
+
             private static LocalState CreateReachableOrUnreachableState(Variables variables, bool reachable)
             {
                 var container = variables.Container is null ?
                     null :
                     new Boxed(CreateReachableOrUnreachableState(variables.Container, reachable));
-                int capacity = reachable ? variables.NextAvailableIndex : 1;
-                return new LocalState(variables.Id, container, CreateBitVector(capacity, reachable));
+
+                return new LocalState(variables.Id, container, CreateBitVector(reachable));
             }
 
             public LocalState CreateNestedMethodState(Variables variables)
             {
                 Debug.Assert(Id == variables.Container!.Id);
-                return new LocalState(variables.Id, container: new Boxed(this), CreateBitVector(capacity: 1, reachable: true));
+                return new LocalState(variables.Id, container: new Boxed(this), CreateBitVector(reachable: true));
             }
 
-            private static BitVector CreateBitVector(int capacity, bool reachable)
+            private static BitVector CreateBitVector(bool reachable)
             {
-                if (capacity < 1)
-                    capacity = 1;
-
-                BitVector state = BitVector.Create(capacity * 2);
+                BitVector state = BitVector.Create(2);
                 state[0] = reachable;
                 return state;
             }
@@ -11358,73 +11404,79 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return false;
                 }
                 (int id, int index) = Variables.DeconstructSlot(slot);
-                return HasVariable(id, index);
+                return hasVariableCore(ref this, id, index);
+
+                bool hasVariableCore(ref LocalState state, int id, int index)
+                {
+                    if (state.Id > id)
+                    {
+                        return hasVariableCore(ref state._container!.Value, id, index);
+                    }
+                    else
+                    {
+                        return state.Id == id;
+                    }
+                }
             }
 
-            private bool HasVariable(int id, int index)
+            public void NormalizeIfNeeded(int slot, NullableWalker walker, Variables variables, bool useNotNullsAsDefault = false)
             {
-                if (Id > id)
+                if (!hasValue(ref this, slot))
+                    Normalize(walker, variables, useNotNullsAsDefault);
+
+                bool hasValue(ref LocalState state, int slot)
                 {
-                    return _container!.Value.HasValue(id, index);
+                    if (slot <= 0)
+                    {
+                        return false;
+                    }
+                    (int id, int index) = Variables.DeconstructSlot(slot);
+                    return hasValueCore(ref state, id, index);
                 }
-                else
+
+                bool hasValueCore(ref LocalState state, int id, int index)
                 {
-                    return Id == id;
+                    if (state.Id != id)
+                    {
+                        Debug.Assert(state.Id > id);
+                        return hasValueCore(ref state._container!.Value, id, index);
+                    }
+                    else
+                    {
+                        return index < state.Capacity;
+                    }
                 }
             }
 
-            public bool HasValue(int slot)
-            {
-                if (slot <= 0)
-                {
-                    return false;
-                }
-                (int id, int index) = Variables.DeconstructSlot(slot);
-                return HasValue(id, index);
-            }
-
-            private bool HasValue(int id, int index)
-            {
-                if (Id != id)
-                {
-                    Debug.Assert(Id > id);
-                    return _container!.Value.HasValue(id, index);
-                }
-                else
-                {
-                    return index < Capacity;
-                }
-            }
-
-            public void Normalize(NullableWalker walker, Variables variables)
+            public void Normalize(NullableWalker walker, Variables variables, bool useNotNullsAsDefault = false)
             {
                 if (Id != variables.Id)
                 {
                     Debug.Assert(Id < variables.Id);
-                    Normalize(walker, variables.Container!);
+                    Normalize(walker, variables.Container!, useNotNullsAsDefault);
                 }
                 else
                 {
-                    _container?.Value.Normalize(walker, variables.Container!);
+                    _container?.Value.Normalize(walker, variables.Container!, useNotNullsAsDefault);
                     int start = Capacity;
                     EnsureCapacity(variables.NextAvailableIndex);
-                    Populate(walker, start);
+                    Populate(walker, start, useNotNullsAsDefault);
                 }
             }
 
             public void PopulateAll(NullableWalker walker)
             {
                 _container?.Value.PopulateAll(walker);
-                Populate(walker, start: 1);
+                Populate(walker, start: 1, useNotNullsAsDefault: false);
             }
 
-            private void Populate(NullableWalker walker, int start)
+            private void Populate(NullableWalker walker, int start, bool useNotNullsAsDefault)
             {
                 int capacity = Capacity;
                 for (int index = start; index < capacity; index++)
                 {
                     int slot = Variables.ConstructSlot(Id, index);
-                    SetValue(Id, index, walker.GetDefaultState(ref this, slot));
+                    SetValue(Id, index, useNotNullsAsDefault ? NullableFlowState.NotNull : walker.GetDefaultState(ref this, slot));
                 }
             }
 
@@ -11449,22 +11501,25 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(Id > id);
                     return _container!.Value.GetValue(id, index);
                 }
-                else
+                return GetValue(index);
+            }
+
+            private NullableFlowState GetValue(int index)
+            {
+                if (!this.Reachable)
                 {
-                    if (index < Capacity && this.Reachable)
-                    {
-                        index *= 2;
-                        var result = (_state[index + 1], _state[index]) switch
-                        {
-                            (false, false) => NullableFlowState.NotNull,
-                            (false, true) => NullableFlowState.MaybeNull,
-                            (true, false) => throw ExceptionUtilities.UnexpectedValue(index),
-                            (true, true) => NullableFlowState.MaybeDefault
-                        };
-                        return result;
-                    }
                     return NullableFlowState.NotNull;
                 }
+                Debug.Assert(index < Capacity);
+                index *= 2;
+                var result = (_state[index], _state[index + 1]) switch
+                {
+                    (false, false) => throw ExceptionUtilities.Unreachable(),
+                    (true, false) => NullableFlowState.MaybeNull,
+                    (false, true) => NullableFlowState.MaybeDefault,
+                    (true, true) => NullableFlowState.NotNull
+                };
+                return result;
             }
 
             private void SetValue(int id, int index, NullableFlowState value)
@@ -11476,12 +11531,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    // No states should be modified in unreachable code, as there is only one unreachable state.
-                    if (!this.Reachable) return;
-                    index *= 2;
-                    _state[index] = (value != NullableFlowState.NotNull);
-                    _state[index + 1] = (value == NullableFlowState.MaybeDefault);
+                    SetValue(index, value);
                 }
+            }
+
+            private void SetValue(int index, NullableFlowState value)
+            {
+                // No states should be modified in unreachable code, as there is only one unreachable state.
+                if (!this.Reachable) return;
+                index *= 2;
+                _state[index] = (value is NullableFlowState.NotNull or NullableFlowState.MaybeNull);
+                _state[index + 1] = (value is NullableFlowState.NotNull or NullableFlowState.MaybeDefault);
             }
 
             internal void ForEach<TArg>(Action<int, TArg> action, TArg arg)
@@ -11516,31 +11576,53 @@ namespace Microsoft.CodeAnalysis.CSharp
             public bool Join(in LocalState other)
             {
                 Debug.Assert(Id == other.Id);
-                bool result = false;
+                bool hasChanged = false;
                 if (_container is { } && _container.Value.Join(in other._container!.Value))
                 {
-                    result = true;
+                    hasChanged = true;
                 }
-                if (_state.UnionWith(in other._state))
+
+                Debug.Assert(_state.Capacity == other._state.Capacity);
+                var oldReachable = Reachable;
+                var newReachable = oldReachable | other.Reachable;
+                _state[0] = newReachable;
+                hasChanged |= (oldReachable != newReachable);
+
+                for (int i = 1; i < Capacity; i++)
                 {
-                    result = true;
+                    var oldValue = GetValue(i);
+                    var newValue = oldValue.Join(other.GetValue(i));
+                    SetValue(i, newValue);
+                    hasChanged |= (oldValue != newValue);
                 }
-                return result;
+
+                return hasChanged;
             }
 
             public bool Meet(in LocalState other)
             {
                 Debug.Assert(Id == other.Id);
-                bool result = false;
+                bool hasChanged = false;
                 if (_container is { } && _container.Value.Meet(in other._container!.Value))
                 {
-                    result = true;
+                    hasChanged = true;
                 }
-                if (_state.IntersectWith(in other._state))
+
+                Debug.Assert(_state.Capacity == other._state.Capacity);
+                var oldReachable = Reachable;
+                var newReachable = oldReachable & other.Reachable;
+                _state[0] = newReachable;
+                hasChanged |= (oldReachable != newReachable);
+
+                for (int i = 1; i < Capacity; i++)
                 {
-                    result = true;
+                    var oldValue = GetValue(i);
+                    var newValue = oldValue.Meet(other.GetValue(i));
+                    SetValue(i, newValue);
+                    hasChanged |= (oldValue != newValue);
                 }
-                return result;
+
+                return hasChanged;
             }
 
             internal string GetDebuggerDisplay()
@@ -11550,7 +11632,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 builder.Append(" ");
                 int n = Math.Min(Capacity, 8);
                 for (int i = n - 1; i >= 0; i--)
-                    builder.Append(_state[i * 2] ? '?' : '!');
+                {
+                    var mayBeNull = GetValue(i) is NullableFlowState.MaybeNull or NullableFlowState.MaybeDefault;
+                    builder.Append(mayBeNull ? '?' : '!');
+                }
 
                 return pooledBuilder.ToStringAndFree();
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -11536,8 +11536,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // No states should be modified in unreachable code, as there is only one unreachable state.
                 if (!this.Reachable) return;
                 index *= 2;
-                _state[index] = (value is NullableFlowState.NotNull or NullableFlowState.MaybeNull);
-                _state[index + 1] = (value is NullableFlowState.NotNull or NullableFlowState.MaybeDefault);
+
+                (_state[index], _state[index + 1]) = value switch
+                {
+                    NullableFlowState.MaybeNull => (true, false),
+                    NullableFlowState.MaybeDefault => (false, true),
+                    NullableFlowState.NotNull => (true, true),
+                    _ => throw ExceptionUtilities.Unreachable()
+                };
             }
 
             internal void ForEach<TArg>(Action<int, TArg> action, TArg arg)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -428,7 +428,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                         }
                                         Debug.Assert(!IsConditionalState);
                                         Unsplit();
-                                        State[outputSlot] = NullableFlowState.NotNull;
+                                        SetState(ref State, outputSlot, NullableFlowState.NotNull);
                                         addToTempMap(output, outputSlot, e.Type);
                                         break;
                                     }
@@ -519,7 +519,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                         var outputSlot = makeDagTempSlot(type, output);
                                         Debug.Assert(outputSlot > 0);
                                         addToTempMap(output, outputSlot, type.Type);
-                                        this.State[outputSlot] = NullableFlowState.NotNull; // Slice value is assumed to be never null
+                                        SetState(ref this.State, outputSlot, NullableFlowState.NotNull); // Slice value is assumed to be never null
                                         break;
                                     }
                                 case BoundDagAssignmentEvaluation e:
@@ -549,7 +549,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     gotoNode(p.WhenFalse, this.StateWhenFalse, nodeBelievedReachable);
                                     break;
                                 case BoundDagNonNullTest t:
-                                    var inputMaybeNull = this.StateWhenTrue[inputSlot].MayBeNull();
+                                    var inputMaybeNull = GetState(ref this.StateWhenTrue, inputSlot).MayBeNull();
 
                                     if (inputSlot > 0)
                                     {
@@ -622,7 +622,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             if (foundTemp) // in erroneous programs, we might not have seen a temp defined.
                             {
                                 var (tempSlot, tempType) = tempSlotAndType;
-                                var tempState = this.State[tempSlot];
+                                var tempState = GetState(ref this.State, tempSlot);
                                 if (variableAccess is BoundLocal { LocalSymbol: SourceLocalSymbol local } boundLocal)
                                 {
                                     var value = TypeWithState.Create(tempType, tempState);


### PR DESCRIPTION
Previously, we were relying on the BitVector automatically getting extended when accessed. The extra slots would be filled with `false`, which has a meaning of `NotNull` (`false, false` pair).
This change modifies the BitVector encoding so that `false, false` is disallowed (see `LocalState.GetValue`, `LocalState.SetValue` and few related methods). The question is how the BitVector should be filled when a position further out than the capacity is read or written. To solve this, I've opted to leverage the existing mechanism for filling in missing values whenever we read or write it, namely using `Normalize`. 
But normalization requires a `NullableWalker` (so that we can get the default state for a slot). So the `this[int slot] { get; set; }` indexer is replaced with a pair of methods (`GetSlot`, `SetSlot`).