### PR TITLE
Emit defensive copy for constrained call on `in` parameter

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -1632,9 +1632,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     // we use a constrained virtual call. If possible, it will skip boxing.
                     if (method.IsMetadataVirtual())
                     {
-                        // NB: all methods that a struct could inherit from bases are non-mutating
-                        //     treat receiver as ReadOnly
-                        tempOpt = EmitReceiverRef(receiver, methodContainingType.IsInterface ? AddressKind.Writeable : AddressKind.ReadOnly);
+                        tempOpt = EmitReceiverRef(receiver, AddressKind.Writeable);
                         callKind = CallKind.ConstrainedCallVirt;
                     }
                     else

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -1626,7 +1626,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 }
                 else
                 {
-                    // calling a method defined in a base class.
+                    // calling a method defined in a base class or interface.
 
                     // When calling a method that is virtual in metadata on a struct receiver, 
                     // we use a constrained virtual call. If possible, it will skip boxing.
@@ -1634,7 +1634,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     {
                         // NB: all methods that a struct could inherit from bases are non-mutating
                         //     treat receiver as ReadOnly
-                        tempOpt = EmitReceiverRef(receiver, AddressKind.ReadOnly);
+                        tempOpt = EmitReceiverRef(receiver, methodContainingType.IsInterface ? AddressKind.Writeable : AddressKind.ReadOnly);
                         callKind = CallKind.ConstrainedCallVirt;
                     }
                     else

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
@@ -514,18 +514,22 @@ class Program
 
             comp.VerifyIL("Program.S1.Test()", @"
 {
-  // Code size       39 (0x27)
+  // Code size       47 (0x2f)
   .maxstack  1
+  .locals init (Program.S1 V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldobj      ""Program.S1""
   IL_0006:  box        ""Program.S1""
   IL_000b:  call       ""System.Type object.GetType()""
   IL_0010:  call       ""void System.Console.Write(object)""
   IL_0015:  ldarg.0
-  IL_0016:  constrained. ""Program.S1""
-  IL_001c:  callvirt   ""string object.ToString()""
-  IL_0021:  call       ""void System.Console.Write(string)""
-  IL_0026:  ret
+  IL_0016:  ldobj      ""Program.S1""
+  IL_001b:  stloc.0
+  IL_001c:  ldloca.s   V_0
+  IL_001e:  constrained. ""Program.S1""
+  IL_0024:  callvirt   ""string object.ToString()""
+  IL_0029:  call       ""void System.Console.Write(string)""
+  IL_002e:  ret
 }");
         }
 
@@ -2162,30 +2166,40 @@ public struct S
             var comp = CompileAndVerify(csharp);
             comp.VerifyDiagnostics();
 
-            // ToString/GetHashCode/Equals should pass the address of 'this' (not a temp). GetType should box 'this'.
+            // GetType should box 'this'.
             comp.VerifyIL("S.M", @"
 {
-  // Code size       58 (0x3a)
+  // Code size       82 (0x52)
   .maxstack  2
+  .locals init (S V_0)
   IL_0000:  ldarg.0
   IL_0001:  ldobj      ""S""
   IL_0006:  box        ""S""
   IL_000b:  call       ""System.Type object.GetType()""
   IL_0010:  pop
   IL_0011:  ldarg.0
-  IL_0012:  constrained. ""S""
-  IL_0018:  callvirt   ""string object.ToString()""
-  IL_001d:  pop
-  IL_001e:  ldarg.0
-  IL_001f:  constrained. ""S""
-  IL_0025:  callvirt   ""int object.GetHashCode()""
-  IL_002a:  pop
-  IL_002b:  ldarg.0
-  IL_002c:  ldnull
-  IL_002d:  constrained. ""S""
-  IL_0033:  callvirt   ""bool object.Equals(object)""
-  IL_0038:  pop
-  IL_0039:  ret
+  IL_0012:  ldobj      ""S""
+  IL_0017:  stloc.0
+  IL_0018:  ldloca.s   V_0
+  IL_001a:  constrained. ""S""
+  IL_0020:  callvirt   ""string object.ToString()""
+  IL_0025:  pop
+  IL_0026:  ldarg.0
+  IL_0027:  ldobj      ""S""
+  IL_002c:  stloc.0
+  IL_002d:  ldloca.s   V_0
+  IL_002f:  constrained. ""S""
+  IL_0035:  callvirt   ""int object.GetHashCode()""
+  IL_003a:  pop
+  IL_003b:  ldarg.0
+  IL_003c:  ldobj      ""S""
+  IL_0041:  stloc.0
+  IL_0042:  ldloca.s   V_0
+  IL_0044:  ldnull
+  IL_0045:  constrained. ""S""
+  IL_004b:  callvirt   ""bool object.Equals(object)""
+  IL_0050:  pop
+  IL_0051:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenReadonlyStructTests.cs
@@ -489,7 +489,7 @@ class Program
 
         }
 
-        [Fact]
+        [Fact, WorkItem(66365, "https://github.com/dotnet/roslyn/issues/66365")]
         public void InvokeOnThisBaseMethods()
         {
             var text = @"
@@ -512,6 +512,8 @@ class Program
 
             var comp = CompileAndVerify(text, parseOptions: TestOptions.Regular, verify: Verification.Passes, expectedOutput: @"Program+S1Program+S1");
 
+            // We may be able to optimize this case (ie. avoid defensive copy) since the struct and the caller are in the same module
+            // Tracked by https://github.com/dotnet/roslyn/issues/66365
             comp.VerifyIL("Program.S1.Test()", @"
 {
   // Code size       47 (0x2f)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenStructsAndEnum.cs
@@ -1554,17 +1554,19 @@ public class D
 
             var compilation = CompileAndVerify(source, expectedOutput: "S1", verify: Verification.Skipped);
 
-            compilation.VerifyIL("Program.Main",
-@"
+            compilation.VerifyIL("Program.Main", @"
 {
-  // Code size       27 (0x1b)
+  // Code size       30 (0x1e)
   .maxstack  1
+  .locals init (S1 V_0)
   IL_0000:  newobj     ""C1..ctor()""
-  IL_0005:  ldflda     ""S1 C1.field""
-  IL_000a:  constrained. ""S1""
-  IL_0010:  callvirt   ""string object.ToString()""
-  IL_0015:  call       ""void System.Console.WriteLine(string)""
-  IL_001a:  ret
+  IL_0005:  ldfld      ""S1 C1.field""
+  IL_000a:  stloc.0
+  IL_000b:  ldloca.s   V_0
+  IL_000d:  constrained. ""S1""
+  IL_0013:  callvirt   ""string object.ToString()""
+  IL_0018:  call       ""void System.Console.WriteLine(string)""
+  IL_001d:  ret
 }
 ");
             compilation = CompileAndVerify(source, expectedOutput: "S1", parseOptions: TestOptions.Regular.WithPEVerifyCompatFeature());

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -5372,21 +5372,24 @@ record struct C1
 
             v.VerifyIL("C1." + WellKnownMemberNames.PrintMembersMethodName, @"
 {
-  // Code size       38 (0x26)
+  // Code size       41 (0x29)
   .maxstack  2
+  .locals init (int V_0)
   IL_0000:  ldarg.1
   IL_0001:  ldstr      ""field = ""
   IL_0006:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
   IL_000b:  pop
   IL_000c:  ldarg.1
   IL_000d:  ldarg.0
-  IL_000e:  ldflda     ""int C1.field""
-  IL_0013:  constrained. ""int""
-  IL_0019:  callvirt   ""string object.ToString()""
-  IL_001e:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
-  IL_0023:  pop
-  IL_0024:  ldc.i4.1
-  IL_0025:  ret
+  IL_000e:  ldfld      ""int C1.field""
+  IL_0013:  stloc.0
+  IL_0014:  ldloca.s   V_0
+  IL_0016:  constrained. ""int""
+  IL_001c:  callvirt   ""string object.ToString()""
+  IL_0021:  callvirt   ""System.Text.StringBuilder System.Text.StringBuilder.Append(string)""
+  IL_0026:  pop
+  IL_0027:  ldc.i4.1
+  IL_0028:  ret
 }
 ");
         }

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/MeMyBaseMyClassTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/MeMyBaseMyClassTests.vb
@@ -1476,6 +1476,81 @@ End Structure
 ]]>)
         End Sub
 
+        <Fact>
+        Public Sub MyClassUsedInStructureWithMutation()
+            CompileAndVerify(
+<compilation name="MyClassUsedInStructure">
+    <file name="a.vb">
+Imports System
+Structure S1
+    Dim i As Integer
+
+    Public Shared Sub Main()
+        Dim s = New S1()
+        s.Goo()
+        s.Goo()
+    End Sub
+
+    Sub Goo()
+        Console.Write(MyClass.M())
+    End Sub
+
+    Function M() As String
+        i = i + 1
+        Return i.ToString()
+    End Function
+End Structure
+    </file>
+</compilation>, expectedOutput:="12").VerifyIL("S1.Goo", <![CDATA[
+{
+  // Code size       12 (0xc)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  call       "Function S1.M() As String"
+  IL_0006:  call       "Sub System.Console.Write(String)"
+  IL_000b:  ret
+}
+]]>)
+        End Sub
+
+        <Fact>
+        Public Sub MyClassUsedInStructureWithMutationInOverride()
+            CompileAndVerify(
+<compilation name="MyClassUsedInStructure">
+    <file name="a.vb">
+Imports System
+Structure S1
+    Dim i As Integer
+
+    Public Shared Sub Main()
+        Dim s = New S1()
+        s.Goo()
+        s.Goo()
+    End Sub
+
+    Sub Goo()
+        Console.Write(MyClass.ToString())
+    End Sub
+
+    Public Overrides Function ToString() As String
+        i = i + 1
+        Return i.ToString()
+    End Function
+End Structure
+    </file>
+</compilation>, expectedOutput:="12").VerifyIL("S1.Goo", <![CDATA[
+{
+  // Code size       18 (0x12)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  constrained. "S1"
+  IL_0007:  callvirt   "Function Object.ToString() As String"
+  IL_000c:  call       "Sub System.Console.Write(String)"
+  IL_0011:  ret
+}
+]]>)
+        End Sub
+
         ' 'MyClass' is valid only within an instance method.
         <Fact>
         Public Sub MyClassOnlyValidInInstanceMethod()


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/66135