### PR TITLE
Adding ability to filter async modifiers for methods without a body in SyntaxGenerator

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -226,19 +226,15 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             IEnumerable<SyntaxNode>? statements)
         {
             var hasBody = !modifiers.IsAbstract && (!modifiers.IsPartial || statements != null);
-            var modifiersList = AsModifierList(accessibility, modifiers, SyntaxKind.MethodDeclaration);
 
-            if (modifiersList.Any(m => m.IsKind(SyntaxKind.AsyncKeyword)))
+            if (!hasBody)
             {
-                if (!hasBody)
-                {
-                    modifiersList = SyntaxFactory.TokenList(modifiersList.Where(m => !m.IsKind(SyntaxKind.AsyncKeyword)));
-                }
+                modifiers = modifiers - DeclarationModifiers.Async;
             }
 
             return SyntaxFactory.MethodDeclaration(
                 attributeLists: default,
-                modifiers: modifiersList,
+                modifiers: AsModifierList(accessibility, modifiers, SyntaxKind.MethodDeclaration),
                 returnType: returnType != null ? (TypeSyntax)returnType : SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
                 explicitInterfaceSpecifier: null,
                 identifier: name.ToIdentifierToken(),

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -228,9 +228,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             var hasBody = !modifiers.IsAbstract && (!modifiers.IsPartial || statements != null);
 
             if (!hasBody)
-            {
-                modifiers = modifiers - DeclarationModifiers.Async;
-            }
+                modifiers -= DeclarationModifiers.Async;
 
             return SyntaxFactory.MethodDeclaration(
                 attributeLists: default,

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -226,10 +226,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             IEnumerable<SyntaxNode>? statements)
         {
             var hasBody = !modifiers.IsAbstract && (!modifiers.IsPartial || statements != null);
+            var modifiersList = AsModifierList(accessibility, modifiers, SyntaxKind.MethodDeclaration);
+
+            if (modifiersList.Any(m => m.IsKind(SyntaxKind.AsyncKeyword)))
+            {
+                if (!hasBody)
+                {
+                    modifiersList = SyntaxFactory.TokenList(modifiersList.Where(m => !m.IsKind(SyntaxKind.AsyncKeyword)));
+                }
+            }
 
             return SyntaxFactory.MethodDeclaration(
                 attributeLists: default,
-                modifiers: AsModifierList(accessibility, modifiers, SyntaxKind.MethodDeclaration),
+                modifiers: modifiersList,
                 returnType: returnType != null ? (TypeSyntax)returnType : SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
                 explicitInterfaceSpecifier: null,
                 identifier: name.ToIdentifierToken(),

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -842,20 +842,8 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
                 "partial void m()\r\n{\r\n    y;\r\n}");
 
             VerifySyntax<MethodDeclarationSyntax>(
-                   SyntaxFactory.MethodDeclaration(
-                       SyntaxFactory.PredefinedType(
-                           SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
-                       SyntaxFactory.Identifier("DoSomethingAsync"))
-                   .WithModifiers(
-                       SyntaxFactory.TokenList(
-                           new[]{
-                               SyntaxFactory.Token(SyntaxKind.PublicKeyword),
-                               SyntaxFactory.Token(SyntaxKind.OverrideKeyword),
-                               SyntaxFactory.Token(SyntaxKind.AsyncKeyword)}))
-                   .WithBody(
-                       SyntaxFactory.Block())
-                   .NormalizeWhitespace(),
-                   "public override async void DoSomething() {}");
+                   Generator.MethodDeclaration("m", modifiers: DeclarationModifiers.Partial | DeclarationModifiers.Async, statements: null),
+                "partial void m();");
         }
 
         [Fact]
@@ -4040,24 +4028,13 @@ public class C : IDisposable
         }
 
         [Fact, WorkItem(1084965, " https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1084965")]
-        public void TestMethodModifiers1()
+        public void TestMethodModifiers()
         {
             TestModifiersAsync(DeclarationModifiers.Sealed | DeclarationModifiers.Override,
                 @"
 class C
 {
     [|public sealed override void M() { }|]
-}");
-        }
-
-        [Fact]
-        public void TestRemoveAsyncFromMethodWithoutBodyModifiers()
-        {
-            TestModifiersAsync(DeclarationModifiers.Override,
-                @"
-class C : D
-{
-    [|public override async void M() { }|]
 }");
         }
 

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -840,6 +840,22 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
             VerifySyntax<MethodDeclarationSyntax>(
                 Generator.MethodDeclaration("m", modifiers: DeclarationModifiers.Partial, statements: new[] { Generator.IdentifierName("y") }),
                 "partial void m()\r\n{\r\n    y;\r\n}");
+
+            VerifySyntax<MethodDeclarationSyntax>(
+                   SyntaxFactory.MethodDeclaration(
+                       SyntaxFactory.PredefinedType(
+                           SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
+                       SyntaxFactory.Identifier("DoSomethingAsync"))
+                   .WithModifiers(
+                       SyntaxFactory.TokenList(
+                           new[]{
+                               SyntaxFactory.Token(SyntaxKind.PublicKeyword),
+                               SyntaxFactory.Token(SyntaxKind.OverrideKeyword),
+                               SyntaxFactory.Token(SyntaxKind.AsyncKeyword)}))
+                   .WithBody(
+                       SyntaxFactory.Block())
+                   .NormalizeWhitespace(),
+                   "public override async void DoSomething() {}");
         }
 
         [Fact]
@@ -4031,6 +4047,17 @@ public class C : IDisposable
 class C
 {
     [|public sealed override void M() { }|]
+}");
+        }
+
+        [Fact]
+        public void TestRemoveAsyncFromMethodWithoutBodyModifiers()
+        {
+            TestModifiersAsync(DeclarationModifiers.Override,
+                @"
+class C : D
+{
+    [|public override async void M() { }|]
 }");
         }
 


### PR DESCRIPTION
Closes #66173 