### PR TITLE
Adjust assert to account for error scenarios

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -55,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert(!implicitlyInitializedFields.IsEmpty);
 
                         // It's not expected to have implicitly initialized fields when a constructor initializer is present, except in error scenarios.
-                        Debug.Assert(!originalBodyNested || block.HasErrors);
+                        Debug.Assert(method is not SourceMemberMethodSymbol { SyntaxNode: ConstructorDeclarationSyntax { Initializer: not null } } || block.HasErrors);
 
                         block = PrependImplicitInitializations(block, method, implicitlyInitializedFields, compilationState, diagnostics);
                     }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
@@ -53,7 +53,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (!implicitlyInitializedFields.IsDefault)
                     {
                         Debug.Assert(!implicitlyInitializedFields.IsEmpty);
-                        Debug.Assert(!originalBodyNested);
+
+                        // It's not expected to have implicitly initialized fields when a constructor initializer is present, except in error scenarios.
+                        Debug.Assert(!originalBodyNested || block.HasErrors);
+
                         block = PrependImplicitInitializations(block, method, implicitlyInitializedFields, compilationState, diagnostics);
                     }
                     if (needsImplicitReturn)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
@@ -4091,7 +4091,7 @@ public struct S
 ");
         }
 
-        [Fact]
+        [Fact, WorkItem(66046, "https://github.com/dotnet/roslyn/issues/66046")]
         public void ImplicitlyInitializedField_ConstructorInitializer_01()
         {
             var source = """
@@ -4111,7 +4111,7 @@ public struct S1
                 Diagnostic(ErrorCode.ERR_ObjectRequired, "F").WithArguments("S1.F").WithLocation(7, 24));
         }
 
-        [Fact]
+        [Fact, WorkItem(66046, "https://github.com/dotnet/roslyn/issues/66046")]
         public void ImplicitlyInitializedField_ConstructorInitializer_02()
         {
             var source = """

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
@@ -4091,6 +4091,48 @@ public struct S
 ");
         }
 
+        [Fact]
+        public void ImplicitlyInitializedField_ConstructorInitializer_01()
+        {
+            var source = """
+public struct S1
+{
+    public int F;
+
+    S1(int x) {}
+
+    public S1() : this(F) {}
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (7,24): error CS0120: An object reference is required for the non-static field, method, or property 'S1.F'
+                //     public S1() : this(F) {}
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "F").WithArguments("S1.F").WithLocation(7, 24));
+        }
+
+        [Fact]
+        public void ImplicitlyInitializedField_ConstructorInitializer_02()
+        {
+            var source = """
+public struct S1
+{
+    public int F;
+
+    S1(int x) {}
+
+    public static int M(int y) => y;
+
+    public S1() : this(M(F)) {}
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (9,26): error CS0120: An object reference is required for the non-static field, method, or property 'S1.F'
+                //     public S1() : this(M(F)) {}
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "F").WithArguments("S1.F").WithLocation(9, 26));
+        }
+
         [Theory]
         [InlineData(LanguageVersion.CSharp10)]
         [InlineData(LanguageVersion.CSharp11)]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StructConstructorTests.cs
@@ -4133,6 +4133,29 @@ public struct S1
                 Diagnostic(ErrorCode.ERR_ObjectRequired, "F").WithArguments("S1.F").WithLocation(9, 26));
         }
 
+        [Fact, WorkItem(66046, "https://github.com/dotnet/roslyn/issues/66046")]
+        public void ImplicitlyInitializedField_ConstructorInitializer_03()
+        {
+            var source = """
+public struct S1
+{
+    public int F;
+
+    S1(int x) {}
+
+    public S1() : base(F) {}
+}
+""";
+            var comp = CreateCompilation(source);
+            comp.VerifyDiagnostics(
+                // (7,12): error CS0522: 'S1': structs cannot call base class constructors
+                //     public S1() : base(F) {}
+                Diagnostic(ErrorCode.ERR_StructWithBaseConstructorCall, "S1").WithArguments("S1").WithLocation(7, 12),
+                // (7,24): error CS0120: An object reference is required for the non-static field, method, or property 'S1.F'
+                //     public S1() : base(F) {}
+                Diagnostic(ErrorCode.ERR_ObjectRequired, "F").WithArguments("S1.F").WithLocation(7, 24));
+        }
+
         [Theory]
         [InlineData(LanguageVersion.CSharp10)]
         [InlineData(LanguageVersion.CSharp11)]


### PR DESCRIPTION
Related to #66046

The effect of a constructor initializer is to prepend a statement to the effect of

```cs
S..ctor()
{
    S..otherCtor(out this, ...);
    // ... original constructor body statements
}
```

The point of this assert is that if a constructor initializer is present, it doesn't make sense for implicitly initialized fields to also be present, since you cannot access `this` until after the constructor initializer runs, which fully assigns `this`.

In error scenarios we can still end up referencing instance fields before the constructor initializer, so we relax the assert to allow the "unexpected" implicit initializations in this case.

Auto-default logic runs simply as a part of definite assignment analysis, so I think there is not a ton to be gained by skipping it when a constructor initializer is present. We could consider avoiding adding to the `implicitlyInitializedFields` when we notice a constructor initializer is present, but IMO this isn't necessary, and it's a little simpler to just adjust this assert to reflect our expectations. I'm open to discussion on this point, though.

In the future, if this assert fails, it means we are using an unassigned field before the constructor initializer has run in code without errors.

@AlekseyTs @dotnet/roslyn-compiler for review.