### PR TITLE
Add tests that verify options with language specific storage location…

### DIFF
--- a/src/Features/LanguageServer/ProtocolUnitTests/Microsoft.CodeAnalysis.LanguageServer.Protocol.UnitTests.csproj
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Microsoft.CodeAnalysis.LanguageServer.Protocol.UnitTests.csproj
@@ -47,6 +47,8 @@
     <ProjectReference Include="..\..\Core\Portable\Microsoft.CodeAnalysis.Features.csproj" />
     <ProjectReference Include="..\..\CSharp\Portable\Microsoft.CodeAnalysis.CSharp.Features.csproj" />
     <ProjectReference Include="..\..\VisualBasic\Portable\Microsoft.CodeAnalysis.VisualBasic.Features.vbproj" />
+    <ProjectReference Include="..\Microsoft.CodeAnalysis.CSharp.LanguageServer.Protocol\Microsoft.CodeAnalysis.CSharp.LanguageServer.Protocol.csproj" />
+    <ProjectReference Include="..\Microsoft.CodeAnalysis.VisualBasic.LanguageServer.Protocol\Microsoft.CodeAnalysis.VisualBasic.LanguageServer.Protocol.vbproj" />
     <ProjectReference Include="..\Protocol\Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Features/LanguageServer/ProtocolUnitTests/Options/LspOptionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Options/LspOptionsTests.cs
@@ -48,10 +48,10 @@ public class LspOptionsTests : AbstractLanguageServerProtocolTests
     [Fact]
     public async Task TestCanRetrieveVisualBasicOptionsWithOnlyLspLayer()
     {
-        var markup ="";
+        var markup = "";
         await using var testLspServer = await CreateVisualBasicTestLspServerAsync(markup);
         var globalOptions = testLspServer.TestWorkspace.ExportProvider.GetExportedValue<IGlobalOptionService>();
-        var project = testLspServer.GetCurrentSolution().Projects.Single().LanguageServices.LanguageServices;
+        var project = testLspServer.GetCurrentSolution().Projects.Single().Services;
         Assert.NotNull(globalOptions.GetAddImportPlacementOptions(project));
         Assert.NotNull(globalOptions.GetCodeGenerationOptions(project));
         Assert.NotNull(globalOptions.GetCodeStyleOptions(project));

--- a/src/Features/LanguageServer/ProtocolUnitTests/Options/LspOptionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Options/LspOptionsTests.cs
@@ -37,7 +37,7 @@ public class LspOptionsTests : AbstractLanguageServerProtocolTests
         var markup = "";
         await using var testLspServer = await CreateTestLspServerAsync(markup);
         var globalOptions = testLspServer.TestWorkspace.ExportProvider.GetExportedValue<IGlobalOptionService>();
-        var project = testLspServer.GetCurrentSolution().Projects.Single().LanguageServices.LanguageServices;
+        var project = testLspServer.GetCurrentSolution().Projects.Single().Services;
         Assert.NotNull(globalOptions.GetAddImportPlacementOptions(project));
         Assert.NotNull(globalOptions.GetCodeGenerationOptions(project));
         Assert.NotNull(globalOptions.GetCodeStyleOptions(project));

--- a/src/Features/LanguageServer/ProtocolUnitTests/Options/LspOptionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Options/LspOptionsTests.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.AddImport;
+using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Editor.Test;
+using Microsoft.CodeAnalysis.Editor.UnitTests;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Simplification;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.References;
+public class LspOptionsTests : AbstractLanguageServerProtocolTests
+{
+    public LspOptionsTests(ITestOutputHelper? testOutputHelper) : base(testOutputHelper)
+    {
+    }
+
+    protected override TestComposition Composition => EditorTestCompositions.LanguageServerProtocol
+        .AddAssemblies(Assembly.Load("Microsoft.CodeAnalysis.CSharp.LanguageServer.Protocol"))
+        .AddAssemblies(Assembly.Load("Microsoft.CodeAnalysis.VisualBasic.LanguageServer.Protocol"))
+        .AddParts(typeof(TestDocumentTrackingService))
+        .AddParts(typeof(TestWorkspaceRegistrationService));
+
+    [Fact]
+    public async Task TestCanRetrieveCSharpOptionsWithOnlyLspLayer()
+    {
+        var markup = "";
+        await using var testLspServer = await CreateTestLspServerAsync(markup);
+        var globalOptions = testLspServer.TestWorkspace.ExportProvider.GetExportedValue<IGlobalOptionService>();
+        var project = testLspServer.GetCurrentSolution().Projects.Single().LanguageServices.LanguageServices;
+        Assert.NotNull(globalOptions.GetAddImportPlacementOptions(project));
+        Assert.NotNull(globalOptions.GetCodeGenerationOptions(project));
+        Assert.NotNull(globalOptions.GetCodeStyleOptions(project));
+        Assert.NotNull(globalOptions.GetSyntaxFormattingOptions(project));
+        Assert.NotNull(globalOptions.GetSimplifierOptions(project));
+    }
+
+    [Fact]
+    public async Task TestCanRetrieveVisualBasicOptionsWithOnlyLspLayer()
+    {
+        var markup ="";
+        await using var testLspServer = await CreateVisualBasicTestLspServerAsync(markup);
+        var globalOptions = testLspServer.TestWorkspace.ExportProvider.GetExportedValue<IGlobalOptionService>();
+        var project = testLspServer.GetCurrentSolution().Projects.Single().LanguageServices.LanguageServices;
+        Assert.NotNull(globalOptions.GetAddImportPlacementOptions(project));
+        Assert.NotNull(globalOptions.GetCodeGenerationOptions(project));
+        Assert.NotNull(globalOptions.GetCodeStyleOptions(project));
+        Assert.NotNull(globalOptions.GetSyntaxFormattingOptions(project));
+        Assert.NotNull(globalOptions.GetSimplifierOptions(project));
+    }
+}


### PR DESCRIPTION
…s can be read using only the LSP layer

as requested by @tmat 