### PR TITLE
Apply XAML template on AbstractCheckBoxViewModel instead of one specific subclass

### DIFF
--- a/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml
@@ -13,7 +13,7 @@
     mc:Ignorable="d" d:DesignHeight="279" d:DesignWidth="514">
 
     <options:AbstractOptionPageControl.Resources>
-        <DataTemplate DataType="{x:Type options:CheckBoxOptionViewModel}">
+        <DataTemplate DataType="{x:Type options:AbstractCheckBoxViewModel}">
             <StackPanel Orientation="Horizontal">
                 <CheckBox x:Uid="OptionCheckBox"
                                         AutomationProperties.LabeledBy="{Binding ElementName=OptionText}"


### PR DESCRIPTION
Fixes display of formatting options backed by flags enum view.
Follow up on https://github.com/dotnet/roslyn/pull/65800