### PR TITLE
Avoid contract failures in PreviewSolutionCrawlerRegistrationService …

### DIFF
--- a/src/EditorFeatures/Core/Shared/Preview/PreviewSolutionCrawlerRegistrationService.cs
+++ b/src/EditorFeatures/Core/Shared/Preview/PreviewSolutionCrawlerRegistrationService.cs
@@ -117,18 +117,24 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
             {
                 Contract.ThrowIfFalse(workspace == _workspace);
 
-                var analyzeTask = _analyzeTask;
-                if (analyzeTask != null)
-                {
-                    // wait for analyzer work to be finished
-                    await analyzeTask.ConfigureAwait(false);
-                }
-
                 _source.Cancel();
-                _source.Dispose();
 
-                // ask it to reset its stages for the given workspace
-                _owner._analyzerService.ShutdownAnalyzerFrom(_workspace);
+                try
+                {
+                    var analyzeTask = _analyzeTask;
+                    if (analyzeTask != null)
+                    {
+                        // wait for analyzer work to be finished
+                        await analyzeTask.ConfigureAwait(false);
+                    }
+                }
+                finally
+                {
+                    _source.Dispose();
+
+                    // ask it to reset its stages for the given workspace
+                    _owner._analyzerService.ShutdownAnalyzerFrom(_workspace);
+                }
             }
 
             public void AddAnalyzerProvider(IIncrementalAnalyzerProvider provider, IncrementalAnalyzerProviderMetadata metadata)

--- a/src/EditorFeatures/Core/Shared/Preview/PreviewSolutionCrawlerRegistrationService.cs
+++ b/src/EditorFeatures/Core/Shared/Preview/PreviewSolutionCrawlerRegistrationService.cs
@@ -116,12 +116,16 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
             private async Task UnregisterAsync(Workspace workspace)
             {
                 Contract.ThrowIfFalse(workspace == _workspace);
-                Contract.ThrowIfNull(_analyzeTask);
+
+                var analyzeTask = _analyzeTask;
+                if (analyzeTask != null)
+                {
+                    // wait for analyzer work to be finished
+                    await analyzeTask.ConfigureAwait(false);
+                }
 
                 _source.Cancel();
-
-                // wait for analyzer work to be finished
-                await _analyzeTask.ConfigureAwait(false);
+                _source.Dispose();
 
                 // ask it to reset its stages for the given workspace
                 _owner._analyzerService.ShutdownAnalyzerFrom(_workspace);

--- a/src/Workspaces/Core/Portable/SolutionCrawler/ISolutionCrawlerRegistrationService.cs
+++ b/src/Workspaces/Core/Portable/SolutionCrawler/ISolutionCrawlerRegistrationService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.SolutionCrawler
@@ -14,6 +12,11 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
     internal interface ISolutionCrawlerRegistrationService : IWorkspaceService
     {
         void Register(Workspace workspace);
+
+        /// <summary>
+        /// Unregisters solution crawler for given <paramref name="workspace"/>.
+        /// No-op if never registered or already unregistered.
+        /// </summary>
         void Unregister(Workspace workspace, bool blockingShutdown = false);
 
         void AddAnalyzerProvider(IIncrementalAnalyzerProvider provider, IncrementalAnalyzerProviderMetadata metadata);


### PR DESCRIPTION
…when Unregister is called without solution crawler being registered.

This happens for preview in Tools Options.

Fixes https://github.com/dotnet/roslyn/issues/66106