### PR TITLE
Fix potential invalid TextSpan when reporting FAR results

### DIFF
--- a/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpanFactory.cs
+++ b/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpanFactory.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -60,7 +61,11 @@ namespace Microsoft.CodeAnalysis.Classification
             var sourceLine = sourceText.Lines.GetLineFromPosition(referenceSpan.Start);
             var firstNonWhitespacePosition = sourceLine.GetFirstNonWhitespacePosition().Value;
 
-            return TextSpan.FromBounds(firstNonWhitespacePosition, sourceLine.End);
+            // Get the span of the line from the first non-whitespace character to the end of it. Note: the reference
+            // span might actually start in the leading whitespace of the line (nothing prevents any of our
+            // languages/providers from doing that), so ensure that the line snap we clip out at least starts at that
+            // position so that our span math will be correct.
+            return TextSpan.FromBounds(Math.Min(firstNonWhitespacePosition, referenceSpan.Start), sourceLine.End);
         }
 
         private static async Task<ClassifiedSpansAndHighlightSpan> GetTaggedTextForDocumentRegionAsync(


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1713186.

Have seen a few hits in the wild of a crash when producing the excerpt of text used in FAR to display the result.  The crash location is in this code:

```c#
        private static async Task<ClassifiedSpansAndHighlightSpan> GetTaggedTextForDocumentRegionAsync(
            Document document, TextSpan narrowSpan, TextSpan widenedSpan, ClassificationOptions options, CancellationToken cancellationToken)
        {
            var highlightSpan = new TextSpan(
                start: narrowSpan.Start - widenedSpan.Start,
                length: narrowSpan.Length);
```

where 'start' is invalid (which means it must be negative).  The only way this seems possible (since 'widenedSpan' is computed from 'narrowSpan') is the problem listed in the comment added with the fix.  Specifically, that some provider is oddly (but legally) producing a definition or reference-span that eats into the leading-whitespace of the line.  In such a case we would end up with the 'widenedSpan' actually starting after the 'narrowSpan' and we will produce the invalid text span. 

Since there is nothing technically illegal about a provider doing this, i'm just making this code correctly be resilient to it.
