### PR TITLE
workaround tabular data control focus issue

### DIFF
--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/SettingsViewModelBase.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/SettingsViewModelBase.cs
@@ -80,6 +80,8 @@ namespace Microsoft.VisualStudio.LanguageServices.EditorConfigSettings.Common
                     fixedColumns);
 
             control.KeepSelectionInView = true;
+            control.DoNotLoseFocusOnBucketExpandOrCollapse();
+
             return control;
         }
 

--- a/src/VisualStudio/Core/Def/EditorConfigSettings/Common/TableControlFocusFixer.cs
+++ b/src/VisualStudio/Core/Def/EditorConfigSettings/Common/TableControlFocusFixer.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Microsoft.VisualStudio.Shell.TableControl;
+
+namespace Microsoft.VisualStudio.LanguageServices
+{
+    internal static class TableControlFocusFixer
+    {
+        /// <summary>
+        /// A Workaround for a focus issue in the tabular data control.
+        /// When buckets are collapsed, depending on which element has focus at the time,
+        /// focus is shifted to the outer control making keyboard navigation difficult.
+        /// In some cases this behavior is fine (like the find-all-references tool window)
+        /// because we already navigate the user (and therefore change focus) to the symbol definition
+        /// on focus. Use this workaround in cases where we must not change keyboard focus.
+        /// </summary>
+        public static void DoNotLoseFocusOnBucketExpandOrCollapse(this IWpfTableControl tableControl)
+        {
+            tableControl.Control.PreviewLostKeyboardFocus += (object sender, KeyboardFocusChangedEventArgs e) =>
+            {
+                // The tabular data control is a list view, the new focus changing to a different control tells us we've hit this case.
+                // This workaround will break if the underlying implementation of the tabular data control is changed someday.
+                if (e.NewFocus is not ListView && (e.KeyboardDevice.IsKeyDown(Key.Left) || e.KeyboardDevice.IsKeyDown(Key.Right)))
+                {
+                    // Set handled to true to indicate that we want to not do this focus change.
+                    e.Handled = true;
+                }
+            };
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/UnusedReferences/Dialog/UnusedReferencesTableProvider.cs
+++ b/src/VisualStudio/Core/Def/UnusedReferences/Dialog/UnusedReferencesTableProvider.cs
@@ -44,6 +44,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.UnusedReference
             tableControl.ShowGroupingLine = true;
             tableControl.DoColumnsAutoAdjust = true;
             tableControl.DoSortingAndGroupingWhileUnstable = true;
+            tableControl.DoNotLoseFocusOnBucketExpandOrCollapse();
 
             return tableControl;
 


### PR DESCRIPTION
fixes [ADO#1642253](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1642253)

Without this fix keyboard navigation is inconsistent in the tabular data control.

If you have selected the entire header and not any inner elements (the mouse will select more inner elements) and attempt to collapse the group, your focus will be shifted to the parent control.

![Focus_To_Outer_Control](https://user-images.githubusercontent.com/9797472/210665419-f8b6fe27-be92-460b-840b-0083f3c2cf18.gif)

With this change we intercept this specific behavior and opt-out of the focus change.

![Focus_To_Table_Control](https://user-images.githubusercontent.com/9797472/210666305-0f00bbe5-2823-42c0-a4f8-a7ce884e98d3.gif)
