### PR TITLE
Unify `ConstantValueOpt` and `ConstantValue` properties

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -554,7 +554,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // constants/literals are strictly RValues
             // void is not even an RValue
-            if ((expr.ConstantValue != null) || (expr.Type.GetSpecialTypeSafe() == SpecialType.System_Void))
+            if ((expr.ConstantValueOpt != null) || (expr.Type.GetSpecialTypeSafe() == SpecialType.System_Void))
             {
                 Error(diagnostics, GetStandardLvalueError(valueKind), node);
                 return false;
@@ -2758,7 +2758,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // constants/literals cannot ref-escape current scope
-            if (expr.ConstantValue != null)
+            if (expr.ConstantValueOpt != null)
             {
                 return scopeOfTheContainingExpression;
             }
@@ -3002,7 +3002,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // references to constants/literals cannot escape higher.
-            if (expr.ConstantValue != null)
+            if (expr.ConstantValueOpt != null)
             {
                 Error(diagnostics, GetStandardRValueRefEscapeError(escapeTo), node);
                 return false;
@@ -3299,7 +3299,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // constants/literals cannot refer to local state
-            if (expr.ConstantValue != null)
+            if (expr.ConstantValueOpt != null)
             {
                 return Binder.CallingMethodScope;
             }
@@ -3720,7 +3720,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // constants/literals cannot refer to local state
-            if (expr.ConstantValue != null)
+            if (expr.ConstantValueOpt != null)
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -941,7 +941,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // Validate Statement 2) of the spec comment above.
 
-                ConstantValue? constantValue = node.ConstantValue;
+                ConstantValue? constantValue = node.ConstantValueOpt;
                 if (constantValue != null)
                 {
                     if (constantValue.IsBad)
@@ -969,7 +969,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private TypedConstant VisitConversion(BoundConversion node, BindingDiagnosticBag diagnostics, ref bool attrHasErrors, bool curArgumentHasErrors)
             {
-                Debug.Assert(node.ConstantValue == null);
+                Debug.Assert(node.ConstantValueOpt == null);
 
                 // We have a bound conversion with a non-constant value.
                 // According to statement 2) of the spec comment, this is not a valid attribute argument.

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         CheckOverflowAtRuntime,
                         explicitCastInCode: isCast && !wasCompilerGenerated,
                         conversionGroupOpt,
-                        convertedSwitch.ConstantValue,
+                        convertedSwitch.ConstantValueOpt,
                         destination,
                         hasErrors);
                 }
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         CheckOverflowAtRuntime,
                         explicitCastInCode: isCast && !wasCompilerGenerated,
                         conversionGroupOpt,
-                        convertedConditional.ConstantValue,
+                        convertedConditional.ConstantValueOpt,
                         destination,
                         hasErrors);
                 }
@@ -190,7 +190,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         unconvertedSource.Syntax,
                         interpolationData: null,
                         BindInterpolatedStringParts(unconvertedSource, diagnostics),
-                        unconvertedSource.ConstantValue,
+                        unconvertedSource.ConstantValueOpt,
                         unconvertedSource.Type,
                         unconvertedSource.HasErrors);
                 }
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                   node.Binder.CheckOverflowAtRuntime,
                                   explicitCastInCode: isCast && !wasCompilerGenerated,
                                   conversionGroupOpt,
-                                  expr.ConstantValue,
+                                  expr.ConstantValueOpt,
                                   destination)
             { WasCompilerGenerated = wasCompilerGenerated };
 
@@ -1513,7 +1513,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // TODO: Some conversions can produce errors or warnings depending on checked/unchecked.
             // TODO: Fold conversions on enums and strings too.
 
-            var sourceConstantValue = source.ConstantValue;
+            var sourceConstantValue = source.ConstantValueOpt;
             if (sourceConstantValue == null)
             {
                 if (conversion.Kind == ConversionKind.DefaultLiteral)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -353,7 +353,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         result = new BoundDefaultExpression(
                             defaultExpr.Syntax,
                             targetType: null,
-                            defaultExpr.ConstantValue,
+                            defaultExpr.ConstantValueOpt,
                             CreateErrorType(),
                             hasErrors: true).WithSuppression(defaultExpr.IsSuppressed);
                     }
@@ -2596,7 +2596,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // It's possible for the S -> T conversion to produce a 'better' constant value.  If this 
                 // constant value is produced place it in the tree so that it gets emitted.  This maintains 
                 // parity with the native compiler which also evaluated the conversion at compile time. 
-                if (underlyingExpr.ConstantValue != null &&
+                if (underlyingExpr.ConstantValueOpt != null &&
                     !underlyingExpr.HasErrors && !bag.HasAnyErrors())
                 {
                     underlyingExpr.WasCompilerGenerated = true;
@@ -3922,7 +3922,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            var constantValue = expression.ConstantValue;
+            var constantValue = expression.ConstantValueOpt;
 
             if (constantValue == null || constantValue.IsBad || expression.Type.SpecialType != SpecialType.System_Int32)
             {
@@ -3941,7 +3941,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            var constantValue = expression.ConstantValue;
+            var constantValue = expression.ConstantValueOpt;
             if (constantValue == null || constantValue.IsBad)
             {
                 return false;
@@ -6677,7 +6677,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void WarnOnAccessOfOffDefault(SyntaxNode node, BoundExpression boundLeft, BindingDiagnosticBag diagnostics)
         {
-            if ((boundLeft is BoundDefaultLiteral || boundLeft is BoundDefaultExpression) && boundLeft.ConstantValue == ConstantValue.Null &&
+            if ((boundLeft is BoundDefaultLiteral || boundLeft is BoundDefaultExpression) && boundLeft.ConstantValueOpt == ConstantValue.Null &&
                 Compilation.LanguageVersion < MessageID.IDS_FeatureNullableReferenceTypes.RequiredVersion())
             {
                 Error(diagnostics, ErrorCode.WRN_DotOnDefault, node, boundLeft.Type);
@@ -7417,7 +7417,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         @checked: true,
                         explicitCastInCode: false,
                         conversionGroupOpt: null,
-                        constantValueOpt: expr.ConstantValue,
+                        constantValueOpt: expr.ConstantValueOpt,
                         type: underlyingType);
                 }
             }
@@ -7860,7 +7860,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Answer: Because multidimensional arrays can have nonzero lower bounds in the CLR.
                 if (rank == 1 && !index.HasAnyErrors)
                 {
-                    ConstantValue constant = index.ConstantValue;
+                    ConstantValue constant = index.ConstantValueOpt;
                     if (constant != null && constant.IsNegativeNumeric)
                     {
                         Error(diagnostics, ErrorCode.WRN_NegativeArrayIndex, index.Syntax);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_InterpolatedString.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 if (interpolation.AlignmentClause != null)
                                 {
                                     alignment = GenerateConversionForAssignment(intType, BindValue(interpolation.AlignmentClause.Value, diagnostics, Binder.BindValueKind.RValue), diagnostics);
-                                    var alignmentConstant = alignment.ConstantValue;
+                                    var alignmentConstant = alignment.ConstantValueOpt;
                                     if (alignmentConstant != null && !alignmentConstant.IsBad)
                                     {
                                         const int magnitudeLimit = 32767;
@@ -139,16 +139,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                                 builder.Add(new BoundStringInsert(interpolation, value, alignment, format, isInterpolatedStringHandlerAppendCall: false));
                                 if (!isResultConstant ||
-                                    value.ConstantValue == null ||
+                                    value.ConstantValueOpt == null ||
                                     !(interpolation is { FormatClause: null, AlignmentClause: null }) ||
-                                    !(value.ConstantValue is { IsString: true, IsBad: false }))
+                                    !(value.ConstantValueOpt is { IsString: true, IsBad: false }))
                                 {
                                     isResultConstant = false;
                                     continue;
                                 }
                                 resultConstant = (resultConstant is null)
-                                    ? value.ConstantValue
-                                    : FoldStringConcatenation(BinaryOperatorKind.StringConcatenation, resultConstant, value.ConstantValue);
+                                    ? value.ConstantValueOpt
+                                    : FoldStringConcatenation(BinaryOperatorKind.StringConcatenation, resultConstant, value.ConstantValueOpt);
                                 continue;
                             }
                         case SyntaxKind.InterpolatedStringText:
@@ -237,7 +237,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // We need to do the determination of 1, 2, 3, or 4/5 up front, rather than in lowering, as it affects diagnostics (ref structs not being
             // able to be used, for example). However, between 4 and 5, we don't need to know at this point, so that logic is deferred for lowering.
 
-            if (unconvertedInterpolatedString.ConstantValue is not null)
+            if (unconvertedInterpolatedString.ConstantValueOpt is not null)
             {
                 // Case 1
                 Debug.Assert(unconvertedInterpolatedString.Parts.All(static part => part.Type is null or { SpecialType: SpecialType.System_String }));
@@ -265,7 +265,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     unconvertedInterpolatedString.Syntax,
                     data,
                     parts,
-                    unconvertedInterpolatedString.ConstantValue,
+                    unconvertedInterpolatedString.ConstantValueOpt,
                     unconvertedInterpolatedString.Type,
                     unconvertedInterpolatedString.HasErrors);
 
@@ -318,7 +318,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // The constant value is folded as part of creating the unconverted operator. If there is a constant value, then the top-level binary operator
             // will have one.
-            if (binaryOperator.ConstantValue is not null)
+            if (binaryOperator.ConstantValueOpt is not null)
             {
                 // This is case 1. Let the standard machinery handle it
                 return false;
@@ -386,7 +386,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     expression.Syntax,
                     interpolationData: null,
                     arg.AppendCalls[i],
-                    expression.ConstantValue,
+                    expression.ConstantValueOpt,
                     expression.Type,
                     expression.HasErrors);
             }
@@ -397,7 +397,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     BinaryOperatorKind.StringConcatenation,
                     left,
                     right,
-                    original.ConstantValue,
+                    original.ConstantValueOpt,
                     methodOpt: null,
                     constrainedToTypeOpt: null,
                     LookupResultKind.Viable,
@@ -447,7 +447,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 unconvertedInterpolatedString.Syntax,
                 interpolationData,
                 appendCalls[0],
-                unconvertedInterpolatedString.ConstantValue,
+                unconvertedInterpolatedString.ConstantValueOpt,
                 unconvertedInterpolatedString.Type,
                 unconvertedInterpolatedString.HasErrors);
         }
@@ -782,8 +782,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     else
                     {
                         var boundLiteral = (BoundLiteral)part;
-                        Debug.Assert(boundLiteral.ConstantValue != null && boundLiteral.ConstantValue.IsString);
-                        var literalText = boundLiteral.ConstantValue.StringValue;
+                        Debug.Assert(boundLiteral.ConstantValueOpt != null && boundLiteral.ConstantValueOpt.IsString);
+                        var literalText = boundLiteral.ConstantValueOpt.StringValue;
                         methodName = BoundInterpolatedString.AppendLiteralMethod;
                         argumentsBuilder.Add(boundLiteral.Update(ConstantValue.Create(literalText), boundLiteral.Type));
                         isLiteral = true;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -1771,8 +1771,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return nullableEqualityResult;
             }
 
-            var valueLeft = left.ConstantValue;
-            var valueRight = right.ConstantValue;
+            var valueLeft = left.ConstantValueOpt;
+            var valueRight = right.ConstantValueOpt;
             if (valueLeft == null || valueRight == null)
             {
                 return null;
@@ -1916,8 +1916,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         BoundConversion leftConv = (BoundConversion)left;
                         BoundConversion rightConv = (BoundConversion)right;
-                        ConstantValue? leftConstant = leftConv.Operand.ConstantValue;
-                        ConstantValue? rightConstant = rightConv.Operand.ConstantValue;
+                        ConstantValue? leftConstant = leftConv.Operand.ConstantValueOpt;
+                        ConstantValue? rightConstant = rightConv.Operand.ConstantValueOpt;
 
                         if (leftConstant != null && rightConstant != null)
                         {
@@ -2796,7 +2796,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            var value = operand.ConstantValue;
+            var value = operand.ConstantValueOpt;
             if (value == null || value.IsBad)
             {
                 return value;
@@ -3227,7 +3227,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
 
-            if (operand.ConstantValue == ConstantValue.Null ||
+            if (operand.ConstantValueOpt == ConstantValue.Null ||
                 operand.Kind == BoundKind.MethodGroup ||
                 operand.Type.IsVoidType())
             {
@@ -3269,7 +3269,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Conversion conversion = Conversions.ClassifyBuiltInConversion(operandType, targetType, isChecked: CheckOverflowAtRuntime, ref useSiteInfo);
             diagnostics.Add(node, useSiteInfo);
-            ReportIsOperatorDiagnostics(node, diagnostics, operandType, targetType, conversion.Kind, operand.ConstantValue);
+            ReportIsOperatorDiagnostics(node, diagnostics, operandType, targetType, conversion.Kind, operand.ConstantValueOpt);
             return new BoundIsOperator(node, operand, typeExpression, conversion.Kind, resultType);
 
             bool tryBindAsType(
@@ -3736,7 +3736,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
             Conversion conversion = Conversions.ClassifyBuiltInConversion(operandType, targetType, isChecked: CheckOverflowAtRuntime, ref useSiteInfo);
             diagnostics.Add(node, useSiteInfo);
-            bool hasErrors = ReportAsOperatorConversionDiagnostics(node, diagnostics, this.Compilation, operandType, targetType, conversion.Kind, operand.ConstantValue);
+            bool hasErrors = ReportAsOperatorConversionDiagnostics(node, diagnostics, this.Compilation, operandType, targetType, conversion.Kind, operand.ConstantValueOpt);
 
             if (conversion.Exists)
             {
@@ -4308,19 +4308,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private static ConstantValue FoldConditionalOperator(BoundExpression condition, BoundExpression trueExpr, BoundExpression falseExpr)
         {
-            ConstantValue trueValue = trueExpr.ConstantValue;
+            ConstantValue trueValue = trueExpr.ConstantValueOpt;
             if (trueValue == null || trueValue.IsBad)
             {
                 return trueValue;
             }
 
-            ConstantValue falseValue = falseExpr.ConstantValue;
+            ConstantValue falseValue = falseExpr.ConstantValueOpt;
             if (falseValue == null || falseValue.IsBad)
             {
                 return falseValue;
             }
 
-            ConstantValue conditionValue = condition.ConstantValue;
+            ConstantValue conditionValue = condition.ConstantValueOpt;
             if (conditionValue == null || conditionValue.IsBad)
             {
                 return conditionValue;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
             }
-            else if (expression.ConstantValue != null)
+            else if (expression.ConstantValueOpt != null)
             {
                 decisionDag = decisionDag.SimplifyDecisionDagIfConstantInput(expression);
                 if (!hasErrors && getConstantResult(decisionDag, negated, whenTrueLabel, whenFalseLabel) is { } simplifiedResult)
@@ -598,10 +598,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 convertedExpression = expression;
                 // If the expression does not have a constant value, an error will be reported in the caller
-                if (!hasErrors && expression.ConstantValue is object)
+                if (!hasErrors && expression.ConstantValueOpt is object)
                 {
                     CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
-                    if (expression.ConstantValue == ConstantValue.Null)
+                    if (expression.ConstantValueOpt == ConstantValue.Null)
                     {
                         // Pointers are value types, but they can be assigned null, so they can be matched against null.
                         if (inputType.IsNonNullableValueType() && !inputType.IsPointerOrFunctionPointer())
@@ -664,7 +664,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     convertedExpression = BindToNaturalType(expression, diagnostics);
 
-                    constantValue = convertedExpression.ConstantValue;
+                    constantValue = convertedExpression.ConstantValueOpt;
                     if (constantValue == ConstantValue.Null)
                     {
                         diagnostics.Add(ErrorCode.ERR_PatternSpanCharCannotBeStringNull, convertedExpression.Syntax.Location, inputType);
@@ -684,14 +684,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var conversion = (BoundConversion)convertedExpression;
                     BoundExpression operand = conversion.Operand;
-                    if (inputType.IsNullableType() && (convertedExpression.ConstantValue == null || !convertedExpression.ConstantValue.IsNull))
+                    if (inputType.IsNullableType() && (convertedExpression.ConstantValueOpt == null || !convertedExpression.ConstantValueOpt.IsNull))
                     {
                         // Null is a special case here because we want to compare null to the Nullable<T> itself, not to the underlying type.
                         // We are not interested in the diagnostic that get created here
                         convertedExpression = CreateConversion(operand, inputType.GetNullableUnderlyingType(), BindingDiagnosticBag.Discarded);
                     }
                     else if ((conversion.ConversionKind == ConversionKind.Boxing || conversion.ConversionKind == ConversionKind.ImplicitReference)
-                        && operand.ConstantValue != null && convertedExpression.ConstantValue == null)
+                        && operand.ConstantValueOpt != null && convertedExpression.ConstantValueOpt == null)
                     {
                         // A boxed constant (or string converted to object) is a special case because we prefer
                         // to compare to the pre-converted value by casting the input value to the type of the constant
@@ -708,7 +708,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            constantValue = convertedExpression.ConstantValue;
+            constantValue = convertedExpression.ConstantValueOpt;
             return convertedExpression;
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2410,7 +2410,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var sourceType = operand.Type;
             if ((object)sourceType != null)
             {
-                GenerateImplicitConversionError(diagnostics, this.Compilation, syntax, conversion, sourceType, targetType, operand.ConstantValue);
+                GenerateImplicitConversionError(diagnostics, this.Compilation, syntax, conversion, sourceType, targetType, operand.ConstantValueOpt);
                 return;
             }
 
@@ -2599,7 +2599,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (expr.Kind == BoundKind.AssignmentOperator)
                     {
                         var assignment = (BoundAssignmentOperator)expr;
-                        if (assignment.Right.Kind == BoundKind.Literal && assignment.Right.ConstantValue.Discriminator == ConstantValueTypeDiscriminator.Boolean)
+                        if (assignment.Right.Kind == BoundKind.Literal && assignment.Right.ConstantValueOpt.Discriminator == ConstantValueTypeDiscriminator.Boolean)
                         {
                             Error(diagnostics, ErrorCode.WRN_IncorrectBooleanAssg, assignment.Syntax);
                         }
@@ -3268,11 +3268,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             MessageID.IDS_FeatureExceptionFilter.CheckFeatureAvailability(diagnostics, filter, filter.WhenKeyword.GetLocation());
 
             BoundExpression boundFilter = this.BindBooleanExpression(filter.FilterExpression, diagnostics);
-            if (boundFilter.ConstantValue != ConstantValue.NotAvailable)
+            if (boundFilter.ConstantValueOpt != ConstantValue.NotAvailable)
             {
                 // Depending on whether the filter constant is true or false, and whether there are other catch clauses,
                 // we suggest different actions
-                var errorCode = boundFilter.ConstantValue.BooleanValue
+                var errorCode = boundFilter.ConstantValueOpt.BooleanValue
                     ? ErrorCode.WRN_FilterIsConstantTrue
                     : (filter.Parent.Parent is TryStatementSyntax s && s.Catches.Count == 1 && s.Finally == null)
                         ? ErrorCode.WRN_FilterIsConstantFalseRedundantTryCatch

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -1853,7 +1853,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// <summary>
             /// Is the pattern in a state in which it is fully matched and there is no when clause?
             /// </summary>
-            public bool IsFullyMatched => RemainingTests is Tests.True && (WhenClause is null || WhenClause.ConstantValue == ConstantValue.True);
+            public bool IsFullyMatched => RemainingTests is Tests.True && (WhenClause is null || WhenClause.ConstantValueOpt == ConstantValue.True);
 
             /// <summary>
             /// Is the pattern fully matched and ready for the when clause to be evaluated (if any)?

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -1003,7 +1003,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool ReportConstantNullCollectionExpr(BoundExpression collectionExpr, BindingDiagnosticBag diagnostics)
         {
-            if (collectionExpr.ConstantValue is { IsNull: true })
+            if (collectionExpr.ConstantValueOpt is { IsNull: true })
             {
                 // Spec seems to refer to null literals, but Dev10 reports anything known to be null.
                 diagnostics.Add(ErrorCode.ERR_NullNotValid, _syntax.Expression.Location);

--- a/src/Compilers/CSharp/Portable/Binder/LockBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LockBinder.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if ((object)exprType == null)
             {
-                if (expr.ConstantValue != ConstantValue.Null || Compilation.FeatureStrictEnabled) // Dev10 allows the null literal.
+                if (expr.ConstantValueOpt != ConstantValue.Null || Compilation.FeatureStrictEnabled) // Dev10 allows the null literal.
                 {
                     Error(diagnostics, ErrorCode.ERR_LockNeedsReference, exprSyntax, expr.Display);
                     hasErrors = true;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1273,7 +1273,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static bool HasImplicitConstantExpressionConversion(BoundExpression source, TypeSymbol destination)
         {
-            var constantValue = source.ConstantValue;
+            var constantValue = source.ConstantValueOpt;
 
             if (constantValue == null || (object)source.Type == null)
             {
@@ -1382,7 +1382,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            var sourceConstantValue = source.ConstantValue;
+            var sourceConstantValue = source.ConstantValueOpt;
             return sourceConstantValue != null &&
                 source.Type is object &&
                 IsNumericType(source.Type) &&

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorEasyOut.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorEasyOut.cs
@@ -337,7 +337,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // int, both have to be bool, or both have to be string. Otherwise
             // we skip the easy out and go for the slow path.
 
-            if (left.ConstantValue == null && right.ConstantValue == null)
+            if (left.ConstantValueOpt == null && right.ConstantValueOpt == null)
             {
                 // Neither is constant. Go for the easy out.
                 return false;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2456,7 +2456,7 @@ outerDefault:
             // choice after we received customer reports of problems in the space.
             // https://github.com/dotnet/roslyn/issues/55345
             if (_binder.Compilation.IsFeatureEnabled(MessageID.IDS_FeatureImprovedInterpolatedStrings) &&
-                node is BoundUnconvertedInterpolatedString { ConstantValueOpt: null } or BoundBinaryOperator { IsUnconvertedInterpolatedStringAddition: true, ConstantValue: null })
+                node is BoundUnconvertedInterpolatedString { ConstantValueOpt: null } or BoundBinaryOperator { IsUnconvertedInterpolatedStringAddition: true, ConstantValueOpt: null })
             {
                 switch ((conv1.Kind, conv2.Kind))
                 {

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDecisionDag.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDecisionDag.cs
@@ -137,13 +137,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         public BoundDecisionDag SimplifyDecisionDagIfConstantInput(BoundExpression input)
         {
-            if (input.ConstantValue == null)
+            if (input.ConstantValueOpt == null)
             {
                 return this;
             }
             else
             {
-                ConstantValue inputConstant = input.ConstantValue;
+                ConstantValue inputConstant = input.ConstantValueOpt;
                 return Rewrite(makeReplacement);
 
                 // Make a replacement for a given node, using the precomputed replacements for its successors.

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public virtual ConstantValue? ConstantValue
+        public virtual ConstantValue? ConstantValueOpt
         {
             get
             {
@@ -211,11 +211,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class BoundPassByCopy
     {
-        public override ConstantValue? ConstantValue
+        public override ConstantValue? ConstantValueOpt
         {
             get
             {
-                Debug.Assert(Expression.ConstantValue == null);
+                Debug.Assert(Expression.ConstantValueOpt == null);
                 return null;
             }
         }
@@ -270,11 +270,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class BoundLocal
     {
-        public override ConstantValue? ConstantValue
-        {
-            get { return this.ConstantValueOpt; }
-        }
-
         public override Symbol ExpressionSymbol
         {
             get { return this.LocalSymbol; }
@@ -293,11 +288,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class BoundFieldAccess
     {
-        public override ConstantValue? ConstantValue
-        {
-            get { return this.ConstantValueOpt; }
-        }
-
         public override Symbol? ExpressionSymbol
         {
             get { return this.FieldSymbol; }
@@ -362,7 +352,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class BoundBinaryOperator
     {
-        public override ConstantValue? ConstantValue => Data?.ConstantValue;
+        public override ConstantValue? ConstantValueOpt => Data?.ConstantValue;
 
         public override Symbol? ExpressionSymbol => this.Method;
 
@@ -377,14 +367,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal ImmutableArray<MethodSymbol> OriginalUserDefinedOperatorsOpt => Data?.OriginalUserDefinedOperatorsOpt ?? default(ImmutableArray<MethodSymbol>);
     }
 
-    internal partial class BoundInterpolatedStringBase
-    {
-        public sealed override ConstantValue? ConstantValue
-        {
-            get { return this.ConstantValueOpt; }
-        }
-    }
-
     internal partial class BoundUserDefinedConditionalLogicalOperator
     {
         public override Symbol ExpressionSymbol
@@ -395,11 +377,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class BoundUnaryOperator
     {
-        public override ConstantValue? ConstantValue
-        {
-            get { return this.ConstantValueOpt; }
-        }
-
         public override Symbol? ExpressionSymbol
         {
             get { return this.MethodOpt; }
@@ -422,21 +399,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal partial class BoundLiteral
-    {
-        public override ConstantValue? ConstantValue
-        {
-            get { return this.ConstantValueOpt; }
-        }
-    }
-
     internal partial class BoundConversion
     {
-        public override ConstantValue? ConstantValue
-        {
-            get { return this.ConstantValueOpt; }
-        }
-
         public ConversionKind ConversionKind
         {
             get { return this.Conversion.Kind; }
@@ -464,7 +428,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundConversion UpdateOperand(BoundExpression operand)
         {
-            return this.Update(operand: operand, this.Conversion, this.IsBaseConversion, this.Checked, this.ExplicitCastInCode, this.ConstantValue, this.ConversionGroupOpt, this.OriginalUserDefinedConversionsOpt, this.Type);
+            return this.Update(operand: operand, this.Conversion, this.IsBaseConversion, this.Checked, this.ExplicitCastInCode, this.ConstantValueOpt, this.ConversionGroupOpt, this.OriginalUserDefinedConversionsOpt, this.Type);
         }
 
         /// <summary>
@@ -500,11 +464,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class BoundObjectCreationExpression
     {
-        public override ConstantValue? ConstantValue
-        {
-            get { return this.ConstantValueOpt; }
-        }
-
         public override Symbol ExpressionSymbol
         {
             get { return this.Constructor; }
@@ -567,7 +526,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class BoundDefaultLiteral
     {
-        public override ConstantValue? ConstantValue
+        public override ConstantValue? ConstantValueOpt
         {
             get { return null; }
         }
@@ -575,14 +534,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class BoundConditionalOperator
     {
-        public override ConstantValue? ConstantValue
-        {
-            get
-            {
-                return this.ConstantValueOpt;
-            }
-        }
-
         public bool IsDynamic
         {
             get
@@ -590,28 +541,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // IsTrue dynamic operator is invoked at runtime if the condition is of the type dynamic.
                 // The type of the operator itself is Boolean, so we need to check its kind.
                 return this.Condition.Kind == BoundKind.UnaryOperator && ((BoundUnaryOperator)this.Condition).OperatorKind.IsDynamic();
-            }
-        }
-    }
-
-    internal partial class BoundUnconvertedConditionalOperator
-    {
-        public override ConstantValue? ConstantValue
-        {
-            get
-            {
-                return this.ConstantValueOpt;
-            }
-        }
-    }
-
-    internal partial class BoundSizeOfOperator
-    {
-        public override ConstantValue? ConstantValue
-        {
-            get
-            {
-                return this.ConstantValueOpt;
             }
         }
     }
@@ -665,17 +594,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override bool SuppressVirtualCalls
         {
             get { return true; }
-        }
-    }
-
-    internal partial class BoundNameOfOperator
-    {
-        public override ConstantValue ConstantValue
-        {
-            get
-            {
-                return this.ConstantValueOpt;
-            }
         }
     }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpressionExtensions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public static bool IsLiteralNull(this BoundExpression node)
         {
-            return node is { Kind: BoundKind.Literal, ConstantValue: { Discriminator: ConstantValueTypeDiscriminator.Null } };
+            return node is { Kind: BoundKind.Literal, ConstantValueOpt: { Discriminator: ConstantValueTypeDiscriminator.Null } };
         }
 
         public static bool IsLiteralDefault(this BoundExpression node)
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return true;
             }
 
-            var constValue = node.ConstantValue;
+            var constValue = node.ConstantValueOpt;
             if (constValue != null)
             {
                 return constValue.IsDefaultValue;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode_Source.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode_Source.cs
@@ -220,13 +220,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     case BoundLiteral literal:
                         {
-                            var value = literal.ConstantValue?.Value?.ToString();
+                            var value = literal.ConstantValueOpt?.Value?.ToString();
                             if (value is null)
                             {
                                 append("null");
                                 break;
                             }
-                            switch (literal.ConstantValue?.Discriminator)
+                            switch (literal.ConstantValueOpt?.Discriminator)
                             {
                                 case ConstantValueTypeDiscriminator.String:
                                     append($@"""{value}""");

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -339,7 +339,7 @@
 
     <Field Name="OperatorKind" Type="UnaryOperatorKind"/>
     <Field Name="Operand" Type="BoundExpression"/>
-    <Field Name="ConstantValueOpt" Type="ConstantValue?"/>
+    <Field Name="ConstantValueOpt" Type="ConstantValue?" PropertyOverrides="true"/>
     <Field Name="MethodOpt" Type="MethodSymbol?"/>
     <Field Name="ConstrainedToTypeOpt" Type="TypeSymbol?" Null="allow"/>
     <Field Name="ResultKind" PropertyOverrides="true" Type="LookupResultKind"/>
@@ -635,7 +635,7 @@
     <Field Name="Condition" Type="BoundExpression"/>
     <Field Name="Consequence" Type="BoundExpression"/>
     <Field Name="Alternative" Type="BoundExpression"/>
-    <Field Name="ConstantValueOpt" Type="ConstantValue?"/>
+    <Field Name="ConstantValueOpt" Type="ConstantValue?" PropertyOverrides="true"/>
     <Field Name="NoCommonTypeError" Type="ErrorCode"/>
   </Node>
 
@@ -647,7 +647,7 @@
     <Field Name="Consequence" Type="BoundExpression"/>
     <Field Name="Alternative" Type="BoundExpression"/>
 
-    <Field Name="ConstantValueOpt" Type="ConstantValue?"/>
+    <Field Name="ConstantValueOpt" Type="ConstantValue?" PropertyOverrides="true"/>
 
     <Field Name="NaturalTypeOpt" Type="TypeSymbol?" Null="allow"/>
     <Field Name="WasTargetTyped" Type="bool" />
@@ -780,7 +780,7 @@
     <!-- Converted default expression must have a type. -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="TargetType" Type="BoundTypeExpression?" SkipInVisitor="true"/>
-    <Field Name="ConstantValueOpt" Type="ConstantValue?"/>
+    <Field Name="ConstantValueOpt" Type="ConstantValue?" PropertyOverrides="true"/>
   </Node>
 
   <Node Name="BoundIsOperator" Base="BoundExpression">
@@ -812,7 +812,7 @@
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="SourceType" Type="BoundTypeExpression"/>
-    <Field Name="ConstantValueOpt" Type="ConstantValue?"/>
+    <Field Name="ConstantValueOpt" Type="ConstantValue?" PropertyOverrides="true"/>
   </Node>
 
   <Node Name="BoundConversion" Base="BoundExpression">
@@ -825,7 +825,7 @@
     <Field Name="IsBaseConversion" Type="bool"/>
     <Field Name="Checked" Type="bool"/>
     <Field Name="ExplicitCastInCode" Type="bool"/>
-    <Field Name="ConstantValueOpt" Type="ConstantValue?"/>
+    <Field Name="ConstantValueOpt" Type="ConstantValue?" PropertyOverrides="true"/>
      <!--
          A group instance common to all BoundConversions that represent a single Conversion. The
          field is used in NullableWalker to identify the chained conversions in user-defined
@@ -1309,7 +1309,7 @@
   </Node>
 
   <Node Name="BoundLiteral" Base="BoundExpression">
-    <Field Name="ConstantValueOpt" Type="ConstantValue?"/>
+    <Field Name="ConstantValueOpt" Type="ConstantValue?" PropertyOverrides="true"/>
   </Node>
 
   <Node Name="BoundUtf8String" Base="BoundExpression">
@@ -1344,7 +1344,7 @@
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="LocalSymbol" Type="LocalSymbol"/>
     <Field Name="DeclarationKind" Type="BoundLocalDeclarationKind" Null="NotApplicable"/>
-    <Field Name="ConstantValueOpt" Type="ConstantValue?"/>
+    <Field Name="ConstantValueOpt" Type="ConstantValue?" PropertyOverrides="true"/>
     <!-- True if LocalSymbol.Type.IsNullable could not be inferred. -->
     <Field Name="IsNullableUnknown" Type="bool"/>
   </Node>
@@ -1826,7 +1826,7 @@
     <Field Name="Expanded" Type="bool" PropertyOverrides="true"/>
     <Field Name="ArgsToParamsOpt" Type="ImmutableArray&lt;int&gt;" Null="allow" PropertyOverrides="true"/>
     <Field Name="DefaultArguments" Type="BitVector" PropertyOverrides="true"/>
-    <Field Name="ConstantValueOpt" Type="ConstantValue?"/>
+    <Field Name="ConstantValueOpt" Type="ConstantValue?" PropertyOverrides="true"/>
     <Field Name="InitializerExpressionOpt" Type="BoundObjectInitializerExpressionBase?" PropertyOverrides="true"/>
     <Field Name="WasTargetTyped" Type="bool" PropertyOverrides="true"/>
   </Node>
@@ -2048,7 +2048,7 @@
 
     <Field Name="ReceiverOpt" Type="BoundExpression?"/>
     <Field Name="FieldSymbol" Type="FieldSymbol"/>
-    <Field Name="ConstantValueOpt" Type="ConstantValue?"/>
+    <Field Name="ConstantValueOpt" Type="ConstantValue?" PropertyOverrides="true"/>
     <Field Name="ResultKind" PropertyOverrides="true" Type="LookupResultKind"/>
     <Field Name="IsByValue" Type="bool"/>
     <Field Name="IsDeclaration" Type="bool" />
@@ -2187,7 +2187,7 @@
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="Argument" Type="BoundExpression" Null="disallow"/>
-    <Field Name="ConstantValueOpt" Type="ConstantValue" Null="disallow"/>
+    <Field Name="ConstantValueOpt" Type="ConstantValue" PropertyOverrides="true"/>
   </Node>
 
   <AbstractNode Name="BoundInterpolatedStringBase" Base="BoundExpression">
@@ -2195,7 +2195,7 @@
          from the literal parts of the input. The odd numbered positions are the string inserts. If the interpolated
          string has been bound using the builder pattern, literals are replaced with calls. -->
     <Field Name="Parts" Type="ImmutableArray&lt;BoundExpression&gt;"/>
-    <Field Name="ConstantValueOpt" Type="ConstantValue?"/>
+    <Field Name="ConstantValueOpt" Type="ConstantValue?" PropertyOverrides="true"/>
   </AbstractNode>
 
   <Node Name="BoundUnconvertedInterpolatedString" Base="BoundInterpolatedStringBase">

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -622,8 +622,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             : this(syntax, targetType: null, type.GetDefaultValue(), type, hasErrors)
         {
         }
-
-        public override ConstantValue? ConstantValue => ConstantValueOpt;
     }
 
     internal partial class BoundTryStatement

--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override object Display
         {
-            get { return ConstantValue?.IsNull == true ? MessageID.IDS_NULL.Localize() : base.Display; }
+            get { return ConstantValueOpt?.IsNull == true ? MessageID.IDS_NULL.Localize() : base.Display; }
         }
     }
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -209,7 +209,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         /// </remarks>
         private void EmitConditionalOperatorAddress(BoundConditionalOperator expr, AddressKind addressKind)
         {
-            Debug.Assert(expr.ConstantValue == null, "Constant value should have been emitted directly");
+            Debug.Assert(expr.ConstantValueOpt == null, "Constant value should have been emitted directly");
 
             object consequenceLabel = new object();
             object doneLabel = new object();

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitArrayInitializer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitArrayInitializer.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 return false;
             }
 
-            return includeConstants || init.ConstantValue == null;
+            return includeConstants || init.ConstantValueOpt == null;
         }
 
         /// <summary>
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private static ConstantValue AsConstOrDefault(BoundExpression init)
         {
-            ConstantValue initConstantValueOpt = init.ConstantValue;
+            ConstantValue initConstantValueOpt = init.ConstantValueOpt;
 
             if (initConstantValueOpt != null)
             {
@@ -326,7 +326,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     if (!init.IsDefaultValue())
                     {
                         initCount += 1;
-                        if (init.ConstantValue != null)
+                        if (init.ConstantValueOpt != null)
                         {
                             constInits += 1;
                         }
@@ -508,19 +508,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             if (start is not null)
             {
                 // The start expression needs to be 0.
-                if (start.ConstantValue?.IsDefaultValue != true || start.ConstantValue.Discriminator != ConstantValueTypeDiscriminator.Int32)
+                if (start.ConstantValueOpt?.IsDefaultValue != true || start.ConstantValueOpt.Discriminator != ConstantValueTypeDiscriminator.Int32)
                 {
                     return false;
                 }
 
                 // The length expression needs to be an Int32, and it needs to be in the range [0, elementCount].
                 Debug.Assert(length is not null);
-                if (length.ConstantValue?.Discriminator != ConstantValueTypeDiscriminator.Int32)
+                if (length.ConstantValueOpt?.Discriminator != ConstantValueTypeDiscriminator.Int32)
                 {
                     return false;
                 }
 
-                lengthForConstructor = length.ConstantValue.Int32Value;
+                lengthForConstructor = length.ConstantValueOpt.Int32Value;
 
                 if (lengthForConstructor > elementCount || lengthForConstructor < 0)
                 {
@@ -741,7 +741,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
 
             var initializers = initializer.Initializers;
-            if (initializers.Any(static init => init.ConstantValue == null))
+            if (initializers.Any(static init => init.ConstantValueOpt == null))
             {
                 return -1;
             }
@@ -757,7 +757,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
             foreach (var init in initializer.Initializers)
             {
-                init.ConstantValue.Serialize(writer);
+                init.ConstantValueOpt.Serialize(writer);
             }
 
             data = writer.ToImmutableArray();

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                         // doing this or marking somewhere else that this is necessary.
 
                         // Don't need to do this for constants, however.
-                        if (conversion.Operand.ConstantValue == null)
+                        if (conversion.Operand.ConstantValueOpt == null)
                         {
                             EmitNumericConversion(conversion);
                         }

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 return;
             }
 
-            var constantValue = expression.ConstantValue;
+            var constantValue = expression.ConstantValueOpt;
             if (constantValue != null)
             {
                 if (!used)
@@ -382,7 +382,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             Debug.Assert(!receiverType.IsValueType ||
                 (receiverType.IsNullableType() && expression.HasValueMethodOpt != null), "conditional receiver cannot be a struct");
 
-            var receiverConstant = receiver.ConstantValue;
+            var receiverConstant = receiver.ConstantValueOpt;
             if (receiverConstant?.IsNull == false)
             {
                 // const but not null, must be a reference type
@@ -1400,7 +1400,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             Debug.Assert(receiver.Type.IsVerifierReference(), "this is not a reference");
             Debug.Assert(receiver.Kind != BoundKind.BaseReference, "base should always use call");
 
-            var constVal = receiver.ConstantValue;
+            var constVal = receiver.ConstantValueOpt;
             if (constVal != null)
             {
                 // only when this is a constant Null, we need a callvirt
@@ -1817,7 +1817,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 var current = expression;
                 while (true)
                 {
-                    if (current.ConstantValue != null)
+                    if (current.ConstantValueOpt != null)
                     {
                         return true;
                     }
@@ -2300,7 +2300,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // in-place is not advantageous for reference types or constants
             if (!rightType.IsTypeParameter())
             {
-                if (rightType.IsReferenceType || (right.ConstantValue != null && rightType.SpecialType != SpecialType.System_Decimal))
+                if (rightType.IsReferenceType || (right.ConstantValueOpt != null && rightType.SpecialType != SpecialType.System_Decimal))
                 {
                     return false;
                 }
@@ -3361,7 +3361,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         /// </remarks>
         private void EmitConditionalOperator(BoundConditionalOperator expr, bool used)
         {
-            Debug.Assert(expr.ConstantValue == null, "Constant value should have been emitted directly");
+            Debug.Assert(expr.ConstantValueOpt == null, "Constant value should have been emitted directly");
 
             object consequenceLabel = new object();
             object doneLabel = new object();

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitOperators.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitOperators.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             BoundExpression child = expression.Left;
 
-            if (child.Kind != BoundKind.BinaryOperator || child.ConstantValue != null)
+            if (child.Kind != BoundKind.BinaryOperator || child.ConstantValueOpt != null)
             {
                 EmitBinaryOperatorSimple(expression);
                 return;
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 stack.Push(binary);
                 child = binary.Left;
 
-                if (child.Kind != BoundKind.BinaryOperator || child.ConstantValue != null)
+                if (child.Kind != BoundKind.BinaryOperator || child.ConstantValueOpt != null)
                 {
                     break;
                 }
@@ -357,12 +357,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
                 case BinaryOperatorKind.Equal:
 
-                    var constant = binOp.Left.ConstantValue;
+                    var constant = binOp.Left.ConstantValueOpt;
                     var comparand = binOp.Right;
 
                     if (constant == null)
                     {
-                        constant = comparand.ConstantValue;
+                        constant = comparand.ConstantValueOpt;
                         comparand = binOp.Left;
                     }
 
@@ -481,7 +481,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
             Debug.Assert(condition.Type.SpecialType == SpecialType.System_Boolean);
 
-            var constantValue = condition.ConstantValue;
+            var constantValue = condition.ConstantValueOpt;
             if (constantValue != null)
             {
                 Debug.Assert(constantValue.Discriminator == ConstantValueTypeDiscriminator.Boolean);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStackAllocInitializer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStackAllocInitializer.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 Debug.Assert(!(init is BoundArrayInitialization), "Nested initializers are not allowed for stackalloc");
 
                 initCount += 1;
-                if (init.ConstantValue != null)
+                if (init.ConstantValueOpt != null)
                 {
                     constInits += 1;
                 }
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             int elementTypeSizeInBytes = elementType.SpecialType.SizeInBytes();
             foreach (BoundExpression init in inits)
             {
-                if (includeConstants || init.ConstantValue == null)
+                if (includeConstants || init.ConstantValueOpt == null)
                 {
                     _builder.EmitOpCode(ILOpCode.Dup);
                     EmitPointerElementAccess(init, elementType, elementTypeSizeInBytes, index);

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -232,7 +232,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                         opKind == BinaryOperatorKind.NotEqual);
 
             BoundExpression nonConstOp;
-            BoundExpression constOp = (condition.Left.ConstantValue != null) ? condition.Left : null;
+            BoundExpression constOp = (condition.Left.ConstantValueOpt != null) ? condition.Left : null;
 
             if (constOp != null)
             {
@@ -240,7 +240,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
             else
             {
-                constOp = (condition.Right.ConstantValue != null) ? condition.Right : null;
+                constOp = (condition.Right.ConstantValueOpt != null) ? condition.Right : null;
                 if (constOp == null)
                 {
                     return null;
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
 
             bool isBool = nonConstType.PrimitiveTypeCode == Microsoft.Cci.PrimitiveTypeCode.Boolean;
-            bool isZero = constOp.ConstantValue.IsDefaultValue;
+            bool isZero = constOp.ConstantValueOpt.IsDefaultValue;
 
             // bool is special, only it can be compared to true and false...
             if (!isBool && !isZero)
@@ -395,9 +395,9 @@ oneMoreTime:
 
             ILOpCode ilcode;
 
-            if (condition.ConstantValue != null)
+            if (condition.ConstantValueOpt != null)
             {
-                bool taken = condition.ConstantValue.IsDefaultValue != sense;
+                bool taken = condition.ConstantValueOpt.IsDefaultValue != sense;
 
                 if (taken)
                 {
@@ -1126,7 +1126,7 @@ oneMoreTime:
             KeyValuePair<ConstantValue, object>[] switchCaseLabels,
             LabelSymbol fallThroughLabel)
         {
-            Debug.Assert(expression.ConstantValue == null);
+            Debug.Assert(expression.ConstantValueOpt == null);
             Debug.Assert((object)expression.Type != null &&
                 (expression.Type.IsValidV6SwitchGoverningType() || expression.Type.IsSpanOrReadOnlySpanChar()));
             Debug.Assert(switchCaseLabels.Length > 0);

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -465,7 +465,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             _context = context;
 
             // Do not recurse into constant expressions. Their children do not push any values.
-            var result = node.ConstantValue == null ?
+            var result = node.ConstantValueOpt == null ?
                 node = (BoundExpression)base.Visit(node) :
                 node;
 
@@ -1247,7 +1247,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             Debug.Assert(node.InitializerExpressionOpt == null);
 
             return node.Update(constructor, rewrittenArguments, node.ArgumentNamesOpt, node.ArgumentRefKindsOpt,
-                node.Expanded, node.ArgsToParamsOpt, node.DefaultArguments, node.ConstantValue, initializerExpressionOpt: null, node.Type);
+                node.Expanded, node.ArgsToParamsOpt, node.DefaultArguments, node.ConstantValueOpt, initializerExpressionOpt: null, node.Type);
         }
 
         public override BoundNode VisitArrayAccess(BoundArrayAccess node)
@@ -1401,7 +1401,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             BoundExpression child = node.Left;
 
-            if (child.Kind != BoundKind.BinaryOperator || child.ConstantValue != null)
+            if (child.Kind != BoundKind.BinaryOperator || child.ConstantValueOpt != null)
             {
                 return VisitBinaryOperatorSimple(node);
             }
@@ -1417,7 +1417,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 stack.Push(binary);
                 child = binary.Left;
 
-                if (child.Kind != BoundKind.BinaryOperator || child.ConstantValue != null)
+                if (child.Kind != BoundKind.BinaryOperator || child.ConstantValueOpt != null)
                 {
                     break;
                 }
@@ -1451,7 +1451,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 }
 
                 var type = this.VisitType(binary.Type);
-                left = binary.Update(binary.OperatorKind, binary.ConstantValue, binary.Method, binary.ConstrainedToType, binary.ResultKind, left, right, type);
+                left = binary.Update(binary.OperatorKind, binary.ConstantValueOpt, binary.Method, binary.ConstrainedToType, binary.ResultKind, left, right, type);
 
                 if (stack.Count == 0)
                 {
@@ -1485,7 +1485,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
                 EnsureStackState(cookie);   // implicit label here
 
-                return node.Update(node.OperatorKind, node.ConstantValue, node.Method, node.ConstrainedToType, node.ResultKind, left, right, node.Type);
+                return node.Update(node.OperatorKind, node.ConstantValueOpt, node.Method, node.ConstrainedToType, node.ResultKind, left, right, node.Type);
             }
 
             return base.VisitBinaryOperator(node);
@@ -1964,7 +1964,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             // so we will not go into constant nodes. 
             // CodeGen will not do that either.
             var asExpression = node as BoundExpression;
-            if (asExpression != null && asExpression.ConstantValue != null)
+            if (asExpression != null && asExpression.ConstantValueOpt != null)
             {
                 result = node;
             }
@@ -1982,7 +1982,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             BoundExpression child = node.Left;
 
-            if (child.Kind != BoundKind.BinaryOperator || child.ConstantValue != null)
+            if (child.Kind != BoundKind.BinaryOperator || child.ConstantValueOpt != null)
             {
                 return base.VisitBinaryOperator(node);
             }
@@ -1998,7 +1998,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 stack.Push(binary);
                 child = binary.Left;
 
-                if (child.Kind != BoundKind.BinaryOperator || child.ConstantValue != null)
+                if (child.Kind != BoundKind.BinaryOperator || child.ConstantValueOpt != null)
                 {
                     break;
                 }
@@ -2013,7 +2013,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 binary = stack.Pop();
                 var right = (BoundExpression)this.Visit(binary.Right);
                 var type = this.VisitType(binary.Type);
-                left = binary.Update(binary.OperatorKind, binary.ConstantValue, binary.Method, binary.ConstrainedToType, binary.ResultKind, left, right, type);
+                left = binary.Update(binary.OperatorKind, binary.ConstantValueOpt, binary.Method, binary.ConstrainedToType, binary.ResultKind, left, right, type);
 
                 if (stack.Count == 0)
                 {

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -1251,7 +1251,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (boundExpr == null) return default(Optional<object>);
 
-            ConstantValue constantValue = boundExpr.ConstantValue;
+            ConstantValue constantValue = boundExpr.ConstantValueOpt;
             return constantValue == null || constantValue.IsBad
                 ? default(Optional<object>)
                 : new Optional<object>(constantValue.Value);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -667,17 +667,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected static bool IsConstantTrue(BoundExpression node)
         {
-            return node.ConstantValue == ConstantValue.True;
+            return node.ConstantValueOpt == ConstantValue.True;
         }
 
         protected static bool IsConstantFalse(BoundExpression node)
         {
-            return node.ConstantValue == ConstantValue.False;
+            return node.ConstantValueOpt == ConstantValue.False;
         }
 
         protected static bool IsConstantNull(BoundExpression node)
         {
-            return node.ConstantValue == ConstantValue.Null;
+            return node.ConstantValueOpt == ConstantValue.Null;
         }
 
         /// <summary>
@@ -1567,7 +1567,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected void SplitIfBooleanConstant(BoundExpression node)
         {
-            if (node.ConstantValue is { IsBoolean: true, BooleanValue: bool booleanValue })
+            if (node.ConstantValueOpt is { IsBoolean: true, BooleanValue: bool booleanValue })
             {
                 var unreachable = UnreachableState();
                 Split();
@@ -2380,7 +2380,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Meet(ref stateWhenNotNull, ref State);
                 }
 
-                var isNullConstant = binary.Right.ConstantValue?.IsNull == true;
+                var isNullConstant = binary.Right.ConstantValueOpt?.IsNull == true;
                 SetConditionalState(isNullConstant == isEquals(binary)
                     ? (State, stateWhenNotNull)
                     : (stateWhenNotNull, State));
@@ -2419,7 +2419,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             static bool isKnownNullOrNotNull(BoundExpression expr)
             {
-                return expr.ConstantValue is object
+                return expr.ConstantValueOpt is object
                     || (expr is BoundConversion { ConversionKind: ConversionKind.ExplicitNullable or ConversionKind.ImplicitNullable } conv
                         && conv.Operand.Type!.IsNonNullableValueType());
             }
@@ -2433,7 +2433,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // `true == a?.b(out x)`
                 if (isKnownNullOrNotNull(binary.Left) && TryVisitConditionalAccess(binary.Right, out var stateWhenNotNull))
                 {
-                    var isNullConstant = binary.Left.ConstantValue?.IsNull == true;
+                    var isNullConstant = binary.Left.ConstantValueOpt?.IsNull == true;
                     SetConditionalState(isNullConstant == isEquals(binary)
                         ? (State, stateWhenNotNull)
                         : (stateWhenNotNull, State));
@@ -2441,7 +2441,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
                 }
                 // `a && b(out x) == true`
-                else if (IsConditionalState && binary.Right.ConstantValue is { IsBoolean: true } rightConstant)
+                else if (IsConditionalState && binary.Right.ConstantValueOpt is { IsBoolean: true } rightConstant)
                 {
                     var (stateWhenTrue, stateWhenFalse) = (StateWhenTrue.Clone(), StateWhenFalse.Clone());
                     Unsplit();
@@ -2453,7 +2453,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
                 }
                 // `true == a && b(out x)`
-                else if (binary.Left.ConstantValue is { IsBoolean: true } leftConstant)
+                else if (binary.Left.ConstantValueOpt is { IsBoolean: true } leftConstant)
                 {
                     Unsplit();
                     Visit(binary.Right);
@@ -2739,7 +2739,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     savedState = State.Clone();
                 }
 
-                if (node.LeftOperand.ConstantValue != null)
+                if (node.LeftOperand.ConstantValueOpt != null)
                 {
                     SetUnreachable();
                 }
@@ -2839,7 +2839,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 stateWhenNotNull = this.State.Clone();
             }
 
-            if (node.Receiver.ConstantValue != null && !IsConstantNull(node.Receiver))
+            if (node.Receiver.ConstantValueOpt != null && !IsConstantNull(node.Receiver))
             {
                 // Consider a scenario like `"a"?.M0(x = 1)?.M0(y = 1)`.
                 // We can "know" that `.M0(x = 1)` was evaluated unconditionally but not `M0(y = 1)`.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_Switch.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass_Switch.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 foreach (var label in section.SwitchLabels)
                 {
                     if (reachableLabels.Contains(label.Label) || label.HasErrors ||
-                        label == node.DefaultLabel && node.Expression.ConstantValue == null && IsTraditionalSwitch(node))
+                        label == node.DefaultLabel && node.Expression.ConstantValueOpt == null && IsTraditionalSwitch(node))
                     {
                         SetState(initialState.Clone());
                     }
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             TLocalState afterSwitchState = UnreachableState();
             if (node.ReachabilityDecisionDag.ReachableLabels.Contains(node.BreakLabel) ||
-                (node.DefaultLabel == null && node.Expression.ConstantValue == null && IsTraditionalSwitch(node)))
+                (node.DefaultLabel == null && node.Expression.ConstantValueOpt == null && IsTraditionalSwitch(node)))
             {
                 Join(ref afterSwitchState, ref initialState);
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -857,7 +857,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 type.SpecialType != SpecialType.System_String &&
                 type is not ArrayTypeSymbol { IsSZArray: true, ElementType.SpecialType: SpecialType.System_Byte })
             {
-                return value.ConstantValue != ConstantValue.Null;
+                return value.ConstantValueOpt != ConstantValue.Null;
             }
 
             if ((object)type != null && type.IsPointerOrFunctionPointer())
@@ -870,7 +870,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // that used them were always considered used. We now consider interpolated strings that are
             // made up of only constant expressions to be constant values, but for backcompat we consider
             // the writes to be uses anyway.
-            if (value is { ConstantValue: not null, Kind: not BoundKind.InterpolatedString }) return false;
+            if (value is { ConstantValueOpt: not null, Kind: not BoundKind.InterpolatedString }) return false;
 
             switch (value.Kind)
             {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
@@ -244,7 +244,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // If the constant value of a when clause is true, it can be skipped by the dag
                 // generator as an optimization. In that case, it's a value type and will be set
                 // as not nullable in the output.
-                if (node.WhenClause?.ConstantValue != ConstantValue.True)
+                if (node.WhenClause?.ConstantValueOpt != ConstantValue.True)
                 {
                     this.Visit(node.WhenClause);
                 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -756,7 +756,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (pendingReturn.IsConditionalState)
                 {
-                    if (returnStatement.ExpressionOpt is { ConstantValue: { IsBoolean: true, BooleanValue: bool value } })
+                    if (returnStatement.ExpressionOpt is { ConstantValueOpt: { IsBoolean: true, BooleanValue: bool value } })
                     {
                         enforceMemberNotNullWhen(returnStatement.Syntax, sense: value, pendingReturn.State);
                         return;
@@ -780,7 +780,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
                 }
-                else if (returnStatement.ExpressionOpt is { ConstantValue: { IsBoolean: true, BooleanValue: bool value } })
+                else if (returnStatement.ExpressionOpt is { ConstantValueOpt: { IsBoolean: true, BooleanValue: bool value } })
                 {
                     enforceMemberNotNullWhen(returnStatement.Syntax, sense: value, pendingReturn.State);
                 }
@@ -1071,7 +1071,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (pendingReturn.IsConditionalState)
                 {
-                    if (returnStatement.ExpressionOpt is { ConstantValue: { IsBoolean: true, BooleanValue: bool value } })
+                    if (returnStatement.ExpressionOpt is { ConstantValueOpt: { IsBoolean: true, BooleanValue: bool value } })
                     {
                         EnforceParameterNotNullWhenOnExit(returnStatement.Syntax, parameters, sense: value, stateWhen: pendingReturn.State);
                         return;
@@ -1092,7 +1092,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                     }
                 }
-                else if (returnStatement.ExpressionOpt is { ConstantValue: { IsBoolean: true, BooleanValue: bool value } })
+                else if (returnStatement.ExpressionOpt is { ConstantValueOpt: { IsBoolean: true, BooleanValue: bool value } })
                 {
                     // example: return (bool)true;
                     EnforceParameterNotNullWhenOnExit(returnStatement.Syntax, parameters, sense: value, stateWhen: pendingReturn.State);
@@ -2164,7 +2164,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            if (value.ConstantValue?.IsNull == true && !useLegacyWarnings)
+            if (value.ConstantValueOpt?.IsNull == true && !useLegacyWarnings)
             {
                 // Report warning converting null literal to non-nullable reference type.
                 // target (e.g.: `object F() => null;` or calling `void F(object y)` with `F(null)`).
@@ -4405,7 +4405,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ReinferBinaryOperatorAndSetResult(leftOperand, leftConversion, leftType, rightOperand, rightConversion, rightType, binary);
                 if (isKnownNullOrNotNull(rightOperand, rightType))
                 {
-                    var isNullConstant = rightOperand.ConstantValue?.IsNull == true;
+                    var isNullConstant = rightOperand.ConstantValueOpt?.IsNull == true;
                     SetConditionalState(isNullConstant == isEquals(binary)
                         ? (State, stateWhenNotNull)
                         : (stateWhenNotNull, State));
@@ -4447,7 +4447,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             static bool isKnownNullOrNotNull(BoundExpression expr, TypeWithState resultType)
             {
                 return resultType.State.IsNotNull()
-                    || expr.ConstantValue is object;
+                    || expr.ConstantValueOpt is object;
             }
 
             LocalState getUnconditionalStateWhenNotNull(BoundExpression otherOperand, PossiblyConditionalState conditionalStateWhenNotNull)
@@ -4457,7 +4457,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     stateWhenNotNull = conditionalStateWhenNotNull.State;
                 }
-                else if (isEquals(binary) && otherOperand.ConstantValue is { IsBoolean: true, BooleanValue: var boolValue })
+                else if (isEquals(binary) && otherOperand.ConstantValueOpt is { IsBoolean: true, BooleanValue: var boolValue })
                 {
                     // can preserve conditional state from `.TryGetValue` in `dict?.TryGetValue(key, out value) == true`,
                     // but not in `dict?.TryGetValue(key, out value) != false`
@@ -4489,7 +4489,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     ReinferBinaryOperatorAndSetResult(leftOperand, leftConversion, leftResult, rightOperand, rightConversion, rightType: ResultType, binary);
 
                     var stateWhenNotNull = getUnconditionalStateWhenNotNull(leftOperand, conditionalStateWhenNotNull);
-                    var isNullConstant = leftOperand.ConstantValue?.IsNull == true;
+                    var isNullConstant = leftOperand.ConstantValueOpt?.IsNull == true;
                     SetConditionalState(isNullConstant == isEquals(binary)
                         ? (State, stateWhenNotNull)
                         : (stateWhenNotNull, State));
@@ -4504,7 +4504,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 // `(x != null) == true`
-                if (IsConditionalState && binary.Right.ConstantValue is { IsBoolean: true } rightConstant)
+                if (IsConditionalState && binary.Right.ConstantValueOpt is { IsBoolean: true } rightConstant)
                 {
                     var (stateWhenTrue, stateWhenFalse) = (StateWhenTrue.Clone(), StateWhenFalse.Clone());
                     Unsplit();
@@ -4515,7 +4515,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         : (stateWhenFalse, stateWhenTrue));
                 }
                 // `true == (x != null)`
-                else if (binary.Left.ConstantValue is { IsBoolean: true } leftConstant)
+                else if (binary.Left.ConstantValueOpt is { IsBoolean: true } leftConstant)
                 {
                     Unsplit();
                     Visit(binary.Right);
@@ -4686,11 +4686,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // learn from null constant
                 BoundExpression? operandComparedToNull = null;
-                if (binary.Right.ConstantValue?.IsNull == true)
+                if (binary.Right.ConstantValueOpt?.IsNull == true)
                 {
                     operandComparedToNull = binary.Left;
                 }
-                else if (binary.Left.ConstantValue?.IsNull == true)
+                else if (binary.Left.ConstantValueOpt?.IsNull == true)
                 {
                     operandComparedToNull = binary.Right;
                 }
@@ -4895,7 +4895,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void LearnFromNullTest(BoundExpression expression, ref LocalState state)
         {
             // nothing to learn about a constant
-            if (expression.ConstantValue != null)
+            if (expression.ConstantValueOpt != null)
                 return;
 
             // We should not blindly strip conversions here. Tracked by https://github.com/dotnet/roslyn/issues/36164
@@ -5049,7 +5049,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Unsplit();
             LearnFromNullTest(leftOperand, ref this.State);
 
-            bool leftIsConstant = leftOperand.ConstantValue != null;
+            bool leftIsConstant = leftOperand.ConstantValueOpt != null;
             if (leftIsConstant)
             {
                 SetUnreachable();
@@ -5204,7 +5204,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _currentConditionalReceiverVisitResult = _visitResult;
             var previousConditionalAccessSlot = _lastConditionalAccessSlot;
 
-            if (receiver.ConstantValue is { IsNull: false })
+            if (receiver.ConstantValueOpt is { IsNull: false })
             {
                 // Consider a scenario like `"a"?.M0(x = 1)?.M0(y = 1)`.
                 // We can "know" that `.M0(x = 1)` was evaluated unconditionally but not `M0(y = 1)`.
@@ -5761,13 +5761,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // comparing anything to a null literal gives maybe-null when true and not-null when false
                 // comparing a maybe-null to a not-null gives us not-null when true, nothing learned when false
-                if (left.ConstantValue?.IsNull == true)
+                if (left.ConstantValueOpt?.IsNull == true)
                 {
                     Split();
                     LearnFromNullTest(right, ref StateWhenTrue);
                     LearnFromNonNullTest(right, ref StateWhenFalse);
                 }
-                else if (right.ConstantValue?.IsNull == true)
+                else if (right.ConstantValueOpt?.IsNull == true)
                 {
                     Split();
                     LearnFromNullTest(left, ref StateWhenTrue);
@@ -5844,7 +5844,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var comparand = compareExchangeInfo.Arguments[comparandIndex];
             var valueFlowState = compareExchangeInfo.Results[valueIndex].RValueType.State;
-            if (comparand.ConstantValue?.IsNull == true)
+            if (comparand.ConstantValueOpt?.IsNull == true)
             {
                 // If location contained a null, then the write `location = value` definitely occurred
             }
@@ -7017,7 +7017,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case BoundKind.DefaultLiteral:
                     case BoundKind.DefaultExpression:
                     case BoundKind.Literal:
-                        return expr.ConstantValue == ConstantValue.NotAvailable || !expr.ConstantValue.IsNull || expr.IsSuppressed ? NullableAnnotation.NotAnnotated : NullableAnnotation.Annotated;
+                        return expr.ConstantValueOpt == ConstantValue.NotAvailable || !expr.ConstantValueOpt.IsNull || expr.IsSuppressed ? NullableAnnotation.NotAnnotated : NullableAnnotation.Annotated;
                     case BoundKind.ExpressionWithNullability:
                         return ((BoundExpressionWithNullability)expr).NullableAnnotation;
                     case BoundKind.MethodGroup:
@@ -7212,7 +7212,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 return false;
             }
-            if (value.Type is null || value.Type.IsDynamic() || value.ConstantValue != null)
+            if (value.Type is null || value.Type.IsDynamic() || value.ConstantValueOpt != null)
             {
                 return true;
             }
@@ -10589,7 +10589,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(!IsConditionalState);
             var result = base.VisitLiteral(node);
-            SetResultType(node, TypeWithState.Create(node.Type, node.Type?.CanContainNull() != false && node.ConstantValue?.IsNull == true ? NullableFlowState.MaybeDefault : NullableFlowState.NotNull));
+            SetResultType(node, TypeWithState.Create(node.Type, node.Type?.CanContainNull() != false && node.ConstantValueOpt?.IsNull == true ? NullableFlowState.MaybeDefault : NullableFlowState.NotNull));
             return result;
         }
 
@@ -10693,7 +10693,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             VisitRvalue(node.Argument);
             // https://github.com/dotnet/roslyn/issues/31018: Check for delegate mismatch.
-            if (node.Argument.ConstantValue?.IsNull != true
+            if (node.Argument.ConstantValueOpt?.IsNull != true
                 && MakeMemberSlot(receiverOpt, @event) is > 0 and var memberSlot)
             {
                 this.State[memberSlot] = node.IsAddition

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             switch (pattern)
             {
                 case BoundConstantPattern cp:
-                    bool isExplicitNullCheck = cp.Value.ConstantValue == ConstantValue.Null;
+                    bool isExplicitNullCheck = cp.Value.ConstantValueOpt == ConstantValue.Null;
                     if (isExplicitNullCheck)
                     {
                         // Since we're not branching on this null test here, we just infer the top level
@@ -647,7 +647,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                         }
 
-                        if (w.WhenExpression != null && w.WhenExpression.ConstantValue != ConstantValue.True)
+                        if (w.WhenExpression != null && w.WhenExpression.ConstantValueOpt != ConstantValue.True)
                         {
                             VisitCondition(w.WhenExpression);
                             Debug.Assert(this.IsConditionalState);

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -1194,7 +1194,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public new TypeSymbol Type => base.Type!;
         public UnaryOperatorKind OperatorKind { get; }
         public BoundExpression Operand { get; }
-        public ConstantValue? ConstantValueOpt { get; }
+        public override ConstantValue? ConstantValueOpt { get; }
         public MethodSymbol? MethodOpt { get; }
         public TypeSymbol? ConstrainedToTypeOpt { get; }
         public override LookupResultKind ResultKind { get; }
@@ -1977,7 +1977,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundExpression Condition { get; }
         public BoundExpression Consequence { get; }
         public BoundExpression Alternative { get; }
-        public ConstantValue? ConstantValueOpt { get; }
+        public override ConstantValue? ConstantValueOpt { get; }
         public ErrorCode NoCommonTypeError { get; }
 
         [DebuggerStepThrough]
@@ -2020,7 +2020,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BoundExpression Condition { get; }
         public BoundExpression Consequence { get; }
         public BoundExpression Alternative { get; }
-        public ConstantValue? ConstantValueOpt { get; }
+        public override ConstantValue? ConstantValueOpt { get; }
         public TypeSymbol? NaturalTypeOpt { get; }
         public bool WasTargetTyped { get; }
 
@@ -2567,7 +2567,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public new TypeSymbol Type => base.Type!;
         public BoundTypeExpression? TargetType { get; }
-        public ConstantValue? ConstantValueOpt { get; }
+        public override ConstantValue? ConstantValueOpt { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitDefaultExpression(this);
@@ -2671,7 +2671,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public new TypeSymbol Type => base.Type!;
         public BoundTypeExpression SourceType { get; }
-        public ConstantValue? ConstantValueOpt { get; }
+        public override ConstantValue? ConstantValueOpt { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitSizeOfOperator(this);
@@ -2713,7 +2713,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public bool IsBaseConversion { get; }
         public bool Checked { get; }
         public bool ExplicitCastInCode { get; }
-        public ConstantValue? ConstantValueOpt { get; }
+        public override ConstantValue? ConstantValueOpt { get; }
         public ConversionGroup? ConversionGroupOpt { get; }
         public ImmutableArray<MethodSymbol> OriginalUserDefinedConversionsOpt { get; }
 
@@ -4045,7 +4045,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.ConstantValueOpt = constantValueOpt;
         }
 
-        public ConstantValue? ConstantValueOpt { get; }
+        public override ConstantValue? ConstantValueOpt { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitLiteral(this);
@@ -4267,7 +4267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public new TypeSymbol Type => base.Type!;
         public LocalSymbol LocalSymbol { get; }
         public BoundLocalDeclarationKind DeclarationKind { get; }
-        public ConstantValue? ConstantValueOpt { get; }
+        public override ConstantValue? ConstantValueOpt { get; }
         public bool IsNullableUnknown { get; }
 
         [DebuggerStepThrough]
@@ -6100,7 +6100,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override bool Expanded { get; }
         public override ImmutableArray<int> ArgsToParamsOpt { get; }
         public override BitVector DefaultArguments { get; }
-        public ConstantValue? ConstantValueOpt { get; }
+        public override ConstantValue? ConstantValueOpt { get; }
         public override BoundObjectInitializerExpressionBase? InitializerExpressionOpt { get; }
         public override bool WasTargetTyped { get; }
 
@@ -6848,7 +6848,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public new TypeSymbol Type => base.Type!;
         public BoundExpression? ReceiverOpt { get; }
         public FieldSymbol FieldSymbol { get; }
-        public ConstantValue? ConstantValueOpt { get; }
+        public override ConstantValue? ConstantValueOpt { get; }
         public override LookupResultKind ResultKind { get; }
         public bool IsByValue { get; }
         public bool IsDeclaration { get; }
@@ -7281,7 +7281,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public new TypeSymbol Type => base.Type!;
         public BoundExpression Argument { get; }
-        public ConstantValue ConstantValueOpt { get; }
+        public override ConstantValue ConstantValueOpt { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitNameOfOperator(this);
@@ -7311,7 +7311,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         public ImmutableArray<BoundExpression> Parts { get; }
-        public ConstantValue? ConstantValueOpt { get; }
+        public override ConstantValue? ConstantValueOpt { get; }
     }
 
     internal sealed partial class BoundUnconvertedInterpolatedString : BoundInterpolatedStringBase

--- a/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ExpressionLambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/ClosureConversion/ExpressionLambdaRewriter.cs
@@ -485,7 +485,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (literal != null)
             {
                 // for compat reasons enum literals are directly promoted into underlying values
-                return Constant(literal.Update(literal.ConstantValue, promotedType));
+                return Constant(literal.Update(literal.ConstantValueOpt, promotedType));
             }
             else
             {
@@ -737,7 +737,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundExpression VisitIsOperator(BoundIsOperator node)
         {
             var operand = node.Operand;
-            if ((object)operand.Type == null && operand.ConstantValue != null && operand.ConstantValue.IsNull)
+            if ((object)operand.Type == null && operand.ConstantValueOpt != null && operand.ConstantValueOpt.IsNull)
             {
                 operand = _bound.Null(_objectType);
             }
@@ -956,7 +956,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression VisitObjectCreationExpressionInternal(BoundObjectCreationExpression node)
         {
-            if (node.ConstantValue != null)
+            if (node.ConstantValueOpt != null)
             {
                 // typically a decimal constant.
                 return Constant(node);

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_ExpressionTrees.cs
@@ -129,7 +129,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitSizeOfOperator(BoundSizeOfOperator node)
         {
-            if (_inExpressionLambda && node.ConstantValue == null)
+            if (_inExpressionLambda && node.ConstantValueOpt == null)
             {
                 Error(ErrorCode.ERR_ExpressionTreeContainsPointerOp, node);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs
@@ -314,25 +314,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             // is doing something like "if (0xFFFFFFFFU == 0)" -- these are likely to be machine-
             // generated code. 
 
-            if (node.Left.ConstantValue != null && node.Right.ConstantValue == null && node.Right.Kind == BoundKind.Conversion)
+            if (node.Left.ConstantValueOpt != null && node.Right.ConstantValueOpt == null && node.Right.Kind == BoundKind.Conversion)
             {
-                CheckVacuousComparisons(node, node.Left.ConstantValue, node.Right);
+                CheckVacuousComparisons(node, node.Left.ConstantValueOpt, node.Right);
             }
 
-            if (node.Right.ConstantValue != null && node.Left.ConstantValue == null && node.Left.Kind == BoundKind.Conversion)
+            if (node.Right.ConstantValueOpt != null && node.Left.ConstantValueOpt == null && node.Left.Kind == BoundKind.Conversion)
             {
-                CheckVacuousComparisons(node, node.Right.ConstantValue, node.Left);
+                CheckVacuousComparisons(node, node.Right.ConstantValueOpt, node.Left);
             }
 
             if (node.OperatorKind == BinaryOperatorKind.ObjectEqual || node.OperatorKind == BinaryOperatorKind.ObjectNotEqual)
             {
                 TypeSymbol t;
-                if (node.Left.Type.SpecialType == SpecialType.System_Object && !IsExplicitCast(node.Left) && !(node.Left.ConstantValue != null && node.Left.ConstantValue.IsNull) && ConvertedHasEqual(node.OperatorKind, node.Right, out t))
+                if (node.Left.Type.SpecialType == SpecialType.System_Object && !IsExplicitCast(node.Left) && !(node.Left.ConstantValueOpt != null && node.Left.ConstantValueOpt.IsNull) && ConvertedHasEqual(node.OperatorKind, node.Right, out t))
                 {
                     // Possible unintended reference comparison; to get a value comparison, cast the left hand side to type '{0}'
                     _diagnostics.Add(ErrorCode.WRN_BadRefCompareLeft, node.Syntax.Location, t);
                 }
-                else if (node.Right.Type.SpecialType == SpecialType.System_Object && !IsExplicitCast(node.Right) && !(node.Right.ConstantValue != null && node.Right.ConstantValue.IsNull) && ConvertedHasEqual(node.OperatorKind, node.Left, out t))
+                else if (node.Right.Type.SpecialType == SpecialType.System_Object && !IsExplicitCast(node.Right) && !(node.Right.ConstantValueOpt != null && node.Right.ConstantValueOpt.IsNull) && ConvertedHasEqual(node.OperatorKind, node.Left, out t))
                 {
                     // Possible unintended reference comparison; to get a value comparison, cast the right hand side to type '{0}'
                     _diagnostics.Add(ErrorCode.WRN_BadRefCompareRight, node.Syntax.Location, t);
@@ -525,7 +525,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // when they are non-constants, or when one is a constant, that we would similarly warn 
             // when both are constants.
 
-            if (node.ConstantValue != null)
+            if (node.ConstantValueOpt != null)
             {
                 return;
             }
@@ -583,7 +583,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            ConstantValue constVal = operand.ConstantValue;
+            ConstantValue constVal = operand.ConstantValueOpt;
 
             if (constVal == null || !constVal.IsIntegral)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/Extensions.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Extensions.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(expr != null);
 
-            if ((object)expr.Type == null && expr.ConstantValue == ConstantValue.Null)
+            if ((object)expr.Type == null && expr.ConstantValueOpt == ConstantValue.Null)
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector_SequencePoints.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector_SequencePoints.cs
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Add hidden sequence point unless the condition is a constant expression.
             // Constant expression must stay a const to not invalidate results of control flow analysis.
-            var valueExpression = (condition.ConstantValue == null) ?
+            var valueExpression = (condition.ConstantValueOpt == null) ?
                 new BoundSequencePointExpression(syntax: null, expression: factory.Local(local), type: condition.Type) :
                 condition;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.DecisionDagRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.DecisionDagRewriter.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 public override BoundNode Visit(BoundNode node)
                 {
                     // A constant expression cannot mutate anything
-                    if (node is BoundExpression { ConstantValue: { } })
+                    if (node is BoundExpression { ConstantValueOpt: { } })
                         return null;
 
                     // Stop visiting once we determine something might get assigned
@@ -959,7 +959,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (node is BoundWhenDecisionDagNode whenNode)
                     {
                         var whenExpression = whenNode.WhenExpression;
-                        if (whenExpression is not null && whenExpression.ConstantValue != ConstantValue.True)
+                        if (whenExpression is not null && whenExpression.ConstantValueOpt != ConstantValue.True)
                         {
                             LabelSymbol labelToWhenExpression;
                             if (whenExpressionMap.TryGetValue(whenExpression, out var whenExpressionInfo))
@@ -1111,7 +1111,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     var whenFalse = whenClause.WhenFalse;
                     var trueLabel = GetDagNodeLabel(whenTrue);
-                    if (whenClause.WhenExpression != null && whenClause.WhenExpression.ConstantValue != ConstantValue.True)
+                    if (whenClause.WhenExpression != null && whenClause.WhenExpression.ConstantValueOpt != ConstantValue.True)
                     {
                         addConditionalGoto(whenClause.WhenExpression, whenClause.Syntax, trueLabel, sectionBuilder);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.PatternLocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.PatternLocalRewriter.cs
@@ -513,7 +513,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // We share input variables if there is no when clause (because a when clause might mutate them).
                 bool anyWhenClause =
                     decisionDag.TopologicallySortedNodes
-                    .Any(static node => node is BoundWhenDecisionDagNode { WhenExpression: { ConstantValue: null } });
+                    .Any(static node => node is BoundWhenDecisionDagNode { WhenExpression: { ConstantValueOpt: null } });
 
                 var inputDagTemp = BoundDagTemp.ForOriginalInput(loweredInput);
                 if ((loweredInput.Kind == BoundKind.Local || loweredInput.Kind == BoundKind.Parameter)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression? VisitExpressionImpl(BoundExpression node)
         {
-            ConstantValue? constantValue = node.ConstantValue;
+            ConstantValue? constantValue = node.ConstantValueOpt;
             if (constantValue != null)
             {
                 TypeSymbol? type = node.Type;
@@ -871,7 +871,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         //
         internal static bool CanBePassedByReference(BoundExpression expr)
         {
-            if (expr.ConstantValue != null)
+            if (expr.ConstantValueOpt != null)
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AsOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_AsOperator.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var conversion = BoundNode.GetConversion(operandConversion, operandPlaceholder);
 
-                ConstantValue constantValue = Binder.GetAsOperatorConstantResult(rewrittenOperand.Type, rewrittenType, conversion.Kind, rewrittenOperand.ConstantValue);
+                ConstantValue constantValue = Binder.GetAsOperatorConstantResult(rewrittenOperand.Type, rewrittenType, conversion.Kind, rewrittenOperand.ConstantValueOpt);
 
                 if (constantValue != null)
                 {
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(constantValue.IsNull);
                     BoundExpression result = rewrittenType.IsNullableType() ? new BoundDefaultExpression(syntax, rewrittenType) : MakeLiteral(syntax, constantValue, rewrittenType);
 
-                    if (rewrittenOperand.ConstantValue != null)
+                    if (rewrittenOperand.ConstantValueOpt != null)
                     {
                         // No need to preserve any side-effects from the operand. 
                         // We also can keep the "constant" notion of the result, which

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var stack = ArrayBuilder<BoundBinaryOperator>.GetInstance();
 
-            for (BoundBinaryOperator? current = node; current != null && current.ConstantValue == null; current = current.Left as BoundBinaryOperator)
+            for (BoundBinaryOperator? current = node; current != null && current.ConstantValueOpt == null; current = current.Left as BoundBinaryOperator)
             {
                 // The regular visit mechanism will handle this.
                 if (current.InterpolatedStringHandlerData is not null || current.OperatorKind is BinaryOperatorKind.Utf8Addition)
@@ -275,9 +275,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return RewriteDelegateOperation(syntax, operatorKind, loweredLeft, loweredRight, type, SpecialMember.System_Delegate__op_Inequality);
 
                     case BinaryOperatorKind.LogicalBoolAnd:
-                        if (loweredRight.ConstantValue == ConstantValue.True) return loweredLeft;
-                        if (loweredLeft.ConstantValue == ConstantValue.True) return loweredRight;
-                        if (loweredLeft.ConstantValue == ConstantValue.False) return loweredLeft;
+                        if (loweredRight.ConstantValueOpt == ConstantValue.True) return loweredLeft;
+                        if (loweredLeft.ConstantValueOpt == ConstantValue.True) return loweredRight;
+                        if (loweredLeft.ConstantValueOpt == ConstantValue.False) return loweredLeft;
 
                         if (loweredRight.Kind == BoundKind.Local || loweredRight.Kind == BoundKind.Parameter)
                         {
@@ -287,9 +287,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         goto default;
 
                     case BinaryOperatorKind.LogicalBoolOr:
-                        if (loweredRight.ConstantValue == ConstantValue.False) return loweredLeft;
-                        if (loweredLeft.ConstantValue == ConstantValue.False) return loweredRight;
-                        if (loweredLeft.ConstantValue == ConstantValue.True) return loweredLeft;
+                        if (loweredRight.ConstantValueOpt == ConstantValue.False) return loweredLeft;
+                        if (loweredLeft.ConstantValueOpt == ConstantValue.False) return loweredRight;
+                        if (loweredLeft.ConstantValueOpt == ConstantValue.True) return loweredLeft;
 
                         if (loweredRight.Kind == BoundKind.Local || loweredRight.Kind == BoundKind.Parameter)
                         {
@@ -299,8 +299,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         goto default;
 
                     case BinaryOperatorKind.BoolAnd:
-                        if (loweredRight.ConstantValue == ConstantValue.True) return loweredLeft;
-                        if (loweredLeft.ConstantValue == ConstantValue.True) return loweredRight;
+                        if (loweredRight.ConstantValueOpt == ConstantValue.True) return loweredLeft;
+                        if (loweredLeft.ConstantValueOpt == ConstantValue.True) return loweredRight;
 
                         // Note that we are using IsDefaultValue instead of False.
                         // That is just to catch cases like default(bool) or others resulting in 
@@ -320,48 +320,48 @@ namespace Microsoft.CodeAnalysis.CSharp
                         goto default;
 
                     case BinaryOperatorKind.BoolOr:
-                        if (loweredRight.ConstantValue == ConstantValue.False) return loweredLeft;
-                        if (loweredLeft.ConstantValue == ConstantValue.False) return loweredRight;
+                        if (loweredRight.ConstantValueOpt == ConstantValue.False) return loweredLeft;
+                        if (loweredLeft.ConstantValueOpt == ConstantValue.False) return loweredRight;
                         goto default;
 
                     case BinaryOperatorKind.BoolEqual:
-                        if (loweredLeft.ConstantValue == ConstantValue.True) return loweredRight;
-                        if (loweredRight.ConstantValue == ConstantValue.True) return loweredLeft;
+                        if (loweredLeft.ConstantValueOpt == ConstantValue.True) return loweredRight;
+                        if (loweredRight.ConstantValueOpt == ConstantValue.True) return loweredLeft;
 
                         Debug.Assert(loweredLeft.Type is { });
                         Debug.Assert(loweredRight.Type is { });
-                        if (loweredLeft.ConstantValue == ConstantValue.False)
+                        if (loweredLeft.ConstantValueOpt == ConstantValue.False)
                             return MakeUnaryOperator(UnaryOperatorKind.BoolLogicalNegation, syntax, method: null, constrainedToTypeOpt: null, loweredRight, loweredRight.Type);
 
-                        if (loweredRight.ConstantValue == ConstantValue.False)
+                        if (loweredRight.ConstantValueOpt == ConstantValue.False)
                             return MakeUnaryOperator(UnaryOperatorKind.BoolLogicalNegation, syntax, method: null, constrainedToTypeOpt: null, loweredLeft, loweredLeft.Type);
 
                         goto default;
 
                     case BinaryOperatorKind.BoolNotEqual:
-                        if (loweredLeft.ConstantValue == ConstantValue.False) return loweredRight;
-                        if (loweredRight.ConstantValue == ConstantValue.False) return loweredLeft;
+                        if (loweredLeft.ConstantValueOpt == ConstantValue.False) return loweredRight;
+                        if (loweredRight.ConstantValueOpt == ConstantValue.False) return loweredLeft;
 
                         Debug.Assert(loweredLeft.Type is { });
                         Debug.Assert(loweredRight.Type is { });
-                        if (loweredLeft.ConstantValue == ConstantValue.True)
+                        if (loweredLeft.ConstantValueOpt == ConstantValue.True)
                             return MakeUnaryOperator(UnaryOperatorKind.BoolLogicalNegation, syntax, method: null, constrainedToTypeOpt: null, loweredRight, loweredRight.Type);
 
-                        if (loweredRight.ConstantValue == ConstantValue.True)
+                        if (loweredRight.ConstantValueOpt == ConstantValue.True)
                             return MakeUnaryOperator(UnaryOperatorKind.BoolLogicalNegation, syntax, method: null, constrainedToTypeOpt: null, loweredLeft, loweredLeft.Type);
 
                         goto default;
 
                     case BinaryOperatorKind.BoolXor:
-                        if (loweredLeft.ConstantValue == ConstantValue.False) return loweredRight;
-                        if (loweredRight.ConstantValue == ConstantValue.False) return loweredLeft;
+                        if (loweredLeft.ConstantValueOpt == ConstantValue.False) return loweredRight;
+                        if (loweredRight.ConstantValueOpt == ConstantValue.False) return loweredLeft;
 
                         Debug.Assert(loweredLeft.Type is { });
                         Debug.Assert(loweredRight.Type is { });
-                        if (loweredLeft.ConstantValue == ConstantValue.True)
+                        if (loweredLeft.ConstantValueOpt == ConstantValue.True)
                             return MakeUnaryOperator(UnaryOperatorKind.BoolLogicalNegation, syntax, method: null, constrainedToTypeOpt: null, loweredRight, loweredRight.Type);
 
-                        if (loweredRight.ConstantValue == ConstantValue.True)
+                        if (loweredRight.ConstantValueOpt == ConstantValue.True)
                             return MakeUnaryOperator(UnaryOperatorKind.BoolLogicalNegation, syntax, method: null, constrainedToTypeOpt: null, loweredLeft, loweredLeft.Type);
 
                         goto default;
@@ -466,11 +466,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             return _factory.MakeSequence(loweredLeft, loweredRight);
                         }
-                        if (loweredLeft.ConstantValue?.UInt64Value == 1)
+                        if (loweredLeft.ConstantValueOpt?.UInt64Value == 1)
                         {
                             return loweredRight;
                         }
-                        if (loweredRight.ConstantValue?.UInt64Value == 1)
+                        if (loweredRight.ConstantValueOpt?.UInt64Value == 1)
                         {
                             return loweredLeft;
                         }
@@ -528,7 +528,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return (oldNode != null) ?
-                oldNode.Update(operatorKind, oldNode.ConstantValue, oldNode.Method, oldNode.ConstrainedToType, oldNode.ResultKind, loweredLeft, loweredRight, type) :
+                oldNode.Update(operatorKind, oldNode.ConstantValueOpt, oldNode.Method, oldNode.ConstrainedToType, oldNode.ResultKind, loweredLeft, loweredRight, type) :
                 new BoundBinaryOperator(syntax, operatorKind, constantValueOpt: null, methodOpt: null, constrainedToTypeOpt: null, LookupResultKind.Viable, loweredLeft, loweredRight, type);
         }
 
@@ -619,7 +619,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // VisitUnaryOperator ensures we are never called with parentUnaryOperator != null when we can't perform the optimization.
             Debug.Assert(applyParentUnaryOperator == null || applyParentUnaryOperator.OperatorKind == testOperator);
 
-            ConstantValue? constantLeft = loweredLeft.ConstantValue ?? UnboxConstant(loweredLeft);
+            ConstantValue? constantLeft = loweredLeft.ConstantValueOpt ?? UnboxConstant(loweredLeft);
             if (testOperator == UnaryOperatorKind.DynamicFalse && constantLeft == ConstantValue.False ||
                 testOperator == UnaryOperatorKind.DynamicTrue && constantLeft == ConstantValue.True)
             {
@@ -712,7 +712,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var conversion = (BoundConversion)expression;
                 if (conversion.ConversionKind == ConversionKind.Boxing)
                 {
-                    return conversion.Operand.ConstantValue;
+                    return conversion.Operand.ConstantValueOpt;
                 }
             }
 
@@ -1304,7 +1304,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // TODO: There are expressions other than constants that have no side effects
             // TODO: or elidable side effects.
 
-            if (sideEffect.ConstantValue != null)
+            if (sideEffect.ConstantValueOpt != null)
             {
                 return new BoundDefaultExpression(syntax, type);
             }
@@ -1523,7 +1523,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // operation smaller; the rest is gravy.
 
             BoundExpression? nonNullRight = NullableAlwaysHasValue(right);
-            if (nonNullRight != null && nonNullRight.ConstantValue != null && left.Kind == BoundKind.Sequence)
+            if (nonNullRight != null && nonNullRight.ConstantValueOpt != null && left.Kind == BoundKind.Sequence)
             {
                 BoundSequence seq = (BoundSequence)left;
                 if (seq.Value.Kind == BoundKind.ConditionalOperator)
@@ -1913,9 +1913,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression RewriteStringEquality(BoundBinaryOperator? oldNode, SyntaxNode syntax, BinaryOperatorKind operatorKind, BoundExpression loweredLeft, BoundExpression loweredRight, TypeSymbol type, SpecialMember member)
         {
-            if (oldNode != null && (loweredLeft.ConstantValue == ConstantValue.Null || loweredRight.ConstantValue == ConstantValue.Null))
+            if (oldNode != null && (loweredLeft.ConstantValueOpt == ConstantValue.Null || loweredRight.ConstantValueOpt == ConstantValue.Null))
             {
-                return oldNode.Update(operatorKind, oldNode.ConstantValue, oldNode.Method, oldNode.ConstrainedToType, oldNode.ResultKind, loweredLeft, loweredRight, type);
+                return oldNode.Update(operatorKind, oldNode.ConstantValueOpt, oldNode.Method, oldNode.ConstrainedToType, oldNode.ResultKind, loweredLeft, loweredRight, type);
             }
 
             var method = UnsafeGetSpecialTypeMethod(syntax, member);
@@ -2002,14 +2002,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol boolType = _compilation.GetSpecialType(SpecialType.System_Boolean);
 
             // Fold compile-time comparisons.
-            if (rewrittenExpr.ConstantValue != null)
+            if (rewrittenExpr.ConstantValueOpt != null)
             {
                 switch (operatorKind)
                 {
                     case BinaryOperatorKind.Equal:
-                        return MakeLiteral(syntax, ConstantValue.Create(rewrittenExpr.ConstantValue.IsNull, ConstantValueTypeDiscriminator.Boolean), boolType);
+                        return MakeLiteral(syntax, ConstantValue.Create(rewrittenExpr.ConstantValueOpt.IsNull, ConstantValueTypeDiscriminator.Boolean), boolType);
                     case BinaryOperatorKind.NotEqual:
-                        return MakeLiteral(syntax, ConstantValue.Create(!rewrittenExpr.ConstantValue.IsNull, ConstantValueTypeDiscriminator.Boolean), boolType);
+                        return MakeLiteral(syntax, ConstantValue.Create(!rewrittenExpr.ConstantValueOpt.IsNull, ConstantValueTypeDiscriminator.Boolean), boolType);
                 }
             }
 
@@ -2052,7 +2052,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             int rightMask)
         {
             SyntaxNode rightSyntax = loweredRight.Syntax;
-            ConstantValue? rightConstantValue = loweredRight.ConstantValue;
+            ConstantValue? rightConstantValue = loweredRight.ConstantValueOpt;
             Debug.Assert(loweredRight.Type is { });
             TypeSymbol rightType = loweredRight.Type;
             Debug.Assert(rightType.SpecialType == SpecialType.System_Int32);
@@ -2124,7 +2124,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol leftType = loweredLeft.Type;
             Debug.Assert(leftType.SpecialType is SpecialType.System_IntPtr or SpecialType.System_UIntPtr);
 
-            ConstantValue? rightConstantValue = loweredRight.ConstantValue;
+            ConstantValue? rightConstantValue = loweredRight.ConstantValueOpt;
             Debug.Assert(loweredRight.Type is { });
             TypeSymbol rightType = loweredRight.Type;
             Debug.Assert(rightType.SpecialType == SpecialType.System_Int32);
@@ -2224,7 +2224,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(sizeOfExpression.Type is { SpecialType: SpecialType.System_Int32 });
 
             // Common case: adding or subtracting one  (e.g. for ++)
-            if (numericOperand.ConstantValue?.UInt64Value == 1)
+            if (numericOperand.ConstantValueOpt?.UInt64Value == 1)
             {
                 // We could convert this to a native int (as the unoptimized multiplication would be),
                 // but that would be a no-op (int to native int), so don't bother.
@@ -2235,7 +2235,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var numericSpecialType = numericOperand.Type.SpecialType;
 
             // Optimization: the size is exactly one byte, then multiplication is unnecessary.
-            if (sizeOfExpression.ConstantValue?.Int32Value == 1)
+            if (sizeOfExpression.ConstantValueOpt?.Int32Value == 1)
             {
                 // As in ExpressionBinder::bindPtrAddMul, we apply the following conversions:
                 //   int -> int (add allows int32 operands and will extend to native int if necessary)
@@ -2256,7 +2256,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // As a result, in checked contexts, we will force sign-extending cast to be sure
                         if (isChecked)
                         {
-                            var constVal = numericOperand.ConstantValue;
+                            var constVal = numericOperand.ConstantValueOpt;
                             if (constVal == null || constVal.Int32Value < 0)
                             {
                                 destinationType = SpecialType.System_IntPtr;
@@ -2267,7 +2267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             // add operator treats operands as signed and will sign-extend on x64
                             // to prevent sign-extending, convert the operand to unsigned native int.
-                            var constVal = numericOperand.ConstantValue;
+                            var constVal = numericOperand.ConstantValueOpt;
                             if (constVal == null || constVal.UInt32Value > int.MaxValue)
                             {
                                 destinationType = SpecialType.System_UIntPtr;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var current = expression;
             while (true)
             {
-                if (current.ConstantValue != null)
+                if (current.ConstantValueOpt != null)
                 {
                     return true;
                 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_CompoundAssignmentOperator.cs
@@ -716,7 +716,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (TransformCompoundAssignmentFieldOrEventAccessReceiver(eventAccess.EventSymbol, ref receiverOpt, stores, temps))
                         {
-                            return MakeEventAccess(eventAccess.Syntax, receiverOpt, eventAccess.EventSymbol, eventAccess.ConstantValue, eventAccess.ResultKind, eventAccess.Type);
+                            return MakeEventAccess(eventAccess.Syntax, receiverOpt, eventAccess.EventSymbol, eventAccess.ConstantValueOpt, eventAccess.ResultKind, eventAccess.Type);
                         }
                     }
                     break;
@@ -754,7 +754,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Conversion.Boxing,
                 memberContainingType,
                 @checked: false,
-                constantValueOpt: rewrittenReceiver.ConstantValue);
+                constantValueOpt: rewrittenReceiver.ConstantValueOpt);
         }
 
         private BoundExpression SpillArrayElementAccess(
@@ -812,7 +812,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            if (expression.ConstantValue != null)
+            if (expression.ConstantValueOpt != null)
             {
                 var type = expression.Type;
                 return !ConstantValueIsTrivial(type);
@@ -848,7 +848,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static bool ReadIsSideeffecting(
             BoundExpression expression)
         {
-            if (expression.ConstantValue != null)
+            if (expression.ConstantValueOpt != null)
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ConditionalOperator.cs
@@ -18,13 +18,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitConditionalOperator(BoundConditionalOperator node)
         {
             // just a fact, not a requirement (VisitExpression would have rewritten otherwise)
-            Debug.Assert(node.ConstantValue == null);
+            Debug.Assert(node.ConstantValueOpt == null);
 
             var rewrittenCondition = VisitExpression(node.Condition);
             var rewrittenConsequence = VisitExpression(node.Consequence);
             var rewrittenAlternative = VisitExpression(node.Alternative);
 
-            if (rewrittenCondition.ConstantValue == null)
+            if (rewrittenCondition.ConstantValueOpt == null)
             {
                 return node.Update(node.IsRef, rewrittenCondition, rewrittenConsequence, rewrittenAlternative, node.ConstantValueOpt, node.NaturalTypeOpt, node.WasTargetTyped, node.Type);
             }
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol rewrittenType,
             bool isRef)
         {
-            ConstantValue? conditionConstantValue = rewrittenCondition.ConstantValue;
+            ConstantValue? conditionConstantValue = rewrittenCondition.ConstantValueOpt;
             if (conditionConstantValue == ConstantValue.True)
             {
                 return rewrittenConsequence;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var rewrittenOperand = VisitExpression(node.Operand);
             _inExpressionLambda = wasInExpressionLambda;
 
-            var result = MakeConversionNode(node, node.Syntax, rewrittenOperand, node.Conversion, node.Checked, node.ExplicitCastInCode, node.ConstantValue, rewrittenType);
+            var result = MakeConversionNode(node, node.Syntax, rewrittenOperand, node.Conversion, node.Checked, node.ExplicitCastInCode, node.ConstantValueOpt, rewrittenType);
 
             var toType = node.Type;
             Debug.Assert(result.Type!.Equals(toType, TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            if (rewrittenNode.ConstantValue != null)
+            if (rewrittenNode.ConstantValueOpt != null)
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     VisitExpression(conditional.Condition),
                     RewriteDeconstruction(lhsTargets, conversion, leftType, conditional.Consequence, isUsed: true)!,
                     RewriteDeconstruction(lhsTargets, conversion, leftType, conditional.Alternative, isUsed: true)!,
-                    conditional.ConstantValue,
+                    conditional.ConstantValueOpt,
                     leftType,
                     wasTargetTyped: true,
                     leftType);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Event.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(node.IsUsableAsField);
 
             BoundExpression? rewrittenReceiver = VisitExpression(node.ReceiverOpt);
-            return MakeEventAccess(node.Syntax, rewrittenReceiver, node.EventSymbol, node.ConstantValue, node.ResultKind, node.Type);
+            return MakeEventAccess(node.Syntax, rewrittenReceiver, node.EventSymbol, node.ConstantValueOpt, node.ResultKind, node.Type);
         }
 
         private BoundExpression MakeEventAccess(

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Field.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Field.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitFieldAccess(BoundFieldAccess node)
         {
             BoundExpression? rewrittenReceiver = VisitExpression(node.ReceiverOpt);
-            return MakeFieldAccess(node.Syntax, rewrittenReceiver, node.FieldSymbol, node.ConstantValue, node.ResultKind, node.Type, node);
+            return MakeFieldAccess(node.Syntax, rewrittenReceiver, node.FieldSymbol, node.ConstantValueOpt, node.ResultKind, node.Type, node);
         }
 
         private BoundExpression MakeFieldAccess(

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IndexerAccess.cs
@@ -302,7 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     BoundExpression lengthAccess = VisitExpression(node.LengthOrCountAccess);
 
                     // ensure we evaluate the input before accessing length, unless it is an array length
-                    if (makeOffsetInput.ConstantValue is null && lengthAccess.Kind is not BoundKind.ArrayLength)
+                    if (makeOffsetInput.ConstantValueOpt is null && lengthAccess.Kind is not BoundKind.ArrayLength)
                     {
                         makeOffsetInput = F.StoreToTemp(makeOffsetInput, out BoundAssignmentOperator inputStore);
                         locals.Add(((BoundLocal)makeOffsetInput).LocalSymbol);
@@ -401,7 +401,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(lengthAccess is not null);
                     Debug.Assert(loweredExpr.Type!.SpecialType == SpecialType.System_Int32);
 
-                    if (loweredExpr.ConstantValue?.Int32Value == 0)
+                    if (loweredExpr.ConstantValueOpt?.Int32Value == 0)
                     {
                         return lengthAccess;
                     }
@@ -471,8 +471,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if (unloweredExpr is BoundObjectCreationExpression { Constructor: MethodSymbol constructor, Arguments: { Length: 2 } arguments, ArgsToParamsOpt: { IsDefaultOrEmpty: true }, InitializerExpressionOpt: null } &&
                      (object)constructor == _compilation.GetWellKnownTypeMember(WellKnownMember.System_Index__ctor) &&
-                     arguments[0] is { Type.SpecialType: SpecialType.System_Int32, ConstantValue.Value: int _ and >= 0 } index &&
-                     arguments[1] is { Type.SpecialType: SpecialType.System_Boolean, ConstantValue.Value: bool fromEnd })
+                     arguments[0] is { Type.SpecialType: SpecialType.System_Int32, ConstantValueOpt.Value: int _ and >= 0 } index &&
+                     arguments[1] is { Type.SpecialType: SpecialType.System_Boolean, ConstantValueOpt.Value: bool fromEnd })
             {
                 if (fromEnd)
                 {
@@ -637,7 +637,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if ((rewriteFlags & captureStartOffset) != 0)
                 {
                     Debug.Assert(startMakeOffsetInput is not null);
-                    if (startMakeOffsetInput.ConstantValue is null)
+                    if (startMakeOffsetInput.ConstantValueOpt is null)
                     {
                         startMakeOffsetInput = F.StoreToTemp(startMakeOffsetInput, out BoundAssignmentOperator inputStore);
                         localsBuilder.Add(((BoundLocal)startMakeOffsetInput).LocalSymbol);
@@ -648,7 +648,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if ((rewriteFlags & captureEndOffset) != 0)
                 {
                     Debug.Assert(endMakeOffsetInput is not null);
-                    if (endMakeOffsetInput.ConstantValue is null)
+                    if (endMakeOffsetInput.ConstantValueOpt is null)
                     {
                         endMakeOffsetInput = F.StoreToTemp(endMakeOffsetInput, out BoundAssignmentOperator inputStore);
                         localsBuilder.Add(((BoundLocal)endMakeOffsetInput).LocalSymbol);
@@ -674,7 +674,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 startExpr = MakePatternIndexOffsetExpression(startMakeOffsetInput, lengthAccess, startStrategy);
 
-                if ((rewriteFlags & captureStartValue) != 0 && startExpr.ConstantValue is null)
+                if ((rewriteFlags & captureStartValue) != 0 && startExpr.ConstantValueOpt is null)
                 {
                     var startLocal = F.StoreToTemp(startExpr, out var startStore);
                     localsBuilder.Add(startLocal.LocalSymbol);
@@ -684,11 +684,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 BoundExpression endExpr = MakePatternIndexOffsetExpression(endMakeOffsetInput, lengthAccess, endStrategy);
 
-                if (startExpr.ConstantValue?.Int32Value == 0)
+                if (startExpr.ConstantValueOpt?.Int32Value == 0)
                 {
                     rangeSizeExpr = endExpr;
                 }
-                else if (startExpr.ConstantValue is { Int32Value: var startConst } && endExpr.ConstantValue is { Int32Value: var endConst })
+                else if (startExpr.ConstantValueOpt is { Int32Value: var startConst } && endExpr.ConstantValueOpt is { Int32Value: var endConst })
                 {
                     rangeSizeExpr = F.Literal(unchecked(endConst - startConst));
                 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsOperator.cs
@@ -48,14 +48,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             var operandType = rewrittenOperand.Type;
             var targetType = rewrittenTargetType.Type;
 
-            Debug.Assert(operandType is { } || rewrittenOperand.ConstantValue!.IsNull);
+            Debug.Assert(operandType is { } || rewrittenOperand.ConstantValueOpt!.IsNull);
             Debug.Assert(targetType is { });
 
             // TODO: Handle dynamic operand type and target type
 
             if (!_inExpressionLambda)
             {
-                ConstantValue constantValue = Binder.GetIsOperatorConstantResult(operandType, targetType, conversionKind, rewrittenOperand.ConstantValue);
+                ConstantValue constantValue = Binder.GetIsOperatorConstantResult(operandType, targetType, conversionKind, rewrittenOperand.ConstantValueOpt);
 
                 if (constantValue != null)
                 {

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Literal.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Literal.cs
@@ -16,8 +16,8 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override BoundNode VisitLiteral(BoundLiteral node)
         {
-            Debug.Assert(node.ConstantValue is { });
-            return MakeLiteral(node.Syntax, node.ConstantValue, node.Type, oldNodeOpt: node);
+            Debug.Assert(node.ConstantValueOpt is { });
+            return MakeLiteral(node.Syntax, node.ConstantValueOpt, node.Type, oldNodeOpt: node);
         }
 
         private BoundExpression MakeLiteral(SyntaxNode syntax, ConstantValue constantValue, TypeSymbol? type, BoundLiteral? oldNodeOpt = null)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LockStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LockStatement.cs
@@ -29,11 +29,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // This isn't particularly elegant, but hopefully locking on null is
                 // not very common.
-                Debug.Assert(rewrittenArgument.ConstantValue == ConstantValue.Null);
+                Debug.Assert(rewrittenArgument.ConstantValueOpt == ConstantValue.Null);
                 argumentType = _compilation.GetSpecialType(SpecialType.System_Object);
                 rewrittenArgument = MakeLiteral(
                     rewrittenArgument.Syntax,
-                    rewrittenArgument.ConstantValue,
+                    rewrittenArgument.ConstantValueOpt,
                     argumentType); //need to have a non-null type here for TempHelpers.StoreToTemp.
             }
 
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Conversion.Boxing,
                     argumentType,
                     @checked: false,
-                    constantValueOpt: rewrittenArgument.ConstantValue);
+                    constantValueOpt: rewrittenArgument.ConstantValueOpt);
             }
 
             BoundAssignmentOperator assignmentToLockTemp;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
@@ -72,9 +72,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return rewrittenRight;
                 }
 
-                if (rewrittenLeft.ConstantValue != null)
+                if (rewrittenLeft.ConstantValueOpt != null)
                 {
-                    Debug.Assert(!rewrittenLeft.ConstantValue.IsNull);
+                    Debug.Assert(!rewrittenLeft.ConstantValueOpt.IsNull);
 
                     return GetConvertedLeftForNullCoalescingOperator(rewrittenLeft, leftPlaceholder, leftConversion, rewrittenResultType);
                 }
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenType: rewrittenResultType,
                 isRef: false);
 
-            Debug.Assert(conditionalExpression.ConstantValue == null); // we shouldn't have hit this else case otherwise
+            Debug.Assert(conditionalExpression.ConstantValueOpt == null); // we shouldn't have hit this else case otherwise
             Debug.Assert(conditionalExpression.Type!.Equals(rewrittenResultType, TypeCompareKind.IgnoreDynamicAndTupleNames | TypeCompareKind.IgnoreNullableModifiersForReferenceTypes));
 
             return new BoundSequence(

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_PatternSwitchStatement.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // EnC: We need to insert a hidden sequence point to handle function remapping in case
                     // the containing method is edited while methods invoked in the expression are being executed.
                     var instrumentedExpression = _localRewriter._instrumenter.InstrumentSwitchStatementExpression(node, loweredSwitchGoverningExpression, _factory);
-                    if (loweredSwitchGoverningExpression.ConstantValue == null)
+                    if (loweredSwitchGoverningExpression.ConstantValueOpt == null)
                     {
                         loweredSwitchGoverningExpression = instrumentedExpression;
                     }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StackAlloc.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StackAlloc.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var type = stackAllocNode.Type;
             Debug.Assert(type is { });
 
-            if (rewrittenCount.ConstantValue?.Int32Value == 0)
+            if (rewrittenCount.ConstantValueOpt?.Int32Value == 0)
             {
                 // either default(span) or nullptr
                 return _factory.Default(type);
@@ -116,14 +116,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundExpression sizeOfExpression = _factory.Sizeof(elementType);
 
-            var sizeConst = sizeOfExpression.ConstantValue;
+            var sizeConst = sizeOfExpression.ConstantValueOpt;
             if (sizeConst != null)
             {
                 int size = sizeConst.Int32Value;
                 Debug.Assert(size > 0);
 
                 // common case: stackalloc int[123]
-                var countConst = countExpression.ConstantValue;
+                var countConst = countExpression.ConstantValueOpt;
                 if (countConst != null)
                 {
                     var count = countConst.Int32Value;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_StringInterpolation.cs
@@ -222,13 +222,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     stringBuilder.Append('{').Append(nextFormatPosition++);
                     if (fillin.Alignment != null && !fillin.Alignment.HasErrors)
                     {
-                        Debug.Assert(fillin.Alignment.ConstantValue is { });
-                        stringBuilder.Append(',').Append(fillin.Alignment.ConstantValue.Int64Value);
+                        Debug.Assert(fillin.Alignment.ConstantValueOpt is { });
+                        stringBuilder.Append(',').Append(fillin.Alignment.ConstantValueOpt.Int64Value);
                     }
                     if (fillin.Format != null && !fillin.Format.HasErrors)
                     {
-                        Debug.Assert(fillin.Format.ConstantValue is { });
-                        stringBuilder.Append(':').Append(fillin.Format.ConstantValue.StringValue);
+                        Debug.Assert(fillin.Format.ConstantValueOpt is { });
+                        stringBuilder.Append(':').Append(fillin.Format.ConstantValueOpt.StringValue);
                     }
                     stringBuilder.Append('}');
                     var value = fillin.Value;
@@ -241,10 +241,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    Debug.Assert(part is BoundLiteral && part.ConstantValue?.StringValue != null);
+                    Debug.Assert(part is BoundLiteral && part.ConstantValueOpt?.StringValue != null);
                     // this is one of the literal parts.  If it contains a { or } then we need to escape those so that
                     // they're treated the same way in string.Format.
-                    stringBuilder.Append(escapeInterpolatedStringLiteral(part.ConstantValue.StringValue));
+                    stringBuilder.Append(escapeInterpolatedStringLiteral(part.ConstantValueOpt.StringValue));
                 }
             }
 
@@ -310,8 +310,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     else
                     {
                         // this is one of the literal parts
-                        Debug.Assert(part is BoundLiteral && part.ConstantValue?.StringValue is not null);
-                        part = _factory.StringLiteral(part.ConstantValue.StringValue);
+                        Debug.Assert(part is BoundLiteral && part.ConstantValueOpt?.StringValue is not null);
+                        part = _factory.StringLiteral(part.ConstantValueOpt.StringValue);
                     }
 
                     result = result == null ?
@@ -322,7 +322,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // We need to ensure that the result of the interpolated string is not null. If the single part has a non-null constant value
                 // or is itself an interpolated string (which by proxy cannot be null), then there's nothing else that needs to be done. Otherwise,
                 // we need to test for null and ensure "" if it is.
-                if (length == 1 && result is not ({ Kind: BoundKind.InterpolatedString } or { ConstantValue.IsString: true }))
+                if (length == 1 && result is not ({ Kind: BoundKind.InterpolatedString } or { ConstantValueOpt.IsString: true }))
                 {
                     Debug.Assert(result is not null);
                     Debug.Assert(result.Type is not null);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TryStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TryStatement.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return base.VisitCatchBlock(node);
             }
 
-            if (node.ExceptionFilterOpt.ConstantValue?.BooleanValue == false)
+            if (node.ExceptionFilterOpt.ConstantValueOpt?.BooleanValue == false)
             {
                 return null;
             }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleBinaryOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleBinaryOperator.cs
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             switch (expr)
             {
-                case { ConstantValue: { } }:
+                case { ConstantValueOpt: { } }:
                     return VisitExpression(expr);
                 case BoundConversion { Conversion: { Kind: ConversionKind.DefaultLiteral } }:
                     // This conversion can be performed lazily, but need not be saved.  It is treated as non-side-effecting.
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             bool boolValue = operatorKind == BinaryOperatorKind.Equal; // true/false
 
-            if (rightHasValue.ConstantValue == ConstantValue.False)
+            if (rightHasValue.ConstantValueOpt == ConstantValue.False)
             {
                 // The outer sequence degenerates when we known that `rightHasValue` is false
                 // Produce: !leftHasValue (or leftHasValue for inequality comparison)
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     result: boolValue ? _factory.Not(leftHasValue) : leftHasValue);
             }
 
-            if (leftHasValue.ConstantValue == ConstantValue.False)
+            if (leftHasValue.ConstantValueOpt == ConstantValue.False)
             {
                 // The outer sequence degenerates when we known that `leftHasValue` is false
                 // Produce: !rightHasValue (or rightHasValue for inequality comparison)
@@ -609,7 +609,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ? MakeConversionNode(
                     oldNodeOpt: conv, syntax: conv.Syntax, rewrittenOperand: LowerConversions(conv.Operand),
                     conversion: conv.Conversion, @checked: conv.Checked, explicitCastInCode: conv.ExplicitCastInCode,
-                    constantValueOpt: conv.ConstantValue, rewrittenType: conv.Type)
+                    constantValueOpt: conv.ConstantValueOpt, rewrittenType: conv.Type)
                 : expr;
         }
     }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleCreationExpression.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     currentCreation.Expanded,
                     currentCreation.ArgsToParamsOpt,
                     currentCreation.DefaultArguments,
-                    currentCreation.ConstantValue,
+                    currentCreation.ConstantValueOpt,
                     currentCreation.InitializerExpressionOpt,
                     type);
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // If expr is the constant null then we can elide the whole thing and simply generate the statement. 
 
             BoundExpression rewrittenExpression = VisitExpression(node.ExpressionOpt);
-            if (rewrittenExpression.ConstantValue == ConstantValue.Null)
+            if (rewrittenExpression.ConstantValueOpt == ConstantValue.Null)
             {
                 Debug.Assert(node.Locals.IsEmpty); // TODO: This might not be a valid assumption in presence of semicolon operator.
                 return tryBlock;
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Conversion.ImplicitDynamic,
                     iDisposableType,
                     @checked: false,
-                    constantValueOpt: rewrittenExpression.ConstantValue);
+                    constantValueOpt: rewrittenExpression.ConstantValueOpt);
 
                 boundTemp = _factory.StoreToTemp(tempInit, out tempAssignment, kind: SynthesizedLocalKind.Using);
             }
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol localType = localSymbol.Type;
             Debug.Assert((object)localType != null); //otherwise, there wouldn't be a conversion to IDisposable
 
-            BoundLocal boundLocal = new BoundLocal(declarationSyntax, localSymbol, localDeclaration.InitializerOpt.ConstantValue, localType);
+            BoundLocal boundLocal = new BoundLocal(declarationSyntax, localSymbol, localDeclaration.InitializerOpt.ConstantValueOpt, localType);
 
             BoundStatement? rewrittenDeclaration = VisitStatement(localDeclaration);
             Debug.Assert(rewrittenDeclaration is { });
@@ -226,7 +226,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // will fail, and the Dispose call will never happen.  That is, the finally block will have no effect.
             // Consequently, we can simply skip the whole try-finally construct and just create a block containing
             // the new declaration.
-            if (boundLocal.ConstantValue == ConstantValue.Null)
+            if (boundLocal.ConstantValueOpt == ConstantValue.Null)
             {
                 //localSymbol will be declared by an enclosing block
                 return BoundBlock.SynthesizedNoLocals(declarationSyntax, rewrittenDeclaration, tryBlock);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LoweredDynamicOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LoweredDynamicOperationFactory.cs
@@ -863,7 +863,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             //
             // as well as the alternative where x is a const null of type object.
 
-            if (boundArgument.ConstantValue != null)
+            if (boundArgument.ConstantValueOpt != null)
             {
                 flags |= CSharpArgumentInfoFlags.Constant;
             }

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -258,7 +258,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             return node.Update(
                 node.OperatorKind,
-                node.ConstantValue,
+                node.ConstantValueOpt,
                 VisitMethodSymbol(node.Method),
                 VisitType(node.ConstrainedToType),
                 node.ResultKind,

--- a/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
@@ -479,7 +479,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 Operand: BoundDefaultExpression { Type: var typeOfDefault },
                                 Type.SpecialType: SpecialType.System_Object
                             },
-                            Right: BoundLiteral { ConstantValue.IsNull: true, Type.SpecialType: SpecialType.System_Object }
+                            Right: BoundLiteral { ConstantValueOpt.IsNull: true, Type.SpecialType: SpecialType.System_Object }
                         } isValueTypeCheck,
 
                         Consequence: BoundLocal { LocalSymbol: { SynthesizedKind: SynthesizedLocalKind.LoweringTemp, RefKind: RefKind.Ref } } valueTypeReceiver,
@@ -958,7 +958,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            return UpdateExpression(builder, node.Update(node.OperatorKind, node.ConstantValue, node.Method, node.ConstrainedToType, node.ResultKind, left, right, node.Type));
+            return UpdateExpression(builder, node.Update(node.OperatorKind, node.ConstantValueOpt, node.Method, node.ConstrainedToType, node.ResultKind, left, right, node.Type));
         }
 
         public override BoundNode VisitCall(BoundCall node)

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -623,7 +623,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     goto default;
 
                 default:
-                    if (expr.ConstantValue != null)
+                    if (expr.ConstantValueOpt != null)
                     {
                         return expr;
                     }

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -1585,14 +1585,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol boolType = Compilation.GetSpecialType(CodeAnalysis.SpecialType.System_Boolean);
 
             // Fold compile-time comparisons.
-            if (rewrittenExpr.ConstantValue != null)
+            if (rewrittenExpr.ConstantValueOpt != null)
             {
                 switch (operatorKind)
                 {
                     case BinaryOperatorKind.Equal:
-                        return Literal(ConstantValue.Create(rewrittenExpr.ConstantValue.IsNull, ConstantValueTypeDiscriminator.Boolean), boolType);
+                        return Literal(ConstantValue.Create(rewrittenExpr.ConstantValueOpt.IsNull, ConstantValueTypeDiscriminator.Boolean), boolType);
                     case BinaryOperatorKind.NotEqual:
-                        return Literal(ConstantValue.Create(rewrittenExpr.ConstantValue.IsNull, ConstantValueTypeDiscriminator.Boolean), boolType);
+                        return Literal(ConstantValue.Create(rewrittenExpr.ConstantValueOpt.IsNull, ConstantValueTypeDiscriminator.Boolean), boolType);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -301,7 +301,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 case BoundKind.TypeExpression:
                 case BoundKind.TypeOrValueExpression:
 
-                    ConstantValue? constantValue = (boundNode as BoundExpression)?.ConstantValue;
+                    ConstantValue? constantValue = (boundNode as BoundExpression)?.ConstantValueOpt;
                     bool isImplicit = boundNode.WasCompilerGenerated;
 
                     if (!isImplicit)
@@ -439,7 +439,7 @@ namespace Microsoft.CodeAnalysis.Operations
             MethodSymbol targetMethod = boundCall.Method;
             SyntaxNode syntax = boundCall.Syntax;
             ITypeSymbol? type = boundCall.GetPublicTypeSymbol();
-            ConstantValue? constantValue = boundCall.ConstantValue;
+            ConstantValue? constantValue = boundCall.ConstantValueOpt;
             bool isImplicit = boundCall.WasCompilerGenerated;
 
             if (!boundCall.OriginalMethodsOpt.IsDefault || IsMethodInvalid(boundCall.ResultKind, targetMethod))
@@ -510,7 +510,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 Debug.Assert(initializer.Initializers.All(i => i is ISimpleAssignmentOperation));
             }
 
-            var objectCreationOperation = new ObjectCreationOperation(boundAttribute.Constructor.GetPublicSymbol(), initializer, DeriveArguments(boundAttribute), _semanticModel, boundAttribute.Syntax, boundAttribute.GetPublicTypeSymbol(), boundAttribute.ConstantValue, isImplicit: true);
+            var objectCreationOperation = new ObjectCreationOperation(boundAttribute.Constructor.GetPublicSymbol(), initializer, DeriveArguments(boundAttribute), _semanticModel, boundAttribute.Syntax, boundAttribute.GetPublicTypeSymbol(), boundAttribute.ConstantValueOpt, isImplicit: true);
             return new AttributeOperation(objectCreationOperation, _semanticModel, boundAttribute.Syntax, isAttributeImplicit);
         }
 
@@ -552,7 +552,7 @@ namespace Microsoft.CodeAnalysis.Operations
             bool isDeclaration = boundLocal.DeclarationKind != BoundLocalDeclarationKind.None;
             SyntaxNode syntax = boundLocal.Syntax;
             ITypeSymbol? type = boundLocal.GetPublicTypeSymbol();
-            ConstantValue? constantValue = boundLocal.ConstantValue;
+            ConstantValue? constantValue = boundLocal.ConstantValueOpt;
             bool isImplicit = boundLocal.WasCompilerGenerated;
             if (isDeclaration && syntax is DeclarationExpressionSyntax declarationExpressionSyntax)
             {
@@ -572,7 +572,7 @@ namespace Microsoft.CodeAnalysis.Operations
             bool isDeclaration = boundFieldAccess.IsDeclaration;
             SyntaxNode syntax = boundFieldAccess.Syntax;
             ITypeSymbol? type = boundFieldAccess.GetPublicTypeSymbol();
-            ConstantValue? constantValue = boundFieldAccess.ConstantValue;
+            ConstantValue? constantValue = boundFieldAccess.ConstantValueOpt;
             bool isImplicit = boundFieldAccess.WasCompilerGenerated;
             if (isDeclaration && syntax is DeclarationExpressionSyntax declarationExpressionSyntax)
             {
@@ -672,7 +672,7 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             SyntaxNode syntax = boundLiteral.Syntax;
             ITypeSymbol? type = boundLiteral.GetPublicTypeSymbol();
-            ConstantValue? constantValue = boundLiteral.ConstantValue;
+            ConstantValue? constantValue = boundLiteral.ConstantValueOpt;
             bool isImplicit = boundLiteral.WasCompilerGenerated || @implicit;
             return new LiteralOperation(_semanticModel, syntax, type, constantValue, isImplicit);
         }
@@ -700,7 +700,7 @@ namespace Microsoft.CodeAnalysis.Operations
             MethodSymbol constructor = boundObjectCreationExpression.Constructor;
             SyntaxNode syntax = boundObjectCreationExpression.Syntax;
             ITypeSymbol? type = boundObjectCreationExpression.GetPublicTypeSymbol();
-            ConstantValue? constantValue = boundObjectCreationExpression.ConstantValue;
+            ConstantValue? constantValue = boundObjectCreationExpression.ConstantValueOpt;
             bool isImplicit = boundObjectCreationExpression.WasCompilerGenerated;
 
             Debug.Assert(constructor is not null);
@@ -921,7 +921,7 @@ namespace Microsoft.CodeAnalysis.Operations
             ImmutableArray<IArgumentOperation> arguments = DeriveArguments(boundCollectionElementInitializer);
             SyntaxNode syntax = boundCollectionElementInitializer.Syntax;
             ITypeSymbol? type = boundCollectionElementInitializer.GetPublicTypeSymbol();
-            ConstantValue? constantValue = boundCollectionElementInitializer.ConstantValue;
+            ConstantValue? constantValue = boundCollectionElementInitializer.ConstantValueOpt;
             bool isImplicit = boundCollectionElementInitializer.WasCompilerGenerated;
 
             if (IsMethodInvalid(boundCollectionElementInitializer.ResultKind, addMethod))
@@ -1106,7 +1106,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 }
 
                 ITypeSymbol? type = boundConversion.GetPublicTypeSymbol();
-                ConstantValue? constantValue = boundConversion.ConstantValue;
+                ConstantValue? constantValue = boundConversion.ConstantValueOpt;
 
                 // If this is a lambda or method group conversion to a delegate type, we return a delegate creation instead of a conversion
                 if ((boundOperand.Kind == BoundKind.Lambda ||
@@ -1180,7 +1180,7 @@ namespace Microsoft.CodeAnalysis.Operations
             Debug.Assert(typeOperand is not null);
             SyntaxNode syntax = boundSizeOfOperator.Syntax;
             ITypeSymbol? type = boundSizeOfOperator.GetPublicTypeSymbol();
-            ConstantValue? constantValue = boundSizeOfOperator.ConstantValue;
+            ConstantValue? constantValue = boundSizeOfOperator.ConstantValueOpt;
             bool isImplicit = boundSizeOfOperator.WasCompilerGenerated;
             return new SizeOfOperation(typeOperand, _semanticModel, syntax, type, constantValue, isImplicit);
         }
@@ -1217,7 +1217,7 @@ namespace Microsoft.CodeAnalysis.Operations
         private IDefaultValueOperation CreateBoundDefaultLiteralOperation(BoundDefaultLiteral boundDefaultLiteral)
         {
             SyntaxNode syntax = boundDefaultLiteral.Syntax;
-            ConstantValue? constantValue = boundDefaultLiteral.ConstantValue;
+            ConstantValue? constantValue = boundDefaultLiteral.ConstantValueOpt;
             bool isImplicit = boundDefaultLiteral.WasCompilerGenerated;
             return new DefaultValueOperation(_semanticModel, syntax, type: null, constantValue, isImplicit);
         }
@@ -1226,7 +1226,7 @@ namespace Microsoft.CodeAnalysis.Operations
         {
             SyntaxNode syntax = boundDefaultExpression.Syntax;
             ITypeSymbol? type = boundDefaultExpression.GetPublicTypeSymbol();
-            ConstantValue? constantValue = boundDefaultExpression.ConstantValue;
+            ConstantValue? constantValue = ((BoundExpression)boundDefaultExpression).ConstantValueOpt;
             bool isImplicit = boundDefaultExpression.WasCompilerGenerated;
             return new DefaultValueOperation(_semanticModel, syntax, type, constantValue, isImplicit);
         }
@@ -1269,7 +1269,7 @@ namespace Microsoft.CodeAnalysis.Operations
             bool isRef = boundAssignmentOperator.IsRef;
             SyntaxNode syntax = boundAssignmentOperator.Syntax;
             ITypeSymbol? type = boundAssignmentOperator.GetPublicTypeSymbol();
-            ConstantValue? constantValue = boundAssignmentOperator.ConstantValue;
+            ConstantValue? constantValue = boundAssignmentOperator.ConstantValueOpt;
             bool isImplicit = boundAssignmentOperator.WasCompilerGenerated;
             return new SimpleAssignmentOperation(isRef, target, value, _semanticModel, syntax, type, constantValue, isImplicit);
         }
@@ -1368,7 +1368,7 @@ namespace Microsoft.CodeAnalysis.Operations
             IMethodSymbol? operatorMethod = boundUnaryOperator.MethodOpt.GetPublicSymbol();
             SyntaxNode syntax = boundUnaryOperator.Syntax;
             ITypeSymbol? type = boundUnaryOperator.GetPublicTypeSymbol();
-            ConstantValue? constantValue = boundUnaryOperator.ConstantValue;
+            ConstantValue? constantValue = boundUnaryOperator.ConstantValueOpt;
             bool isLifted = boundUnaryOperator.OperatorKind.IsLifted();
             bool isChecked = boundUnaryOperator.OperatorKind.IsChecked() || (boundUnaryOperator.MethodOpt is not null && SyntaxFacts.IsCheckedOperator(boundUnaryOperator.MethodOpt.Name));
             bool isImplicit = boundUnaryOperator.WasCompilerGenerated;
@@ -1422,7 +1422,7 @@ namespace Microsoft.CodeAnalysis.Operations
                                                         boundBinaryOperator.TrueOperator.GetPublicSymbol();
                 SyntaxNode syntax = boundBinaryOperator.Syntax;
                 ITypeSymbol? type = boundBinaryOperator.GetPublicTypeSymbol();
-                ConstantValue? constantValue = boundBinaryOperator.ConstantValue;
+                ConstantValue? constantValue = boundBinaryOperator.ConstantValueOpt;
                 bool isLifted = boundBinaryOperator.OperatorKind.IsLifted();
                 bool isChecked = boundBinaryOperator.OperatorKind.IsChecked();
                 bool isCompareText = false;
@@ -1454,7 +1454,7 @@ namespace Microsoft.CodeAnalysis.Operations
 
             SyntaxNode syntax = boundBinaryOperator.Syntax;
             ITypeSymbol? type = boundBinaryOperator.GetPublicTypeSymbol();
-            ConstantValue? constantValue = boundBinaryOperator.ConstantValue;
+            ConstantValue? constantValue = boundBinaryOperator.ConstantValueOpt;
             bool isLifted = boundBinaryOperator.OperatorKind.IsLifted();
             bool isChecked = boundBinaryOperator.OperatorKind.IsChecked() || (boundBinaryOperator.Method is not null && SyntaxFacts.IsCheckedOperator(boundBinaryOperator.Method.Name));
             bool isCompareText = false;
@@ -1510,7 +1510,7 @@ namespace Microsoft.CodeAnalysis.Operations
             bool isRef = boundConditionalOperator.IsRef;
             SyntaxNode syntax = boundConditionalOperator.Syntax;
             ITypeSymbol? type = boundConditionalOperator.GetPublicTypeSymbol();
-            ConstantValue? constantValue = boundConditionalOperator.ConstantValue;
+            ConstantValue? constantValue = boundConditionalOperator.ConstantValueOpt;
             bool isImplicit = boundConditionalOperator.WasCompilerGenerated;
             return new ConditionalOperation(condition, whenTrue, whenFalse, isRef, _semanticModel, syntax, type, constantValue, isImplicit);
         }
@@ -1521,7 +1521,7 @@ namespace Microsoft.CodeAnalysis.Operations
             IOperation whenNull = Create(boundNullCoalescingOperator.RightOperand);
             SyntaxNode syntax = boundNullCoalescingOperator.Syntax;
             ITypeSymbol? type = boundNullCoalescingOperator.GetPublicTypeSymbol();
-            ConstantValue? constantValue = boundNullCoalescingOperator.ConstantValue;
+            ConstantValue? constantValue = boundNullCoalescingOperator.ConstantValueOpt;
             bool isImplicit = boundNullCoalescingOperator.WasCompilerGenerated;
             Conversion valueConversion = BoundNode.GetConversion(boundNullCoalescingOperator.LeftConversion, boundNullCoalescingOperator.LeftPlaceholder);
 
@@ -1592,7 +1592,7 @@ namespace Microsoft.CodeAnalysis.Operations
             IOperation argument = Create(boundNameOfOperator.Argument);
             SyntaxNode syntax = boundNameOfOperator.Syntax;
             ITypeSymbol? type = boundNameOfOperator.GetPublicTypeSymbol();
-            ConstantValue constantValue = boundNameOfOperator.ConstantValue;
+            ConstantValue constantValue = boundNameOfOperator.ConstantValueOpt;
             bool isImplicit = boundNameOfOperator.WasCompilerGenerated;
             return new NameOfOperation(argument, _semanticModel, syntax, type, constantValue, isImplicit);
         }
@@ -2146,7 +2146,7 @@ namespace Microsoft.CodeAnalysis.Operations
             ImmutableArray<IInterpolatedStringContentOperation> parts = CreateBoundInterpolatedStringContentOperation(boundInterpolatedString.Parts, positionInfo ?? boundInterpolatedString.InterpolationData?.PositionInfo[0]);
             SyntaxNode syntax = boundInterpolatedString.Syntax;
             ITypeSymbol? type = boundInterpolatedString.GetPublicTypeSymbol();
-            ConstantValue? constantValue = boundInterpolatedString.ConstantValue;
+            ConstantValue? constantValue = boundInterpolatedString.ConstantValueOpt;
             bool isImplicit = boundInterpolatedString.WasCompilerGenerated;
             return new InterpolatedStringOperation(parts, _semanticModel, syntax, type, constantValue, isImplicit);
         }
@@ -2352,7 +2352,7 @@ namespace Microsoft.CodeAnalysis.Operations
                             _semanticModel,
                             interpolatedString.Syntax,
                             interpolatedString.GetPublicTypeSymbol(),
-                            interpolatedString.ConstantValue,
+                            interpolatedString.ConstantValueOpt,
                             isImplicit: interpolatedString.WasCompilerGenerated);
 
                     default:
@@ -2369,7 +2369,7 @@ namespace Microsoft.CodeAnalysis.Operations
 
             if (placeholder.ArgumentIndex == BoundInterpolatedStringArgumentPlaceholder.UnspecifiedParameter)
             {
-                return new InvalidOperation(ImmutableArray<IOperation>.Empty, _semanticModel, syntax, type, placeholder.ConstantValue, isImplicit);
+                return new InvalidOperation(ImmutableArray<IOperation>.Empty, _semanticModel, syntax, type, placeholder.ConstantValueOpt, isImplicit);
             }
 
             const int NonArgumentIndex = -1;

--- a/src/Compilers/CSharp/Portable/Symbols/ConstantValueUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstantValueUtils.cs
@@ -101,9 +101,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     // If we have already computed the unconverted constant value, then this call is cheap
                     // because BoundConversions store their constant values (i.e. not recomputing anything).
-                    var constantValue = boundValue.ConstantValue;
+                    var constantValue = boundValue.ConstantValueOpt;
 
-                    var unconvertedConstantValue = unconvertedBoundValue.ConstantValue;
+                    var unconvertedConstantValue = unconvertedBoundValue.ConstantValueOpt;
                     if (unconvertedConstantValue != null &&
                         !unconvertedConstantValue.IsNull &&
                         typeSymbol.IsReferenceType &&

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -843,7 +843,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             //
             // Also when valuetype S has a parameterless constructor, 
             // new S() is clearly not a constant expression and should produce an error
-            if (expression.ConstantValue != null)
+            if (expression.ConstantValueOpt != null)
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -380,7 +380,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // If we have something like M(double? x = 1) then the expression we'll get is (double?)1, which
             // does not have a constant value. The constant value we want is (double)1.
             // The default literal conversion is an exception: (double)default would give the wrong value for M(double? x = default).
-            if (convertedExpression.ConstantValue == null && convertedExpression.Kind == BoundKind.Conversion &&
+            if (convertedExpression.ConstantValueOpt == null && convertedExpression.Kind == BoundKind.Conversion &&
                 ((BoundConversion)convertedExpression).ConversionKind != ConversionKind.DefaultLiteral)
             {
                 if (parameterType.Type.IsNullableType())
@@ -391,7 +391,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // represent default(struct) by a Null constant:
-            var value = convertedExpression.ConstantValue ?? ConstantValue.Null;
+            var value = convertedExpression.ConstantValueOpt ?? ConstantValue.Null;
             return value;
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -1454,8 +1454,8 @@ ulong.MinValue --> 0";
             var constants = BoundTreeSequencer.GetNodes(block).
                 Where(predicate).
                 OfType<BoundExpression>().
-                Where(node => node.ConstantValue != null).
-                Select(node => node.Syntax.ToFullString().Trim() + " --> " + ExtractValue(node.ConstantValue));
+                Where(node => node.ConstantValueOpt != null).
+                Select(node => node.Syntax.ToFullString().Trim() + " --> " + ExtractValue(node.ConstantValueOpt));
             var result = string.Join(Environment.NewLine, constants);
             return result;
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -643,7 +643,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             else if (expressionType.SpecialType == SpecialType.System_Void)
             {
                 flags |= DkmClrCompilationResultFlags.ReadOnlyResult;
-                Debug.Assert(expression.ConstantValue == null);
+                Debug.Assert(expression.ConstantValueOpt == null);
                 resultProperties = expression.ExpressionSymbol.GetResultProperties(flags, isConstant: false);
                 return new BoundExpressionStatement(syntax, expression) { WasCompilerGenerated = true };
             }
@@ -657,7 +657,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 flags |= DkmClrCompilationResultFlags.ReadOnlyResult;
             }
 
-            resultProperties = expression.ExpressionSymbol.GetResultProperties(flags, expression.ConstantValue != null);
+            resultProperties = expression.ExpressionSymbol.GetResultProperties(flags, expression.ConstantValueOpt != null);
             return new BoundReturnStatement(syntax, RefKind.None, expression, @checked: false) { WasCompilerGenerated = true };
         }
 


### PR DESCRIPTION
There's always two members showing up for expressions: ConstantValue and ConstantValueOpt. This merges the two.

Note: instead of rename (done in second commit) could add `ConstantValue => ConstantValueOpt;` to reduce the diff size, but that would defeat the purpose.

