### PR TITLE
use dnceng vms to kickoff helix runs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,6 +79,7 @@ stages:
         testArtifactName: Transport_Artifacts_Windows_Debug
         configuration: Debug
         testArguments: -testDesktop -testArch x86
+        queueName: windows.vs2022preview.amd64.open
 
   - template: eng/pipelines/test-windows-job.yml
     parameters:
@@ -87,6 +88,7 @@ stages:
       testArtifactName: Transport_Artifacts_Windows_Debug
       configuration: Debug
       testArguments: -testDesktop -testArch x64
+      queueName: windows.vs2022preview.amd64.open
 
 - stage: Windows_Release_Desktop
   dependsOn: Windows_Release_Build
@@ -98,6 +100,7 @@ stages:
       testArtifactName: Transport_Artifacts_Windows_Release
       configuration: Release
       testArguments: -testDesktop -testArch x86
+      queueName: windows.vs2022preview.amd64.open
 
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - template: eng/pipelines/test-windows-job.yml
@@ -107,6 +110,7 @@ stages:
         testArtifactName: Transport_Artifacts_Windows_Release
         configuration: Release
         testArguments: -testDesktop -testArch x64
+        queueName: windows.vs2022preview.amd64.open
 
   - template: eng/pipelines/test-windows-job.yml
     parameters:
@@ -115,6 +119,7 @@ stages:
       testArtifactName: Transport_Artifacts_Windows_Release
       configuration: Release
       testArguments: -testDesktop -testArch x64 -helixQueueName Windows.10.Amd64.Server2022.ES.Open
+      queueName: windows.vs2022preview.amd64.open
 
 - stage: Windows_Debug_CoreClr
   dependsOn: Windows_Debug_Build
@@ -126,6 +131,7 @@ stages:
       testArtifactName: Transport_Artifacts_Windows_Debug
       configuration: Debug
       testArguments: -testCoreClr
+      queueName: windows.vs2022preview.amd64.open
 
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - template: eng/pipelines/test-windows-job-single-machine.yml
@@ -143,6 +149,7 @@ stages:
       testArtifactName: Transport_Artifacts_Windows_Debug
       configuration: Debug
       testArguments: -testCoreClr -testIOperation -testCompilerOnly
+      queueName: windows.vs2022preview.amd64.open
 
   # This leg runs almost all the compiler tests supported on CoreCLR, but
   #  with additional validation for used assemblies and GetEmitDiagnostics
@@ -153,6 +160,7 @@ stages:
       testArtifactName: Transport_Artifacts_Windows_Debug
       configuration: Debug
       testArguments: -testCoreClr -testUsedAssemblies -testCompilerOnly
+      queueName: windows.vs2022preview.amd64.open
 
 - stage: Windows_Release_CoreClr
   dependsOn: Windows_Release_Build
@@ -164,6 +172,7 @@ stages:
       testArtifactName: Transport_Artifacts_Windows_Release
       configuration: Release
       testArguments: -testCoreClr
+      queueName: windows.vs2022preview.amd64.open
 
 - stage: Unix_Debug_CoreClr
   dependsOn: Unix_Build
@@ -175,6 +184,7 @@ stages:
       testArtifactName: Transport_Artifacts_Unix_Debug
       configuration: Debug
       testArguments: --testCoreClr --helixQueueName Ubuntu.1804.Amd64.Open
+      queueName: Build.Ubuntu.1804.Amd64.Open
 
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     - template: eng/pipelines/test-unix-job-single-machine.yml
@@ -193,6 +203,7 @@ stages:
       testArtifactName: Transport_Artifacts_Unix_Debug
       configuration: Debug
       testArguments: --testCoreClr --helixQueueName OSX.1015.Amd64.Open
+      queueName: Build.Ubuntu.1804.Amd64.Open
 
 - stage: Correctness
   dependsOn: []
@@ -304,7 +315,7 @@ stages:
 
   - job: Correctness_TodoCheck
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
     timeoutInMinutes: 10
     steps:
       - template: eng/pipelines/checkout-unix-task.yml

--- a/eng/pipelines/test-unix-job.yml
+++ b/eng/pipelines/test-unix-job.yml
@@ -15,14 +15,22 @@ parameters:
 - name: testArguments
   type: string
   default: ''
+- name: queueName
+  type: string
+  default: ''
+- name: vmImageName
+  type: string
+  default: ''
 
 jobs:
 - job: ${{ parameters.jobName }}
   pool:
-    # Note that when helix is enabled, the agent running this job is essentially
-    # a thin client that kicks off a helix job and waits for it to complete.
-    # Thus we don't use a helix queue to run the job here, and instead use the plentiful AzDO vmImages.
-    vmImage: ubuntu-20.04
+    ${{ if ne(parameters.queueName, '') }}:
+      name: NetCore-Public
+      demands: ImageOverride -equals ${{ parameters.queueName }}
+
+    ${{ if ne(parameters.vmImageName, '') }}:
+      vmImage: ${{ parameters.vmImageName }}
   timeoutInMinutes: 90
   steps:
     - checkout: none

--- a/eng/pipelines/test-windows-job.yml
+++ b/eng/pipelines/test-windows-job.yml
@@ -15,14 +15,22 @@ parameters:
 - name: testArguments
   type: string
   default: ''
+- name: queueName
+  type: string
+  default: ''
+- name: vmImageName
+  type: string
+  default: ''
 
 jobs:
 - job: ${{ parameters.jobName }}
   pool:
-    # Note that when helix is enabled, the agent running this job is essentially
-    # a thin client that kicks off a helix job and waits for it to complete.
-    # Thus we don't use a helix queue to run the job here, and instead use the plentiful AzDO vmImages.
-    vmImage: windows-2019
+    ${{ if ne(parameters.queueName, '') }}:
+      name: NetCore-Public
+      demands: ImageOverride -equals ${{ parameters.queueName }}
+
+    ${{ if ne(parameters.vmImageName, '') }}:
+      vmImage: ${{ parameters.vmImageName }}
   timeoutInMinutes: 120
   steps:
     - checkout: none


### PR DESCRIPTION
## Background

As the comment in the yaml file said: when helix is enabled, the agent running this job is essentially a thin client that kicks off a helix job and waits for it to complete. At the time it was thought that the best behavior was to not burn a dnceng vm for no reason and instead use a bog-standard azdo vm.

## Problem

Unfortunately, we can only have 200 of these types of VMs running concurrently for the entire github.com/dotnet org. If no other team ever uses these and we never have more than 22 PRs running (we currently kick off 9 per-run) then all is well. If this limit is hit however, we are then stuck wait ing for test test job to even get kicked off.

In addition, if we are over 200 vms because of roslyn-ci it can take 40+ minutes for one of these slots to be made available. This ends up hard-locking our concurrent PR count at 22.

## Solution

I think we should use dnceng images for any long-running jobs moving forward. I am keeping azdo images for the `Determine_Changes` and `Correctness_TodoCheck` jobs because they both execute in under 30 seconds (90% of the time in under 10 seconds) and I think it's reasonable to use these images for these sorts of very short jobs. 