### PR TITLE
[LSP] Temporarily report NFWs in `RangeToTextSpan`

### DIFF
--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             // Temporary exception reporting to investigate https://github.com/dotnet/roslyn/issues/66258.
             catch when (FatalError.ReportAndPropagate(new Exception($"Failed GetTextSpan calculation.")))
             {
-                throw ExceptionUtilities.Unreachable();
+                throw;
             }
         }
 

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -201,7 +201,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
                 return text.Lines.GetTextSpan(linePositionSpan);
             }
             // Temporary exception reporting to investigate https://github.com/dotnet/roslyn/issues/66258.
-            catch when (FatalError.ReportAndPropagate(new Exception($"Failed GetTextSpan calculation.")))
+            catch (Exception e) when (FatalError.ReportAndPropagate(e))
             {
                 throw;
             }

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -12,6 +12,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.DocumentHighlighting;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Indentation;
@@ -194,7 +195,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         public static TextSpan RangeToTextSpan(LSP.Range range, SourceText text)
         {
             var linePositionSpan = RangeToLinePositionSpan(range);
-            return text.Lines.GetTextSpan(linePositionSpan);
+
+            try
+            {
+                return text.Lines.GetTextSpan(linePositionSpan);
+            }
+            // Temporary exception reporting to investigate https://github.com/dotnet/roslyn/issues/66258.
+            catch when (FatalError.ReportAndPropagate(new Exception($"Failed GetTextSpan calculation.")))
+            {
+                throw ExceptionUtilities.Unreachable();
+            }
         }
 
         public static LSP.TextEdit TextChangeToTextEdit(TextChange textChange, SourceText oldText)


### PR DESCRIPTION
This PR is meant to aid investigation of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1534360 (MSFT internal).

There is already NFW logging in LSP, however the produced dumps didn't contain the needed stack information to investigate. This change should hopefully make future dumps more useful, however it's likely not the long-term fix.