### PR TITLE
If we hit an exception while indexing, say which document it was with and try to recover

### DIFF
--- a/src/Features/Lsif/Generator/Program.cs
+++ b/src/Features/Lsif/Generator/Program.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
             var options = GeneratorOptions.Default;
 
             await logFile.WriteLineAsync($"Load completed in {solutionLoadStopwatch.Elapsed.ToDisplayString()}.");
-            var lsifGenerator = Generator.CreateAndWriteCapabilitiesVertex(lsifWriter);
+            var lsifGenerator = Generator.CreateAndWriteCapabilitiesVertex(lsifWriter, logFile);
 
             var totalTimeInGenerationAndCompilationFetchStopwatch = Stopwatch.StartNew();
             var totalTimeInGenerationPhase = TimeSpan.Zero;
@@ -218,7 +218,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
             await logFile.WriteLineAsync($"Load of the project completed in {compilerInvocationLoadStopwatch.Elapsed.ToDisplayString()}.");
 
             var generationStopwatch = Stopwatch.StartNew();
-            var lsifGenerator = Generator.CreateAndWriteCapabilitiesVertex(lsifWriter);
+            var lsifGenerator = Generator.CreateAndWriteCapabilitiesVertex(lsifWriter, logFile);
 
             await lsifGenerator.GenerateForProjectAsync(project, GeneratorOptions.Default, cancellationToken);
             await logFile.WriteLineAsync($"Generation for {project.FilePath} completed in {generationStopwatch.Elapsed.ToDisplayString()}.");
@@ -234,7 +234,7 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
 
             await logFile.WriteLineAsync($"Load of the binlog complete; {msbuildInvocations.Length} invocations were found.");
 
-            var lsifGenerator = Generator.CreateAndWriteCapabilitiesVertex(lsifWriter);
+            var lsifGenerator = Generator.CreateAndWriteCapabilitiesVertex(lsifWriter, logFile);
 
             foreach (var msbuildInvocation in msbuildInvocations)
             {

--- a/src/Features/Lsif/GeneratorTest/Utilities/TestLsifOutput.vb
+++ b/src/Features/Lsif/GeneratorTest/Utilities/TestLsifOutput.vb
@@ -11,6 +11,7 @@ Imports LSP = Microsoft.VisualStudio.LanguageServer.Protocol
 Imports Roslyn.Utilities
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports System.Threading
+Imports System.IO
 
 Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests.Utilities
     Friend Class TestLsifOutput
@@ -45,7 +46,8 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests.U
             ' world function of the indexer.
             Assert.Equal(workspace.Composition, TestComposition)
 
-            Dim lsifGenerator = Generator.CreateAndWriteCapabilitiesVertex(jsonWriter)
+            Dim log = New StringWriter()
+            Dim lsifGenerator = Generator.CreateAndWriteCapabilitiesVertex(jsonWriter, log)
 
             For Each project In workspace.CurrentSolution.Projects
                 Dim compilation = Await project.GetCompilationAsync()
@@ -55,6 +57,9 @@ Namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.UnitTests.U
 
                 Await lsifGenerator.GenerateForProjectAsync(project, GeneratorOptions.Default, CancellationToken.None)
             Next
+
+            ' The only things would have logged were an error, so this should be empty
+            Assert.Empty(log.ToString())
         End Function
 
         Public Function GetElementById(Of T As Element)(id As Id(Of T)) As T


### PR DESCRIPTION
If we hit an exception while indexing a document, log it. Also, still finalize the LSIF output in the case of exceptions so it's at least marginally complete so hopefully it can still be ingested even in the presence of an error.