### PR TITLE
Promote regular item to "Preferred" state

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/AsyncCompletionLogger.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/AsyncCompletionLogger.cs
@@ -17,10 +17,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         {
             // # of sessions where import completion is enabled by default
             SessionWithTypeImportCompletionEnabled,
-            // # of sessions that we wait for import compeltion task to complete before return
-            // curerntly it's decided by "responsive completion" options
+            // # of sessions that we wait for import completion task to complete before return.
+            // Currently it's decided by "responsive completion" options
             SessionWithImportCompletionBlocking,
-            // # of sessions where items from import completion are not included intially 
+            // # of sessions where items from import completion are not included initially 
             SessionWithImportCompletionDelayed,
             // # of session among SessionWithImportCompletionDelayed where import completion items
             // are later included in list update. Note this doesn't include using of expander.
@@ -28,11 +28,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             // Among sessions in SessionWithImportCompletionDelayed, how much longer it takes 
             // for import completion task to finish after regular item task is completed.
             // Knowing this would help us to decide whether a short wait would have ensure import completion
-            // items to be included in the intial list.
+            // items to be included in the initial list.
             AdditionalTicksToCompleteDelayedImportCompletion,
             ExpanderUsageCount,
-
-            GetDefaultsMatchTicks,
 
             SourceInitializationTicks,
             SourceGetContextCompletedTicks,
@@ -65,9 +63,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
         internal static void LogExpanderUsage()
             => s_countLogAggregator.IncreaseCount(ActionInfo.ExpanderUsageCount);
-
-        internal static void LogGetDefaultsMatchTicksDataPoint(int count)
-            => s_statisticLogAggregator.AddDataPoint(ActionInfo.GetDefaultsMatchTicks, count);
 
         internal static void LogSourceInitializationTicksDataPoint(TimeSpan elapsed)
         {

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionItemData.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionItemData.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
     {
         private const string RoslynCompletionItemData = nameof(RoslynCompletionItemData);
 
-        public static bool TryGetData(CompletionItem vsCompletionitem, out CompletionItemData data)
-            => vsCompletionitem.Properties.TryGetProperty(RoslynCompletionItemData, out data);
+        public static bool TryGetData(CompletionItem vsCompletionItem, out CompletionItemData data)
+            => vsCompletionItem.Properties.TryGetProperty(RoslynCompletionItemData, out data);
 
         public static RoslynCompletionItem GetOrAddDummyRoslynItem(CompletionItem vsItem)
         {
@@ -27,8 +27,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             return roslynItem;
         }
 
-        public static void AddData(CompletionItem vsCompletionitem, RoslynCompletionItem roslynItem, SnapshotPoint? triggerLocation)
-            => vsCompletionitem.Properties[RoslynCompletionItemData] = new CompletionItemData(roslynItem, triggerLocation);
+        public static void AddData(CompletionItem vsCompletionItem, RoslynCompletionItem roslynItem, SnapshotPoint? triggerLocation)
+            => vsCompletionItem.Properties[RoslynCompletionItemData] = new CompletionItemData(roslynItem, triggerLocation);
 
         private static RoslynCompletionItem CreateDummyRoslynItem(CompletionItem vsItem)
             => RoslynCompletionItem.Create(

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
@@ -266,20 +266,23 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     {
                         list.Add(matchResult);
 
-                        // Collect all the preferred items from Pythia and regular items matched defaults provided by WLC.
-                        // We will use this info next to "promote" regular default items to "preferred" state on behalf of
-                        // WLC to provide a coherent IntelliCode completion experience.
-                        if (matchResult.CompletionItem.IsPreferredItem())
+                        if (!_snapshotData.Defaults.IsEmpty)
                         {
-                            includedPreferredItems.Add(matchResult.CompletionItem.FilterText);
-                        }
-                        else
-                        {
-                            var defaultIndex = unmatchedDefaults.IndexOf(matchResult.CompletionItem.FilterText);
-                            if (defaultIndex >= 0)
+                            // Collect all the preferred items from Pythia and regular items matched defaults provided by WLC.
+                            // We will use this info next to "promote" regular default items to "preferred" state on behalf of
+                            // WLC to provide a coherent IntelliCode completion experience.
+                            if (matchResult.CompletionItem.IsPreferredItem())
                             {
-                                unmatchedDefaults = unmatchedDefaults.RemoveAt(defaultIndex);
-                                includedDefaults.Add(matchResult);
+                                includedPreferredItems.Add(matchResult.CompletionItem.FilterText);
+                            }
+                            else
+                            {
+                                var defaultIndex = unmatchedDefaults.IndexOf(matchResult.CompletionItem.FilterText);
+                                if (defaultIndex >= 0)
+                                {
+                                    unmatchedDefaults = unmatchedDefaults.RemoveAt(defaultIndex);
+                                    includedDefaults.Add(matchResult);
+                                }
                             }
                         }
                     }
@@ -316,8 +319,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     }
                 }
 
-                // This ensures promoted default items are sorted in the same relative order and (would have been) before other
-                // items from initial sorted list of all. 
+                // This ensures promoted items are sorted in the same relative order as in defaults list, as well as before all
+                // items from initial sorted list (by giving them negative value as index). 
                 // e.g. if Defaults.Length = 3, we set index of Defaults[0] to -3, Defaults[1] to -2, etc. where the last one is -1.
                 // All other items have original index >= 0.
                 int DefaultIndexToFabricatedOriginalSortedIndex(int i)

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
@@ -238,6 +238,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 // FilterStateHelper is used to decide whether a given item should be included in the list based on the state of filter/expander buttons.
                 var filterHelper = new FilterStateHelper(_snapshotData.SelectedFilters);
 
+                using var _1 = PooledHashSet<string>.GetInstance(out var includedPreferredItems);
+                using var _2 = ArrayBuilder<MatchResult>.GetInstance(out var includedDefaults);
+                var unmatchedDefaults = _snapshotData.Defaults;
+
                 // Filter items based on the selected filters and matching.
                 var totalCount = _snapshotData.InitialSortedItemList.Count;
                 for (var currentIndex = 0; currentIndex < totalCount; currentIndex++)
@@ -245,30 +249,79 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     cancellationToken.ThrowIfCancellationRequested();
                     var item = _snapshotData.InitialSortedItemList[currentIndex];
 
+                    // All items passed in should contain a CompletionItemData object in the property bag,
+                    // which is guaranteed in `ItemManager.SortCompletionListAsync`.
+                    if (!CompletionItemData.TryGetData(item, out var itemData))
+                        throw ExceptionUtilities.Unreachable();
+
                     if (filterHelper.ShouldBeFilteredOut(item))
                         continue;
 
-                    if (CompletionItemData.TryGetData(item, out var itemData))
+                    // currentIndex is used to track the index of the VS CompletionItem in the initial sorted list to maintain a map from Roslyn item to VS item.
+                    // It's also used to sort the items by pattern matching results while preserving the original alphabetical order for items with
+                    // same pattern match score since `List<T>.Sort` isn't stable.
+                    if (CompletionHelper.TryCreateMatchResult(_completionHelper, itemData.RoslynItem, _filterText,
+                        roslynInitialTriggerKind, roslynFilterReason, _recentItemsManager.GetRecentItemIndex(itemData.RoslynItem), _highlightMatchingPortions, currentIndex,
+                        out var matchResult))
                     {
-                        // currentIndex is used to track the index of the VS CompletionItem in the initial sorted list to maintain a map from Roslyn item to VS item.
-                        // It's also used to sort the items by pattern matching results while preserving the original alphabetical order for items with
-                        // same pattern match score since `List<T>.Sort` isn't stable.
-                        if (CompletionHelper.TryCreateMatchResult(_completionHelper, itemData.RoslynItem, _filterText,
-                            roslynInitialTriggerKind, roslynFilterReason, _recentItemsManager.GetRecentItemIndex(itemData.RoslynItem), _highlightMatchingPortions, currentIndex,
-                            out var matchResult))
+                        list.Add(matchResult);
+
+                        // Collect all the preferred items from Pythia and regular items matched defaults provided by WLC.
+                        // We will use this info next to "promote" regular default items to "preferred" state on behalf of
+                        // WLC to provide a coherent IntelliCode completion experience.
+                        if (matchResult.CompletionItem.IsPreferredItem())
                         {
-                            list.Add(matchResult);
+                            includedPreferredItems.Add(matchResult.CompletionItem.FilterText);
                         }
-                    }
-                    else
-                    {
-                        // All items passed in should contain a CompletionItemData object in the property bag,
-                        // which is guaranteed in `ItemManager.SortCompletionListAsync`.
-                        throw ExceptionUtilities.Unreachable();
+                        else
+                        {
+                            var defaultIndex = unmatchedDefaults.IndexOf(matchResult.CompletionItem.FilterText);
+                            if (defaultIndex >= 0)
+                            {
+                                unmatchedDefaults = unmatchedDefaults.RemoveAt(defaultIndex);
+                                includedDefaults.Add(matchResult);
+                            }
+                        }
                     }
                 }
 
+                PromoteDefaultItemsToPreferredState();
                 list.Sort(MatchResult.SortingComparer);
+
+                // Go through items matched with defaults. If it doesn't have
+                // a corresponding preferred items, we will add one that mimic
+                // the "starred" item from Pythia.
+                void PromoteDefaultItemsToPreferredState()
+                {
+                    foreach (var includedDefault in includedDefaults)
+                    {
+                        var completionItem = includedDefault.CompletionItem;
+
+                        // There a preferred item matches the same default, so no need to promote this.
+                        if (includedPreferredItems.Contains(completionItem.FilterText))
+                            continue;
+
+                        var defaultIndex = _snapshotData.Defaults.IndexOf(completionItem.FilterText);
+                        var fabricatedIndex = DefaultIndexToFabricatedOriginalSortedIndex(defaultIndex);
+
+                        var promotedDefaultItemMatchResult = new MatchResult(
+                            Helpers.PromoteItem(completionItem, includedDefault.IndexInOriginalSortedOrder),
+                            includedDefault.ShouldBeConsideredMatchingFilterText,
+                            includedDefault.PatternMatch,
+                            fabricatedIndex,
+                            matchedAdditionalFilterText: includedDefault.MatchedAdditionalFilterText,
+                            includedDefault.RecentItemIndex);
+
+                        list.Add(promotedDefaultItemMatchResult);
+                    }
+                }
+
+                // This ensures promoted default items are sorted in the same relative order and (would have been) before other
+                // items from initial sorted list of all. 
+                // e.g. if Defaults.Length = 3, we set index of Defaults[0] to -3, Defaults[1] to -2, etc. where the last one is -1.
+                // All other items have original index >= 0.
+                int DefaultIndexToFabricatedOriginalSortedIndex(int i)
+                    => i - _snapshotData.Defaults.Length;
             }
 
             private ItemSelection? HandleNormalFiltering(IReadOnlyList<MatchResult> matchResults, CancellationToken cancellationToken)
@@ -376,7 +429,36 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             private VSCompletionItem GetCorrespondingVsCompletionItem(MatchResult matchResult, CancellationToken cancellationToken)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                return _snapshotData.InitialSortedItemList[matchResult.IndexInOriginalSortedOrder];
+
+                if (matchResult.IndexInOriginalSortedOrder >= 0)
+                    return _snapshotData.InitialSortedItemList[matchResult.IndexInOriginalSortedOrder];
+
+                // This is a "promoted" item added by us, so there's no corresponding VS item from initial sorted list.
+                // We need to craft one based on the data of the original item.
+                var item = matchResult.CompletionItem;
+                if (Helpers.TryGetOriginalIndexOfPromotedItem(item, out var unpromotedIndex))
+                {
+                    var unpromotedVsItem = _snapshotData.InitialSortedItemList[unpromotedIndex];
+                    var promotedVsItem = new VSCompletionItem(
+                        displayText: item.GetEntireDisplayText(),
+                        unpromotedVsItem.Source,
+                        unpromotedVsItem.Icon,
+                        unpromotedVsItem.Filters,
+                        unpromotedVsItem.Suffix,
+                        unpromotedVsItem.InsertText,
+                        unpromotedVsItem.SortText,
+                        unpromotedVsItem.FilterText,
+                        unpromotedVsItem.AutomationText,
+                        unpromotedVsItem.AttributeIcons);
+
+                    // This is guaranteed to return true here
+                    CompletionItemData.TryGetData(unpromotedVsItem, out var data);
+                    CompletionItemData.AddData(promotedVsItem, item, data.TriggerLocation);
+
+                    return promotedVsItem;
+                }
+
+                throw ExceptionUtilities.Unreachable();
             }
 
             private ItemSelection? HandleDeletionTrigger(IReadOnlyList<MatchResult> items, CancellationToken cancellationToken)
@@ -757,17 +839,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     return itemSelection;
 
                 // "Preselect" is only used when we have high confidence with the selection, so don't override it;
-                // unless it's an IntelliCode item, in which case the default item wins.
+                // unless it's a real Pythia item (i.e. not fake one from us,) in which case the default item wins.
                 var selectedItem = items[itemSelection.SelectedItemIndex].CompletionItem;
-                if (selectedItem.Rules.MatchPriority >= MatchPriority.Preselect && !selectedItem.IsPreferredItem())
-                    return itemSelection;
+                if (selectedItem.Rules.MatchPriority >= MatchPriority.Preselect)
+                {
+                    // This is a high priority item provided by Roslyn, either a regular or preferred one promoted by us
+                    // (because it matches one of the defaults even though it might not be the best default) so we want to stick with this selection. 
+                    if (!selectedItem.IsPreferredItem() || Helpers.TryGetOriginalIndexOfPromotedItem(selectedItem, out _))
+                        return itemSelection;
+                }
 
-                var tick = Environment.TickCount;
-
-                var finalSelection = GetDefaultsMatch(items, itemSelection, cancellationToken);
-
-                AsyncCompletionLogger.LogGetDefaultsMatchTicksDataPoint(Environment.TickCount - tick);
-                return finalSelection;
+                return GetDefaultsMatch(items, itemSelection, cancellationToken);
             }
 
             /// <summary>
@@ -775,19 +857,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             /// If the suggested default is no worse than current selected item (in a case-sensitive manner,) use the suggested default. Otherwise use the original selection.
             /// For example, if user typed "C", roslyn might select "CancellationToken", but with suggested default "Console" we will end up selecting "Console" instead.
             /// </summary>
-            private ItemSelection GetDefaultsMatch(IReadOnlyList<MatchResult> items, ItemSelection initialSelection, CancellationToken cancellationToken)
+            private ItemSelection GetDefaultsMatch(IReadOnlyList<MatchResult> matches, ItemSelection initialSelection, CancellationToken cancellationToken)
             {
-                // Because the items are already sorted based on pattern-matching score, try to limit the range for the items we compare default with
-                // by searching for the first "inferior" item, so we can avoid always going through the entire list.
+                // Because the items are already sorted based on pattern-matching score, try to limit the range for the items we search
+                // by stopping as soon as we encountered the top item from original default list, or at the first match that is inferior than current selection.
                 int inferiorItemIndex;
                 if (_filterText.Length == 0)
                 {
                     // Without filterText, all items are equally good match (w.r.t to the empty filterText), so we have to consider all of them.
-                    inferiorItemIndex = items.Count;
+                    inferiorItemIndex = matches.Count;
                 }
                 else
                 {
-                    var selectedItemMatch = items[initialSelection.SelectedItemIndex].PatternMatch;
+                    var selectedItemMatch = matches[initialSelection.SelectedItemIndex].PatternMatch;
 
                     // It's possible that an item doesn't match filter text but still ended up being selected, this is because we just always keep all the
                     // items in the list in some cases. For example, user brought up completion with ctrl-j or through deletion.
@@ -799,9 +881,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     // -- as far as the pattern matcher is concerned -- equivalent items (items with identical PatternMatch.Kind and IsCaseSensitive).
                     // Find the last items in the range and use that to limit the items searched for from the defaults list.     
                     inferiorItemIndex = initialSelection.SelectedItemIndex;
-                    while (++inferiorItemIndex < items.Count)
+                    while (++inferiorItemIndex < matches.Count)
                     {
-                        var itemMatch = items[inferiorItemIndex].PatternMatch;
+                        var itemMatch = matches[inferiorItemIndex].PatternMatch;
                         if (!itemMatch.HasValue
                             || itemMatch.Value.Kind != selectedItemMatch.Value.Kind
                             || itemMatch.Value.IsCaseSensitive != selectedItemMatch.Value.IsCaseSensitive)
@@ -811,26 +893,43 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                     }
                 }
 
-                foreach (var defaultText in _snapshotData.Defaults)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
-                    // The range includes all items that are as good of a match as what we initially selected (and in descending order of matching score)
-                    // so we just need to search for the first item that matches the suggested default.
-                    for (var i = 0; i < inferiorItemIndex; ++i)
+                // The range includes all items that are as good of a match as what we initially selected (and in descending order of matching score)
+                // so we just need to search for a preferred item with best default match.
+                var bestPromotedItemSoFar = -1;
+                var bestDefaultIndex = -1;
+                for (var i = 0; i < inferiorItemIndex; ++i)
+                {
+                    var item = matches[i].CompletionItem;
+                    if (item.IsPreferredItem())
                     {
-                        if (items[i].CompletionItem.FilterText == defaultText)
+                        var defaultIndex = _snapshotData.Defaults.IndexOf(matches[i].CompletionItem.FilterText);
+
+                        // This is not a starred item that matches default
+                        if (defaultIndex < 0)
+                            continue;
+
+                        if (bestPromotedItemSoFar < 0 || defaultIndex <= bestDefaultIndex)
                         {
-                            // If user hasn't typed anything, we'd like to hard select the default item.
-                            // This way, they can easily commit the default item which matches what WLC shows.
-                            var selectionHint = _filterText.Length == 0 ? UpdateSelectionHint.Selected : initialSelection.SelectionHint;
-                            return initialSelection with { SelectedItemIndex = i, SelectionHint = selectionHint };
+                            bestPromotedItemSoFar = i;
+                            bestDefaultIndex = defaultIndex;
                         }
+
+                        // We have found the top default item, no need to proceed.
+                        if (bestDefaultIndex == 0)
+                            break;
                     }
                 }
 
                 // Don't change the original selection since there's no match to the defaults provided.
-                return initialSelection;
+                if (bestPromotedItemSoFar < 0)
+                    return initialSelection;
+
+                // If user hasn't typed anything, we'd like to hard select the default item.
+                // This way, they can easily commit the default item which matches what WLC shows.
+                var selectionHint = _filterText.Length == 0 ? UpdateSelectionHint.Selected : initialSelection.SelectionHint;
+                return initialSelection with { SelectedItemIndex = bestPromotedItemSoFar, SelectionHint = selectionHint };
             }
 
             private sealed class FilterStateHelper

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
@@ -17,8 +17,33 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
     <Trait(Traits.Feature, Traits.Features.Completion)>
     Public Class CSharpCompletionCommandHandlerTests_DefaultsSource
 
+        Private Shared Async Function AssertCompletionItemsContainPromotedItem(state As TestState, displayText As String) As Task
+            Dim x As Integer
+            Await state.AssertCompletionItemsContain(Function(i) i.DisplayText = displayText AndAlso i.DisplayTextSuffix = "" AndAlso Helpers.TryGetOriginalIndexOfPromotedItem(i, x))
+        End Function
+
+        Private Shared Sub AssertCompletionItemsInRelativeOrder(state As TestState, expectedItems As List(Of ValueTuple(Of String, Boolean)))
+
+            Dim list = state.GetCompletionItems()
+            Dim current = 0
+            For Each item In list
+
+                If current = expectedItems.Count Then
+                    Exit For
+                End If
+
+                Dim currentExpectedItem = expectedItems(current)
+                If item.DisplayText = currentExpectedItem.Item1 Then
+                    Dim x As Integer
+                    Assert.Equal(currentExpectedItem.Item2, Helpers.TryGetOriginalIndexOfPromotedItem(item, x))
+
+                    current += 1
+                End If
+            Next
+        End Sub
+
         <WpfFact>
-        Public Async Function TestNoItemMatchesDefaults() As Task
+        Public Async Function TestNoItemMatchesDefaults_NoMatchingItem() As Task
             ' We are not adding the additional file which contains type MyAB and MyA
             ' the the suggestion from default source doesn't match anything in the completion list.
             Using state = TestStateFactory.CreateCSharpTestState(
@@ -33,18 +58,45 @@ class C
                               </Document>,
                               extraExportedTypes:={GetType(MockDefaultSource)}.ToList())
 
+                MockDefaultSource.Defaults = ImmutableArray.Create("MyAB", "MyA")
+
                 state.SendInvokeCompletionList()
 
-                Await state.AssertCompletionItemsDoNotContainAny("MyAB", "MyA")
+                Await state.AssertCompletionItemsDoNotContainAny("MyAB", "MyA", "★ MyAB", "★ MyA")
                 Await state.AssertSelectedCompletionItem("MyMethod", isHardSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact>
+        Public Async Function TestNoItemMatchesDefaults_NoDefaultProvided() As Task
+            Using state = CreateTestStateWithAdditionalDocumentAndMockDefaultSource(
+                              <Document>
+using NS1;
+class C
+{
+    void MyMethod()
+    {
+        My$$
+    }
+}
+                              </Document>)
+
+                ' We are not setting any default
+                MockDefaultSource.Defaults = ImmutableArray(Of String).Empty
+
+                state.SendInvokeCompletionList()
+
+                Await state.AssertCompletionItemsDoNotContainAny("★ MyAB", "★ MyA")
+                Await state.AssertCompletionItemsContainAll("MyAB", "MyA", "MyMethod")
+                Await state.AssertSelectedCompletionItem("MyA", isHardSelected:=True)
 
             End Using
         End Function
 
-        <WpfFact, CombinatorialData>
+        <WpfFact>
         <WorkItem(61120, "https://github.com/dotnet/roslyn/issues/61120")>
         Public Async Function SelectFirstMatchingDefaultIfNoFilterText() As Task
-            Using state = CreateTestStateWithAdditionalDocument(
+            Using state = CreateTestStateWithAdditionalDocumentAndMockDefaultSource(
                               <Document>
 using NS1;
 class C
@@ -56,14 +108,31 @@ class C
 }
                               </Document>)
 
+                MockDefaultSource.Defaults = ImmutableArray.Create("MyAB", "MyA")
+
                 state.SendInvokeCompletionList()
-                Await state.AssertSelectedCompletionItem("MyAB", isHardSelected:=True) ' hard-selected since filter text is empty
+
+                Dim expectedItems = New List(Of ValueTuple(Of String, Boolean)) From {
+                    CreateExpectedItem("★ MyAB", isPromoted:=True),
+                    CreateExpectedItem("★ MyA", isPromoted:=True),
+                    CreateExpectedItem("MyA", isPromoted:=False),
+                    CreateExpectedItem("MyAB", isPromoted:=False),
+                    CreateExpectedItem("MyMethod", isPromoted:=False)
+                }
+
+                AssertCompletionItemsInRelativeOrder(state, expectedItems)
+
+                Await state.AssertSelectedCompletionItem("★ MyAB", isHardSelected:=True) ' hard-selected since filter text is empty
             End Using
         End Function
 
-        <WpfFact, CombinatorialData>
+        Private Shared Function CreateExpectedItem(displayText As String, isPromoted As Boolean) As ValueTuple(Of String, Boolean)
+            Return New ValueTuple(Of String, Boolean)(displayText, isPromoted)
+        End Function
+
+        <WpfFact>
         Public Async Function SelectFirstMatchingDefaultWithPrefixFilterText() As Task
-            Using state = CreateTestStateWithAdditionalDocument(
+            Using state = CreateTestStateWithAdditionalDocumentAndMockDefaultSource(
                               <Document>
 using NS1;
 class C
@@ -74,16 +143,28 @@ class C
     }
 }
                               </Document>)
+
+                MockDefaultSource.Defaults = ImmutableArray.Create("MyAB", "MyA")
+
                 state.SendInvokeCompletionList()
-                Await state.AssertCompletionItemsContain("MyA", displayTextSuffix:="")
-                Await state.AssertCompletionItemsContain("MyMethod", displayTextSuffix:="")
-                Await state.AssertSelectedCompletionItem("MyAB", isHardSelected:=True)
+
+                Dim expectedItems = New List(Of ValueTuple(Of String, Boolean)) From {
+                    CreateExpectedItem("★ MyAB", isPromoted:=True),
+                    CreateExpectedItem("★ MyA", isPromoted:=True),
+                    CreateExpectedItem("MyA", isPromoted:=False),
+                    CreateExpectedItem("MyAB", isPromoted:=False),
+                    CreateExpectedItem("MyMethod", isPromoted:=False)
+                }
+
+                AssertCompletionItemsInRelativeOrder(state, expectedItems)
+
+                Await state.AssertSelectedCompletionItem("★ MyAB", isHardSelected:=True)
             End Using
         End Function
 
         <WpfFact>
-        Public Async Function DoNotChangeSelectionIfBetterMatch_CaseSensivePrefix() As Task
-            Using state = CreateTestStateWithAdditionalDocument(
+        Public Async Function DoNotChangeSelectionIfBetterMatch_CaseSensitivePrefix() As Task
+            Using state = CreateTestStateWithAdditionalDocumentAndMockDefaultSource(
                               <Document>
 using NS1;
 class C
@@ -95,10 +176,19 @@ class C
 }
                               </Document>)
 
+                MockDefaultSource.Defaults = ImmutableArray.Create("MyAB", "MyA")
+
                 state.SendInvokeCompletionList()
 
-                Await state.AssertCompletionItemsContain("MyA", displayTextSuffix:="")
-                Await state.AssertCompletionItemsContain("MyAB", displayTextSuffix:="")
+                Dim expectedItems = New List(Of ValueTuple(Of String, Boolean)) From {
+                    CreateExpectedItem("my", isPromoted:=False),
+                    CreateExpectedItem("★ MyA", isPromoted:=True),
+                    CreateExpectedItem("MyA", isPromoted:=False),
+                    CreateExpectedItem("★ MyAB", isPromoted:=True),
+                    CreateExpectedItem("MyAB", isPromoted:=False)
+                }
+
+                AssertCompletionItemsInRelativeOrder(state, expectedItems)
                 Await state.AssertSelectedCompletionItem("my", isHardSelected:=True)
 
             End Using
@@ -106,7 +196,7 @@ class C
 
         <WpfFact>
         Public Async Function DoNotChangeSelectionIfBetterMatch_ExactOverPrefix() As Task
-            Using state = CreateTestStateWithAdditionalDocument(
+            Using state = CreateTestStateWithAdditionalDocumentAndMockDefaultSource(
                               <Document>
 using NS1;
 class My
@@ -118,10 +208,19 @@ class My
 }
                               </Document>)
 
+                MockDefaultSource.Defaults = ImmutableArray.Create("MyAB", "MyA")
+
                 state.SendInvokeCompletionList()
 
-                Await state.AssertCompletionItemsContain("MyA", displayTextSuffix:="")
-                Await state.AssertCompletionItemsContain("MyAB", displayTextSuffix:="")
+                Dim expectedItems = New List(Of ValueTuple(Of String, Boolean)) From {
+                    CreateExpectedItem("My", isPromoted:=False),
+                    CreateExpectedItem("★ MyA", isPromoted:=True),
+                    CreateExpectedItem("MyA", isPromoted:=False),
+                    CreateExpectedItem("★ MyAB", isPromoted:=True),
+                    CreateExpectedItem("MyAB", isPromoted:=False)
+                }
+
+                AssertCompletionItemsInRelativeOrder(state, expectedItems)
                 Await state.AssertSelectedCompletionItem("My", isHardSelected:=True)
 
             End Using
@@ -129,7 +228,7 @@ class My
 
         <WpfFact>
         Public Async Function DoNotChangeIfPreselection() As Task
-            Using state = CreateTestStateWithAdditionalDocument(
+            Using state = CreateTestStateWithAdditionalDocumentAndMockDefaultSource(
                               <Document>
 using NS1;
 class C
@@ -141,17 +240,26 @@ class C
 }
                               </Document>)
 
+                MockDefaultSource.Defaults = ImmutableArray.Create("MyAB", "MyA")
+
                 state.SendInvokeCompletionList()
 
-                Await state.AssertCompletionItemsContain("MyA", displayTextSuffix:="")
-                Await state.AssertCompletionItemsContain("MyAB", displayTextSuffix:="")
+                Dim expectedItems = New List(Of ValueTuple(Of String, Boolean)) From {
+                    CreateExpectedItem("★ MyAB", isPromoted:=True),
+                    CreateExpectedItem("★ MyA", isPromoted:=True),
+                    CreateExpectedItem("C", isPromoted:=False),
+                    CreateExpectedItem("MyA", isPromoted:=False),
+                    CreateExpectedItem("MyAB", isPromoted:=False)
+                }
+
+                AssertCompletionItemsInRelativeOrder(state, expectedItems)
+
                 ' "C" is an item with preselect priority
                 Await state.AssertSelectedCompletionItem("C", isHardSelected:=True)
             End Using
         End Function
 
-        Private Shared Function CreateTestStateWithAdditionalDocument(documentElement As XElement) As TestState
-            MockDefaultSource.Defaults = ImmutableArray.Create("MyAB", "MyA")
+        Private Shared Function CreateTestStateWithAdditionalDocumentAndMockDefaultSource(documentElement As XElement) As TestState
             Return TestStateFactory.CreateTestStateFromWorkspace(
                 <Workspace>
                     <Project Language="C#" LanguageVersion="Preview" CommonReferences="true">
@@ -197,7 +305,7 @@ namespace NS1
         End Class
 
         <WpfFact>
-        Public Async Function SelectDefaultItemOverStarredItem() As Task
+        Public Async Function SelectDefaultItemOverStarredItem_WithPromotion() As Task
             Using state = TestStateFactory.CreateCSharpTestState(
                 <Document>
 class MyClass 
@@ -219,20 +327,42 @@ class Test
                 MockDefaultSource.Defaults = ImmutableArray.Create("FirstDefault")
                 state.SendTypeChars(".")
 
-                Await state.AssertCompletionItemsContainAll("★ FirstStarred", "★ SecondStarred", "FirstStarred", "SecondStarred", "FirstDefault")
-                Await state.AssertSelectedCompletionItem("FirstDefault", isHardSelected:=True)
+                Dim expectedItems1 = New List(Of ValueTuple(Of String, Boolean)) From {
+                    CreateExpectedItem("★ FirstDefault", isPromoted:=True),
+                    CreateExpectedItem("★ FirstStarred", isPromoted:=False),
+                    CreateExpectedItem("★ SecondStarred", isPromoted:=False),
+                    CreateExpectedItem("FirstDefault", isPromoted:=False),
+                    CreateExpectedItem("FirstStarred", isPromoted:=False),
+                    CreateExpectedItem("SecondStarred", isPromoted:=False)
+                }
+
+                AssertCompletionItemsInRelativeOrder(state, expectedItems1)
+                Await state.AssertSelectedCompletionItem("★ FirstDefault", isHardSelected:=True)
+
+                Dim expectedItems2 = New List(Of ValueTuple(Of String, Boolean)) From {
+                    CreateExpectedItem("★ FirstDefault", isPromoted:=True),
+                    CreateExpectedItem("FirstDefault", isPromoted:=False),
+                    CreateExpectedItem("★ FirstStarred", isPromoted:=False),
+                    CreateExpectedItem("FirstStarred", isPromoted:=False)
+                }
 
                 state.SendTypeChars("First")
-                Await state.AssertCompletionItemsContainAll("★ FirstStarred", "FirstStarred", "FirstDefault")
-                Await state.AssertSelectedCompletionItem("FirstDefault", isHardSelected:=True)
+                AssertCompletionItemsInRelativeOrder(state, expectedItems2)
+                Await state.AssertSelectedCompletionItem("★ FirstDefault", isHardSelected:=True)
+
+                Dim expectedItems3 = New List(Of ValueTuple(Of String, Boolean)) From {
+                    CreateExpectedItem("★ FirstStarred", isPromoted:=False),
+                    CreateExpectedItem("FirstStarred", isPromoted:=False)
+                }
 
                 state.SendTypeChars("S")
+                AssertCompletionItemsInRelativeOrder(state, expectedItems3)
                 Await state.AssertSelectedCompletionItem("★ FirstStarred", isHardSelected:=True)
             End Using
         End Function
 
         <WpfFact>
-        Public Async Function SelectStarredItemInDefaultList() As Task
+        Public Async Function SelectStarredItemInDefaultList_NoPromotion() As Task
             Using state = TestStateFactory.CreateCSharpTestState(
                 <Document>
 class MyClass 
@@ -254,11 +384,26 @@ class Test
                 MockDefaultSource.Defaults = ImmutableArray.Create("SecondStarred")
                 state.SendTypeChars(".")
 
-                Await state.AssertCompletionItemsContainAll("★ FirstStarred", "★ SecondStarred", "FirstStarred", "SecondStarred", "FirstDefault")
+                Dim expectedItems1 = New List(Of ValueTuple(Of String, Boolean)) From {
+                    CreateExpectedItem("★ FirstStarred", isPromoted:=False),
+                    CreateExpectedItem("★ SecondStarred", isPromoted:=False),
+                    CreateExpectedItem("FirstDefault", isPromoted:=False),
+                    CreateExpectedItem("FirstStarred", isPromoted:=False),
+                    CreateExpectedItem("SecondStarred", isPromoted:=False)
+                }
+
+                AssertCompletionItemsInRelativeOrder(state, expectedItems1)
                 Await state.AssertSelectedCompletionItem("★ SecondStarred", isHardSelected:=True)
 
+                Dim expectedItems2 = New List(Of ValueTuple(Of String, Boolean)) From {
+                    CreateExpectedItem("★ FirstStarred", isPromoted:=False),
+                    CreateExpectedItem("★ SecondStarred", isPromoted:=False),
+                    CreateExpectedItem("FirstStarred", isPromoted:=False),
+                    CreateExpectedItem("SecondStarred", isPromoted:=False)
+                }
+
                 state.SendTypeChars("starred")
-                Await state.AssertCompletionItemsContainAll("★ FirstStarred", "FirstStarred", "★ SecondStarred", "SecondStarred")
+                AssertCompletionItemsInRelativeOrder(state, expectedItems2)
                 Await state.AssertSelectedCompletionItem("★ SecondStarred", isHardSelected:=True)
             End Using
         End Function
@@ -275,6 +420,7 @@ class Test
             End Sub
 
             Public Overrides Function ProvideCompletionsAsync(context As CompletionContext) As Task
+                ' Pythia sets the priority to Preselect
                 Dim rules = CompletionItemRules.Default.WithSelectionBehavior(CompletionItemSelectionBehavior.HardSelection).WithMatchPriority(MatchPriority.Preselect)
                 context.AddItem(CompletionItem.Create(displayText:="★ FirstStarred", filterText:="FirstStarred", sortText:=GetSortText(1), rules:=rules))
                 context.AddItem(CompletionItem.Create(displayText:="★ SecondStarred", filterText:="SecondStarred", sortText:=GetSortText(2), rules:=rules))

--- a/src/Features/Core/Portable/Completion/MatchResult.cs
+++ b/src/Features/Core/Portable/Completion/MatchResult.cs
@@ -10,23 +10,23 @@ namespace Microsoft.CodeAnalysis.Completion
     internal readonly struct MatchResult
     {
         /// <summary>
-        /// The CompletinoItem used to create this MatchResult.
+        /// The CompletionItem used to create this MatchResult.
         /// </summary>
         public readonly CompletionItem CompletionItem;
 
         public readonly PatternMatch? PatternMatch;
 
-        // The value of `ShouldBeConsideredMatchingFilterText` doesn't 100% refect the actual PatternMatch result.
+        // The value of `ShouldBeConsideredMatchingFilterText` doesn't 100% reflect the actual PatternMatch result.
         // In certain cases, there'd be no match but we'd still want to consider it a match (e.g. when the item is in MRU list,)
         // and this is why PatternMatch can be null. There's also cases it's a match but we want to consider it a non-match
-        // (e.g. when not a prefix match in deleteion sceanrio).
+        // (e.g. when not a prefix match in deletion scenario).
         public readonly bool ShouldBeConsideredMatchingFilterText;
 
-        public string FilterTextUsed => _matchedAddtionalFilterText ?? CompletionItem.FilterText;
+        public string FilterTextUsed => MatchedAdditionalFilterText ?? CompletionItem.FilterText;
 
         // We want to preserve the original alphabetical order for items with same pattern match score,
         // but `ArrayBuilder.Sort` we currently use isn't stable. So we have to add a monotonically increasing 
-        // integer to archieve this.
+        // integer to achieve this.
         public readonly int IndexInOriginalSortedOrder;
         public readonly int RecentItemIndex;
 
@@ -34,9 +34,9 @@ namespace Microsoft.CodeAnalysis.Completion
         /// If `CompletionItem.AdditionalFilterTexts` was used to create this MatchResult, then this is set to the one that was used.
         /// Otherwise this is set to null.
         /// </summary>
-        private readonly string? _matchedAddtionalFilterText;
+        public readonly string? MatchedAdditionalFilterText;
 
-        public bool MatchedWithAdditionalFilterTexts => _matchedAddtionalFilterText is not null;
+        public bool MatchedWithAdditionalFilterTexts => MatchedAdditionalFilterText is not null;
 
         public MatchResult(
             CompletionItem completionItem,
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Completion
             PatternMatch = patternMatch;
             IndexInOriginalSortedOrder = index;
             RecentItemIndex = recentItemIndex;
-            _matchedAddtionalFilterText = matchedAdditionalFilterText;
+            MatchedAdditionalFilterText = matchedAdditionalFilterText;
         }
 
         public static IComparer<MatchResult> SortingComparer { get; } = new Comparer();

--- a/src/Features/Core/Portable/Completion/Utilities.cs
+++ b/src/Features/Core/Portable/Completion/Utilities.cs
@@ -41,9 +41,9 @@ namespace Microsoft.CodeAnalysis.Completion
 
         // This is a temporarily method to support preference of IntelliCode items comparing to non-IntelliCode items.
         // We expect that Editor will introduce this support and we will get rid of relying on the "★" then.
-        // We check both the display text and the display text prefix to account for IntelliCode item providers
-        // that may be using the prefix to include the ★.
-        internal static bool IsPreferredItem(this CompletionItem completionItem)
-            => completionItem.DisplayText.StartsWith("★") || completionItem.DisplayTextPrefix.StartsWith("★");
+        public static bool IsPreferredItem(this CompletionItem completionItem)
+            => completionItem.DisplayText.StartsWith(UnicodeStarAndSpace);
+
+        public const string UnicodeStarAndSpace = "\u2605 ";
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/dotnet/roslyn/pull/66159, to address the remaining issue from #65982: this part in particular `if the gray text matches something elsewhere in the completion list, star that item and place in the starred section, and select it.`  

To keep the implementation simple, I tweaked the original proposal a bit: Instead of adding star only to the selected default item, I opt to promote all items have matched with default list. Although I have to admit it's not clear to me in what scenario we'd get multiple defaults and how it is supposed to work.

Also this only adds "star" to the promoted item, but no additional text like "Suggested by intelliCode". 