### PR TITLE
Include LSP loghub logs when collecting watson dumps for NFW

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -141,8 +141,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             // the updated diagnostics are.
             var documentToPreviousDiagnosticParams = GetIdToPreviousDiagnosticParams(context, previousResults, out var removedResults);
 
-            throw new Exception("test");
-
             // First, let the client know if any workspace documents have gone away.  That way it can remove those for
             // the user from squiggles or error-list.
             HandleRemovedDocuments(context, removedResults, progress);

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -141,6 +141,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             // the updated diagnostics are.
             var documentToPreviousDiagnosticParams = GetIdToPreviousDiagnosticParams(context, previousResults, out var removedResults);
 
+            throw new Exception("test");
+
             // First, let the client know if any workspace documents have gone away.  That way it can remove those for
             // the user from squiggles or error-list.
             HandleRemovedDocuments(context, removedResults, progress);

--- a/src/VisualStudio/Core/Def/Watson/FaultReporter.cs
+++ b/src/VisualStudio/Core/Def/Watson/FaultReporter.cs
@@ -240,49 +240,42 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         {
             var paths = new List<string>();
 
-            try
+            if (!Directory.Exists(logDirectoryPath))
             {
-                if (!Directory.Exists(logDirectoryPath))
-                {
-                    return paths;
-                }
-
-                // attach all log files that are modified less than 1 day before.
-                var now = DateTime.UtcNow;
-                var oneDay = TimeSpan.FromDays(1);
-
-                foreach (var path in Directory.EnumerateFiles(logDirectoryPath, logFileExtension))
-                {
-                    try
-                    {
-                        var name = Path.GetFileNameWithoutExtension(path);
-
-                        // TODO: https://github.com/dotnet/roslyn/issues/42582 
-                        // name our services more consistently to simplify filtering
-
-                        // filter logs that are not relevant to Roslyn investigation
-                        if (shouldExcludeLogFile(name))
-                        {
-                            continue;
-                        }
-
-                        var lastWrite = File.GetLastWriteTimeUtc(path);
-                        if (now - lastWrite > oneDay)
-                        {
-                            continue;
-                        }
-
-                        paths.Add(path);
-                    }
-                    catch
-                    {
-                        // ignore file that can't be accessed
-                    }
-                }
+                return paths;
             }
-            catch (Exception)
+
+            // attach all log files that are modified less than 1 day before.
+            var now = DateTime.UtcNow;
+            var oneDay = TimeSpan.FromDays(1);
+
+            foreach (var path in Directory.EnumerateFiles(logDirectoryPath, logFileExtension))
             {
-                // ignore failures
+                try
+                {
+                    var name = Path.GetFileNameWithoutExtension(path);
+
+                    // TODO: https://github.com/dotnet/roslyn/issues/42582 
+                    // name our services more consistently to simplify filtering
+
+                    // filter logs that are not relevant to Roslyn investigation
+                    if (shouldExcludeLogFile(name))
+                    {
+                        continue;
+                    }
+
+                    var lastWrite = File.GetLastWriteTimeUtc(path);
+                    if (now - lastWrite > oneDay)
+                    {
+                        continue;
+                    }
+
+                    paths.Add(path);
+                }
+                catch
+                {
+                    // ignore file that can't be accessed
+                }
             }
 
             return paths;

--- a/src/VisualStudio/Core/Def/Watson/FaultReporter.cs
+++ b/src/VisualStudio/Core/Def/Watson/FaultReporter.cs
@@ -222,6 +222,9 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             try
             {
                 var logPath = Path.Combine(Path.GetTempPath(), "servicehub", "logs");
+
+                // TODO: https://github.com/dotnet/roslyn/issues/42582 
+                // name our services more consistently to simplify filtering
                 var logs = CollectFilePaths(logPath, "*.log", (name) => !name.Contains("-" + ServiceDescriptor.ServiceNameTopLevelPrefix) &&
                         !name.Contains("-CodeLens") &&
                         !name.Contains("-ManagedLanguage.IDE.RemoteHostClient") &&
@@ -254,9 +257,6 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                 try
                 {
                     var name = Path.GetFileNameWithoutExtension(path);
-
-                    // TODO: https://github.com/dotnet/roslyn/issues/42582 
-                    // name our services more consistently to simplify filtering
 
                     // filter logs that are not relevant to Roslyn investigation
                     if (shouldExcludeLogFile(name))

--- a/src/VisualStudio/Core/Def/Watson/FaultReporter.cs
+++ b/src/VisualStudio/Core/Def/Watson/FaultReporter.cs
@@ -206,7 +206,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             try
             {
                 var logPath = Path.Combine(Path.GetTempPath(), "VSLogs");
-                var logs = CollectFilePaths(logPath, "*.svclog", (name) => !name.Contains("Roslyn") && !name.Contains("LSPClient"));
+                var logs = CollectFilePaths(logPath, "*.svclog", shouldExcludeLogFile: (name) => !name.Contains("Roslyn") && !name.Contains("LSPClient"));
                 return logs;
             }
             catch (Exception)
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
 
                 // TODO: https://github.com/dotnet/roslyn/issues/42582 
                 // name our services more consistently to simplify filtering
-                var logs = CollectFilePaths(logPath, "*.log", (name) => !name.Contains("-" + ServiceDescriptor.ServiceNameTopLevelPrefix) &&
+                var logs = CollectFilePaths(logPath, "*.log", shouldExcludeLogFile: (name) => !name.Contains("-" + ServiceDescriptor.ServiceNameTopLevelPrefix) &&
                         !name.Contains("-CodeLens") &&
                         !name.Contains("-ManagedLanguage.IDE.RemoteHostClient") &&
                         !name.Contains("-hub"));

--- a/src/VisualStudio/Core/Def/Watson/FaultReporter.cs
+++ b/src/VisualStudio/Core/Def/Watson/FaultReporter.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Telemetry;
 using Microsoft.VisualStudio.LanguageServices.Telemetry;
 using Microsoft.VisualStudio.Telemetry;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.ErrorReporting
 {
@@ -130,6 +131,11 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                             {
                                 faultUtility.AddFile(path);
                             }
+
+                            foreach (var loghubPath in CollectLogHubFilePaths())
+                            {
+                                faultUtility.AddFile(loghubPath);
+                            }
                         }
 
                         // Returning "0" signals that, if sampled, we should send data to Watson. 
@@ -195,14 +201,48 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
             return exception.Message;
         }
 
-        private static List<string> CollectServiceHubLogFilePaths()
+        private static IList<string> CollectLogHubFilePaths()
+        {
+            try
+            {
+                var logPath = Path.Combine(Path.GetTempPath(), "VSLogs");
+                var logs = CollectFilePaths(logPath, "*.svclog", (name) => !name.Contains("Roslyn") && !name.Contains("LSPClient"));
+                return logs;
+            }
+            catch (Exception)
+            {
+                // ignore failures
+            }
+
+            return SpecializedCollections.EmptyList<string>();
+        }
+
+        private static IList<string> CollectServiceHubLogFilePaths()
+        {
+            try
+            {
+                var logPath = Path.Combine(Path.GetTempPath(), "servicehub", "logs");
+                var logs = CollectFilePaths(logPath, "*.log", (name) => !name.Contains("-" + ServiceDescriptor.ServiceNameTopLevelPrefix) &&
+                        !name.Contains("-CodeLens") &&
+                        !name.Contains("-ManagedLanguage.IDE.RemoteHostClient") &&
+                        !name.Contains("-hub"));
+                return logs;
+            }
+            catch (Exception)
+            {
+                // ignore failures
+            }
+
+            return SpecializedCollections.EmptyList<string>();
+        }
+
+        private static List<string> CollectFilePaths(string logDirectoryPath, string logFileExtension, Func<string, bool> shouldExcludeLogFile)
         {
             var paths = new List<string>();
 
             try
             {
-                var logPath = Path.Combine(Path.GetTempPath(), "servicehub", "logs");
-                if (!Directory.Exists(logPath))
+                if (!Directory.Exists(logDirectoryPath))
                 {
                     return paths;
                 }
@@ -211,7 +251,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                 var now = DateTime.UtcNow;
                 var oneDay = TimeSpan.FromDays(1);
 
-                foreach (var path in Directory.EnumerateFiles(logPath, "*.log"))
+                foreach (var path in Directory.EnumerateFiles(logDirectoryPath, logFileExtension))
                 {
                     try
                     {
@@ -221,10 +261,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
                         // name our services more consistently to simplify filtering
 
                         // filter logs that are not relevant to Roslyn investigation
-                        if (!name.Contains("-" + ServiceDescriptor.ServiceNameTopLevelPrefix) &&
-                            !name.Contains("-CodeLens") &&
-                            !name.Contains("-ManagedLanguage.IDE.RemoteHostClient") &&
-                            !name.Contains("-hub"))
+                        if (shouldExcludeLogFile(name))
                         {
                             continue;
                         }


### PR DESCRIPTION
I couldn't get the event to show up locally in my telemetry monitor, but debugging through the code everything looks fine (the `faultUtility` includes both servicehub and loghub logs, didn't see any obvious exceptions).