### PR TITLE
Doc relationship between GetUsedAssemblyReferences and DocumentationMode

### DIFF
--- a/docs/features/UsedAssemblyReferences.md
+++ b/docs/features/UsedAssemblyReferences.md
@@ -5,7 +5,7 @@ The *Used Assembly References* feature provides a ```GetUsedAssemblyReferences``
 of metadata assembly references that are considered to be used by the compilation. For example, if a type declared in a
 referenced assembly is referenced in source code within the compilation, the reference is considered to be used. Etc.
 
-Note that documentation must be processed for best results. Since types in xml docs rely on usings, all usings are
-assumed to be used when the usage analysis wasn't performed on doc comments.
+Note that documentation must be processed for best results. Types referenced in xml docs are missed when documentation isn't processed.
+Conversely, all usings are assumed to be used when the usage analysis wasn't performed on doc comments.
 
 See https://github.com/dotnet/roslyn/issues/37768 for more information.

--- a/docs/features/UsedAssemblyReferences.md
+++ b/docs/features/UsedAssemblyReferences.md
@@ -5,7 +5,8 @@ The *Used Assembly References* feature provides a ```GetUsedAssemblyReferences``
 of metadata assembly references that are considered to be used by the compilation. For example, if a type declared in a
 referenced assembly is referenced in source code within the compilation, the reference is considered to be used. Etc.
 
-Note that documentation must be processed for best results. Types referenced in xml docs are missed when documentation isn't processed.
-Conversely, all usings are assumed to be used when the usage analysis wasn't performed on doc comments.
+Note that documentation must be processed for best results.
+References unique to xml docs are not included when compilation is configured to not process the documentation.
+Also, all references in usings are assumed to be used under these conditions.
 
 See https://github.com/dotnet/roslyn/issues/37768 for more information.

--- a/docs/features/UsedAssemblyReferences.md
+++ b/docs/features/UsedAssemblyReferences.md
@@ -5,4 +5,7 @@ The *Used Assembly References* feature provides a ```GetUsedAssemblyReferences``
 of metadata assembly references that are considered to be used by the compilation. For example, if a type declared in a
 referenced assembly is referenced in source code within the compilation, the reference is considered to be used. Etc.
 
+Note that documentation must be processed for best results. Since types in xml docs rely on usings, all usings are
+assumed to be used when the usage analysis wasn't performed on doc comments.
+
 See https://github.com/dotnet/roslyn/issues/37768 for more information.

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1762,6 +1762,10 @@ namespace Microsoft.CodeAnalysis
         /// within this compilation, the reference is considered to be used. Etc.
         /// The returned set is a subset of references returned by <see cref="References"/> API.
         /// The result is undefined if the compilation contains errors.
+        ///
+        /// Note that documentation must be processed for best results (<see cref="DocumentationMode"/>).
+        /// Since types in xml docs rely on usings, all usings are assumed to be used when the usage analysis
+        /// wasn't performed on doc comments.
         /// </summary>
         public abstract ImmutableArray<MetadataReference> GetUsedAssemblyReferences(CancellationToken cancellationToken = default(CancellationToken));
 

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1764,8 +1764,8 @@ namespace Microsoft.CodeAnalysis
         /// The result is undefined if the compilation contains errors.
         ///
         /// Note that documentation must be processed for best results (<see cref="DocumentationMode"/>).
-        /// Since types in xml docs rely on usings, all usings are assumed to be used when the usage analysis
-        /// wasn't performed on doc comments.
+        /// Types referenced in xml docs are missed when documentation isn't processed.
+        /// Conversely, all usings are assumed to be used when the usage analysis wasn't performed on doc comments.
         /// </summary>
         public abstract ImmutableArray<MetadataReference> GetUsedAssemblyReferences(CancellationToken cancellationToken = default(CancellationToken));
 

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1764,8 +1764,8 @@ namespace Microsoft.CodeAnalysis
         /// The result is undefined if the compilation contains errors.
         ///
         /// Note that documentation must be processed for best results (<see cref="DocumentationMode"/>).
-        /// Types referenced in xml docs are missed when documentation isn't processed.
-        /// Conversely, all usings are assumed to be used when the usage analysis wasn't performed on doc comments.
+        /// References unique to xml docs are not included when compilation is configured to not process the documentation.
+        /// Also, all references in usings are assumed to be used under these conditions.
         /// </summary>
         public abstract ImmutableArray<MetadataReference> GetUsedAssemblyReferences(CancellationToken cancellationToken = default(CancellationToken));
 


### PR DESCRIPTION
Closes https://github.com/dotnet/roslyn/issues/66188