### PR TITLE
Allow specifying expected IL verification baseline

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
         {
         }
 
-        private CompilationVerifier CompileAndVerify(string source, string expectedOutput = null, IEnumerable<MetadataReference> references = null, CSharpCompilationOptions options = null, Verification verify = Verification.Passes)
+        private CompilationVerifier CompileAndVerify(string source, string expectedOutput = null, IEnumerable<MetadataReference> references = null, CSharpCompilationOptions options = null, Verification verify = default)
         {
             references = (references != null) ? references.Concat(s_asyncRefs) : s_asyncRefs;
             return base.CompileAndVerify(source, targetFramework: TargetFramework.Empty, expectedOutput: expectedOutput, references: references, options: options, verify: verify);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             return CreateCompilationWithMscorlib45(source, options: options, references: references);
         }
 
-        private CompilationVerifier CompileAndVerify(string source, string expectedOutput, IEnumerable<MetadataReference> references = null, CSharpCompilationOptions options = null, Verification verify = Verification.Passes)
+        private CompilationVerifier CompileAndVerify(string source, string expectedOutput, IEnumerable<MetadataReference> references = null, CSharpCompilationOptions options = null, Verification verify = default)
         {
             var compilation = CreateCompilation(source, references: references, options: options);
             return base.CompileAndVerify(compilation, expectedOutput: expectedOutput, verify: verify);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             [CallerFilePath] string callerPath = null,
             [CallerLineNumber] int callerLine = 0,
             CSharpParseOptions parseOptions = null,
-            Verification verify = Verification.Passes)
+            Verification verify = default)
         {
             references = references ?? new[] { SystemCoreRef, CSharpRef };
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             string expectedOutput = null,
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
-            Verification verify = Verification.Passes) => CompileAndVerify(source, references, targetFramework: TargetFramework.Standard, expectedOutput: expectedOutput, options: options, parseOptions: parseOptions, verify: verify);
+            Verification verify = default) => CompileAndVerify(source, references, targetFramework: TargetFramework.Standard, expectedOutput: expectedOutput, options: options, parseOptions: parseOptions, verify: verify);
 
         /// <summary>
         /// Reference to an assembly that defines Expression Trees.

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -6298,7 +6298,7 @@ public class Program
             CompileAndVerify(source, targetFramework: TargetFramework.StandardAndCSharp, expectedOutput: "44");
         }
 
-        internal CompilationVerifier VerifyOutput(string source, string output, CSharpCompilationOptions options, Verification verify = Verification.Passes)
+        internal CompilationVerifier VerifyOutput(string source, string output, CSharpCompilationOptions options, Verification verify = default)
         {
             var comp = CreateCompilationWithMscorlib45AndCSharp(source, options: options);
             return CompileAndVerify(comp, expectedOutput: output, verify: verify).VerifyDiagnostics(); // no diagnostics

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             string source,
             string expectedOutput = null,
             CSharpCompilationOptions options = null,
-            Verification verify = Verification.Passes)
+            Verification verify = default)
         {
             return CompileAndVerify(
                 source,

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTests.cs
@@ -17217,7 +17217,14 @@ class Program
 System.Threading.Tasks.Task`1[System.Object]
 Success
 True
-", verify: Verification.FailsILVerify).VerifyDiagnostics();
+", verify: Verification.FailsILVerify with
+            {
+                ILVerifyMessage =
+                    """
+                    [GetReference]: TypedReference not supported in .NET Core
+                    [MoveNext]: TypedReference not supported in .NET Core
+                    """
+            }).VerifyDiagnostics();
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -10328,10 +10328,13 @@ public class Test
     }
 }
 ";
-            // PEVerify:
-            // [ : ChannelServices::.cctor][mdToken=0x6000005][offset 0x0000000C][found unmanaged pointer][expected unmanaged pointer] Unexpected type on the stack.
-            // [ : ChannelServices::GetPrivateContextsPerfCounters][mdToken= 0x6000002][offset 0x00000002][found Native Int][expected unmanaged pointer] Unexpected type on the stack.
-            CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, verify: Verification.FailsPEVerify).VerifyDiagnostics();
+            CompileAndVerify(text, options: TestOptions.UnsafeReleaseExe, verify: Verification.FailsPEVerify with
+            {
+                PEVerifyMessage = """
+                    [ : ChannelServices::.cctor][offset 0x0000000C][found unmanaged pointer][expected unmanaged pointer] Unexpected type on the stack.
+                    [ : ChannelServices::GetPrivateContextsPerfCounters][offset 0x00000002][found Native Int][expected unmanaged pointer] Unexpected type on the stack.
+                    """,
+            }).VerifyDiagnostics();
         }
 
         [WorkItem(545026, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545026")]
@@ -10345,9 +10348,12 @@ class C
     unsafe int* p = (int*)2;
 }
 ";
-            // PEVerify:
-            // [ : C::.ctor][mdToken=0x6000001][offset 0x0000000A][found Native Int][expected unmanaged pointer] Unexpected type on the stack.
-            CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.FailsPEVerify).VerifyDiagnostics(
+            var c = CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.FailsPEVerify with
+            {
+                PEVerifyMessage = "[ : C::.ctor][mdToken=0x6000001][offset 0x0000000A][found Native Int][expected unmanaged pointer] Unexpected type on the stack."
+            });
+
+            c.VerifyDiagnostics(
                 // (4,9): warning CS0414: The field 'C.x' is assigned but its value is never used
                 //     int x = 1;
                 Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "x").WithArguments("C.x"));
@@ -10364,9 +10370,12 @@ class C
     int x = 1;
 }
 ";
-            // PEVerify:
-            // [ : C::.ctor][mdToken=0x6000001][offset 0x00000003][found Native Int][expected unmanaged pointer] Unexpected type on the stack.
-            CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.FailsPEVerify).VerifyDiagnostics(
+            var c = CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.FailsPEVerify with
+            {
+                PEVerifyMessage = "[ : C::.ctor][offset 0x00000003][found Native Int][expected unmanaged pointer] Unexpected type on the stack."
+            });
+            
+            c.VerifyDiagnostics(
                 // (5,9): warning CS0414: The field 'C.x' is assigned but its value is never used
                 //     int x = 1;
                 Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "x").WithArguments("C.x"));

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -10350,7 +10350,7 @@ class C
 ";
             var c = CompileAndVerify(text, options: TestOptions.UnsafeReleaseDll, verify: Verification.FailsPEVerify with
             {
-                PEVerifyMessage = "[ : C::.ctor][mdToken=0x6000001][offset 0x0000000A][found Native Int][expected unmanaged pointer] Unexpected type on the stack."
+                PEVerifyMessage = "[ : C::.ctor][offset 0x0000000A][found Native Int][expected unmanaged pointer] Unexpected type on the stack."
             });
 
             c.VerifyDiagnostics(

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/UnsafeTests.cs
@@ -10374,7 +10374,7 @@ class C
             {
                 PEVerifyMessage = "[ : C::.ctor][offset 0x00000003][found Native Int][expected unmanaged pointer] Unexpected type on the stack."
             });
-            
+
             c.VerifyDiagnostics(
                 // (5,9): warning CS0414: The field 'C.x' is assigned but its value is never used
                 //     int x = 1;

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -3514,7 +3514,7 @@ static void Test()
             Assert.True(expected == instrumented, $"Method '{qualifiedMethodName}' should {(expected ? "be" : "not be")} instrumented. Actual IL:{Environment.NewLine}{il}");
         }
 
-        private CompilationVerifier CompileAndVerify(string source, string expectedOutput = null, CSharpCompilationOptions options = null, CSharpParseOptions parseOptions = null, Verification verify = Verification.Passes)
+        private CompilationVerifier CompileAndVerify(string source, string expectedOutput = null, CSharpCompilationOptions options = null, CSharpParseOptions parseOptions = null, Verification verify = default)
         {
             return base.CompileAndVerify(
                 source,

--- a/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -10311,7 +10311,7 @@ public class C
 
         #region SkipLocalsInitAttribute
 
-        private CompilationVerifier CompileAndVerifyWithSkipLocalsInit(string src, CSharpCompilationOptions options, CSharpParseOptions parseOptions = null, Verification verify = Verification.Fails)
+        private CompilationVerifier CompileAndVerifyWithSkipLocalsInit(string src, CSharpCompilationOptions options, CSharpParseOptions parseOptions = null, Verification? verify = null)
         {
             const string skipLocalsInitDef = @"
 namespace System.Runtime.CompilerServices
@@ -10322,12 +10322,12 @@ namespace System.Runtime.CompilerServices
 }";
 
             var comp = CreateCompilation(new[] { src, skipLocalsInitDef }, options: options, parseOptions: parseOptions);
-            return CompileAndVerify(comp, verify: verify);
+            return CompileAndVerify(comp, verify: verify ?? Verification.Fails);
         }
 
-        private CompilationVerifier CompileAndVerifyWithSkipLocalsInit(string src, CSharpParseOptions parseOptions = null, Verification verify = Verification.Fails)
+        private CompilationVerifier CompileAndVerifyWithSkipLocalsInit(string src, CSharpParseOptions parseOptions = null, Verification? verify = null)
         {
-            return CompileAndVerifyWithSkipLocalsInit(src, TestOptions.UnsafeReleaseDll, parseOptions, verify);
+            return CompileAndVerifyWithSkipLocalsInit(src, TestOptions.UnsafeReleaseDll, parseOptions, verify ?? Verification.Fails);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -8998,7 +8998,7 @@ $@"public class Library
                 comp = CreateCompilation(sourceB, references: new[] { refA }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
                 // Investigating flaky IL verification issue. Tracked by https://github.com/dotnet/roslyn/issues/63782
-                CompileAndVerify(comp, verify: Verification.PassesOrFailFast | Verification.FailsPEVerify, expectedOutput: IncludeExpectedOutput(expectedResult));
+                CompileAndVerify(comp, verify: new Verification(VerificationStatus.PassesOrFailFast | VerificationStatus.FailsPEVerify), expectedOutput: IncludeExpectedOutput(expectedResult));
                 Assert.NotNull(expectedResult);
             }
 
@@ -9033,7 +9033,7 @@ class Program
                 }
 
                 // Investigating flaky IL verification issue. Tracked by https://github.com/dotnet/roslyn/issues/63782
-                CompileAndVerify(comp, verify: Verification.FailsPEVerify | Verification.PassesOrFailFast, expectedOutput: IncludeExpectedOutput(expectedResult)).VerifyDiagnostics(expectedDiagnostics);
+                CompileAndVerify(comp, verify: new Verification(VerificationStatus.FailsPEVerify | VerificationStatus.PassesOrFailFast), expectedOutput: IncludeExpectedOutput(expectedResult)).VerifyDiagnostics(expectedDiagnostics);
                 Assert.NotNull(expectedResult);
             }
         }

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -8998,7 +8998,7 @@ $@"public class Library
                 comp = CreateCompilation(sourceB, references: new[] { refA }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular9, targetFramework: TargetFramework.Net70);
 
                 // Investigating flaky IL verification issue. Tracked by https://github.com/dotnet/roslyn/issues/63782
-                CompileAndVerify(comp, verify: new Verification(VerificationStatus.PassesOrFailFast | VerificationStatus.FailsPEVerify), expectedOutput: IncludeExpectedOutput(expectedResult));
+                CompileAndVerify(comp, verify: new Verification() { Status = VerificationStatus.PassesOrFailFast | VerificationStatus.FailsPEVerify }, expectedOutput: IncludeExpectedOutput(expectedResult));
                 Assert.NotNull(expectedResult);
             }
 
@@ -9033,7 +9033,7 @@ class Program
                 }
 
                 // Investigating flaky IL verification issue. Tracked by https://github.com/dotnet/roslyn/issues/63782
-                CompileAndVerify(comp, verify: new Verification(VerificationStatus.FailsPEVerify | VerificationStatus.PassesOrFailFast), expectedOutput: IncludeExpectedOutput(expectedResult)).VerifyDiagnostics(expectedDiagnostics);
+                CompileAndVerify(comp, verify: new Verification() { Status = VerificationStatus.FailsPEVerify | VerificationStatus.PassesOrFailFast }, expectedOutput: IncludeExpectedOutput(expectedResult)).VerifyDiagnostics(expectedDiagnostics);
                 Assert.NotNull(expectedResult);
             }
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/DefaultInterfaceImplementationTests.cs
@@ -31560,7 +31560,7 @@ class Test1 : I1.T1
             ValidateNestedTypes_01(source1);
         }
 
-        private void ValidateNestedTypes_01(string source1, Accessibility expected = Accessibility.Public, TargetFramework targetFramework = TargetFramework.Standard, bool execute = true, Verification verify = Verification.Passes)
+        private void ValidateNestedTypes_01(string source1, Accessibility expected = Accessibility.Public, TargetFramework targetFramework = TargetFramework.Standard, bool execute = true, Verification verify = default)
         {
             var compilation1 = CreateCompilation(source1, options: TestOptions.DebugExe,
                                                  parseOptions: TestOptions.Regular,

--- a/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
+++ b/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
@@ -230,7 +230,7 @@ namespace Roslyn.Test.Utilities
 
     public class IsEnglishLocal : ExecutionCondition
     {
-        public static readonly IsEnglishLocal Instance = new();
+        public static readonly IsEnglishLocal Instance = new IsEnglishLocal();
 
         public override bool ShouldSkip
         {

--- a/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
+++ b/src/Compilers/Test/Core/Assert/ConditionalFactAttribute.cs
@@ -230,6 +230,8 @@ namespace Roslyn.Test.Utilities
 
     public class IsEnglishLocal : ExecutionCondition
     {
+        public static readonly IsEnglishLocal Instance = new();
+
         public override bool ShouldSkip
         {
             get

--- a/src/Compilers/Test/Core/CommonTestBase.cs
+++ b/src/Compilers/Test/Core/CommonTestBase.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -25,10 +23,14 @@ using Xunit;
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
     [Flags]
-    public enum Verification
+    public enum VerificationStatus
     {
-        Skipped = 0,
-        Passes = 1 << 1,
+        /// <summary>
+        /// default(<see cref="Verification"/>) should be passing.
+        /// </summary>
+        Passes = 0,
+
+        Skipped = 1 << 1,
 
         FailsPEVerify = 1 << 2,
         FailsILVerify = 1 << 3,
@@ -36,6 +38,18 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         PassesOrFailFast = 1 << 4,
     }
+
+    public readonly record struct Verification(VerificationStatus Status, string? ILVerifyMessage = null, string? PEVerifyMessage = null)
+    {
+        public static readonly Verification Skipped = new(VerificationStatus.Skipped);
+        public static readonly Verification Passes = new(VerificationStatus.Passes);
+        public static readonly Verification FailsPEVerify = new(VerificationStatus.FailsPEVerify);
+        public static readonly Verification FailsILVerify = new(VerificationStatus.FailsILVerify);
+        public static readonly Verification Fails = new(VerificationStatus.Fails);
+        public static readonly Verification PassesOrFailFast = new(VerificationStatus.PassesOrFailFast);
+    }
+
+#nullable disable
 
     /// <summary>
     /// Base class for all language specific tests.
@@ -57,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             int? expectedReturnCode = null,
             string[] args = null,
             EmitOptions emitOptions = null,
-            Verification verify = Verification.Passes)
+            Verification verify = default)
         {
             Assert.NotNull(compilation);
 

--- a/src/Compilers/Test/Core/CommonTestBase.cs
+++ b/src/Compilers/Test/Core/CommonTestBase.cs
@@ -39,14 +39,23 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         PassesOrFailFast = 1 << 4,
     }
 
-    public readonly record struct Verification(VerificationStatus Status, string? ILVerifyMessage = null, string? PEVerifyMessage = null)
+    public readonly struct Verification
     {
-        public static readonly Verification Skipped = new(VerificationStatus.Skipped);
-        public static readonly Verification Passes = new(VerificationStatus.Passes);
-        public static readonly Verification FailsPEVerify = new(VerificationStatus.FailsPEVerify);
-        public static readonly Verification FailsILVerify = new(VerificationStatus.FailsILVerify);
-        public static readonly Verification Fails = new(VerificationStatus.Fails);
-        public static readonly Verification PassesOrFailFast = new(VerificationStatus.PassesOrFailFast);
+        public VerificationStatus Status { get; init; }
+        public string? ILVerifyMessage { get; init; }
+        public string? PEVerifyMessage { get; init; }
+
+        /// <summary>
+        /// True if the expected messages include member tokens.
+        /// </summary>
+        public bool IncludeTokens { get; init; }
+
+        public static readonly Verification Skipped = new() { Status = VerificationStatus.Skipped };
+        public static readonly Verification Passes = new() { Status = VerificationStatus.Passes };
+        public static readonly Verification FailsPEVerify = new() { Status = VerificationStatus.FailsPEVerify };
+        public static readonly Verification FailsILVerify = new() { Status = VerificationStatus.FailsILVerify };
+        public static readonly Verification Fails = new() { Status = VerificationStatus.Fails };
+        public static readonly Verification PassesOrFailFast = new() { Status = VerificationStatus.PassesOrFailFast };
     }
 
 #nullable disable

--- a/src/Compilers/Test/Core/CompilationVerifier.cs
+++ b/src/Compilers/Test/Core/CompilationVerifier.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     }
                     else
                     {
-                        throw new Exception($"Didn't find method '{methodName}'. Available/distinguishable methods are: {Environment.NewLine}}{string.Join(Environment.NewLine, map.Keys)}");
+                        throw new Exception($"Didn't find method '{methodName}'. Available/distinguishable methods are: {Environment.NewLine}{string.Join(Environment.NewLine, map.Keys)}");
                     }
                 }
 

--- a/src/Compilers/Test/Core/CompilationVerifier.cs
+++ b/src/Compilers/Test/Core/CompilationVerifier.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     }
                     else
                     {
-                        throw new Exception($"Didn't find method '{methodName}'. Available/distinguishable methods are: \r\n{string.Join("\r\n", map.Keys)}");
+                        throw new Exception($"Didn't find method '{methodName}'. Available/distinguishable methods are: {Environment.NewLine}}{string.Join(Environment.NewLine, map.Keys)}");
                     }
                 }
 
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             if (actualSuccess != expectedSuccess)
             {
                 throw new Exception(expectedSuccess ?
-                    "IL Verify failed unexpectedly: \r\n" + actualMessage :
+                    $"IL Verify failed unexpectedly:{Environment.NewLine}{actualMessage}" :
                     "IL Verify succeeded unexpectedly");
             }
 
@@ -375,7 +375,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             static string printVerificationResult(IEnumerable<ILVerify.VerificationResult> result, MetadataReader metadataReader)
             {
-                return string.Join("\r\n", result.Select(r => printMethod(r.Method, metadataReader) + r.Message + printErrorArguments(r.ErrorArguments)));
+                return string.Join(Environment.NewLine, result.Select(r => printMethod(r.Method, metadataReader) + r.Message + printErrorArguments(r.ErrorArguments)));
             }
 
             static string printMethod(MethodDefinitionHandle method, MetadataReader metadataReader)
@@ -578,7 +578,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
                 if (actualPdbXml.StartsWith("<error>"))
                 {
-                    throw new Exception($"Failed to extract PDB information for method '{sequencePoints}'. PdbToXmlConverter returned:\r\n{actualPdbXml}");
+                    throw new Exception($"Failed to extract PDB information for method '{sequencePoints}'. PdbToXmlConverter returned:{Environment.NewLine}{actualPdbXml}");
                 }
 
                 markers = ILValidation.GetSequencePointMarkers(actualPdbXml, source);

--- a/src/Compilers/Test/Core/CompilationVerifier.cs
+++ b/src/Compilers/Test/Core/CompilationVerifier.cs
@@ -342,7 +342,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     "IL Verify succeeded unexpectedly");
             }
 
-            if (!actualSuccess && verification.ILVerifyMessage != null)
+            if (!actualSuccess && verification.ILVerifyMessage != null && !IsEnglishLocal.Instance.ShouldSkip)
             {
                 AssertEx.AssertEqualToleratingWhitespaceDifferences(verification.ILVerifyMessage, actualMessage);
             }

--- a/src/Compilers/Test/Core/CompilationVerifier.cs
+++ b/src/Compilers/Test/Core/CompilationVerifier.cs
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 ILVerify(peVerify);
 #endif
             }
-            catch (Exception) when ((peVerify & Verification.PassesOrFailFast) != 0)
+            catch (Exception) when (peVerify.Status.HasFlag(VerificationStatus.PassesOrFailFast))
             {
                 var il = DumpIL();
                 Console.WriteLine(il);
@@ -295,7 +295,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         private void ILVerify(Verification verification)
         {
-            if (verification == Verification.Skipped)
+            if (verification.Status.HasFlag(VerificationStatus.Skipped))
             {
                 return;
             }
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 string name = module.SimpleName;
                 if (imagesByName.ContainsKey(name))
                 {
-                    if ((verification & Verification.FailsILVerify) != 0)
+                    if (verification.Status.HasFlag(VerificationStatus.FailsILVerify) && verification.ILVerifyMessage is null)
                     {
                         return;
                     }
@@ -321,7 +321,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var mscorlibModule = _allModuleData.SingleOrDefault(m => m.IsCorLib);
             if (mscorlibModule is null)
             {
-                if ((verification & Verification.FailsILVerify) != 0)
+                if (verification.Status.HasFlag(VerificationStatus.FailsILVerify) && verification.ILVerifyMessage is null)
                 {
                     return;
                 }
@@ -332,19 +332,22 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             // Main module is the first one
             var mainModuleReader = resolver.Resolve(_allModuleData[0].SimpleName);
 
-            var (succeeded, errorMessage) = verify(verifier, mscorlibModule.SimpleName, mainModuleReader);
+            var (actualSuccess, actualMessage) = verify(verifier, mscorlibModule.SimpleName, mainModuleReader);
+            var expectedSuccess = !verification.Status.HasFlag(VerificationStatus.FailsILVerify);
 
-            switch (succeeded, (verification & Verification.FailsILVerify) == 0)
+            if (actualSuccess != expectedSuccess)
             {
-                case (true, true):
-                    return;
-                case (true, false):
-                    throw new Exception("IL Verify succeeded unexpectedly");
-                case (false, false):
-                    return;
-                case (false, true):
-                    throw new Exception("IL Verify failed unexpectedly: \r\n" + errorMessage);
+                throw new Exception(expectedSuccess ?
+                    "IL Verify failed unexpectedly: \r\n" + actualMessage :
+                    "IL Verify succeeded unexpectedly");
             }
+
+            if (!actualSuccess && verification.ILVerifyMessage != null)
+            {
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(verification.ILVerifyMessage, actualMessage);
+            }
+
+            return;
 
             static (bool, string) verify(ILVerify.Verifier verifier, string corlibName, PEReader mainModule)
             {

--- a/src/Compilers/Test/Core/Platform/Desktop/DesktopRuntimeEnvironment.cs
+++ b/src/Compilers/Test/Core/Platform/Desktop/DesktopRuntimeEnvironment.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -337,7 +338,7 @@ namespace Roslyn.Test.Utilities.Desktop
                 }
 
                 var expectedMessage = verification.PEVerifyMessage;
-                if (expectedMessage != null)
+                if (expectedMessage != null && !IsEnglishLocal.Instance.ShouldSkip)
                 {
                     var actualMessage = ex.Output;
                     

--- a/src/Compilers/Test/Core/Platform/Desktop/DesktopRuntimeEnvironment.cs
+++ b/src/Compilers/Test/Core/Platform/Desktop/DesktopRuntimeEnvironment.cs
@@ -336,11 +336,15 @@ namespace Roslyn.Test.Utilities.Desktop
                     throw new Exception("Verification failed", ex);
                 }
 
-                if (verification.PEVerifyMessage != null)
+                var expectedMessage = verification.PEVerifyMessage;
+                if (expectedMessage != null)
                 {
-                    // remove token values to avoid dependency on on metadata ordering
-                    var actualMessage = Regex.Replace(ex.Output, @"\[mdToken=0x[0-9a-fA-F]+\]", "");
-                    var expectedMessage = Regex.Replace(verification.PEVerifyMessage, @"\[mdToken=0x[0-9a-fA-F]+\]", "");
+                    var actualMessage = ex.Output;
+                    
+                    if (!verification.IncludeTokens)
+                    {
+                        actualMessage = Regex.Replace(ex.Output, @"\[mdToken=0x[0-9a-fA-F]+\]", "");
+                    }
 
                     AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedMessage, actualMessage);
                 }

--- a/src/Compilers/Test/Utilities/CSharp/BasicCompilationUtils.cs
+++ b/src/Compilers/Test/Utilities/CSharp/BasicCompilationUtils.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public static class BasicCompilationUtils
     {
-        public static MetadataReference CompileToMetadata(string source, string assemblyName = null, IEnumerable<MetadataReference> references = null, Verification verify = Verification.Passes)
+        public static MetadataReference CompileToMetadata(string source, string assemblyName = null, IEnumerable<MetadataReference> references = null, Verification verify = default)
         {
             if (references == null)
             {

--- a/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp/CSharpTestBase.cs
@@ -726,7 +726,7 @@ namespace System.Diagnostics.CodeAnalysis
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
-            Verification verify = Verification.Passes) =>
+            Verification verify = default) =>
             CompileAndVerify(
                 source,
                 references,
@@ -762,7 +762,7 @@ namespace System.Diagnostics.CodeAnalysis
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
-            Verification verify = Verification.Passes) =>
+            Verification verify = default) =>
             CompileAndVerify(
                 source,
                 references,
@@ -799,7 +799,7 @@ namespace System.Diagnostics.CodeAnalysis
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
-            Verification verify = Verification.Passes)
+            Verification verify = default)
         {
             options = options ?? TestOptions.ReleaseDll.WithOutputKind((expectedOutput != null) ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary);
             var compilation = CreateExperimentalCompilationWithMscorlib45(source, feature, references, options, parseOptions, assemblyName: GetUniqueName());
@@ -840,7 +840,7 @@ namespace System.Diagnostics.CodeAnalysis
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
-            Verification verify = Verification.Passes) =>
+            Verification verify = default) =>
             CompileAndVerify(
                 source,
                 references,
@@ -876,7 +876,7 @@ namespace System.Diagnostics.CodeAnalysis
             CSharpCompilationOptions options = null,
             CSharpParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
-            Verification verify = Verification.Passes) =>
+            Verification verify = default) =>
             CompileAndVerify(
                 source,
                 references,
@@ -913,7 +913,7 @@ namespace System.Diagnostics.CodeAnalysis
             CSharpParseOptions parseOptions = null,
             EmitOptions emitOptions = null,
             TargetFramework targetFramework = TargetFramework.Standard,
-            Verification verify = Verification.Passes)
+            Verification verify = default)
         {
             options = options ?? (expectedOutput != null ? TestOptions.ReleaseExe : CheckForTopLevelStatements(source.GetSyntaxTrees(parseOptions)));
             var compilation = CreateCompilation(source, references, options, parseOptions, targetFramework, assemblyName: GetUniqueName());
@@ -946,7 +946,7 @@ namespace System.Diagnostics.CodeAnalysis
             int? expectedReturnCode = null,
             string[] args = null,
             EmitOptions emitOptions = null,
-            Verification verify = Verification.Passes)
+            Verification verify = default)
         {
             Action<IModuleSymbol> translate(Action<ModuleSymbol> action)
             {
@@ -1449,13 +1449,13 @@ namespace System.Diagnostics.CodeAnalysis
         /// <typeparam name="T">Expected type of the exception.</typeparam>
         /// <param name="source">Program to compile and execute.</param>
         /// <param name="expectedMessage">Ignored if null.</param>
-        internal CompilationVerifier CompileAndVerifyException<T>(string source, string expectedMessage = null, bool allowUnsafe = false, Verification verify = Verification.Passes) where T : Exception
+        internal CompilationVerifier CompileAndVerifyException<T>(string source, string expectedMessage = null, bool allowUnsafe = false, Verification verify = default) where T : Exception
         {
             var comp = CreateCompilation(source, options: TestOptions.ReleaseExe.WithAllowUnsafe(allowUnsafe));
             return CompileAndVerifyException<T>(comp, expectedMessage, verify);
         }
 
-        internal CompilationVerifier CompileAndVerifyException<T>(CSharpCompilation comp, string expectedMessage = null, Verification verify = Verification.Passes) where T : Exception
+        internal CompilationVerifier CompileAndVerifyException<T>(CSharpCompilation comp, string expectedMessage = null, Verification verify = default) where T : Exception
         {
             try
             {

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -39,7 +39,7 @@ Public MustInherit Class BasicTestBase
         Optional options As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
         Optional emitOptions As EmitOptions = Nothing,
-        Optional verify As Verification = Verification.Passes
+        Optional verify As Verification = Nothing
     ) As CompilationVerifier
 
         Return CompileAndVerify(
@@ -73,7 +73,7 @@ Public MustInherit Class BasicTestBase
         Optional expectedReturnCode As Integer? = Nothing,
         Optional args As String() = Nothing,
         Optional emitOptions As EmitOptions = Nothing,
-        Optional verify As Verification = Verification.Passes) As CompilationVerifier
+        Optional verify As Verification = Nothing) As CompilationVerifier
 
         Return MyBase.CompileAndVerifyCommon(
             compilation,
@@ -103,7 +103,7 @@ Public MustInherit Class BasicTestBase
         Optional symbolValidator As Action(Of ModuleSymbol) = Nothing,
         Optional expectedSignatures As SignatureDescription() = Nothing,
         Optional emitOptions As EmitOptions = Nothing,
-        Optional verify As Verification = Verification.Passes) As CompilationVerifier
+        Optional verify As Verification = Nothing) As CompilationVerifier
 
         Return CompileAndVerify(
             compilation,
@@ -136,7 +136,7 @@ Public MustInherit Class BasicTestBase
         Optional options As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
         Optional emitOptions As EmitOptions = Nothing,
-        Optional verify As Verification = Verification.Passes,
+        Optional verify As Verification = Nothing,
         Optional useLatestFramework As Boolean = False
     ) As CompilationVerifier
 
@@ -176,7 +176,7 @@ Public MustInherit Class BasicTestBase
         Optional options As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
         Optional emitOptions As EmitOptions = Nothing,
-        Optional verify As Verification = Verification.Passes
+        Optional verify As Verification = Nothing
     ) As CompilationVerifier
 
         If options Is Nothing Then
@@ -217,7 +217,7 @@ Public MustInherit Class BasicTestBase
         Optional expectedSignatures As SignatureDescription() = Nothing,
         Optional options As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
-        Optional verify As Verification = Verification.Passes
+        Optional verify As Verification = Nothing
     ) As CompilationVerifier
         Return Me.CompileAndVerify(
             source,
@@ -250,7 +250,7 @@ Public MustInherit Class BasicTestBase
         Optional expectedSignatures As SignatureDescription() = Nothing,
         Optional options As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
-        Optional verify As Verification = Verification.Passes
+        Optional verify As Verification = Nothing
     ) As CompilationVerifier
         Return CompileAndVerifyOnWin8Only(
             source,
@@ -280,7 +280,7 @@ Public MustInherit Class BasicTestBase
         Optional expectedSignatures As SignatureDescription() = Nothing,
         Optional options As VisualBasicCompilationOptions = Nothing,
         Optional parseOptions As VisualBasicParseOptions = Nothing,
-        Optional verify As Verification = Verification.Passes,
+        Optional verify As Verification = Nothing,
         Optional useLatestFramework As Boolean = False
     ) As CompilationVerifier
         Return CompileAndVerify(
@@ -314,7 +314,7 @@ Public MustInherit Class BasicTestBase
         Optional parseOptions As VisualBasicParseOptions = Nothing,
         Optional emitOptions As EmitOptions = Nothing,
         Optional assemblyName As String = Nothing,
-        Optional verify As Verification = Verification.Passes,
+        Optional verify As Verification = Nothing,
         Optional targetFramework As TargetFramework = TargetFramework.StandardAndVBRuntime
     ) As CompilationVerifier
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -3843,7 +3843,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlib40(source1, OutputKind.NetModule)
             Dim metadataRef = comp.EmitToImageReference()
-            CompileAndVerify(source2, references:={metadataRef}, options:=TestOptions.ReleaseModule, verify:=Verification.FailsPEVerify Or Verification.FailsILVerify)
+            CompileAndVerify(source2, references:={metadataRef}, options:=TestOptions.ReleaseModule, verify:=Verification.Fails)
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/CodeGenExprLambda.vb
@@ -1816,7 +1816,7 @@ End Structure
                                                      Optional optimize As Boolean = True,
                                                      Optional latestReferences As Boolean = False,
                                                      Optional addXmlReferences As Boolean = False,
-                                                     Optional verify As Verification = Verification.Passes) As CompilationVerifier
+                                                     Optional verify As Verification = Nothing) As CompilationVerifier
 
             Debug.Assert(Not latestReferences OrElse Not addXmlReferences) ' NYI
 
@@ -1839,7 +1839,7 @@ End Structure
                                         Optional latestReferences As Boolean = False,
                                         Optional addXmlReferences As Boolean = False,
                                         Optional diagnostics() As DiagnosticDescription = Nothing,
-                                        Optional verify As Verification = Verification.Passes)
+                                        Optional verify As Verification = Nothing)
 
             TestExpressionTreesVerifier(sourceFile, result, checked, optimize, latestReferences, addXmlReferences, verify).VerifyDiagnostics(If(diagnostics, {}))
         End Sub


### PR DESCRIPTION
Currently a test can only specify whether IL verification should pass or fail. 
This change allows it to specify what exactly causes the IL verification to fail, so that the test can define list of expected IL verification violations and guard against unexpected ones.