### PR TITLE
Treat `TypedReference` as managed

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -1,5 +1,18 @@
 # This document lists known breaking changes in Roslyn after .NET 6 all the way to .NET 7.
 
+## System.TypedReference considered managed
+
+***Introduced in Visual Studio 2022 version 17.6***
+
+Moving forward the `System.TypedReference` type is considered managed.
+
+```csharp
+unsafe
+{
+    TypeReference* r = null; // warning: This takes the address of, gets the size of, or declares a pointer to a managed type
+}
+```
+
 ## Ref safety errors do not affect conversion from lambda expression to delegate
 
 ***Introduced in Visual Studio 2022 version 17.5***

--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -9,7 +9,8 @@ Moving forward the `System.TypedReference` type is considered managed.
 ```csharp
 unsafe
 {
-    TypeReference* r = null; // warning: This takes the address of, gets the size of, or declares a pointer to a managed type
+    TypedReference* r = null; // warning: This takes the address of, gets the size of, or declares a pointer to a managed type
+    var a = stackalloc TypedReference[1]; // error: Cannot take the address of, get the size of, or declare a pointer to a managed type
 }
 ```
 

--- a/src/Compilers/CSharp/Portable/Symbols/BaseTypeAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/BaseTypeAnalysis.cs
@@ -271,10 +271,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SpecialType.System_Double:
                 case SpecialType.System_IntPtr:
                 case SpecialType.System_UIntPtr:
-                case SpecialType.System_TypedReference:
                 case SpecialType.System_ArgIterator:
                 case SpecialType.System_RuntimeArgumentHandle:
                     return (ThreeState.False, false);
+                case SpecialType.System_TypedReference:
+                    return (ThreeState.True, false);
                 case SpecialType.None:
                 default:
                     // CONSIDER: could provide cases for other common special types.

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenMscorlib.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenMscorlib.cs
@@ -126,7 +126,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             TypedReference result = new TypedReference ();
             unsafe
             {
-                FCallGetNextArg (&result);
+                FCallGetNextArg (&result); // 1
             }
             return result;
         }
@@ -152,7 +152,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 }";
             var c = CreateEmptyCompilation(text, options: TestOptions.UnsafeReleaseDll);
 
-            c.VerifyDiagnostics();
+            c.VerifyDiagnostics(
+                // (100,34): warning CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type ('TypedReference')
+                //                 FCallGetNextArg (&result); // 1
+                Diagnostic(ErrorCode.WRN_ManagedAddr, "&result").WithArguments("System.TypedReference").WithLocation(100, 34)
+                );
         }
 
         [WorkItem(544918, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544918")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StackAllocInitializerTests.cs
@@ -31,7 +31,7 @@ class C
         var x1 = stackalloc RefS[10];
         var x2 = stackalloc RefG<string>[10];
         var x3 = stackalloc RefG<int>[10];
-        var x4 = stackalloc System.TypedReference[10]; // Note: this should be disallowed by adding a dummy field to the ref assembly for TypedReference
+        var x4 = stackalloc System.TypedReference[10];
         var x5 = stackalloc System.ArgIterator[10];
         var x6 = stackalloc System.RuntimeArgumentHandle[10];
 
@@ -62,6 +62,9 @@ class C
                 // (10,29): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('RefG<string>')
                 //         var x2 = stackalloc RefG<string>[10];
                 Diagnostic(ErrorCode.ERR_ManagedAddr, "RefG<string>").WithArguments("RefG<string>").WithLocation(10, 29),
+                // (12,29): error CS0208: Cannot take the address of, get the size of, or declare a pointer to a managed type ('TypedReference')
+                //         var x4 = stackalloc System.TypedReference[10];
+                Diagnostic(ErrorCode.ERR_ManagedAddr, "System.TypedReference").WithArguments("System.TypedReference").WithLocation(12, 29),
                 // (16,22): error CS0611: Array elements cannot be of type 'RefS'
                 //         var y1 = new RefS[10];
                 Diagnostic(ErrorCode.ERR_ArrayElementCantBeRefAny, "RefS").WithArguments("RefS").WithLocation(16, 22),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -3075,6 +3075,7 @@ unsafe class C
                 //     void M(System.TypedReference* r) { }
                 Diagnostic(ErrorCode.WRN_ManagedAddr, "r").WithArguments("System.TypedReference").WithLocation(4, 35)
                 );
+            compilation.VerifyEmitDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -3112,6 +3112,29 @@ unsafe class D
         }
 
         [Fact, WorkItem(65530, "https://github.com/dotnet/roslyn/issues/65530")]
+        public void TypedReference_InArray()
+        {
+            var src = @"
+public class C
+{
+    public static System.TypedReference[] M(System.TypedReference[] r)
+    {
+        return r;
+    }
+}
+";
+            var comp = CreateCompilation(src);
+            comp.VerifyEmitDiagnostics(
+                // (4,19): error CS0611: Array elements cannot be of type 'TypedReference'
+                //     public static System.TypedReference[] M(System.TypedReference[] r)
+                Diagnostic(ErrorCode.ERR_ArrayElementCantBeRefAny, "System.TypedReference").WithArguments("System.TypedReference").WithLocation(4, 19),
+                // (4,45): error CS0611: Array elements cannot be of type 'TypedReference'
+                //     public static System.TypedReference[] M(System.TypedReference[] r)
+                Diagnostic(ErrorCode.ERR_ArrayElementCantBeRefAny, "System.TypedReference").WithArguments("System.TypedReference").WithLocation(4, 45)
+                );
+        }
+
+        [Fact, WorkItem(65530, "https://github.com/dotnet/roslyn/issues/65530")]
         public void TypedReference_ByValue()
         {
             var libSrc = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -3248,17 +3248,23 @@ public class C<T>
         public void TypedReference_Field()
         {
             var libSrc = @"
-public class C
+public ref struct C
 {
     public System.TypedReference field;
+    public ref System.TypedReference field2;
 }
 ";
-            var comp = CreateCompilation(libSrc);
-            Assert.True(comp.GetSpecialType(SpecialType.System_TypedReference).IsManagedTypeNoUseSiteDiagnostics);
+            var comp = CreateCompilation(libSrc, targetFramework: TargetFramework.Net70);
             comp.VerifyEmitDiagnostics(
                 // (4,12): error CS0610: Field or property cannot be of type 'TypedReference'
                 //     public System.TypedReference field;
-                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "System.TypedReference").WithArguments("System.TypedReference").WithLocation(4, 12)
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "System.TypedReference").WithArguments("System.TypedReference").WithLocation(4, 12),
+                // (5,12): error CS9050: A ref field cannot refer to a ref struct.
+                //     public ref System.TypedReference field2;
+                Diagnostic(ErrorCode.ERR_RefFieldCannotReferToRefStruct, "ref System.TypedReference").WithLocation(5, 12),
+                // (5,12): error CS0610: Field or property cannot be of type 'TypedReference'
+                //     public ref System.TypedReference field2;
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "ref System.TypedReference").WithArguments("System.TypedReference").WithLocation(5, 12)
                 );
         }
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -3724,6 +3724,7 @@ namespace Microsoft.Cci
         {
             while (true)
             {
+                // TODO2
                 // TYPEDREF is only allowed in RetType, Param, LocalVarSig signatures
                 Debug.Assert(!module.IsPlatformType(typeReference, PlatformType.SystemTypedReference));
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -3020,12 +3020,6 @@ namespace Microsoft.Cci
                 SerializeCustomModifiers(encoder.CustomModifiers(), local.CustomModifiers);
             }
 
-            if (module.IsPlatformType(local.Type, PlatformType.SystemTypedReference))
-            {
-                encoder.TypedReference();
-                return;
-            }
-
             SerializeTypeReference(encoder.Type(local.IsReference, local.IsPinned), local.Type);
         }
 
@@ -3319,23 +3313,13 @@ namespace Microsoft.Cci
         {
             var type = parameterTypeInformation.GetType(Context);
 
-            if (module.IsPlatformType(type, PlatformType.SystemTypedReference))
-            {
-                Debug.Assert(!parameterTypeInformation.IsByReference);
-                SerializeCustomModifiers(encoder.CustomModifiers(), parameterTypeInformation.CustomModifiers);
+            Debug.Assert(parameterTypeInformation.RefCustomModifiers.Length == 0 || parameterTypeInformation.IsByReference);
+            SerializeCustomModifiers(encoder.CustomModifiers(), parameterTypeInformation.RefCustomModifiers);
 
-                encoder.TypedReference();
-            }
-            else
-            {
-                Debug.Assert(parameterTypeInformation.RefCustomModifiers.Length == 0 || parameterTypeInformation.IsByReference);
-                SerializeCustomModifiers(encoder.CustomModifiers(), parameterTypeInformation.RefCustomModifiers);
+            var typeEncoder = encoder.Type(parameterTypeInformation.IsByReference);
 
-                var typeEncoder = encoder.Type(parameterTypeInformation.IsByReference);
-
-                SerializeCustomModifiers(typeEncoder.CustomModifiers(), parameterTypeInformation.CustomModifiers);
-                SerializeTypeReference(typeEncoder, type);
-            }
+            SerializeCustomModifiers(typeEncoder.CustomModifiers(), parameterTypeInformation.CustomModifiers);
+            SerializeTypeReference(typeEncoder, type);
         }
 
         private void SerializeFieldSignature(IFieldReference fieldReference, BlobBuilder builder)
@@ -3679,14 +3663,7 @@ namespace Microsoft.Cci
 
             encoder.Parameters(declaredParameters.Length + varargParameters.Length, out returnTypeEncoder, out parametersEncoder);
 
-            if (module.IsPlatformType(returnType, PlatformType.SystemTypedReference))
-            {
-                Debug.Assert(!signature.ReturnValueIsByRef);
-                SerializeCustomModifiers(returnTypeEncoder.CustomModifiers(), signature.ReturnValueCustomModifiers);
-
-                returnTypeEncoder.TypedReference();
-            }
-            else if (module.IsPlatformType(returnType, PlatformType.SystemVoid))
+            if (module.IsPlatformType(returnType, PlatformType.SystemVoid))
             {
                 Debug.Assert(!signature.ReturnValueIsByRef);
                 Debug.Assert(signature.RefCustomModifiers.IsEmpty);
@@ -3724,9 +3701,13 @@ namespace Microsoft.Cci
         {
             while (true)
             {
-                // TODO2
-                // TYPEDREF is only allowed in RetType, Param, LocalVarSig signatures
-                Debug.Assert(!module.IsPlatformType(typeReference, PlatformType.SystemTypedReference));
+                if (module.IsPlatformType(typeReference, PlatformType.SystemTypedReference))
+                {
+                    // We should use `SignatureTypeEncoder.TypedReference()` once such a method is available
+                    // Tracked by https://github.com/dotnet/runtime/issues/80812
+                    encoder.Builder.WriteByte((byte)SignatureTypeCode.TypedReference);
+                    return;
+                }
 
                 if (typeReference is IModifiedTypeReference modifiedTypeReference)
                 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/65530

From discussion with runtime team, `ArgIterator` and `RuntimeArgumentHandle` should be left as unmanaged for now.

Filed API request for SRM: https://github.com/dotnet/runtime/issues/80812