### PR TITLE
Report telemetry event with LSP server capabilities

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -589,5 +589,8 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         // 670-680 for newer rename ids
         Rename_TryApplyRename_WorkspaceChanged = 670,
+
+        // 680-690 LSP Initialization info ids.
+        LSP_Initialize = 680,
     }
 }


### PR DESCRIPTION
On initialize, report the capabilities the server was started with.  This is useful for session debugging so we know what LSP features are on/off.

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/5749229/211414072-7cb43710-6b20-45be-aba9-ce05f8d1e24d.png">
