### PR TITLE
Improve VS settings integration test, fix deserialization of enum options from registry

### DIFF
--- a/src/Compilers/Test/Core/Assert/AssertEx.cs
+++ b/src/Compilers/Test/Core/Assert/AssertEx.cs
@@ -37,7 +37,7 @@ namespace Roslyn.Test.Utilities
 
         private class AssertEqualityComparer<T> : IEqualityComparer<T>
         {
-            private static readonly IEqualityComparer<T> s_instance = new AssertEqualityComparer<T>();
+            public static readonly IEqualityComparer<T> Instance = new AssertEqualityComparer<T>();
 
             private static bool CanBeNull()
             {
@@ -58,7 +58,7 @@ namespace Roslyn.Test.Utilities
 
             public static bool Equals(T left, T right)
             {
-                return s_instance.Equals(left, right);
+                return Instance.Equals(left, right);
             }
 
             bool IEqualityComparer<T>.Equals(T x, T y)
@@ -141,23 +141,30 @@ namespace Roslyn.Test.Utilities
 
             if (expected == null)
             {
-                Fail("expected was null, but actual wasn't\r\n" + message);
+                Fail("expected was null, but actual wasn't" + Environment.NewLine + message);
             }
             else if (actual == null)
             {
-                Fail("actual was null, but expected wasn't\r\n" + message);
+                Fail("actual was null, but expected wasn't" + Environment.NewLine + message);
             }
-            else
+            else if (!(comparer ?? AssertEqualityComparer<T>.Instance).Equals(expected, actual))
             {
-                if (!(comparer != null ?
-                    comparer.Equals(expected, actual) :
-                    AssertEqualityComparer<T>.Equals(expected, actual)))
+                string expectedAndActual;
+                if (expected is IEnumerable expectedEnumerable && actual is IEnumerable actualEnumerable)
                 {
-                    Fail("Expected and actual were different.\r\n" +
-                         "Expected:\r\n" + expected + "\r\n" +
-                         "Actual:\r\n" + actual + "\r\n" +
-                         message);
+                    expectedAndActual = GetAssertMessage(expectedEnumerable.OfType<object>(), actualEnumerable.OfType<object>(), comparer: null);
                 }
+                else
+                {
+                    expectedAndActual = $"""
+                        Expected:
+                        {expected}
+                        Actual:
+                        {actual}
+                        """;
+                }
+
+                Fail(message + Environment.NewLine + expectedAndActual);
             }
         }
 

--- a/src/VisualStudio/Core/Def/Options/FeatureFlagPersister.cs
+++ b/src/VisualStudio/Core/Def/Options/FeatureFlagPersister.cs
@@ -46,13 +46,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Options
             return true;
         }
 
-        public bool TryPersist(string flagName, object? value)
+        public void Persist(string flagName, object? value)
         {
-            if (_featureFlags == null)
-            {
-                return false;
-            }
-
             if (value is not bool flag)
             {
                 throw ExceptionUtilities.UnexpectedValue(value);
@@ -60,14 +55,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Options
 
             try
             {
-                ((IVsFeatureFlags2)_featureFlags).EnableFeatureFlag(flagName, flag);
+                ((IVsFeatureFlags2?)_featureFlags)?.EnableFeatureFlag(flagName, flag);
             }
             catch (Exception e) when (FatalError.ReportAndCatch(e))
             {
-                return false;
             }
-
-            return true;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionPersister.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeStyle;
@@ -53,14 +54,23 @@ internal sealed class VisualStudioOptionPersister : IOptionPersister
         };
 
     public bool TryPersist(OptionKey2 optionKey, object? value)
-        => VisualStudioOptionStorage.Storages.TryGetValue(optionKey.Option.Definition.ConfigName, out var storage) && TryPersist(storage, optionKey, value);
+    {
+        if (!VisualStudioOptionStorage.Storages.TryGetValue(optionKey.Option.Definition.ConfigName, out var storage))
+        {
+            return false;
+        }
 
-    public bool TryPersist(VisualStudioOptionStorage storage, OptionKey2 optionKey, object? value)
+        // fire and forget:
+        PersistAsync(storage, optionKey, value).ReportNonFatalErrorAsync();
+        return true;
+    }
+
+    public Task PersistAsync(VisualStudioOptionStorage storage, OptionKey2 optionKey, object? value)
         => storage switch
         {
-            VisualStudioOptionStorage.RoamingProfileStorage roaming => roaming.TryPersist(_visualStudioSettingsOptionPersister, optionKey, value),
-            VisualStudioOptionStorage.FeatureFlagStorage featureFlags => featureFlags.TryPersist(_featureFlagPersister, value),
-            VisualStudioOptionStorage.LocalUserProfileStorage local => local.TryPersist(_localUserRegistryPersister, optionKey, value),
+            VisualStudioOptionStorage.RoamingProfileStorage roaming => roaming.PersistAsync(_visualStudioSettingsOptionPersister, optionKey, value),
+            VisualStudioOptionStorage.FeatureFlagStorage featureFlags => featureFlags.PersistAsync(_featureFlagPersister, value),
+            VisualStudioOptionStorage.LocalUserProfileStorage local => local.PersistAsync(_localUserRegistryPersister, optionKey, value),
             _ => throw ExceptionUtilities.UnexpectedValue(storage)
         };
 }

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionPersisterProvider.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionPersisterProvider.cs
@@ -20,6 +20,7 @@ using SAsyncServiceProvider = Microsoft.VisualStudio.Shell.Interop.SAsyncService
 namespace Microsoft.VisualStudio.LanguageServices.Options
 {
     [Export(typeof(IOptionPersisterProvider))]
+    [Export(typeof(VisualStudioOptionPersisterProvider))]
     internal sealed class VisualStudioOptionPersisterProvider : IOptionPersisterProvider
     {
         private readonly IAsyncServiceProvider _serviceProvider;

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -58,8 +58,8 @@ internal abstract class VisualStudioOptionStorage
                 _ => language // handles F#, TypeScript and Xaml
             });
 
-        public bool TryPersist(VisualStudioSettingsOptionPersister persister, OptionKey2 optionKey, object? value)
-            => persister.TryPersist(optionKey, GetKey(optionKey.Language), value);
+        public Task PersistAsync(VisualStudioSettingsOptionPersister persister, OptionKey2 optionKey, object? value)
+            => persister.PersistAsync(optionKey, GetKey(optionKey.Language), value);
 
         public bool TryFetch(VisualStudioSettingsOptionPersister persister, OptionKey2 optionKey, out object? value)
             => persister.TryFetch(optionKey, GetKey(optionKey.Language), out value);
@@ -74,8 +74,11 @@ internal abstract class VisualStudioOptionStorage
             FlagName = flagName;
         }
 
-        public bool TryPersist(FeatureFlagPersister persister, object? value)
-            => persister.TryPersist(FlagName, value);
+        public Task PersistAsync(FeatureFlagPersister persister, object? value)
+        {
+            persister.Persist(FlagName, value);
+            return Task.CompletedTask;
+        }
 
         public bool TryFetch(FeatureFlagPersister persister, OptionKey2 optionKey, out object? value)
             => persister.TryFetch(optionKey, FlagName, out value);
@@ -92,8 +95,11 @@ internal abstract class VisualStudioOptionStorage
             _key = key;
         }
 
-        public bool TryPersist(LocalUserRegistryOptionPersister persister, OptionKey2 optionKey, object? value)
-            => persister.TryPersist(optionKey, _path, _key, value);
+        public Task PersistAsync(LocalUserRegistryOptionPersister persister, OptionKey2 optionKey, object? value)
+        {
+            persister.Persist(optionKey, _path, _key, value);
+            return Task.CompletedTask;
+        }
 
         public bool TryFetch(LocalUserRegistryOptionPersister persister, OptionKey2 optionKey, out object? value)
             => persister.TryFetch(optionKey, _path, _key, out value);

--- a/src/VisualStudio/Core/Def/Options/VisualStudioSettingsOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioSettingsOptionPersister.cs
@@ -171,13 +171,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Options
             return default;
         }
 
-        public bool TryPersist(OptionKey2 optionKey, string storageKey, object? value)
+        public Task PersistAsync(OptionKey2 optionKey, string storageKey, object? value)
         {
-            if (_settingManager == null)
-            {
-                Debug.Fail("Manager field is unexpectedly null.");
-                return false;
-            }
+            Contract.ThrowIfNull(_settingManager);
 
             RecordObservedValueToWatchForChanges(optionKey, storageKey, optionKey.Option.Type);
 
@@ -194,9 +190,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Options
                     value = valueToSerialize.CreateXElement().ToString();
                 }
             }
+            else if (value is ImmutableArray<string> stringArray)
+            {
+                value = stringArray.ToArray();
+            }
 
-            _settingManager.SetValueAsync(storageKey, value, isMachineLocal: false);
-            return true;
+            return _settingManager.SetValueAsync(storageKey, value, isMachineLocal: false);
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Options/VisualStudioSettingsOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioSettingsOptionPersister.cs
@@ -192,7 +192,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Options
             }
             else if (value is ImmutableArray<string> stringArray)
             {
-                value = stringArray.ToArray();
+                value = stringArray.IsDefault ? null : stringArray.ToArray();
             }
 
             return _settingManager.SetValueAsync(storageKey, value, isMachineLocal: false);

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/Options/GlobalOptionsTest.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/Options/GlobalOptionsTest.cs
@@ -10,10 +10,12 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.TaskList;
 using Microsoft.CodeAnalysis.UnitTests;
 using Microsoft.VisualStudio.IntegrationTest.Utilities;
 using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.LanguageServices.Options;
+using Microsoft.VisualStudio.Settings;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Roslyn.VisualStudio.IntegrationTests;
@@ -30,7 +32,9 @@ public sealed class GlobalOptionsTest : AbstractIntegrationTest
     [IdeFact]
     public async Task ValidateAllOptions()
     {
-        var globalOptions = await TestServices.Shell.GetComponentModelServiceAsync<IGlobalOptionService>(HangMitigatingCancellationToken);
+        var globalOptions = (GlobalOptionService)await TestServices.Shell.GetComponentModelServiceAsync<IGlobalOptionService>(HangMitigatingCancellationToken);
+        var provider = await TestServices.Shell.GetComponentModelServiceAsync<VisualStudioOptionPersisterProvider>(HangMitigatingCancellationToken);
+        var vsSettingsPersister = (VisualStudioOptionPersister)await provider.GetOrCreatePersisterAsync(HangMitigatingCancellationToken);
 
         var optionsInfo = OptionsTestInfo.CollectOptions(Path.GetDirectoryName(typeof(GlobalOptionsTest).Assembly.Location!));
         var allLanguages = new[] { LanguageNames.CSharp, LanguageNames.VisualBasic };
@@ -51,6 +55,12 @@ public sealed class GlobalOptionsTest : AbstractIntegrationTest
                 continue;
             }
 
+            // TODO: issue https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1585884
+            if (option == TaskListOptionsStorage.Descriptors)
+            {
+                continue;
+            }
+
             foreach (var language in option.IsPerLanguage ? allLanguages : noLanguages)
             {
                 var key = new OptionKey2(option, language);
@@ -64,20 +74,23 @@ public sealed class GlobalOptionsTest : AbstractIntegrationTest
                 }
 
                 var differentValue = OptionsTestHelpers.GetDifferentValue(option.Type, currentValue);
-                globalOptions.SetGlobalOption(key, differentValue);
+
+                await vsSettingsPersister.PersistAsync(storage, key, differentValue);
+
+                // make sure we fetch the value from the storage:
+                globalOptions.ClearCachedValues();
 
                 object? updatedValue;
-
                 try
                 {
                     updatedValue = globalOptions.GetOption<object?>(key);
                 }
                 finally
                 {
-                    globalOptions.SetGlobalOption(key, currentValue);
+                    await vsSettingsPersister.PersistAsync(storage, key, currentValue);
                 }
 
-                Assert.Equal(differentValue, updatedValue);
+                AssertEx.AreEqual(differentValue, updatedValue, message: $"Option '{option.Definition.ConfigName}' failed to persist to VS settings.");
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
@@ -250,5 +250,14 @@ namespace Microsoft.CodeAnalysis.Options
                 }
             }
         }
+
+        // for testing
+        public void ClearCachedValues()
+        {
+            lock (_gate)
+            {
+                _currentValues = ImmutableDictionary.Create<OptionKey2, object?>();
+            }
+        }
     }
 }

--- a/src/Workspaces/CoreTestUtilities/Options/OptionsTestHelpers.cs
+++ b/src/Workspaces/CoreTestUtilities/Options/OptionsTestHelpers.cs
@@ -129,10 +129,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 _ when type == typeof(bool?) => value is null ? true : null,
                 _ when type == typeof(int?) => value is null ? 1 : null,
                 _ when type == typeof(long?) => value is null ? 1L : null,
-                ImmutableArray<bool> array => array.IsEmpty ? ImmutableArray.Create("X") : ImmutableArray<bool>.Empty,
-                ImmutableArray<string> array => array.IsEmpty ? ImmutableArray.Create("X") : ImmutableArray<string>.Empty,
-                ImmutableArray<int> array => array.IsEmpty ? ImmutableArray.Create("X") : ImmutableArray<int>.Empty,
-                ImmutableArray<long> array => array.IsEmpty ? ImmutableArray.Create("X") : ImmutableArray<long>.Empty,
+                ImmutableArray<bool> array => array.IsEmpty ? ImmutableArray.Create(true) : ImmutableArray<bool>.Empty,
+                ImmutableArray<string> array => array is ["X"] ? ImmutableArray.Create("X", "Y") : ImmutableArray.Create("X"),
+                ImmutableArray<int> array => array.IsEmpty ? ImmutableArray.Create(1) : ImmutableArray<int>.Empty,
+                ImmutableArray<long> array => array.IsEmpty ? ImmutableArray.Create(1L) : ImmutableArray<long>.Empty,
 
                 // Hit when a new option is introduced that uses type not handled above:
                 _ => throw ExceptionUtilities.UnexpectedValue(type)


### PR DESCRIPTION
Previously the test did not actually validate the values persisted to VS setting storage since it was hitting the global option cache and value persisting was fire-and-forget async task. 

Refactor the persister so that the test can await completion of the value persisting task.

Also fixes deserialization of enum values from registry.
