### PR TITLE
Reduce When New Rename Is Dismissed

### DIFF
--- a/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
+++ b/src/EditorFeatures/Core.Wpf/InlineRename/UI/Adornment/RenameFlyout.xaml.cs
@@ -49,10 +49,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
 
                 IdentifierTextBox.Focus();
                 IdentifierTextBox.Select(_viewModel.StartingSelection.Start, _viewModel.StartingSelection.Length);
-
-                // Don't hook up our close events until we're done loading and have focused within the textbox
-                _textView.LostAggregateFocus += TextView_LostFocus;
-                IsKeyboardFocusWithinChanged += RenameFlyout_IsKeyboardFocusWithinChanged;
             };
 
             InitializeComponent();
@@ -91,39 +87,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
         public string PreviewChanges => EditorFeaturesResources.Preview_changes1;
         public string SubmitText => EditorFeaturesWpfResources.Enter_to_rename_shift_enter_to_preview;
 #pragma warning restore CA1822 // Mark members as static
-
-        private void RenameFlyout_IsKeyboardFocusWithinChanged(object sender, DependencyPropertyChangedEventArgs e)
-        {
-            // When previewing changes, focus will be lost and put 
-            // into a preview changes window. If we're returning back
-            // to this UI, reset the flag to false. Otherwise, just ignore
-            // this focus change. No need to cancel in that case 
-            if (_viewModel.PreviewChangesFlag)
-            {
-                if (IsKeyboardFocused)
-                {
-                    _viewModel.PreviewChangesFlag = false;
-                }
-
-                return;
-            }
-
-            if (!IsKeyboardFocused)
-            {
-                _viewModel.Cancel();
-            }
-        }
-
-        private void TextView_LostFocus(object sender, EventArgs e)
-        {
-            // Preview changes is happening, no need to act on focus changes.
-            if (_viewModel.PreviewChangesFlag)
-            {
-                return;
-            }
-
-            _viewModel.Cancel();
-        }
 
         private void TextView_ViewPortChanged(object sender, EventArgs e)
             => PositionAdornment();
@@ -170,7 +133,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             _textView.LayoutChanged -= TextView_LayoutChanged;
             _textView.ViewportHeightChanged -= TextView_ViewPortChanged;
             _textView.ViewportWidthChanged -= TextView_ViewPortChanged;
-            _textView.LostAggregateFocus -= TextView_LostFocus;
 
             // Restore focus back to the textview
             _textView.VisualElement.Focus();


### PR DESCRIPTION
Previously the dialog would dismiss if it no longer had focus. While I had good intentions, there are far too many cases where focus can temporarily change. Instead of trying to handle them all, let's let users go wild. 

Now it takes an explicit action from the user, or typing outside of a field correlating to the identifier (similar to previous rename). 

Fixes [AB#1705938](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1705938)
