### PR TITLE
Fix issue where Solution-Explorer symbol nodes collapse after an edit.

### DIFF
--- a/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphBuilder.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -836,11 +837,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             }
         }
 
-        public IEnumerable<GraphNode> GetCreatedNodes(CancellationToken cancellationToken)
+        public ImmutableArray<GraphNode> GetCreatedNodes(CancellationToken cancellationToken)
         {
             using (_gate.DisposableWait(cancellationToken))
             {
-                return _createdNodes.ToArray();
+                return _createdNodes.ToImmutableArray();
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Progression/GraphProvider.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphProvider.cs
@@ -165,10 +165,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             var graphQueries = GetGraphQueries(context, _threadingContext, _asyncListener);
 
             // Perform the queries asynchronously  in a fire-and-forget fashion.  This helper will be responsible
-            // for always completing the context.
+            // for always completing the context. AddQueriesAsync is `async`, so it always returns a task and will never
+            // bubble out an exception synchronously (so CompletesAsyncOperation is safe).
             var asyncToken = _asyncListener.BeginAsyncOperation(nameof(BeginGetGraphData));
             _ = _graphQueryManager
-                .AddQueriesAsync(context, graphQueries)
+                .AddQueriesAsync(context, graphQueries, _threadingContext.DisposalToken)
                 .CompletesAsyncOperation(asyncToken);
         }
 

--- a/src/VisualStudio/Core/Def/Progression/GraphProvider.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphProvider.cs
@@ -166,7 +166,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
             // Perform the queries asynchronously  in a fire-and-forget fashion.  This helper will be responsible
             // for always completing the context.
-            _ = _graphQueryManager.AddQueriesAsync(context, graphQueries);
+            var asyncToken = _asyncListener.BeginAsyncOperation(nameof(BeginGetGraphData));
+            _ = _graphQueryManager
+                .AddQueriesAsync(context, graphQueries)
+                .CompletesAsyncOperation(asyncToken);
         }
 
         public IEnumerable<GraphCommand> GetCommands(IEnumerable<GraphNode> nodes)

--- a/src/VisualStudio/Core/Def/Progression/GraphProvider.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphProvider.cs
@@ -164,15 +164,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
             var graphQueries = GetGraphQueries(context, _threadingContext, _asyncListener);
 
-            if (graphQueries.Length > 0)
-            {
-                _graphQueryManager.AddQueries(context, graphQueries);
-            }
-            else
-            {
-                // It's an unknown query type, so we're done
-                context.OnCompleted();
-            }
+            // Perform the queries asynchronously  in a fire-and-forget fashion.  This helper will be responsible
+            // for always completing the context.
+            _ = _graphQueryManager.AddQueriesAsync(context, graphQueries);
         }
 
         public IEnumerable<GraphCommand> GetCommands(IEnumerable<GraphNode> nodes)

--- a/src/VisualStudio/Core/Def/Progression/GraphProvider.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphProvider.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             _asyncListener = listenerProvider.GetListener(FeatureAttribute.GraphProvider);
             _workspace = workspace;
             _streamingPresenter = streamingPresenter;
-            _graphQueryManager = new GraphQueryManager(workspace, _asyncListener);
+            _graphQueryManager = new GraphQueryManager(workspace, threadingContext, _asyncListener);
         }
 
         private void EnsureInitialized()

--- a/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
@@ -56,14 +56,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             _workspace.WorkspaceChanged += (_, _) => _updateQueue.AddWork();
         }
 
-        public async Task AddQueriesAsync(IGraphContext context, ImmutableArray<IGraphQuery> graphQueries)
+        public async Task AddQueriesAsync(IGraphContext context, ImmutableArray<IGraphQuery> graphQueries, CancellationToken disposalToken)
         {
             try
             {
                 var solution = _workspace.CurrentSolution;
 
                 // Perform the actual graph query first.
-                await PopulateContextGraphAsync(solution, context, graphQueries).ConfigureAwait(false);
+                await PopulateContextGraphAsync(solution, context, graphQueries, disposalToken).ConfigureAwait(false);
 
                 // If this context would like to be continuously updated with live changes to this query, then add the
                 // tracked query to our tracking list, keeping it alive as long as those is keeping the context alive.

--- a/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
         private Task UpdateAsync()
         {
-            ImmutableArray<(IGraphContext, ImmutableArray<IGraphQuery>)> liveQueries;
+            ImmutableArray<(IGraphContext context, ImmutableArray<IGraphQuery> queries)> liveQueries;
             lock (_gate)
             {
                 liveQueries = _trackedQueries
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             }
 
             var solution = _workspace.CurrentSolution;
-            var tasks = liveQueries.Select(t => PopulateContextGraphAsync(solution, t.Item2, t.Item1)).ToArray();
+            var tasks = liveQueries.Select(t => PopulateContextGraphAsync(solution, t.queries, t.context)).ToArray();
             var whenAllTask = Task.WhenAll(tasks);
 
             return whenAllTask.SafeContinueWith(t => PostUpdate(solution), TaskScheduler.Default);
@@ -158,54 +158,45 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             ImmutableArray<IGraphQuery> graphQueries,
             IGraphContext context)
         {
+            Contract.ThrowIfTrue(graphQueries.IsEmpty);
             var cancellationToken = context.CancelToken;
 
             try
             {
-                if (graphQueries.Length == 0)
-                {
-                    // If we got no queries to populate, just clean out whatever was there before.
 
+                // Compute all queries in parallel.  Then as each finishes, update the graph.
+
+                var tasks = graphQueries.Select(q => Task.Run(() => q.GetGraphAsync(solution, context, cancellationToken), cancellationToken)).ToHashSet();
+
+                var first = true;
+                while (tasks.Count > 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var completedTask = await Task.WhenAny(tasks).ConfigureAwait(false);
+                    tasks.Remove(completedTask);
+
+                    // if this is the first task finished, clear out the existing results and add all the new
+                    // results as a single transaction.  Doing this as a single transaction is vital for
+                    // solution-explorer as that is how it can map the prior elements to the new ones, preserving the
+                    // view-state (like ensuring the same nodes stay collapsed/expanded).
+                    //
+                    // As additional queries finish, add those results in after without clearing the results of the
+                    // prior queries.
+
+                    var graphBuilder = await completedTask.ConfigureAwait(false);
                     using var transaction = new GraphTransactionScope();
-                    context.Graph.Links.Clear();
-                    transaction.Complete();
-                }
-                else
-                {
-                    // Compute all queries in parallel.  Then as each finishes, update the graph.
 
-                    var tasks = graphQueries.Select(q => Task.Run(() => q.GetGraphAsync(solution, context, cancellationToken), cancellationToken)).ToHashSet();
-
-                    var first = true;
-                    while (tasks.Count > 0)
+                    if (first)
                     {
-                        cancellationToken.ThrowIfCancellationRequested();
-
-                        var completedTask = await Task.WhenAny(tasks).ConfigureAwait(false);
-                        tasks.Remove(completedTask);
-
-                        // if this is the first task finished, clear out the existing results and add all the new
-                        // results as a single transaction.  Doing this as a single transaction is vital for
-                        // solution-explorer as that is how it can map the prior elements to the new ones, preserving the
-                        // view-state (like ensuring the same nodes stay collapsed/expanded).
-                        //
-                        // As additional queries finish, add those results in after without clearing the results of the
-                        // prior queries.
-
-                        var graphBuilder = await completedTask.ConfigureAwait(false);
-                        using var transaction = new GraphTransactionScope();
-
-                        if (first)
-                        {
-                            first = false;
-                            context.Graph.Links.Clear();
-                        }
-
-                        graphBuilder.ApplyToGraph(context.Graph, cancellationToken);
-                        context.OutputNodes.AddAll(graphBuilder.GetCreatedNodes(cancellationToken));
-
-                        transaction.Complete();
+                        first = false;
+                        context.Graph.Links.Clear();
                     }
+
+                    graphBuilder.ApplyToGraph(context.Graph, cancellationToken);
+                    context.OutputNodes.AddAll(graphBuilder.GetCreatedNodes(cancellationToken));
+
+                    transaction.Complete();
                 }
             }
             catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, ErrorSeverity.Diagnostic))

--- a/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             }
             finally
             {
-                // // We want to ensure that no matter what happens, this initial context is completed
+                // We want to ensure that no matter what happens, this initial context is completed
                 context.OnCompleted();
             }
         }

--- a/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.GraphModel;
+using Microsoft.VisualStudio.Progression;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
@@ -161,26 +162,47 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             {
                 var cancellationToken = context.CancelToken;
 
-                // Perform the actual graph transaction 
-                using (var transaction1 = new GraphTransactionScope())
+                if (graphQueries.Length == 1)
                 {
-                    // Remove any links that may have been added by a previous population. We don't
-                    // remove nodes to maintain node identity, matching the behavior of the old
-                    // providers.
+                    // When we have just a single query, do the entire clear and production of new values as a single
+                    // transaction.  This also helps solution-explorer track the old values to the new values, keeping
+                    // the view-state persistent across edits.
+                    // Perform the actual graph transaction 
+                    using var transaction = new GraphTransactionScope();
                     context.Graph.Links.Clear();
-                    transaction1.Complete();
-                }
 
-                foreach (var query in graphQueries)
-                {
-                    var graphBuilder = await query.GetGraphAsync(solution, context, cancellationToken).ConfigureAwait(false);
-
-                    using var transaction2 = new GraphTransactionScope();
-
+                    var graphBuilder = await graphQueries.Single().GetGraphAsync(solution, context, cancellationToken).ConfigureAwait(false);
                     graphBuilder.ApplyToGraph(context.Graph, cancellationToken);
+
                     context.OutputNodes.AddAll(graphBuilder.GetCreatedNodes(cancellationToken));
 
-                    transaction2.Complete();
+                    transaction.Complete();
+                }
+                else
+                {
+                    // If we have multiple queries (for example, when performing a search), first clear out the existing
+                    // results, then perform each query serially, updating the output nodes with the results of them.
+
+                    using (var transaction1 = new GraphTransactionScope())
+                    {
+                        // Remove any links that may have been added by a previous population. We don't
+                        // remove nodes to maintain node identity, matching the behavior of the old
+                        // providers.
+                        context.Graph.Links.Clear();
+                        transaction1.Complete();
+                    }
+
+                    foreach (var query in graphQueries)
+                    {
+                        var graphBuilder = await query.GetGraphAsync(solution, context, cancellationToken).ConfigureAwait(false);
+
+                        using var transaction2 = new GraphTransactionScope();
+
+                        graphBuilder.ApplyToGraph(context.Graph, cancellationToken);
+                        context.OutputNodes.AddAll(graphBuilder.GetCreatedNodes(cancellationToken));
+
+                        transaction2.Complete();
+                    }
                 }
             }
             catch (Exception ex) when (FatalError.ReportAndPropagateUnlessCanceled(ex, ErrorSeverity.Diagnostic))

--- a/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
@@ -48,6 +48,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                 asyncListener,
                 threadingContext.DisposalToken);
 
+            // Note: this ends up always listening for workspace events, even if we have no active 'live' queries that
+            // need updating.  But this should basically be practically no cost.  The queue just holds a single item
+            // indicating a change happened.  And when UpdateExistingQueriesAsync fires, it will just see that there are
+            // no live queries and immediately return.  So it's just simple to do things this way instead of trying to 
+            // have state management where we try to decide if we should listen or not.
             _workspace.WorkspaceChanged += (_, _) => _updateQueue.AddWork();
         }
 

--- a/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
@@ -25,7 +25,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
     internal class GraphQueryManager
     {
         private readonly Workspace _workspace;
-        private readonly IAsynchronousOperationListener _asyncListener;
 
         /// <summary>
         /// This gate locks manipulation of <see cref="_trackedQueries"/>.
@@ -41,7 +40,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             IAsynchronousOperationListener asyncListener)
         {
             _workspace = workspace;
-            _asyncListener = asyncListener;
 
             // Update any existing live/tracking queries 1.5 seconds after every workspace changes.
             _updateQueue = new AsyncBatchingWorkQueue(
@@ -55,7 +53,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
         public async Task AddQueriesAsync(IGraphContext context, ImmutableArray<IGraphQuery> graphQueries)
         {
-            using var asyncToken = _asyncListener.BeginAsyncOperation(nameof(AddQueriesAsync));
             try
             {
                 var solution = _workspace.CurrentSolution;

--- a/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
+++ b/src/VisualStudio/Core/Def/Progression/GraphQueryManager.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
                 if (_trackedQueries.IsEmpty)
                     _workspace.WorkspaceChanged += OnWorkspaceChanged;
 
-                _trackedQueries = _trackedQueries.Add(ValueTuple.Create(contextWeakReference, graphQueries));
+                _trackedQueries = _trackedQueries.Add((contextWeakReference, graphQueries));
             }
 
             EnqueueUpdateIfSolutionIsStale(solution);
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
 
         private Task UpdateAsync()
         {
-            ImmutableArray<ValueTuple<IGraphContext, ImmutableArray<IGraphQuery>>> liveQueries;
+            ImmutableArray<(IGraphContext, ImmutableArray<IGraphQuery>)> liveQueries;
             lock (_gate)
             {
                 liveQueries = _trackedQueries


### PR DESCRIPTION
Fixes [AB#1708110](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1708110)
Fixes [AB#1548520](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1548520)

THe core issue here is that solution-explorer cannot track nodes (and open/closed state) unless the entire content change happens in a single transaction.  This is how we used to update things until a perf change was made a while back for solution-explorer-search.  To speed up that search, we perform the search in two passes.  The first pass searches normal documents.  THe second pass generates SG documents and then searches those.  Because we needed the first pass to show up immediately (and not at the end), we broke things into two transactions, which broke solution-explorer-tracking.

The fix here is to go back to only having a single transaction in the case where we're just doing a normal solution-explorer symbol population.  For solution-explorer-search though, we continue having multiple transactions.  

There was also a lot of complexity and old patterns in this code.  It's been extensively cleaned up and moved to more modern patterns (like AsyncBatchingWorkQueue) to help the code out.