### PR TITLE
Handle compiler diagnostics reported in .cshtml files during build

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -206,9 +206,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 if (documentId != null)
                 {
                     // file doesn't exist in current solution
-                    var document = await project.Solution.GetDocumentAsync(
+                    var document = await project.Solution.GetTextDocumentAsync(
                         documentId,
-                        includeSourceGenerated: project.Solution.Services.GetService<ISolutionCrawlerOptionsService>()?.EnableDiagnosticsInSourceGeneratedFiles == true,
                         cancellationToken).ConfigureAwait(false);
 
                     if (document == null)

--- a/src/VisualStudio/Core/Def/TableDataSource/AbstractRoslynTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/TableDataSource/AbstractRoslynTableDataSource.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 
@@ -22,7 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
 
         protected ImmutableArray<DocumentId> GetDocumentsWithSameFilePath(Solution solution, DocumentId documentId)
         {
-            var document = solution.GetDocument(documentId);
+            var document = solution.GetTextDocument(documentId);
             if (document == null)
             {
                 return ImmutableArray<DocumentId>.Empty;

--- a/src/VisualStudio/Core/Def/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -797,6 +797,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                     return false;
                 }
 
+                // Compiler diagnostics reported on additional documents indicate mapped diagnostics, such as compiler diagnostics
+                // in razor files which are actually reported on generated source files but mapped to razor files during build.
+                // These are not reported on additional files during live analysis, and can be considered to be build-only diagnostics.
+                if (IsAdditionalDocumentDiagnostic(project, diagnosticData) &&
+                    diagnosticData.CustomTags.Contains(WellKnownDiagnosticTags.Compiler))
+                {
+                    return false;
+                }
+
                 if (IsSupportedLiveDiagnosticId(project, diagnosticData.Id))
                 {
                     return true;
@@ -834,6 +843,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                         (diagnosticData.DataLocation.UnmappedFileSpan.StartLinePosition.Line > 0 ||
                          diagnosticData.DataLocation.UnmappedFileSpan.StartLinePosition.Character > 0);
                 }
+
+                static bool IsAdditionalDocumentDiagnostic(Project project, DiagnosticData diagnosticData)
+                    => diagnosticData.DocumentId != null && project.ContainsAdditionalDocument(diagnosticData.DocumentId);
             }
 
             private bool IsSupportedLiveDiagnosticId(Project project, string id)


### PR DESCRIPTION
Fixes [AB#1511940](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1511940)

Compiler errors/warnings reported in .cshtml files during build were not being reported in the error list, but reported just in the output window if the .cshtml files were not open in VS. If the user opens these files in VS after the build, intellisense kicks in and reports these diagnostics on the generated .ide.g.cs files with a mapped location in the .cshtml files.

In order to ensure that these build diagnostics in .cshtml are reported in error list for closed .cshtml files, we now classify these as build-only additional file diagnostics. I also fixed couple of places in the code path where we were not handling diagnostics from build being reported on non-source text documents. I verified that after these fixes, the repro in the above feedback ticket is fixed.

One other alternative approach to fix this issue would be to not classify these .cshtml file diagnostics from build as build-only diagnostics, but instead perform the reverse secondary buffer mapping as done by `VisualStudioVenusSpanMappingService` here: https://github.com/dotnet/roslyn/blob/4298934df345f501fa0a74b675fab8efd8355709/src/VisualStudio/Core/Def/Diagnostics/VisualStudioVenusSpanMappingService.cs#L29-L31 and convert it to live diagnostic with primary location in the backing .ide.g.cs file and secondary mapped location in the .cshtml file, and this should ensure correct build-live diagnostic de-deduping. However, this seems to be non-trivial amount of work, and certainly not a bug fix level change. I'll let the razor team decide if they want to explore this route, and if so extend the `VisualStudioVenusSpanMappingService` to support this reverse mapping.

### Experience before fix
![CshtmlErrors_BeforeFix](https://user-images.githubusercontent.com/10605811/211781194-e29a68d8-5833-4fef-b53e-f211487a9027.gif)

### Experience after fix
![CshtmlErrors_AfterFix](https://user-images.githubusercontent.com/10605811/211781231-cc7173fa-11fb-4284-868e-27acb983e07c.gif)
