### PR TITLE
Improve our testing of DefaultAnalyzerAssemblyLoader

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp;
@@ -18,6 +19,14 @@ using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
+using Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE;
+#if NETCOREAPP
+using Roslyn.Test.Utilities.CoreClr;
+using System.Runtime.Loader;
+#else
+using Roslyn.Test.Utilities.Desktop;
+#endif
 
 namespace Microsoft.CodeAnalysis.UnitTests
 {
@@ -28,127 +37,195 @@ namespace Microsoft.CodeAnalysis.UnitTests
         private AssemblyLoadTestFixtureCollection() { }
     }
 
-    [Collection(AssemblyLoadTestFixtureCollection.Name)]
     public sealed class DefaultAnalyzerAssemblyLoaderTests : TestBase
     {
+#if NETCOREAPP
+        private sealed class AssemblyLoadContextInvokeUtil
+        {
+            public void Exec(string typeName, string methodName) => InvokeTestCode(typeName, methodName);
+        }
+#else
+        private sealed class AppDomainInvokeUtil : MarshalByRefObject
+        {
+            public void Exec(string typeName, string methodName) => InvokeTestCode(typeName, methodName);
+        }
+#endif
+
         private static readonly CSharpCompilationOptions s_dllWithMaxWarningLevel = new(OutputKind.DynamicallyLinkedLibrary, warningLevel: CodeAnalysis.Diagnostic.MaxWarningLevel);
         private readonly ITestOutputHelper _output;
-        private readonly AssemblyLoadTestFixture _testFixture;
-        public DefaultAnalyzerAssemblyLoaderTests(ITestOutputHelper output, AssemblyLoadTestFixture testFixture)
+
+        public DefaultAnalyzerAssemblyLoaderTests(ITestOutputHelper output)
         {
             _output = output;
-            _testFixture = testFixture;
+        }
+
+        private void Run(Action<DefaultAnalyzerAssemblyLoader, AssemblyLoadTestFixture> action, [CallerMemberName] string? memberName = null)
+        {
+#if NETCOREAPP
+            var alc = AssemblyLoadContextUtils.Create($"Test {memberName}");
+            var assembly = alc.LoadFromAssemblyName(typeof(AssemblyLoadContextInvokeUtil).Assembly.GetName());
+            var util = assembly.CreateInstance(typeof(AssemblyLoadContextInvokeUtil).FullName)!;
+            var method = util.GetType().GetMethod("Exec", BindingFlags.Public | BindingFlags.Instance)!;
+            method.Invoke(util, new object[] { action.Method.DeclaringType!.FullName!, action.Method.Name });
+
+#else
+            AppDomain? appDomain = null;
+            try
+            {
+                appDomain = AppDomainUtils.Create($"Test {memberName}");
+                var type = typeof(AppDomainInvokeUtil);
+                var util = (AppDomainInvokeUtil)appDomain.CreateInstanceAndUnwrap(type.Assembly.FullName, type.FullName);
+                util.Exec(action.Method.DeclaringType.FullName, action.Method.Name);
+            }
+            finally
+            {
+                AppDomain.Unload(appDomain);
+            }
+#endif
+        }
+
+        /// <summary>
+        /// This is called from our newly created AppDomain or AssemblyLoadContext and needs to get 
+        /// us back to the actual test code to execute. The intent is to invoke the lambda / static
+        /// local func where the code exists.
+        /// </summary>
+        private static void InvokeTestCode(string typeName, string methodName)
+        {
+            var type = typeof(DefaultAnalyzerAssemblyLoaderTests).Assembly.GetType(typeName, throwOnError: false)!;
+            var member = type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)!;
+
+            // A static lambda will still be an instance method so we need to create the closure
+            // here.
+            var obj = member.IsStatic
+                ? null
+                : type.Assembly.CreateInstance(typeName);
+
+            using var fixture = new AssemblyLoadTestFixture();
+            var loader = new DefaultAnalyzerAssemblyLoader();
+            member.Invoke(obj, new object[] { loader, fixture });
         }
 
         [Fact, WorkItem(32226, "https://github.com/dotnet/roslyn/issues/32226")]
         public void LoadWithDependency()
         {
-            var analyzerDependencyFile = _testFixture.AnalyzerDependency;
-            var analyzerMainFile = _testFixture.AnalyzerWithDependency;
-            var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(analyzerDependencyFile.Path);
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                var analyzerDependencyFile = testFixture.AnalyzerDependency;
+                var analyzerMainFile = testFixture.AnalyzerWithDependency;
+                loader.AddDependencyLocation(analyzerDependencyFile.Path);
 
-            var analyzerMainReference = new AnalyzerFileReference(analyzerMainFile.Path, loader);
-            analyzerMainReference.AnalyzerLoadFailed += (_, e) => AssertEx.Fail(e.Exception!.Message);
-            var analyzerDependencyReference = new AnalyzerFileReference(analyzerDependencyFile.Path, loader);
-            analyzerDependencyReference.AnalyzerLoadFailed += (_, e) => AssertEx.Fail(e.Exception!.Message);
+                var analyzerMainReference = new AnalyzerFileReference(analyzerMainFile.Path, loader);
+                analyzerMainReference.AnalyzerLoadFailed += (_, e) => AssertEx.Fail(e.Exception!.Message);
+                var analyzerDependencyReference = new AnalyzerFileReference(analyzerDependencyFile.Path, loader);
+                analyzerDependencyReference.AnalyzerLoadFailed += (_, e) => AssertEx.Fail(e.Exception!.Message);
 
-            var analyzers = analyzerMainReference.GetAnalyzersForAllLanguages();
-            Assert.Equal(1, analyzers.Length);
-            Assert.Equal("TestAnalyzer", analyzers[0].ToString());
+                var analyzers = analyzerMainReference.GetAnalyzersForAllLanguages();
+                Assert.Equal(1, analyzers.Length);
+                Assert.Equal("TestAnalyzer", analyzers[0].ToString());
 
-            Assert.Equal(0, analyzerDependencyReference.GetAnalyzersForAllLanguages().Length);
+                Assert.Equal(0, analyzerDependencyReference.GetAnalyzersForAllLanguages().Length);
 
-            Assert.NotNull(analyzerDependencyReference.GetAssembly());
+                Assert.NotNull(analyzerDependencyReference.GetAssembly());
+            });
         }
 
         [Fact]
         public void AddDependencyLocationThrowsOnNull()
         {
-            var loader = new DefaultAnalyzerAssemblyLoader();
-
-            Assert.Throws<ArgumentNullException>("fullPath", () => loader.AddDependencyLocation(null!));
-            Assert.Throws<ArgumentException>("fullPath", () => loader.AddDependencyLocation("a"));
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                Assert.Throws<ArgumentNullException>("fullPath", () => loader.AddDependencyLocation(null!));
+                Assert.Throws<ArgumentException>("fullPath", () => loader.AddDependencyLocation("a"));
+            });
         }
 
         [Fact]
         public void ThrowsForMissingFile()
         {
-            var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".dll");
-
-            var loader = new DefaultAnalyzerAssemblyLoader();
-
-            Assert.ThrowsAny<Exception>(() => loader.LoadFromPath(path));
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".dll");
+                Assert.ThrowsAny<Exception>(() => loader.LoadFromPath(path));
+            });
         }
 
         [Fact]
         public void BasicLoad()
         {
-            var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(_testFixture.Alpha.Path);
-            Assembly alpha = loader.LoadFromPath(_testFixture.Alpha.Path);
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                loader.AddDependencyLocation(testFixture.Alpha.Path);
+                Assembly alpha = loader.LoadFromPath(testFixture.Alpha.Path);
 
-            Assert.NotNull(alpha);
+                Assert.NotNull(alpha);
+            });
         }
 
         [Fact]
         public void AssemblyLoading()
         {
-            StringBuilder sb = new StringBuilder();
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                StringBuilder sb = new StringBuilder();
 
-            var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(_testFixture.Alpha.Path);
-            loader.AddDependencyLocation(_testFixture.Beta.Path);
-            loader.AddDependencyLocation(_testFixture.Gamma.Path);
-            loader.AddDependencyLocation(_testFixture.Delta1.Path);
+                loader.AddDependencyLocation(testFixture.Alpha.Path);
+                loader.AddDependencyLocation(testFixture.Beta.Path);
+                loader.AddDependencyLocation(testFixture.Gamma.Path);
+                loader.AddDependencyLocation(testFixture.Delta1.Path);
 
-            Assembly alpha = loader.LoadFromPath(_testFixture.Alpha.Path);
+                Assembly alpha = loader.LoadFromPath(testFixture.Alpha.Path);
 
-            var a = alpha.CreateInstance("Alpha.A")!;
-            a.GetType().GetMethod("Write")!.Invoke(a, new object[] { sb, "Test A" });
+                var a = alpha.CreateInstance("Alpha.A")!;
+                a.GetType().GetMethod("Write")!.Invoke(a, new object[] { sb, "Test A" });
 
-            Assembly beta = loader.LoadFromPath(_testFixture.Beta.Path);
+                Assembly beta = loader.LoadFromPath(testFixture.Beta.Path);
 
-            var b = beta.CreateInstance("Beta.B")!;
-            b.GetType().GetMethod("Write")!.Invoke(b, new object[] { sb, "Test B" });
+                var b = beta.CreateInstance("Beta.B")!;
+                b.GetType().GetMethod("Write")!.Invoke(b, new object[] { sb, "Test B" });
 
-            var expected = @"Delta: Gamma: Alpha: Test A
+                var expected = @"Delta: Gamma: Alpha: Test A
 Delta: Gamma: Beta: Test B
 ";
 
-            var actual = sb.ToString();
+                var actual = sb.ToString();
 
-            Assert.Equal(expected, actual);
+                Assert.Equal(expected, actual);
+            });
         }
 
         [ConditionalFact(typeof(CoreClrOnly))]
         public void AssemblyLoading_AssemblyLocationNotAdded()
         {
-            var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(_testFixture.Gamma.Path);
-            loader.AddDependencyLocation(_testFixture.Delta1.Path);
-            Assert.Throws<FileNotFoundException>(() => loader.LoadFromPath(_testFixture.Beta.Path));
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                loader.AddDependencyLocation(testFixture.Gamma.Path);
+                loader.AddDependencyLocation(testFixture.Delta1.Path);
+                Assert.Throws<InvalidOperationException>(() => loader.LoadFromPath(testFixture.Beta.Path));
+            });
         }
 
         [ConditionalFact(typeof(CoreClrOnly))]
         public void AssemblyLoading_DependencyLocationNotAdded()
         {
-            StringBuilder sb = new StringBuilder();
-            var loader = new DefaultAnalyzerAssemblyLoader();
-            // We don't pass Alpha's path to AddDependencyLocation here, and therefore expect
-            // calling Beta.B.Write to fail.
-            loader.AddDependencyLocation(_testFixture.Gamma.Path);
-            loader.AddDependencyLocation(_testFixture.Beta.Path);
-            Assembly beta = loader.LoadFromPath(_testFixture.Beta.Path);
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                StringBuilder sb = new StringBuilder();
 
-            var b = beta.CreateInstance("Beta.B")!;
-            var writeMethod = b.GetType().GetMethod("Write")!;
-            var exception = Assert.Throws<TargetInvocationException>(
-                () => writeMethod.Invoke(b, new object[] { sb, "Test B" }));
-            Assert.IsAssignableFrom<FileNotFoundException>(exception.InnerException);
+                // We don't pass Alpha's path to AddDependencyLocation here, and therefore expect
+                // calling Beta.B.Write to fail.
+                loader.AddDependencyLocation(testFixture.Gamma.Path);
+                loader.AddDependencyLocation(testFixture.Beta.Path);
+                Assembly beta = loader.LoadFromPath(testFixture.Beta.Path);
 
-            var actual = sb.ToString();
-            Assert.Equal(@"", actual);
+                var b = beta.CreateInstance("Beta.B")!;
+                var writeMethod = b.GetType().GetMethod("Write")!;
+                var exception = Assert.Throws<TargetInvocationException>(
+                    () => writeMethod.Invoke(b, new object[] { sb, "Test B" }));
+                Assert.IsAssignableFrom<FileNotFoundException>(exception.InnerException);
+
+                var actual = sb.ToString();
+                Assert.Equal(@"", actual);
+            });
         }
 
         private static void VerifyAssemblies(IEnumerable<Assembly> assemblies, params (string simpleName, string version, string path)[] expected)
@@ -159,511 +236,651 @@ Delta: Gamma: Beta: Test B
         [ConditionalFact(typeof(CoreClrOnly))]
         public void AssemblyLoading_DependencyInDifferentDirectory()
         {
-            StringBuilder sb = new StringBuilder();
-            var loader = new DefaultAnalyzerAssemblyLoader();
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                using var temp = new TempRoot();
+                StringBuilder sb = new StringBuilder();
 
-            var tempDir = Temp.CreateDirectory();
+                var deltaFile = temp.CreateDirectory().CreateFile("Delta.dll").CopyContentFrom(testFixture.Delta1.Path);
+                var gammaFile = temp.CreateDirectory().CreateFile("Gamma.dll").CopyContentFrom(testFixture.Gamma.Path);
 
-            var deltaFile = tempDir.CreateFile("Delta.dll").CopyContentFrom(_testFixture.Delta1.Path);
-            loader.AddDependencyLocation(deltaFile.Path);
-            loader.AddDependencyLocation(_testFixture.Gamma.Path);
-            Assembly gamma = loader.LoadFromPath(_testFixture.Gamma.Path);
+                loader.AddDependencyLocation(deltaFile.Path);
+                loader.AddDependencyLocation(gammaFile.Path);
+                Assembly gamma = loader.LoadFromPath(gammaFile.Path);
 
-            var b = gamma.CreateInstance("Gamma.G")!;
-            var writeMethod = b.GetType().GetMethod("Write")!;
-            writeMethod.Invoke(b, new object[] { sb, "Test G" });
+                var b = gamma.CreateInstance("Gamma.G")!;
+                var writeMethod = b.GetType().GetMethod("Write")!;
+                writeMethod.Invoke(b, new object[] { sb, "Test G" });
 
-            var actual = sb.ToString();
-            Assert.Equal(@"Delta: Gamma: Test G
+                var actual = sb.ToString();
+                Assert.Equal(@"Delta: Gamma: Test G
 ", actual);
 
 #if NETCOREAPP
-            var alcs = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader);
-            Assert.Equal(1, alcs.Length);
 
-            VerifyAssemblies(
-                alcs[0].Assemblies,
-                ("Delta", "1.0.0.0", deltaFile.Path),
-                ("Gamma", "0.0.0.0", _testFixture.Gamma.Path)
-            );
+                var alcs = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader);
+                Assert.Equal(1, alcs.Length);
+
+                VerifyAssemblies(
+                    alcs[0].Assemblies,
+                    ("Delta", "1.0.0.0", deltaFile.Path),
+                    ("Gamma", "0.0.0.0", gammaFile.Path)
+                );
+
 #endif
+            });
+        }
+
+        /// <summary>
+        /// Similar to <see cref="AssemblyLoading_DependencyInDifferentDirectory"/> except want to validate
+        /// a dependency in the same directory is preferred over one in a different directory.
+        /// </summary>
+        [Fact]
+        public void AssemblyLoading_DependencyInDifferentDirectory2()
+        {
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                using var temp = new TempRoot();
+                StringBuilder sb = new StringBuilder();
+
+                var deltaFile1 = temp.CreateDirectory().CreateFile("Delta.dll").CopyContentFrom(testFixture.Delta1.Path);
+                var tempDir = temp.CreateDirectory();
+                var gammaFile = tempDir.CreateFile("Gamma.dll").CopyContentFrom(testFixture.Gamma.Path);
+                var deltaFile2 = tempDir.CreateFile("Delta.dll").CopyContentFrom(testFixture.Delta1.Path);
+
+                loader.AddDependencyLocation(deltaFile1.Path);
+                loader.AddDependencyLocation(deltaFile2.Path);
+                loader.AddDependencyLocation(gammaFile.Path);
+                Assembly gamma = loader.LoadFromPath(gammaFile.Path);
+
+                var b = gamma.CreateInstance("Gamma.G")!;
+                var writeMethod = b.GetType().GetMethod("Write")!;
+                writeMethod.Invoke(b, new object[] { sb, "Test G" });
+
+                var actual = sb.ToString();
+                Assert.Equal(@"Delta: Gamma: Test G
+", actual);
+
+#if NETCOREAPP
+
+                var alcs = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader);
+                Assert.Equal(1, alcs.Length);
+
+                VerifyAssemblies(
+                    alcs[0].Assemblies,
+                    ("Delta", "1.0.0.0", deltaFile2.Path),
+                    ("Gamma", "0.0.0.0", gammaFile.Path)
+                );
+
+#endif
+            });
+        }
+
+        /// <summary>
+        /// This is very similar to <see cref="AssemblyLoading_DependencyInDifferentDirectory2"/> except 
+        /// that we ensure the code does not prefer a dependency in the same directory if it's 
+        /// unregistered
+        /// </summary>
+        [Fact]
+        public void AssemblyLoading_DependencyInDifferentDirectory3()
+        {
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                using var temp = new TempRoot();
+                StringBuilder sb = new StringBuilder();
+
+                var deltaFile = temp.CreateDirectory().CreateFile("Delta.dll").CopyContentFrom(testFixture.Delta1.Path);
+                var gammaFile = temp.CreateDirectory().CreateFile("Gamma.dll").CopyContentFrom(testFixture.Gamma.Path);
+
+                loader.AddDependencyLocation(deltaFile.Path);
+                loader.AddDependencyLocation(gammaFile.Path);
+                Assembly gamma = loader.LoadFromPath(gammaFile.Path);
+
+                var b = gamma.CreateInstance("Gamma.G")!;
+                var writeMethod = b.GetType().GetMethod("Write")!;
+                writeMethod.Invoke(b, new object[] { sb, "Test G" });
+
+                var actual = sb.ToString();
+                Assert.Equal(@"Delta: Gamma: Test G
+", actual);
+
+#if NETCOREAPP
+                var alcs = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader);
+                Assert.Equal(1, alcs.Length);
+
+                VerifyAssemblies(
+                    alcs[0].Assemblies,
+                    ("Delta", "1.0.0.0", deltaFile.Path),
+                    ("Gamma", "0.0.0.0", gammaFile.Path)
+                );
+
+#endif
+            });
         }
 
         [Fact]
         public void AssemblyLoading_MultipleVersions()
         {
-            StringBuilder sb = new StringBuilder();
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                StringBuilder sb = new StringBuilder();
 
-            var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(_testFixture.Gamma.Path);
-            loader.AddDependencyLocation(_testFixture.Delta1.Path);
-            loader.AddDependencyLocation(_testFixture.Epsilon.Path);
-            loader.AddDependencyLocation(_testFixture.Delta2.Path);
+                loader.AddDependencyLocation(testFixture.Gamma.Path);
+                loader.AddDependencyLocation(testFixture.Delta1.Path);
+                loader.AddDependencyLocation(testFixture.Epsilon.Path);
+                loader.AddDependencyLocation(testFixture.Delta2.Path);
 
-            Assembly gamma = loader.LoadFromPath(_testFixture.Gamma.Path);
-            var g = gamma.CreateInstance("Gamma.G")!;
-            g.GetType().GetMethod("Write")!.Invoke(g, new object[] { sb, "Test G" });
+                Assembly gamma = loader.LoadFromPath(testFixture.Gamma.Path);
+                var g = gamma.CreateInstance("Gamma.G")!;
+                g.GetType().GetMethod("Write")!.Invoke(g, new object[] { sb, "Test G" });
 
-            Assembly epsilon = loader.LoadFromPath(_testFixture.Epsilon.Path);
-            var e = epsilon.CreateInstance("Epsilon.E")!;
-            e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
+                Assembly epsilon = loader.LoadFromPath(testFixture.Epsilon.Path);
+                var e = epsilon.CreateInstance("Epsilon.E")!;
+                e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
 
 #if NETCOREAPP
-            var alcs = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader);
-            Assert.Equal(2, alcs.Length);
+                var alcs = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader);
+                Assert.Equal(2, alcs.Length);
 
-            VerifyAssemblies(
-                alcs[0].Assemblies,
-                ("Delta", "1.0.0.0", _testFixture.Delta1.Path),
-                ("Gamma", "0.0.0.0", _testFixture.Gamma.Path)
-            );
+                VerifyAssemblies(
+                    alcs[0].Assemblies,
+                    ("Delta", "1.0.0.0", testFixture.Delta1.Path),
+                    ("Gamma", "0.0.0.0", testFixture.Gamma.Path)
+                );
 
-            VerifyAssemblies(
-                alcs[1].Assemblies,
-                ("Delta", "2.0.0.0", _testFixture.Delta2.Path),
-                ("Epsilon", "0.0.0.0", _testFixture.Epsilon.Path));
+                VerifyAssemblies(
+                    alcs[1].Assemblies,
+                    ("Delta", "2.0.0.0", testFixture.Delta2.Path),
+                    ("Epsilon", "0.0.0.0", testFixture.Epsilon.Path));
 #endif
 
-            var actual = sb.ToString();
-            if (ExecutionConditionUtil.IsCoreClr)
-            {
-                Assert.Equal(
-@"Delta: Gamma: Test G
+                var actual = sb.ToString();
+                if (ExecutionConditionUtil.IsCoreClr)
+                {
+                    Assert.Equal(
+    @"Delta: Gamma: Test G
 Delta.2: Epsilon: Test E
 ",
-                    actual);
-            }
-            else
-            {
-                Assert.Equal(
-@"Delta: Gamma: Test G
+                        actual);
+                }
+                else
+                {
+                    Assert.Equal(
+    @"Delta: Gamma: Test G
 Delta: Epsilon: Test E
 ",
-                    actual);
-            }
+                        actual);
+                }
+            });
         }
 
         [Fact]
         public void AssemblyLoading_MultipleVersions_NoExactMatch()
         {
-            StringBuilder sb = new StringBuilder();
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                StringBuilder sb = new StringBuilder();
 
-            var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(_testFixture.Delta1.Path);
-            loader.AddDependencyLocation(_testFixture.Epsilon.Path);
-            loader.AddDependencyLocation(_testFixture.Delta3.Path);
+                loader.AddDependencyLocation(testFixture.Delta1.Path);
+                loader.AddDependencyLocation(testFixture.Epsilon.Path);
+                loader.AddDependencyLocation(testFixture.Delta3.Path);
 
-            Assembly epsilon = loader.LoadFromPath(_testFixture.Epsilon.Path);
-            var e = epsilon.CreateInstance("Epsilon.E")!;
-            e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
+                Assembly epsilon = loader.LoadFromPath(testFixture.Epsilon.Path);
+                var e = epsilon.CreateInstance("Epsilon.E")!;
+                e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
 
 #if NETCOREAPP
-            var alcs = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader);
-            Assert.Equal(1, alcs.Length);
+                var alcs = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader);
+                Assert.Equal(1, alcs.Length);
 
-            VerifyAssemblies(
-                alcs[0].Assemblies,
-                ("Delta", "3.0.0.0", _testFixture.Delta3.Path),
-                ("Epsilon", "0.0.0.0", _testFixture.Epsilon.Path));
+                VerifyAssemblies(
+                    alcs[0].Assemblies,
+                    ("Delta", "3.0.0.0", testFixture.Delta3.Path),
+                    ("Epsilon", "0.0.0.0", testFixture.Epsilon.Path));
 #endif
 
-            var actual = sb.ToString();
-            if (ExecutionConditionUtil.IsCoreClr)
-            {
-                Assert.Equal(
-@"Delta.3: Epsilon: Test E
+                var actual = sb.ToString();
+                if (ExecutionConditionUtil.IsCoreClr)
+                {
+                    Assert.Equal(
+    @"Delta.3: Epsilon: Test E
 ",
-                    actual);
-            }
-            else
-            {
-                Assert.Equal(
-@"Delta: Epsilon: Test E
+                        actual);
+                }
+                else
+                {
+                    Assert.Equal(
+    @"Delta: Epsilon: Test E
 ",
-                    actual);
-            }
+                        actual);
+                }
+            });
         }
 
         [Fact]
         public void AssemblyLoading_MultipleVersions_MultipleEqualMatches()
         {
-            StringBuilder sb = new StringBuilder();
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                StringBuilder sb = new StringBuilder();
 
-            // Delta2B and Delta2 have the same version, but we prefer Delta2 because it's in the same directory as Epsilon.
-            var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(_testFixture.Delta2B.Path);
-            loader.AddDependencyLocation(_testFixture.Delta2.Path);
-            loader.AddDependencyLocation(_testFixture.Epsilon.Path);
+                // Delta2B and Delta2 have the same version, but we prefer Delta2 because it's in the same directory as Epsilon.
+                loader.AddDependencyLocation(testFixture.Delta2B.Path);
+                loader.AddDependencyLocation(testFixture.Delta2.Path);
+                loader.AddDependencyLocation(testFixture.Epsilon.Path);
 
-            Assembly epsilon = loader.LoadFromPath(_testFixture.Epsilon.Path);
-            var e = epsilon.CreateInstance("Epsilon.E")!;
-            e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
+                Assembly epsilon = loader.LoadFromPath(testFixture.Epsilon.Path);
+                var e = epsilon.CreateInstance("Epsilon.E")!;
+                e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
 
 #if NETCOREAPP
-            var alcs = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader);
-            Assert.Equal(1, alcs.Length);
+                var alcs = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader);
+                Assert.Equal(1, alcs.Length);
 
-            VerifyAssemblies(
-                alcs[0].Assemblies,
-                ("Delta", "2.0.0.0", _testFixture.Delta2.Path),
-                ("Epsilon", "0.0.0.0", _testFixture.Epsilon.Path));
+                VerifyAssemblies(
+                    alcs[0].Assemblies,
+                    ("Delta", "2.0.0.0", testFixture.Delta2.Path),
+                    ("Epsilon", "0.0.0.0", testFixture.Epsilon.Path));
 #endif
 
-            var actual = sb.ToString();
-            if (ExecutionConditionUtil.IsCoreClr)
-            {
-                Assert.Equal(
-@"Delta.2: Epsilon: Test E
+                var actual = sb.ToString();
+                if (ExecutionConditionUtil.IsCoreClr)
+                {
+                    Assert.Equal(
+    @"Delta.2: Epsilon: Test E
 ",
-                    actual);
-            }
-            else
-            {
-                Assert.Equal(
-@"Delta: Epsilon: Test E
+                        actual);
+                }
+                else
+                {
+                    Assert.Equal(
+    @"Delta: Epsilon: Test E
 ",
-                    actual);
-            }
+                        actual);
+                }
+            });
         }
 
         [Fact]
         public void AssemblyLoading_MultipleVersions_MultipleVersionsOfSameAnalyzerItself()
         {
-            StringBuilder sb = new StringBuilder();
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                StringBuilder sb = new StringBuilder();
 
-            var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(_testFixture.Delta2.Path);
-            loader.AddDependencyLocation(_testFixture.Delta2B.Path);
+                loader.AddDependencyLocation(testFixture.Delta2.Path);
+                loader.AddDependencyLocation(testFixture.Delta2B.Path);
 
-            Assembly delta2 = loader.LoadFromPath(_testFixture.Delta2.Path);
-            Assembly delta2B = loader.LoadFromPath(_testFixture.Delta2B.Path);
+                Assembly delta2 = loader.LoadFromPath(testFixture.Delta2.Path);
+                Assembly delta2B = loader.LoadFromPath(testFixture.Delta2B.Path);
 
-            // 2B or not 2B? That is the question...that depends on whether we're on .NET Core or not.
+                // 2B or not 2B? That is the question...that depends on whether we're on .NET Core or not.
 
 #if NETCOREAPP
 
-            // On Core, we're able to load both of these into separate AssemblyLoadContexts.
-            Assert.NotEqual(delta2B.Location, delta2.Location);
-            Assert.Equal(_testFixture.Delta2.Path, delta2.Location);
-            Assert.Equal(_testFixture.Delta2B.Path, delta2B.Location);
+                // On Core, we're able to load both of these into separate AssemblyLoadContexts.
+                Assert.NotEqual(delta2B.Location, delta2.Location);
+                Assert.Equal(testFixture.Delta2.Path, delta2.Location);
+                Assert.Equal(testFixture.Delta2B.Path, delta2B.Location);
 
 #else
 
-            // In non-core, we cache by assembly identity; since we don't use multiple AppDomains we have no
-            // way to load different assemblies with the same identity, no matter what. Thus, we'll get the
-            // same assembly for both of these.
-            Assert.Same(delta2B, delta2);
+                // In non-core, we cache by assembly identity; since we don't use multiple AppDomains we have no
+                // way to load different assemblies with the same identity, no matter what. Thus, we'll get the
+                // same assembly for both of these.
+                Assert.Same(delta2B, delta2);
 #endif
+            });
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/60763")]
         public void AssemblyLoading_MultipleVersions_ExactAndGreaterMatch()
         {
-            StringBuilder sb = new StringBuilder();
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                StringBuilder sb = new StringBuilder();
 
-            var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(_testFixture.Delta2B.Path);
-            loader.AddDependencyLocation(_testFixture.Delta3.Path);
-            loader.AddDependencyLocation(_testFixture.Epsilon.Path);
+                loader.AddDependencyLocation(testFixture.Delta2B.Path);
+                loader.AddDependencyLocation(testFixture.Delta3.Path);
+                loader.AddDependencyLocation(testFixture.Epsilon.Path);
 
-            Assembly epsilon = loader.LoadFromPath(_testFixture.Epsilon.Path);
-            var e = epsilon.CreateInstance("Epsilon.E")!;
-            e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
+                Assembly epsilon = loader.LoadFromPath(testFixture.Epsilon.Path);
+                var e = epsilon.CreateInstance("Epsilon.E")!;
+                e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
 
 #if NETCOREAPP
-            var alcs = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader);
-            Assert.Equal(1, alcs.Length);
+                var alcs = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader);
+                Assert.Equal(1, alcs.Length);
 
-            VerifyAssemblies(
-                alcs[0].Assemblies,
-                ("Delta", "2.0.0.0", _testFixture.Delta2B.Path),
-                ("Epsilon", "0.0.0.0", _testFixture.Epsilon.Path));
+                VerifyAssemblies(
+                    alcs[0].Assemblies,
+                    ("Delta", "2.0.0.0", testFixture.Delta2B.Path),
+                    ("Epsilon", "0.0.0.0", testFixture.Epsilon.Path));
 #endif
 
-            var actual = sb.ToString();
-            if (ExecutionConditionUtil.IsCoreClr)
-            {
-                Assert.Equal(
-@"Delta.2B: Epsilon: Test E
+                var actual = sb.ToString();
+                if (ExecutionConditionUtil.IsCoreClr)
+                {
+                    Assert.Equal(
+    @"Delta.2B: Epsilon: Test E
 ",
-                    actual);
-            }
-            else
-            {
-                Assert.Equal(
-@"Delta: Epsilon: Test E
+                        actual);
+                }
+                else
+                {
+                    Assert.Equal(
+    @"Delta: Epsilon: Test E
 ",
-                    actual);
-            }
+                        actual);
+                }
+            });
         }
 
         [Fact]
         public void AssemblyLoading_MultipleVersions_WorseMatchInSameDirectory()
         {
-            StringBuilder sb = new StringBuilder();
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                using var temp = new TempRoot();
+                StringBuilder sb = new StringBuilder();
 
-            var tempDir = Temp.CreateDirectory();
-            var epsilonFile = tempDir.CreateFile("Epsilon.dll").CopyContentFrom(_testFixture.Epsilon.Path);
-            var delta1File = tempDir.CreateFile("Delta.dll").CopyContentFrom(_testFixture.Delta1.Path);
+                var tempDir = temp.CreateDirectory();
+                var epsilonFile = tempDir.CreateFile("Epsilon.dll").CopyContentFrom(testFixture.Epsilon.Path);
+                var delta1File = tempDir.CreateFile("Delta.dll").CopyContentFrom(testFixture.Delta1.Path);
 
-            // Epsilon wants Delta2, but since Delta1 is in the same directory, we prefer Delta1 over Delta2.
-            // This is because the CLR will see it first and load it, without giving us any chance to redirect
-            // in the AssemblyResolve hook.
-            var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(delta1File.Path);
-            loader.AddDependencyLocation(_testFixture.Delta2.Path);
-            loader.AddDependencyLocation(epsilonFile.Path);
+                // Epsilon wants Delta2, but since Delta1 is in the same directory, we prefer Delta1 over Delta2.
+                // This is because the CLR will see it first and load it, without giving us any chance to redirect
+                // in the AssemblyResolve hook.
+                loader.AddDependencyLocation(delta1File.Path);
+                loader.AddDependencyLocation(testFixture.Delta2.Path);
+                loader.AddDependencyLocation(epsilonFile.Path);
 
-            Assembly epsilon = loader.LoadFromPath(epsilonFile.Path);
-            var e = epsilon.CreateInstance("Epsilon.E")!;
-            e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
+                Assembly epsilon = loader.LoadFromPath(epsilonFile.Path);
+                var e = epsilon.CreateInstance("Epsilon.E")!;
+                e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
 
 #if NETCOREAPP
-            var alcs = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader);
-            Assert.Equal(1, alcs.Length);
+                var alcs = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader);
+                Assert.Equal(1, alcs.Length);
 
-            VerifyAssemblies(
-                alcs[0].Assemblies,
-                ("Delta", "1.0.0.0", delta1File.Path),
-                ("Epsilon", "0.0.0.0", epsilonFile.Path));
+                VerifyAssemblies(
+                    alcs[0].Assemblies,
+                    ("Delta", "1.0.0.0", delta1File.Path),
+                    ("Epsilon", "0.0.0.0", epsilonFile.Path));
 #endif
 
-            var actual = sb.ToString();
-            Assert.Equal(
-@"Delta: Epsilon: Test E
+                var actual = sb.ToString();
+                Assert.Equal(
+    @"Delta: Epsilon: Test E
 ",
-                actual);
+                    actual);
+            });
         }
 
         [Fact]
         public void AssemblyLoading_MultipleVersions_MultipleLoaders()
         {
-            StringBuilder sb = new StringBuilder();
+            Run(static (DefaultAnalyzerAssemblyLoader loader1, AssemblyLoadTestFixture testFixture) =>
+            {
+                StringBuilder sb = new StringBuilder();
 
-            var loader1 = new DefaultAnalyzerAssemblyLoader();
-            loader1.AddDependencyLocation(_testFixture.Gamma.Path);
-            loader1.AddDependencyLocation(_testFixture.Delta1.Path);
+                loader1.AddDependencyLocation(testFixture.Gamma.Path);
+                loader1.AddDependencyLocation(testFixture.Delta1.Path);
 
-            var loader2 = new DefaultAnalyzerAssemblyLoader();
-            loader2.AddDependencyLocation(_testFixture.Epsilon.Path);
-            loader2.AddDependencyLocation(_testFixture.Delta2.Path);
+                var loader2 = new DefaultAnalyzerAssemblyLoader();
+                loader2.AddDependencyLocation(testFixture.Epsilon.Path);
+                loader2.AddDependencyLocation(testFixture.Delta2.Path);
 
-            Assembly gamma = loader1.LoadFromPath(_testFixture.Gamma.Path);
-            var g = gamma.CreateInstance("Gamma.G")!;
-            g.GetType().GetMethod("Write")!.Invoke(g, new object[] { sb, "Test G" });
+                Assembly gamma = loader1.LoadFromPath(testFixture.Gamma.Path);
+                var g = gamma.CreateInstance("Gamma.G")!;
+                g.GetType().GetMethod("Write")!.Invoke(g, new object[] { sb, "Test G" });
 
-            Assembly epsilon = loader2.LoadFromPath(_testFixture.Epsilon.Path);
-            var e = epsilon.CreateInstance("Epsilon.E")!;
-            e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
+                Assembly epsilon = loader2.LoadFromPath(testFixture.Epsilon.Path);
+                var e = epsilon.CreateInstance("Epsilon.E")!;
+                e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
 
 #if NETCOREAPP
-            var alcs1 = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader1);
-            Assert.Equal(1, alcs1.Length);
+                var alcs1 = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader1);
+                Assert.Equal(1, alcs1.Length);
 
-            VerifyAssemblies(
-                alcs1[0].Assemblies,
-                ("Delta", "1.0.0.0", _testFixture.Delta1.Path),
-                ("Gamma", "0.0.0.0", _testFixture.Gamma.Path));
+                VerifyAssemblies(
+                    alcs1[0].Assemblies,
+                    ("Delta", "1.0.0.0", testFixture.Delta1.Path),
+                    ("Gamma", "0.0.0.0", testFixture.Gamma.Path));
 
-            var alcs2 = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader2);
-            Assert.Equal(1, alcs2.Length);
+                var alcs2 = DefaultAnalyzerAssemblyLoader.TestAccessor.GetOrderedLoadContexts(loader2);
+                Assert.Equal(1, alcs2.Length);
 
-            VerifyAssemblies(
-                alcs2[0].Assemblies,
-                ("Delta", "2.0.0.0", _testFixture.Delta2.Path),
-                ("Epsilon", "0.0.0.0", _testFixture.Epsilon.Path));
+                VerifyAssemblies(
+                    alcs2[0].Assemblies,
+                    ("Delta", "2.0.0.0", testFixture.Delta2.Path),
+                    ("Epsilon", "0.0.0.0", testFixture.Epsilon.Path));
 #endif
 
-            var actual = sb.ToString();
-            if (ExecutionConditionUtil.IsCoreClr)
-            {
-                Assert.Equal(
-@"Delta: Gamma: Test G
+                var actual = sb.ToString();
+                if (ExecutionConditionUtil.IsCoreClr)
+                {
+                    Assert.Equal(
+    @"Delta: Gamma: Test G
 Delta.2: Epsilon: Test E
 ",
-                    actual);
-            }
-            else
-            {
-                Assert.Equal(
-@"Delta: Gamma: Test G
+                        actual);
+                }
+                else
+                {
+                    Assert.Equal(
+    @"Delta: Gamma: Test G
 Delta: Epsilon: Test E
 ",
-                    actual);
-            }
+                        actual);
+                }
+            });
         }
 
         [Fact]
         public void AssemblyLoading_MultipleVersions_MissingVersion()
         {
-            StringBuilder sb = new StringBuilder();
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                StringBuilder sb = new StringBuilder();
 
-            var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(_testFixture.Gamma.Path);
-            loader.AddDependencyLocation(_testFixture.Delta1.Path);
-            loader.AddDependencyLocation(_testFixture.Epsilon.Path);
+                loader.AddDependencyLocation(testFixture.Gamma.Path);
+                loader.AddDependencyLocation(testFixture.Delta1.Path);
+                loader.AddDependencyLocation(testFixture.Epsilon.Path);
 
-            Assembly gamma = loader.LoadFromPath(_testFixture.Gamma.Path);
-            var g = gamma.CreateInstance("Gamma.G")!;
-            g.GetType().GetMethod("Write")!.Invoke(g, new object[] { sb, "Test G" });
+                Assembly gamma = loader.LoadFromPath(testFixture.Gamma.Path);
+                var g = gamma.CreateInstance("Gamma.G")!;
+                g.GetType().GetMethod("Write")!.Invoke(g, new object[] { sb, "Test G" });
 
-            Assembly epsilon = loader.LoadFromPath(_testFixture.Epsilon.Path);
-            var e = epsilon.CreateInstance("Epsilon.E")!;
-            var eWrite = e.GetType().GetMethod("Write")!;
+                Assembly epsilon = loader.LoadFromPath(testFixture.Epsilon.Path);
+                var e = epsilon.CreateInstance("Epsilon.E")!;
+                var eWrite = e.GetType().GetMethod("Write")!;
 
-            var actual = sb.ToString();
-            eWrite.Invoke(e, new object[] { sb, "Test E" });
-            Assert.Equal(
-@"Delta: Gamma: Test G
+                var actual = sb.ToString();
+                eWrite.Invoke(e, new object[] { sb, "Test E" });
+                Assert.Equal(
+    @"Delta: Gamma: Test G
 ",
-                actual);
+                    actual);
+            });
         }
 
         [Fact]
         public void AssemblyLoading_UnifyToHighest()
         {
-            var sb = new StringBuilder();
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                var sb = new StringBuilder();
 
-            var loader = new DefaultAnalyzerAssemblyLoader();
+                // Gamma depends on Delta v1, and Epsilon depends on Delta v2. But both should load
+                // and both use Delta v2. We intentionally here are not adding a reference to Delta1, since
+                // this test is testing what happens if it's not present. A simple example for this scenario
+                // is an analyzer that depends on both Gamma and Epsilon; an analyzer package can't reasonably
+                // package both Delta v1 and Delta v2, so it'll only package the highest and things should work.
+                loader.AddDependencyLocation(testFixture.GammaReferencingPublicSigned.Path);
+                loader.AddDependencyLocation(testFixture.EpsilonReferencingPublicSigned.Path);
+                loader.AddDependencyLocation(testFixture.DeltaPublicSigned2.Path);
 
-            // Gamma depends on Delta v1, and Epsilon depends on Delta v2. But both should load
-            // and both use Delta v2. We intentionally here are not adding a reference to Delta1, since
-            // this test is testing what happens if it's not present. A simple example for this scenario
-            // is an analyzer that depends on both Gamma and Epsilon; an analyzer package can't reasonably
-            // package both Delta v1 and Delta v2, so it'll only package the highest and things should work.
-            loader.AddDependencyLocation(_testFixture.GammaReferencingPublicSigned.Path);
-            loader.AddDependencyLocation(_testFixture.EpsilonReferencingPublicSigned.Path);
-            loader.AddDependencyLocation(_testFixture.DeltaPublicSigned2.Path);
+                var gamma = loader.LoadFromPath(testFixture.GammaReferencingPublicSigned.Path);
+                var g = gamma.CreateInstance("Gamma.G")!;
+                g.GetType().GetMethod("Write")!.Invoke(g, new object[] { sb, "Test G" });
 
-            var gamma = loader.LoadFromPath(_testFixture.GammaReferencingPublicSigned.Path);
-            var g = gamma.CreateInstance("Gamma.G")!;
-            g.GetType().GetMethod("Write")!.Invoke(g, new object[] { sb, "Test G" });
+                var epsilon = loader.LoadFromPath(testFixture.EpsilonReferencingPublicSigned.Path);
+                var e = epsilon.CreateInstance("Epsilon.E")!;
+                e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
 
-            var epsilon = loader.LoadFromPath(_testFixture.EpsilonReferencingPublicSigned.Path);
-            var e = epsilon.CreateInstance("Epsilon.E")!;
-            e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
+                var actual = sb.ToString();
 
-            var actual = sb.ToString();
-
-            Assert.Equal(
-@"Delta.2: Gamma: Test G
+                Assert.Equal(
+    @"Delta.2: Gamma: Test G
 Delta.2: Epsilon: Test E
 ",
-                actual);
+                    actual);
+            });
         }
 
         [Fact]
         public void AssemblyLoading_CanLoadDifferentVersionsDirectly()
         {
-            var sb = new StringBuilder();
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                var sb = new StringBuilder();
 
-            var loader = new DefaultAnalyzerAssemblyLoader();
+                // Ensure that no matter what, if we have two analyzers of different versions, we never unify them.
+                loader.AddDependencyLocation(testFixture.DeltaPublicSigned1.Path);
+                loader.AddDependencyLocation(testFixture.DeltaPublicSigned2.Path);
 
-            // Ensure that no matter what, if we have two analyzers of different versions, we never unify them.
-            loader.AddDependencyLocation(_testFixture.DeltaPublicSigned1.Path);
-            loader.AddDependencyLocation(_testFixture.DeltaPublicSigned2.Path);
+                var delta1Assembly = loader.LoadFromPath(testFixture.DeltaPublicSigned1.Path);
+                var delta1Instance = delta1Assembly.CreateInstance("Delta.D")!;
+                delta1Instance.GetType().GetMethod("Write")!.Invoke(delta1Instance, new object[] { sb, "Test D1" });
 
-            var delta1Assembly = loader.LoadFromPath(_testFixture.DeltaPublicSigned1.Path);
-            var delta1Instance = delta1Assembly.CreateInstance("Delta.D")!;
-            delta1Instance.GetType().GetMethod("Write")!.Invoke(delta1Instance, new object[] { sb, "Test D1" });
+                var delta2Assembly = loader.LoadFromPath(testFixture.DeltaPublicSigned2.Path);
+                var delta2Instance = delta2Assembly.CreateInstance("Delta.D")!;
+                delta2Instance.GetType().GetMethod("Write")!.Invoke(delta2Instance, new object[] { sb, "Test D2" });
 
-            var delta2Assembly = loader.LoadFromPath(_testFixture.DeltaPublicSigned2.Path);
-            var delta2Instance = delta2Assembly.CreateInstance("Delta.D")!;
-            delta2Instance.GetType().GetMethod("Write")!.Invoke(delta2Instance, new object[] { sb, "Test D2" });
+                var actual = sb.ToString();
 
-            var actual = sb.ToString();
-
-            Assert.Equal(
-@"Delta: Test D1
+                Assert.Equal(
+    @"Delta: Test D1
 Delta.2: Test D2
 ",
-                actual);
+                    actual);
+            });
         }
 
         [Fact]
         public void AssemblyLoading_AnalyzerReferencesSystemCollectionsImmutable_01()
         {
-            StringBuilder sb = new StringBuilder();
-
-            var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(_testFixture.UserSystemCollectionsImmutable.Path);
-            loader.AddDependencyLocation(_testFixture.AnalyzerReferencesSystemCollectionsImmutable1.Path);
-
-            Assembly analyzerAssembly = loader.LoadFromPath(_testFixture.AnalyzerReferencesSystemCollectionsImmutable1.Path);
-            var analyzer = analyzerAssembly.CreateInstance("Analyzer")!;
-
-            if (ExecutionConditionUtil.IsCoreClr)
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
             {
-                var ex = Assert.ThrowsAny<Exception>(() => analyzer.GetType().GetMethod("Method")!.Invoke(analyzer, new object[] { sb }));
-                Assert.True(ex is MissingMethodException or TargetInvocationException, $@"Unexpected exception type: ""{ex.GetType()}""");
-            }
-            else
-            {
-                analyzer.GetType().GetMethod("Method")!.Invoke(analyzer, new object[] { sb });
-                Assert.Equal("42", sb.ToString());
-            }
+                StringBuilder sb = new StringBuilder();
+
+                loader.AddDependencyLocation(testFixture.UserSystemCollectionsImmutable.Path);
+                loader.AddDependencyLocation(testFixture.AnalyzerReferencesSystemCollectionsImmutable1.Path);
+
+                Assembly analyzerAssembly = loader.LoadFromPath(testFixture.AnalyzerReferencesSystemCollectionsImmutable1.Path);
+                var analyzer = analyzerAssembly.CreateInstance("Analyzer")!;
+
+                if (ExecutionConditionUtil.IsCoreClr)
+                {
+                    var ex = Assert.ThrowsAny<Exception>(() => analyzer.GetType().GetMethod("Method")!.Invoke(analyzer, new object[] { sb }));
+                    Assert.True(ex is MissingMethodException or TargetInvocationException, $@"Unexpected exception type: ""{ex.GetType()}""");
+                }
+                else
+                {
+                    analyzer.GetType().GetMethod("Method")!.Invoke(analyzer, new object[] { sb });
+                    Assert.Equal("42", sb.ToString());
+                }
+            });
         }
 
         [Fact]
         public void AssemblyLoading_AnalyzerReferencesSystemCollectionsImmutable_02()
         {
-            StringBuilder sb = new StringBuilder();
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                StringBuilder sb = new StringBuilder();
 
-            var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(_testFixture.UserSystemCollectionsImmutable.Path);
-            loader.AddDependencyLocation(_testFixture.AnalyzerReferencesSystemCollectionsImmutable2.Path);
+                loader.AddDependencyLocation(testFixture.UserSystemCollectionsImmutable.Path);
+                loader.AddDependencyLocation(testFixture.AnalyzerReferencesSystemCollectionsImmutable2.Path);
 
-            Assembly analyzerAssembly = loader.LoadFromPath(_testFixture.AnalyzerReferencesSystemCollectionsImmutable2.Path);
-            var analyzer = analyzerAssembly.CreateInstance("Analyzer")!;
-            analyzer.GetType().GetMethod("Method")!.Invoke(analyzer, new object[] { sb });
-            Assert.Equal(ExecutionConditionUtil.IsCoreClr ? "1" : "42", sb.ToString());
+                Assembly analyzerAssembly = loader.LoadFromPath(testFixture.AnalyzerReferencesSystemCollectionsImmutable2.Path);
+                var analyzer = analyzerAssembly.CreateInstance("Analyzer")!;
+                analyzer.GetType().GetMethod("Method")!.Invoke(analyzer, new object[] { sb });
+                Assert.Equal(ExecutionConditionUtil.IsCoreClr ? "1" : "42", sb.ToString());
+            });
         }
 
-        [ConditionalFact(typeof(WindowsOnly), typeof(CoreClrOnly))]
+        [Fact]
+        public void AssemblyLoading_CompilerDependencyDuplicated()
+        {
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                var assembly = typeof(ImmutableArray<int>).Assembly;
+
+                // Copy the dependency to a new location to simulate it being deployed by an 
+                // analyzer / generator
+                using var tempRoot = new TempRoot();
+                var destFile = tempRoot.CreateDirectory().CreateOrOpenFile($"{assembly.GetName().Name}.dll");
+                destFile.CopyContentFrom(assembly.Location);
+                loader.AddDependencyLocation(destFile.Path);
+
+                var copiedAssembly = loader.LoadFromPath(destFile.Path);
+                Assert.Single(AppDomain.CurrentDomain.GetAssemblies().Where(x => x.FullName == assembly.FullName));
+                Assert.Same(copiedAssembly, assembly);
+            });
+        }
+
+        [Fact]
         public void AssemblyLoading_NativeDependency()
         {
-            var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(_testFixture.AnalyzerWithNativeDependency.Path);
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
+            {
+                const int INVALID_FILE_ATTRIBUTES = -1;
+                loader.AddDependencyLocation(testFixture.AnalyzerWithNativeDependency.Path);
 
-            Assembly analyzerAssembly = loader.LoadFromPath(_testFixture.AnalyzerWithNativeDependency.Path);
-            var analyzer = analyzerAssembly.CreateInstance("Class1")!;
-            var result = analyzer.GetType().GetMethod("GetFileAttributes")!.Invoke(analyzer, new[] { _testFixture.AnalyzerWithNativeDependency.Path });
-            Assert.Equal(0, Marshal.GetLastWin32Error());
-            Assert.Equal(FileAttributes.Archive, (FileAttributes)result!);
+                Assembly analyzerAssembly = loader.LoadFromPath(testFixture.AnalyzerWithNativeDependency.Path);
+                var analyzer = analyzerAssembly.CreateInstance("Class1")!;
+                var result = analyzer.GetType().GetMethod("GetFileAttributes")!.Invoke(analyzer, new[] { testFixture.AnalyzerWithNativeDependency.Path });
+                Assert.NotEqual(INVALID_FILE_ATTRIBUTES, result);
+                Assert.Equal(FileAttributes.Archive, (FileAttributes)result!);
+            });
         }
 
         [Fact]
         public void AssemblyLoading_Delete()
         {
-            StringBuilder sb = new StringBuilder();
-
-            var loader = new DefaultAnalyzerAssemblyLoader();
-
-            var tempDir = Temp.CreateDirectory();
-            var deltaCopy = tempDir.CreateFile("Delta.dll").CopyContentFrom(_testFixture.Delta1.Path);
-            loader.AddDependencyLocation(deltaCopy.Path);
-            Assembly delta = loader.LoadFromPath(deltaCopy.Path);
-
-            try
+            Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>
             {
-                File.Delete(deltaCopy.Path);
-            }
-            catch (UnauthorizedAccessException)
-            {
-                return;
-            }
+                using var temp = new TempRoot();
+                StringBuilder sb = new StringBuilder();
 
-            // The above call may or may not throw depending on the platform configuration.
-            // If it doesn't throw, we might as well check that things are still functioning reasonably.
+                var tempDir = temp.CreateDirectory();
+                var deltaCopy = tempDir.CreateFile("Delta.dll").CopyContentFrom(testFixture.Delta1.Path);
+                loader.AddDependencyLocation(deltaCopy.Path);
+                Assembly delta = loader.LoadFromPath(deltaCopy.Path);
 
-            var d = delta.CreateInstance("Delta.D");
-            d!.GetType().GetMethod("Write")!.Invoke(d, new object[] { sb, "Test D" });
+                try
+                {
+                    File.Delete(deltaCopy.Path);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    return;
+                }
 
-            var actual = sb.ToString();
-            Assert.Equal(
-@"Delta: Test D
+                // The above call may or may not throw depending on the platform configuration.
+                // If it doesn't throw, we might as well check that things are still functioning reasonably.
+
+                var d = delta.CreateInstance("Delta.D");
+                d!.GetType().GetMethod("Write")!.Invoke(d, new object[] { sb, "Test D" });
+
+                var actual = sb.ToString();
+                Assert.Equal(
+    @"Delta: Test D
 ",
-                actual);
+                    actual);
+            });
         }
 
 #if NETCOREAPP
@@ -723,17 +940,19 @@ Delta.2: Test D2
         [Fact]
         public void AssemblyLoadingInNonDefaultContext_AnalyzerReferencesSystemCollectionsImmutable()
         {
+            using var testFixture = new AssemblyLoadTestFixture();
+
             // Create a separate ALC as the compiler context, load the compiler assembly and a modified version of S.C.I into it,
             // then use that to load and run `AssemblyLoadingInNonDefaultContextHelper1` below. We expect the analyzer running in
             // its own `DirectoryLoadContext` would use the bogus S.C.I loaded in the compiler load context instead of the real one
             // in the default context.
             var compilerContext = new System.Runtime.Loader.AssemblyLoadContext("compilerContext");
-            _ = compilerContext.LoadFromAssemblyPath(_testFixture.UserSystemCollectionsImmutable.Path);
+            _ = compilerContext.LoadFromAssemblyPath(testFixture.UserSystemCollectionsImmutable.Path);
             _ = compilerContext.LoadFromAssemblyPath(typeof(DefaultAnalyzerAssemblyLoader).GetTypeInfo().Assembly.Location);
 
             var testAssembly = compilerContext.LoadFromAssemblyPath(typeof(DefaultAnalyzerAssemblyLoaderTests).GetTypeInfo().Assembly.Location);
             var testObject = testAssembly.CreateInstance(typeof(DefaultAnalyzerAssemblyLoaderTests).FullName!,
-                ignoreCase: false, BindingFlags.Default, binder: null, args: new object[] { _output, _testFixture }, null, null)!;
+                ignoreCase: false, BindingFlags.Default, binder: null, args: new object[] { _output, testFixture }, null, null)!;
 
             StringBuilder sb = new StringBuilder();
             testObject.GetType().GetMethod(nameof(AssemblyLoadingInNonDefaultContextHelper1), BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(testObject, new object[] { sb });
@@ -743,11 +962,12 @@ Delta.2: Test D2
         // This helper does the same thing as in `AssemblyLoading_AnalyzerReferencesSystemCollectionsImmutable_01` test above except the assertions.
         private void AssemblyLoadingInNonDefaultContextHelper1(StringBuilder sb)
         {
+            using var testFixture = new AssemblyLoadTestFixture();
             var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(_testFixture.UserSystemCollectionsImmutable.Path);
-            loader.AddDependencyLocation(_testFixture.AnalyzerReferencesSystemCollectionsImmutable1.Path);
+            loader.AddDependencyLocation(testFixture.UserSystemCollectionsImmutable.Path);
+            loader.AddDependencyLocation(testFixture.AnalyzerReferencesSystemCollectionsImmutable1.Path);
 
-            Assembly analyzerAssembly = loader.LoadFromPath(_testFixture.AnalyzerReferencesSystemCollectionsImmutable1.Path);
+            Assembly analyzerAssembly = loader.LoadFromPath(testFixture.AnalyzerReferencesSystemCollectionsImmutable1.Path);
             var analyzer = analyzerAssembly.CreateInstance("Analyzer")!;
             analyzer.GetType().GetMethod("Method")!.Invoke(analyzer, new object[] { sb });
         }
@@ -755,16 +975,17 @@ Delta.2: Test D2
         [Fact]
         public void AssemblyLoadingInNonDefaultContext_AnalyzerReferencesNonCompilerAssemblyUsedByDefaultContext()
         {
+            using var testFixture = new AssemblyLoadTestFixture();
             // Load the V2 of Delta to default ALC, then create a separate ALC for compiler and load compiler assembly.
             // Next use compiler context to load and run `AssemblyLoadingInNonDefaultContextHelper2` below. We expect the analyzer running in
             // its own `DirectoryLoadContext` would load and use Delta V1 located in its directory instead of V2 already loaded in the default context.
-            _ = System.Runtime.Loader.AssemblyLoadContext.Default.LoadFromAssemblyPath(_testFixture.Delta2.Path);
+            _ = System.Runtime.Loader.AssemblyLoadContext.Default.LoadFromAssemblyPath(testFixture.Delta2.Path);
             var compilerContext = new System.Runtime.Loader.AssemblyLoadContext("compilerContext");
             _ = compilerContext.LoadFromAssemblyPath(typeof(DefaultAnalyzerAssemblyLoader).GetTypeInfo().Assembly.Location);
 
             var testAssembly = compilerContext.LoadFromAssemblyPath(typeof(DefaultAnalyzerAssemblyLoaderTests).GetTypeInfo().Assembly.Location);
             var testObject = testAssembly.CreateInstance(typeof(DefaultAnalyzerAssemblyLoaderTests).FullName!,
-                ignoreCase: false, BindingFlags.Default, binder: null, args: new object[] { _output, _testFixture }, null, null)!;
+                ignoreCase: false, BindingFlags.Default, binder: null, args: new object[] { _output, testFixture }, null, null)!;
 
             StringBuilder sb = new StringBuilder();
             testObject.GetType().GetMethod(nameof(AssemblyLoadingInNonDefaultContextHelper2), BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(testObject, new object[] { sb });
@@ -776,11 +997,12 @@ Delta.2: Test D2
 
         private void AssemblyLoadingInNonDefaultContextHelper2(StringBuilder sb)
         {
+            using var testFixture = new AssemblyLoadTestFixture();
             var loader = new DefaultAnalyzerAssemblyLoader();
-            loader.AddDependencyLocation(_testFixture.AnalyzerReferencesDelta1.Path);
-            loader.AddDependencyLocation(_testFixture.Delta1.Path);
+            loader.AddDependencyLocation(testFixture.AnalyzerReferencesDelta1.Path);
+            loader.AddDependencyLocation(testFixture.Delta1.Path);
 
-            Assembly analyzerAssembly = loader.LoadFromPath(_testFixture.AnalyzerReferencesDelta1.Path);
+            Assembly analyzerAssembly = loader.LoadFromPath(testFixture.AnalyzerReferencesDelta1.Path);
             var analyzer = analyzerAssembly.CreateInstance("Analyzer")!;
             analyzer.GetType().GetMethod("Method")!.Invoke(analyzer, new object[] { sb });
         }

--- a/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
@@ -259,9 +259,8 @@ Delta: Gamma: Beta: Test B
             loadedAssemblies = alcs[0].Assemblies;
 #else
 
-            // Unfortunately in .NET Framework we cannot determine which Assemblies are in the LoadFrom context
-            // which is what we want here. Our ability to verify here is less robust and instead we filter out 
-            // all the DLLs we know are simply a part of the application and examine what is left.
+            // The assemblies in the LoadFrom context are the assemblies loaded from 
+            // analyzer dependencies.
             loadedAssemblies = AppDomain.CurrentDomain
                 .GetAssemblies()
                 .Where(x => isInLoadFromContext(loader, x));

--- a/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
@@ -245,7 +245,7 @@ Delta: Gamma: Beta: Test B
         }
 
         /// <summary>
-        /// Verify the set of asesmblies loaded as analyzer dependencies are the specified assembly paths
+        /// Verify the set of assemblies loaded as analyzer dependencies are the specified assembly paths
         /// </summary>
         private static void VerifyDependencyAssemblies(DefaultAnalyzerAssemblyLoader loader, params string[] assemblyPaths)
         {

--- a/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
@@ -266,17 +266,10 @@ Delta: Gamma: Beta: Test B
                 .Where(x =>
                 {
                     var name = x.GetName().Name;
-                    if (name.StartsWith("System") ||
-                        name.StartsWith("Microsoft") ||
-                        name.StartsWith("xunit") ||
-                        name.StartsWith("Basic") ||
-                        name.StartsWith("netstandard") ||
-                        name.StartsWith("mscorlib"))
-                    {
-                        return false;
-                    }
-
-                    return true;
+                    return
+                        name.StartsWith("Delta") ||
+                        name.StartsWith("Gamma") ||
+                        name.StartsWith("Epsilon");
                 });
 
 #endif
@@ -463,7 +456,6 @@ Delta: Epsilon: Test E
                 Assembly epsilon = loader.LoadFromPath(testFixture.Epsilon.Path);
                 var e = epsilon.CreateInstance("Epsilon.E")!;
                 e.GetType().GetMethod("Write")!.Invoke(e, new object[] { sb, "Test E" });
-
 
                 var actual = sb.ToString();
                 if (ExecutionConditionUtil.IsCoreClr)

--- a/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
@@ -39,12 +39,12 @@ namespace Microsoft.CodeAnalysis.UnitTests
     public sealed class DefaultAnalyzerAssemblyLoaderTests : TestBase
     {
 #if NETCOREAPP
-        private sealed class AssemblyLoadContextInvokeUtil
+        private sealed class InvokeUtil
         {
             public void Exec(string typeName, string methodName) => InvokeTestCode(typeName, methodName);
         }
 #else
-        private sealed class AppDomainInvokeUtil : MarshalByRefObject
+        private sealed class InvokeUtil : MarshalByRefObject
         {
             public void Exec(string typeName, string methodName)
             {
@@ -73,8 +73,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
 #if NETCOREAPP
             var alc = AssemblyLoadContextUtils.Create($"Test {memberName}");
-            var assembly = alc.LoadFromAssemblyName(typeof(AssemblyLoadContextInvokeUtil).Assembly.GetName());
-            var util = assembly.CreateInstance(typeof(AssemblyLoadContextInvokeUtil).FullName)!;
+            var assembly = alc.LoadFromAssemblyName(typeof(InvokeUtil).Assembly.GetName());
+            var util = assembly.CreateInstance(typeof(InvokeUtil).FullName)!;
             var method = util.GetType().GetMethod("Exec", BindingFlags.Public | BindingFlags.Instance)!;
             method.Invoke(util, new object[] { action.Method.DeclaringType!.FullName!, action.Method.Name });
 
@@ -83,8 +83,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             try
             {
                 appDomain = AppDomainUtils.Create($"Test {memberName}");
-                var type = typeof(AppDomainInvokeUtil);
-                var util = (AppDomainInvokeUtil)appDomain.CreateInstanceAndUnwrap(type.Assembly.FullName, type.FullName);
+                var type = typeof(InvokeUtil);
+                var util = (InvokeUtil)appDomain.CreateInstanceAndUnwrap(type.Assembly.FullName, type.FullName);
                 util.Exec(action.Method.DeclaringType.FullName, action.Method.Name);
             }
             finally

--- a/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/DefaultAnalyzerAssemblyLoaderTests.cs
@@ -827,7 +827,7 @@ Delta.2: Test D2
             });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(WindowsOnly))]
         public void AssemblyLoading_NativeDependency()
         {
             Run(static (DefaultAnalyzerAssemblyLoader loader, AssemblyLoadTestFixture testFixture) =>

--- a/src/Compilers/Test/Core/Platform/CoreClr/AssemblyLoadContextUtils.cs
+++ b/src/Compilers/Test/Core/Platform/CoreClr/AssemblyLoadContextUtils.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NETCOREAPP
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Roslyn.Test.Utilities.CoreClr
+{
+    public static class AssemblyLoadContextUtils
+    {
+        public static SimpleAssemblyLoadContext Create(string name, string? probingPath = null) =>
+            new SimpleAssemblyLoadContext(name, probingPath);
+    }
+
+    public sealed class SimpleAssemblyLoadContext : AssemblyLoadContext
+    {
+        private readonly string _probingPath;
+
+        public SimpleAssemblyLoadContext(string name, string? probingPath = null)
+            : base(name, isCollectible: false)
+        {
+            _probingPath = probingPath ?? Path.GetDirectoryName(typeof(SimpleAssemblyLoadContext).Assembly.Location)!;
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            var assemblyPath = Path.Combine(_probingPath, $"{assemblyName.Name}.dll");
+            if (File.Exists(assemblyPath))
+            {
+                return LoadFromAssemblyPath(assemblyPath);
+            }
+
+            return null;
+        }
+    }
+}
+
+#endif

--- a/src/Compilers/Test/Core/Platform/CoreClr/AssemblyLoadContextUtils.cs
+++ b/src/Compilers/Test/Core/Platform/CoreClr/AssemblyLoadContextUtils.cs
@@ -5,15 +5,9 @@
 #if NETCOREAPP
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Roslyn.Test.Utilities.CoreClr
 {


### PR DESCRIPTION
As I was working on the fix for #66104 I noticed that our tests for `DefaultAnalyzerAssemblyLoader` weren't actually behaving the way they should. The reasoning is that all of the tests in the class ran inside the same `AppDomain / AssemblyLoadContext`. These tests are all about how we load assemblies and manage them. Most assumed they were starting from a clean state but in reality were being polluted by the tests that ran before them. Specifically ...

For .NET Framework there is just one `AppDomain`. Every assembly was being loaded into that `AppDomain`. It meant that implicit loads during tests were getting results from the previous test thus impacting the outcome. Even worse is `DefaultAnalyzerAssemblyLoader` hooks `AppDomain.AssemblyResolve` so new tests were potentially getting interferred with by previous `DefaultAnalyzerAssemblyLoader` instances resolve functions. 

For .NET Core the same compiler `AssemblyLoadContext` was used between tests. That had similar pollution problems. It also meant that all of our tests were validating our behavior when the `AssemblyLoadContext` for the compiler was the same as the default `AssemblyLoadContext`. That is definitely true for command line invocations of the compiler but is not true when the compiler is hosted in Visual Studio. The behavior there is different and it has resulted in bugs in the past. 

This change fixes the issues here by forcing the tests to execute on a new `AppDomain / AssemblyLoadContext`. The change has two commits to help with reviewing: 

- Commit 1 is simply the structural change to use separate `AppDomain / AssemblyLoadContext` per test. It's a bit of setup code + lots of mechanical changes to let the code execute in a different context. 
- Commit 2 is fixing up the test failures that resulted from the increased isolation in the tests. 