### PR TITLE
Ignore containing document name from method debug info from Windows PDB

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1366,8 +1366,8 @@ symIsHidden:;
                 {
                     if (binder is BuckStopsHereBinder lastBinder)
                     {
-                        // we never expect to bind a file type in a context where the BuckStopsHereBinder lacks an AssociatedFileIdentifier
-                        return lastBinder.AssociatedFileIdentifier.Value;
+                        // BuckStopsHereBinder.AssociatedFileIdentifier may be null from the EE.
+                        return lastBinder.AssociatedFileIdentifier.GetValueOrDefault();
                     }
                 }
 

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/MethodDebugInfo.Native.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/MethodDebugInfo.Native.cs
@@ -170,17 +170,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
                 var reuseSpan = GetReuseSpan(allScopes, ilOffset, isVisualBasicMethod);
 
-                string? name = null;
-                if (symReader.GetMethod(methodToken) is ISymEncUnmanagedMethod and ISymUnmanagedMethod methodInfo)
-                {
-                    // We need a receiver of type `ISymUnmanagedMethod` to call the extension `GetDocumentsForMethod()` here.
-                    // We also need to ensure that the receiver implements `ISymEncUnmanagedMethod` to prevent the extension from throwing.
-                    if (methodInfo.GetDocumentsForMethod() is [var singleDocument])
-                    {
-                        name = singleDocument.GetName();
-                    }
-                }
-
+                // containingDocumentName is not set since ISymUnmanagedMethod.GetDocumentsForMethod()
+                // may fail (see https://github.com/dotnet/roslyn/issues/66260). The result is that
+                // symbols from file-local types will not bind successfully in the EE.
                 return new MethodDebugInfo<TTypeSymbol, TLocalSymbol>(
                     hoistedLocalScopeRecords,
                     importRecordGroups,
@@ -191,7 +183,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     containingScopes.GetLocalNames(),
                     constantsBuilder.ToImmutableAndFree(),
                     reuseSpan,
-                    name);
+                    containingDocumentName: null);
             }
             catch (InvalidOperationException)
             {


### PR DESCRIPTION
File-local types are members are not available from the EE using Windows PDB.