### PR TITLE
Allow multiple documents in method debug info

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1367,8 +1367,8 @@ symIsHidden:;
                 {
                     if (binder is BuckStopsHereBinder lastBinder)
                     {
-                        // BuckStopsHereBinder.AssociatedFileIdentifier may be null from the EE.
-                        return lastBinder.AssociatedFileIdentifier.GetValueOrDefault();
+                        // we never expect to bind a file type in a context where the BuckStopsHereBinder lacks an AssociatedFileIdentifier
+                        return lastBinder.AssociatedFileIdentifier.Value;
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -1367,8 +1367,8 @@ symIsHidden:;
                 {
                     if (binder is BuckStopsHereBinder lastBinder)
                     {
-                        // we never expect to bind a file type in a context where the BuckStopsHereBinder lacks an AssociatedFileIdentifier
-                        return lastBinder.AssociatedFileIdentifier.Value;
+                        // BuckStopsHereBinder.AssociatedFileIdentifier may be null from the EE.
+                        return lastBinder.AssociatedFileIdentifier.GetValueOrDefault();
                     }
                 }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -60,11 +60,17 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             // added (anonymous types, for instance).
             Debug.Assert(Compilation != compilation);
 
+            // Binder.IsInScopeOfAssociatedSyntaxTree() expects a non-null AssociatedFileIdentifier when
+            // looking up file-local types. If there is no document name, use an invalid FilePathChecksumOpt.
+            FileIdentifier fileIdentifier = methodDebugInfo.ContainingDocumentName is { } documentName
+                ? FileIdentifier.Create(documentName)
+                : new FileIdentifier { EncoderFallbackErrorMessage = null, FilePathChecksumOpt = ImmutableArray<byte>.Empty, DisplayFilePath = string.Empty };
+
             NamespaceBinder = CreateBinderChain(
                 Compilation,
                 currentFrame.ContainingNamespace,
                 methodDebugInfo.ImportRecordGroups,
-                methodDebugInfo.ContainingDocumentName is { } documentName ? FileIdentifier.Create(documentName) : null);
+                fileIdentifier: fileIdentifier);
 
             if (_methodNotType)
             {

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CompileExpressionsTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/CompileExpressionsTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.ExpressionEvaluator;
 using Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio.Debugger.Evaluation;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -1026,6 +1027,115 @@ class Program
                 });
         }
 
+        [WorkItem(66109, "https://github.com/dotnet/roslyn/issues/66109")]
+        [WorkItem(64098, "https://github.com/dotnet/roslyn/issues/64098")]
+        [Fact]
+        public void FileLocalType_07()
+        {
+            var sourceA = """
+                file class A
+                {
+                    public int F1() => 1;
+                    public int F2() => 2;
+                }
+                class Program
+                {
+                    static void M1()
+                    {
+                        A x = new A();
+                    }
+                    static void M2()
+                    {
+                #line 100 "B.cs"
+                        A y = new A();
+                #line 200 "C.cs"
+                        A z = new A();
+                    }
+                }
+                """;
+            var sourceB = """
+                class B
+                {
+                }
+                """;
+            var sourceC = """
+                class C
+                {
+                }
+                """;
+            var comp = CreateCompilation(
+                new[]
+                {
+                    SyntaxFactory.ParseSyntaxTree(sourceA, path: "path/to/A.cs", encoding: Encoding.Default),
+                    SyntaxFactory.ParseSyntaxTree(sourceB, path: "path/to/B.cs", encoding: Encoding.Default),
+                    SyntaxFactory.ParseSyntaxTree(sourceC, path: "path/to/C.cs", encoding: Encoding.Default),
+                },
+                options: TestOptions.DebugDll);
+
+            WithRuntimeInstance(
+                comp,
+                references: null,
+                includeLocalSignatures: true,
+                includeIntrinsicAssembly: false,
+                validator: runtime =>
+                {
+                    var context = CreateMethodContext(runtime, "Program.M1");
+                    var testData = new CompilationTestData();
+                    ResultProperties resultProperties;
+                    string error;
+                    ImmutableArray<AssemblyIdentity> missingAssemblyIdentities;
+                    var result = context.CompileExpression(
+                        "x.F1() + (new A()).F2()",
+                        DkmEvaluationFlags.TreatAsExpression,
+                        NoAliases,
+                        DebuggerDiagnosticFormatter.Instance,
+                        out resultProperties,
+                        out error,
+                        out missingAssemblyIdentities,
+                        EnsureEnglishUICulture.PreferredOrNull,
+                        testData);
+                    if (runtime.DebugFormat == DebugInformationFormat.Pdb)
+                    {
+                        Assert.Null(result);
+                        Assert.Equal("error CS1061: 'A' does not contain a definition for 'F1' and no accessible extension method 'F1' accepting a first argument of type 'A' could be found (are you missing a using directive or an assembly reference?)", error);
+                    }
+                    else
+                    {
+                        Assert.NotNull(result.Assembly);
+                        Assert.Null(error);
+                        testData.GetMethodData("<>x.<>m0").VerifyIL("""
+                            {
+                              // Code size       18 (0x12)
+                              .maxstack  2
+                              .locals init (A V_0) //x
+                              IL_0000:  ldloc.0
+                              IL_0001:  callvirt   "int A.F1()"
+                              IL_0006:  newobj     "A..ctor()"
+                              IL_000b:  call       "int A.F2()"
+                              IL_0010:  add
+                              IL_0011:  ret
+                            }
+                            """);
+                    }
+
+                    // https://github.com/dotnet/roslyn/issues/64098: EE doesn't handle methods that span multiple documents correctly
+                    context = CreateMethodContext(runtime, "Program.M2");
+                    testData = new CompilationTestData();
+                    result = context.CompileExpression(
+                        "y.F1() + (new A()).F2()",
+                        DkmEvaluationFlags.TreatAsExpression,
+                        NoAliases,
+                        DebuggerDiagnosticFormatter.Instance,
+                        out resultProperties,
+                        out error,
+                        out missingAssemblyIdentities,
+                        EnsureEnglishUICulture.PreferredOrNull,
+                        testData);
+                    Assert.Null(result);
+                    Assert.Equal("error CS1061: 'A' does not contain a definition for 'F1' and no accessible extension method 'F1' accepting a first argument of type 'A' could be found (are you missing a using directive or an assembly reference?)", error);
+                });
+        }
+
         [Fact]
         public void IllFormedFilePath_01()
         {
@@ -1070,7 +1180,7 @@ class Program
 
         [WorkItem(66109, "https://github.com/dotnet/roslyn/issues/66109")]
         [Fact]
-        public void SequencePointsMultipleDocuments()
+        public void SequencePointsMultipleDocuments_01()
         {
             var sourceA =
 @"partial class Program
@@ -1223,7 +1333,6 @@ class Program
                     var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
                     string typeName;
                     var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
-
                     Assert.Equal(2, locals.Count);
                     VerifyLocal(testData, typeName, locals[0], "<>m0", "this", expectedILOpt: """
                         {
@@ -1243,6 +1352,189 @@ class Program
                             IL_0001:  ret
                         }
                         """);
+                    locals.Free();
+                });
+        }
+
+        [WorkItem(66109, "https://github.com/dotnet/roslyn/issues/66109")]
+        [Fact]
+        public void SequencePointsMultipleDocuments_02()
+        {
+            var sourceA = """
+                class A
+                {
+                    static void Main()
+                    {
+                        int x = 1;
+                #line 100 "B.cs"
+                        int y = 2;
+                #line 200 "C.cs"
+                        int z = 3;
+                    }
+                }
+                """;
+            var sourceB = """
+                class B
+                {
+                }
+                """;
+            var sourceC = """
+                class C
+                {
+                }
+                """;
+            var comp = CreateCompilation(
+                new[]
+                {
+                    SyntaxFactory.ParseSyntaxTree(sourceA, path: "A.cs", encoding: Encoding.Default),
+                    SyntaxFactory.ParseSyntaxTree(sourceB, path: "B.cs", encoding: Encoding.Default),
+                    SyntaxFactory.ParseSyntaxTree(sourceC, path: "C.cs", encoding: Encoding.Default),
+                },
+                options: TestOptions.DebugDll);
+
+            comp.VerifyPdb("""
+                <symbols>
+                  <files>
+                    <file id="1" name="A.cs" language="C#" checksumAlgorithm="SHA1" checksum="8E-FF-02-A2-A9-6A-80-AA-31-CC-19-BE-FA-C4-84-88-5B-C8-09-08" />
+                    <file id="2" name="B.cs" language="C#" checksumAlgorithm="SHA1" checksum="29-99-77-37-69-95-33-C4-02-3B-65-8D-5F-61-43-CF-F0-04-61-C2" />
+                    <file id="3" name="C.cs" language="C#" checksumAlgorithm="SHA1" checksum="A2-ED-D2-5C-84-2F-E1-0E-AB-C5-11-C8-51-E6-76-03-C8-5A-6D-06" />
+                  </files>
+                  <methods>
+                    <method containingType="A" name="Main">
+                      <customDebugInfo>
+                        <using>
+                          <namespace usingCount="0" />
+                        </using>
+                        <encLocalSlotMap>
+                          <slot kind="0" offset="15" />
+                          <slot kind="0" offset="53" />
+                          <slot kind="0" offset="91" />
+                        </encLocalSlotMap>
+                      </customDebugInfo>
+                      <sequencePoints>
+                        <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="6" document="1" />
+                        <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="19" document="1" />
+                        <entry offset="0x3" startLine="100" startColumn="9" endLine="100" endColumn="19" document="2" />
+                        <entry offset="0x5" startLine="200" startColumn="9" endLine="200" endColumn="19" document="3" />
+                        <entry offset="0x7" startLine="201" startColumn="5" endLine="201" endColumn="6" document="3" />
+                      </sequencePoints>
+                      <scope startOffset="0x0" endOffset="0x8">
+                        <local name="x" il_index="0" il_start="0x0" il_end="0x8" attributes="0" />
+                        <local name="y" il_index="1" il_start="0x0" il_end="0x8" attributes="0" />
+                        <local name="z" il_index="2" il_start="0x0" il_end="0x8" attributes="0" />
+                      </scope>
+                    </method>
+                  </methods>
+                </symbols>
+                """,
+                format: Microsoft.CodeAnalysis.Emit.DebugInformationFormat.Pdb);
+            comp.VerifyPdb("""
+                <symbols>
+                  <files>
+                    <file id="1" name="A.cs" language="C#" checksumAlgorithm="SHA1" checksum="8E-FF-02-A2-A9-6A-80-AA-31-CC-19-BE-FA-C4-84-88-5B-C8-09-08" />
+                    <file id="2" name="B.cs" language="C#" checksumAlgorithm="SHA1" checksum="29-99-77-37-69-95-33-C4-02-3B-65-8D-5F-61-43-CF-F0-04-61-C2" />
+                    <file id="3" name="C.cs" language="C#" checksumAlgorithm="SHA1" checksum="A2-ED-D2-5C-84-2F-E1-0E-AB-C5-11-C8-51-E6-76-03-C8-5A-6D-06" />
+                  </files>
+                  <methods>
+                    <method containingType="A" name="Main">
+                      <customDebugInfo>
+                        <using>
+                          <namespace usingCount="0" />
+                        </using>
+                        <encLocalSlotMap>
+                          <slot kind="0" offset="15" />
+                          <slot kind="0" offset="53" />
+                          <slot kind="0" offset="91" />
+                        </encLocalSlotMap>
+                      </customDebugInfo>
+                      <sequencePoints>
+                        <entry offset="0x0" startLine="4" startColumn="5" endLine="4" endColumn="6" document="1" />
+                        <entry offset="0x1" startLine="5" startColumn="9" endLine="5" endColumn="19" document="1" />
+                        <entry offset="0x3" startLine="100" startColumn="9" endLine="100" endColumn="19" document="2" />
+                        <entry offset="0x5" startLine="200" startColumn="9" endLine="200" endColumn="19" document="3" />
+                        <entry offset="0x7" startLine="201" startColumn="5" endLine="201" endColumn="6" document="3" />
+                      </sequencePoints>
+                      <scope startOffset="0x0" endOffset="0x8">
+                        <local name="x" il_index="0" il_start="0x0" il_end="0x8" attributes="0" />
+                        <local name="y" il_index="1" il_start="0x0" il_end="0x8" attributes="0" />
+                        <local name="z" il_index="2" il_start="0x0" il_end="0x8" attributes="0" />
+                      </scope>
+                    </method>
+                  </methods>
+                </symbols>
+                """,
+                format: Microsoft.CodeAnalysis.Emit.DebugInformationFormat.PortablePdb);
+
+            WithRuntimeInstance(
+                comp,
+                references: null,
+                includeLocalSignatures: true,
+                includeIntrinsicAssembly: false,
+                validator: runtime =>
+                {
+                    var context = CreateMethodContext(runtime, "A.Main");
+                    var testData = new CompilationTestData();
+                    var result = context.CompileExpression(
+                        "x + y + z",
+                        out var error,
+                        testData);
+                    Assert.Null(error);
+                    Assert.NotNull(result.Assembly);
+                    testData.GetMethodData("<>x.<>m0").VerifyIL("""
+                        {
+                          // Code size        6 (0x6)
+                          .maxstack  2
+                          .locals init (int V_0, //x
+                                        int V_1, //y
+                                        int V_2) //z
+                          IL_0000:  ldloc.0
+                          IL_0001:  ldloc.1
+                          IL_0002:  add
+                          IL_0003:  ldloc.2
+                          IL_0004:  add
+                          IL_0005:  ret
+                        }
+                        """);
+
+                    testData = new CompilationTestData();
+                    var locals = ArrayBuilder<LocalAndMethod>.GetInstance();
+                    string typeName;
+                    var assembly = context.CompileGetLocals(locals, argumentsOnly: false, typeName: out typeName, testData: testData);
+                    Assert.Equal(3, locals.Count);
+                    VerifyLocal(testData, typeName, locals[0], "<>m0", "x", expectedILOpt: """
+                        {
+                          // Code size        2 (0x2)
+                          .maxstack  1
+                          .locals init (int V_0, //x
+                                        int V_1, //y
+                                        int V_2) //z
+                          IL_0000:  ldloc.0
+                          IL_0001:  ret
+                        }
+                        """);
+                    VerifyLocal(testData, typeName, locals[1], "<>m1", "y", expectedILOpt: """
+                        {
+                          // Code size        2 (0x2)
+                          .maxstack  1
+                          .locals init (int V_0, //x
+                                        int V_1, //y
+                                        int V_2) //z
+                          IL_0000:  ldloc.1
+                          IL_0001:  ret
+                        }
+                        """);
+                    VerifyLocal(testData, typeName, locals[2], "<>m2", "z", expectedILOpt: """
+                        {
+                          // Code size        2 (0x2)
+                          .maxstack  1
+                          .locals init (int V_0, //x
+                                        int V_1, //y
+                                        int V_2) //z
+                          IL_0000:  ldloc.2
+                          IL_0001:  ret
+                        }
+                        """);
+                    locals.Free();
                 });
         }
     }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/MethodDebugInfo.Native.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/MethodDebugInfo.Native.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
         public static unsafe MethodDebugInfo<TTypeSymbol, TLocalSymbol> ReadMethodDebugInfo(
             ISymUnmanagedReader3? symReader,
-            EESymbolProvider<TTypeSymbol, TLocalSymbol>? symbolProvider, // TODO: only null in DTEE case where we looking for default namesapace
+            EESymbolProvider<TTypeSymbol, TLocalSymbol>? symbolProvider, // TODO: only null in DTEE case where we looking for default namespace
             int methodToken,
             int methodVersion,
             int ilOffset,
@@ -170,20 +170,9 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
                 var reuseSpan = GetReuseSpan(allScopes, ilOffset, isVisualBasicMethod);
 
-                string? name = null;
-                if (symReader.GetMethod(methodToken) is ISymEncUnmanagedMethod and ISymUnmanagedMethod methodInfo)
-                {
-                    // We need a receiver of type `ISymUnmanagedMethod` to call the extension `GetDocumentsForMethod()` here.
-                    // We also need to ensure that the receiver implements `ISymEncUnmanagedMethod` to prevent the extension from throwing.
-                    var doc = methodInfo.GetDocumentsForMethod() switch
-                    {
-                        [var singleDocument] => singleDocument,
-                        var documents => throw ExceptionUtilities.UnexpectedValue(documents)
-                    };
-
-                    name = doc.GetName();
-                }
-
+                // containingDocumentName is not set since ISymUnmanagedMethod.GetDocumentsForMethod()
+                // may fail (see https://github.com/dotnet/roslyn/issues/66260). The result is that
+                // symbols from file-local types will not bind successfully in the EE.
                 return new MethodDebugInfo<TTypeSymbol, TLocalSymbol>(
                     hoistedLocalScopeRecords,
                     importRecordGroups,
@@ -194,7 +183,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                     containingScopes.GetLocalNames(),
                     constantsBuilder.ToImmutableAndFree(),
                     reuseSpan,
-                    name);
+                    containingDocumentName: null);
             }
             catch (InvalidOperationException)
             {

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/MethodDebugInfo.Portable.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/PDB/MethodDebugInfo.Portable.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
 
             var methodHandle = GetDeltaRelativeMethodDefinitionHandle(reader, methodToken);
 
-            // TODO: only null in DTEE case where we looking for default namesapace
+            // TODO: only null in DTEE case where we looking for default namespace
             if (symbolProvider != null)
             {
                 ReadLocalScopeInformation(
@@ -64,8 +64,12 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             ReadMethodCustomDebugInformation(reader, methodHandle, out var hoistedLocalScopes, out var defaultNamespace);
 
             var documentHandle = reader.GetMethodDebugInformation(methodHandle).Document;
-            var document = reader.GetDocument(documentHandle);
-            var documentName = reader.GetString(document.Name);
+            string? documentName = null;
+            if (!documentHandle.IsNil)
+            {
+                var document = reader.GetDocument(documentHandle);
+                documentName = reader.GetString(document.Name);
+            }
 
             return new MethodDebugInfo<TTypeSymbol, TLocalSymbol>(
                 hoistedLocalScopes,


### PR DESCRIPTION
The EE uses the document name from the method debug info in the PDB to recognize _file-local types_, and the EE was assuming the method debug info contained a single document in all cases, otherwise the debug info was ignored. For methods with sequence points from multiple documents (for example, a constructor for a type with a field initializer in a separate partial class), this resulted in no local scopes in the EE within those methods.

For portable PDBs, if the method has sequence points from multiple documents, no document is included in the method debug info. The fix is to skip reading the document in that case.

For Windows PDBs, reading the document info when there are multiple documents is not possible currently (see https://github.com/dotnet/roslyn/issues/66260), so documents are ignored from Windows PDBs, and as a result, _file-local types_ are not available from the EE when debugging with a Windows PDB.

Fixes #66109

VSO bug [#1713184](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1713184/?triage=true)