### PR TITLE
Temporarily stop merging in main-vs-deps

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -118,12 +118,14 @@ stages:
           MainValidationBuild
       condition: and(succeeded(), eq(variables['SourceBranchName'], 'main'))
 
-    - task: PowerShell@2
-      displayName: Merge main-vs-deps into source branch
-      inputs:
-        filePath: 'scripts\merge-vs-deps.ps1'
-        arguments: '-accessToken $(dn-bot-dnceng-build-rw-code-rw)'
-      condition: and(succeeded(), eq(variables['SourceBranchName'], 'main'))
+    # Don't run this while we don't have a main-vs-deps to merge. Should be uncommented when the branch comes back.
+    #
+    # - task: PowerShell@2
+    #  displayName: Merge main-vs-deps into source branch
+    #  inputs:
+    #    filePath: 'scripts\merge-vs-deps.ps1'
+    #    arguments: '-accessToken $(dn-bot-dnceng-build-rw-code-rw)'
+    #  condition: and(succeeded(), eq(variables['SourceBranchName'], 'main'))
 
     - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
       displayName: Setting VisualStudio.DropName variable


### PR DESCRIPTION
Right now the contents of the branch is from an internal mirror that's stale, so it doesn't make sense to merge. Worse off, doing this means that our official NuGet packages right now are being stamped with the a commit SHA that doesn't exist.