### PR TITLE
Visit query lambda by `NullableWalker` even without conversion

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -10933,6 +10933,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitQueryClause(BoundQueryClause node)
         {
             var result = base.VisitQueryClause(node);
+
+            if (node.Value is BoundLambda lambda)
+            {
+                // 'VisitConversion' only visits a lambda when the lambda has an AnonymousFunction conversion.
+                // This lambda doesn't have a conversion, so we need to visit it here.
+                Debug.Assert(node.HasAnyErrors);
+                VisitLambda(lambda, delegateTypeOpt: null);
+            }
+
             SetNotNullResult(node); // https://github.com/dotnet/roslyn/issues/29863 Implement nullability analysis in LINQ queries
             return result;
         }


### PR DESCRIPTION
Fixes #65053.

The added test reproduces the error from https://github.com/dotnet/roslyn/issues/65053#issuecomment-1294237444. I wasn't able to write a test for the original error from the issue, but was able to verify manually that it goes away with this fix.