### PR TITLE
Fix `SyntaxGenerator` when generating delegate declaration from symbol

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -878,7 +878,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             return SyntaxFactory.DelegateDeclaration(
                 default,
-                AsModifierList(accessibility, modifiers & GetAllowedModifiers(SyntaxKind.DelegateDeclaration)),
+                AsModifierList(accessibility, modifiers, SyntaxKind.DelegateDeclaration),
                 returnType != null ? (TypeSyntax)returnType : SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
                 name.ToIdentifierToken(),
                 AsTypeParameterList(typeParameters),

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -878,7 +878,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             return SyntaxFactory.DelegateDeclaration(
                 default,
-                AsModifierList(accessibility, modifiers),
+                AsModifierList(accessibility, modifiers & GetAllowedModifiers(SyntaxKind.DelegateDeclaration)),
                 returnType != null ? (TypeSyntax)returnType : SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
                 name.ToIdentifierToken(),
                 AsTypeParameterList(typeParameters),

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -2151,6 +2151,34 @@ public class C { } // end").Members[0];
 }");
         }
 
+        [Fact]
+        public void TestEnumWithUnderlyingTypeFromSymbol()
+        {
+            VerifySyntax<EnumDeclarationSyntax>(
+                    Generator.Declaration(
+                        _emptyCompilation.GetTypeByMetadataName("System.Security.SecurityRuleSet")),
+@"public enum SecurityRuleSet : byte
+{
+    None = 0,
+    Level1 = 1,
+    Level2 = 2
+}");
+        }
+
+        [Fact, WorkItem(66381, "https://github.com/dotnet/roslyn/issues/66381")]
+        public void TestDelegateDeclarationFromSymbol()
+        {
+            var compilation = _emptyCompilation.AddSyntaxTrees(SyntaxFactory.ParseSyntaxTree("""
+                public delegate void D();
+                """));
+
+            var type = compilation.GetTypeByMetadataName("D");
+
+            VerifySyntax<DelegateDeclarationSyntax>(Generator.Declaration(type), """
+                public delegate void D();
+                """);
+        }
+
         [Fact, WorkItem(65638, "https://github.com/dotnet/roslyn/issues/65638")]
         public void TestMethodDeclarationFromSymbol1()
         {
@@ -2193,20 +2221,6 @@ public class C { } // end").Members[0];
                 {
                 }
                 """);
-        }
-
-        [Fact]
-        public void TestEnumWithUnderlyingTypeFromSymbol()
-        {
-            VerifySyntax<EnumDeclarationSyntax>(
-                    Generator.Declaration(
-                        _emptyCompilation.GetTypeByMetadataName("System.Security.SecurityRuleSet")),
-@"public enum SecurityRuleSet : byte
-{
-    None = 0,
-    Level1 = 1,
-    Level2 = 2
-}");
         }
 
         #endregion

--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Editing
                     isExtern: symbol.IsExtern,
                     isAsync: method?.IsAsync == true,
                     isRequired: symbol.IsRequired(),
-                    isFile: (symbol as INamedTypeSymbol)?.IsFileLocal == true);
+                    isFile: type?.IsFileLocal == true);
             }
 
             // Only named types, members of named types, and local functions have modifiers.

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -8,11 +8,9 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Utilities;
@@ -628,13 +626,12 @@ namespace Microsoft.CodeAnalysis.Editing
                                 members: type.GetMembers().Where(s => s.Kind == SymbolKind.Field).Select(Declaration));
                             break;
                         case TypeKind.Delegate:
-                            var invoke = type.GetMembers("Invoke").First() as IMethodSymbol;
-                            if (invoke != null)
+                            if (type.GetMembers("Invoke") is [IMethodSymbol invoke, ..])
                             {
                                 declaration = DelegateDeclaration(
                                     type.Name,
                                     parameters: invoke.Parameters.Select(p => ParameterDeclaration(p)),
-                                    returnType: TypeExpression(invoke.ReturnType),
+                                    returnType: invoke.ReturnsVoid ? null : TypeExpression(invoke.ReturnType),
                                     accessibility: type.DeclaredAccessibility,
                                     modifiers: DeclarationModifiers.From(type));
                             }

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -2303,6 +2303,13 @@ End Enum")
     Level2 = CByte(2)
 End Enum")
         End Sub
+
+        <Fact, WorkItem(66381, "https://github.com/dotnet/roslyn/issues/66381")>
+        Public Sub TestDelegateDeclarationFromSymbol()
+            Dim compilation = _emptyCompilation.AddSyntaxTrees(SyntaxFactory.ParseSyntaxTree("Public Delegate Sub D()"))
+            Dim type = compilation.GetTypeByMetadataName("D")
+            VerifySyntax(Of DelegateStatementSyntax)(Generator.Declaration(type), "Public Delegate Sub D()")
+        End Sub
 #End Region
 
 #Region "Add/Insert/Remove/Get/Set members & elements"


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/66381
Fixes: https://github.com/dotnet/arcade/issues/11937