### PR TITLE
Add entry for RazorCompiler

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -55,6 +55,7 @@
       "Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp": "arcade",
       "Microsoft.CodeAnalysis.ExternalAccess.AspNetCore": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.Razor": "vs-impl",
+      "Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.TypeScript": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.UnitTesting": "vs-impl",
       "Microsoft.CodeAnalysis.ExternalAccess.Xamarin.Remote": "vs-impl",


### PR DESCRIPTION
This PR https://github.com/dotnet/roslyn/pull/65831 add EA.RazorComplier to the Solution file so it cause the pipeline to build RazorCompiler package, and given there is no entry in PublishData.json, it breaks the signed build.

Follow the pattern of EA.Razor, add this to vs-impl.

Need to create a build to see if it fix the pipeline.

---
Update: It seems impossible to create a val signed build since pipeline always use publishData.json from main :(