### PR TITLE
Ensure event handler generation and navigation in webforms works properly

### DIFF
--- a/src/VisualStudio/Core/Def/Venus/ContainedLanguage.IVsContainedLanguageCodeSupport.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedLanguage.IVsContainedLanguageCodeSupport.cs
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                     {
                         succeeded = true;
                         itemId = this.ContainedDocument.FindItemIdOfDocument(targetDocument);
-                        if (itemId == (uint) VSITEMID.Nil)
+                        if (itemId == (uint)VSITEMID.Nil)
                         {
                             // The FindItemIdOfDocument call can fail when the point maps directly into the containing document. In this case, return the containing document's itemid.
                             itemId = GetContainingDocumentItemId();

--- a/src/VisualStudio/Core/Def/Venus/ContainedLanguage.IVsContainedLanguageCodeSupport.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedLanguage.IVsContainedLanguageCodeSupport.cs
@@ -11,11 +11,8 @@ using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
-using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
-using static Microsoft.VisualStudio.VSConstants;
 using TextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
@@ -54,19 +51,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             var targetDocument = thisDocument.Project.Solution.GetDocument(targetDocumentId);
             if (targetDocument == null)
             {
-                // The requested insertion itemid doesn't exist in this project. Check if the containing
-                //   document matches the requested itemid.
-                var containingDocumentItemid = GetContainingDocumentItemId();
-
-                if (containingDocumentItemid != itemidInsertionPoint)
-                {
-                    // Can't generate into this itemid
-                    pbstrUniqueMemberID = null;
-                    pbstrEventBody = null;
-                    return VSConstants.E_FAIL;
-                }
-
-                targetDocument = thisDocument;
+                // Can't generate into this itemid
+                pbstrUniqueMemberID = null;
+                pbstrEventBody = null;
+                return VSConstants.E_FAIL;
             }
 
             Tuple<string, string, TextSpan> idBodyAndInsertionPoint = null;
@@ -171,11 +159,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                     {
                         succeeded = true;
                         itemId = this.ContainedDocument.FindItemIdOfDocument(targetDocument);
-                        if (itemId == (uint)VSITEMID.Nil)
-                        {
-                            // The FindItemIdOfDocument call can fail when the point maps directly into the containing document. In this case, return the containing document's itemid.
-                            itemId = GetContainingDocumentItemId();
-                        }
                     }
                 });
 
@@ -265,21 +248,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                     current = IntPtr.Add(current, IntPtr.Size);
                 }
             }
-        }
-
-        private uint GetContainingDocumentItemId()
-        {
-            Marshal.ThrowExceptionForHR(BufferCoordinator.GetPrimaryBuffer(out var primaryTextLines));
-            var primaryBufferDocumentBuffer = _editorAdaptersFactoryService.GetDocumentBuffer(primaryTextLines)!;
-
-            var textDocumentFactoryService = ComponentModel.GetService<ITextDocumentFactoryService>();
-            textDocumentFactoryService.TryGetTextDocument(primaryBufferDocumentBuffer, out var textDocument);
-            var documentPath = textDocument.FilePath;
-
-            var hierarchy = ((VisualStudioWorkspace)Workspace).GetHierarchy(Project.Id);
-            var itemId = hierarchy.TryGetItemId(documentPath);
-
-            return itemId;
         }
     }
 }


### PR DESCRIPTION
Ensure event handler generation and navigation in webforms works properly after recent change to secondary buffer text document name.

This commit (https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/WebTools/commit/3663cc0b5f5c3e94dc5e72235d769fc2d1fb42a2?refName=refs%2Fheads%2Fmain) changed the moniker webtools applies to generated buffers to be something like "c:\foo.aspx.__projection.g.cs" instead of "c:\foo.aspx" as it used to be. This was done as the TS team was hitting issues with their projection buffer's textdocument having the same value as the containing html/aspx document.

Unfortunately, this has had several undesired side effects that have needed addressed. This particular one is that server event generation and navigation in code-inline webforms no longer was working. This change modified the generation/navigation code to fallback to using the containing document's itemid if the desired C# document itemid can't be found.