### PR TITLE
Move VisualStudioOptionsProcessor down alongside ProjectSystemProject

### DIFF
--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSCompilerConfig.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSCompilerConfig.cs
@@ -27,18 +27,18 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
 
         public void ResetAllOptions()
         {
-            VisualStudioProjectOptionsProcessor[CompilerOptions.OPTID_CCSYMBOLS] = string.Empty;
-            VisualStudioProjectOptionsProcessor[CompilerOptions.OPTID_KEYFILE] = string.Empty;
-            VisualStudioProjectOptionsProcessor[CompilerOptions.OPTID_NOWARNLIST] = string.Empty;
-            VisualStudioProjectOptionsProcessor[CompilerOptions.OPTID_WARNASERRORLIST] = string.Empty;
-            VisualStudioProjectOptionsProcessor[CompilerOptions.OPTID_WARNNOTASERRORLIST] = string.Empty;
-            VisualStudioProjectOptionsProcessor[CompilerOptions.OPTID_UNSAFE] = false;
-            VisualStudioProjectOptionsProcessor[CompilerOptions.OPTID_XML_DOCFILE] = string.Empty;
+            ProjectSystemProjectOptionsProcessor[CompilerOptions.OPTID_CCSYMBOLS] = string.Empty;
+            ProjectSystemProjectOptionsProcessor[CompilerOptions.OPTID_KEYFILE] = string.Empty;
+            ProjectSystemProjectOptionsProcessor[CompilerOptions.OPTID_NOWARNLIST] = string.Empty;
+            ProjectSystemProjectOptionsProcessor[CompilerOptions.OPTID_WARNASERRORLIST] = string.Empty;
+            ProjectSystemProjectOptionsProcessor[CompilerOptions.OPTID_WARNNOTASERRORLIST] = string.Empty;
+            ProjectSystemProjectOptionsProcessor[CompilerOptions.OPTID_UNSAFE] = false;
+            ProjectSystemProjectOptionsProcessor[CompilerOptions.OPTID_XML_DOCFILE] = string.Empty;
         }
 
         public int SetOption(CompilerOptions optionID, HACK_VariantStructure value)
         {
-            VisualStudioProjectOptionsProcessor[optionID] = value.ConvertToObject();
+            ProjectSystemProjectOptionsProcessor[optionID] = value.ConvertToObject();
 
             if (optionID == CompilerOptions.OPTID_COMPATIBILITY)
             {
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
         }
 
         public void GetOption(CompilerOptions optionID, IntPtr variant)
-            => Marshal.GetNativeVariantForObject(VisualStudioProjectOptionsProcessor[optionID], variant);
+            => Marshal.GetNativeVariantForObject(ProjectSystemProjectOptionsProcessor[optionID], variant);
 
         public int CommitChanges(ref ICSError error)
         {

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSInputSet.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.ICSInputSet.cs
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
         }
 
         public void SetOutputFileType(OutputFileType fileType)
-            => VisualStudioProjectOptionsProcessor.SetOutputFileType(fileType);
+            => ProjectSystemProjectOptionsProcessor.SetOutputFileType(fileType);
 
         public void SetImageBase(uint imageBase)
         {
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
         }
 
         public void SetMainClass(string fullyQualifiedClassName)
-            => VisualStudioProjectOptionsProcessor.SetMainTypeName(fullyQualifiedClassName);
+            => ProjectSystemProjectOptionsProcessor.SetMainTypeName(fullyQualifiedClassName);
 
         public void SetWin32Icon(string iconFileName)
         {

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.OptionsProcessor.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.OptionsProcessor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
 {
     internal partial class CSharpProjectShim
     {
-        private class OptionsProcessor : VisualStudioProjectOptionsProcessor
+        private class OptionsProcessor : ProjectSystemProjectOptionsProcessor
         {
             private readonly ProjectSystemProject _projectSystemProject;
 

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
@@ -40,10 +40,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
         /// <summary>
         /// Fetches the options processor for this C# project. Equivalent to the underlying member, but fixed to the derived type.
         /// </summary>
-        private new OptionsProcessor VisualStudioProjectOptionsProcessor
+        private new OptionsProcessor ProjectSystemProjectOptionsProcessor
         {
-            get => (OptionsProcessor)base.VisualStudioProjectOptionsProcessor;
-            set => base.VisualStudioProjectOptionsProcessor = value;
+            get => (OptionsProcessor)base.ProjectSystemProjectOptionsProcessor;
+            set => base.ProjectSystemProjectOptionsProcessor = value;
         }
 
         public CSharpProjectShim(
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
             var componentModel = (IComponentModel)serviceProvider.GetService(typeof(SComponentModel));
 
             this.ProjectCodeModel = componentModel.GetService<IProjectCodeModelFactory>().CreateProjectCodeModel(ProjectSystemProject.Id, this);
-            this.VisualStudioProjectOptionsProcessor = new OptionsProcessor(this.ProjectSystemProject, Workspace.Services.SolutionServices);
+            this.ProjectSystemProjectOptionsProcessor = new OptionsProcessor(this.ProjectSystemProject, Workspace.Services.SolutionServices);
 
             // Ensure the default options are set up
             ResetAllOptions();

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/AnalyzersTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/LegacyProject/AnalyzersTests.cs
@@ -148,7 +148,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.LegacyProject
 
             ((IAnalyzerHost)project).SetRuleSetFile(pathWithExtraBackslashes);
 
-            var projectRuleSetFile = project.VisualStudioProjectOptionsProcessor.ExplicitRuleSetFilePath;
+            var projectRuleSetFile = project.ProjectSystemProjectOptionsProcessor.ExplicitRuleSetFilePath;
 
             Assert.Equal(expected: ruleSetFile.Path, actual: projectRuleSetFile);
         }

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
     {
         public IVsHierarchy Hierarchy { get; }
         protected ProjectSystemProject ProjectSystemProject { get; }
-        internal ProjectSystemProjectOptionsProcessor VisualStudioProjectOptionsProcessor { get; set; }
+        internal ProjectSystemProjectOptionsProcessor ProjectSystemProjectOptionsProcessor { get; set; }
         protected IProjectCodeModel ProjectCodeModel { get; set; }
         protected VisualStudioWorkspace Workspace { get; }
 
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
 
             workspaceImpl.AddProjectRuleSetFileToInternalMaps(
                 ProjectSystemProject,
-                () => VisualStudioProjectOptionsProcessor.EffectiveRuleSetFilePath);
+                () => ProjectSystemProjectOptionsProcessor.EffectiveRuleSetFilePath);
 
             // Right now VB doesn't have the concept of "default namespace". But we conjure one in workspace 
             // by assigning the value of the project's root namespace to it. So various feature can choose to 
@@ -161,7 +161,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
         {
             _batchScopeCreator.StopTrackingProject(ProjectSystemProject);
 
-            VisualStudioProjectOptionsProcessor?.Dispose();
+            ProjectSystemProjectOptionsProcessor?.Dispose();
             ProjectCodeModel.OnProjectClosed();
             ProjectSystemProject.RemoveFromWorkspace();
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
     {
         public IVsHierarchy Hierarchy { get; }
         protected ProjectSystemProject ProjectSystemProject { get; }
-        internal VisualStudioProjectOptionsProcessor VisualStudioProjectOptionsProcessor { get; set; }
+        internal ProjectSystemProjectOptionsProcessor VisualStudioProjectOptionsProcessor { get; set; }
         protected IProjectCodeModel ProjectCodeModel { get; set; }
         protected VisualStudioWorkspace Workspace { get; }
 

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IAnalyzerHost.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_IAnalyzerHost.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
                 ruleSetFileFullPath = null;
             }
 
-            VisualStudioProjectOptionsProcessor.ExplicitRuleSetFilePath = ruleSetFileFullPath;
+            ProjectSystemProjectOptionsProcessor.ExplicitRuleSetFilePath = ruleSetFileFullPath;
         }
 
         void IAnalyzerHost.AddAdditionalFile(string additionalFilePath)

--- a/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_ICompilerOptionsHostObject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/Legacy/AbstractLegacyProject_ICompilerOptionsHostObject.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
         int ICompilerOptionsHostObject.SetCompilerOptions(string compilerOptions, out bool supported)
         {
 #pragma warning disable CS0618 // Type or member is obsolete (Legacy API that cannot be changed)
-            VisualStudioProjectOptionsProcessor.SetCommandLine(compilerOptions);
+            ProjectSystemProjectOptionsProcessor.SetCommandLine(compilerOptions);
 #pragma warning restore CS0618
             supported = true;
             return VSConstants.S_OK;

--- a/src/VisualStudio/Core/Def/ProjectSystem/RuleSets/VisualStudioRuleSetManager.RuleSetFile.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/RuleSets/VisualStudioRuleSetManager.RuleSetFile.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ProjectSystem;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {

--- a/src/VisualStudio/Core/Def/ProjectSystem/RuleSets/VisualStudioRuleSetManager.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/RuleSets/VisualStudioRuleSetManager.cs
@@ -8,11 +8,12 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.ProjectSystem;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
-    internal sealed partial class VisualStudioRuleSetManager : IWorkspaceService
+    internal sealed partial class VisualStudioRuleSetManager : IRuleSetManager
     {
         private readonly IThreadingContext _threadingContext;
         private readonly IFileChangeWatcher _fileChangeWatcher;

--- a/src/VisualStudio/Core/Def/ProjectSystem/RuleSets/VisualStudioRuleSetManagerFactory.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/RuleSets/VisualStudioRuleSetManagerFactory.cs
@@ -8,10 +8,11 @@ using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
+using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
-    [ExportWorkspaceServiceFactory(typeof(VisualStudioRuleSetManager), ServiceLayer.Host), Shared]
+    [ExportWorkspaceServiceFactory(typeof(IRuleSetManager), ServiceLayer.Host), Shared]
     internal sealed class VisualStudioRuleSetManagerFactory : IWorkspaceServiceFactory
     {
         private readonly IThreadingContext _threadingContext;

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -24,10 +24,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         private readonly ProjectSystemProject _projectSystemProject;
 
         /// <summary>
-        /// The <see cref="VisualStudioProjectOptionsProcessor"/> we're using to parse command line options. Null if we don't
+        /// The <see cref="ProjectSystemProjectOptionsProcessor"/> we're using to parse command line options. Null if we don't
         /// have the ability to parse command line options.
         /// </summary>
-        private readonly VisualStudioProjectOptionsProcessor? _visualStudioProjectOptionsProcessor;
+        private readonly ProjectSystemProjectOptionsProcessor? _visualStudioProjectOptionsProcessor;
 
         private readonly VisualStudioWorkspaceImpl _visualStudioWorkspace;
         private readonly IProjectCodeModel _projectCodeModel;
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             // If we have a command line parser service for this language, also set up our ability to process options if they come in
             if (visualStudioWorkspace.Services.GetLanguageServices(projectSystemProject.Language).GetService<ICommandLineParserService>() != null)
             {
-                _visualStudioProjectOptionsProcessor = new VisualStudioProjectOptionsProcessor(_projectSystemProject, visualStudioWorkspace.Services.SolutionServices);
+                _visualStudioProjectOptionsProcessor = new ProjectSystemProjectOptionsProcessor(_projectSystemProject, visualStudioWorkspace.Services.SolutionServices);
                 _visualStudioWorkspace.AddProjectRuleSetFileToInternalMaps(
                     projectSystemProject,
                     () => _visualStudioProjectOptionsProcessor.EffectiveRuleSetFilePath);

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         /// The <see cref="ProjectSystemProjectOptionsProcessor"/> we're using to parse command line options. Null if we don't
         /// have the ability to parse command line options.
         /// </summary>
-        private readonly ProjectSystemProjectOptionsProcessor? _visualStudioProjectOptionsProcessor;
+        private readonly ProjectSystemProjectOptionsProcessor? _projectSystemProjectOptionsProcessor;
 
         private readonly VisualStudioWorkspaceImpl _visualStudioWorkspace;
         private readonly IProjectCodeModel _projectCodeModel;
@@ -88,10 +88,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             // If we have a command line parser service for this language, also set up our ability to process options if they come in
             if (visualStudioWorkspace.Services.GetLanguageServices(projectSystemProject.Language).GetService<ICommandLineParserService>() != null)
             {
-                _visualStudioProjectOptionsProcessor = new ProjectSystemProjectOptionsProcessor(_projectSystemProject, visualStudioWorkspace.Services.SolutionServices);
+                _projectSystemProjectOptionsProcessor = new ProjectSystemProjectOptionsProcessor(_projectSystemProject, visualStudioWorkspace.Services.SolutionServices);
                 _visualStudioWorkspace.AddProjectRuleSetFileToInternalMaps(
                     projectSystemProject,
-                    () => _visualStudioProjectOptionsProcessor.EffectiveRuleSetFilePath);
+                    () => _projectSystemProjectOptionsProcessor.EffectiveRuleSetFilePath);
             }
 
             Guid = projectGuid;
@@ -136,10 +136,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         public ProjectId Id => _projectSystemProject.Id;
 
         public void SetOptions(string commandLineForOptions)
-            => _visualStudioProjectOptionsProcessor?.SetCommandLine(commandLineForOptions);
+            => _projectSystemProjectOptionsProcessor?.SetCommandLine(commandLineForOptions);
 
         public void SetOptions(ImmutableArray<string> arguments)
-            => _visualStudioProjectOptionsProcessor?.SetCommandLine(arguments);
+            => _projectSystemProjectOptionsProcessor?.SetCommandLine(arguments);
 
         public void SetProperty(string name, string? value)
         {
@@ -238,7 +238,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         public void Dispose()
         {
             _projectCodeModel?.OnProjectClosed();
-            _visualStudioProjectOptionsProcessor?.Dispose();
+            _projectSystemProjectOptionsProcessor?.Dispose();
             _projectSystemProject.RemoveFromWorkspace();
         }
 

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/MockRuleSetFile.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/MockRuleSetFile.vb
@@ -4,6 +4,7 @@
 
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Workspaces.ProjectSystem
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.OptionsProcessor.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.OptionsProcessor.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
     ''' <remarks></remarks>
     Partial Friend NotInheritable Class VisualBasicProject
         Friend NotInheritable Class OptionsProcessor
-            Inherits VisualStudioProjectOptionsProcessor
+            Inherits ProjectSystemProjectOptionsProcessor
 
             Private _rawOptions As VBCompilerOptions
             Private ReadOnly _imports As New List(Of GlobalImport)

--- a/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/ProjectSystemShim/VisualBasicProject.vb
@@ -54,10 +54,10 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 
         Private Shadows Property VisualStudioProjectOptionsProcessor As OptionsProcessor
             Get
-                Return DirectCast(MyBase.VisualStudioProjectOptionsProcessor, OptionsProcessor)
+                Return DirectCast(MyBase.ProjectSystemProjectOptionsProcessor, OptionsProcessor)
             End Get
             Set(value As OptionsProcessor)
-                MyBase.VisualStudioProjectOptionsProcessor = value
+                MyBase.ProjectSystemProjectOptionsProcessor = value
             End Set
         End Property
 

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IRuleSetFile.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IRuleSetFile.cs
@@ -8,7 +8,7 @@ using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 
-namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
 {
     internal interface IRuleSetFile
     {

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IRuleSetManager.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IRuleSetManager.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.Host;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
+{
+    internal interface IRuleSetManager : IWorkspaceService
+    {
+        IReferenceCountedDisposable<ICacheEntry<string, IRuleSetFile>> GetOrCreateRuleSet(string ruleSetFileFullPath);
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectOptionsProcessor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectOptionsProcessor.cs
@@ -3,19 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
-using System.Threading;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Scripting.Hosting;
-using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Roslyn.Utilities;
 
-namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
+namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
 {
-    internal class VisualStudioProjectOptionsProcessor : IDisposable
+    internal class ProjectSystemProjectOptionsProcessor : IDisposable
     {
         private readonly ProjectSystemProject _project;
         private readonly SolutionServices _workspaceServices;
@@ -47,7 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private string? _explicitRuleSetFilePath;
         private IReferenceCountedDisposable<ICacheEntry<string, IRuleSetFile>>? _ruleSetFile = null;
 
-        public VisualStudioProjectOptionsProcessor(
+        public ProjectSystemProjectOptionsProcessor(
             ProjectSystemProject project,
             SolutionServices workspaceServices)
         {
@@ -174,7 +169,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
                 if (effectiveRuleSetPath != null)
                 {
-                    _ruleSetFile = _workspaceServices.GetRequiredService<VisualStudioRuleSetManager>().GetOrCreateRuleSet(effectiveRuleSetPath);
+                    _ruleSetFile = _workspaceServices.GetRequiredService<IRuleSetManager>().GetOrCreateRuleSet(effectiveRuleSetPath);
                     _ruleSetFile.Target.Value.UpdatedOnDisk += RuleSetFile_UpdatedOnDisk;
                 }
             }
@@ -209,8 +204,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _project.ChecksumAlgorithm = _commandLineArgumentsForCommandLine.ChecksumAlgorithm;
         }
 
-        private void RuleSetFile_UpdatedOnDisk(object sender, EventArgs e)
+        private void RuleSetFile_UpdatedOnDisk(object? sender, EventArgs e)
         {
+            Contract.ThrowIfNull(sender);
+
             lock (_gate)
             {
                 // This event might have gotten fired "late" if the file change was already in flight. We can see if this is still our current file;


### PR DESCRIPTION
This just moves the type down, and introduces an IRuleSetManager interface to abstract out the VS layer. Further refactoring will need to be made to move the implementations down, but for now this makes the code available to other hosts.