### PR TITLE
Fix reading VB editor options from ISettingsManager (17.4)

### DIFF
--- a/src/EditorFeatures/Core/Options/NavigationBarViewOptionsStorage.cs
+++ b/src/EditorFeatures/Core/Options/NavigationBarViewOptionsStorage.cs
@@ -11,5 +11,5 @@ internal sealed class NavigationBarViewOptionsStorage
     private const string FeatureName = "NavigationBarOptions";
 
     public static readonly PerLanguageOption2<bool> ShowNavigationBar = new(
-        FeatureName, "ShowNavigationBar", defaultValue: true, new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Dropdown Bar"));
+        FeatureName, "ShowNavigationBar", defaultValue: true, new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Dropdown Bar", useEditorLanguageName: true));
 }

--- a/src/EditorFeatures/Core/Options/SignatureHelpViewOptionsStorage.cs
+++ b/src/EditorFeatures/Core/Options/SignatureHelpViewOptionsStorage.cs
@@ -11,5 +11,5 @@ internal sealed class SignatureHelpViewOptionsStorage
     private const string FeatureName = "SignatureHelpOptions";
 
     public static readonly PerLanguageOption2<bool> ShowSignatureHelp = new(
-        FeatureName, "ShowSignatureHelp", defaultValue: true, new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Auto List Params"));
+        FeatureName, "ShowSignatureHelp", defaultValue: true, new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Auto List Params", useEditorLanguageName: true));
 }

--- a/src/Features/LanguageServer/Protocol/Features/Options/CompletionOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/CompletionOptionsStorage.cs
@@ -49,11 +49,11 @@ internal static class CompletionOptionsStorage
 
     public static readonly PerLanguageOption2<bool> HideAdvancedMembers = new(
         "CompletionOptions", "HideAdvancedMembers", CompletionOptions.Default.HideAdvancedMembers,
-        new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Hide Advanced Auto List Members"));
+        new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Hide Advanced Auto List Members", useEditorLanguageName: true));
 
     public static readonly PerLanguageOption2<bool> TriggerOnTyping = new(
         "CompletionOptions", "TriggerOnTyping", CompletionOptions.Default.TriggerOnTyping,
-        new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Auto List Members"));
+        new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Auto List Members", useEditorLanguageName: true));
 
     public static readonly PerLanguageOption2<bool> TriggerOnTypingLetters = new(nameof(CompletionOptions), nameof(TriggerOnTypingLetters), CompletionOptions.Default.TriggerOnTypingLetters,
         storageLocation: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.TriggerOnTypingLetters"));

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/FormattingOptions2.cs
@@ -41,19 +41,19 @@ namespace Microsoft.CodeAnalysis.Formatting
             new(FeatureName, FormattingOptionGroups.IndentationAndSpacing, nameof(UseTabs), LineFormattingOptions.Default.UseTabs,
             storageLocations: ImmutableArray.Create<OptionStorageLocation2>(
                 new EditorConfigStorageLocation<bool>("indent_style", s => s == "tab", isSet => isSet ? "tab" : "space"),
-                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Insert Tabs")));
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Insert Tabs", useEditorLanguageName: true)));
 
         public static PerLanguageOption2<int> TabSize =
             new(FeatureName, FormattingOptionGroups.IndentationAndSpacing, nameof(TabSize), LineFormattingOptions.Default.TabSize,
             storageLocations: ImmutableArray.Create<OptionStorageLocation2>(
                 EditorConfigStorageLocation.ForInt32Option("tab_width"),
-                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Tab Size")));
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Tab Size", useEditorLanguageName: true)));
 
         public static PerLanguageOption2<int> IndentationSize =
             new(FeatureName, FormattingOptionGroups.IndentationAndSpacing, nameof(IndentationSize), LineFormattingOptions.Default.IndentationSize,
             storageLocations: ImmutableArray.Create<OptionStorageLocation2>(
                 EditorConfigStorageLocation.ForInt32Option("indent_size"),
-                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Indent Size")));
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Indent Size", useEditorLanguageName: true)));
 
         public static PerLanguageOption2<string> NewLine =
             new(FeatureName, FormattingOptionGroups.NewLine, nameof(NewLine), LineFormattingOptions.Default.NewLine,
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         public static PerLanguageOption2<IndentStyle> SmartIndent { get; } =
             new(FeatureName, FormattingOptionGroups.IndentationAndSpacing, nameof(SmartIndent), defaultValue: IndentationOptions.DefaultIndentStyle,
-                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Indent Style"));
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Indent Style", useEditorLanguageName: true));
 
 #if !CODE_STYLE
         internal static readonly ImmutableArray<IOption> Options = ImmutableArray.Create<IOption>(

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/ClientSettingsStorageLocation.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/ClientSettingsStorageLocation.cs
@@ -17,9 +17,13 @@ namespace Microsoft.CodeAnalysis.Options;
 internal abstract class ClientSettingsStorageLocation : OptionStorageLocation2
 {
     private readonly Func<string?, string> _keyNameFromLanguageName;
+    private readonly bool _useEditorLanguageName;
 
-    public ClientSettingsStorageLocation(string keyName)
-        => _keyNameFromLanguageName = _ => keyName;
+    public ClientSettingsStorageLocation(string keyName, bool useEditorLanguageName)
+    {
+        _keyNameFromLanguageName = _ => keyName;
+        _useEditorLanguageName = useEditorLanguageName;
+    }
 
     /// <summary>
     /// Creates a <see cref="ClientSettingsStorageLocation"/> that has different key names for different languages.
@@ -39,7 +43,7 @@ internal abstract class ClientSettingsStorageLocation : OptionStorageLocation2
             keyName = keyName.Replace("%LANGUAGE%", languageName switch
             {
                 LanguageNames.CSharp => "CSharp",
-                LanguageNames.VisualBasic => "VisualBasic",
+                LanguageNames.VisualBasic => _useEditorLanguageName ? "Basic" : "VisualBasic",
                 _ => languageName // handles F#, TypeScript and Xaml
             });
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/LocalClientSettingsStorageLocation.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/LocalClientSettingsStorageLocation.cs
@@ -20,7 +20,7 @@ internal sealed class LocalClientSettingsStorageLocation : ClientSettingsStorage
     public override bool IsMachineLocal => true;
 
     public LocalClientSettingsStorageLocation(string keyName)
-        : base(keyName)
+        : base(keyName, useEditorLanguageName: false)
     {
     }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/RoamingProfileStorageLocation.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/RoamingProfileStorageLocation.cs
@@ -13,8 +13,8 @@ internal sealed class RoamingProfileStorageLocation : ClientSettingsStorageLocat
 {
     public override bool IsMachineLocal => false;
 
-    public RoamingProfileStorageLocation(string keyName)
-        : base(keyName)
+    public RoamingProfileStorageLocation(string keyName, bool useEditorLanguageName = false)
+        : base(keyName, useEditorLanguageName)
     {
     }
 


### PR DESCRIPTION
We regressed a few VB editor options in 17.4 (PR: https://github.com/dotnet/roslyn/pull/62759) when we switched reading these options from IVsTextManagerEvents4 to ISettingsManager API.
- formatting: "Use Tabs", "Indent Size", "Tab Size". "Smart Indent",
- statement completion: "Auto list members", "Hide advanced members", "Parameter information",
- settings: "Navigation bar"

We don't read their values for VS settings correctly for VB because we use language name "VisualBasic" while the editor uses "Basic" in the option storage name.

This does not affect other languages (C#, F#).

Fixes https://github.com/dotnet/roslyn/issues/66325
VS issue: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1717717