### PR TITLE
Fix reading VB editor options from ISettingsManager (main)

### DIFF
--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -127,7 +127,9 @@ internal abstract class VisualStudioOptionStorage
         {"CompletionOptions_BlockForCompletionItems", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.BlockForCompletionItems")},
         {"CompletionOptions_EnableArgumentCompletionSnippets", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.EnableArgumentCompletionSnippets")},
         {"CompletionOptions_EnterKeyBehavior", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.EnterKeyBehavior")},
-        {"CompletionOptions_HideAdvancedMembers", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Hide Advanced Auto List Members")},
+#pragma warning disable CS0612 // Type or member is obsolete
+        {"CompletionOptions_HideAdvancedMembers", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Hide Advanced Auto List Members", vbKey: "TextEditor.Basic.Hide Advanced Auto List Members")},
+#pragma warning restore
         {"CompletionOptions_HighlightMatchingPortionsOfCompletionListItems", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.HighlightMatchingPortionsOfCompletionListItems")},
         {"CompletionOptions_ShowCompletionItemFilters", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ShowCompletionItemFilters")},
         {"CompletionOptions_ShowItemsFromUnimportedNamespaces", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ShowItemsFromUnimportedNamespaces")},
@@ -137,7 +139,9 @@ internal abstract class VisualStudioOptionStorage
         {"CompletionOptions_SnippetsBehavior", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.SnippetsBehavior")},
         {"CompletionOptions_TriggerInArgumentLists", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.TriggerInArgumentLists")},
         {"CompletionOptions_TriggerOnDeletion", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.TriggerOnDeletion")},
-        {"CompletionOptions_TriggerOnTyping", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Auto List Members")},
+#pragma warning disable CS0612 // Type or member is obsolete
+        {"CompletionOptions_TriggerOnTyping", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Auto List Members", vbKey: "TextEditor.Basic.Auto List Members")},
+#pragma warning restore
         {"CompletionOptions_TriggerOnTypingLetters", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.TriggerOnTypingLetters")},
         {"CompletionOptions_UnnamedSymbolCompletionDisabledFeatureFlag", new FeatureFlagStorage(@"Roslyn.UnnamedSymbolCompletionDisabled")},
         {"csharp_indent_block_contents", new RoamingProfileStorage("TextEditor.CSharp.Specific.IndentBlock")},
@@ -304,15 +308,19 @@ internal abstract class VisualStudioOptionStorage
         {"FormattingOptions_AutoFormattingOnSemicolon", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.Auto Formatting On Semicolon")},
         {"FormattingOptions_AutoFormattingOnTyping", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.Auto Formatting On Typing")},
         {"FormattingOptions_FormatOnPaste", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.FormatOnPaste")},
-        {"FormattingOptions_SmartIndent", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Indent Style")},
+#pragma warning disable CS0612 // Type or member is obsolete
+        {"FormattingOptions_SmartIndent", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Indent Style", vbKey: "TextEditor.Basic.Indent Style")},
+#pragma warning restore
         {"GenerateConstructorFromMembersOptions_AddNullChecks", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.GenerateConstructorFromMembersOptions.AddNullChecks")},
         {"GenerateEqualsAndGetHashCodeFromMembersOptions_GenerateOperators", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.GenerateEqualsAndGetHashCodeFromMembersOptions.GenerateOperators")},
         {"GenerateEqualsAndGetHashCodeFromMembersOptions_ImplementIEquatable", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.GenerateEqualsAndGetHashCodeFromMembersOptions.ImplementIEquatable")},
         {"GenerateOverridesOptions_SelectAll", new RoamingProfileStorage("TextEditor.Specific.GenerateOverridesOptions.SelectAll")},
         {"ImplementTypeOptions_InsertionBehavior", new RoamingProfileStorage("TextEditor.%LANGUAGE%.ImplementTypeOptions.InsertionBehavior")},
         {"ImplementTypeOptions_PropertyGenerationBehavior", new RoamingProfileStorage("TextEditor.%LANGUAGE%.ImplementTypeOptions.PropertyGenerationBehavior")},
-        {"indent_size", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Indent Size")},
-        {"indent_style", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Insert Tabs")},
+#pragma warning disable CS0612 // Type or member is obsolete
+        {"indent_size", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Indent Size", vbKey: "TextEditor.Basic.Indent Size")},
+        {"indent_style", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Insert Tabs", vbKey: "TextEditor.Basic.Insert Tabs")},
+#pragma warning restore
         {"InlineDiagnosticsOptions_EnableInlineDiagnostics", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.InlineDiagnostics")},
         {"InlineDiagnosticsOptions_Location", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.InlineDiagnostics.LocationOption")},
         {"InlineHintsOptions_ColorHints", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ColorHints")},
@@ -372,7 +380,9 @@ internal abstract class VisualStudioOptionStorage
         {"LspOptions_LspEditorFeatureFlag", new FeatureFlagStorage(@"Roslyn.LSP.Editor")},
         {"LspOptions_LspSemanticTokensFeatureFlag", new FeatureFlagStorage(@"Roslyn.LSP.SemanticTokens")},
         {"LspOptions_MaxCompletionListSize", new LocalUserProfileStorage(@"Roslyn\Internal\Lsp", "MaxCompletionListSize")},
-        {"NavigationBarOptions_ShowNavigationBar", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Dropdown Bar")},
+#pragma warning disable CS0612 // Type or member is obsolete
+        {"NavigationBarOptions_ShowNavigationBar", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Dropdown Bar", vbKey: "TextEditor.Basic.Dropdown Bar")},
+#pragma warning restore
         {"QuickInfoOptions_IncludeNavigationHintsInQuickInfo", new RoamingProfileStorage("TextEditor.Specific.IncludeNavigationHintsInQuickInfo")},
         {"QuickInfoOptions_ShowRemarksInQuickInfo", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ShowRemarks")},
         {"RegularExpressionsOptions_ColorizeRegexPatterns", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ColorizeRegexPatterns")},
@@ -380,7 +390,9 @@ internal abstract class VisualStudioOptionStorage
         {"RegularExpressionsOptions_ProvideRegexCompletions", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ProvideRegexCompletions")},
         {"RegularExpressionsOptions_ReportInvalidRegexPatterns", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ReportInvalidRegexPatterns")},
         {"ServiceFeatureOnOffOptions_RemoveDocumentDiagnosticsOnDocumentClose", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.RemoveDocumentDiagnosticsOnDocumentClose")},
-        {"SignatureHelpOptions_ShowSignatureHelp", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Auto List Params")},
+#pragma warning disable CS0612 // Type or member is obsolete
+        {"SignatureHelpOptions_ShowSignatureHelp", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Auto List Params", vbKey: "TextEditor.Basic.Auto List Params")},
+#pragma warning restore
         {"SimplificationOptions_NamingPreferences", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.NamingPreferences5")},
         {"SolutionCrawlerOptionsStorage_BackgroundAnalysisScopeOption", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.BackgroundAnalysisScopeOption")},
         {"SolutionCrawlerOptionsStorage_CompilerDiagnosticsScopeOption", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.CompilerDiagnosticsScopeOption")},
@@ -392,7 +404,9 @@ internal abstract class VisualStudioOptionStorage
         {"SymbolSearchOptions_Enabled", new LocalUserProfileStorage(@"Roslyn\Features\SymbolSearch", "Enabled")},
         {"SymbolSearchOptions_SuggestForTypesInNuGetPackages", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.SuggestForTypesInNuGetPackages")},
         {"SymbolSearchOptions_SuggestForTypesInReferenceAssemblies", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.SuggestForTypesInReferenceAssemblies")},
-        {"tab_width", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Tab Size")},
+#pragma warning disable CS0612 // Type or member is obsolete
+        {"tab_width", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Tab Size", "TextEditor.Basic.Tab Size")},
+#pragma warning restore
         {"TaskListOptionsStorage_ComputeTaskListItemsForClosedFiles", new RoamingProfileStorage("TextEditor.Specific.ComputeTaskListItemsForClosedFiles")},
         {"TaskListOptionsStorage_Descriptors", new RoamingProfileStorage("Microsoft.VisualStudio.ErrorListPkg.Shims.TaskListOptions.CommentTokens")},
         {"UseConditionalExpressionOptions_ConditionalExpressionWrappingLength", new RoamingProfileStorage("TextEditor.%LANGUAGE%.Specific.ConditionalExpressionWrappingLength")},


### PR DESCRIPTION
We regressed a few VB editor options in 17.4 (PR: https://github.com/dotnet/roslyn/pull/62759) when we switched reading these options from IVsTextManagerEvents4 to ISettingsManager API.
- formatting: "Use Tabs", "Indent Size", "Tab Size". "Smart Indent",
- statement completion: "Auto list members", "Hide advanced members", "Parameter information",
- settings: "Navigation bar"

We don't read their values for VS settings correctly for VB because we use language name "VisualBasic" while the editor uses "Basic" in the option storage name.

This does not affect other languages (C#, F#).

Fixes https://github.com/dotnet/roslyn/issues/66325