### PR TITLE
Revert "Do not copy nullable value type receiver of a constrained call."

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -4579,21 +4579,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                         stackLocalsOpt));
                     goto case BoundKind.ConditionalReceiver;
 
-                case BoundKind.ComplexReceiver:
-                    Debug.Assert(HasHome(
-                        ((BoundComplexReceiver)expression).ValueTypeReceiver,
-                        addressKind,
-                        containingSymbol,
-                        peVerifyCompatEnabled,
-                        stackLocalsOpt));
-                    Debug.Assert(HasHome(
-                        ((BoundComplexReceiver)expression).ReferenceTypeReceiver,
-                        addressKind,
-                        containingSymbol,
-                        peVerifyCompatEnabled,
-                        stackLocalsOpt));
-                    goto case BoundKind.ConditionalReceiver;
-
                 case BoundKind.ConditionalReceiver:
                     //ConditionalReceiver is a noop from Emit point of view. - it represents something that has already been pushed. 
                     //We should never need a temp for it. 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1714,22 +1714,12 @@
     <Field Name="Id" Type="int"/>
   </Node>
 
-  <!--  This node represents a complex receiver for a conditional access.  
-        At runtime, when its type is a non-nullable value type, ValueTypeReceiver should be used as a receiver. 
+  <!--  This node represents a complex receiver for a call, or a conditional access.  
+        At runtime, when its type is a value type, ValueTypeReceiver should be used as a receiver. 
         Otherwise, ReferenceTypeReceiver should be used.  
         This kind of receiver is created only by SpillSequenceSpiller rewriter. 
   -->
   <Node Name="BoundComplexConditionalReceiver" Base="BoundExpression">
-    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
-    <Field Name="ValueTypeReceiver" Type="BoundExpression" Null="disallow"/>
-    <Field Name="ReferenceTypeReceiver" Type="BoundExpression" Null="disallow"/>
-  </Node>
-
-  <!--  This node represents a complex receiver for a call.  
-        At runtime, when its type is a value type (including nullable value type), ValueTypeReceiver should be used as a receiver. 
-        Otherwise, ReferenceTypeReceiver should be used.  
-  -->
-  <Node Name="BoundComplexReceiver" Base="BoundExpression">
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="ValueTypeReceiver" Type="BoundExpression" Null="disallow"/>
     <Field Name="ReferenceTypeReceiver" Type="BoundExpression" Null="disallow"/>

--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -224,14 +224,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             hasStackAlloc = _sawStackalloc;
             Debug.Assert(_asyncCatchHandlerOffset >= 0);
 
-            asyncCatchHandlerOffset = _diagnostics.HasAnyErrors() ? -1 : _builder.GetILOffsetFromMarker(_asyncCatchHandlerOffset);
+            asyncCatchHandlerOffset = _builder.GetILOffsetFromMarker(_asyncCatchHandlerOffset);
 
             ArrayBuilder<int> yieldPoints = _asyncYieldPoints;
             ArrayBuilder<int> resumePoints = _asyncResumePoints;
 
             Debug.Assert((yieldPoints == null) == (resumePoints == null));
 
-            if (yieldPoints == null || _diagnostics.HasAnyErrors())
+            if (yieldPoints == null)
             {
                 asyncYieldPoints = ImmutableArray<int>.Empty;
                 asyncResumePoints = ImmutableArray<int>.Empty;

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitAddress.cs
@@ -48,10 +48,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     EmitComplexConditionalReceiverAddress((BoundComplexConditionalReceiver)expression);
                     break;
 
-                case BoundKind.ComplexReceiver:
-                    EmitComplexReceiverAddress((BoundComplexReceiver)expression);
-                    break;
-
                 case BoundKind.Parameter:
                     return EmitParameterAddress((BoundParameter)expression, addressKind);
 

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -316,10 +316,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     EmitComplexConditionalReceiver((BoundComplexConditionalReceiver)expression, used);
                     break;
 
-                case BoundKind.ComplexReceiver:
-                    EmitComplexReceiver((BoundComplexReceiver)expression, used);
-                    break;
-
                 case BoundKind.PseudoVariable:
                     EmitPseudoVariableValue((BoundPseudoVariable)expression, used);
                     break;
@@ -369,11 +365,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
             EmitExpression(expression.ReferenceTypeReceiver, used);
             _builder.EmitBranch(ILOpCode.Br, doneLabel);
-
-            if (used)
-            {
-                _builder.AdjustStack(-1);
-            }
+            _builder.AdjustStack(-1);
 
             _builder.MarkLabel(whenValueTypeLabel);
             EmitExpression(expression.ValueTypeReceiver, used);
@@ -420,8 +412,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                                    ((TypeParameterSymbol)receiverType).EffectiveInterfacesNoUseSiteDiagnostics.IsEmpty) || // This could be a nullable value type, which must be copied in order to not mutate the original value
                                    LocalRewriter.CanChangeValueBetweenReads(receiver, localsMayBeAssignedOrCaptured: false) ||
                                    (receiverType.IsReferenceType && receiverType.TypeKind == TypeKind.TypeParameter) ||
-                                   (receiver.Kind == BoundKind.Local && IsStackLocal(((BoundLocal)receiver).LocalSymbol)) ||
-                                   (notConstrained && IsConditionalConstrainedCallThatMustUseTempForReferenceTypeReceiverWalker.Analyze(expression));
+                                   (receiver.Kind == BoundKind.Local && IsStackLocal(((BoundLocal)receiver).LocalSymbol));
 
             // ===== RECEIVER
             if (nullCheckOnCopy)
@@ -570,60 +561,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             if (receiverTemp != null)
             {
                 FreeTemp(receiverTemp);
-            }
-        }
-
-        private sealed class IsConditionalConstrainedCallThatMustUseTempForReferenceTypeReceiverWalker : BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
-        {
-            private readonly BoundLoweredConditionalAccess _conditionalAccess;
-            private bool? _result;
-
-            private IsConditionalConstrainedCallThatMustUseTempForReferenceTypeReceiverWalker(BoundLoweredConditionalAccess conditionalAccess)
-                : base()
-            {
-                _conditionalAccess = conditionalAccess;
-            }
-
-            public static bool Analyze(BoundLoweredConditionalAccess conditionalAccess)
-            {
-                var walker = new IsConditionalConstrainedCallThatMustUseTempForReferenceTypeReceiverWalker(conditionalAccess);
-                walker.Visit(conditionalAccess.WhenNotNull);
-                Debug.Assert(walker._result.HasValue);
-                return walker._result.GetValueOrDefault();
-            }
-
-            public override BoundNode Visit(BoundNode node)
-            {
-                if (_result.HasValue)
-                {
-                    return null;
-                }
-
-                return base.Visit(node);
-            }
-
-            public override BoundNode VisitCall(BoundCall node)
-            {
-                if (node.ReceiverOpt is BoundConditionalReceiver { Id: var id } && id == _conditionalAccess.Id)
-                {
-                    Debug.Assert(!_result.HasValue);
-                    _result = !IsSafeToDereferenceReceiverRefAfterEvaluatingArguments(node.Arguments);
-                    return null;
-                }
-
-                return base.VisitCall(node);
-            }
-
-            public override BoundNode VisitConditionalReceiver(BoundConditionalReceiver node)
-            {
-                if (node.Id == _conditionalAccess.Id)
-                {
-                    Debug.Assert(!_result.HasValue);
-                    _result = false;
-                    return null;
-                }
-
-                return base.VisitConditionalReceiver(node);
             }
         }
 
@@ -1815,21 +1752,25 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     // reference to the stack. So, for a class we need to emit a reference to a temporary
                     // location, rather than to the original location
 
-                    // We will emit a runtime check for a class, but the check is really a JIT-time 
+                    // Struct values are never nulls.
+                    // We will emit a check for such case, but the check is really a JIT-time 
                     // constant since JIT will know if T is a struct or not.
 
-                    // if (!typeof(T).IsValueType)
+                    // if ((object)default(T) == null) 
                     // {
                     //     temp = receiverRef
                     //     receiverRef = ref temp
                     // }
 
-                    object whenValueTypeLabel = null;
+                    object whenNotNullLabel = null;
 
                     if (!receiverType.IsReferenceType)
                     {
-                        // if (!typeof(T).IsValueType)
-                        whenValueTypeLabel = TryEmitIsValueTypeBranch(receiverType, receiver.Syntax);
+                        // if ((object)default(T) == null) 
+                        EmitDefaultValue(receiverType, true, receiver.Syntax);
+                        EmitBox(receiverType, receiver.Syntax);
+                        whenNotNullLabel = new object();
+                        _builder.EmitBranch(ILOpCode.Brtrue, whenNotNullLabel);
                     }
 
                     //     temp = receiverRef
@@ -1839,89 +1780,14 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     _builder.EmitLocalStore(tempOpt);
                     _builder.EmitLocalAddress(tempOpt);
 
-                    if (whenValueTypeLabel is not null)
+                    if (whenNotNullLabel is not null)
                     {
-                        _builder.MarkLabel(whenValueTypeLabel);
+                        _builder.MarkLabel(whenNotNullLabel);
                     }
                 }
 
                 return tempOpt;
             }
-        }
-
-        private object TryEmitIsValueTypeBranch(TypeSymbol type, SyntaxNode syntax)
-        {
-            if (Binder.GetWellKnownTypeMember(_module.Compilation, WellKnownMember.System_Type__GetTypeFromHandle, _diagnostics, syntax: syntax, isOptional: false) is MethodSymbol getTypeFromHandle &&
-                Binder.GetWellKnownTypeMember(_module.Compilation, WellKnownMember.System_Type__get_IsValueType, _diagnostics, syntax: syntax, isOptional: false) is MethodSymbol getIsValueType)
-            {
-                _builder.EmitOpCode(ILOpCode.Ldtoken);
-                EmitSymbolToken(type, syntax);
-                _builder.EmitOpCode(ILOpCode.Call, stackAdjustment: 0); // argument off, return value on
-                EmitSymbolToken(getTypeFromHandle, syntax, null);
-                _builder.EmitOpCode(ILOpCode.Call, stackAdjustment: 0); // instance off, return value on
-                EmitSymbolToken(getIsValueType, syntax, null);
-                var whenValueTypeLabel = new object();
-                _builder.EmitBranch(ILOpCode.Brtrue, whenValueTypeLabel);
-
-                return whenValueTypeLabel;
-            }
-
-            return null;
-        }
-
-        private void EmitComplexReceiver(BoundComplexReceiver expression, bool used)
-        {
-            Debug.Assert(!used);
-            Debug.Assert(!expression.Type.IsReferenceType);
-            Debug.Assert(!expression.Type.IsValueType);
-
-            var receiverType = expression.Type;
-
-            // if (!typeof(T).IsValueType)
-            object whenValueTypeLabel = TryEmitIsValueTypeBranch(receiverType, expression.Syntax);
-
-            EmitExpression(expression.ReferenceTypeReceiver, used);
-            var doneLabel = new object();
-            _builder.EmitBranch(ILOpCode.Br, doneLabel);
-
-            if (whenValueTypeLabel is not null)
-            {
-                if (used)
-                {
-                    _builder.AdjustStack(-1);
-                }
-
-                _builder.MarkLabel(whenValueTypeLabel);
-                EmitExpression(expression.ValueTypeReceiver, used);
-            }
-
-            _builder.MarkLabel(doneLabel);
-        }
-
-        private void EmitComplexReceiverAddress(BoundComplexReceiver expression)
-        {
-            Debug.Assert(!expression.Type.IsReferenceType);
-            Debug.Assert(!expression.Type.IsValueType);
-
-            var receiverType = expression.Type;
-
-            // if (!typeof(T).IsValueType)
-            object whenValueTypeLabel = TryEmitIsValueTypeBranch(receiverType, expression.Syntax);
-
-            var receiverTemp = EmitAddress(expression.ReferenceTypeReceiver, AddressKind.ReadOnly);
-            Debug.Assert(receiverTemp == null);
-            var doneLabel = new Object();
-            _builder.EmitBranch(ILOpCode.Br, doneLabel);
-
-            if (whenValueTypeLabel is not null)
-            {
-                _builder.AdjustStack(-1);
-                _builder.MarkLabel(whenValueTypeLabel);
-                // we will not write through this receiver, but it could be a target of mutating calls
-                EmitReceiverRef(expression.ValueTypeReceiver, AddressKind.Constrained);
-            }
-
-            _builder.MarkLabel(doneLabel);
         }
 
         internal static bool IsPossibleReferenceTypeReceiverOfConstrainedCall(BoundExpression receiver)
@@ -1945,9 +1811,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
             if (receiver is
                     BoundLocal { LocalSymbol.IsKnownToReferToTempIfReferenceType: true } or
-                    BoundComplexConditionalReceiver or
-                    BoundComplexReceiver or
-                    BoundConditionalReceiver { Type: { IsReferenceType: false, IsValueType: false } })
+                    BoundComplexConditionalReceiver)
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/AbstractFlowPass.cs
@@ -2940,20 +2940,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        public override BoundNode VisitComplexReceiver(BoundComplexReceiver node)
-        {
-            var savedState = this.State.Clone();
-
-            VisitRvalue(node.ValueTypeReceiver);
-            Join(ref this.State, ref savedState);
-
-            savedState = this.State.Clone();
-            VisitRvalue(node.ReferenceTypeReceiver);
-            Join(ref this.State, ref savedState);
-
-            return null;
-        }
-
         public override BoundNode VisitSequence(BoundSequence node)
         {
             var sideEffects = node.SideEffects;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.PlaceholderLocal.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.PlaceholderLocal.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Roslyn.Utilities;
 
@@ -61,14 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             internal override ConstantValue GetConstantValue(SyntaxNode node, LocalSymbol inProgress, BindingDiagnosticBag diagnostics = null) => null;
             internal override ImmutableBindingDiagnostic<AssemblySymbol> GetConstantValueDiagnostics(BoundExpression boundInitValue) => ImmutableBindingDiagnostic<AssemblySymbol>.Empty;
             internal override SyntaxNode GetDeclaratorSyntax() => throw ExceptionUtilities.Unreachable();
-            internal override LocalSymbol WithSynthesizedLocalKindAndSyntax(
-                SynthesizedLocalKind kind, SyntaxNode syntax
-#if DEBUG
-                ,
-                [CallerLineNumber] int createdAtLineNumber = 0,
-                [CallerFilePath] string createdAtFilePath = null
-#endif
-                ) => throw ExceptionUtilities.Unreachable();
+            internal override LocalSymbol WithSynthesizedLocalKindAndSyntax(SynthesizedLocalKind kind, SyntaxNode syntax) => throw ExceptionUtilities.Unreachable();
             internal override ScopedKind Scope => ScopedKind.None;
         }
     }

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -173,7 +173,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         LoweredConditionalAccess,
         ConditionalReceiver,
         ComplexConditionalReceiver,
-        ComplexReceiver,
         MethodGroup,
         PropertyGroup,
         Call,
@@ -5796,39 +5795,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal sealed partial class BoundComplexReceiver : BoundExpression
-    {
-        public BoundComplexReceiver(SyntaxNode syntax, BoundExpression valueTypeReceiver, BoundExpression referenceTypeReceiver, TypeSymbol type, bool hasErrors = false)
-            : base(BoundKind.ComplexReceiver, syntax, type, hasErrors || valueTypeReceiver.HasErrors() || referenceTypeReceiver.HasErrors())
-        {
-
-            RoslynDebug.Assert(valueTypeReceiver is object, "Field 'valueTypeReceiver' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
-            RoslynDebug.Assert(referenceTypeReceiver is object, "Field 'referenceTypeReceiver' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
-            RoslynDebug.Assert(type is object, "Field 'type' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
-
-            this.ValueTypeReceiver = valueTypeReceiver;
-            this.ReferenceTypeReceiver = referenceTypeReceiver;
-        }
-
-        public new TypeSymbol Type => base.Type!;
-        public BoundExpression ValueTypeReceiver { get; }
-        public BoundExpression ReferenceTypeReceiver { get; }
-
-        [DebuggerStepThrough]
-        public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitComplexReceiver(this);
-
-        public BoundComplexReceiver Update(BoundExpression valueTypeReceiver, BoundExpression referenceTypeReceiver, TypeSymbol type)
-        {
-            if (valueTypeReceiver != this.ValueTypeReceiver || referenceTypeReceiver != this.ReferenceTypeReceiver || !TypeSymbol.Equals(type, this.Type, TypeCompareKind.ConsiderEverything))
-            {
-                var result = new BoundComplexReceiver(this.Syntax, valueTypeReceiver, referenceTypeReceiver, type, this.HasErrors);
-                result.CopyAttributes(this);
-                return result;
-            }
-            return this;
-        }
-    }
-
     internal sealed partial class BoundMethodGroup : BoundMethodOrPropertyGroup
     {
         public BoundMethodGroup(SyntaxNode syntax, ImmutableArray<TypeWithAnnotations> typeArgumentsOpt, string name, ImmutableArray<MethodSymbol> methods, Symbol? lookupSymbolOpt, DiagnosticInfo? lookupError, BoundMethodGroupFlags? flags, FunctionTypeSymbol? functionType, BoundExpression? receiverOpt, LookupResultKind resultKind, bool hasErrors = false)
@@ -8682,8 +8648,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitConditionalReceiver((BoundConditionalReceiver)node, arg);
                 case BoundKind.ComplexConditionalReceiver:
                     return VisitComplexConditionalReceiver((BoundComplexConditionalReceiver)node, arg);
-                case BoundKind.ComplexReceiver:
-                    return VisitComplexReceiver((BoundComplexReceiver)node, arg);
                 case BoundKind.MethodGroup:
                     return VisitMethodGroup((BoundMethodGroup)node, arg);
                 case BoundKind.PropertyGroup:
@@ -8979,7 +8943,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual R VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitConditionalReceiver(BoundConditionalReceiver node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitComplexConditionalReceiver(BoundComplexConditionalReceiver node, A arg) => this.DefaultVisit(node, arg);
-        public virtual R VisitComplexReceiver(BoundComplexReceiver node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitMethodGroup(BoundMethodGroup node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitPropertyGroup(BoundPropertyGroup node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitCall(BoundCall node, A arg) => this.DefaultVisit(node, arg);
@@ -9204,7 +9167,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual BoundNode? VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitConditionalReceiver(BoundConditionalReceiver node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitComplexConditionalReceiver(BoundComplexConditionalReceiver node) => this.DefaultVisit(node);
-        public virtual BoundNode? VisitComplexReceiver(BoundComplexReceiver node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitMethodGroup(BoundMethodGroup node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitPropertyGroup(BoundPropertyGroup node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitCall(BoundCall node) => this.DefaultVisit(node);
@@ -9926,12 +9888,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         public override BoundNode? VisitConditionalReceiver(BoundConditionalReceiver node) => null;
         public override BoundNode? VisitComplexConditionalReceiver(BoundComplexConditionalReceiver node)
-        {
-            this.Visit(node.ValueTypeReceiver);
-            this.Visit(node.ReferenceTypeReceiver);
-            return null;
-        }
-        public override BoundNode? VisitComplexReceiver(BoundComplexReceiver node)
         {
             this.Visit(node.ValueTypeReceiver);
             this.Visit(node.ReferenceTypeReceiver);
@@ -11148,13 +11104,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return node.Update(node.Id, type);
         }
         public override BoundNode? VisitComplexConditionalReceiver(BoundComplexConditionalReceiver node)
-        {
-            BoundExpression valueTypeReceiver = (BoundExpression)this.Visit(node.ValueTypeReceiver);
-            BoundExpression referenceTypeReceiver = (BoundExpression)this.Visit(node.ReferenceTypeReceiver);
-            TypeSymbol? type = this.VisitType(node.Type);
-            return node.Update(valueTypeReceiver, referenceTypeReceiver, type);
-        }
-        public override BoundNode? VisitComplexReceiver(BoundComplexReceiver node)
         {
             BoundExpression valueTypeReceiver = (BoundExpression)this.Visit(node.ValueTypeReceiver);
             BoundExpression referenceTypeReceiver = (BoundExpression)this.Visit(node.ReferenceTypeReceiver);
@@ -13184,24 +13133,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundExpression valueTypeReceiver = (BoundExpression)this.Visit(node.ValueTypeReceiver);
             BoundExpression referenceTypeReceiver = (BoundExpression)this.Visit(node.ReferenceTypeReceiver);
             BoundComplexConditionalReceiver updatedNode;
-
-            if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
-            {
-                updatedNode = node.Update(valueTypeReceiver, referenceTypeReceiver, infoAndType.Type!);
-                updatedNode.TopLevelNullability = infoAndType.Info;
-            }
-            else
-            {
-                updatedNode = node.Update(valueTypeReceiver, referenceTypeReceiver, node.Type);
-            }
-            return updatedNode;
-        }
-
-        public override BoundNode? VisitComplexReceiver(BoundComplexReceiver node)
-        {
-            BoundExpression valueTypeReceiver = (BoundExpression)this.Visit(node.ValueTypeReceiver);
-            BoundExpression referenceTypeReceiver = (BoundExpression)this.Visit(node.ReferenceTypeReceiver);
-            BoundComplexReceiver updatedNode;
 
             if (_updatedNullabilities.TryGetValue(node, out (NullabilityInfo Info, TypeSymbol? Type) infoAndType))
             {
@@ -15546,15 +15477,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
         );
         public override TreeDumperNode VisitComplexConditionalReceiver(BoundComplexConditionalReceiver node, object? arg) => new TreeDumperNode("complexConditionalReceiver", null, new TreeDumperNode[]
-        {
-            new TreeDumperNode("valueTypeReceiver", null, new TreeDumperNode[] { Visit(node.ValueTypeReceiver, null) }),
-            new TreeDumperNode("referenceTypeReceiver", null, new TreeDumperNode[] { Visit(node.ReferenceTypeReceiver, null) }),
-            new TreeDumperNode("type", node.Type, null),
-            new TreeDumperNode("isSuppressed", node.IsSuppressed, null),
-            new TreeDumperNode("hasErrors", node.HasErrors, null)
-        }
-        );
-        public override TreeDumperNode VisitComplexReceiver(BoundComplexReceiver node, object? arg) => new TreeDumperNode("complexReceiver", null, new TreeDumperNode[]
         {
             new TreeDumperNode("valueTypeReceiver", null, new TreeDumperNode[] { Visit(node.ValueTypeReceiver, null) }),
             new TreeDumperNode("referenceTypeReceiver", null, new TreeDumperNode[] { Visit(node.ReferenceTypeReceiver, null) }),

--- a/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SpillSequenceSpiller.cs
@@ -21,12 +21,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private readonly SyntheticBoundNodeFactory _F;
         private readonly PooledDictionary<LocalSymbol, LocalSymbol> _tempSubstitution;
-        private readonly PooledDictionary<LocalSymbol, BoundComplexReceiver> _receiverSubstitution;
+        private readonly PooledDictionary<LocalSymbol, BoundComplexConditionalReceiver> _receiverSubstitution;
 
         private SpillSequenceSpiller(
             MethodSymbol method, SyntaxNode syntaxNode, TypeCompilationState compilationState,
             PooledDictionary<LocalSymbol, LocalSymbol> tempSubstitution,
-            PooledDictionary<LocalSymbol, BoundComplexReceiver> receiverSubstitution,
+            PooledDictionary<LocalSymbol, BoundComplexConditionalReceiver> receiverSubstitution,
             BindingDiagnosticBag diagnostics)
         {
             _F = new SyntheticBoundNodeFactory(method, syntaxNode, compilationState, diagnostics);
@@ -182,11 +182,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         private sealed class LocalSubstituter : BoundTreeRewriterWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
         {
             private readonly PooledDictionary<LocalSymbol, LocalSymbol> _tempSubstitution;
-            private readonly PooledDictionary<LocalSymbol, BoundComplexReceiver> _receiverSubstitution;
+            private readonly PooledDictionary<LocalSymbol, BoundComplexConditionalReceiver> _receiverSubstitution;
 
             private LocalSubstituter(
                 PooledDictionary<LocalSymbol, LocalSymbol> tempSubstitution,
-                PooledDictionary<LocalSymbol, BoundComplexReceiver> receiverSubstitution,
+                PooledDictionary<LocalSymbol, BoundComplexConditionalReceiver> receiverSubstitution,
                 int recursionDepth = 0)
                 : base(recursionDepth)
             {
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public static BoundNode Rewrite(
                 PooledDictionary<LocalSymbol, LocalSymbol> tempSubstitution,
-                PooledDictionary<LocalSymbol, BoundComplexReceiver> receiverSubstitution,
+                PooledDictionary<LocalSymbol, BoundComplexConditionalReceiver> receiverSubstitution,
                 BoundNode node)
             {
                 if (tempSubstitution.Count == 0)
@@ -233,7 +233,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static BoundStatement Rewrite(BoundStatement body, MethodSymbol method, TypeCompilationState compilationState, BindingDiagnosticBag diagnostics)
         {
             var tempSubstitution = PooledDictionary<LocalSymbol, LocalSymbol>.GetInstance();
-            var receiverSubstitution = PooledDictionary<LocalSymbol, BoundComplexReceiver>.GetInstance();
+            var receiverSubstitution = PooledDictionary<LocalSymbol, BoundComplexConditionalReceiver>.GetInstance();
             var spiller = new SpillSequenceSpiller(method, body.Syntax, compilationState, tempSubstitution, receiverSubstitution, diagnostics);
             BoundNode result = spiller.Visit(body);
             result = LocalSubstituter.Rewrite(tempSubstitution, receiverSubstitution, result);
@@ -356,14 +356,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 IsComplexConditionalInitializationOfReceiverRef(
                                     assignment,
                                     out LocalSymbol receiverRefLocal,
-                                    out BoundComplexReceiver complexReceiver,
+                                    out BoundBinaryOperator isValueTypeCheck,
+                                    out BoundAssignmentOperator referenceTypeReceiverCloning,
                                     out BoundLocal valueTypeReceiver,
                                     out BoundLocal referenceTypeReceiver))
                             {
                                 Debug.Assert(receiverRefLocal.IsKnownToReferToTempIfReferenceType);
-                                builder.AddStatement(_F.ExpressionStatement(complexReceiver));
+                                builder.AddStatement(_F.If(_F.Not(isValueTypeCheck), _F.ExpressionStatement(referenceTypeReceiverCloning)));
 
-                                _receiverSubstitution.Add(receiverRefLocal, complexReceiver.Update(valueTypeReceiver, referenceTypeReceiver, complexReceiver.Type));
+                                _receiverSubstitution.Add(receiverRefLocal, _F.ComplexConditionalReceiver(valueTypeReceiver, referenceTypeReceiver));
                                 return null;
                             }
                             else
@@ -457,7 +458,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal static bool IsComplexConditionalInitializationOfReceiverRef(
             BoundAssignmentOperator assignment,
             out LocalSymbol outReceiverRefLocal,
-            out BoundComplexReceiver outComplexReceiver,
+            out BoundBinaryOperator outIsValueTypeCheck,
+            out BoundAssignmentOperator outReferenceTypeReceiverCloning,
             out BoundLocal outValueTypeReceiver,
             out BoundLocal outReferenceTypeReceiver)
         {
@@ -465,10 +467,24 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     IsRef: true,
                     Left: BoundLocal { LocalSymbol: { SynthesizedKind: SynthesizedLocalKind.LoweringTemp, RefKind: RefKind.Ref } receiverRefLocal },
-                    Right: BoundComplexReceiver
+                    Right: BoundConditionalOperator
                     {
-                        ValueTypeReceiver: BoundLocal { LocalSymbol: { SynthesizedKind: SynthesizedLocalKind.LoweringTemp, RefKind: RefKind.Ref } } valueTypeReceiver,
-                        ReferenceTypeReceiver: BoundSequence
+                        IsRef: true,
+                        Condition: BoundBinaryOperator
+                        {
+                            OperatorKind: BinaryOperatorKind.ObjectNotEqual,
+                            Left: BoundConversion
+                            {
+                                Conversion: { IsUserDefined: false },
+                                Operand: BoundDefaultExpression { Type: var typeOfDefault },
+                                Type.SpecialType: SpecialType.System_Object
+                            },
+                            Right: BoundLiteral { ConstantValueOpt.IsNull: true, Type.SpecialType: SpecialType.System_Object }
+                        } isValueTypeCheck,
+
+                        Consequence: BoundLocal { LocalSymbol: { SynthesizedKind: SynthesizedLocalKind.LoweringTemp, RefKind: RefKind.Ref } } valueTypeReceiver,
+
+                        Alternative: BoundSequence
                         {
                             Locals.IsEmpty: true,
                             SideEffects:
@@ -478,11 +494,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 IsRef: false,
                                 Left: BoundLocal { LocalSymbol: { SynthesizedKind: SynthesizedLocalKind.LoweringTemp, RefKind: RefKind.None } referenceTypeClone },
                                 Right: BoundLocal { LocalSymbol: { SynthesizedKind: SynthesizedLocalKind.LoweringTemp, RefKind: RefKind.Ref } originalReceiverReference }
-                            }
+                            } referenceTypeReceiverCloning
                             ],
                             Value: BoundLocal { LocalSymbol: { SynthesizedKind: SynthesizedLocalKind.LoweringTemp, RefKind: RefKind.None } } referenceTypeReceiver
                         }
-                    } complexReceiver,
+                    }
                 }
                 && (object)referenceTypeClone == referenceTypeReceiver.LocalSymbol
                 && (object)originalReceiverReference == valueTypeReceiver.LocalSymbol
@@ -491,19 +507,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 && receiverRefLocal.Type.IsTypeParameter()
                 && !receiverRefLocal.Type.IsReferenceType
                 && !receiverRefLocal.Type.IsValueType
+                && typeOfDefault.Equals(receiverRefLocal.Type, TypeCompareKind.AllIgnoreOptions)
                 && valueTypeReceiver.Type.Equals(receiverRefLocal.Type, TypeCompareKind.AllIgnoreOptions)
                 && referenceTypeReceiver.Type.Equals(receiverRefLocal.Type, TypeCompareKind.AllIgnoreOptions)
             )
             {
                 outReceiverRefLocal = receiverRefLocal;
-                outComplexReceiver = complexReceiver;
+                outIsValueTypeCheck = isValueTypeCheck;
+                outReferenceTypeReceiverCloning = referenceTypeReceiverCloning;
                 outValueTypeReceiver = valueTypeReceiver;
                 outReferenceTypeReceiver = referenceTypeReceiver;
                 return true;
             }
 
             outReceiverRefLocal = null;
-            outComplexReceiver = null;
+            outIsValueTypeCheck = null;
+            outReferenceTypeReceiverCloning = null;
             outValueTypeReceiver = null;
             outReferenceTypeReceiver = null;
             return false;
@@ -979,15 +998,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // reference to the stack. So, for a class we need to emit a reference to a temporary
                     // location, rather than to the original location
 
-                    var save_Syntax = _F.Syntax;
-                    _F.Syntax = node.Syntax;
+                    // If condition `(object)default(T) != null` is true at execution time,
+                    // the T is a value type. And it is a reference type otherwise.
+                    var isValueTypeCheck = _F.ObjectNotEqual(
+                                                _F.Convert(_F.SpecialType(SpecialType.System_Object), _F.Default(receiverType)),
+                                                _F.Null(_F.SpecialType(SpecialType.System_Object)));
 
                     var cache = _F.Local(_F.SynthesizedLocal(receiverType));
                     receiverBuilder.AddLocal(cache.LocalSymbol);
-                    receiverBuilder.AddStatement(_F.ExpressionStatement(new BoundComplexReceiver(node.Syntax, cache, _F.Sequence(new[] { _F.AssignmentExpression(cache, receiver) }, cache), receiverType) { WasCompilerGenerated = true }));
+                    receiverBuilder.AddStatement(_F.If(_F.Not(isValueTypeCheck), _F.Assignment(cache, receiver)));
 
-                    receiver = new BoundComplexReceiver(node.Syntax, receiver, cache, receiverType) { WasCompilerGenerated = true };
-                    _F.Syntax = save_Syntax;
+                    receiver = _F.ComplexConditionalReceiver(receiver, cache);
                 }
 
                 receiverBuilder.Include(builder);

--- a/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/LocalSymbol.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Symbols;
@@ -38,14 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal abstract SyntaxNode ScopeDesignatorOpt { get; }
 
-        internal abstract LocalSymbol WithSynthesizedLocalKindAndSyntax(
-            SynthesizedLocalKind kind, SyntaxNode syntax
-#if DEBUG
-            ,
-            [CallerLineNumber] int createdAtLineNumber = 0,
-            [CallerFilePath] string createdAtFilePath = null
-#endif
-            );
+        internal abstract LocalSymbol WithSynthesizedLocalKindAndSyntax(SynthesizedLocalKind kind, SyntaxNode syntax);
 
         internal abstract bool IsImportedFromMetadata
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
@@ -230,14 +229,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return SynthesizedLocalKind.UserDefined; }
         }
 
-        internal override LocalSymbol WithSynthesizedLocalKindAndSyntax(
-            SynthesizedLocalKind kind, SyntaxNode syntax
-#if DEBUG
-            ,
-            [CallerLineNumber] int createdAtLineNumber = 0,
-            [CallerFilePath] string createdAtFilePath = null
-#endif
-            )
+        internal override LocalSymbol WithSynthesizedLocalKindAndSyntax(SynthesizedLocalKind kind, SyntaxNode syntax)
         {
             throw ExceptionUtilities.Unreachable();
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedLocal.cs
@@ -70,14 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _syntaxOpt; }
         }
 
-        internal sealed override LocalSymbol WithSynthesizedLocalKindAndSyntax(
-            SynthesizedLocalKind kind, SyntaxNode syntax
-#if DEBUG
-            ,
-            [CallerLineNumber] int createdAtLineNumber = 0,
-            [CallerFilePath] string createdAtFilePath = null
-#endif
-            )
+        internal sealed override LocalSymbol WithSynthesizedLocalKindAndSyntax(SynthesizedLocalKind kind, SyntaxNode syntax)
         {
             return new SynthesizedLocal(
                 _containingMethodOpt,
@@ -86,13 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 syntax,
                 _isPinned,
                 _isKnownToReferToTempIfReferenceType,
-                _refKind
-#if DEBUG
-                ,
-                createdAtLineNumber,
-                createdAtFilePath
-#endif
-                );
+                _refKind);
         }
 
         public sealed override RefKind RefKind

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -120,25 +119,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _originalVariable.GetConstantValueDiagnostics(boundInitValue);
         }
 
-        internal override LocalSymbol WithSynthesizedLocalKindAndSyntax(
-            SynthesizedLocalKind kind, SyntaxNode syntax
-#if DEBUG
-            ,
-            [CallerLineNumber] int createdAtLineNumber = 0,
-            [CallerFilePath] string createdAtFilePath = null
-#endif
-            )
+        internal override LocalSymbol WithSynthesizedLocalKindAndSyntax(SynthesizedLocalKind kind, SyntaxNode syntax)
         {
             var origSynthesized = (SynthesizedLocal)_originalVariable;
             return new TypeSubstitutedLocalSymbol(
-                    origSynthesized.WithSynthesizedLocalKindAndSyntax(
-                        kind, syntax
-#if DEBUG
-                        ,
-                        createdAtLineNumber,
-                        createdAtFilePath
-#endif
-                        ),
+                    origSynthesized.WithSynthesizedLocalKindAndSyntax(kind, syntax),
                     _type,
                     _containingSymbol
                 );

--- a/src/Compilers/CSharp/Portable/Symbols/UpdatedContainingSymbolLocal.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UpdatedContainingSymbolLocal.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -96,14 +95,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _underlyingLocal.GetConstantValueDiagnostics(boundInitValue);
         internal override SyntaxNode GetDeclaratorSyntax() =>
             _underlyingLocal.GetDeclaratorSyntax();
-        internal override LocalSymbol WithSynthesizedLocalKindAndSyntax(
-            SynthesizedLocalKind kind, SyntaxNode syntax
-#if DEBUG
-            ,
-            [CallerLineNumber] int createdAtLineNumber = 0,
-            [CallerFilePath] string? createdAtFilePath = null
-#endif
-            ) => throw ExceptionUtilities.Unreachable();
+        internal override LocalSymbol WithSynthesizedLocalKindAndSyntax(SynthesizedLocalKind kind, SyntaxNode syntax) =>
+            throw ExceptionUtilities.Unreachable();
         #endregion
     }
 }

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenCallTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenCallTests.cs
@@ -95,22 +95,23 @@ Position GetName for item '2'
             verifier.VerifyIL("Program.Call2<T>",
 @"
 {
-  // Code size       46 (0x2e)
+  // Code size       45 (0x2d)
   .maxstack  2
   .locals init (T V_0)
   IL_0000:  ldarga.s   V_0
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
-  IL_0011:  brtrue.s   IL_001b
-  IL_0013:  ldobj      ""T""
-  IL_0018:  stloc.0
-  IL_0019:  ldloca.s   V_0
-  IL_001b:  ldarga.s   V_0
-  IL_001d:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0022:  constrained. ""T""
-  IL_0028:  callvirt   ""void IMoveable.GetName(int)""
-  IL_002d:  ret
+  IL_0002:  ldloca.s   V_0
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.0
+  IL_000b:  box        ""T""
+  IL_0010:  brtrue.s   IL_001a
+  IL_0012:  ldobj      ""T""
+  IL_0017:  stloc.0
+  IL_0018:  ldloca.s   V_0
+  IL_001a:  ldarga.s   V_0
+  IL_001c:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_0021:  constrained. ""T""
+  IL_0027:  callvirt   ""void IMoveable.GetName(int)""
+  IL_002c:  ret
 }
 ");
         }
@@ -265,22 +266,23 @@ Position GetName for item '2'
             verifier.VerifyIL("Program.Call2<T>",
 @"
 {
-  // Code size       44 (0x2c)
+  // Code size       43 (0x2b)
   .maxstack  2
   .locals init (T V_0)
   IL_0000:  ldarg.0
-  IL_0001:  ldtoken    ""T""
-  IL_0006:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000b:  call       ""bool System.Type.IsValueType.get""
-  IL_0010:  brtrue.s   IL_001a
-  IL_0012:  ldobj      ""T""
-  IL_0017:  stloc.0
-  IL_0018:  ldloca.s   V_0
-  IL_001a:  ldarg.0
-  IL_001b:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0020:  constrained. ""T""
-  IL_0026:  callvirt   ""void IMoveable.GetName(int)""
-  IL_002b:  ret
+  IL_0001:  ldloca.s   V_0
+  IL_0003:  initobj    ""T""
+  IL_0009:  ldloc.0
+  IL_000a:  box        ""T""
+  IL_000f:  brtrue.s   IL_0019
+  IL_0011:  ldobj      ""T""
+  IL_0016:  stloc.0
+  IL_0017:  ldloca.s   V_0
+  IL_0019:  ldarg.0
+  IL_001a:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_001f:  constrained. ""T""
+  IL_0025:  callvirt   ""void IMoveable.GetName(int)""
+  IL_002a:  ret
 }
 ");
         }
@@ -517,86 +519,89 @@ Position GetName for item '2'
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
-                System.Exception V_3)
+                T V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
+                System.Exception V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Call2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0069
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
-    IL_0019:  brtrue.s   IL_0027
+    IL_0008:  brfalse.s  IL_0068
+    IL_000a:  ldloca.s   V_2
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.2
+    IL_0013:  box        ""T""
+    IL_0018:  brtrue.s   IL_0026
+    IL_001a:  ldarg.0
     IL_001b:  ldarg.0
-    IL_001c:  ldarg.0
-    IL_001d:  ldfld      ""T Program.<Call2>d__2<T>.item""
-    IL_0022:  stfld      ""T Program.<Call2>d__2<T>.<>7__wrap1""
-    IL_0027:  ldarg.0
-    IL_0028:  ldflda     ""T Program.<Call2>d__2<T>.item""
-    IL_002d:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0032:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003c:  stloc.2
-    IL_003d:  ldloca.s   V_2
-    IL_003f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0044:  brtrue.s   IL_0085
-    IL_0046:  ldarg.0
-    IL_0047:  ldc.i4.0
-    IL_0048:  dup
-    IL_0049:  stloc.0
-    IL_004a:  stfld      ""int Program.<Call2>d__2<T>.<>1__state""
-    IL_004f:  ldarg.0
-    IL_0050:  ldloc.2
-    IL_0051:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Call2>d__2<T>.<>u__1""
-    IL_0056:  ldarg.0
-    IL_0057:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Call2>d__2<T>.<>t__builder""
-    IL_005c:  ldloca.s   V_2
-    IL_005e:  ldarg.0
-    IL_005f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Call2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Call2>d__2<T>)""
-    IL_0064:  leave      IL_00f0
-    IL_0069:  ldarg.0
-    IL_006a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Call2>d__2<T>.<>u__1""
-    IL_006f:  stloc.2
-    IL_0070:  ldarg.0
-    IL_0071:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Call2>d__2<T>.<>u__1""
-    IL_0076:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_007c:  ldarg.0
-    IL_007d:  ldc.i4.m1
-    IL_007e:  dup
-    IL_007f:  stloc.0
-    IL_0080:  stfld      ""int Program.<Call2>d__2<T>.<>1__state""
-    IL_0085:  ldloca.s   V_2
-    IL_0087:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_008c:  stloc.1
-    IL_008d:  ldtoken    ""T""
-    IL_0092:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0097:  call       ""bool System.Type.IsValueType.get""
-    IL_009c:  brtrue.s   IL_00a6
-    IL_009e:  ldarg.0
-    IL_009f:  ldflda     ""T Program.<Call2>d__2<T>.<>7__wrap1""
-    IL_00a4:  br.s       IL_00ac
-    IL_00a6:  ldarg.0
-    IL_00a7:  ldflda     ""T Program.<Call2>d__2<T>.item""
-    IL_00ac:  ldloc.1
-    IL_00ad:  constrained. ""T""
-    IL_00b3:  callvirt   ""void IMoveable.GetName(int)""
-    IL_00b8:  ldarg.0
-    IL_00b9:  ldflda     ""T Program.<Call2>d__2<T>.<>7__wrap1""
-    IL_00be:  initobj    ""T""
-    IL_00c4:  leave.s    IL_00dd
+    IL_001c:  ldfld      ""T Program.<Call2>d__2<T>.item""
+    IL_0021:  stfld      ""T Program.<Call2>d__2<T>.<>7__wrap1""
+    IL_0026:  ldarg.0
+    IL_0027:  ldflda     ""T Program.<Call2>d__2<T>.item""
+    IL_002c:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0031:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_0036:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_003b:  stloc.3
+    IL_003c:  ldloca.s   V_3
+    IL_003e:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0043:  brtrue.s   IL_0084
+    IL_0045:  ldarg.0
+    IL_0046:  ldc.i4.0
+    IL_0047:  dup
+    IL_0048:  stloc.0
+    IL_0049:  stfld      ""int Program.<Call2>d__2<T>.<>1__state""
+    IL_004e:  ldarg.0
+    IL_004f:  ldloc.3
+    IL_0050:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Call2>d__2<T>.<>u__1""
+    IL_0055:  ldarg.0
+    IL_0056:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Call2>d__2<T>.<>t__builder""
+    IL_005b:  ldloca.s   V_3
+    IL_005d:  ldarg.0
+    IL_005e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Call2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Call2>d__2<T>)""
+    IL_0063:  leave      IL_00f0
+    IL_0068:  ldarg.0
+    IL_0069:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Call2>d__2<T>.<>u__1""
+    IL_006e:  stloc.3
+    IL_006f:  ldarg.0
+    IL_0070:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Call2>d__2<T>.<>u__1""
+    IL_0075:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_007b:  ldarg.0
+    IL_007c:  ldc.i4.m1
+    IL_007d:  dup
+    IL_007e:  stloc.0
+    IL_007f:  stfld      ""int Program.<Call2>d__2<T>.<>1__state""
+    IL_0084:  ldloca.s   V_3
+    IL_0086:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_008b:  stloc.1
+    IL_008c:  ldloca.s   V_2
+    IL_008e:  initobj    ""T""
+    IL_0094:  ldloc.2
+    IL_0095:  box        ""T""
+    IL_009a:  brtrue.s   IL_00a4
+    IL_009c:  ldarg.0
+    IL_009d:  ldflda     ""T Program.<Call2>d__2<T>.<>7__wrap1""
+    IL_00a2:  br.s       IL_00aa
+    IL_00a4:  ldarg.0
+    IL_00a5:  ldflda     ""T Program.<Call2>d__2<T>.item""
+    IL_00aa:  ldloc.1
+    IL_00ab:  constrained. ""T""
+    IL_00b1:  callvirt   ""void IMoveable.GetName(int)""
+    IL_00b6:  ldarg.0
+    IL_00b7:  ldflda     ""T Program.<Call2>d__2<T>.<>7__wrap1""
+    IL_00bc:  initobj    ""T""
+    IL_00c2:  leave.s    IL_00dd
   }
   catch System.Exception
   {
-    IL_00c6:  stloc.3
-    IL_00c7:  ldarg.0
-    IL_00c8:  ldc.i4.s   -2
-    IL_00ca:  stfld      ""int Program.<Call2>d__2<T>.<>1__state""
-    IL_00cf:  ldarg.0
-    IL_00d0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Call2>d__2<T>.<>t__builder""
-    IL_00d5:  ldloc.3
+    IL_00c4:  stloc.s    V_4
+    IL_00c6:  ldarg.0
+    IL_00c7:  ldc.i4.s   -2
+    IL_00c9:  stfld      ""int Program.<Call2>d__2<T>.<>1__state""
+    IL_00ce:  ldarg.0
+    IL_00cf:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Call2>d__2<T>.<>t__builder""
+    IL_00d4:  ldloc.s    V_4
     IL_00d6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_00db:  leave.s    IL_00f0
   }
@@ -962,8 +967,9 @@ Position GetName for item '2'
                 System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_1,
                 System.Runtime.CompilerServices.YieldAwaitable V_2,
                 int V_3,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
-                System.Exception V_5)
+                T V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_5,
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Call2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -1009,9 +1015,10 @@ Position GetName for item '2'
     IL_0062:  stfld      ""int Program.<Call2>d__2<T>.<>1__state""
     IL_0067:  ldloca.s   V_1
     IL_0069:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_006e:  ldtoken    ""T""
-    IL_0073:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0078:  call       ""bool System.Type.IsValueType.get""
+    IL_006e:  ldloca.s   V_4
+    IL_0070:  initobj    ""T""
+    IL_0076:  ldloc.s    V_4
+    IL_0078:  box        ""T""
     IL_007d:  brtrue.s   IL_008b
     IL_007f:  ldarg.0
     IL_0080:  ldarg.0
@@ -1022,8 +1029,8 @@ Position GetName for item '2'
     IL_0091:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0096:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_009b:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_00a0:  stloc.s    V_4
-    IL_00a2:  ldloca.s   V_4
+    IL_00a0:  stloc.s    V_5
+    IL_00a2:  ldloca.s   V_5
     IL_00a4:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_00a9:  brtrue.s   IL_00ec
     IL_00ab:  ldarg.0
@@ -1032,17 +1039,17 @@ Position GetName for item '2'
     IL_00ae:  stloc.0
     IL_00af:  stfld      ""int Program.<Call2>d__2<T>.<>1__state""
     IL_00b4:  ldarg.0
-    IL_00b5:  ldloc.s    V_4
+    IL_00b5:  ldloc.s    V_5
     IL_00b7:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Call2>d__2<T>.<>u__2""
     IL_00bc:  ldarg.0
     IL_00bd:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Call2>d__2<T>.<>t__builder""
-    IL_00c2:  ldloca.s   V_4
+    IL_00c2:  ldloca.s   V_5
     IL_00c4:  ldarg.0
     IL_00c5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Call2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Call2>d__2<T>)""
     IL_00ca:  leave      IL_0159
     IL_00cf:  ldarg.0
     IL_00d0:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Call2>d__2<T>.<>u__2""
-    IL_00d5:  stloc.s    V_4
+    IL_00d5:  stloc.s    V_5
     IL_00d7:  ldarg.0
     IL_00d8:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Call2>d__2<T>.<>u__2""
     IL_00dd:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -1051,12 +1058,13 @@ Position GetName for item '2'
     IL_00e5:  dup
     IL_00e6:  stloc.0
     IL_00e7:  stfld      ""int Program.<Call2>d__2<T>.<>1__state""
-    IL_00ec:  ldloca.s   V_4
+    IL_00ec:  ldloca.s   V_5
     IL_00ee:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_00f3:  stloc.3
-    IL_00f4:  ldtoken    ""T""
-    IL_00f9:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00fe:  call       ""bool System.Type.IsValueType.get""
+    IL_00f4:  ldloca.s   V_4
+    IL_00f6:  initobj    ""T""
+    IL_00fc:  ldloc.s    V_4
+    IL_00fe:  box        ""T""
     IL_0103:  brtrue.s   IL_010d
     IL_0105:  ldarg.0
     IL_0106:  ldflda     ""T Program.<Call2>d__2<T>.<>7__wrap1""
@@ -1073,13 +1081,13 @@ Position GetName for item '2'
   }
   catch System.Exception
   {
-    IL_012d:  stloc.s    V_5
+    IL_012d:  stloc.s    V_6
     IL_012f:  ldarg.0
     IL_0130:  ldc.i4.s   -2
     IL_0132:  stfld      ""int Program.<Call2>d__2<T>.<>1__state""
     IL_0137:  ldarg.0
     IL_0138:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Call2>d__2<T>.<>t__builder""
-    IL_013d:  ldloc.s    V_5
+    IL_013d:  ldloc.s    V_6
     IL_013f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0144:  leave.s    IL_0159
   }
@@ -1400,36 +1408,38 @@ Position GetName for item '2'
   // Code size       86 (0x56)
   .maxstack  6
   .locals init (T& V_0,
-                T V_1,
-                T& V_2,
-                DummyHandler V_3)
+            T V_1,
+            T& V_2,
+            T V_3,
+            DummyHandler V_4)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.2
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
-  IL_0012:  brtrue.s   IL_001f
-  IL_0014:  ldloc.2
-  IL_0015:  ldobj      ""T""
-  IL_001a:  stloc.1
-  IL_001b:  ldloca.s   V_1
-  IL_001d:  br.s       IL_0020
-  IL_001f:  ldloc.2
-  IL_0020:  stloc.0
-  IL_0021:  ldloc.0
-  IL_0022:  ldarga.s   V_0
-  IL_0024:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0029:  ldloca.s   V_3
-  IL_002b:  ldc.i4.3
-  IL_002c:  ldc.i4.0
-  IL_002d:  ldloc.0
-  IL_002e:  ldobj      ""T""
-  IL_0033:  box        ""T""
-  IL_0038:  call       ""DummyHandler..ctor(int, int, IMoveable)""
-  IL_003d:  ldloca.s   V_3
-  IL_003f:  ldstr      ""log""
-  IL_0044:  call       ""void DummyHandler.AppendLiteral(string)""
-  IL_0049:  ldloc.3
+  IL_0003:  ldloca.s   V_3
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.3
+  IL_000c:  box        ""T""
+  IL_0011:  brtrue.s   IL_001e
+  IL_0013:  ldloc.2
+  IL_0014:  ldobj      ""T""
+  IL_0019:  stloc.1
+  IL_001a:  ldloca.s   V_1
+  IL_001c:  br.s       IL_001f
+  IL_001e:  ldloc.2
+  IL_001f:  stloc.0
+  IL_0020:  ldloc.0
+  IL_0021:  ldarga.s   V_0
+  IL_0023:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_0028:  ldloca.s   V_4
+  IL_002a:  ldc.i4.3
+  IL_002b:  ldc.i4.0
+  IL_002c:  ldloc.0
+  IL_002d:  ldobj      ""T""
+  IL_0032:  box        ""T""
+  IL_0037:  call       ""DummyHandler..ctor(int, int, IMoveable)""
+  IL_003c:  ldloca.s   V_4
+  IL_003e:  ldstr      ""log""
+  IL_0043:  call       ""void DummyHandler.AppendLiteral(string)""
+  IL_0048:  ldloc.s    V_4
   IL_004a:  constrained. ""T""
   IL_0050:  callvirt   ""void IMoveable.GetName(int, DummyHandler)""
   IL_0055:  ret
@@ -1672,36 +1682,38 @@ Position GetName for item '2'
   // Code size       84 (0x54)
   .maxstack  6
   .locals init (T& V_0,
-                T V_1,
-                T& V_2,
-                DummyHandler V_3)
+            T V_1,
+            T& V_2,
+            T V_3,
+            DummyHandler V_4)
   IL_0000:  ldarg.0
   IL_0001:  stloc.2
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
-  IL_0011:  brtrue.s   IL_001e
-  IL_0013:  ldloc.2
-  IL_0014:  ldobj      ""T""
-  IL_0019:  stloc.1
-  IL_001a:  ldloca.s   V_1
-  IL_001c:  br.s       IL_001f
-  IL_001e:  ldloc.2
-  IL_001f:  stloc.0
-  IL_0020:  ldloc.0
-  IL_0021:  ldarg.0
-  IL_0022:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0027:  ldloca.s   V_3
-  IL_0029:  ldc.i4.3
-  IL_002a:  ldc.i4.0
-  IL_002b:  ldloc.0
-  IL_002c:  ldobj      ""T""
-  IL_0031:  box        ""T""
-  IL_0036:  call       ""DummyHandler..ctor(int, int, IMoveable)""
-  IL_003b:  ldloca.s   V_3
-  IL_003d:  ldstr      ""log""
-  IL_0042:  call       ""void DummyHandler.AppendLiteral(string)""
-  IL_0047:  ldloc.3
+  IL_0002:  ldloca.s   V_3
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.3
+  IL_000b:  box        ""T""
+  IL_0010:  brtrue.s   IL_001d
+  IL_0012:  ldloc.2
+  IL_0013:  ldobj      ""T""
+  IL_0018:  stloc.1
+  IL_0019:  ldloca.s   V_1
+  IL_001b:  br.s       IL_001e
+  IL_001d:  ldloc.2
+  IL_001e:  stloc.0
+  IL_001f:  ldloc.0
+  IL_0020:  ldarg.0
+  IL_0021:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_0026:  ldloca.s   V_4
+  IL_0028:  ldc.i4.3
+  IL_0029:  ldc.i4.0
+  IL_002a:  ldloc.0
+  IL_002b:  ldobj      ""T""
+  IL_0030:  box        ""T""
+  IL_0035:  call       ""DummyHandler..ctor(int, int, IMoveable)""
+  IL_003a:  ldloca.s   V_4
+  IL_003c:  ldstr      ""log""
+  IL_0041:  call       ""void DummyHandler.AppendLiteral(string)""
+  IL_0046:  ldloc.s    V_4
   IL_0048:  constrained. ""T""
   IL_004e:  callvirt   ""void IMoveable.GetName(int, DummyHandler)""
   IL_0053:  ret
@@ -1900,28 +1912,26 @@ Position GetName for item '2'
             verifier.VerifyIL("Program.Call2<T>",
 @"
 {
-  // Code size       55 (0x37)
+  // Code size       53 (0x35)
   .maxstack  2
   .locals init (T V_0)
-  IL_0000:  ldarga.s   V_0
-  IL_0002:  ldloca.s   V_0
-  IL_0004:  initobj    ""T""
-  IL_000a:  ldloc.0
-  IL_000b:  box        ""T""
-  IL_0010:  brtrue.s   IL_0024
-  IL_0012:  ldobj      ""T""
-  IL_0017:  stloc.0
-  IL_0018:  ldloca.s   V_0
-  IL_001a:  ldloc.0
-  IL_001b:  box        ""T""
-  IL_0020:  brtrue.s   IL_0024
-  IL_0022:  pop
-  IL_0023:  ret
-  IL_0024:  ldarga.s   V_0
-  IL_0026:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_002b:  constrained. ""T""
-  IL_0031:  callvirt   ""void IMoveable.GetName(int)""
-  IL_0036:  ret
+  IL_0000:  ldarg.0
+  IL_0001:  box        ""T""
+  IL_0006:  brfalse.s  IL_0034
+  IL_0008:  ldarga.s   V_0
+  IL_000a:  ldloca.s   V_0
+  IL_000c:  initobj    ""T""
+  IL_0012:  ldloc.0
+  IL_0013:  box        ""T""
+  IL_0018:  brtrue.s   IL_0022
+  IL_001a:  ldobj      ""T""
+  IL_001f:  stloc.0
+  IL_0020:  ldloca.s   V_0
+  IL_0022:  ldarga.s   V_0
+  IL_0024:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_0029:  constrained. ""T""
+  IL_002f:  callvirt   ""void IMoveable.GetName(int)""
+  IL_0034:  ret
 }
 ");
         }
@@ -2054,9 +2064,10 @@ Position GetName for item '2'
             verifier.VerifyIL("Program.Call2<T>",
 @"
 {
-  // Code size       53 (0x35)
+  // Code size       77 (0x4d)
   .maxstack  2
-  .locals init (T V_0)
+  .locals init (T V_0,
+            T V_1)
   IL_0000:  ldarg.0
   IL_0001:  ldloca.s   V_0
   IL_0003:  initobj    ""T""
@@ -2071,11 +2082,19 @@ Position GetName for item '2'
   IL_001f:  brtrue.s   IL_0023
   IL_0021:  pop
   IL_0022:  ret
-  IL_0023:  ldarg.0
-  IL_0024:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0029:  constrained. ""T""
-  IL_002f:  callvirt   ""void IMoveable.GetName(int)""
-  IL_0034:  ret
+  IL_0023:  ldloca.s   V_1
+  IL_0025:  initobj    ""T""
+  IL_002b:  ldloc.1
+  IL_002c:  box        ""T""
+  IL_0031:  brtrue.s   IL_003b
+  IL_0033:  ldobj      ""T""
+  IL_0038:  stloc.1
+  IL_0039:  ldloca.s   V_1
+  IL_003b:  ldarg.0
+  IL_003c:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_0041:  constrained. ""T""
+  IL_0047:  callvirt   ""void IMoveable.GetName(int)""
+  IL_004c:  ret
 }
 ");
         }
@@ -2948,29 +2967,30 @@ Position set for item '2'
             verifier.VerifyIL("Program.Shift2<T>",
 @"
 {
-  // Code size       61 (0x3d)
+  // Code size       60 (0x3c)
   .maxstack  3
   .locals init (T& V_0,
                 T V_1)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.0
   IL_0003:  ldloc.0
-  IL_0004:  ldtoken    ""T""
-  IL_0009:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000e:  call       ""bool System.Type.IsValueType.get""
-  IL_0013:  brtrue.s   IL_001d
-  IL_0015:  ldobj      ""T""
-  IL_001a:  stloc.1
-  IL_001b:  ldloca.s   V_1
-  IL_001d:  ldloc.0
-  IL_001e:  constrained. ""T""
-  IL_0024:  callvirt   ""int IMoveable.Position.get""
-  IL_0029:  ldarga.s   V_0
-  IL_002b:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0030:  add
-  IL_0031:  constrained. ""T""
-  IL_0037:  callvirt   ""void IMoveable.Position.set""
-  IL_003c:  ret
+  IL_0004:  ldloca.s   V_1
+  IL_0006:  initobj    ""T""
+  IL_000c:  ldloc.1
+  IL_000d:  box        ""T""
+  IL_0012:  brtrue.s   IL_001c
+  IL_0014:  ldobj      ""T""
+  IL_0019:  stloc.1
+  IL_001a:  ldloca.s   V_1
+  IL_001c:  ldloc.0
+  IL_001d:  constrained. ""T""
+  IL_0023:  callvirt   ""int IMoveable.Position.get""
+  IL_0028:  ldarga.s   V_0
+  IL_002a:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_002f:  add
+  IL_0030:  constrained. ""T""
+  IL_0036:  callvirt   ""void IMoveable.Position.set""
+  IL_003b:  ret
 }
 ");
         }
@@ -3156,29 +3176,30 @@ Position set for item '2'
             verifier.VerifyIL("Program.Shift2<T>",
 @"
 {
-  // Code size       59 (0x3b)
+  // Code size       58 (0x3a)
   .maxstack  3
   .locals init (T& V_0,
-                T V_1)
+            T V_1)
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
-  IL_0012:  brtrue.s   IL_001c
-  IL_0014:  ldobj      ""T""
-  IL_0019:  stloc.1
-  IL_001a:  ldloca.s   V_1
-  IL_001c:  ldloc.0
-  IL_001d:  constrained. ""T""
-  IL_0023:  callvirt   ""int IMoveable.Position.get""
-  IL_0028:  ldarg.0
-  IL_0029:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_002e:  add
-  IL_002f:  constrained. ""T""
-  IL_0035:  callvirt   ""void IMoveable.Position.set""
-  IL_003a:  ret
+  IL_0003:  ldloca.s   V_1
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.1
+  IL_000c:  box        ""T""
+  IL_0011:  brtrue.s   IL_001b
+  IL_0013:  ldobj      ""T""
+  IL_0018:  stloc.1
+  IL_0019:  ldloca.s   V_1
+  IL_001b:  ldloc.0
+  IL_001c:  constrained. ""T""
+  IL_0022:  callvirt   ""int IMoveable.Position.get""
+  IL_0027:  ldarg.0
+  IL_0028:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_002d:  add
+  IL_002e:  constrained. ""T""
+  IL_0034:  callvirt   ""void IMoveable.Position.set""
+  IL_0039:  ret
 }
 ");
         }
@@ -3451,95 +3472,98 @@ Position set for item '2'
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
-                System.Exception V_3)
+                T V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
+                System.Exception V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0080
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
-    IL_0019:  brtrue.s   IL_0027
+    IL_0008:  brfalse.s  IL_007f
+    IL_000a:  ldloca.s   V_2
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.2
+    IL_0013:  box        ""T""
+    IL_0018:  brtrue.s   IL_0026
+    IL_001a:  ldarg.0
     IL_001b:  ldarg.0
-    IL_001c:  ldarg.0
-    IL_001d:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0022:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_001c:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0021:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0026:  ldarg.0
     IL_0027:  ldarg.0
-    IL_0028:  ldarg.0
-    IL_0029:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_002e:  constrained. ""T""
-    IL_0034:  callvirt   ""int IMoveable.Position.get""
-    IL_0039:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_003e:  ldarg.0
-    IL_003f:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_0044:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0049:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_004e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0053:  stloc.2
-    IL_0054:  ldloca.s   V_2
-    IL_0056:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_005b:  brtrue.s   IL_009c
-    IL_005d:  ldarg.0
-    IL_005e:  ldc.i4.0
-    IL_005f:  dup
-    IL_0060:  stloc.0
-    IL_0061:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0066:  ldarg.0
-    IL_0067:  ldloc.2
-    IL_0068:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_006d:  ldarg.0
-    IL_006e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0073:  ldloca.s   V_2
-    IL_0075:  ldarg.0
-    IL_0076:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
-    IL_007b:  leave      IL_010e
-    IL_0080:  ldarg.0
-    IL_0081:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0086:  stloc.2
-    IL_0087:  ldarg.0
-    IL_0088:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_008d:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0093:  ldarg.0
-    IL_0094:  ldc.i4.m1
-    IL_0095:  dup
-    IL_0096:  stloc.0
-    IL_0097:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_009c:  ldloca.s   V_2
-    IL_009e:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_00a3:  stloc.1
-    IL_00a4:  ldtoken    ""T""
-    IL_00a9:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00ae:  call       ""bool System.Type.IsValueType.get""
-    IL_00b3:  brtrue.s   IL_00bd
-    IL_00b5:  ldarg.0
-    IL_00b6:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00bb:  br.s       IL_00c3
-    IL_00bd:  ldarg.0
-    IL_00be:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00c3:  ldarg.0
-    IL_00c4:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_00c9:  ldloc.1
-    IL_00ca:  add
-    IL_00cb:  constrained. ""T""
-    IL_00d1:  callvirt   ""void IMoveable.Position.set""
-    IL_00d6:  ldarg.0
-    IL_00d7:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00dc:  initobj    ""T""
-    IL_00e2:  leave.s    IL_00fb
+    IL_0028:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_002d:  constrained. ""T""
+    IL_0033:  callvirt   ""int IMoveable.Position.get""
+    IL_0038:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_003d:  ldarg.0
+    IL_003e:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0043:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0048:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_004d:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_0052:  stloc.3
+    IL_0053:  ldloca.s   V_3
+    IL_0055:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_005a:  brtrue.s   IL_009b
+    IL_005c:  ldarg.0
+    IL_005d:  ldc.i4.0
+    IL_005e:  dup
+    IL_005f:  stloc.0
+    IL_0060:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0065:  ldarg.0
+    IL_0066:  ldloc.3
+    IL_0067:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_006c:  ldarg.0
+    IL_006d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_0072:  ldloca.s   V_3
+    IL_0074:  ldarg.0
+    IL_0075:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
+    IL_007a:  leave      IL_010e
+    IL_007f:  ldarg.0
+    IL_0080:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0085:  stloc.3
+    IL_0086:  ldarg.0
+    IL_0087:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_008c:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0092:  ldarg.0
+    IL_0093:  ldc.i4.m1
+    IL_0094:  dup
+    IL_0095:  stloc.0
+    IL_0096:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_009b:  ldloca.s   V_3
+    IL_009d:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_00a2:  stloc.1
+    IL_00a3:  ldloca.s   V_2
+    IL_00a5:  initobj    ""T""
+    IL_00ab:  ldloc.2
+    IL_00ac:  box        ""T""
+    IL_00b1:  brtrue.s   IL_00bb
+    IL_00b3:  ldarg.0
+    IL_00b4:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00b9:  br.s       IL_00c1
+    IL_00bb:  ldarg.0
+    IL_00bc:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00c1:  ldarg.0
+    IL_00c2:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_00c7:  ldloc.1
+    IL_00c8:  add
+    IL_00c9:  constrained. ""T""
+    IL_00cf:  callvirt   ""void IMoveable.Position.set""
+    IL_00d4:  ldarg.0
+    IL_00d5:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00da:  initobj    ""T""
+    IL_00e0:  leave.s    IL_00fb
   }
   catch System.Exception
   {
-    IL_00e4:  stloc.3
-    IL_00e5:  ldarg.0
-    IL_00e6:  ldc.i4.s   -2
-    IL_00e8:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00ed:  ldarg.0
-    IL_00ee:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_00f3:  ldloc.3
+    IL_00e2:  stloc.s    V_4
+    IL_00e4:  ldarg.0
+    IL_00e5:  ldc.i4.s   -2
+    IL_00e7:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00ec:  ldarg.0
+    IL_00ed:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_00f2:  ldloc.s    V_4
     IL_00f4:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_00f9:  leave.s    IL_010e
   }
@@ -3946,8 +3970,9 @@ Position set for item '2'
                 System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_1,
                 System.Runtime.CompilerServices.YieldAwaitable V_2,
                 int V_3,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
-                System.Exception V_5)
+                T V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_5,
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -3993,9 +4018,10 @@ Position set for item '2'
     IL_0062:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0067:  ldloca.s   V_1
     IL_0069:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_006e:  ldtoken    ""T""
-    IL_0073:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0078:  call       ""bool System.Type.IsValueType.get""
+    IL_006e:  ldloca.s   V_4
+    IL_0070:  initobj    ""T""
+    IL_0076:  ldloc.s    V_4
+    IL_0078:  box        ""T""
     IL_007d:  brtrue.s   IL_008b
     IL_007f:  ldarg.0
     IL_0080:  ldarg.0
@@ -4012,8 +4038,8 @@ Position set for item '2'
     IL_00a8:  call       ""int Program.GetOffset<T>(ref T)""
     IL_00ad:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_00b2:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_00b7:  stloc.s    V_4
-    IL_00b9:  ldloca.s   V_4
+    IL_00b7:  stloc.s    V_5
+    IL_00b9:  ldloca.s   V_5
     IL_00bb:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_00c0:  brtrue.s   IL_0103
     IL_00c2:  ldarg.0
@@ -4022,17 +4048,17 @@ Position set for item '2'
     IL_00c5:  stloc.0
     IL_00c6:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_00cb:  ldarg.0
-    IL_00cc:  ldloc.s    V_4
+    IL_00cc:  ldloc.s    V_5
     IL_00ce:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__2""
     IL_00d3:  ldarg.0
     IL_00d4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_00d9:  ldloca.s   V_4
+    IL_00d9:  ldloca.s   V_5
     IL_00db:  ldarg.0
     IL_00dc:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_00e1:  leave      IL_0177
     IL_00e6:  ldarg.0
     IL_00e7:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__2""
-    IL_00ec:  stloc.s    V_4
+    IL_00ec:  stloc.s    V_5
     IL_00ee:  ldarg.0
     IL_00ef:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__2""
     IL_00f4:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -4041,12 +4067,13 @@ Position set for item '2'
     IL_00fc:  dup
     IL_00fd:  stloc.0
     IL_00fe:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0103:  ldloca.s   V_4
+    IL_0103:  ldloca.s   V_5
     IL_0105:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_010a:  stloc.3
-    IL_010b:  ldtoken    ""T""
-    IL_0110:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0115:  call       ""bool System.Type.IsValueType.get""
+    IL_010b:  ldloca.s   V_4
+    IL_010d:  initobj    ""T""
+    IL_0113:  ldloc.s    V_4
+    IL_0115:  box        ""T""
     IL_011a:  brtrue.s   IL_0124
     IL_011c:  ldarg.0
     IL_011d:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -4066,13 +4093,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_014b:  stloc.s    V_5
+    IL_014b:  stloc.s    V_6
     IL_014d:  ldarg.0
     IL_014e:  ldc.i4.s   -2
     IL_0150:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0155:  ldarg.0
     IL_0156:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_015b:  ldloc.s    V_5
+    IL_015b:  ldloc.s    V_6
     IL_015d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0162:  leave.s    IL_0177
   }
@@ -4401,33 +4428,35 @@ Position set for item '2'
   .locals init (T& V_0,
                 T V_1,
                 T& V_2,
-                int? V_3,
-                int? V_4)
+                T V_3,
+                int? V_4,
+                int? V_5)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.2
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
-  IL_0012:  brtrue.s   IL_001f
-  IL_0014:  ldloc.2
-  IL_0015:  ldobj      ""T""
-  IL_001a:  stloc.1
-  IL_001b:  ldloca.s   V_1
-  IL_001d:  br.s       IL_0020
-  IL_001f:  ldloc.2
-  IL_0020:  stloc.0
-  IL_0021:  ldloc.0
-  IL_0022:  constrained. ""T""
-  IL_0028:  callvirt   ""int? IMoveable.Position.get""
-  IL_002d:  stloc.3
-  IL_002e:  ldloca.s   V_3
+  IL_0003:  ldloca.s   V_3
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.3
+  IL_000c:  box        ""T""
+  IL_0011:  brtrue.s   IL_001e
+  IL_0013:  ldloc.2
+  IL_0014:  ldobj      ""T""
+  IL_0019:  stloc.1
+  IL_001a:  ldloca.s   V_1
+  IL_001c:  br.s       IL_001f
+  IL_001e:  ldloc.2
+  IL_001f:  stloc.0
+  IL_0020:  ldloc.0
+  IL_0021:  constrained. ""T""
+  IL_0027:  callvirt   ""int? IMoveable.Position.get""
+  IL_002c:  stloc.s    V_4
+  IL_002e:  ldloca.s   V_4
   IL_0030:  call       ""bool int?.HasValue.get""
   IL_0035:  brtrue.s   IL_004d
   IL_0037:  ldloc.0
   IL_0038:  ldarga.s   V_0
   IL_003a:  call       ""int? Program.GetOffset<T>(ref T)""
   IL_003f:  dup
-  IL_0040:  stloc.s    V_4
+  IL_0040:  stloc.s    V_5
   IL_0042:  constrained. ""T""
   IL_0048:  callvirt   ""void IMoveable.Position.set""
   IL_004d:  ret
@@ -4638,33 +4667,35 @@ Position set for item '2'
   .locals init (T& V_0,
                 T V_1,
                 T& V_2,
-                int? V_3,
-                int? V_4)
+                T V_3,
+                int? V_4,
+                int? V_5)
   IL_0000:  ldarg.0
   IL_0001:  stloc.2
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
-  IL_0011:  brtrue.s   IL_001e
-  IL_0013:  ldloc.2
-  IL_0014:  ldobj      ""T""
-  IL_0019:  stloc.1
-  IL_001a:  ldloca.s   V_1
-  IL_001c:  br.s       IL_001f
-  IL_001e:  ldloc.2
-  IL_001f:  stloc.0
-  IL_0020:  ldloc.0
-  IL_0021:  constrained. ""T""
-  IL_0027:  callvirt   ""int? IMoveable.Position.get""
-  IL_002c:  stloc.3
-  IL_002d:  ldloca.s   V_3
+  IL_0002:  ldloca.s   V_3
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.3
+  IL_000b:  box        ""T""
+  IL_0010:  brtrue.s   IL_001d
+  IL_0012:  ldloc.2
+  IL_0013:  ldobj      ""T""
+  IL_0018:  stloc.1
+  IL_0019:  ldloca.s   V_1
+  IL_001b:  br.s       IL_001e
+  IL_001d:  ldloc.2
+  IL_001e:  stloc.0
+  IL_001f:  ldloc.0
+  IL_0020:  constrained. ""T""
+  IL_0026:  callvirt   ""int? IMoveable.Position.get""
+  IL_002b:  stloc.s    V_4
+  IL_002d:  ldloca.s   V_4
   IL_002f:  call       ""bool int?.HasValue.get""
   IL_0034:  brtrue.s   IL_004b
   IL_0036:  ldloc.0
   IL_0037:  ldarg.0
   IL_0038:  call       ""int? Program.GetOffset<T>(ref T)""
   IL_003d:  dup
-  IL_003e:  stloc.s    V_4
+  IL_003e:  stloc.s    V_5
   IL_0040:  constrained. ""T""
   IL_0046:  callvirt   ""void IMoveable.Position.set""
   IL_004b:  ret
@@ -4952,119 +4983,123 @@ Position set for item '2'
             verifier.VerifyIL("Program.<Shift2>d__2<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"
 {
-  // Code size      306 (0x132)
+  // Code size      304 (0x130)
   .maxstack  3
   .locals init (int V_0,
                 int? V_1,
-                int? V_2,
+                T V_2,
                 int? V_3,
-                System.Runtime.CompilerServices.TaskAwaiter<int?> V_4,
-                System.Exception V_5)
+                int? V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<int?> V_5,
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse    IL_00a5
-    IL_000d:  ldtoken    ""T""
-    IL_0012:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0017:  call       ""bool System.Type.IsValueType.get""
-    IL_001c:  brtrue.s   IL_002a
+    IL_0008:  brfalse    IL_00a3
+    IL_000d:  ldloca.s   V_2
+    IL_000f:  initobj    ""T""
+    IL_0015:  ldloc.2
+    IL_0016:  box        ""T""
+    IL_001b:  brtrue.s   IL_0029
+    IL_001d:  ldarg.0
     IL_001e:  ldarg.0
-    IL_001f:  ldarg.0
-    IL_0020:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0025:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_002a:  ldtoken    ""T""
-    IL_002f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0034:  call       ""bool System.Type.IsValueType.get""
-    IL_0039:  brtrue.s   IL_0043
-    IL_003b:  ldarg.0
-    IL_003c:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0041:  br.s       IL_0049
-    IL_0043:  ldarg.0
-    IL_0044:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_0049:  constrained. ""T""
-    IL_004f:  callvirt   ""int? IMoveable.Position.get""
-    IL_0054:  stloc.1
-    IL_0055:  ldloca.s   V_1
-    IL_0057:  call       ""bool int?.HasValue.get""
-    IL_005c:  brtrue     IL_00f7
-    IL_0061:  ldarg.0
-    IL_0062:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_0067:  call       ""int? Program.GetOffset<T>(ref T)""
-    IL_006c:  call       ""System.Threading.Tasks.Task<int?> Program.GetOffsetAsync(int?)""
-    IL_0071:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int?> System.Threading.Tasks.Task<int?>.GetAwaiter()""
-    IL_0076:  stloc.s    V_4
-    IL_0078:  ldloca.s   V_4
-    IL_007a:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int?>.IsCompleted.get""
-    IL_007f:  brtrue.s   IL_00c2
-    IL_0081:  ldarg.0
-    IL_0082:  ldc.i4.0
-    IL_0083:  dup
-    IL_0084:  stloc.0
-    IL_0085:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_008a:  ldarg.0
-    IL_008b:  ldloc.s    V_4
-    IL_008d:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int?> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0092:  ldarg.0
-    IL_0093:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0098:  ldloca.s   V_4
-    IL_009a:  ldarg.0
-    IL_009b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int?>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int?>, ref Program.<Shift2>d__2<T>)""
-    IL_00a0:  leave      IL_0131
-    IL_00a5:  ldarg.0
-    IL_00a6:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int?> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00ab:  stloc.s    V_4
-    IL_00ad:  ldarg.0
-    IL_00ae:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int?> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00b3:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int?>""
-    IL_00b9:  ldarg.0
-    IL_00ba:  ldc.i4.m1
-    IL_00bb:  dup
-    IL_00bc:  stloc.0
-    IL_00bd:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00c2:  ldloca.s   V_4
-    IL_00c4:  call       ""int? System.Runtime.CompilerServices.TaskAwaiter<int?>.GetResult()""
-    IL_00c9:  stloc.2
-    IL_00ca:  ldtoken    ""T""
-    IL_00cf:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00d4:  call       ""bool System.Type.IsValueType.get""
-    IL_00d9:  brtrue.s   IL_00e3
-    IL_00db:  ldarg.0
-    IL_00dc:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00e1:  br.s       IL_00e9
-    IL_00e3:  ldarg.0
-    IL_00e4:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00e9:  ldloc.2
-    IL_00ea:  dup
-    IL_00eb:  stloc.3
-    IL_00ec:  constrained. ""T""
-    IL_00f2:  callvirt   ""void IMoveable.Position.set""
-    IL_00f7:  ldarg.0
-    IL_00f8:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00fd:  initobj    ""T""
-    IL_0103:  leave.s    IL_011e
+    IL_001f:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0024:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0029:  ldloca.s   V_2
+    IL_002b:  initobj    ""T""
+    IL_0031:  ldloc.2
+    IL_0032:  box        ""T""
+    IL_0037:  brtrue.s   IL_0041
+    IL_0039:  ldarg.0
+    IL_003a:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_003f:  br.s       IL_0047
+    IL_0041:  ldarg.0
+    IL_0042:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0047:  constrained. ""T""
+    IL_004d:  callvirt   ""int? IMoveable.Position.get""
+    IL_0052:  stloc.1
+    IL_0053:  ldloca.s   V_1
+    IL_0055:  call       ""bool int?.HasValue.get""
+    IL_005a:  brtrue     IL_00f5
+    IL_005f:  ldarg.0
+    IL_0060:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0065:  call       ""int? Program.GetOffset<T>(ref T)""
+    IL_006a:  call       ""System.Threading.Tasks.Task<int?> Program.GetOffsetAsync(int?)""
+    IL_006f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int?> System.Threading.Tasks.Task<int?>.GetAwaiter()""
+    IL_0074:  stloc.s    V_5
+    IL_0076:  ldloca.s   V_5
+    IL_0078:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int?>.IsCompleted.get""
+    IL_007d:  brtrue.s   IL_00c0
+    IL_007f:  ldarg.0
+    IL_0080:  ldc.i4.0
+    IL_0081:  dup
+    IL_0082:  stloc.0
+    IL_0083:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0088:  ldarg.0
+    IL_0089:  ldloc.s    V_5
+    IL_008b:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int?> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0090:  ldarg.0
+    IL_0091:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_0096:  ldloca.s   V_5
+    IL_0098:  ldarg.0
+    IL_0099:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int?>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int?>, ref Program.<Shift2>d__2<T>)""
+    IL_009e:  leave      IL_012f
+    IL_00a3:  ldarg.0
+    IL_00a4:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int?> Program.<Shift2>d__2<T>.<>u__1""
+    IL_00a9:  stloc.s    V_5
+    IL_00ab:  ldarg.0
+    IL_00ac:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int?> Program.<Shift2>d__2<T>.<>u__1""
+    IL_00b1:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int?>""
+    IL_00b7:  ldarg.0
+    IL_00b8:  ldc.i4.m1
+    IL_00b9:  dup
+    IL_00ba:  stloc.0
+    IL_00bb:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00c0:  ldloca.s   V_5
+    IL_00c2:  call       ""int? System.Runtime.CompilerServices.TaskAwaiter<int?>.GetResult()""
+    IL_00c7:  stloc.3
+    IL_00c8:  ldloca.s   V_2
+    IL_00ca:  initobj    ""T""
+    IL_00d0:  ldloc.2
+    IL_00d1:  box        ""T""
+    IL_00d6:  brtrue.s   IL_00e0
+    IL_00d8:  ldarg.0
+    IL_00d9:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00de:  br.s       IL_00e6
+    IL_00e0:  ldarg.0
+    IL_00e1:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00e6:  ldloc.3
+    IL_00e7:  dup
+    IL_00e8:  stloc.s    V_4
+    IL_00ea:  constrained. ""T""
+    IL_00f0:  callvirt   ""void IMoveable.Position.set""
+    IL_00f5:  ldarg.0
+    IL_00f6:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00fb:  initobj    ""T""
+    IL_0101:  leave.s    IL_011c
   }
   catch System.Exception
   {
-    IL_0105:  stloc.s    V_5
-    IL_0107:  ldarg.0
-    IL_0108:  ldc.i4.s   -2
-    IL_010a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_010f:  ldarg.0
-    IL_0110:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0115:  ldloc.s    V_5
-    IL_0117:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_011c:  leave.s    IL_0131
+    IL_0103:  stloc.s    V_6
+    IL_0105:  ldarg.0
+    IL_0106:  ldc.i4.s   -2
+    IL_0108:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_010d:  ldarg.0
+    IL_010e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_0113:  ldloc.s    V_6
+    IL_0115:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_011a:  leave.s    IL_012f
   }
-  IL_011e:  ldarg.0
-  IL_011f:  ldc.i4.s   -2
-  IL_0121:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-  IL_0126:  ldarg.0
-  IL_0127:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-  IL_012c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0131:  ret
+  IL_011c:  ldarg.0
+  IL_011d:  ldc.i4.s   -2
+  IL_011f:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+  IL_0124:  ldarg.0
+  IL_0125:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+  IL_012a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_012f:  ret
 }
 ");
         }
@@ -5470,10 +5505,11 @@ Position set for item '2'
                 System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_1,
                 System.Runtime.CompilerServices.YieldAwaitable V_2,
                 int? V_3,
-                int? V_4,
+                T V_4,
                 int? V_5,
-                System.Runtime.CompilerServices.TaskAwaiter<int?> V_6,
-                System.Exception V_7)
+                int? V_6,
+                System.Runtime.CompilerServices.TaskAwaiter<int?> V_7,
+                System.Exception V_8)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -5519,17 +5555,19 @@ Position set for item '2'
     IL_0062:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0067:  ldloca.s   V_1
     IL_0069:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_006e:  ldtoken    ""T""
-    IL_0073:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0078:  call       ""bool System.Type.IsValueType.get""
+    IL_006e:  ldloca.s   V_4
+    IL_0070:  initobj    ""T""
+    IL_0076:  ldloc.s    V_4
+    IL_0078:  box        ""T""
     IL_007d:  brtrue.s   IL_008b
     IL_007f:  ldarg.0
     IL_0080:  ldarg.0
     IL_0081:  ldfld      ""T Program.<Shift2>d__2<T>.item""
     IL_0086:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_008b:  ldtoken    ""T""
-    IL_0090:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0095:  call       ""bool System.Type.IsValueType.get""
+    IL_008b:  ldloca.s   V_4
+    IL_008d:  initobj    ""T""
+    IL_0093:  ldloc.s    V_4
+    IL_0095:  box        ""T""
     IL_009a:  brtrue.s   IL_00a4
     IL_009c:  ldarg.0
     IL_009d:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -5547,8 +5585,8 @@ Position set for item '2'
     IL_00c8:  call       ""int? Program.GetOffset<T>(ref T)""
     IL_00cd:  call       ""System.Threading.Tasks.Task<int?> Program.GetOffsetAsync(int?)""
     IL_00d2:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int?> System.Threading.Tasks.Task<int?>.GetAwaiter()""
-    IL_00d7:  stloc.s    V_6
-    IL_00d9:  ldloca.s   V_6
+    IL_00d7:  stloc.s    V_7
+    IL_00d9:  ldloca.s   V_7
     IL_00db:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int?>.IsCompleted.get""
     IL_00e0:  brtrue.s   IL_0123
     IL_00e2:  ldarg.0
@@ -5557,17 +5595,17 @@ Position set for item '2'
     IL_00e5:  stloc.0
     IL_00e6:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_00eb:  ldarg.0
-    IL_00ec:  ldloc.s    V_6
+    IL_00ec:  ldloc.s    V_7
     IL_00ee:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int?> Program.<Shift2>d__2<T>.<>u__2""
     IL_00f3:  ldarg.0
     IL_00f4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_00f9:  ldloca.s   V_6
+    IL_00f9:  ldloca.s   V_7
     IL_00fb:  ldarg.0
     IL_00fc:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int?>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int?>, ref Program.<Shift2>d__2<T>)""
     IL_0101:  leave      IL_0195
     IL_0106:  ldarg.0
     IL_0107:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int?> Program.<Shift2>d__2<T>.<>u__2""
-    IL_010c:  stloc.s    V_6
+    IL_010c:  stloc.s    V_7
     IL_010e:  ldarg.0
     IL_010f:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int?> Program.<Shift2>d__2<T>.<>u__2""
     IL_0114:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int?>""
@@ -5576,21 +5614,22 @@ Position set for item '2'
     IL_011c:  dup
     IL_011d:  stloc.0
     IL_011e:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0123:  ldloca.s   V_6
+    IL_0123:  ldloca.s   V_7
     IL_0125:  call       ""int? System.Runtime.CompilerServices.TaskAwaiter<int?>.GetResult()""
-    IL_012a:  stloc.s    V_4
-    IL_012c:  ldtoken    ""T""
-    IL_0131:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0136:  call       ""bool System.Type.IsValueType.get""
+    IL_012a:  stloc.s    V_5
+    IL_012c:  ldloca.s   V_4
+    IL_012e:  initobj    ""T""
+    IL_0134:  ldloc.s    V_4
+    IL_0136:  box        ""T""
     IL_013b:  brtrue.s   IL_0145
     IL_013d:  ldarg.0
     IL_013e:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
     IL_0143:  br.s       IL_014b
     IL_0145:  ldarg.0
     IL_0146:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_014b:  ldloc.s    V_4
+    IL_014b:  ldloc.s    V_5
     IL_014d:  dup
-    IL_014e:  stloc.s    V_5
+    IL_014e:  stloc.s    V_6
     IL_0150:  constrained. ""T""
     IL_0156:  callvirt   ""void IMoveable.Position.set""
     IL_015b:  ldarg.0
@@ -5600,13 +5639,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_0169:  stloc.s    V_7
+    IL_0169:  stloc.s    V_8
     IL_016b:  ldarg.0
     IL_016c:  ldc.i4.s   -2
     IL_016e:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0173:  ldarg.0
     IL_0174:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0179:  ldloc.s    V_7
+    IL_0179:  ldloc.s    V_8
     IL_017b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0180:  leave.s    IL_0195
   }
@@ -5936,12 +5975,14 @@ Position set for item '2'
   .locals init (T& V_0,
                 T V_1,
                 T& V_2,
-                int V_3)
+                int V_3,
+                T V_4)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.2
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
+  IL_0003:  ldloca.s   V_4
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_4
+  IL_000d:  box        ""T""
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.2
   IL_0015:  ldobj      ""T""
@@ -6167,12 +6208,14 @@ Position set for item '2'
   .locals init (T& V_0,
                 T V_1,
                 T& V_2,
-                int V_3)
+                int V_3,
+                T V_4)
   IL_0000:  ldarg.0
   IL_0001:  stloc.2
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
+  IL_0002:  ldloca.s   V_4
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_4
+  IL_000c:  box        ""T""
   IL_0011:  brtrue.s   IL_001e
   IL_0013:  ldloc.2
   IL_0014:  ldobj      ""T""
@@ -6466,114 +6509,118 @@ Position set for item '2'
             verifier.VerifyIL("Program.<Shift2>d__2<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"
 {
-  // Code size      286 (0x11e)
+  // Code size      285 (0x11d)
   .maxstack  4
   .locals init (int V_0,
                 int V_1,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
-                System.Exception V_3)
+                T V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
+                System.Exception V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0069
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
-    IL_0019:  brtrue.s   IL_0027
+    IL_0008:  brfalse.s  IL_0068
+    IL_000a:  ldloca.s   V_2
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.2
+    IL_0013:  box        ""T""
+    IL_0018:  brtrue.s   IL_0026
+    IL_001a:  ldarg.0
     IL_001b:  ldarg.0
-    IL_001c:  ldarg.0
-    IL_001d:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0022:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0027:  ldarg.0
-    IL_0028:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_002d:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0032:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003c:  stloc.2
-    IL_003d:  ldloca.s   V_2
-    IL_003f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0044:  brtrue.s   IL_0085
-    IL_0046:  ldarg.0
-    IL_0047:  ldc.i4.0
-    IL_0048:  dup
-    IL_0049:  stloc.0
-    IL_004a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_004f:  ldarg.0
-    IL_0050:  ldloc.2
-    IL_0051:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0056:  ldarg.0
-    IL_0057:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_005c:  ldloca.s   V_2
-    IL_005e:  ldarg.0
-    IL_005f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
-    IL_0064:  leave      IL_011d
-    IL_0069:  ldarg.0
-    IL_006a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_006f:  stloc.2
-    IL_0070:  ldarg.0
-    IL_0071:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0076:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_007c:  ldarg.0
-    IL_007d:  ldc.i4.m1
-    IL_007e:  dup
-    IL_007f:  stloc.0
-    IL_0080:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0085:  ldloca.s   V_2
-    IL_0087:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_008c:  stloc.1
-    IL_008d:  ldtoken    ""T""
-    IL_0092:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0097:  call       ""bool System.Type.IsValueType.get""
-    IL_009c:  brtrue.s   IL_00a6
-    IL_009e:  ldarg.0
-    IL_009f:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00a4:  br.s       IL_00ac
-    IL_00a6:  ldarg.0
-    IL_00a7:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00ac:  ldloc.1
-    IL_00ad:  ldtoken    ""T""
-    IL_00b2:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00b7:  call       ""bool System.Type.IsValueType.get""
-    IL_00bc:  brtrue.s   IL_00c6
-    IL_00be:  ldarg.0
-    IL_00bf:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00c4:  br.s       IL_00cc
-    IL_00c6:  ldarg.0
-    IL_00c7:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00cc:  ldloc.1
-    IL_00cd:  constrained. ""T""
-    IL_00d3:  callvirt   ""int IMoveable.this[int].get""
-    IL_00d8:  ldc.i4.1
-    IL_00d9:  add
-    IL_00da:  constrained. ""T""
-    IL_00e0:  callvirt   ""void IMoveable.this[int].set""
-    IL_00e5:  ldarg.0
-    IL_00e6:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00eb:  initobj    ""T""
-    IL_00f1:  leave.s    IL_010a
+    IL_001c:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0021:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0026:  ldarg.0
+    IL_0027:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_002c:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0031:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_0036:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_003b:  stloc.3
+    IL_003c:  ldloca.s   V_3
+    IL_003e:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0043:  brtrue.s   IL_0084
+    IL_0045:  ldarg.0
+    IL_0046:  ldc.i4.0
+    IL_0047:  dup
+    IL_0048:  stloc.0
+    IL_0049:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_004e:  ldarg.0
+    IL_004f:  ldloc.3
+    IL_0050:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0055:  ldarg.0
+    IL_0056:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_005b:  ldloca.s   V_3
+    IL_005d:  ldarg.0
+    IL_005e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
+    IL_0063:  leave      IL_011c
+    IL_0068:  ldarg.0
+    IL_0069:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_006e:  stloc.3
+    IL_006f:  ldarg.0
+    IL_0070:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0075:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_007b:  ldarg.0
+    IL_007c:  ldc.i4.m1
+    IL_007d:  dup
+    IL_007e:  stloc.0
+    IL_007f:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0084:  ldloca.s   V_3
+    IL_0086:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_008b:  stloc.1
+    IL_008c:  ldloca.s   V_2
+    IL_008e:  initobj    ""T""
+    IL_0094:  ldloc.2
+    IL_0095:  box        ""T""
+    IL_009a:  brtrue.s   IL_00a4
+    IL_009c:  ldarg.0
+    IL_009d:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00a2:  br.s       IL_00aa
+    IL_00a4:  ldarg.0
+    IL_00a5:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00aa:  ldloc.1
+    IL_00ab:  ldloca.s   V_2
+    IL_00ad:  initobj    ""T""
+    IL_00b3:  ldloc.2
+    IL_00b4:  box        ""T""
+    IL_00b9:  brtrue.s   IL_00c3
+    IL_00bb:  ldarg.0
+    IL_00bc:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00c1:  br.s       IL_00c9
+    IL_00c3:  ldarg.0
+    IL_00c4:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00c9:  ldloc.1
+    IL_00ca:  constrained. ""T""
+    IL_00d0:  callvirt   ""int IMoveable.this[int].get""
+    IL_00d5:  ldc.i4.1
+    IL_00d6:  add
+    IL_00d7:  constrained. ""T""
+    IL_00dd:  callvirt   ""void IMoveable.this[int].set""
+    IL_00e2:  ldarg.0
+    IL_00e3:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00e8:  initobj    ""T""
+    IL_00ee:  leave.s    IL_0109
   }
   catch System.Exception
   {
-    IL_00f3:  stloc.3
-    IL_00f4:  ldarg.0
-    IL_00f5:  ldc.i4.s   -2
-    IL_00f7:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00fc:  ldarg.0
-    IL_00fd:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0102:  ldloc.3
-    IL_0103:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_0108:  leave.s    IL_011d
+    IL_00f0:  stloc.s    V_4
+    IL_00f2:  ldarg.0
+    IL_00f3:  ldc.i4.s   -2
+    IL_00f5:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00fa:  ldarg.0
+    IL_00fb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_0100:  ldloc.s    V_4
+    IL_0102:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0107:  leave.s    IL_011c
   }
-  IL_010a:  ldarg.0
-  IL_010b:  ldc.i4.s   -2
-  IL_010d:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-  IL_0112:  ldarg.0
-  IL_0113:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-  IL_0118:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_011d:  ret
+  IL_0109:  ldarg.0
+  IL_010a:  ldc.i4.s   -2
+  IL_010c:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+  IL_0111:  ldarg.0
+  IL_0112:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+  IL_0117:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_011c:  ret
 }
 ");
         }
@@ -6963,8 +7010,9 @@ Position set for item '2'
                 System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_1,
                 System.Runtime.CompilerServices.YieldAwaitable V_2,
                 int V_3,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
-                System.Exception V_5)
+                T V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_5,
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -7010,9 +7058,10 @@ Position set for item '2'
     IL_0062:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0067:  ldloca.s   V_1
     IL_0069:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_006e:  ldtoken    ""T""
-    IL_0073:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0078:  call       ""bool System.Type.IsValueType.get""
+    IL_006e:  ldloca.s   V_4
+    IL_0070:  initobj    ""T""
+    IL_0076:  ldloc.s    V_4
+    IL_0078:  box        ""T""
     IL_007d:  brtrue.s   IL_008b
     IL_007f:  ldarg.0
     IL_0080:  ldarg.0
@@ -7023,8 +7072,8 @@ Position set for item '2'
     IL_0091:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0096:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_009b:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_00a0:  stloc.s    V_4
-    IL_00a2:  ldloca.s   V_4
+    IL_00a0:  stloc.s    V_5
+    IL_00a2:  ldloca.s   V_5
     IL_00a4:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_00a9:  brtrue.s   IL_00ec
     IL_00ab:  ldarg.0
@@ -7033,17 +7082,17 @@ Position set for item '2'
     IL_00ae:  stloc.0
     IL_00af:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_00b4:  ldarg.0
-    IL_00b5:  ldloc.s    V_4
+    IL_00b5:  ldloc.s    V_5
     IL_00b7:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__2""
     IL_00bc:  ldarg.0
     IL_00bd:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_00c2:  ldloca.s   V_4
+    IL_00c2:  ldloca.s   V_5
     IL_00c4:  ldarg.0
     IL_00c5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_00ca:  leave      IL_0186
     IL_00cf:  ldarg.0
     IL_00d0:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__2""
-    IL_00d5:  stloc.s    V_4
+    IL_00d5:  stloc.s    V_5
     IL_00d7:  ldarg.0
     IL_00d8:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__2""
     IL_00dd:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -7052,12 +7101,13 @@ Position set for item '2'
     IL_00e5:  dup
     IL_00e6:  stloc.0
     IL_00e7:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00ec:  ldloca.s   V_4
+    IL_00ec:  ldloca.s   V_5
     IL_00ee:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_00f3:  stloc.3
-    IL_00f4:  ldtoken    ""T""
-    IL_00f9:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00fe:  call       ""bool System.Type.IsValueType.get""
+    IL_00f4:  ldloca.s   V_4
+    IL_00f6:  initobj    ""T""
+    IL_00fc:  ldloc.s    V_4
+    IL_00fe:  box        ""T""
     IL_0103:  brtrue.s   IL_010d
     IL_0105:  ldarg.0
     IL_0106:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -7065,9 +7115,10 @@ Position set for item '2'
     IL_010d:  ldarg.0
     IL_010e:  ldflda     ""T Program.<Shift2>d__2<T>.item""
     IL_0113:  ldloc.3
-    IL_0114:  ldtoken    ""T""
-    IL_0119:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_011e:  call       ""bool System.Type.IsValueType.get""
+    IL_0114:  ldloca.s   V_4
+    IL_0116:  initobj    ""T""
+    IL_011c:  ldloc.s    V_4
+    IL_011e:  box        ""T""
     IL_0123:  brtrue.s   IL_012d
     IL_0125:  ldarg.0
     IL_0126:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -7088,13 +7139,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_015a:  stloc.s    V_5
+    IL_015a:  stloc.s    V_6
     IL_015c:  ldarg.0
     IL_015d:  ldc.i4.s   -2
     IL_015f:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0164:  ldarg.0
     IL_0165:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_016a:  ldloc.s    V_5
+    IL_016a:  ldloc.s    V_6
     IL_016c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0171:  leave.s    IL_0186
   }
@@ -7419,12 +7470,14 @@ Position set for item '2'
   .locals init (T V_0,
                 T& V_1,
                 int V_2,
-                int V_3)
+                int V_3,
+                T V_4)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.1
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
+  IL_0003:  ldloca.s   V_4
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_4
+  IL_000d:  box        ""T""
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.1
   IL_0015:  ldobj      ""T""
@@ -7650,12 +7703,14 @@ Position set for item '2'
   .locals init (T V_0,
                 T& V_1,
                 int V_2,
-                int V_3)
+                int V_3,
+                T V_4)
   IL_0000:  ldarg.0
   IL_0001:  stloc.1
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
+  IL_0002:  ldloca.s   V_4
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_4
+  IL_000c:  box        ""T""
   IL_0011:  brtrue.s   IL_001e
   IL_0013:  ldloc.1
   IL_0014:  ldobj      ""T""
@@ -7957,76 +8012,80 @@ Position set for item '2'
   .locals init (int V_0,
                 int V_1,
                 int V_2,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
-                System.Exception V_4)
+                T V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0069
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
-    IL_0019:  brtrue.s   IL_0027
+    IL_0008:  brfalse.s  IL_006a
+    IL_000a:  ldloca.s   V_3
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.3
+    IL_0013:  box        ""T""
+    IL_0018:  brtrue.s   IL_0026
+    IL_001a:  ldarg.0
     IL_001b:  ldarg.0
-    IL_001c:  ldarg.0
-    IL_001d:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0022:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0027:  ldarg.0
-    IL_0028:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_002d:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0032:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003c:  stloc.3
-    IL_003d:  ldloca.s   V_3
+    IL_001c:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0021:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0026:  ldarg.0
+    IL_0027:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_002c:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0031:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_0036:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_003b:  stloc.s    V_4
+    IL_003d:  ldloca.s   V_4
     IL_003f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0044:  brtrue.s   IL_0085
+    IL_0044:  brtrue.s   IL_0087
     IL_0046:  ldarg.0
     IL_0047:  ldc.i4.0
     IL_0048:  dup
     IL_0049:  stloc.0
     IL_004a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_004f:  ldarg.0
-    IL_0050:  ldloc.3
-    IL_0051:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0056:  ldarg.0
-    IL_0057:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_005c:  ldloca.s   V_3
-    IL_005e:  ldarg.0
-    IL_005f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
-    IL_0064:  leave      IL_0121
-    IL_0069:  ldarg.0
-    IL_006a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_006f:  stloc.3
-    IL_0070:  ldarg.0
-    IL_0071:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0076:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_007c:  ldarg.0
-    IL_007d:  ldc.i4.m1
-    IL_007e:  dup
-    IL_007f:  stloc.0
-    IL_0080:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0085:  ldloca.s   V_3
-    IL_0087:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_008c:  stloc.1
-    IL_008d:  ldtoken    ""T""
-    IL_0092:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0097:  call       ""bool System.Type.IsValueType.get""
-    IL_009c:  brtrue.s   IL_00a6
-    IL_009e:  ldarg.0
-    IL_009f:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00a4:  br.s       IL_00ac
-    IL_00a6:  ldarg.0
-    IL_00a7:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00ac:  ldloc.1
-    IL_00ad:  constrained. ""T""
-    IL_00b3:  callvirt   ""int IMoveable.this[int].get""
-    IL_00b8:  stloc.2
-    IL_00b9:  ldtoken    ""T""
-    IL_00be:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00c3:  call       ""bool System.Type.IsValueType.get""
+    IL_0050:  ldloc.s    V_4
+    IL_0052:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0057:  ldarg.0
+    IL_0058:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_005d:  ldloca.s   V_4
+    IL_005f:  ldarg.0
+    IL_0060:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
+    IL_0065:  leave      IL_0121
+    IL_006a:  ldarg.0
+    IL_006b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0070:  stloc.s    V_4
+    IL_0072:  ldarg.0
+    IL_0073:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0078:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_007e:  ldarg.0
+    IL_007f:  ldc.i4.m1
+    IL_0080:  dup
+    IL_0081:  stloc.0
+    IL_0082:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0087:  ldloca.s   V_4
+    IL_0089:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_008e:  stloc.1
+    IL_008f:  ldloca.s   V_3
+    IL_0091:  initobj    ""T""
+    IL_0097:  ldloc.3
+    IL_0098:  box        ""T""
+    IL_009d:  brtrue.s   IL_00a7
+    IL_009f:  ldarg.0
+    IL_00a0:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00a5:  br.s       IL_00ad
+    IL_00a7:  ldarg.0
+    IL_00a8:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00ad:  ldloc.1
+    IL_00ae:  constrained. ""T""
+    IL_00b4:  callvirt   ""int IMoveable.this[int].get""
+    IL_00b9:  stloc.2
+    IL_00ba:  ldloca.s   V_3
+    IL_00bc:  initobj    ""T""
+    IL_00c2:  ldloc.3
+    IL_00c3:  box        ""T""
     IL_00c8:  brtrue.s   IL_00d2
     IL_00ca:  ldarg.0
     IL_00cb:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -8046,13 +8105,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_00f5:  stloc.s    V_4
+    IL_00f5:  stloc.s    V_5
     IL_00f7:  ldarg.0
     IL_00f8:  ldc.i4.s   -2
     IL_00fa:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_00ff:  ldarg.0
     IL_0100:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0105:  ldloc.s    V_4
+    IL_0105:  ldloc.s    V_5
     IL_0107:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_010c:  leave.s    IL_0121
   }
@@ -8459,8 +8518,9 @@ Position set for item '2'
                 System.Runtime.CompilerServices.YieldAwaitable V_2,
                 int V_3,
                 int V_4,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_5,
-                System.Exception V_6)
+                T V_5,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_6,
+                System.Exception V_7)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -8506,9 +8566,10 @@ Position set for item '2'
     IL_0062:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0067:  ldloca.s   V_1
     IL_0069:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_006e:  ldtoken    ""T""
-    IL_0073:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0078:  call       ""bool System.Type.IsValueType.get""
+    IL_006e:  ldloca.s   V_5
+    IL_0070:  initobj    ""T""
+    IL_0076:  ldloc.s    V_5
+    IL_0078:  box        ""T""
     IL_007d:  brtrue.s   IL_008b
     IL_007f:  ldarg.0
     IL_0080:  ldarg.0
@@ -8519,8 +8580,8 @@ Position set for item '2'
     IL_0091:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0096:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_009b:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_00a0:  stloc.s    V_5
-    IL_00a2:  ldloca.s   V_5
+    IL_00a0:  stloc.s    V_6
+    IL_00a2:  ldloca.s   V_6
     IL_00a4:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_00a9:  brtrue.s   IL_00ec
     IL_00ab:  ldarg.0
@@ -8529,17 +8590,17 @@ Position set for item '2'
     IL_00ae:  stloc.0
     IL_00af:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_00b4:  ldarg.0
-    IL_00b5:  ldloc.s    V_5
+    IL_00b5:  ldloc.s    V_6
     IL_00b7:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__2""
     IL_00bc:  ldarg.0
     IL_00bd:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_00c2:  ldloca.s   V_5
+    IL_00c2:  ldloca.s   V_6
     IL_00c4:  ldarg.0
     IL_00c5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_00ca:  leave      IL_018a
     IL_00cf:  ldarg.0
     IL_00d0:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__2""
-    IL_00d5:  stloc.s    V_5
+    IL_00d5:  stloc.s    V_6
     IL_00d7:  ldarg.0
     IL_00d8:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__2""
     IL_00dd:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -8548,12 +8609,13 @@ Position set for item '2'
     IL_00e5:  dup
     IL_00e6:  stloc.0
     IL_00e7:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00ec:  ldloca.s   V_5
+    IL_00ec:  ldloca.s   V_6
     IL_00ee:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_00f3:  stloc.3
-    IL_00f4:  ldtoken    ""T""
-    IL_00f9:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00fe:  call       ""bool System.Type.IsValueType.get""
+    IL_00f4:  ldloca.s   V_5
+    IL_00f6:  initobj    ""T""
+    IL_00fc:  ldloc.s    V_5
+    IL_00fe:  box        ""T""
     IL_0103:  brtrue.s   IL_010d
     IL_0105:  ldarg.0
     IL_0106:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -8564,9 +8626,10 @@ Position set for item '2'
     IL_0114:  constrained. ""T""
     IL_011a:  callvirt   ""int IMoveable.this[int].get""
     IL_011f:  stloc.s    V_4
-    IL_0121:  ldtoken    ""T""
-    IL_0126:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_012b:  call       ""bool System.Type.IsValueType.get""
+    IL_0121:  ldloca.s   V_5
+    IL_0123:  initobj    ""T""
+    IL_0129:  ldloc.s    V_5
+    IL_012b:  box        ""T""
     IL_0130:  brtrue.s   IL_013a
     IL_0132:  ldarg.0
     IL_0133:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -8586,13 +8649,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_015e:  stloc.s    V_6
+    IL_015e:  stloc.s    V_7
     IL_0160:  ldarg.0
     IL_0161:  ldc.i4.s   -2
     IL_0163:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0168:  ldarg.0
     IL_0169:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_016e:  ldloc.s    V_6
+    IL_016e:  ldloc.s    V_7
     IL_0170:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0175:  leave.s    IL_018a
   }
@@ -8937,12 +9000,14 @@ Position set for item '2'
                 int V_3,
                 int? V_4,
                 int V_5,
-                int? V_6)
+                T V_6,
+                int? V_7)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.2
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
+  IL_0003:  ldloca.s   V_6
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_6
+  IL_000d:  box        ""T""
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.2
   IL_0015:  ldobj      ""T""
@@ -8969,10 +9034,10 @@ Position set for item '2'
   IL_004b:  stloc.s    V_5
   IL_004d:  ldloc.0
   IL_004e:  ldloc.3
-  IL_004f:  ldloca.s   V_6
+  IL_004f:  ldloca.s   V_7
   IL_0051:  ldloc.s    V_5
   IL_0053:  call       ""int?..ctor(int)""
-  IL_0058:  ldloc.s    V_6
+  IL_0058:  ldloc.s    V_7
   IL_005a:  constrained. ""T""
   IL_0060:  callvirt   ""void IMoveable.this[int].set""
   IL_0065:  ret
@@ -9210,12 +9275,14 @@ Position set for item '2'
                 int V_3,
                 int? V_4,
                 int V_5,
-                int? V_6)
+                T V_6,
+                int? V_7)
   IL_0000:  ldarg.0
   IL_0001:  stloc.2
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
+  IL_0002:  ldloca.s   V_6
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_6
+  IL_000c:  box        ""T""
   IL_0011:  brtrue.s   IL_001e
   IL_0013:  ldloc.2
   IL_0014:  ldobj      ""T""
@@ -9242,10 +9309,10 @@ Position set for item '2'
   IL_0049:  stloc.s    V_5
   IL_004b:  ldloc.0
   IL_004c:  ldloc.3
-  IL_004d:  ldloca.s   V_6
+  IL_004d:  ldloca.s   V_7
   IL_004f:  ldloc.s    V_5
   IL_0051:  call       ""int?..ctor(int)""
-  IL_0056:  ldloc.s    V_6
+  IL_0056:  ldloc.s    V_7
   IL_0058:  constrained. ""T""
   IL_005e:  callvirt   ""void IMoveable.this[int].set""
   IL_0063:  ret
@@ -9554,9 +9621,10 @@ Position set for item '2'
                 int V_1,
                 int? V_2,
                 int V_3,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
-                int? V_5,
-                System.Exception V_6)
+                T V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_5,
+                int? V_6,
+                System.Exception V_7)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -9564,9 +9632,10 @@ Position set for item '2'
   {
     IL_0007:  ldloc.0
     IL_0008:  brfalse.s  IL_006b
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
+    IL_000a:  ldloca.s   V_4
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.s    V_4
+    IL_0014:  box        ""T""
     IL_0019:  brtrue.s   IL_0027
     IL_001b:  ldarg.0
     IL_001c:  ldarg.0
@@ -9577,8 +9646,8 @@ Position set for item '2'
     IL_002d:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0032:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003c:  stloc.s    V_4
-    IL_003e:  ldloca.s   V_4
+    IL_003c:  stloc.s    V_5
+    IL_003e:  ldloca.s   V_5
     IL_0040:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_0045:  brtrue.s   IL_0088
     IL_0047:  ldarg.0
@@ -9587,17 +9656,17 @@ Position set for item '2'
     IL_004a:  stloc.0
     IL_004b:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0050:  ldarg.0
-    IL_0051:  ldloc.s    V_4
+    IL_0051:  ldloc.s    V_5
     IL_0053:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_0058:  ldarg.0
     IL_0059:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_005e:  ldloca.s   V_4
+    IL_005e:  ldloca.s   V_5
     IL_0060:  ldarg.0
     IL_0061:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_0066:  leave      IL_013d
     IL_006b:  ldarg.0
     IL_006c:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0071:  stloc.s    V_4
+    IL_0071:  stloc.s    V_5
     IL_0073:  ldarg.0
     IL_0074:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_0079:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -9606,12 +9675,13 @@ Position set for item '2'
     IL_0081:  dup
     IL_0082:  stloc.0
     IL_0083:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0088:  ldloca.s   V_4
+    IL_0088:  ldloca.s   V_5
     IL_008a:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_008f:  stloc.1
-    IL_0090:  ldtoken    ""T""
-    IL_0095:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_009a:  call       ""bool System.Type.IsValueType.get""
+    IL_0090:  ldloca.s   V_4
+    IL_0092:  initobj    ""T""
+    IL_0098:  ldloc.s    V_4
+    IL_009a:  box        ""T""
     IL_009f:  brtrue.s   IL_00a9
     IL_00a1:  ldarg.0
     IL_00a2:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -9630,9 +9700,10 @@ Position set for item '2'
     IL_00cb:  brtrue.s   IL_0103
     IL_00cd:  ldc.i4.1
     IL_00ce:  stloc.3
-    IL_00cf:  ldtoken    ""T""
-    IL_00d4:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00d9:  call       ""bool System.Type.IsValueType.get""
+    IL_00cf:  ldloca.s   V_4
+    IL_00d1:  initobj    ""T""
+    IL_00d7:  ldloc.s    V_4
+    IL_00d9:  box        ""T""
     IL_00de:  brtrue.s   IL_00e8
     IL_00e0:  ldarg.0
     IL_00e1:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -9643,7 +9714,7 @@ Position set for item '2'
     IL_00ef:  ldloc.3
     IL_00f0:  newobj     ""int?..ctor(int)""
     IL_00f5:  dup
-    IL_00f6:  stloc.s    V_5
+    IL_00f6:  stloc.s    V_6
     IL_00f8:  constrained. ""T""
     IL_00fe:  callvirt   ""void IMoveable.this[int].set""
     IL_0103:  ldarg.0
@@ -9653,13 +9724,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_0111:  stloc.s    V_6
+    IL_0111:  stloc.s    V_7
     IL_0113:  ldarg.0
     IL_0114:  ldc.i4.s   -2
     IL_0116:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_011b:  ldarg.0
     IL_011c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0121:  ldloc.s    V_6
+    IL_0121:  ldloc.s    V_7
     IL_0123:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0128:  leave.s    IL_013d
   }
@@ -10089,9 +10160,10 @@ Position set for item '2'
                 int V_3,
                 int? V_4,
                 int V_5,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_6,
-                int? V_7,
-                System.Exception V_8)
+                T V_6,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_7,
+                int? V_8,
+                System.Exception V_9)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -10137,9 +10209,10 @@ Position set for item '2'
     IL_0062:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0067:  ldloca.s   V_1
     IL_0069:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-    IL_006e:  ldtoken    ""T""
-    IL_0073:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0078:  call       ""bool System.Type.IsValueType.get""
+    IL_006e:  ldloca.s   V_6
+    IL_0070:  initobj    ""T""
+    IL_0076:  ldloc.s    V_6
+    IL_0078:  box        ""T""
     IL_007d:  brtrue.s   IL_008b
     IL_007f:  ldarg.0
     IL_0080:  ldarg.0
@@ -10150,8 +10223,8 @@ Position set for item '2'
     IL_0091:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0096:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_009b:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_00a0:  stloc.s    V_6
-    IL_00a2:  ldloca.s   V_6
+    IL_00a0:  stloc.s    V_7
+    IL_00a2:  ldloca.s   V_7
     IL_00a4:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_00a9:  brtrue.s   IL_00ec
     IL_00ab:  ldarg.0
@@ -10160,17 +10233,17 @@ Position set for item '2'
     IL_00ae:  stloc.0
     IL_00af:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_00b4:  ldarg.0
-    IL_00b5:  ldloc.s    V_6
+    IL_00b5:  ldloc.s    V_7
     IL_00b7:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__2""
     IL_00bc:  ldarg.0
     IL_00bd:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_00c2:  ldloca.s   V_6
+    IL_00c2:  ldloca.s   V_7
     IL_00c4:  ldarg.0
     IL_00c5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_00ca:  leave      IL_01a5
     IL_00cf:  ldarg.0
     IL_00d0:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__2""
-    IL_00d5:  stloc.s    V_6
+    IL_00d5:  stloc.s    V_7
     IL_00d7:  ldarg.0
     IL_00d8:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__2""
     IL_00dd:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -10179,12 +10252,13 @@ Position set for item '2'
     IL_00e5:  dup
     IL_00e6:  stloc.0
     IL_00e7:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00ec:  ldloca.s   V_6
+    IL_00ec:  ldloca.s   V_7
     IL_00ee:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_00f3:  stloc.3
-    IL_00f4:  ldtoken    ""T""
-    IL_00f9:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00fe:  call       ""bool System.Type.IsValueType.get""
+    IL_00f4:  ldloca.s   V_6
+    IL_00f6:  initobj    ""T""
+    IL_00fc:  ldloc.s    V_6
+    IL_00fe:  box        ""T""
     IL_0103:  brtrue.s   IL_010d
     IL_0105:  ldarg.0
     IL_0106:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -10203,9 +10277,10 @@ Position set for item '2'
     IL_0131:  brtrue.s   IL_016b
     IL_0133:  ldc.i4.1
     IL_0134:  stloc.s    V_5
-    IL_0136:  ldtoken    ""T""
-    IL_013b:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0140:  call       ""bool System.Type.IsValueType.get""
+    IL_0136:  ldloca.s   V_6
+    IL_0138:  initobj    ""T""
+    IL_013e:  ldloc.s    V_6
+    IL_0140:  box        ""T""
     IL_0145:  brtrue.s   IL_014f
     IL_0147:  ldarg.0
     IL_0148:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -10216,7 +10291,7 @@ Position set for item '2'
     IL_0156:  ldloc.s    V_5
     IL_0158:  newobj     ""int?..ctor(int)""
     IL_015d:  dup
-    IL_015e:  stloc.s    V_7
+    IL_015e:  stloc.s    V_8
     IL_0160:  constrained. ""T""
     IL_0166:  callvirt   ""void IMoveable.this[int].set""
     IL_016b:  ldarg.0
@@ -10226,13 +10301,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_0179:  stloc.s    V_8
+    IL_0179:  stloc.s    V_9
     IL_017b:  ldarg.0
     IL_017c:  ldc.i4.s   -2
     IL_017e:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0183:  ldarg.0
     IL_0184:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0189:  ldloc.s    V_8
+    IL_0189:  ldloc.s    V_9
     IL_018b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0190:  leave.s    IL_01a5
   }
@@ -10564,31 +10639,32 @@ Position set for item '2'
             verifier.VerifyIL("Program.Shift2<T>",
 @"
 {
-  // Code size       63 (0x3f)
+  // Code size       62 (0x3e)
   .maxstack  4
   .locals init (T& V_0,
                 T V_1)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.0
   IL_0003:  ldloc.0
-  IL_0004:  ldtoken    ""T""
-  IL_0009:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000e:  call       ""bool System.Type.IsValueType.get""
-  IL_0013:  brtrue.s   IL_001d
-  IL_0015:  ldobj      ""T""
-  IL_001a:  stloc.1
-  IL_001b:  ldloca.s   V_1
-  IL_001d:  ldc.i4.1
-  IL_001e:  ldloc.0
-  IL_001f:  ldc.i4.1
-  IL_0020:  constrained. ""T""
-  IL_0026:  callvirt   ""int IMoveable.this[int].get""
-  IL_002b:  ldarga.s   V_0
-  IL_002d:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0032:  add
-  IL_0033:  constrained. ""T""
-  IL_0039:  callvirt   ""void IMoveable.this[int].set""
-  IL_003e:  ret
+  IL_0004:  ldloca.s   V_1
+  IL_0006:  initobj    ""T""
+  IL_000c:  ldloc.1
+  IL_000d:  box        ""T""
+  IL_0012:  brtrue.s   IL_001c
+  IL_0014:  ldobj      ""T""
+  IL_0019:  stloc.1
+  IL_001a:  ldloca.s   V_1
+  IL_001c:  ldc.i4.1
+  IL_001d:  ldloc.0
+  IL_001e:  ldc.i4.1
+  IL_001f:  constrained. ""T""
+  IL_0025:  callvirt   ""int IMoveable.this[int].get""
+  IL_002a:  ldarga.s   V_0
+  IL_002c:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_0031:  add
+  IL_0032:  constrained. ""T""
+  IL_0038:  callvirt   ""void IMoveable.this[int].set""
+  IL_003d:  ret
 }
 ");
         }
@@ -10781,31 +10857,32 @@ Position set for item '2'
             verifier.VerifyIL("Program.Shift2<T>",
 @"
 {
-  // Code size       61 (0x3d)
+  // Code size       60 (0x3c)
   .maxstack  4
   .locals init (T& V_0,
                 T V_1)
   IL_0000:  ldarg.0
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
-  IL_0012:  brtrue.s   IL_001c
-  IL_0014:  ldobj      ""T""
-  IL_0019:  stloc.1
-  IL_001a:  ldloca.s   V_1
-  IL_001c:  ldc.i4.1
-  IL_001d:  ldloc.0
-  IL_001e:  ldc.i4.1
-  IL_001f:  constrained. ""T""
-  IL_0025:  callvirt   ""int IMoveable.this[int].get""
-  IL_002a:  ldarg.0
-  IL_002b:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0030:  add
-  IL_0031:  constrained. ""T""
-  IL_0037:  callvirt   ""void IMoveable.this[int].set""
-  IL_003c:  ret
+  IL_0003:  ldloca.s   V_1
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.1
+  IL_000c:  box        ""T""
+  IL_0011:  brtrue.s   IL_001b
+  IL_0013:  ldobj      ""T""
+  IL_0018:  stloc.1
+  IL_0019:  ldloca.s   V_1
+  IL_001b:  ldc.i4.1
+  IL_001c:  ldloc.0
+  IL_001d:  ldc.i4.1
+  IL_001e:  constrained. ""T""
+  IL_0024:  callvirt   ""int IMoveable.this[int].get""
+  IL_0029:  ldarg.0
+  IL_002a:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_002f:  add
+  IL_0030:  constrained. ""T""
+  IL_0036:  callvirt   ""void IMoveable.this[int].set""
+  IL_003b:  ret
 }
 ");
         }
@@ -11085,97 +11162,100 @@ Position set for item '2'
   .maxstack  4
   .locals init (int V_0,
                 int V_1,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
-                System.Exception V_3)
+                T V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
+                System.Exception V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0081
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
-    IL_0019:  brtrue.s   IL_0027
+    IL_0008:  brfalse.s  IL_0080
+    IL_000a:  ldloca.s   V_2
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.2
+    IL_0013:  box        ""T""
+    IL_0018:  brtrue.s   IL_0026
+    IL_001a:  ldarg.0
     IL_001b:  ldarg.0
-    IL_001c:  ldarg.0
-    IL_001d:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0022:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_001c:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0021:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0026:  ldarg.0
     IL_0027:  ldarg.0
-    IL_0028:  ldarg.0
-    IL_0029:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_002e:  ldc.i4.1
-    IL_002f:  constrained. ""T""
-    IL_0035:  callvirt   ""int IMoveable.this[int].get""
-    IL_003a:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_003f:  ldarg.0
-    IL_0040:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_0045:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_004a:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_004f:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0054:  stloc.2
-    IL_0055:  ldloca.s   V_2
-    IL_0057:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_005c:  brtrue.s   IL_009d
-    IL_005e:  ldarg.0
-    IL_005f:  ldc.i4.0
-    IL_0060:  dup
-    IL_0061:  stloc.0
-    IL_0062:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0067:  ldarg.0
-    IL_0068:  ldloc.2
-    IL_0069:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_006e:  ldarg.0
-    IL_006f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0074:  ldloca.s   V_2
-    IL_0076:  ldarg.0
-    IL_0077:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
-    IL_007c:  leave      IL_0110
-    IL_0081:  ldarg.0
-    IL_0082:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0087:  stloc.2
-    IL_0088:  ldarg.0
-    IL_0089:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_008e:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0094:  ldarg.0
-    IL_0095:  ldc.i4.m1
-    IL_0096:  dup
-    IL_0097:  stloc.0
-    IL_0098:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_009d:  ldloca.s   V_2
-    IL_009f:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_00a4:  stloc.1
-    IL_00a5:  ldtoken    ""T""
-    IL_00aa:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00af:  call       ""bool System.Type.IsValueType.get""
-    IL_00b4:  brtrue.s   IL_00be
-    IL_00b6:  ldarg.0
-    IL_00b7:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00bc:  br.s       IL_00c4
-    IL_00be:  ldarg.0
-    IL_00bf:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00c4:  ldc.i4.1
-    IL_00c5:  ldarg.0
-    IL_00c6:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_00cb:  ldloc.1
-    IL_00cc:  add
-    IL_00cd:  constrained. ""T""
-    IL_00d3:  callvirt   ""void IMoveable.this[int].set""
-    IL_00d8:  ldarg.0
-    IL_00d9:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00de:  initobj    ""T""
-    IL_00e4:  leave.s    IL_00fd
+    IL_0028:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_002d:  ldc.i4.1
+    IL_002e:  constrained. ""T""
+    IL_0034:  callvirt   ""int IMoveable.this[int].get""
+    IL_0039:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_003e:  ldarg.0
+    IL_003f:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0044:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0049:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_004e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_0053:  stloc.3
+    IL_0054:  ldloca.s   V_3
+    IL_0056:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_005b:  brtrue.s   IL_009c
+    IL_005d:  ldarg.0
+    IL_005e:  ldc.i4.0
+    IL_005f:  dup
+    IL_0060:  stloc.0
+    IL_0061:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0066:  ldarg.0
+    IL_0067:  ldloc.3
+    IL_0068:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_006d:  ldarg.0
+    IL_006e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_0073:  ldloca.s   V_3
+    IL_0075:  ldarg.0
+    IL_0076:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
+    IL_007b:  leave      IL_0110
+    IL_0080:  ldarg.0
+    IL_0081:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0086:  stloc.3
+    IL_0087:  ldarg.0
+    IL_0088:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_008d:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0093:  ldarg.0
+    IL_0094:  ldc.i4.m1
+    IL_0095:  dup
+    IL_0096:  stloc.0
+    IL_0097:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_009c:  ldloca.s   V_3
+    IL_009e:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_00a3:  stloc.1
+    IL_00a4:  ldloca.s   V_2
+    IL_00a6:  initobj    ""T""
+    IL_00ac:  ldloc.2
+    IL_00ad:  box        ""T""
+    IL_00b2:  brtrue.s   IL_00bc
+    IL_00b4:  ldarg.0
+    IL_00b5:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00ba:  br.s       IL_00c2
+    IL_00bc:  ldarg.0
+    IL_00bd:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00c2:  ldc.i4.1
+    IL_00c3:  ldarg.0
+    IL_00c4:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_00c9:  ldloc.1
+    IL_00ca:  add
+    IL_00cb:  constrained. ""T""
+    IL_00d1:  callvirt   ""void IMoveable.this[int].set""
+    IL_00d6:  ldarg.0
+    IL_00d7:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00dc:  initobj    ""T""
+    IL_00e2:  leave.s    IL_00fd
   }
   catch System.Exception
   {
-    IL_00e6:  stloc.3
-    IL_00e7:  ldarg.0
-    IL_00e8:  ldc.i4.s   -2
-    IL_00ea:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00ef:  ldarg.0
-    IL_00f0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_00f5:  ldloc.3
+    IL_00e4:  stloc.s    V_4
+    IL_00e6:  ldarg.0
+    IL_00e7:  ldc.i4.s   -2
+    IL_00e9:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00ee:  ldarg.0
+    IL_00ef:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_00f4:  ldloc.s    V_4
     IL_00f6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_00fb:  leave.s    IL_0110
   }
@@ -11463,12 +11543,14 @@ Position set for item '2'
   .locals init (T& V_0,
                 T V_1,
                 T& V_2,
-                int V_3)
+                int V_3,
+                T V_4)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.2
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
+  IL_0003:  ldloca.s   V_4
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_4
+  IL_000d:  box        ""T""
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.2
   IL_0015:  ldobj      ""T""
@@ -11697,12 +11779,14 @@ Position set for item '2'
   .locals init (T& V_0,
                 T V_1,
                 T& V_2,
-                int V_3)
+                int V_3,
+                T V_4)
   IL_0000:  ldarg.0
   IL_0001:  stloc.2
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
+  IL_0002:  ldloca.s   V_4
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_4
+  IL_000c:  box        ""T""
   IL_0011:  brtrue.s   IL_001e
   IL_0013:  ldloc.2
   IL_0014:  ldobj      ""T""
@@ -12022,8 +12106,9 @@ Position set for item '2'
   .locals init (int V_0,
                 int V_1,
                 int V_2,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
-                System.Exception V_4)
+                T V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -12031,75 +12116,78 @@ Position set for item '2'
   {
     IL_0007:  ldloc.0
     IL_0008:  brfalse    IL_00b0
-    IL_000d:  ldtoken    ""T""
-    IL_0012:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0017:  call       ""bool System.Type.IsValueType.get""
-    IL_001c:  brtrue.s   IL_002a
+    IL_000d:  ldloca.s   V_3
+    IL_000f:  initobj    ""T""
+    IL_0015:  ldloc.3
+    IL_0016:  box        ""T""
+    IL_001b:  brtrue.s   IL_0029
+    IL_001d:  ldarg.0
     IL_001e:  ldarg.0
-    IL_001f:  ldarg.0
-    IL_0020:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0025:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_002a:  ldarg.0
-    IL_002b:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_0030:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0035:  stloc.1
-    IL_0036:  ldarg.0
-    IL_0037:  ldloc.1
-    IL_0038:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_003d:  ldarg.0
-    IL_003e:  ldtoken    ""T""
-    IL_0043:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0048:  call       ""bool System.Type.IsValueType.get""
-    IL_004d:  brtrue.s   IL_0057
-    IL_004f:  ldarg.0
-    IL_0050:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0055:  br.s       IL_005d
-    IL_0057:  ldarg.0
-    IL_0058:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_005d:  ldloc.1
-    IL_005e:  constrained. ""T""
-    IL_0064:  callvirt   ""int IMoveable.this[int].get""
-    IL_0069:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap3""
-    IL_006e:  ldarg.0
-    IL_006f:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_0074:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0079:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_007e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0083:  stloc.3
-    IL_0084:  ldloca.s   V_3
-    IL_0086:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_008b:  brtrue.s   IL_00cc
-    IL_008d:  ldarg.0
-    IL_008e:  ldc.i4.0
-    IL_008f:  dup
-    IL_0090:  stloc.0
-    IL_0091:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0096:  ldarg.0
-    IL_0097:  ldloc.3
+    IL_001f:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0024:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0029:  ldarg.0
+    IL_002a:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_002f:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0034:  stloc.1
+    IL_0035:  ldarg.0
+    IL_0036:  ldloc.1
+    IL_0037:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_003c:  ldarg.0
+    IL_003d:  ldloca.s   V_3
+    IL_003f:  initobj    ""T""
+    IL_0045:  ldloc.3
+    IL_0046:  box        ""T""
+    IL_004b:  brtrue.s   IL_0055
+    IL_004d:  ldarg.0
+    IL_004e:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0053:  br.s       IL_005b
+    IL_0055:  ldarg.0
+    IL_0056:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_005b:  ldloc.1
+    IL_005c:  constrained. ""T""
+    IL_0062:  callvirt   ""int IMoveable.this[int].get""
+    IL_0067:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap3""
+    IL_006c:  ldarg.0
+    IL_006d:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0072:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0077:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_007c:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_0081:  stloc.s    V_4
+    IL_0083:  ldloca.s   V_4
+    IL_0085:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_008a:  brtrue.s   IL_00cd
+    IL_008c:  ldarg.0
+    IL_008d:  ldc.i4.0
+    IL_008e:  dup
+    IL_008f:  stloc.0
+    IL_0090:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0095:  ldarg.0
+    IL_0096:  ldloc.s    V_4
     IL_0098:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_009d:  ldarg.0
     IL_009e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_00a3:  ldloca.s   V_3
+    IL_00a3:  ldloca.s   V_4
     IL_00a5:  ldarg.0
     IL_00a6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_00ab:  leave      IL_0146
     IL_00b0:  ldarg.0
     IL_00b1:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00b6:  stloc.3
-    IL_00b7:  ldarg.0
-    IL_00b8:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00bd:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_00c3:  ldarg.0
-    IL_00c4:  ldc.i4.m1
-    IL_00c5:  dup
-    IL_00c6:  stloc.0
-    IL_00c7:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00cc:  ldloca.s   V_3
-    IL_00ce:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_00d3:  stloc.2
-    IL_00d4:  ldtoken    ""T""
-    IL_00d9:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00de:  call       ""bool System.Type.IsValueType.get""
+    IL_00b6:  stloc.s    V_4
+    IL_00b8:  ldarg.0
+    IL_00b9:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_00be:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_00c4:  ldarg.0
+    IL_00c5:  ldc.i4.m1
+    IL_00c6:  dup
+    IL_00c7:  stloc.0
+    IL_00c8:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00cd:  ldloca.s   V_4
+    IL_00cf:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_00d4:  stloc.2
+    IL_00d5:  ldloca.s   V_3
+    IL_00d7:  initobj    ""T""
+    IL_00dd:  ldloc.3
+    IL_00de:  box        ""T""
     IL_00e3:  brtrue.s   IL_00ed
     IL_00e5:  ldarg.0
     IL_00e6:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -12121,13 +12209,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_011a:  stloc.s    V_4
+    IL_011a:  stloc.s    V_5
     IL_011c:  ldarg.0
     IL_011d:  ldc.i4.s   -2
     IL_011f:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0124:  ldarg.0
     IL_0125:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_012a:  ldloc.s    V_4
+    IL_012a:  ldloc.s    V_5
     IL_012c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0131:  leave.s    IL_0146
   }
@@ -12494,116 +12582,120 @@ Position set for item '2'
             verifier.VerifyIL("Program.<Shift2>d__2<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"
 {
-  // Code size      296 (0x128)
+  // Code size      295 (0x127)
   .maxstack  4
   .locals init (int V_0,
                 int V_1,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
-                System.Exception V_3)
+                T V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
+                System.Exception V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0069
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
-    IL_0019:  brtrue.s   IL_0027
+    IL_0008:  brfalse.s  IL_0068
+    IL_000a:  ldloca.s   V_2
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.2
+    IL_0013:  box        ""T""
+    IL_0018:  brtrue.s   IL_0026
+    IL_001a:  ldarg.0
     IL_001b:  ldarg.0
-    IL_001c:  ldarg.0
-    IL_001d:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0022:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0027:  ldarg.0
-    IL_0028:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_002d:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0032:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003c:  stloc.2
-    IL_003d:  ldloca.s   V_2
-    IL_003f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0044:  brtrue.s   IL_0085
-    IL_0046:  ldarg.0
-    IL_0047:  ldc.i4.0
-    IL_0048:  dup
-    IL_0049:  stloc.0
-    IL_004a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_004f:  ldarg.0
-    IL_0050:  ldloc.2
-    IL_0051:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0056:  ldarg.0
-    IL_0057:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_005c:  ldloca.s   V_2
-    IL_005e:  ldarg.0
-    IL_005f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
-    IL_0064:  leave      IL_0127
-    IL_0069:  ldarg.0
-    IL_006a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_006f:  stloc.2
-    IL_0070:  ldarg.0
-    IL_0071:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0076:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_007c:  ldarg.0
-    IL_007d:  ldc.i4.m1
-    IL_007e:  dup
-    IL_007f:  stloc.0
-    IL_0080:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0085:  ldloca.s   V_2
-    IL_0087:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_008c:  stloc.1
-    IL_008d:  ldtoken    ""T""
-    IL_0092:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0097:  call       ""bool System.Type.IsValueType.get""
-    IL_009c:  brtrue.s   IL_00a6
-    IL_009e:  ldarg.0
-    IL_009f:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00a4:  br.s       IL_00ac
-    IL_00a6:  ldarg.0
-    IL_00a7:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00ac:  ldloc.1
-    IL_00ad:  ldtoken    ""T""
-    IL_00b2:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00b7:  call       ""bool System.Type.IsValueType.get""
-    IL_00bc:  brtrue.s   IL_00c6
-    IL_00be:  ldarg.0
-    IL_00bf:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00c4:  br.s       IL_00cc
-    IL_00c6:  ldarg.0
-    IL_00c7:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00cc:  ldloc.1
-    IL_00cd:  constrained. ""T""
-    IL_00d3:  callvirt   ""int IMoveable.this[int].get""
-    IL_00d8:  ldarg.0
-    IL_00d9:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00de:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_00e3:  add
-    IL_00e4:  constrained. ""T""
-    IL_00ea:  callvirt   ""void IMoveable.this[int].set""
-    IL_00ef:  ldarg.0
-    IL_00f0:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00f5:  initobj    ""T""
-    IL_00fb:  leave.s    IL_0114
+    IL_001c:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0021:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0026:  ldarg.0
+    IL_0027:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_002c:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0031:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_0036:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_003b:  stloc.3
+    IL_003c:  ldloca.s   V_3
+    IL_003e:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0043:  brtrue.s   IL_0084
+    IL_0045:  ldarg.0
+    IL_0046:  ldc.i4.0
+    IL_0047:  dup
+    IL_0048:  stloc.0
+    IL_0049:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_004e:  ldarg.0
+    IL_004f:  ldloc.3
+    IL_0050:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0055:  ldarg.0
+    IL_0056:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_005b:  ldloca.s   V_3
+    IL_005d:  ldarg.0
+    IL_005e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
+    IL_0063:  leave      IL_0126
+    IL_0068:  ldarg.0
+    IL_0069:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_006e:  stloc.3
+    IL_006f:  ldarg.0
+    IL_0070:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0075:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_007b:  ldarg.0
+    IL_007c:  ldc.i4.m1
+    IL_007d:  dup
+    IL_007e:  stloc.0
+    IL_007f:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0084:  ldloca.s   V_3
+    IL_0086:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_008b:  stloc.1
+    IL_008c:  ldloca.s   V_2
+    IL_008e:  initobj    ""T""
+    IL_0094:  ldloc.2
+    IL_0095:  box        ""T""
+    IL_009a:  brtrue.s   IL_00a4
+    IL_009c:  ldarg.0
+    IL_009d:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00a2:  br.s       IL_00aa
+    IL_00a4:  ldarg.0
+    IL_00a5:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00aa:  ldloc.1
+    IL_00ab:  ldloca.s   V_2
+    IL_00ad:  initobj    ""T""
+    IL_00b3:  ldloc.2
+    IL_00b4:  box        ""T""
+    IL_00b9:  brtrue.s   IL_00c3
+    IL_00bb:  ldarg.0
+    IL_00bc:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00c1:  br.s       IL_00c9
+    IL_00c3:  ldarg.0
+    IL_00c4:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00c9:  ldloc.1
+    IL_00ca:  constrained. ""T""
+    IL_00d0:  callvirt   ""int IMoveable.this[int].get""
+    IL_00d5:  ldarg.0
+    IL_00d6:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00db:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_00e0:  add
+    IL_00e1:  constrained. ""T""
+    IL_00e7:  callvirt   ""void IMoveable.this[int].set""
+    IL_00ec:  ldarg.0
+    IL_00ed:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00f2:  initobj    ""T""
+    IL_00f8:  leave.s    IL_0113
   }
   catch System.Exception
   {
-    IL_00fd:  stloc.3
-    IL_00fe:  ldarg.0
-    IL_00ff:  ldc.i4.s   -2
-    IL_0101:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0106:  ldarg.0
-    IL_0107:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_010c:  ldloc.3
-    IL_010d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_0112:  leave.s    IL_0127
+    IL_00fa:  stloc.s    V_4
+    IL_00fc:  ldarg.0
+    IL_00fd:  ldc.i4.s   -2
+    IL_00ff:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0104:  ldarg.0
+    IL_0105:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_010a:  ldloc.s    V_4
+    IL_010c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0111:  leave.s    IL_0126
   }
-  IL_0114:  ldarg.0
-  IL_0115:  ldc.i4.s   -2
-  IL_0117:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-  IL_011c:  ldarg.0
-  IL_011d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-  IL_0122:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0127:  ret
+  IL_0113:  ldarg.0
+  IL_0114:  ldc.i4.s   -2
+  IL_0116:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+  IL_011b:  ldarg.0
+  IL_011c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+  IL_0121:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0126:  ret
 }
 ");
         }
@@ -13003,163 +13095,167 @@ Position set for item '2'
             verifier.VerifyIL("Program.<Shift2>d__2<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"
 {
-  // Code size      421 (0x1a5)
+  // Code size      424 (0x1a8)
   .maxstack  4
   .locals init (int V_0,
                 int V_1,
                 int V_2,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
-                System.Exception V_4)
+                T V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0070
+    IL_0008:  brfalse.s  IL_0071
     IL_000a:  ldloc.0
     IL_000b:  ldc.i4.1
-    IL_000c:  beq        IL_010e
-    IL_0011:  ldtoken    ""T""
-    IL_0016:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_001b:  call       ""bool System.Type.IsValueType.get""
-    IL_0020:  brtrue.s   IL_002e
+    IL_000c:  beq        IL_0111
+    IL_0011:  ldloca.s   V_3
+    IL_0013:  initobj    ""T""
+    IL_0019:  ldloc.3
+    IL_001a:  box        ""T""
+    IL_001f:  brtrue.s   IL_002d
+    IL_0021:  ldarg.0
     IL_0022:  ldarg.0
-    IL_0023:  ldarg.0
-    IL_0024:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0029:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_002e:  ldarg.0
-    IL_002f:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_0034:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0039:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_003e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0043:  stloc.3
-    IL_0044:  ldloca.s   V_3
+    IL_0023:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0028:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_002d:  ldarg.0
+    IL_002e:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0033:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0038:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_003d:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_0042:  stloc.s    V_4
+    IL_0044:  ldloca.s   V_4
     IL_0046:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_004b:  brtrue.s   IL_008c
+    IL_004b:  brtrue.s   IL_008e
     IL_004d:  ldarg.0
     IL_004e:  ldc.i4.0
     IL_004f:  dup
     IL_0050:  stloc.0
     IL_0051:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0056:  ldarg.0
-    IL_0057:  ldloc.3
-    IL_0058:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_005d:  ldarg.0
-    IL_005e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0063:  ldloca.s   V_3
-    IL_0065:  ldarg.0
-    IL_0066:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
-    IL_006b:  leave      IL_01a4
-    IL_0070:  ldarg.0
-    IL_0071:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0076:  stloc.3
-    IL_0077:  ldarg.0
-    IL_0078:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_007d:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0083:  ldarg.0
-    IL_0084:  ldc.i4.m1
-    IL_0085:  dup
-    IL_0086:  stloc.0
-    IL_0087:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_008c:  ldloca.s   V_3
-    IL_008e:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_0093:  stloc.1
-    IL_0094:  ldarg.0
-    IL_0095:  ldloc.1
-    IL_0096:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_009b:  ldarg.0
-    IL_009c:  ldtoken    ""T""
-    IL_00a1:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00a6:  call       ""bool System.Type.IsValueType.get""
-    IL_00ab:  brtrue.s   IL_00b5
-    IL_00ad:  ldarg.0
-    IL_00ae:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00b3:  br.s       IL_00bb
-    IL_00b5:  ldarg.0
-    IL_00b6:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00bb:  ldloc.1
-    IL_00bc:  constrained. ""T""
-    IL_00c2:  callvirt   ""int IMoveable.this[int].get""
-    IL_00c7:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap3""
-    IL_00cc:  ldarg.0
-    IL_00cd:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00d2:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_00d7:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_00dc:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_00e1:  stloc.3
-    IL_00e2:  ldloca.s   V_3
-    IL_00e4:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_00e9:  brtrue.s   IL_012a
-    IL_00eb:  ldarg.0
-    IL_00ec:  ldc.i4.1
-    IL_00ed:  dup
-    IL_00ee:  stloc.0
-    IL_00ef:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00f4:  ldarg.0
-    IL_00f5:  ldloc.3
-    IL_00f6:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00fb:  ldarg.0
-    IL_00fc:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0101:  ldloca.s   V_3
-    IL_0103:  ldarg.0
-    IL_0104:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
-    IL_0109:  leave      IL_01a4
-    IL_010e:  ldarg.0
-    IL_010f:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0114:  stloc.3
-    IL_0115:  ldarg.0
-    IL_0116:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_011b:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_0121:  ldarg.0
-    IL_0122:  ldc.i4.m1
-    IL_0123:  dup
-    IL_0124:  stloc.0
-    IL_0125:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_012a:  ldloca.s   V_3
-    IL_012c:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_0131:  stloc.2
-    IL_0132:  ldtoken    ""T""
-    IL_0137:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_013c:  call       ""bool System.Type.IsValueType.get""
-    IL_0141:  brtrue.s   IL_014b
-    IL_0143:  ldarg.0
-    IL_0144:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0149:  br.s       IL_0151
-    IL_014b:  ldarg.0
-    IL_014c:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_0151:  ldarg.0
-    IL_0152:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_0157:  ldarg.0
-    IL_0158:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap3""
-    IL_015d:  ldloc.2
-    IL_015e:  add
-    IL_015f:  constrained. ""T""
-    IL_0165:  callvirt   ""void IMoveable.this[int].set""
-    IL_016a:  ldarg.0
-    IL_016b:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0170:  initobj    ""T""
-    IL_0176:  leave.s    IL_0191
+    IL_0057:  ldloc.s    V_4
+    IL_0059:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_005e:  ldarg.0
+    IL_005f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_0064:  ldloca.s   V_4
+    IL_0066:  ldarg.0
+    IL_0067:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
+    IL_006c:  leave      IL_01a7
+    IL_0071:  ldarg.0
+    IL_0072:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0077:  stloc.s    V_4
+    IL_0079:  ldarg.0
+    IL_007a:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_007f:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0085:  ldarg.0
+    IL_0086:  ldc.i4.m1
+    IL_0087:  dup
+    IL_0088:  stloc.0
+    IL_0089:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_008e:  ldloca.s   V_4
+    IL_0090:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_0095:  stloc.1
+    IL_0096:  ldarg.0
+    IL_0097:  ldloc.1
+    IL_0098:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_009d:  ldarg.0
+    IL_009e:  ldloca.s   V_3
+    IL_00a0:  initobj    ""T""
+    IL_00a6:  ldloc.3
+    IL_00a7:  box        ""T""
+    IL_00ac:  brtrue.s   IL_00b6
+    IL_00ae:  ldarg.0
+    IL_00af:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00b4:  br.s       IL_00bc
+    IL_00b6:  ldarg.0
+    IL_00b7:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00bc:  ldloc.1
+    IL_00bd:  constrained. ""T""
+    IL_00c3:  callvirt   ""int IMoveable.this[int].get""
+    IL_00c8:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap3""
+    IL_00cd:  ldarg.0
+    IL_00ce:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00d3:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_00d8:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_00dd:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_00e2:  stloc.s    V_4
+    IL_00e4:  ldloca.s   V_4
+    IL_00e6:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_00eb:  brtrue.s   IL_012e
+    IL_00ed:  ldarg.0
+    IL_00ee:  ldc.i4.1
+    IL_00ef:  dup
+    IL_00f0:  stloc.0
+    IL_00f1:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00f6:  ldarg.0
+    IL_00f7:  ldloc.s    V_4
+    IL_00f9:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_00fe:  ldarg.0
+    IL_00ff:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_0104:  ldloca.s   V_4
+    IL_0106:  ldarg.0
+    IL_0107:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
+    IL_010c:  leave      IL_01a7
+    IL_0111:  ldarg.0
+    IL_0112:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0117:  stloc.s    V_4
+    IL_0119:  ldarg.0
+    IL_011a:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_011f:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0125:  ldarg.0
+    IL_0126:  ldc.i4.m1
+    IL_0127:  dup
+    IL_0128:  stloc.0
+    IL_0129:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_012e:  ldloca.s   V_4
+    IL_0130:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_0135:  stloc.2
+    IL_0136:  ldloca.s   V_3
+    IL_0138:  initobj    ""T""
+    IL_013e:  ldloc.3
+    IL_013f:  box        ""T""
+    IL_0144:  brtrue.s   IL_014e
+    IL_0146:  ldarg.0
+    IL_0147:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_014c:  br.s       IL_0154
+    IL_014e:  ldarg.0
+    IL_014f:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0154:  ldarg.0
+    IL_0155:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_015a:  ldarg.0
+    IL_015b:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap3""
+    IL_0160:  ldloc.2
+    IL_0161:  add
+    IL_0162:  constrained. ""T""
+    IL_0168:  callvirt   ""void IMoveable.this[int].set""
+    IL_016d:  ldarg.0
+    IL_016e:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0173:  initobj    ""T""
+    IL_0179:  leave.s    IL_0194
   }
   catch System.Exception
   {
-    IL_0178:  stloc.s    V_4
-    IL_017a:  ldarg.0
-    IL_017b:  ldc.i4.s   -2
-    IL_017d:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0182:  ldarg.0
-    IL_0183:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0188:  ldloc.s    V_4
-    IL_018a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_018f:  leave.s    IL_01a4
+    IL_017b:  stloc.s    V_5
+    IL_017d:  ldarg.0
+    IL_017e:  ldc.i4.s   -2
+    IL_0180:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0185:  ldarg.0
+    IL_0186:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_018b:  ldloc.s    V_5
+    IL_018d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0192:  leave.s    IL_01a7
   }
-  IL_0191:  ldarg.0
-  IL_0192:  ldc.i4.s   -2
-  IL_0194:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-  IL_0199:  ldarg.0
-  IL_019a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-  IL_019f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_01a4:  ret
+  IL_0194:  ldarg.0
+  IL_0195:  ldc.i4.s   -2
+  IL_0197:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+  IL_019c:  ldarg.0
+  IL_019d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+  IL_01a2:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_01a7:  ret
 }
 ");
         }
@@ -13494,12 +13590,14 @@ Position set for item '2'
                 T& V_2,
                 int? V_3,
                 int V_4,
-                int? V_5)
+                T V_5,
+                int? V_6)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.2
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
+  IL_0003:  ldloca.s   V_5
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_5
+  IL_000d:  box        ""T""
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.2
   IL_0015:  ldobj      ""T""
@@ -13524,10 +13622,10 @@ Position set for item '2'
   IL_0048:  stloc.s    V_4
   IL_004a:  ldloc.0
   IL_004b:  ldc.i4.1
-  IL_004c:  ldloca.s   V_5
+  IL_004c:  ldloca.s   V_6
   IL_004e:  ldloc.s    V_4
   IL_0050:  call       ""int?..ctor(int)""
-  IL_0055:  ldloc.s    V_5
+  IL_0055:  ldloc.s    V_6
   IL_0057:  constrained. ""T""
   IL_005d:  callvirt   ""void IMoveable.this[int].set""
   IL_0062:  ret
@@ -13758,12 +13856,14 @@ Position set for item '2'
                 T& V_2,
                 int? V_3,
                 int V_4,
-                int? V_5)
+                T V_5,
+                int? V_6)
   IL_0000:  ldarg.0
   IL_0001:  stloc.2
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
+  IL_0002:  ldloca.s   V_5
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_5
+  IL_000c:  box        ""T""
   IL_0011:  brtrue.s   IL_001e
   IL_0013:  ldloc.2
   IL_0014:  ldobj      ""T""
@@ -13788,10 +13888,10 @@ Position set for item '2'
   IL_0046:  stloc.s    V_4
   IL_0048:  ldloc.0
   IL_0049:  ldc.i4.1
-  IL_004a:  ldloca.s   V_5
+  IL_004a:  ldloca.s   V_6
   IL_004c:  ldloc.s    V_4
   IL_004e:  call       ""int?..ctor(int)""
-  IL_0053:  ldloc.s    V_5
+  IL_0053:  ldloc.s    V_6
   IL_0055:  constrained. ""T""
   IL_005b:  callvirt   ""void IMoveable.this[int].set""
   IL_0060:  ret
@@ -14093,9 +14193,10 @@ Position set for item '2'
   .locals init (int V_0,
                 int? V_1,
                 int V_2,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
-                int? V_4,
-                System.Exception V_5)
+                T V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
+                int? V_5,
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -14103,73 +14204,76 @@ Position set for item '2'
   {
     IL_0007:  ldloc.0
     IL_0008:  brfalse    IL_00ac
-    IL_000d:  ldtoken    ""T""
-    IL_0012:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0017:  call       ""bool System.Type.IsValueType.get""
-    IL_001c:  brtrue.s   IL_002a
+    IL_000d:  ldloca.s   V_3
+    IL_000f:  initobj    ""T""
+    IL_0015:  ldloc.3
+    IL_0016:  box        ""T""
+    IL_001b:  brtrue.s   IL_0029
+    IL_001d:  ldarg.0
     IL_001e:  ldarg.0
-    IL_001f:  ldarg.0
-    IL_0020:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0025:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_002a:  ldtoken    ""T""
-    IL_002f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0034:  call       ""bool System.Type.IsValueType.get""
-    IL_0039:  brtrue.s   IL_0043
-    IL_003b:  ldarg.0
-    IL_003c:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0041:  br.s       IL_0049
-    IL_0043:  ldarg.0
-    IL_0044:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_0049:  ldc.i4.1
-    IL_004a:  constrained. ""T""
-    IL_0050:  callvirt   ""int? IMoveable.this[int].get""
-    IL_0055:  stloc.1
-    IL_0056:  ldloca.s   V_1
-    IL_0058:  call       ""int int?.GetValueOrDefault()""
-    IL_005d:  stloc.2
-    IL_005e:  ldloca.s   V_1
-    IL_0060:  call       ""bool int?.HasValue.get""
-    IL_0065:  brtrue     IL_0104
-    IL_006a:  ldarg.0
-    IL_006b:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_0070:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0075:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_007a:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_007f:  stloc.3
-    IL_0080:  ldloca.s   V_3
-    IL_0082:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0087:  brtrue.s   IL_00c8
-    IL_0089:  ldarg.0
-    IL_008a:  ldc.i4.0
-    IL_008b:  dup
-    IL_008c:  stloc.0
-    IL_008d:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0092:  ldarg.0
-    IL_0093:  ldloc.3
+    IL_001f:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0024:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0029:  ldloca.s   V_3
+    IL_002b:  initobj    ""T""
+    IL_0031:  ldloc.3
+    IL_0032:  box        ""T""
+    IL_0037:  brtrue.s   IL_0041
+    IL_0039:  ldarg.0
+    IL_003a:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_003f:  br.s       IL_0047
+    IL_0041:  ldarg.0
+    IL_0042:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0047:  ldc.i4.1
+    IL_0048:  constrained. ""T""
+    IL_004e:  callvirt   ""int? IMoveable.this[int].get""
+    IL_0053:  stloc.1
+    IL_0054:  ldloca.s   V_1
+    IL_0056:  call       ""int int?.GetValueOrDefault()""
+    IL_005b:  stloc.2
+    IL_005c:  ldloca.s   V_1
+    IL_005e:  call       ""bool int?.HasValue.get""
+    IL_0063:  brtrue     IL_0104
+    IL_0068:  ldarg.0
+    IL_0069:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_006e:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0073:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_0078:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_007d:  stloc.s    V_4
+    IL_007f:  ldloca.s   V_4
+    IL_0081:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0086:  brtrue.s   IL_00c9
+    IL_0088:  ldarg.0
+    IL_0089:  ldc.i4.0
+    IL_008a:  dup
+    IL_008b:  stloc.0
+    IL_008c:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0091:  ldarg.0
+    IL_0092:  ldloc.s    V_4
     IL_0094:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_0099:  ldarg.0
     IL_009a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_009f:  ldloca.s   V_3
+    IL_009f:  ldloca.s   V_4
     IL_00a1:  ldarg.0
     IL_00a2:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_00a7:  leave      IL_013e
     IL_00ac:  ldarg.0
     IL_00ad:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00b2:  stloc.3
-    IL_00b3:  ldarg.0
-    IL_00b4:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00b9:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_00bf:  ldarg.0
-    IL_00c0:  ldc.i4.m1
-    IL_00c1:  dup
-    IL_00c2:  stloc.0
-    IL_00c3:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00c8:  ldloca.s   V_3
-    IL_00ca:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_00cf:  stloc.2
-    IL_00d0:  ldtoken    ""T""
-    IL_00d5:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00da:  call       ""bool System.Type.IsValueType.get""
+    IL_00b2:  stloc.s    V_4
+    IL_00b4:  ldarg.0
+    IL_00b5:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_00ba:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_00c0:  ldarg.0
+    IL_00c1:  ldc.i4.m1
+    IL_00c2:  dup
+    IL_00c3:  stloc.0
+    IL_00c4:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00c9:  ldloca.s   V_4
+    IL_00cb:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_00d0:  stloc.2
+    IL_00d1:  ldloca.s   V_3
+    IL_00d3:  initobj    ""T""
+    IL_00d9:  ldloc.3
+    IL_00da:  box        ""T""
     IL_00df:  brtrue.s   IL_00e9
     IL_00e1:  ldarg.0
     IL_00e2:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -14180,7 +14284,7 @@ Position set for item '2'
     IL_00f0:  ldloc.2
     IL_00f1:  newobj     ""int?..ctor(int)""
     IL_00f6:  dup
-    IL_00f7:  stloc.s    V_4
+    IL_00f7:  stloc.s    V_5
     IL_00f9:  constrained. ""T""
     IL_00ff:  callvirt   ""void IMoveable.this[int].set""
     IL_0104:  ldarg.0
@@ -14190,13 +14294,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_0112:  stloc.s    V_5
+    IL_0112:  stloc.s    V_6
     IL_0114:  ldarg.0
     IL_0115:  ldc.i4.s   -2
     IL_0117:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_011c:  ldarg.0
     IL_011d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0122:  ldloc.s    V_5
+    IL_0122:  ldloc.s    V_6
     IL_0124:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0129:  leave.s    IL_013e
   }
@@ -14508,12 +14612,14 @@ Position set for item '2'
                 int V_3,
                 int? V_4,
                 int V_5,
-                int? V_6)
+                T V_6,
+                int? V_7)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.2
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
+  IL_0003:  ldloca.s   V_6
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_6
+  IL_000d:  box        ""T""
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.2
   IL_0015:  ldobj      ""T""
@@ -14541,10 +14647,10 @@ Position set for item '2'
   IL_0051:  stloc.s    V_5
   IL_0053:  ldloc.0
   IL_0054:  ldloc.3
-  IL_0055:  ldloca.s   V_6
+  IL_0055:  ldloca.s   V_7
   IL_0057:  ldloc.s    V_5
   IL_0059:  call       ""int?..ctor(int)""
-  IL_005e:  ldloc.s    V_6
+  IL_005e:  ldloc.s    V_7
   IL_0060:  constrained. ""T""
   IL_0066:  callvirt   ""void IMoveable.this[int].set""
   IL_006b:  ret
@@ -14784,12 +14890,14 @@ Position set for item '2'
                 int V_3,
                 int? V_4,
                 int V_5,
-                int? V_6)
+                T V_6,
+                int? V_7)
   IL_0000:  ldarg.0
   IL_0001:  stloc.2
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
+  IL_0002:  ldloca.s   V_6
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_6
+  IL_000c:  box        ""T""
   IL_0011:  brtrue.s   IL_001e
   IL_0013:  ldloc.2
   IL_0014:  ldobj      ""T""
@@ -14817,10 +14925,10 @@ Position set for item '2'
   IL_004e:  stloc.s    V_5
   IL_0050:  ldloc.0
   IL_0051:  ldloc.3
-  IL_0052:  ldloca.s   V_6
+  IL_0052:  ldloca.s   V_7
   IL_0054:  ldloc.s    V_5
   IL_0056:  call       ""int?..ctor(int)""
-  IL_005b:  ldloc.s    V_6
+  IL_005b:  ldloc.s    V_7
   IL_005d:  constrained. ""T""
   IL_0063:  callvirt   ""void IMoveable.this[int].set""
   IL_0068:  ret
@@ -15133,9 +15241,10 @@ Position set for item '2'
   .locals init (int V_0,
                 int? V_1,
                 int V_2,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
-                int? V_4,
-                System.Exception V_5)
+                T V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
+                int? V_5,
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -15143,79 +15252,82 @@ Position set for item '2'
   {
     IL_0007:  ldloc.0
     IL_0008:  brfalse    IL_00c2
-    IL_000d:  ldtoken    ""T""
-    IL_0012:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0017:  call       ""bool System.Type.IsValueType.get""
-    IL_001c:  brtrue.s   IL_002a
+    IL_000d:  ldloca.s   V_3
+    IL_000f:  initobj    ""T""
+    IL_0015:  ldloc.3
+    IL_0016:  box        ""T""
+    IL_001b:  brtrue.s   IL_0029
+    IL_001d:  ldarg.0
     IL_001e:  ldarg.0
-    IL_001f:  ldarg.0
-    IL_0020:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0025:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_001f:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0024:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0029:  ldarg.0
     IL_002a:  ldarg.0
-    IL_002b:  ldarg.0
-    IL_002c:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_0031:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0036:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_003b:  ldtoken    ""T""
-    IL_0040:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0045:  call       ""bool System.Type.IsValueType.get""
-    IL_004a:  brtrue.s   IL_0054
-    IL_004c:  ldarg.0
-    IL_004d:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0052:  br.s       IL_005a
-    IL_0054:  ldarg.0
-    IL_0055:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_005a:  ldarg.0
-    IL_005b:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_0060:  constrained. ""T""
-    IL_0066:  callvirt   ""int? IMoveable.this[int].get""
-    IL_006b:  stloc.1
-    IL_006c:  ldloca.s   V_1
-    IL_006e:  call       ""int int?.GetValueOrDefault()""
-    IL_0073:  stloc.2
-    IL_0074:  ldloca.s   V_1
-    IL_0076:  call       ""bool int?.HasValue.get""
-    IL_007b:  brtrue     IL_011f
-    IL_0080:  ldarg.0
-    IL_0081:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_0086:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_008b:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_0090:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0095:  stloc.3
-    IL_0096:  ldloca.s   V_3
-    IL_0098:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_009d:  brtrue.s   IL_00de
-    IL_009f:  ldarg.0
-    IL_00a0:  ldc.i4.0
-    IL_00a1:  dup
-    IL_00a2:  stloc.0
-    IL_00a3:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00a8:  ldarg.0
-    IL_00a9:  ldloc.3
+    IL_002b:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0030:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0035:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_003a:  ldloca.s   V_3
+    IL_003c:  initobj    ""T""
+    IL_0042:  ldloc.3
+    IL_0043:  box        ""T""
+    IL_0048:  brtrue.s   IL_0052
+    IL_004a:  ldarg.0
+    IL_004b:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0050:  br.s       IL_0058
+    IL_0052:  ldarg.0
+    IL_0053:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0058:  ldarg.0
+    IL_0059:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_005e:  constrained. ""T""
+    IL_0064:  callvirt   ""int? IMoveable.this[int].get""
+    IL_0069:  stloc.1
+    IL_006a:  ldloca.s   V_1
+    IL_006c:  call       ""int int?.GetValueOrDefault()""
+    IL_0071:  stloc.2
+    IL_0072:  ldloca.s   V_1
+    IL_0074:  call       ""bool int?.HasValue.get""
+    IL_0079:  brtrue     IL_011f
+    IL_007e:  ldarg.0
+    IL_007f:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0084:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0089:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_008e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_0093:  stloc.s    V_4
+    IL_0095:  ldloca.s   V_4
+    IL_0097:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_009c:  brtrue.s   IL_00df
+    IL_009e:  ldarg.0
+    IL_009f:  ldc.i4.0
+    IL_00a0:  dup
+    IL_00a1:  stloc.0
+    IL_00a2:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00a7:  ldarg.0
+    IL_00a8:  ldloc.s    V_4
     IL_00aa:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_00af:  ldarg.0
     IL_00b0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_00b5:  ldloca.s   V_3
+    IL_00b5:  ldloca.s   V_4
     IL_00b7:  ldarg.0
     IL_00b8:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_00bd:  leave      IL_0159
     IL_00c2:  ldarg.0
     IL_00c3:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00c8:  stloc.3
-    IL_00c9:  ldarg.0
-    IL_00ca:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00cf:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_00d5:  ldarg.0
-    IL_00d6:  ldc.i4.m1
-    IL_00d7:  dup
-    IL_00d8:  stloc.0
-    IL_00d9:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00de:  ldloca.s   V_3
-    IL_00e0:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_00e5:  stloc.2
-    IL_00e6:  ldtoken    ""T""
-    IL_00eb:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00f0:  call       ""bool System.Type.IsValueType.get""
+    IL_00c8:  stloc.s    V_4
+    IL_00ca:  ldarg.0
+    IL_00cb:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_00d0:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_00d6:  ldarg.0
+    IL_00d7:  ldc.i4.m1
+    IL_00d8:  dup
+    IL_00d9:  stloc.0
+    IL_00da:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00df:  ldloca.s   V_4
+    IL_00e1:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_00e6:  stloc.2
+    IL_00e7:  ldloca.s   V_3
+    IL_00e9:  initobj    ""T""
+    IL_00ef:  ldloc.3
+    IL_00f0:  box        ""T""
     IL_00f5:  brtrue.s   IL_00ff
     IL_00f7:  ldarg.0
     IL_00f8:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -15227,7 +15339,7 @@ Position set for item '2'
     IL_010b:  ldloc.2
     IL_010c:  newobj     ""int?..ctor(int)""
     IL_0111:  dup
-    IL_0112:  stloc.s    V_4
+    IL_0112:  stloc.s    V_5
     IL_0114:  constrained. ""T""
     IL_011a:  callvirt   ""void IMoveable.this[int].set""
     IL_011f:  ldarg.0
@@ -15237,13 +15349,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_012d:  stloc.s    V_5
+    IL_012d:  stloc.s    V_6
     IL_012f:  ldarg.0
     IL_0130:  ldc.i4.s   -2
     IL_0132:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0137:  ldarg.0
     IL_0138:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_013d:  ldloc.s    V_5
+    IL_013d:  ldloc.s    V_6
     IL_013f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0144:  leave.s    IL_0159
   }
@@ -15635,9 +15747,10 @@ Position set for item '2'
                 int V_1,
                 int? V_2,
                 int V_3,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
-                int? V_5,
-                System.Exception V_6)
+                T V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_5,
+                int? V_6,
+                System.Exception V_7)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -15645,9 +15758,10 @@ Position set for item '2'
   {
     IL_0007:  ldloc.0
     IL_0008:  brfalse.s  IL_006b
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
+    IL_000a:  ldloca.s   V_4
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.s    V_4
+    IL_0014:  box        ""T""
     IL_0019:  brtrue.s   IL_0027
     IL_001b:  ldarg.0
     IL_001c:  ldarg.0
@@ -15658,8 +15772,8 @@ Position set for item '2'
     IL_002d:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0032:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003c:  stloc.s    V_4
-    IL_003e:  ldloca.s   V_4
+    IL_003c:  stloc.s    V_5
+    IL_003e:  ldloca.s   V_5
     IL_0040:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_0045:  brtrue.s   IL_0088
     IL_0047:  ldarg.0
@@ -15668,17 +15782,17 @@ Position set for item '2'
     IL_004a:  stloc.0
     IL_004b:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0050:  ldarg.0
-    IL_0051:  ldloc.s    V_4
+    IL_0051:  ldloc.s    V_5
     IL_0053:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_0058:  ldarg.0
     IL_0059:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_005e:  ldloca.s   V_4
+    IL_005e:  ldloca.s   V_5
     IL_0060:  ldarg.0
     IL_0061:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_0066:  leave      IL_0147
     IL_006b:  ldarg.0
     IL_006c:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0071:  stloc.s    V_4
+    IL_0071:  stloc.s    V_5
     IL_0073:  ldarg.0
     IL_0074:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_0079:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -15687,12 +15801,13 @@ Position set for item '2'
     IL_0081:  dup
     IL_0082:  stloc.0
     IL_0083:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0088:  ldloca.s   V_4
+    IL_0088:  ldloca.s   V_5
     IL_008a:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_008f:  stloc.1
-    IL_0090:  ldtoken    ""T""
-    IL_0095:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_009a:  call       ""bool System.Type.IsValueType.get""
+    IL_0090:  ldloca.s   V_4
+    IL_0092:  initobj    ""T""
+    IL_0098:  ldloc.s    V_4
+    IL_009a:  box        ""T""
     IL_009f:  brtrue.s   IL_00a9
     IL_00a1:  ldarg.0
     IL_00a2:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -15713,9 +15828,10 @@ Position set for item '2'
     IL_00ce:  ldflda     ""T Program.<Shift2>d__2<T>.item""
     IL_00d3:  call       ""int Program.GetOffset<T>(ref T)""
     IL_00d8:  stloc.3
-    IL_00d9:  ldtoken    ""T""
-    IL_00de:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00e3:  call       ""bool System.Type.IsValueType.get""
+    IL_00d9:  ldloca.s   V_4
+    IL_00db:  initobj    ""T""
+    IL_00e1:  ldloc.s    V_4
+    IL_00e3:  box        ""T""
     IL_00e8:  brtrue.s   IL_00f2
     IL_00ea:  ldarg.0
     IL_00eb:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -15726,7 +15842,7 @@ Position set for item '2'
     IL_00f9:  ldloc.3
     IL_00fa:  newobj     ""int?..ctor(int)""
     IL_00ff:  dup
-    IL_0100:  stloc.s    V_5
+    IL_0100:  stloc.s    V_6
     IL_0102:  constrained. ""T""
     IL_0108:  callvirt   ""void IMoveable.this[int].set""
     IL_010d:  ldarg.0
@@ -15736,13 +15852,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_011b:  stloc.s    V_6
+    IL_011b:  stloc.s    V_7
     IL_011d:  ldarg.0
     IL_011e:  ldc.i4.s   -2
     IL_0120:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0125:  ldarg.0
     IL_0126:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_012b:  ldloc.s    V_6
+    IL_012b:  ldloc.s    V_7
     IL_012d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0132:  leave.s    IL_0147
   }
@@ -16173,9 +16289,10 @@ Position set for item '2'
                 int V_1,
                 int? V_2,
                 int V_3,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
-                int? V_5,
-                System.Exception V_6)
+                T V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_5,
+                int? V_6,
+                System.Exception V_7)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -16186,9 +16303,10 @@ Position set for item '2'
     IL_000a:  ldloc.0
     IL_000b:  ldc.i4.1
     IL_000c:  beq        IL_0127
-    IL_0011:  ldtoken    ""T""
-    IL_0016:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_001b:  call       ""bool System.Type.IsValueType.get""
+    IL_0011:  ldloca.s   V_4
+    IL_0013:  initobj    ""T""
+    IL_0019:  ldloc.s    V_4
+    IL_001b:  box        ""T""
     IL_0020:  brtrue.s   IL_002e
     IL_0022:  ldarg.0
     IL_0023:  ldarg.0
@@ -16199,8 +16317,8 @@ Position set for item '2'
     IL_0034:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0039:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_003e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0043:  stloc.s    V_4
-    IL_0045:  ldloca.s   V_4
+    IL_0043:  stloc.s    V_5
+    IL_0045:  ldloca.s   V_5
     IL_0047:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_004c:  brtrue.s   IL_008f
     IL_004e:  ldarg.0
@@ -16209,17 +16327,17 @@ Position set for item '2'
     IL_0051:  stloc.0
     IL_0052:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0057:  ldarg.0
-    IL_0058:  ldloc.s    V_4
+    IL_0058:  ldloc.s    V_5
     IL_005a:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_005f:  ldarg.0
     IL_0060:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0065:  ldloca.s   V_4
+    IL_0065:  ldloca.s   V_5
     IL_0067:  ldarg.0
     IL_0068:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_006d:  leave      IL_01bf
     IL_0072:  ldarg.0
     IL_0073:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0078:  stloc.s    V_4
+    IL_0078:  stloc.s    V_5
     IL_007a:  ldarg.0
     IL_007b:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_0080:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -16228,15 +16346,16 @@ Position set for item '2'
     IL_0088:  dup
     IL_0089:  stloc.0
     IL_008a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_008f:  ldloca.s   V_4
+    IL_008f:  ldloca.s   V_5
     IL_0091:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_0096:  stloc.1
     IL_0097:  ldarg.0
     IL_0098:  ldloc.1
     IL_0099:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_009e:  ldtoken    ""T""
-    IL_00a3:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00a8:  call       ""bool System.Type.IsValueType.get""
+    IL_009e:  ldloca.s   V_4
+    IL_00a0:  initobj    ""T""
+    IL_00a6:  ldloc.s    V_4
+    IL_00a8:  box        ""T""
     IL_00ad:  brtrue.s   IL_00b7
     IL_00af:  ldarg.0
     IL_00b0:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -16259,8 +16378,8 @@ Position set for item '2'
     IL_00e9:  call       ""int Program.GetOffset<T>(ref T)""
     IL_00ee:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_00f3:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_00f8:  stloc.s    V_4
-    IL_00fa:  ldloca.s   V_4
+    IL_00f8:  stloc.s    V_5
+    IL_00fa:  ldloca.s   V_5
     IL_00fc:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_0101:  brtrue.s   IL_0144
     IL_0103:  ldarg.0
@@ -16269,17 +16388,17 @@ Position set for item '2'
     IL_0106:  stloc.0
     IL_0107:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_010c:  ldarg.0
-    IL_010d:  ldloc.s    V_4
+    IL_010d:  ldloc.s    V_5
     IL_010f:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_0114:  ldarg.0
     IL_0115:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_011a:  ldloca.s   V_4
+    IL_011a:  ldloca.s   V_5
     IL_011c:  ldarg.0
     IL_011d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_0122:  leave      IL_01bf
     IL_0127:  ldarg.0
     IL_0128:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_012d:  stloc.s    V_4
+    IL_012d:  stloc.s    V_5
     IL_012f:  ldarg.0
     IL_0130:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_0135:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -16288,12 +16407,13 @@ Position set for item '2'
     IL_013d:  dup
     IL_013e:  stloc.0
     IL_013f:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0144:  ldloca.s   V_4
+    IL_0144:  ldloca.s   V_5
     IL_0146:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_014b:  stloc.3
-    IL_014c:  ldtoken    ""T""
-    IL_0151:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0156:  call       ""bool System.Type.IsValueType.get""
+    IL_014c:  ldloca.s   V_4
+    IL_014e:  initobj    ""T""
+    IL_0154:  ldloc.s    V_4
+    IL_0156:  box        ""T""
     IL_015b:  brtrue.s   IL_0165
     IL_015d:  ldarg.0
     IL_015e:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -16305,7 +16425,7 @@ Position set for item '2'
     IL_0171:  ldloc.3
     IL_0172:  newobj     ""int?..ctor(int)""
     IL_0177:  dup
-    IL_0178:  stloc.s    V_5
+    IL_0178:  stloc.s    V_6
     IL_017a:  constrained. ""T""
     IL_0180:  callvirt   ""void IMoveable.this[int].set""
     IL_0185:  ldarg.0
@@ -16315,13 +16435,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_0193:  stloc.s    V_6
+    IL_0193:  stloc.s    V_7
     IL_0195:  ldarg.0
     IL_0196:  ldc.i4.s   -2
     IL_0198:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_019d:  ldarg.0
     IL_019e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_01a3:  ldloc.s    V_6
+    IL_01a3:  ldloc.s    V_7
     IL_01a5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_01aa:  leave.s    IL_01bf
   }
@@ -16645,30 +16765,32 @@ Position set for item '2'
             verifier.VerifyIL("Program.Shift2<T>",
 @"
 {
-  // Code size       53 (0x35)
+  // Code size       52 (0x34)
   .maxstack  2
   .locals init (T V_0,
                 T& V_1,
-                int V_2)
+                T V_2,
+                int V_3)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.1
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
-  IL_0012:  brtrue.s   IL_001f
-  IL_0014:  ldloc.1
-  IL_0015:  ldobj      ""T""
-  IL_001a:  stloc.0
-  IL_001b:  ldloca.s   V_0
-  IL_001d:  br.s       IL_0020
-  IL_001f:  ldloc.1
-  IL_0020:  ldarga.s   V_0
-  IL_0022:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0027:  stloc.2
-  IL_0028:  ldloc.2
-  IL_0029:  constrained. ""T""
-  IL_002f:  callvirt   ""void IMoveable.Position.set""
-  IL_0034:  ret
+  IL_0003:  ldloca.s   V_2
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.2
+  IL_000c:  box        ""T""
+  IL_0011:  brtrue.s   IL_001e
+  IL_0013:  ldloc.1
+  IL_0014:  ldobj      ""T""
+  IL_0019:  stloc.0
+  IL_001a:  ldloca.s   V_0
+  IL_001c:  br.s       IL_001f
+  IL_001e:  ldloc.1
+  IL_001f:  ldarga.s   V_0
+  IL_0021:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_0026:  stloc.3
+  IL_0027:  ldloc.3
+  IL_0028:  constrained. ""T""
+  IL_002e:  callvirt   ""void IMoveable.Position.set""
+  IL_0033:  ret
 }
 ");
         }
@@ -16845,30 +16967,32 @@ Position set for item '2'
             verifier.VerifyIL("Program.Shift2<T>",
 @"
 {
-  // Code size       51 (0x33)
+  // Code size       50 (0x32)
   .maxstack  2
   .locals init (T V_0,
                 T& V_1,
-                int V_2)
+                T V_2,
+                int V_3)
   IL_0000:  ldarg.0
   IL_0001:  stloc.1
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
-  IL_0011:  brtrue.s   IL_001e
-  IL_0013:  ldloc.1
-  IL_0014:  ldobj      ""T""
-  IL_0019:  stloc.0
-  IL_001a:  ldloca.s   V_0
-  IL_001c:  br.s       IL_001f
-  IL_001e:  ldloc.1
-  IL_001f:  ldarg.0
-  IL_0020:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0025:  stloc.2
-  IL_0026:  ldloc.2
-  IL_0027:  constrained. ""T""
-  IL_002d:  callvirt   ""void IMoveable.Position.set""
-  IL_0032:  ret
+  IL_0002:  ldloca.s   V_2
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.2
+  IL_000b:  box        ""T""
+  IL_0010:  brtrue.s   IL_001d
+  IL_0012:  ldloc.1
+  IL_0013:  ldobj      ""T""
+  IL_0018:  stloc.0
+  IL_0019:  ldloca.s   V_0
+  IL_001b:  br.s       IL_001e
+  IL_001d:  ldloc.1
+  IL_001e:  ldarg.0
+  IL_001f:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_0024:  stloc.3
+  IL_0025:  ldloc.3
+  IL_0026:  constrained. ""T""
+  IL_002c:  callvirt   ""void IMoveable.Position.set""
+  IL_0031:  ret
 }
 ");
         }
@@ -17124,86 +17248,89 @@ Position set for item '2'
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
-                System.Exception V_3)
+                T V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
+                System.Exception V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0069
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
-    IL_0019:  brtrue.s   IL_0027
+    IL_0008:  brfalse.s  IL_0068
+    IL_000a:  ldloca.s   V_2
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.2
+    IL_0013:  box        ""T""
+    IL_0018:  brtrue.s   IL_0026
+    IL_001a:  ldarg.0
     IL_001b:  ldarg.0
-    IL_001c:  ldarg.0
-    IL_001d:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0022:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0027:  ldarg.0
-    IL_0028:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_002d:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0032:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003c:  stloc.2
-    IL_003d:  ldloca.s   V_2
-    IL_003f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0044:  brtrue.s   IL_0085
-    IL_0046:  ldarg.0
-    IL_0047:  ldc.i4.0
-    IL_0048:  dup
-    IL_0049:  stloc.0
-    IL_004a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_004f:  ldarg.0
-    IL_0050:  ldloc.2
-    IL_0051:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0056:  ldarg.0
-    IL_0057:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_005c:  ldloca.s   V_2
-    IL_005e:  ldarg.0
-    IL_005f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
-    IL_0064:  leave      IL_00f0
-    IL_0069:  ldarg.0
-    IL_006a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_006f:  stloc.2
-    IL_0070:  ldarg.0
-    IL_0071:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0076:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_007c:  ldarg.0
-    IL_007d:  ldc.i4.m1
-    IL_007e:  dup
-    IL_007f:  stloc.0
-    IL_0080:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0085:  ldloca.s   V_2
-    IL_0087:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_008c:  stloc.1
-    IL_008d:  ldtoken    ""T""
-    IL_0092:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0097:  call       ""bool System.Type.IsValueType.get""
-    IL_009c:  brtrue.s   IL_00a6
-    IL_009e:  ldarg.0
-    IL_009f:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00a4:  br.s       IL_00ac
-    IL_00a6:  ldarg.0
-    IL_00a7:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00ac:  ldloc.1
-    IL_00ad:  constrained. ""T""
-    IL_00b3:  callvirt   ""void IMoveable.Position.set""
-    IL_00b8:  ldarg.0
-    IL_00b9:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00be:  initobj    ""T""
-    IL_00c4:  leave.s    IL_00dd
+    IL_001c:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0021:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0026:  ldarg.0
+    IL_0027:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_002c:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0031:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_0036:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_003b:  stloc.3
+    IL_003c:  ldloca.s   V_3
+    IL_003e:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0043:  brtrue.s   IL_0084
+    IL_0045:  ldarg.0
+    IL_0046:  ldc.i4.0
+    IL_0047:  dup
+    IL_0048:  stloc.0
+    IL_0049:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_004e:  ldarg.0
+    IL_004f:  ldloc.3
+    IL_0050:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0055:  ldarg.0
+    IL_0056:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_005b:  ldloca.s   V_3
+    IL_005d:  ldarg.0
+    IL_005e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
+    IL_0063:  leave      IL_00f0
+    IL_0068:  ldarg.0
+    IL_0069:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_006e:  stloc.3
+    IL_006f:  ldarg.0
+    IL_0070:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0075:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_007b:  ldarg.0
+    IL_007c:  ldc.i4.m1
+    IL_007d:  dup
+    IL_007e:  stloc.0
+    IL_007f:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0084:  ldloca.s   V_3
+    IL_0086:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_008b:  stloc.1
+    IL_008c:  ldloca.s   V_2
+    IL_008e:  initobj    ""T""
+    IL_0094:  ldloc.2
+    IL_0095:  box        ""T""
+    IL_009a:  brtrue.s   IL_00a4
+    IL_009c:  ldarg.0
+    IL_009d:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00a2:  br.s       IL_00aa
+    IL_00a4:  ldarg.0
+    IL_00a5:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00aa:  ldloc.1
+    IL_00ab:  constrained. ""T""
+    IL_00b1:  callvirt   ""void IMoveable.Position.set""
+    IL_00b6:  ldarg.0
+    IL_00b7:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00bc:  initobj    ""T""
+    IL_00c2:  leave.s    IL_00dd
   }
   catch System.Exception
   {
-    IL_00c6:  stloc.3
-    IL_00c7:  ldarg.0
-    IL_00c8:  ldc.i4.s   -2
-    IL_00ca:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00cf:  ldarg.0
-    IL_00d0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_00d5:  ldloc.3
+    IL_00c4:  stloc.s    V_4
+    IL_00c6:  ldarg.0
+    IL_00c7:  ldc.i4.s   -2
+    IL_00c9:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00ce:  ldarg.0
+    IL_00cf:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_00d4:  ldloc.s    V_4
     IL_00d6:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_00db:  leave.s    IL_00f0
   }
@@ -17478,17 +17605,19 @@ Position get for item '2'
             verifier.VerifyIL("Program.Shift2<T>",
 @"
 {
-  // Code size       69 (0x45)
+   // Code size       69 (0x45)
   .maxstack  3
   .locals init (T& V_0,
                 T V_1,
                 T& V_2,
-                int V_3)
+                int V_3,
+                T V_4)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.2
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
+  IL_0003:  ldloca.s   V_4
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_4
+  IL_000d:  box        ""T""
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.2
   IL_0015:  ldobj      ""T""
@@ -17725,12 +17854,14 @@ Position get for item '2'
   .locals init (T& V_0,
                 T V_1,
                 T& V_2,
-                int V_3)
+                int V_3,
+                T V_4)
   IL_0000:  ldarg.0
   IL_0001:  stloc.2
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
+  IL_0002:  ldloca.s   V_4
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_4
+  IL_000c:  box        ""T""
   IL_0011:  brtrue.s   IL_001e
   IL_0013:  ldloc.2
   IL_0014:  ldobj      ""T""
@@ -18038,113 +18169,117 @@ Position get for item '2'
             verifier.VerifyIL("Program.<Shift2>d__2<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"
 {
-  // Code size      285 (0x11d)
+  // Code size      284 (0x11c)
   .maxstack  3
   .locals init (int V_0,
                 int V_1,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
-                System.Exception V_3)
+                T V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
+                System.Exception V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0069
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
-    IL_0019:  brtrue.s   IL_0027
+    IL_0008:  brfalse.s  IL_0068
+    IL_000a:  ldloca.s   V_2
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.2
+    IL_0013:  box        ""T""
+    IL_0018:  brtrue.s   IL_0026
+    IL_001a:  ldarg.0
     IL_001b:  ldarg.0
-    IL_001c:  ldarg.0
-    IL_001d:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0022:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0027:  ldarg.0
-    IL_0028:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_002d:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0032:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003c:  stloc.2
-    IL_003d:  ldloca.s   V_2
-    IL_003f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0044:  brtrue.s   IL_0085
-    IL_0046:  ldarg.0
-    IL_0047:  ldc.i4.0
-    IL_0048:  dup
-    IL_0049:  stloc.0
-    IL_004a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_004f:  ldarg.0
-    IL_0050:  ldloc.2
-    IL_0051:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0056:  ldarg.0
-    IL_0057:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_005c:  ldloca.s   V_2
-    IL_005e:  ldarg.0
-    IL_005f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
-    IL_0064:  leave      IL_011c
-    IL_0069:  ldarg.0
-    IL_006a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_006f:  stloc.2
-    IL_0070:  ldarg.0
-    IL_0071:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0076:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_007c:  ldarg.0
-    IL_007d:  ldc.i4.m1
-    IL_007e:  dup
-    IL_007f:  stloc.0
-    IL_0080:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0085:  ldloca.s   V_2
-    IL_0087:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_008c:  stloc.1
-    IL_008d:  ldtoken    ""T""
-    IL_0092:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0097:  call       ""bool System.Type.IsValueType.get""
-    IL_009c:  brtrue.s   IL_00a6
-    IL_009e:  ldarg.0
-    IL_009f:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00a4:  br.s       IL_00ac
-    IL_00a6:  ldarg.0
-    IL_00a7:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00ac:  ldtoken    ""T""
-    IL_00b1:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00b6:  call       ""bool System.Type.IsValueType.get""
-    IL_00bb:  brtrue.s   IL_00c5
-    IL_00bd:  ldarg.0
-    IL_00be:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00c3:  br.s       IL_00cb
-    IL_00c5:  ldarg.0
-    IL_00c6:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00cb:  constrained. ""T""
-    IL_00d1:  callvirt   ""int IMoveable.Length.get""
-    IL_00d6:  ldloc.1
-    IL_00d7:  sub
-    IL_00d8:  constrained. ""T""
-    IL_00de:  callvirt   ""int IMoveable.this[int].get""
-    IL_00e3:  pop
-    IL_00e4:  ldarg.0
-    IL_00e5:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00ea:  initobj    ""T""
-    IL_00f0:  leave.s    IL_0109
+    IL_001c:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0021:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0026:  ldarg.0
+    IL_0027:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_002c:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0031:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_0036:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_003b:  stloc.3
+    IL_003c:  ldloca.s   V_3
+    IL_003e:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0043:  brtrue.s   IL_0084
+    IL_0045:  ldarg.0
+    IL_0046:  ldc.i4.0
+    IL_0047:  dup
+    IL_0048:  stloc.0
+    IL_0049:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_004e:  ldarg.0
+    IL_004f:  ldloc.3
+    IL_0050:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0055:  ldarg.0
+    IL_0056:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_005b:  ldloca.s   V_3
+    IL_005d:  ldarg.0
+    IL_005e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
+    IL_0063:  leave      IL_011b
+    IL_0068:  ldarg.0
+    IL_0069:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_006e:  stloc.3
+    IL_006f:  ldarg.0
+    IL_0070:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0075:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_007b:  ldarg.0
+    IL_007c:  ldc.i4.m1
+    IL_007d:  dup
+    IL_007e:  stloc.0
+    IL_007f:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0084:  ldloca.s   V_3
+    IL_0086:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_008b:  stloc.1
+    IL_008c:  ldloca.s   V_2
+    IL_008e:  initobj    ""T""
+    IL_0094:  ldloc.2
+    IL_0095:  box        ""T""
+    IL_009a:  brtrue.s   IL_00a4
+    IL_009c:  ldarg.0
+    IL_009d:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00a2:  br.s       IL_00aa
+    IL_00a4:  ldarg.0
+    IL_00a5:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00aa:  ldloca.s   V_2
+    IL_00ac:  initobj    ""T""
+    IL_00b2:  ldloc.2
+    IL_00b3:  box        ""T""
+    IL_00b8:  brtrue.s   IL_00c2
+    IL_00ba:  ldarg.0
+    IL_00bb:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00c0:  br.s       IL_00c8
+    IL_00c2:  ldarg.0
+    IL_00c3:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00c8:  constrained. ""T""
+    IL_00ce:  callvirt   ""int IMoveable.Length.get""
+    IL_00d3:  ldloc.1
+    IL_00d4:  sub
+    IL_00d5:  constrained. ""T""
+    IL_00db:  callvirt   ""int IMoveable.this[int].get""
+    IL_00e0:  pop
+    IL_00e1:  ldarg.0
+    IL_00e2:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00e7:  initobj    ""T""
+    IL_00ed:  leave.s    IL_0108
   }
   catch System.Exception
   {
-    IL_00f2:  stloc.3
-    IL_00f3:  ldarg.0
-    IL_00f4:  ldc.i4.s   -2
-    IL_00f6:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00fb:  ldarg.0
-    IL_00fc:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0101:  ldloc.3
-    IL_0102:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_0107:  leave.s    IL_011c
+    IL_00ef:  stloc.s    V_4
+    IL_00f1:  ldarg.0
+    IL_00f2:  ldc.i4.s   -2
+    IL_00f4:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00f9:  ldarg.0
+    IL_00fa:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_00ff:  ldloc.s    V_4
+    IL_0101:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0106:  leave.s    IL_011b
   }
-  IL_0109:  ldarg.0
-  IL_010a:  ldc.i4.s   -2
-  IL_010c:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-  IL_0111:  ldarg.0
-  IL_0112:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-  IL_0117:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_011c:  ret
+  IL_0108:  ldarg.0
+  IL_0109:  ldc.i4.s   -2
+  IL_010b:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+  IL_0110:  ldarg.0
+  IL_0111:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+  IL_0116:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_011b:  ret
 }
 ");
         }
@@ -18443,12 +18578,14 @@ Position set for item '2'
                 T V_1,
                 T& V_2,
                 int V_3,
-                int V_4)
+                int V_4,
+                T V_5)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.2
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
+  IL_0003:  ldloca.s   V_5
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_5
+  IL_000d:  box        ""T""
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.2
   IL_0015:  ldobj      ""T""
@@ -18716,12 +18853,14 @@ Position set for item '2'
                 T V_1,
                 T& V_2,
                 int V_3,
-                int V_4)
+                int V_4,
+                T V_5)
   IL_0000:  ldarg.0
   IL_0001:  stloc.2
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
+  IL_0002:  ldloca.s   V_5
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_5
+  IL_000c:  box        ""T""
   IL_0011:  brtrue.s   IL_001e
   IL_0013:  ldloc.2
   IL_0014:  ldobj      ""T""
@@ -19060,82 +19199,86 @@ Position set for item '2'
             verifier.VerifyIL("Program.<Shift2>d__2<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"
 {
-  // Code size      333 (0x14d)
+  // Code size      332 (0x14c)
   .maxstack  4
   .locals init (int V_0,
                 int V_1,
                 int V_2,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
-                System.Exception V_4)
+                T V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0069
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
-    IL_0019:  brtrue.s   IL_0027
+    IL_0008:  brfalse.s  IL_006a
+    IL_000a:  ldloca.s   V_3
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.3
+    IL_0013:  box        ""T""
+    IL_0018:  brtrue.s   IL_0026
+    IL_001a:  ldarg.0
     IL_001b:  ldarg.0
-    IL_001c:  ldarg.0
-    IL_001d:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0022:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0027:  ldarg.0
-    IL_0028:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_002d:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0032:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003c:  stloc.3
-    IL_003d:  ldloca.s   V_3
+    IL_001c:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0021:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0026:  ldarg.0
+    IL_0027:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_002c:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0031:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_0036:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_003b:  stloc.s    V_4
+    IL_003d:  ldloca.s   V_4
     IL_003f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0044:  brtrue.s   IL_0085
+    IL_0044:  brtrue.s   IL_0087
     IL_0046:  ldarg.0
     IL_0047:  ldc.i4.0
     IL_0048:  dup
     IL_0049:  stloc.0
     IL_004a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_004f:  ldarg.0
-    IL_0050:  ldloc.3
-    IL_0051:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0056:  ldarg.0
-    IL_0057:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_005c:  ldloca.s   V_3
-    IL_005e:  ldarg.0
-    IL_005f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
-    IL_0064:  leave      IL_014c
-    IL_0069:  ldarg.0
-    IL_006a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_006f:  stloc.3
-    IL_0070:  ldarg.0
-    IL_0071:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0076:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_007c:  ldarg.0
-    IL_007d:  ldc.i4.m1
-    IL_007e:  dup
-    IL_007f:  stloc.0
-    IL_0080:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0085:  ldloca.s   V_3
-    IL_0087:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_008c:  stloc.1
-    IL_008d:  ldtoken    ""T""
-    IL_0092:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0097:  call       ""bool System.Type.IsValueType.get""
-    IL_009c:  brtrue.s   IL_00a6
-    IL_009e:  ldarg.0
-    IL_009f:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00a4:  br.s       IL_00ac
-    IL_00a6:  ldarg.0
-    IL_00a7:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00ac:  constrained. ""T""
-    IL_00b2:  callvirt   ""int IMoveable.Length.get""
-    IL_00b7:  ldloc.1
-    IL_00b8:  sub
-    IL_00b9:  stloc.2
-    IL_00ba:  ldtoken    ""T""
-    IL_00bf:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00c4:  call       ""bool System.Type.IsValueType.get""
+    IL_0050:  ldloc.s    V_4
+    IL_0052:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0057:  ldarg.0
+    IL_0058:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_005d:  ldloca.s   V_4
+    IL_005f:  ldarg.0
+    IL_0060:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
+    IL_0065:  leave      IL_014b
+    IL_006a:  ldarg.0
+    IL_006b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0070:  stloc.s    V_4
+    IL_0072:  ldarg.0
+    IL_0073:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0078:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_007e:  ldarg.0
+    IL_007f:  ldc.i4.m1
+    IL_0080:  dup
+    IL_0081:  stloc.0
+    IL_0082:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0087:  ldloca.s   V_4
+    IL_0089:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_008e:  stloc.1
+    IL_008f:  ldloca.s   V_3
+    IL_0091:  initobj    ""T""
+    IL_0097:  ldloc.3
+    IL_0098:  box        ""T""
+    IL_009d:  brtrue.s   IL_00a7
+    IL_009f:  ldarg.0
+    IL_00a0:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00a5:  br.s       IL_00ad
+    IL_00a7:  ldarg.0
+    IL_00a8:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00ad:  constrained. ""T""
+    IL_00b3:  callvirt   ""int IMoveable.Length.get""
+    IL_00b8:  ldloc.1
+    IL_00b9:  sub
+    IL_00ba:  stloc.2
+    IL_00bb:  ldloca.s   V_3
+    IL_00bd:  initobj    ""T""
+    IL_00c3:  ldloc.3
+    IL_00c4:  box        ""T""
     IL_00c9:  brtrue.s   IL_00d3
     IL_00cb:  ldarg.0
     IL_00cc:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -19143,46 +19286,47 @@ Position set for item '2'
     IL_00d3:  ldarg.0
     IL_00d4:  ldflda     ""T Program.<Shift2>d__2<T>.item""
     IL_00d9:  ldloc.2
-    IL_00da:  ldtoken    ""T""
-    IL_00df:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00e4:  call       ""bool System.Type.IsValueType.get""
-    IL_00e9:  brtrue.s   IL_00f3
-    IL_00eb:  ldarg.0
-    IL_00ec:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00f1:  br.s       IL_00f9
-    IL_00f3:  ldarg.0
-    IL_00f4:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00f9:  ldloc.2
-    IL_00fa:  constrained. ""T""
-    IL_0100:  callvirt   ""int IMoveable.this[int].get""
-    IL_0105:  ldc.i4.1
-    IL_0106:  add
-    IL_0107:  constrained. ""T""
-    IL_010d:  callvirt   ""void IMoveable.this[int].set""
-    IL_0112:  ldarg.0
-    IL_0113:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0118:  initobj    ""T""
-    IL_011e:  leave.s    IL_0139
+    IL_00da:  ldloca.s   V_3
+    IL_00dc:  initobj    ""T""
+    IL_00e2:  ldloc.3
+    IL_00e3:  box        ""T""
+    IL_00e8:  brtrue.s   IL_00f2
+    IL_00ea:  ldarg.0
+    IL_00eb:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00f0:  br.s       IL_00f8
+    IL_00f2:  ldarg.0
+    IL_00f3:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00f8:  ldloc.2
+    IL_00f9:  constrained. ""T""
+    IL_00ff:  callvirt   ""int IMoveable.this[int].get""
+    IL_0104:  ldc.i4.1
+    IL_0105:  add
+    IL_0106:  constrained. ""T""
+    IL_010c:  callvirt   ""void IMoveable.this[int].set""
+    IL_0111:  ldarg.0
+    IL_0112:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0117:  initobj    ""T""
+    IL_011d:  leave.s    IL_0138
   }
   catch System.Exception
   {
-    IL_0120:  stloc.s    V_4
-    IL_0122:  ldarg.0
-    IL_0123:  ldc.i4.s   -2
-    IL_0125:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_012a:  ldarg.0
-    IL_012b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0130:  ldloc.s    V_4
-    IL_0132:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_0137:  leave.s    IL_014c
+    IL_011f:  stloc.s    V_5
+    IL_0121:  ldarg.0
+    IL_0122:  ldc.i4.s   -2
+    IL_0124:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0129:  ldarg.0
+    IL_012a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_012f:  ldloc.s    V_5
+    IL_0131:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0136:  leave.s    IL_014b
   }
-  IL_0139:  ldarg.0
-  IL_013a:  ldc.i4.s   -2
-  IL_013c:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-  IL_0141:  ldarg.0
-  IL_0142:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-  IL_0147:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_014c:  ret
+  IL_0138:  ldarg.0
+  IL_0139:  ldc.i4.s   -2
+  IL_013b:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+  IL_0140:  ldarg.0
+  IL_0141:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+  IL_0146:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_014b:  ret
 }
 ");
         }
@@ -19483,7 +19627,7 @@ Position set for item '2'
             verifier.VerifyIL("Program.Shift2<T>",
 @"
 {
-  // Code size       78 (0x4e)
+  // Code size       77 (0x4d)
   .maxstack  4
   .locals init (T& V_0,
                 int V_1,
@@ -19497,24 +19641,25 @@ Position set for item '2'
   IL_0010:  sub
   IL_0011:  stloc.1
   IL_0012:  ldloc.0
-  IL_0013:  ldtoken    ""T""
-  IL_0018:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_001d:  call       ""bool System.Type.IsValueType.get""
-  IL_0022:  brtrue.s   IL_002c
-  IL_0024:  ldobj      ""T""
-  IL_0029:  stloc.2
-  IL_002a:  ldloca.s   V_2
-  IL_002c:  ldloc.1
-  IL_002d:  ldloc.0
-  IL_002e:  ldloc.1
-  IL_002f:  constrained. ""T""
-  IL_0035:  callvirt   ""int IMoveable.this[int].get""
-  IL_003a:  ldarga.s   V_0
-  IL_003c:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0041:  add
-  IL_0042:  constrained. ""T""
-  IL_0048:  callvirt   ""void IMoveable.this[int].set""
-  IL_004d:  ret
+  IL_0013:  ldloca.s   V_2
+  IL_0015:  initobj    ""T""
+  IL_001b:  ldloc.2
+  IL_001c:  box        ""T""
+  IL_0021:  brtrue.s   IL_002b
+  IL_0023:  ldobj      ""T""
+  IL_0028:  stloc.2
+  IL_0029:  ldloca.s   V_2
+  IL_002b:  ldloc.1
+  IL_002c:  ldloc.0
+  IL_002d:  ldloc.1
+  IL_002e:  constrained. ""T""
+  IL_0034:  callvirt   ""int IMoveable.this[int].get""
+  IL_0039:  ldarga.s   V_0
+  IL_003b:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_0040:  add
+  IL_0041:  constrained. ""T""
+  IL_0047:  callvirt   ""void IMoveable.this[int].set""
+  IL_004c:  ret
 }
 ");
         }
@@ -19742,7 +19887,7 @@ Position set for item '2'
             verifier.VerifyIL("Program.Shift2<T>",
 @"
 {
-  // Code size       76 (0x4c)
+  // Code size       75 (0x4b)
   .maxstack  4
   .locals init (T& V_0,
                 int V_1,
@@ -19756,24 +19901,25 @@ Position set for item '2'
   IL_000f:  sub
   IL_0010:  stloc.1
   IL_0011:  ldloc.0
-  IL_0012:  ldtoken    ""T""
-  IL_0017:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_001c:  call       ""bool System.Type.IsValueType.get""
-  IL_0021:  brtrue.s   IL_002b
-  IL_0023:  ldobj      ""T""
-  IL_0028:  stloc.2
-  IL_0029:  ldloca.s   V_2
-  IL_002b:  ldloc.1
-  IL_002c:  ldloc.0
-  IL_002d:  ldloc.1
-  IL_002e:  constrained. ""T""
-  IL_0034:  callvirt   ""int IMoveable.this[int].get""
-  IL_0039:  ldarg.0
-  IL_003a:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_003f:  add
-  IL_0040:  constrained. ""T""
-  IL_0046:  callvirt   ""void IMoveable.this[int].set""
-  IL_004b:  ret
+  IL_0012:  ldloca.s   V_2
+  IL_0014:  initobj    ""T""
+  IL_001a:  ldloc.2
+  IL_001b:  box        ""T""
+  IL_0020:  brtrue.s   IL_002a
+  IL_0022:  ldobj      ""T""
+  IL_0027:  stloc.2
+  IL_0028:  ldloca.s   V_2
+  IL_002a:  ldloc.1
+  IL_002b:  ldloc.0
+  IL_002c:  ldloc.1
+  IL_002d:  constrained. ""T""
+  IL_0033:  callvirt   ""int IMoveable.this[int].get""
+  IL_0038:  ldarg.0
+  IL_0039:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_003e:  add
+  IL_003f:  constrained. ""T""
+  IL_0045:  callvirt   ""void IMoveable.this[int].set""
+  IL_004a:  ret
 }
 ");
         }
@@ -20090,20 +20236,21 @@ Position set for item '2'
             verifier.VerifyIL("Program.<Shift2>d__2<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"
 {
-  // Code size      310 (0x136)
+  // Code size      311 (0x137)
   .maxstack  4
   .locals init (int V_0,
                 int V_1,
                 int V_2,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
-                System.Exception V_4)
+                T V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse    IL_009f
+    IL_0008:  brfalse    IL_00a0
     IL_000d:  ldarg.0
     IL_000e:  ldflda     ""T Program.<Shift2>d__2<T>.item""
     IL_0013:  constrained. ""T""
@@ -20111,102 +20258,104 @@ Position set for item '2'
     IL_001e:  ldc.i4.1
     IL_001f:  sub
     IL_0020:  stloc.1
-    IL_0021:  ldtoken    ""T""
-    IL_0026:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_002b:  call       ""bool System.Type.IsValueType.get""
-    IL_0030:  brtrue.s   IL_003e
+    IL_0021:  ldloca.s   V_3
+    IL_0023:  initobj    ""T""
+    IL_0029:  ldloc.3
+    IL_002a:  box        ""T""
+    IL_002f:  brtrue.s   IL_003d
+    IL_0031:  ldarg.0
     IL_0032:  ldarg.0
-    IL_0033:  ldarg.0
-    IL_0034:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0039:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_003e:  ldarg.0
-    IL_003f:  ldloc.1
-    IL_0040:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_0033:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0038:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_003d:  ldarg.0
+    IL_003e:  ldloc.1
+    IL_003f:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_0044:  ldarg.0
     IL_0045:  ldarg.0
-    IL_0046:  ldarg.0
-    IL_0047:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_004c:  ldloc.1
-    IL_004d:  constrained. ""T""
-    IL_0053:  callvirt   ""int IMoveable.this[int].get""
-    IL_0058:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap3""
-    IL_005d:  ldarg.0
-    IL_005e:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_0063:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0068:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_006d:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0072:  stloc.3
-    IL_0073:  ldloca.s   V_3
+    IL_0046:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_004b:  ldloc.1
+    IL_004c:  constrained. ""T""
+    IL_0052:  callvirt   ""int IMoveable.this[int].get""
+    IL_0057:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap3""
+    IL_005c:  ldarg.0
+    IL_005d:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0062:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0067:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_006c:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_0071:  stloc.s    V_4
+    IL_0073:  ldloca.s   V_4
     IL_0075:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_007a:  brtrue.s   IL_00bb
+    IL_007a:  brtrue.s   IL_00bd
     IL_007c:  ldarg.0
     IL_007d:  ldc.i4.0
     IL_007e:  dup
     IL_007f:  stloc.0
     IL_0080:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0085:  ldarg.0
-    IL_0086:  ldloc.3
-    IL_0087:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_008c:  ldarg.0
-    IL_008d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0092:  ldloca.s   V_3
-    IL_0094:  ldarg.0
-    IL_0095:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
-    IL_009a:  leave      IL_0135
-    IL_009f:  ldarg.0
-    IL_00a0:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00a5:  stloc.3
-    IL_00a6:  ldarg.0
-    IL_00a7:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00ac:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_00b2:  ldarg.0
-    IL_00b3:  ldc.i4.m1
-    IL_00b4:  dup
-    IL_00b5:  stloc.0
-    IL_00b6:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00bb:  ldloca.s   V_3
-    IL_00bd:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_00c2:  stloc.2
-    IL_00c3:  ldtoken    ""T""
-    IL_00c8:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00cd:  call       ""bool System.Type.IsValueType.get""
-    IL_00d2:  brtrue.s   IL_00dc
-    IL_00d4:  ldarg.0
-    IL_00d5:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00da:  br.s       IL_00e2
-    IL_00dc:  ldarg.0
-    IL_00dd:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00e2:  ldarg.0
-    IL_00e3:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_00e8:  ldarg.0
-    IL_00e9:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap3""
-    IL_00ee:  ldloc.2
-    IL_00ef:  add
-    IL_00f0:  constrained. ""T""
-    IL_00f6:  callvirt   ""void IMoveable.this[int].set""
-    IL_00fb:  ldarg.0
-    IL_00fc:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0101:  initobj    ""T""
-    IL_0107:  leave.s    IL_0122
+    IL_0086:  ldloc.s    V_4
+    IL_0088:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_008d:  ldarg.0
+    IL_008e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_0093:  ldloca.s   V_4
+    IL_0095:  ldarg.0
+    IL_0096:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
+    IL_009b:  leave      IL_0136
+    IL_00a0:  ldarg.0
+    IL_00a1:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_00a6:  stloc.s    V_4
+    IL_00a8:  ldarg.0
+    IL_00a9:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_00ae:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_00b4:  ldarg.0
+    IL_00b5:  ldc.i4.m1
+    IL_00b6:  dup
+    IL_00b7:  stloc.0
+    IL_00b8:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00bd:  ldloca.s   V_4
+    IL_00bf:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_00c4:  stloc.2
+    IL_00c5:  ldloca.s   V_3
+    IL_00c7:  initobj    ""T""
+    IL_00cd:  ldloc.3
+    IL_00ce:  box        ""T""
+    IL_00d3:  brtrue.s   IL_00dd
+    IL_00d5:  ldarg.0
+    IL_00d6:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00db:  br.s       IL_00e3
+    IL_00dd:  ldarg.0
+    IL_00de:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00e3:  ldarg.0
+    IL_00e4:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_00e9:  ldarg.0
+    IL_00ea:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap3""
+    IL_00ef:  ldloc.2
+    IL_00f0:  add
+    IL_00f1:  constrained. ""T""
+    IL_00f7:  callvirt   ""void IMoveable.this[int].set""
+    IL_00fc:  ldarg.0
+    IL_00fd:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0102:  initobj    ""T""
+    IL_0108:  leave.s    IL_0123
   }
   catch System.Exception
   {
-    IL_0109:  stloc.s    V_4
-    IL_010b:  ldarg.0
-    IL_010c:  ldc.i4.s   -2
-    IL_010e:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0113:  ldarg.0
-    IL_0114:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0119:  ldloc.s    V_4
-    IL_011b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_0120:  leave.s    IL_0135
+    IL_010a:  stloc.s    V_5
+    IL_010c:  ldarg.0
+    IL_010d:  ldc.i4.s   -2
+    IL_010f:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0114:  ldarg.0
+    IL_0115:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_011a:  ldloc.s    V_5
+    IL_011c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0121:  leave.s    IL_0136
   }
-  IL_0122:  ldarg.0
-  IL_0123:  ldc.i4.s   -2
-  IL_0125:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-  IL_012a:  ldarg.0
-  IL_012b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-  IL_0130:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0135:  ret
+  IL_0123:  ldarg.0
+  IL_0124:  ldc.i4.s   -2
+  IL_0126:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+  IL_012b:  ldarg.0
+  IL_012c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+  IL_0131:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0136:  ret
 }
 ");
         }
@@ -20525,12 +20674,14 @@ Position set for item '2'
                 T V_1,
                 T& V_2,
                 int V_3,
-                int V_4)
+                int V_4,
+                T V_5)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.2
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
+  IL_0003:  ldloca.s   V_5
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_5
+  IL_000d:  box        ""T""
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.2
   IL_0015:  ldobj      ""T""
@@ -20801,12 +20952,14 @@ Position set for item '2'
                 T V_1,
                 T& V_2,
                 int V_3,
-                int V_4)
+                int V_4,
+                T V_5)
   IL_0000:  ldarg.0
   IL_0001:  stloc.2
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
+  IL_0002:  ldloca.s   V_5
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_5
+  IL_000c:  box        ""T""
   IL_0011:  brtrue.s   IL_001e
   IL_0013:  ldloc.2
   IL_0014:  ldobj      ""T""
@@ -21167,8 +21320,9 @@ Position set for item '2'
                 int V_1,
                 int V_2,
                 int V_3,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
-                System.Exception V_5)
+                T V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_5,
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -21176,9 +21330,10 @@ Position set for item '2'
   {
     IL_0007:  ldloc.0
     IL_0008:  brfalse    IL_00df
-    IL_000d:  ldtoken    ""T""
-    IL_0012:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0017:  call       ""bool System.Type.IsValueType.get""
+    IL_000d:  ldloca.s   V_4
+    IL_000f:  initobj    ""T""
+    IL_0015:  ldloc.s    V_4
+    IL_0017:  box        ""T""
     IL_001c:  brtrue.s   IL_002a
     IL_001e:  ldarg.0
     IL_001f:  ldarg.0
@@ -21188,9 +21343,10 @@ Position set for item '2'
     IL_002b:  ldflda     ""T Program.<Shift2>d__2<T>.item""
     IL_0030:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0035:  stloc.1
-    IL_0036:  ldtoken    ""T""
-    IL_003b:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0040:  call       ""bool System.Type.IsValueType.get""
+    IL_0036:  ldloca.s   V_4
+    IL_0038:  initobj    ""T""
+    IL_003e:  ldloc.s    V_4
+    IL_0040:  box        ""T""
     IL_0045:  brtrue.s   IL_004f
     IL_0047:  ldarg.0
     IL_0048:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -21206,9 +21362,10 @@ Position set for item '2'
     IL_0064:  ldloc.2
     IL_0065:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
     IL_006a:  ldarg.0
-    IL_006b:  ldtoken    ""T""
-    IL_0070:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0075:  call       ""bool System.Type.IsValueType.get""
+    IL_006b:  ldloca.s   V_4
+    IL_006d:  initobj    ""T""
+    IL_0073:  ldloc.s    V_4
+    IL_0075:  box        ""T""
     IL_007a:  brtrue.s   IL_0084
     IL_007c:  ldarg.0
     IL_007d:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -21224,8 +21381,8 @@ Position set for item '2'
     IL_00a1:  call       ""int Program.GetOffset<T>(ref T)""
     IL_00a6:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_00ab:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_00b0:  stloc.s    V_4
-    IL_00b2:  ldloca.s   V_4
+    IL_00b0:  stloc.s    V_5
+    IL_00b2:  ldloca.s   V_5
     IL_00b4:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_00b9:  brtrue.s   IL_00fc
     IL_00bb:  ldarg.0
@@ -21234,17 +21391,17 @@ Position set for item '2'
     IL_00be:  stloc.0
     IL_00bf:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_00c4:  ldarg.0
-    IL_00c5:  ldloc.s    V_4
+    IL_00c5:  ldloc.s    V_5
     IL_00c7:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_00cc:  ldarg.0
     IL_00cd:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_00d2:  ldloca.s   V_4
+    IL_00d2:  ldloca.s   V_5
     IL_00d4:  ldarg.0
     IL_00d5:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_00da:  leave      IL_0176
     IL_00df:  ldarg.0
     IL_00e0:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00e5:  stloc.s    V_4
+    IL_00e5:  stloc.s    V_5
     IL_00e7:  ldarg.0
     IL_00e8:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_00ed:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -21253,12 +21410,13 @@ Position set for item '2'
     IL_00f5:  dup
     IL_00f6:  stloc.0
     IL_00f7:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00fc:  ldloca.s   V_4
+    IL_00fc:  ldloca.s   V_5
     IL_00fe:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_0103:  stloc.3
-    IL_0104:  ldtoken    ""T""
-    IL_0109:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_010e:  call       ""bool System.Type.IsValueType.get""
+    IL_0104:  ldloca.s   V_4
+    IL_0106:  initobj    ""T""
+    IL_010c:  ldloc.s    V_4
+    IL_010e:  box        ""T""
     IL_0113:  brtrue.s   IL_011d
     IL_0115:  ldarg.0
     IL_0116:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -21280,13 +21438,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_014a:  stloc.s    V_5
+    IL_014a:  stloc.s    V_6
     IL_014c:  ldarg.0
     IL_014d:  ldc.i4.s   -2
     IL_014f:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0154:  ldarg.0
     IL_0155:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_015a:  ldloc.s    V_5
+    IL_015a:  ldloc.s    V_6
     IL_015c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0161:  leave.s    IL_0176
   }
@@ -21693,82 +21851,86 @@ Position set for item '2'
             verifier.VerifyIL("Program.<Shift2>d__2<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"
 {
-  // Code size      343 (0x157)
+  // Code size      342 (0x156)
   .maxstack  4
   .locals init (int V_0,
                 int V_1,
                 int V_2,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
-                System.Exception V_4)
+                T V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0069
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
-    IL_0019:  brtrue.s   IL_0027
+    IL_0008:  brfalse.s  IL_006a
+    IL_000a:  ldloca.s   V_3
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.3
+    IL_0013:  box        ""T""
+    IL_0018:  brtrue.s   IL_0026
+    IL_001a:  ldarg.0
     IL_001b:  ldarg.0
-    IL_001c:  ldarg.0
-    IL_001d:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0022:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0027:  ldarg.0
-    IL_0028:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_002d:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0032:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003c:  stloc.3
-    IL_003d:  ldloca.s   V_3
+    IL_001c:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0021:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0026:  ldarg.0
+    IL_0027:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_002c:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0031:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_0036:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_003b:  stloc.s    V_4
+    IL_003d:  ldloca.s   V_4
     IL_003f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0044:  brtrue.s   IL_0085
+    IL_0044:  brtrue.s   IL_0087
     IL_0046:  ldarg.0
     IL_0047:  ldc.i4.0
     IL_0048:  dup
     IL_0049:  stloc.0
     IL_004a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_004f:  ldarg.0
-    IL_0050:  ldloc.3
-    IL_0051:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0056:  ldarg.0
-    IL_0057:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_005c:  ldloca.s   V_3
-    IL_005e:  ldarg.0
-    IL_005f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
-    IL_0064:  leave      IL_0156
-    IL_0069:  ldarg.0
-    IL_006a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_006f:  stloc.3
-    IL_0070:  ldarg.0
-    IL_0071:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0076:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_007c:  ldarg.0
-    IL_007d:  ldc.i4.m1
-    IL_007e:  dup
-    IL_007f:  stloc.0
-    IL_0080:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0085:  ldloca.s   V_3
-    IL_0087:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_008c:  stloc.1
-    IL_008d:  ldtoken    ""T""
-    IL_0092:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0097:  call       ""bool System.Type.IsValueType.get""
-    IL_009c:  brtrue.s   IL_00a6
-    IL_009e:  ldarg.0
-    IL_009f:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00a4:  br.s       IL_00ac
-    IL_00a6:  ldarg.0
-    IL_00a7:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00ac:  constrained. ""T""
-    IL_00b2:  callvirt   ""int IMoveable.Length.get""
-    IL_00b7:  ldloc.1
-    IL_00b8:  sub
-    IL_00b9:  stloc.2
-    IL_00ba:  ldtoken    ""T""
-    IL_00bf:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00c4:  call       ""bool System.Type.IsValueType.get""
+    IL_0050:  ldloc.s    V_4
+    IL_0052:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0057:  ldarg.0
+    IL_0058:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_005d:  ldloca.s   V_4
+    IL_005f:  ldarg.0
+    IL_0060:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
+    IL_0065:  leave      IL_0155
+    IL_006a:  ldarg.0
+    IL_006b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0070:  stloc.s    V_4
+    IL_0072:  ldarg.0
+    IL_0073:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0078:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_007e:  ldarg.0
+    IL_007f:  ldc.i4.m1
+    IL_0080:  dup
+    IL_0081:  stloc.0
+    IL_0082:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0087:  ldloca.s   V_4
+    IL_0089:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_008e:  stloc.1
+    IL_008f:  ldloca.s   V_3
+    IL_0091:  initobj    ""T""
+    IL_0097:  ldloc.3
+    IL_0098:  box        ""T""
+    IL_009d:  brtrue.s   IL_00a7
+    IL_009f:  ldarg.0
+    IL_00a0:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00a5:  br.s       IL_00ad
+    IL_00a7:  ldarg.0
+    IL_00a8:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00ad:  constrained. ""T""
+    IL_00b3:  callvirt   ""int IMoveable.Length.get""
+    IL_00b8:  ldloc.1
+    IL_00b9:  sub
+    IL_00ba:  stloc.2
+    IL_00bb:  ldloca.s   V_3
+    IL_00bd:  initobj    ""T""
+    IL_00c3:  ldloc.3
+    IL_00c4:  box        ""T""
     IL_00c9:  brtrue.s   IL_00d3
     IL_00cb:  ldarg.0
     IL_00cc:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -21776,48 +21938,49 @@ Position set for item '2'
     IL_00d3:  ldarg.0
     IL_00d4:  ldflda     ""T Program.<Shift2>d__2<T>.item""
     IL_00d9:  ldloc.2
-    IL_00da:  ldtoken    ""T""
-    IL_00df:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00e4:  call       ""bool System.Type.IsValueType.get""
-    IL_00e9:  brtrue.s   IL_00f3
-    IL_00eb:  ldarg.0
-    IL_00ec:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00f1:  br.s       IL_00f9
-    IL_00f3:  ldarg.0
-    IL_00f4:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00f9:  ldloc.2
-    IL_00fa:  constrained. ""T""
-    IL_0100:  callvirt   ""int IMoveable.this[int].get""
-    IL_0105:  ldarg.0
-    IL_0106:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_010b:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0110:  add
-    IL_0111:  constrained. ""T""
-    IL_0117:  callvirt   ""void IMoveable.this[int].set""
-    IL_011c:  ldarg.0
-    IL_011d:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0122:  initobj    ""T""
-    IL_0128:  leave.s    IL_0143
+    IL_00da:  ldloca.s   V_3
+    IL_00dc:  initobj    ""T""
+    IL_00e2:  ldloc.3
+    IL_00e3:  box        ""T""
+    IL_00e8:  brtrue.s   IL_00f2
+    IL_00ea:  ldarg.0
+    IL_00eb:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00f0:  br.s       IL_00f8
+    IL_00f2:  ldarg.0
+    IL_00f3:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00f8:  ldloc.2
+    IL_00f9:  constrained. ""T""
+    IL_00ff:  callvirt   ""int IMoveable.this[int].get""
+    IL_0104:  ldarg.0
+    IL_0105:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_010a:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_010f:  add
+    IL_0110:  constrained. ""T""
+    IL_0116:  callvirt   ""void IMoveable.this[int].set""
+    IL_011b:  ldarg.0
+    IL_011c:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0121:  initobj    ""T""
+    IL_0127:  leave.s    IL_0142
   }
   catch System.Exception
   {
-    IL_012a:  stloc.s    V_4
-    IL_012c:  ldarg.0
-    IL_012d:  ldc.i4.s   -2
-    IL_012f:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0134:  ldarg.0
-    IL_0135:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_013a:  ldloc.s    V_4
-    IL_013c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_0141:  leave.s    IL_0156
+    IL_0129:  stloc.s    V_5
+    IL_012b:  ldarg.0
+    IL_012c:  ldc.i4.s   -2
+    IL_012e:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0133:  ldarg.0
+    IL_0134:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_0139:  ldloc.s    V_5
+    IL_013b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0140:  leave.s    IL_0155
   }
-  IL_0143:  ldarg.0
-  IL_0144:  ldc.i4.s   -2
-  IL_0146:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-  IL_014b:  ldarg.0
-  IL_014c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-  IL_0151:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_0156:  ret
+  IL_0142:  ldarg.0
+  IL_0143:  ldc.i4.s   -2
+  IL_0145:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+  IL_014a:  ldarg.0
+  IL_014b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+  IL_0150:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0155:  ret
 }
 ");
         }
@@ -22263,8 +22426,9 @@ Position set for item '2'
                 int V_1,
                 int V_2,
                 int V_3,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
-                System.Exception V_5)
+                T V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_5,
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -22275,9 +22439,10 @@ Position set for item '2'
     IL_000a:  ldloc.0
     IL_000b:  ldc.i4.1
     IL_000c:  beq        IL_0140
-    IL_0011:  ldtoken    ""T""
-    IL_0016:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_001b:  call       ""bool System.Type.IsValueType.get""
+    IL_0011:  ldloca.s   V_4
+    IL_0013:  initobj    ""T""
+    IL_0019:  ldloc.s    V_4
+    IL_001b:  box        ""T""
     IL_0020:  brtrue.s   IL_002e
     IL_0022:  ldarg.0
     IL_0023:  ldarg.0
@@ -22288,8 +22453,8 @@ Position set for item '2'
     IL_0034:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0039:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_003e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0043:  stloc.s    V_4
-    IL_0045:  ldloca.s   V_4
+    IL_0043:  stloc.s    V_5
+    IL_0045:  ldloca.s   V_5
     IL_0047:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_004c:  brtrue.s   IL_008f
     IL_004e:  ldarg.0
@@ -22298,17 +22463,17 @@ Position set for item '2'
     IL_0051:  stloc.0
     IL_0052:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0057:  ldarg.0
-    IL_0058:  ldloc.s    V_4
+    IL_0058:  ldloc.s    V_5
     IL_005a:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_005f:  ldarg.0
     IL_0060:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0065:  ldloca.s   V_4
+    IL_0065:  ldloca.s   V_5
     IL_0067:  ldarg.0
     IL_0068:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_006d:  leave      IL_01d7
     IL_0072:  ldarg.0
     IL_0073:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0078:  stloc.s    V_4
+    IL_0078:  stloc.s    V_5
     IL_007a:  ldarg.0
     IL_007b:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_0080:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -22317,12 +22482,13 @@ Position set for item '2'
     IL_0088:  dup
     IL_0089:  stloc.0
     IL_008a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_008f:  ldloca.s   V_4
+    IL_008f:  ldloca.s   V_5
     IL_0091:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_0096:  stloc.1
-    IL_0097:  ldtoken    ""T""
-    IL_009c:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00a1:  call       ""bool System.Type.IsValueType.get""
+    IL_0097:  ldloca.s   V_4
+    IL_0099:  initobj    ""T""
+    IL_009f:  ldloc.s    V_4
+    IL_00a1:  box        ""T""
     IL_00a6:  brtrue.s   IL_00b0
     IL_00a8:  ldarg.0
     IL_00a9:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -22338,9 +22504,10 @@ Position set for item '2'
     IL_00c5:  ldloc.2
     IL_00c6:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
     IL_00cb:  ldarg.0
-    IL_00cc:  ldtoken    ""T""
-    IL_00d1:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00d6:  call       ""bool System.Type.IsValueType.get""
+    IL_00cc:  ldloca.s   V_4
+    IL_00ce:  initobj    ""T""
+    IL_00d4:  ldloc.s    V_4
+    IL_00d6:  box        ""T""
     IL_00db:  brtrue.s   IL_00e5
     IL_00dd:  ldarg.0
     IL_00de:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -22356,8 +22523,8 @@ Position set for item '2'
     IL_0102:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0107:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_010c:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0111:  stloc.s    V_4
-    IL_0113:  ldloca.s   V_4
+    IL_0111:  stloc.s    V_5
+    IL_0113:  ldloca.s   V_5
     IL_0115:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_011a:  brtrue.s   IL_015d
     IL_011c:  ldarg.0
@@ -22366,17 +22533,17 @@ Position set for item '2'
     IL_011f:  stloc.0
     IL_0120:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0125:  ldarg.0
-    IL_0126:  ldloc.s    V_4
+    IL_0126:  ldloc.s    V_5
     IL_0128:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_012d:  ldarg.0
     IL_012e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0133:  ldloca.s   V_4
+    IL_0133:  ldloca.s   V_5
     IL_0135:  ldarg.0
     IL_0136:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_013b:  leave      IL_01d7
     IL_0140:  ldarg.0
     IL_0141:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0146:  stloc.s    V_4
+    IL_0146:  stloc.s    V_5
     IL_0148:  ldarg.0
     IL_0149:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_014e:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -22385,12 +22552,13 @@ Position set for item '2'
     IL_0156:  dup
     IL_0157:  stloc.0
     IL_0158:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_015d:  ldloca.s   V_4
+    IL_015d:  ldloca.s   V_5
     IL_015f:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_0164:  stloc.3
-    IL_0165:  ldtoken    ""T""
-    IL_016a:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_016f:  call       ""bool System.Type.IsValueType.get""
+    IL_0165:  ldloca.s   V_4
+    IL_0167:  initobj    ""T""
+    IL_016d:  ldloc.s    V_4
+    IL_016f:  box        ""T""
     IL_0174:  brtrue.s   IL_017e
     IL_0176:  ldarg.0
     IL_0177:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -22412,13 +22580,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_01ab:  stloc.s    V_5
+    IL_01ab:  stloc.s    V_6
     IL_01ad:  ldarg.0
     IL_01ae:  ldc.i4.s   -2
     IL_01b0:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_01b5:  ldarg.0
     IL_01b6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_01bb:  ldloc.s    V_5
+    IL_01bb:  ldloc.s    V_6
     IL_01bd:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_01c2:  leave.s    IL_01d7
   }
@@ -22804,12 +22972,14 @@ Position set for item '2'
                 int V_4,
                 int? V_5,
                 int V_6,
-                int? V_7)
+                T V_7,
+                int? V_8)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.2
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
+  IL_0003:  ldloca.s   V_7
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_7
+  IL_000d:  box        ""T""
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.2
   IL_0015:  ldobj      ""T""
@@ -22842,10 +23012,10 @@ Position set for item '2'
   IL_005c:  stloc.s    V_6
   IL_005e:  ldloc.0
   IL_005f:  ldloc.s    V_4
-  IL_0061:  ldloca.s   V_7
+  IL_0061:  ldloca.s   V_8
   IL_0063:  ldloc.s    V_6
   IL_0065:  call       ""int?..ctor(int)""
-  IL_006a:  ldloc.s    V_7
+  IL_006a:  ldloc.s    V_8
   IL_006c:  constrained. ""T""
   IL_0072:  callvirt   ""void IMoveable.this[int].set""
   IL_0077:  ret
@@ -23119,12 +23289,14 @@ Position set for item '2'
                 int V_4,
                 int? V_5,
                 int V_6,
-                int? V_7)
+                T V_7,
+                int? V_8)
   IL_0000:  ldarg.0
   IL_0001:  stloc.2
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
+  IL_0002:  ldloca.s   V_7
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_7
+  IL_000c:  box        ""T""
   IL_0011:  brtrue.s   IL_001e
   IL_0013:  ldloc.2
   IL_0014:  ldobj      ""T""
@@ -23157,10 +23329,10 @@ Position set for item '2'
   IL_005a:  stloc.s    V_6
   IL_005c:  ldloc.0
   IL_005d:  ldloc.s    V_4
-  IL_005f:  ldloca.s   V_7
+  IL_005f:  ldloca.s   V_8
   IL_0061:  ldloc.s    V_6
   IL_0063:  call       ""int?..ctor(int)""
-  IL_0068:  ldloc.s    V_7
+  IL_0068:  ldloc.s    V_8
   IL_006a:  constrained. ""T""
   IL_0070:  callvirt   ""void IMoveable.this[int].set""
   IL_0075:  ret
@@ -23509,9 +23681,10 @@ Position set for item '2'
                 int V_2,
                 int? V_3,
                 int V_4,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_5,
-                int? V_6,
-                System.Exception V_7)
+                T V_5,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_6,
+                int? V_7,
+                System.Exception V_8)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -23519,9 +23692,10 @@ Position set for item '2'
   {
     IL_0007:  ldloc.0
     IL_0008:  brfalse.s  IL_006b
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
+    IL_000a:  ldloca.s   V_5
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.s    V_5
+    IL_0014:  box        ""T""
     IL_0019:  brtrue.s   IL_0027
     IL_001b:  ldarg.0
     IL_001c:  ldarg.0
@@ -23532,8 +23706,8 @@ Position set for item '2'
     IL_002d:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0032:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003c:  stloc.s    V_5
-    IL_003e:  ldloca.s   V_5
+    IL_003c:  stloc.s    V_6
+    IL_003e:  ldloca.s   V_6
     IL_0040:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_0045:  brtrue.s   IL_0088
     IL_0047:  ldarg.0
@@ -23542,17 +23716,17 @@ Position set for item '2'
     IL_004a:  stloc.0
     IL_004b:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0050:  ldarg.0
-    IL_0051:  ldloc.s    V_5
+    IL_0051:  ldloc.s    V_6
     IL_0053:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_0058:  ldarg.0
     IL_0059:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_005e:  ldloca.s   V_5
+    IL_005e:  ldloca.s   V_6
     IL_0060:  ldarg.0
     IL_0061:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_0066:  leave      IL_016d
     IL_006b:  ldarg.0
     IL_006c:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0071:  stloc.s    V_5
+    IL_0071:  stloc.s    V_6
     IL_0073:  ldarg.0
     IL_0074:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_0079:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -23561,12 +23735,13 @@ Position set for item '2'
     IL_0081:  dup
     IL_0082:  stloc.0
     IL_0083:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0088:  ldloca.s   V_5
+    IL_0088:  ldloca.s   V_6
     IL_008a:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_008f:  stloc.1
-    IL_0090:  ldtoken    ""T""
-    IL_0095:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_009a:  call       ""bool System.Type.IsValueType.get""
+    IL_0090:  ldloca.s   V_5
+    IL_0092:  initobj    ""T""
+    IL_0098:  ldloc.s    V_5
+    IL_009a:  box        ""T""
     IL_009f:  brtrue.s   IL_00a9
     IL_00a1:  ldarg.0
     IL_00a2:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -23578,9 +23753,10 @@ Position set for item '2'
     IL_00ba:  ldloc.1
     IL_00bb:  sub
     IL_00bc:  stloc.2
-    IL_00bd:  ldtoken    ""T""
-    IL_00c2:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00c7:  call       ""bool System.Type.IsValueType.get""
+    IL_00bd:  ldloca.s   V_5
+    IL_00bf:  initobj    ""T""
+    IL_00c5:  ldloc.s    V_5
+    IL_00c7:  box        ""T""
     IL_00cc:  brtrue.s   IL_00d6
     IL_00ce:  ldarg.0
     IL_00cf:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -23599,9 +23775,10 @@ Position set for item '2'
     IL_00f9:  brtrue.s   IL_0133
     IL_00fb:  ldc.i4.1
     IL_00fc:  stloc.s    V_4
-    IL_00fe:  ldtoken    ""T""
-    IL_0103:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0108:  call       ""bool System.Type.IsValueType.get""
+    IL_00fe:  ldloca.s   V_5
+    IL_0100:  initobj    ""T""
+    IL_0106:  ldloc.s    V_5
+    IL_0108:  box        ""T""
     IL_010d:  brtrue.s   IL_0117
     IL_010f:  ldarg.0
     IL_0110:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -23612,7 +23789,7 @@ Position set for item '2'
     IL_011e:  ldloc.s    V_4
     IL_0120:  newobj     ""int?..ctor(int)""
     IL_0125:  dup
-    IL_0126:  stloc.s    V_6
+    IL_0126:  stloc.s    V_7
     IL_0128:  constrained. ""T""
     IL_012e:  callvirt   ""void IMoveable.this[int].set""
     IL_0133:  ldarg.0
@@ -23622,13 +23799,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_0141:  stloc.s    V_7
+    IL_0141:  stloc.s    V_8
     IL_0143:  ldarg.0
     IL_0144:  ldc.i4.s   -2
     IL_0146:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_014b:  ldarg.0
     IL_014c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0151:  ldloc.s    V_7
+    IL_0151:  ldloc.s    V_8
     IL_0153:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0158:  leave.s    IL_016d
   }
@@ -23975,12 +24152,14 @@ Position set for item '2'
                 int V_3,
                 int? V_4,
                 int V_5,
-                int? V_6)
+                T V_6,
+                int? V_7)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.2
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
+  IL_0003:  ldloca.s   V_6
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_6
+  IL_000d:  box        ""T""
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.2
   IL_0015:  ldobj      ""T""
@@ -24011,10 +24190,10 @@ Position set for item '2'
   IL_0058:  stloc.s    V_5
   IL_005a:  ldloc.0
   IL_005b:  ldloc.3
-  IL_005c:  ldloca.s   V_6
+  IL_005c:  ldloca.s   V_7
   IL_005e:  ldloc.s    V_5
   IL_0060:  call       ""int?..ctor(int)""
-  IL_0065:  ldloc.s    V_6
+  IL_0065:  ldloc.s    V_7
   IL_0067:  constrained. ""T""
   IL_006d:  callvirt   ""void IMoveable.this[int].set""
   IL_0072:  ret
@@ -24281,12 +24460,14 @@ Position set for item '2'
                 int V_3,
                 int? V_4,
                 int V_5,
-                int? V_6)
+                T V_6,
+                int? V_7)
   IL_0000:  ldarg.0
   IL_0001:  stloc.2
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
+  IL_0002:  ldloca.s   V_6
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_6
+  IL_000c:  box        ""T""
   IL_0011:  brtrue.s   IL_001e
   IL_0013:  ldloc.2
   IL_0014:  ldobj      ""T""
@@ -24317,10 +24498,10 @@ Position set for item '2'
   IL_0056:  stloc.s    V_5
   IL_0058:  ldloc.0
   IL_0059:  ldloc.3
-  IL_005a:  ldloca.s   V_6
+  IL_005a:  ldloca.s   V_7
   IL_005c:  ldloc.s    V_5
   IL_005e:  call       ""int?..ctor(int)""
-  IL_0063:  ldloc.s    V_6
+  IL_0063:  ldloc.s    V_7
   IL_0065:  constrained. ""T""
   IL_006b:  callvirt   ""void IMoveable.this[int].set""
   IL_0070:  ret
@@ -24658,90 +24839,94 @@ Position set for item '2'
             verifier.VerifyIL("Program.<Shift2>d__2<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"
 {
-  // Code size      379 (0x17b)
+  // Code size      378 (0x17a)
   .maxstack  4
   .locals init (int V_0,
                 int? V_1,
                 int V_2,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
-                int? V_4,
-                System.Exception V_5)
+                T V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
+                int? V_5,
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse    IL_00e3
-    IL_000d:  ldtoken    ""T""
-    IL_0012:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0017:  call       ""bool System.Type.IsValueType.get""
-    IL_001c:  brtrue.s   IL_002a
+    IL_0008:  brfalse    IL_00e2
+    IL_000d:  ldloca.s   V_3
+    IL_000f:  initobj    ""T""
+    IL_0015:  ldloc.3
+    IL_0016:  box        ""T""
+    IL_001b:  brtrue.s   IL_0029
+    IL_001d:  ldarg.0
     IL_001e:  ldarg.0
-    IL_001f:  ldarg.0
-    IL_0020:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0025:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_002a:  ldarg.0
-    IL_002b:  ldtoken    ""T""
-    IL_0030:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0035:  call       ""bool System.Type.IsValueType.get""
-    IL_003a:  brtrue.s   IL_0044
-    IL_003c:  ldarg.0
-    IL_003d:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0042:  br.s       IL_004a
-    IL_0044:  ldarg.0
-    IL_0045:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_004a:  constrained. ""T""
-    IL_0050:  callvirt   ""int IMoveable.Length.get""
-    IL_0055:  ldc.i4.1
-    IL_0056:  sub
-    IL_0057:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_005c:  ldtoken    ""T""
-    IL_0061:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0066:  call       ""bool System.Type.IsValueType.get""
-    IL_006b:  brtrue.s   IL_0075
-    IL_006d:  ldarg.0
-    IL_006e:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0073:  br.s       IL_007b
-    IL_0075:  ldarg.0
-    IL_0076:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_007b:  ldarg.0
-    IL_007c:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_0081:  constrained. ""T""
-    IL_0087:  callvirt   ""int? IMoveable.this[int].get""
-    IL_008c:  stloc.1
-    IL_008d:  ldloca.s   V_1
-    IL_008f:  call       ""readonly int int?.GetValueOrDefault()""
-    IL_0094:  stloc.2
-    IL_0095:  ldloca.s   V_1
-    IL_0097:  call       ""readonly bool int?.HasValue.get""
-    IL_009c:  brtrue     IL_0140
-    IL_00a1:  ldarg.0
-    IL_00a2:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00a7:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_00ac:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_00b1:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_00b6:  stloc.3
-    IL_00b7:  ldloca.s   V_3
-    IL_00b9:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_00be:  brtrue.s   IL_00ff
-    IL_00c0:  ldarg.0
-    IL_00c1:  ldc.i4.0
-    IL_00c2:  dup
-    IL_00c3:  stloc.0
-    IL_00c4:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00c9:  ldarg.0
-    IL_00ca:  ldloc.3
-    IL_00cb:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00d0:  ldarg.0
-    IL_00d1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_00d6:  ldloca.s   V_3
-    IL_00d8:  ldarg.0
-    IL_00d9:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
-    IL_00de:  leave      IL_017a
-    IL_00e3:  ldarg.0
-    IL_00e4:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00e9:  stloc.3
+    IL_001f:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0024:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0029:  ldarg.0
+    IL_002a:  ldloca.s   V_3
+    IL_002c:  initobj    ""T""
+    IL_0032:  ldloc.3
+    IL_0033:  box        ""T""
+    IL_0038:  brtrue.s   IL_0042
+    IL_003a:  ldarg.0
+    IL_003b:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0040:  br.s       IL_0048
+    IL_0042:  ldarg.0
+    IL_0043:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0048:  constrained. ""T""
+    IL_004e:  callvirt   ""int IMoveable.Length.get""
+    IL_0053:  ldc.i4.1
+    IL_0054:  sub
+    IL_0055:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_005a:  ldloca.s   V_3
+    IL_005c:  initobj    ""T""
+    IL_0062:  ldloc.3
+    IL_0063:  box        ""T""
+    IL_0068:  brtrue.s   IL_0072
+    IL_006a:  ldarg.0
+    IL_006b:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0070:  br.s       IL_0078
+    IL_0072:  ldarg.0
+    IL_0073:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0078:  ldarg.0
+    IL_0079:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_007e:  constrained. ""T""
+    IL_0084:  callvirt   ""int? IMoveable.this[int].get""
+    IL_0089:  stloc.1
+    IL_008a:  ldloca.s   V_1
+    IL_008c:  call       ""readonly int int?.GetValueOrDefault()""
+    IL_0091:  stloc.2
+    IL_0092:  ldloca.s   V_1
+    IL_0094:  call       ""readonly bool int?.HasValue.get""
+    IL_0099:  brtrue     IL_013f
+    IL_009e:  ldarg.0
+    IL_009f:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00a4:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_00a9:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_00ae:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_00b3:  stloc.s    V_4
+    IL_00b5:  ldloca.s   V_4
+    IL_00b7:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_00bc:  brtrue.s   IL_00ff
+    IL_00be:  ldarg.0
+    IL_00bf:  ldc.i4.0
+    IL_00c0:  dup
+    IL_00c1:  stloc.0
+    IL_00c2:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00c7:  ldarg.0
+    IL_00c8:  ldloc.s    V_4
+    IL_00ca:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_00cf:  ldarg.0
+    IL_00d0:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_00d5:  ldloca.s   V_4
+    IL_00d7:  ldarg.0
+    IL_00d8:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
+    IL_00dd:  leave      IL_0179
+    IL_00e2:  ldarg.0
+    IL_00e3:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_00e8:  stloc.s    V_4
     IL_00ea:  ldarg.0
     IL_00eb:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_00f0:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -24750,50 +24935,51 @@ Position set for item '2'
     IL_00f8:  dup
     IL_00f9:  stloc.0
     IL_00fa:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00ff:  ldloca.s   V_3
+    IL_00ff:  ldloca.s   V_4
     IL_0101:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_0106:  stloc.2
-    IL_0107:  ldtoken    ""T""
-    IL_010c:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0111:  call       ""bool System.Type.IsValueType.get""
-    IL_0116:  brtrue.s   IL_0120
-    IL_0118:  ldarg.0
-    IL_0119:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_011e:  br.s       IL_0126
-    IL_0120:  ldarg.0
-    IL_0121:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_0126:  ldarg.0
-    IL_0127:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_012c:  ldloc.2
-    IL_012d:  newobj     ""int?..ctor(int)""
-    IL_0132:  dup
-    IL_0133:  stloc.s    V_4
-    IL_0135:  constrained. ""T""
-    IL_013b:  callvirt   ""void IMoveable.this[int].set""
-    IL_0140:  ldarg.0
-    IL_0141:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0146:  initobj    ""T""
-    IL_014c:  leave.s    IL_0167
+    IL_0107:  ldloca.s   V_3
+    IL_0109:  initobj    ""T""
+    IL_010f:  ldloc.3
+    IL_0110:  box        ""T""
+    IL_0115:  brtrue.s   IL_011f
+    IL_0117:  ldarg.0
+    IL_0118:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_011d:  br.s       IL_0125
+    IL_011f:  ldarg.0
+    IL_0120:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0125:  ldarg.0
+    IL_0126:  ldfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_012b:  ldloc.2
+    IL_012c:  newobj     ""int?..ctor(int)""
+    IL_0131:  dup
+    IL_0132:  stloc.s    V_5
+    IL_0134:  constrained. ""T""
+    IL_013a:  callvirt   ""void IMoveable.this[int].set""
+    IL_013f:  ldarg.0
+    IL_0140:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0145:  initobj    ""T""
+    IL_014b:  leave.s    IL_0166
   }
   catch System.Exception
   {
-    IL_014e:  stloc.s    V_5
-    IL_0150:  ldarg.0
-    IL_0151:  ldc.i4.s   -2
-    IL_0153:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0158:  ldarg.0
-    IL_0159:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_015e:  ldloc.s    V_5
-    IL_0160:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_0165:  leave.s    IL_017a
+    IL_014d:  stloc.s    V_6
+    IL_014f:  ldarg.0
+    IL_0150:  ldc.i4.s   -2
+    IL_0152:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0157:  ldarg.0
+    IL_0158:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_015d:  ldloc.s    V_6
+    IL_015f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0164:  leave.s    IL_0179
   }
-  IL_0167:  ldarg.0
-  IL_0168:  ldc.i4.s   -2
-  IL_016a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-  IL_016f:  ldarg.0
-  IL_0170:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-  IL_0175:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_017a:  ret
+  IL_0166:  ldarg.0
+  IL_0167:  ldc.i4.s   -2
+  IL_0169:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+  IL_016e:  ldarg.0
+  IL_016f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+  IL_0174:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_0179:  ret
 }
 ");
         }
@@ -25134,12 +25320,14 @@ Position set for item '2'
                 int V_4,
                 int? V_5,
                 int V_6,
-                int? V_7)
+                T V_7,
+                int? V_8)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.2
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
+  IL_0003:  ldloca.s   V_7
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_7
+  IL_000d:  box        ""T""
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.2
   IL_0015:  ldobj      ""T""
@@ -25173,10 +25361,10 @@ Position set for item '2'
   IL_0062:  stloc.s    V_6
   IL_0064:  ldloc.0
   IL_0065:  ldloc.s    V_4
-  IL_0067:  ldloca.s   V_7
+  IL_0067:  ldloca.s   V_8
   IL_0069:  ldloc.s    V_6
   IL_006b:  call       ""int?..ctor(int)""
-  IL_0070:  ldloc.s    V_7
+  IL_0070:  ldloc.s    V_8
   IL_0072:  constrained. ""T""
   IL_0078:  callvirt   ""void IMoveable.this[int].set""
   IL_007d:  ret
@@ -25452,12 +25640,14 @@ Position set for item '2'
                 int V_4,
                 int? V_5,
                 int V_6,
-                int? V_7)
+                T V_7,
+                int? V_8)
   IL_0000:  ldarg.0
   IL_0001:  stloc.2
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
+  IL_0002:  ldloca.s   V_7
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_7
+  IL_000c:  box        ""T""
   IL_0011:  brtrue.s   IL_001e
   IL_0013:  ldloc.2
   IL_0014:  ldobj      ""T""
@@ -25491,10 +25681,10 @@ Position set for item '2'
   IL_005f:  stloc.s    V_6
   IL_0061:  ldloc.0
   IL_0062:  ldloc.s    V_4
-  IL_0064:  ldloca.s   V_7
+  IL_0064:  ldloca.s   V_8
   IL_0066:  ldloc.s    V_6
   IL_0068:  call       ""int?..ctor(int)""
-  IL_006d:  ldloc.s    V_7
+  IL_006d:  ldloc.s    V_8
   IL_006f:  constrained. ""T""
   IL_0075:  callvirt   ""void IMoveable.this[int].set""
   IL_007a:  ret
@@ -25847,9 +26037,10 @@ Position set for item '2'
                 int V_1,
                 int? V_2,
                 int V_3,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
-                int? V_5,
-                System.Exception V_6)
+                T V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_5,
+                int? V_6,
+                System.Exception V_7)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -25857,9 +26048,10 @@ Position set for item '2'
   {
     IL_0007:  ldloc.0
     IL_0008:  brfalse    IL_00f1
-    IL_000d:  ldtoken    ""T""
-    IL_0012:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0017:  call       ""bool System.Type.IsValueType.get""
+    IL_000d:  ldloca.s   V_4
+    IL_000f:  initobj    ""T""
+    IL_0015:  ldloc.s    V_4
+    IL_0017:  box        ""T""
     IL_001c:  brtrue.s   IL_002a
     IL_001e:  ldarg.0
     IL_001f:  ldarg.0
@@ -25870,9 +26062,10 @@ Position set for item '2'
     IL_0030:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0035:  stloc.1
     IL_0036:  ldarg.0
-    IL_0037:  ldtoken    ""T""
-    IL_003c:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0041:  call       ""bool System.Type.IsValueType.get""
+    IL_0037:  ldloca.s   V_4
+    IL_0039:  initobj    ""T""
+    IL_003f:  ldloc.s    V_4
+    IL_0041:  box        ""T""
     IL_0046:  brtrue.s   IL_0050
     IL_0048:  ldarg.0
     IL_0049:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -25884,9 +26077,10 @@ Position set for item '2'
     IL_0061:  ldloc.1
     IL_0062:  sub
     IL_0063:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_0068:  ldtoken    ""T""
-    IL_006d:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0072:  call       ""bool System.Type.IsValueType.get""
+    IL_0068:  ldloca.s   V_4
+    IL_006a:  initobj    ""T""
+    IL_0070:  ldloc.s    V_4
+    IL_0072:  box        ""T""
     IL_0077:  brtrue.s   IL_0081
     IL_0079:  ldarg.0
     IL_007a:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -25909,8 +26103,8 @@ Position set for item '2'
     IL_00b3:  call       ""int Program.GetOffset<T>(ref T)""
     IL_00b8:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_00bd:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_00c2:  stloc.s    V_4
-    IL_00c4:  ldloca.s   V_4
+    IL_00c2:  stloc.s    V_5
+    IL_00c4:  ldloca.s   V_5
     IL_00c6:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_00cb:  brtrue.s   IL_010e
     IL_00cd:  ldarg.0
@@ -25919,17 +26113,17 @@ Position set for item '2'
     IL_00d0:  stloc.0
     IL_00d1:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_00d6:  ldarg.0
-    IL_00d7:  ldloc.s    V_4
+    IL_00d7:  ldloc.s    V_5
     IL_00d9:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_00de:  ldarg.0
     IL_00df:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_00e4:  ldloca.s   V_4
+    IL_00e4:  ldloca.s   V_5
     IL_00e6:  ldarg.0
     IL_00e7:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_00ec:  leave      IL_0189
     IL_00f1:  ldarg.0
     IL_00f2:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00f7:  stloc.s    V_4
+    IL_00f7:  stloc.s    V_5
     IL_00f9:  ldarg.0
     IL_00fa:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_00ff:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -25938,12 +26132,13 @@ Position set for item '2'
     IL_0107:  dup
     IL_0108:  stloc.0
     IL_0109:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_010e:  ldloca.s   V_4
+    IL_010e:  ldloca.s   V_5
     IL_0110:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_0115:  stloc.3
-    IL_0116:  ldtoken    ""T""
-    IL_011b:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0120:  call       ""bool System.Type.IsValueType.get""
+    IL_0116:  ldloca.s   V_4
+    IL_0118:  initobj    ""T""
+    IL_011e:  ldloc.s    V_4
+    IL_0120:  box        ""T""
     IL_0125:  brtrue.s   IL_012f
     IL_0127:  ldarg.0
     IL_0128:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -25955,7 +26150,7 @@ Position set for item '2'
     IL_013b:  ldloc.3
     IL_013c:  newobj     ""int?..ctor(int)""
     IL_0141:  dup
-    IL_0142:  stloc.s    V_5
+    IL_0142:  stloc.s    V_6
     IL_0144:  constrained. ""T""
     IL_014a:  callvirt   ""void IMoveable.this[int].set""
     IL_014f:  ldarg.0
@@ -25965,13 +26160,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_015d:  stloc.s    V_6
+    IL_015d:  stloc.s    V_7
     IL_015f:  ldarg.0
     IL_0160:  ldc.i4.s   -2
     IL_0162:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0167:  ldarg.0
     IL_0168:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_016d:  ldloc.s    V_6
+    IL_016d:  ldloc.s    V_7
     IL_016f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0174:  leave.s    IL_0189
   }
@@ -26404,9 +26599,10 @@ Position set for item '2'
                 int V_2,
                 int? V_3,
                 int V_4,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_5,
-                int? V_6,
-                System.Exception V_7)
+                T V_5,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_6,
+                int? V_7,
+                System.Exception V_8)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -26414,9 +26610,10 @@ Position set for item '2'
   {
     IL_0007:  ldloc.0
     IL_0008:  brfalse.s  IL_006b
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
+    IL_000a:  ldloca.s   V_5
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.s    V_5
+    IL_0014:  box        ""T""
     IL_0019:  brtrue.s   IL_0027
     IL_001b:  ldarg.0
     IL_001c:  ldarg.0
@@ -26427,8 +26624,8 @@ Position set for item '2'
     IL_002d:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0032:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003c:  stloc.s    V_5
-    IL_003e:  ldloca.s   V_5
+    IL_003c:  stloc.s    V_6
+    IL_003e:  ldloca.s   V_6
     IL_0040:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_0045:  brtrue.s   IL_0088
     IL_0047:  ldarg.0
@@ -26437,17 +26634,17 @@ Position set for item '2'
     IL_004a:  stloc.0
     IL_004b:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0050:  ldarg.0
-    IL_0051:  ldloc.s    V_5
+    IL_0051:  ldloc.s    V_6
     IL_0053:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_0058:  ldarg.0
     IL_0059:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_005e:  ldloca.s   V_5
+    IL_005e:  ldloca.s   V_6
     IL_0060:  ldarg.0
     IL_0061:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_0066:  leave      IL_0177
     IL_006b:  ldarg.0
     IL_006c:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0071:  stloc.s    V_5
+    IL_0071:  stloc.s    V_6
     IL_0073:  ldarg.0
     IL_0074:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_0079:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -26456,12 +26653,13 @@ Position set for item '2'
     IL_0081:  dup
     IL_0082:  stloc.0
     IL_0083:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0088:  ldloca.s   V_5
+    IL_0088:  ldloca.s   V_6
     IL_008a:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_008f:  stloc.1
-    IL_0090:  ldtoken    ""T""
-    IL_0095:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_009a:  call       ""bool System.Type.IsValueType.get""
+    IL_0090:  ldloca.s   V_5
+    IL_0092:  initobj    ""T""
+    IL_0098:  ldloc.s    V_5
+    IL_009a:  box        ""T""
     IL_009f:  brtrue.s   IL_00a9
     IL_00a1:  ldarg.0
     IL_00a2:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -26473,9 +26671,10 @@ Position set for item '2'
     IL_00ba:  ldloc.1
     IL_00bb:  sub
     IL_00bc:  stloc.2
-    IL_00bd:  ldtoken    ""T""
-    IL_00c2:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00c7:  call       ""bool System.Type.IsValueType.get""
+    IL_00bd:  ldloca.s   V_5
+    IL_00bf:  initobj    ""T""
+    IL_00c5:  ldloc.s    V_5
+    IL_00c7:  box        ""T""
     IL_00cc:  brtrue.s   IL_00d6
     IL_00ce:  ldarg.0
     IL_00cf:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -26496,9 +26695,10 @@ Position set for item '2'
     IL_00fc:  ldflda     ""T Program.<Shift2>d__2<T>.item""
     IL_0101:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0106:  stloc.s    V_4
-    IL_0108:  ldtoken    ""T""
-    IL_010d:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0112:  call       ""bool System.Type.IsValueType.get""
+    IL_0108:  ldloca.s   V_5
+    IL_010a:  initobj    ""T""
+    IL_0110:  ldloc.s    V_5
+    IL_0112:  box        ""T""
     IL_0117:  brtrue.s   IL_0121
     IL_0119:  ldarg.0
     IL_011a:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -26509,7 +26709,7 @@ Position set for item '2'
     IL_0128:  ldloc.s    V_4
     IL_012a:  newobj     ""int?..ctor(int)""
     IL_012f:  dup
-    IL_0130:  stloc.s    V_6
+    IL_0130:  stloc.s    V_7
     IL_0132:  constrained. ""T""
     IL_0138:  callvirt   ""void IMoveable.this[int].set""
     IL_013d:  ldarg.0
@@ -26519,13 +26719,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_014b:  stloc.s    V_7
+    IL_014b:  stloc.s    V_8
     IL_014d:  ldarg.0
     IL_014e:  ldc.i4.s   -2
     IL_0150:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0155:  ldarg.0
     IL_0156:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_015b:  ldloc.s    V_7
+    IL_015b:  ldloc.s    V_8
     IL_015d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0162:  leave.s    IL_0177
   }
@@ -26993,9 +27193,10 @@ Position set for item '2'
                 int V_1,
                 int? V_2,
                 int V_3,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
-                int? V_5,
-                System.Exception V_6)
+                T V_4,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_5,
+                int? V_6,
+                System.Exception V_7)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -27006,9 +27207,10 @@ Position set for item '2'
     IL_000a:  ldloc.0
     IL_000b:  ldc.i4.1
     IL_000c:  beq        IL_0152
-    IL_0011:  ldtoken    ""T""
-    IL_0016:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_001b:  call       ""bool System.Type.IsValueType.get""
+    IL_0011:  ldloca.s   V_4
+    IL_0013:  initobj    ""T""
+    IL_0019:  ldloc.s    V_4
+    IL_001b:  box        ""T""
     IL_0020:  brtrue.s   IL_002e
     IL_0022:  ldarg.0
     IL_0023:  ldarg.0
@@ -27019,8 +27221,8 @@ Position set for item '2'
     IL_0034:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0039:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_003e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0043:  stloc.s    V_4
-    IL_0045:  ldloca.s   V_4
+    IL_0043:  stloc.s    V_5
+    IL_0045:  ldloca.s   V_5
     IL_0047:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_004c:  brtrue.s   IL_008f
     IL_004e:  ldarg.0
@@ -27029,17 +27231,17 @@ Position set for item '2'
     IL_0051:  stloc.0
     IL_0052:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0057:  ldarg.0
-    IL_0058:  ldloc.s    V_4
+    IL_0058:  ldloc.s    V_5
     IL_005a:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_005f:  ldarg.0
     IL_0060:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0065:  ldloca.s   V_4
+    IL_0065:  ldloca.s   V_5
     IL_0067:  ldarg.0
     IL_0068:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_006d:  leave      IL_01ea
     IL_0072:  ldarg.0
     IL_0073:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0078:  stloc.s    V_4
+    IL_0078:  stloc.s    V_5
     IL_007a:  ldarg.0
     IL_007b:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_0080:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -27048,13 +27250,14 @@ Position set for item '2'
     IL_0088:  dup
     IL_0089:  stloc.0
     IL_008a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_008f:  ldloca.s   V_4
+    IL_008f:  ldloca.s   V_5
     IL_0091:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_0096:  stloc.1
     IL_0097:  ldarg.0
-    IL_0098:  ldtoken    ""T""
-    IL_009d:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00a2:  call       ""bool System.Type.IsValueType.get""
+    IL_0098:  ldloca.s   V_4
+    IL_009a:  initobj    ""T""
+    IL_00a0:  ldloc.s    V_4
+    IL_00a2:  box        ""T""
     IL_00a7:  brtrue.s   IL_00b1
     IL_00a9:  ldarg.0
     IL_00aa:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -27066,9 +27269,10 @@ Position set for item '2'
     IL_00c2:  ldloc.1
     IL_00c3:  sub
     IL_00c4:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_00c9:  ldtoken    ""T""
-    IL_00ce:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00d3:  call       ""bool System.Type.IsValueType.get""
+    IL_00c9:  ldloca.s   V_4
+    IL_00cb:  initobj    ""T""
+    IL_00d1:  ldloc.s    V_4
+    IL_00d3:  box        ""T""
     IL_00d8:  brtrue.s   IL_00e2
     IL_00da:  ldarg.0
     IL_00db:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -27091,8 +27295,8 @@ Position set for item '2'
     IL_0114:  call       ""int Program.GetOffset<T>(ref T)""
     IL_0119:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
     IL_011e:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0123:  stloc.s    V_4
-    IL_0125:  ldloca.s   V_4
+    IL_0123:  stloc.s    V_5
+    IL_0125:  ldloca.s   V_5
     IL_0127:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
     IL_012c:  brtrue.s   IL_016f
     IL_012e:  ldarg.0
@@ -27101,17 +27305,17 @@ Position set for item '2'
     IL_0131:  stloc.0
     IL_0132:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0137:  ldarg.0
-    IL_0138:  ldloc.s    V_4
+    IL_0138:  ldloc.s    V_5
     IL_013a:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_013f:  ldarg.0
     IL_0140:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0145:  ldloca.s   V_4
+    IL_0145:  ldloca.s   V_5
     IL_0147:  ldarg.0
     IL_0148:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_014d:  leave      IL_01ea
     IL_0152:  ldarg.0
     IL_0153:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0158:  stloc.s    V_4
+    IL_0158:  stloc.s    V_5
     IL_015a:  ldarg.0
     IL_015b:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_0160:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
@@ -27120,12 +27324,13 @@ Position set for item '2'
     IL_0168:  dup
     IL_0169:  stloc.0
     IL_016a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_016f:  ldloca.s   V_4
+    IL_016f:  ldloca.s   V_5
     IL_0171:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
     IL_0176:  stloc.3
-    IL_0177:  ldtoken    ""T""
-    IL_017c:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0181:  call       ""bool System.Type.IsValueType.get""
+    IL_0177:  ldloca.s   V_4
+    IL_0179:  initobj    ""T""
+    IL_017f:  ldloc.s    V_4
+    IL_0181:  box        ""T""
     IL_0186:  brtrue.s   IL_0190
     IL_0188:  ldarg.0
     IL_0189:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -27137,7 +27342,7 @@ Position set for item '2'
     IL_019c:  ldloc.3
     IL_019d:  newobj     ""int?..ctor(int)""
     IL_01a2:  dup
-    IL_01a3:  stloc.s    V_5
+    IL_01a3:  stloc.s    V_6
     IL_01a5:  constrained. ""T""
     IL_01ab:  callvirt   ""void IMoveable.this[int].set""
     IL_01b0:  ldarg.0
@@ -27147,13 +27352,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_01be:  stloc.s    V_6
+    IL_01be:  stloc.s    V_7
     IL_01c0:  ldarg.0
     IL_01c1:  ldc.i4.s   -2
     IL_01c3:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_01c8:  ldarg.0
     IL_01c9:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_01ce:  ldloc.s    V_6
+    IL_01ce:  ldloc.s    V_7
     IL_01d0:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_01d5:  leave.s    IL_01ea
   }
@@ -27517,31 +27722,33 @@ Position set for item '2'
   .locals init (T V_0,
                 T& V_1,
                 int V_2,
-                int? V_3)
+                T V_3,
+                int? V_4)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.1
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
-  IL_0012:  brtrue.s   IL_001f
-  IL_0014:  ldloc.1
-  IL_0015:  ldobj      ""T""
-  IL_001a:  stloc.0
-  IL_001b:  ldloca.s   V_0
-  IL_001d:  br.s       IL_0020
-  IL_001f:  ldloc.1
-  IL_0020:  dup
-  IL_0021:  constrained. ""T""
-  IL_0027:  callvirt   ""int IMoveable.Length.get""
-  IL_002c:  ldc.i4.1
-  IL_002d:  sub
-  IL_002e:  stloc.2
-  IL_002f:  ldloca.s   V_3
-  IL_0031:  ldarga.s   V_0
-  IL_0033:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0038:  call       ""int?..ctor(int)""
-  IL_003d:  ldloc.2
-  IL_003e:  ldloc.3
+  IL_0003:  ldloca.s   V_3
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.3
+  IL_000c:  box        ""T""
+  IL_0011:  brtrue.s   IL_001e
+  IL_0013:  ldloc.1
+  IL_0014:  ldobj      ""T""
+  IL_0019:  stloc.0
+  IL_001a:  ldloca.s   V_0
+  IL_001c:  br.s       IL_001f
+  IL_001e:  ldloc.1
+  IL_001f:  dup
+  IL_0020:  constrained. ""T""
+  IL_0026:  callvirt   ""int IMoveable.Length.get""
+  IL_002b:  ldc.i4.1
+  IL_002c:  sub
+  IL_002d:  stloc.2
+  IL_002e:  ldloca.s   V_4
+  IL_0030:  ldarga.s   V_0
+  IL_0032:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_0037:  call       ""int?..ctor(int)""
+  IL_003c:  ldloc.2
+  IL_003d:  ldloc.s    V_4
   IL_003f:  constrained. ""T""
   IL_0045:  callvirt   ""void IMoveable.this[int].set""
   IL_004a:  ret
@@ -27765,31 +27972,33 @@ Position set for item '2'
   .locals init (T V_0,
                 T& V_1,
                 int V_2,
-                int? V_3)
+                T V_3,
+                int? V_4)
   IL_0000:  ldarg.0
   IL_0001:  stloc.1
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
-  IL_0011:  brtrue.s   IL_001e
-  IL_0013:  ldloc.1
-  IL_0014:  ldobj      ""T""
-  IL_0019:  stloc.0
-  IL_001a:  ldloca.s   V_0
-  IL_001c:  br.s       IL_001f
-  IL_001e:  ldloc.1
-  IL_001f:  dup
-  IL_0020:  constrained. ""T""
-  IL_0026:  callvirt   ""int IMoveable.Length.get""
-  IL_002b:  ldc.i4.1
-  IL_002c:  sub
-  IL_002d:  stloc.2
-  IL_002e:  ldloca.s   V_3
-  IL_0030:  ldarg.0
-  IL_0031:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0036:  call       ""int?..ctor(int)""
-  IL_003b:  ldloc.2
-  IL_003c:  ldloc.3
+  IL_0002:  ldloca.s   V_3
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.3
+  IL_000b:  box        ""T""
+  IL_0010:  brtrue.s   IL_001d
+  IL_0012:  ldloc.1
+  IL_0013:  ldobj      ""T""
+  IL_0018:  stloc.0
+  IL_0019:  ldloca.s   V_0
+  IL_001b:  br.s       IL_001e
+  IL_001d:  ldloc.1
+  IL_001e:  dup
+  IL_001f:  constrained. ""T""
+  IL_0025:  callvirt   ""int IMoveable.Length.get""
+  IL_002a:  ldc.i4.1
+  IL_002b:  sub
+  IL_002c:  stloc.2
+  IL_002d:  ldloca.s   V_4
+  IL_002f:  ldarg.0
+  IL_0030:  call       ""int Program.GetOffset<T>(ref T)""
+  IL_0035:  call       ""int?..ctor(int)""
+  IL_003a:  ldloc.2
+  IL_003b:  ldloc.s    V_4
   IL_003d:  constrained. ""T""
   IL_0043:  callvirt   ""void IMoveable.this[int].set""
   IL_0048:  ret
@@ -28096,8 +28305,9 @@ Position set for item '2'
   .locals init (int V_0,
                 int V_1,
                 int? V_2,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
-                System.Exception V_4)
+                T V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
+                System.Exception V_5)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -28105,72 +28315,75 @@ Position set for item '2'
   {
     IL_0007:  ldloc.0
     IL_0008:  brfalse    IL_009e
-    IL_000d:  ldtoken    ""T""
-    IL_0012:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0017:  call       ""bool System.Type.IsValueType.get""
-    IL_001c:  brtrue.s   IL_002a
+    IL_000d:  ldloca.s   V_3
+    IL_000f:  initobj    ""T""
+    IL_0015:  ldloc.3
+    IL_0016:  box        ""T""
+    IL_001b:  brtrue.s   IL_0029
+    IL_001d:  ldarg.0
     IL_001e:  ldarg.0
-    IL_001f:  ldarg.0
-    IL_0020:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0025:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_002a:  ldarg.0
-    IL_002b:  ldtoken    ""T""
-    IL_0030:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0035:  call       ""bool System.Type.IsValueType.get""
-    IL_003a:  brtrue.s   IL_0044
-    IL_003c:  ldarg.0
-    IL_003d:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0042:  br.s       IL_004a
-    IL_0044:  ldarg.0
-    IL_0045:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_004a:  constrained. ""T""
-    IL_0050:  callvirt   ""int IMoveable.Length.get""
-    IL_0055:  ldc.i4.1
-    IL_0056:  sub
-    IL_0057:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
-    IL_005c:  ldarg.0
-    IL_005d:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_0062:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0067:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_006c:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_0071:  stloc.3
-    IL_0072:  ldloca.s   V_3
-    IL_0074:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0079:  brtrue.s   IL_00ba
-    IL_007b:  ldarg.0
-    IL_007c:  ldc.i4.0
-    IL_007d:  dup
-    IL_007e:  stloc.0
-    IL_007f:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0084:  ldarg.0
-    IL_0085:  ldloc.3
+    IL_001f:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0024:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0029:  ldarg.0
+    IL_002a:  ldloca.s   V_3
+    IL_002c:  initobj    ""T""
+    IL_0032:  ldloc.3
+    IL_0033:  box        ""T""
+    IL_0038:  brtrue.s   IL_0042
+    IL_003a:  ldarg.0
+    IL_003b:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0040:  br.s       IL_0048
+    IL_0042:  ldarg.0
+    IL_0043:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0048:  constrained. ""T""
+    IL_004e:  callvirt   ""int IMoveable.Length.get""
+    IL_0053:  ldc.i4.1
+    IL_0054:  sub
+    IL_0055:  stfld      ""int Program.<Shift2>d__2<T>.<>7__wrap2""
+    IL_005a:  ldarg.0
+    IL_005b:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_0060:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0065:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_006a:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_006f:  stloc.s    V_4
+    IL_0071:  ldloca.s   V_4
+    IL_0073:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0078:  brtrue.s   IL_00bb
+    IL_007a:  ldarg.0
+    IL_007b:  ldc.i4.0
+    IL_007c:  dup
+    IL_007d:  stloc.0
+    IL_007e:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0083:  ldarg.0
+    IL_0084:  ldloc.s    V_4
     IL_0086:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
     IL_008b:  ldarg.0
     IL_008c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0091:  ldloca.s   V_3
+    IL_0091:  ldloca.s   V_4
     IL_0093:  ldarg.0
     IL_0094:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
     IL_0099:  leave      IL_0134
     IL_009e:  ldarg.0
     IL_009f:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00a4:  stloc.3
-    IL_00a5:  ldarg.0
-    IL_00a6:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_00ab:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_00b1:  ldarg.0
-    IL_00b2:  ldc.i4.m1
-    IL_00b3:  dup
-    IL_00b4:  stloc.0
-    IL_00b5:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00ba:  ldloca.s   V_3
-    IL_00bc:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_00c1:  stloc.1
-    IL_00c2:  ldloc.1
-    IL_00c3:  newobj     ""int?..ctor(int)""
-    IL_00c8:  stloc.2
-    IL_00c9:  ldtoken    ""T""
-    IL_00ce:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00d3:  call       ""bool System.Type.IsValueType.get""
+    IL_00a4:  stloc.s    V_4
+    IL_00a6:  ldarg.0
+    IL_00a7:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_00ac:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_00b2:  ldarg.0
+    IL_00b3:  ldc.i4.m1
+    IL_00b4:  dup
+    IL_00b5:  stloc.0
+    IL_00b6:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00bb:  ldloca.s   V_4
+    IL_00bd:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_00c2:  stloc.1
+    IL_00c3:  ldloc.1
+    IL_00c4:  newobj     ""int?..ctor(int)""
+    IL_00c9:  stloc.2
+    IL_00ca:  ldloca.s   V_3
+    IL_00cc:  initobj    ""T""
+    IL_00d2:  ldloc.3
+    IL_00d3:  box        ""T""
     IL_00d8:  brtrue.s   IL_00e2
     IL_00da:  ldarg.0
     IL_00db:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -28189,13 +28402,13 @@ Position set for item '2'
   }
   catch System.Exception
   {
-    IL_0108:  stloc.s    V_4
+    IL_0108:  stloc.s    V_5
     IL_010a:  ldarg.0
     IL_010b:  ldc.i4.s   -2
     IL_010d:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0112:  ldarg.0
     IL_0113:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0118:  ldloc.s    V_4
+    IL_0118:  ldloc.s    V_5
     IL_011a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_011f:  leave.s    IL_0134
   }
@@ -28495,12 +28708,14 @@ Position Slice for item '2'
   .locals init (T& V_0,
                 T V_1,
                 T& V_2,
-                int V_3)
+                int V_3,
+                T V_4)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.2
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
+  IL_0003:  ldloca.s   V_4
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_4
+  IL_000d:  box        ""T""
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.2
   IL_0015:  ldobj      ""T""
@@ -28727,14 +28942,16 @@ Position Slice for item '2'
   // Code size       68 (0x44)
   .maxstack  4
   .locals init (T& V_0,
-                T V_1,
-                T& V_2,
-                int V_3)
+            T V_1,
+            T& V_2,
+            int V_3,
+            T V_4)
   IL_0000:  ldarg.0
   IL_0001:  stloc.2
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
+  IL_0002:  ldloca.s   V_4
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_4
+  IL_000c:  box        ""T""
   IL_0011:  brtrue.s   IL_001e
   IL_0013:  ldloc.2
   IL_0014:  ldobj      ""T""
@@ -29034,114 +29251,118 @@ Position Slice for item '2'
             verifier.VerifyIL("Program.<Shift2>d__2<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
 @"
 {
-  // Code size      286 (0x11e)
+  // Code size      285 (0x11d)
   .maxstack  4
   .locals init (int V_0,
                 int V_1,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
-                System.Exception V_3)
+                T V_2,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_3,
+                System.Exception V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
   .try
   {
     IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0069
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
-    IL_0019:  brtrue.s   IL_0027
+    IL_0008:  brfalse.s  IL_0068
+    IL_000a:  ldloca.s   V_2
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.2
+    IL_0013:  box        ""T""
+    IL_0018:  brtrue.s   IL_0026
+    IL_001a:  ldarg.0
     IL_001b:  ldarg.0
-    IL_001c:  ldarg.0
-    IL_001d:  ldfld      ""T Program.<Shift2>d__2<T>.item""
-    IL_0022:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_0027:  ldarg.0
-    IL_0028:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_002d:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0032:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003c:  stloc.2
-    IL_003d:  ldloca.s   V_2
-    IL_003f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0044:  brtrue.s   IL_0085
-    IL_0046:  ldarg.0
-    IL_0047:  ldc.i4.0
-    IL_0048:  dup
-    IL_0049:  stloc.0
-    IL_004a:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_004f:  ldarg.0
-    IL_0050:  ldloc.2
-    IL_0051:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0056:  ldarg.0
-    IL_0057:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_005c:  ldloca.s   V_2
-    IL_005e:  ldarg.0
-    IL_005f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
-    IL_0064:  leave      IL_011d
-    IL_0069:  ldarg.0
-    IL_006a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_006f:  stloc.2
-    IL_0070:  ldarg.0
-    IL_0071:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0076:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_007c:  ldarg.0
-    IL_007d:  ldc.i4.m1
-    IL_007e:  dup
-    IL_007f:  stloc.0
-    IL_0080:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0085:  ldloca.s   V_2
-    IL_0087:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_008c:  stloc.1
-    IL_008d:  ldtoken    ""T""
-    IL_0092:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0097:  call       ""bool System.Type.IsValueType.get""
-    IL_009c:  brtrue.s   IL_00a6
-    IL_009e:  ldarg.0
-    IL_009f:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00a4:  br.s       IL_00ac
-    IL_00a6:  ldarg.0
-    IL_00a7:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00ac:  ldc.i4.0
-    IL_00ad:  ldtoken    ""T""
-    IL_00b2:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00b7:  call       ""bool System.Type.IsValueType.get""
-    IL_00bc:  brtrue.s   IL_00c6
-    IL_00be:  ldarg.0
-    IL_00bf:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00c4:  br.s       IL_00cc
-    IL_00c6:  ldarg.0
-    IL_00c7:  ldflda     ""T Program.<Shift2>d__2<T>.item""
-    IL_00cc:  constrained. ""T""
-    IL_00d2:  callvirt   ""int IMoveable.Length.get""
-    IL_00d7:  ldloc.1
-    IL_00d8:  sub
-    IL_00d9:  constrained. ""T""
-    IL_00df:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
-    IL_00e4:  pop
-    IL_00e5:  ldarg.0
-    IL_00e6:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
-    IL_00eb:  initobj    ""T""
-    IL_00f1:  leave.s    IL_010a
+    IL_001c:  ldfld      ""T Program.<Shift2>d__2<T>.item""
+    IL_0021:  stfld      ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_0026:  ldarg.0
+    IL_0027:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_002c:  call       ""int Program.GetOffset<T>(ref T)""
+    IL_0031:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
+    IL_0036:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_003b:  stloc.3
+    IL_003c:  ldloca.s   V_3
+    IL_003e:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0043:  brtrue.s   IL_0084
+    IL_0045:  ldarg.0
+    IL_0046:  ldc.i4.0
+    IL_0047:  dup
+    IL_0048:  stloc.0
+    IL_0049:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_004e:  ldarg.0
+    IL_004f:  ldloc.3
+    IL_0050:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0055:  ldarg.0
+    IL_0056:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_005b:  ldloca.s   V_3
+    IL_005d:  ldarg.0
+    IL_005e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Shift2>d__2<T>)""
+    IL_0063:  leave      IL_011c
+    IL_0068:  ldarg.0
+    IL_0069:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_006e:  stloc.3
+    IL_006f:  ldarg.0
+    IL_0070:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Shift2>d__2<T>.<>u__1""
+    IL_0075:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_007b:  ldarg.0
+    IL_007c:  ldc.i4.m1
+    IL_007d:  dup
+    IL_007e:  stloc.0
+    IL_007f:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_0084:  ldloca.s   V_3
+    IL_0086:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_008b:  stloc.1
+    IL_008c:  ldloca.s   V_2
+    IL_008e:  initobj    ""T""
+    IL_0094:  ldloc.2
+    IL_0095:  box        ""T""
+    IL_009a:  brtrue.s   IL_00a4
+    IL_009c:  ldarg.0
+    IL_009d:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00a2:  br.s       IL_00aa
+    IL_00a4:  ldarg.0
+    IL_00a5:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00aa:  ldc.i4.0
+    IL_00ab:  ldloca.s   V_2
+    IL_00ad:  initobj    ""T""
+    IL_00b3:  ldloc.2
+    IL_00b4:  box        ""T""
+    IL_00b9:  brtrue.s   IL_00c3
+    IL_00bb:  ldarg.0
+    IL_00bc:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00c1:  br.s       IL_00c9
+    IL_00c3:  ldarg.0
+    IL_00c4:  ldflda     ""T Program.<Shift2>d__2<T>.item""
+    IL_00c9:  constrained. ""T""
+    IL_00cf:  callvirt   ""int IMoveable.Length.get""
+    IL_00d4:  ldloc.1
+    IL_00d5:  sub
+    IL_00d6:  constrained. ""T""
+    IL_00dc:  callvirt   ""IMoveable IMoveable.Slice(int, int)""
+    IL_00e1:  pop
+    IL_00e2:  ldarg.0
+    IL_00e3:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
+    IL_00e8:  initobj    ""T""
+    IL_00ee:  leave.s    IL_0109
   }
   catch System.Exception
   {
-    IL_00f3:  stloc.3
-    IL_00f4:  ldarg.0
-    IL_00f5:  ldc.i4.s   -2
-    IL_00f7:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_00fc:  ldarg.0
-    IL_00fd:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_0102:  ldloc.3
-    IL_0103:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_0108:  leave.s    IL_011d
+    IL_00f0:  stloc.s    V_4
+    IL_00f2:  ldarg.0
+    IL_00f3:  ldc.i4.s   -2
+    IL_00f5:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+    IL_00fa:  ldarg.0
+    IL_00fb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+    IL_0100:  ldloc.s    V_4
+    IL_0102:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_0107:  leave.s    IL_011c
   }
-  IL_010a:  ldarg.0
-  IL_010b:  ldc.i4.s   -2
-  IL_010d:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-  IL_0112:  ldarg.0
-  IL_0113:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-  IL_0118:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_011d:  ret
+  IL_0109:  ldarg.0
+  IL_010a:  ldc.i4.s   -2
+  IL_010c:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
+  IL_0111:  ldarg.0
+  IL_0112:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
+  IL_0117:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
+  IL_011c:  ret
 }
 ");
         }
@@ -29437,12 +29658,14 @@ Position Slice for item '2'
                 int V_3,
                 int V_4,
                 int V_5,
-                System.Index V_6)
+                T V_6,
+                System.Index V_7)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.1
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
+  IL_0003:  ldloca.s   V_6
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.s    V_6
+  IL_000d:  box        ""T""
   IL_0012:  brtrue.s   IL_001f
   IL_0014:  ldloc.1
   IL_0015:  ldobj      ""T""
@@ -29459,15 +29682,15 @@ Position Slice for item '2'
   IL_0034:  stloc.3
   IL_0035:  ldloca.s   V_2
   IL_0037:  call       ""System.Index System.Range.Start.get""
-  IL_003c:  stloc.s    V_6
-  IL_003e:  ldloca.s   V_6
+  IL_003c:  stloc.s    V_7
+  IL_003e:  ldloca.s   V_7
   IL_0040:  ldloc.3
   IL_0041:  call       ""int System.Index.GetOffset(int)""
   IL_0046:  stloc.s    V_4
   IL_0048:  ldloca.s   V_2
   IL_004a:  call       ""System.Index System.Range.End.get""
-  IL_004f:  stloc.s    V_6
-  IL_0051:  ldloca.s   V_6
+  IL_004f:  stloc.s    V_7
+  IL_0051:  ldloca.s   V_7
   IL_0053:  ldloc.3
   IL_0054:  call       ""int System.Index.GetOffset(int)""
   IL_0059:  ldloc.s    V_4
@@ -29722,12 +29945,14 @@ Position Slice for item '2'
                 int V_3,
                 int V_4,
                 int V_5,
-                System.Index V_6)
+                T V_6,
+                System.Index V_7)
   IL_0000:  ldarg.0
   IL_0001:  stloc.1
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
+  IL_0002:  ldloca.s   V_6
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.s    V_6
+  IL_000c:  box        ""T""
   IL_0011:  brtrue.s   IL_001e
   IL_0013:  ldloc.1
   IL_0014:  ldobj      ""T""
@@ -29744,15 +29969,15 @@ Position Slice for item '2'
   IL_0032:  stloc.3
   IL_0033:  ldloca.s   V_2
   IL_0035:  call       ""System.Index System.Range.Start.get""
-  IL_003a:  stloc.s    V_6
-  IL_003c:  ldloca.s   V_6
+  IL_003a:  stloc.s    V_7
+  IL_003c:  ldloca.s   V_7
   IL_003e:  ldloc.3
   IL_003f:  call       ""int System.Index.GetOffset(int)""
   IL_0044:  stloc.s    V_4
   IL_0046:  ldloca.s   V_2
   IL_0048:  call       ""System.Index System.Range.End.get""
-  IL_004d:  stloc.s    V_6
-  IL_004f:  ldloca.s   V_6
+  IL_004d:  stloc.s    V_7
+  IL_004f:  ldloca.s   V_7
   IL_0051:  ldloc.3
   IL_0052:  call       ""int System.Index.GetOffset(int)""
   IL_0057:  ldloc.s    V_4
@@ -30085,9 +30310,10 @@ Position Slice for item '2'
                 int V_2,
                 int V_3,
                 int V_4,
-                System.Runtime.CompilerServices.TaskAwaiter<System.Range> V_5,
-                System.Index V_6,
-                System.Exception V_7)
+                T V_5,
+                System.Runtime.CompilerServices.TaskAwaiter<System.Range> V_6,
+                System.Index V_7,
+                System.Exception V_8)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int Program.<Shift2>d__2<T>.<>1__state""
   IL_0006:  stloc.0
@@ -30095,9 +30321,10 @@ Position Slice for item '2'
   {
     IL_0007:  ldloc.0
     IL_0008:  brfalse.s  IL_006b
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
+    IL_000a:  ldloca.s   V_5
+    IL_000c:  initobj    ""T""
+    IL_0012:  ldloc.s    V_5
+    IL_0014:  box        ""T""
     IL_0019:  brtrue.s   IL_0027
     IL_001b:  ldarg.0
     IL_001c:  ldarg.0
@@ -30108,8 +30335,8 @@ Position Slice for item '2'
     IL_002d:  call       ""System.Range Program.GetOffset<T>(ref T)""
     IL_0032:  call       ""System.Threading.Tasks.Task<System.Range> Program.GetOffsetAsync(System.Range)""
     IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> System.Threading.Tasks.Task<System.Range>.GetAwaiter()""
-    IL_003c:  stloc.s    V_5
-    IL_003e:  ldloca.s   V_5
+    IL_003c:  stloc.s    V_6
+    IL_003e:  ldloca.s   V_6
     IL_0040:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<System.Range>.IsCompleted.get""
     IL_0045:  brtrue.s   IL_0088
     IL_0047:  ldarg.0
@@ -30118,17 +30345,17 @@ Position Slice for item '2'
     IL_004a:  stloc.0
     IL_004b:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0050:  ldarg.0
-    IL_0051:  ldloc.s    V_5
+    IL_0051:  ldloc.s    V_6
     IL_0053:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> Program.<Shift2>d__2<T>.<>u__1""
     IL_0058:  ldarg.0
     IL_0059:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_005e:  ldloca.s   V_5
+    IL_005e:  ldloca.s   V_6
     IL_0060:  ldarg.0
     IL_0061:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<System.Range>, Program.<Shift2>d__2<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<System.Range>, ref Program.<Shift2>d__2<T>)""
     IL_0066:  leave      IL_014a
     IL_006b:  ldarg.0
     IL_006c:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> Program.<Shift2>d__2<T>.<>u__1""
-    IL_0071:  stloc.s    V_5
+    IL_0071:  stloc.s    V_6
     IL_0073:  ldarg.0
     IL_0074:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<System.Range> Program.<Shift2>d__2<T>.<>u__1""
     IL_0079:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<System.Range>""
@@ -30137,12 +30364,13 @@ Position Slice for item '2'
     IL_0081:  dup
     IL_0082:  stloc.0
     IL_0083:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
-    IL_0088:  ldloca.s   V_5
+    IL_0088:  ldloca.s   V_6
     IL_008a:  call       ""System.Range System.Runtime.CompilerServices.TaskAwaiter<System.Range>.GetResult()""
     IL_008f:  stloc.1
-    IL_0090:  ldtoken    ""T""
-    IL_0095:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_009a:  call       ""bool System.Type.IsValueType.get""
+    IL_0090:  ldloca.s   V_5
+    IL_0092:  initobj    ""T""
+    IL_0098:  ldloc.s    V_5
+    IL_009a:  box        ""T""
     IL_009f:  brtrue.s   IL_00a9
     IL_00a1:  ldarg.0
     IL_00a2:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -30154,23 +30382,24 @@ Position Slice for item '2'
     IL_00ba:  stloc.2
     IL_00bb:  ldloca.s   V_1
     IL_00bd:  call       ""System.Index System.Range.Start.get""
-    IL_00c2:  stloc.s    V_6
-    IL_00c4:  ldloca.s   V_6
+    IL_00c2:  stloc.s    V_7
+    IL_00c4:  ldloca.s   V_7
     IL_00c6:  ldloc.2
     IL_00c7:  call       ""int System.Index.GetOffset(int)""
     IL_00cc:  stloc.3
     IL_00cd:  ldloca.s   V_1
     IL_00cf:  call       ""System.Index System.Range.End.get""
-    IL_00d4:  stloc.s    V_6
-    IL_00d6:  ldloca.s   V_6
+    IL_00d4:  stloc.s    V_7
+    IL_00d6:  ldloca.s   V_7
     IL_00d8:  ldloc.2
     IL_00d9:  call       ""int System.Index.GetOffset(int)""
     IL_00de:  ldloc.3
     IL_00df:  sub
     IL_00e0:  stloc.s    V_4
-    IL_00e2:  ldtoken    ""T""
-    IL_00e7:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00ec:  call       ""bool System.Type.IsValueType.get""
+    IL_00e2:  ldloca.s   V_5
+    IL_00e4:  initobj    ""T""
+    IL_00ea:  ldloc.s    V_5
+    IL_00ec:  box        ""T""
     IL_00f1:  brtrue.s   IL_00fb
     IL_00f3:  ldarg.0
     IL_00f4:  ldflda     ""T Program.<Shift2>d__2<T>.<>7__wrap1""
@@ -30189,13 +30418,13 @@ Position Slice for item '2'
   }
   catch System.Exception
   {
-    IL_011e:  stloc.s    V_7
+    IL_011e:  stloc.s    V_8
     IL_0120:  ldarg.0
     IL_0121:  ldc.i4.s   -2
     IL_0123:  stfld      ""int Program.<Shift2>d__2<T>.<>1__state""
     IL_0128:  ldarg.0
     IL_0129:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Shift2>d__2<T>.<>t__builder""
-    IL_012e:  ldloc.s    V_7
+    IL_012e:  ldloc.s    V_8
     IL_0130:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
     IL_0135:  leave.s    IL_014a
   }
@@ -30395,330 +30624,6 @@ Position Slice for item '-2'
   IL_00ef:  ret
 }
 ");
-        }
-
-        [Fact]
-        [WorkItem(66162, "https://github.com/dotnet/roslyn/issues/66162")]
-        public void GenericTypeParameterAsReceiver_Call_Nullable()
-        {
-            var source = @"
-using System;
-
-#pragma warning disable CS0659 // 'Item' overrides Object.Equals(object o) but does not override Object.GetHashCode()
-    
-struct Item
-{
-    public int Count;
-
-    public override bool Equals(object obj)
-    {
-        Console.WriteLine(""Position Equals for item '{0}'"", Count);
-        return base.Equals(obj);
-    }
-}
-
-class Program
-{
-    static void Main()
-    {
-        Item? item1 = new Item {Count = 1};
-        Call1(item1);
-        Item? item2 = new Item {Count = 2};
-        Call2(ref item2);
-    }
-
-    static void Call1<T>(T item)
-    {
-        item.Equals(GetOffset(ref item));
-    }
-
-    static void Call2<T>(ref T item)
-    {
-        item.Equals(GetOffset(ref item));
-    }
-    
-    static int value = 0;
-    static int GetOffset<T>(ref T item)
-    {
-        item = (T)(object)new Item {Count = --value};
-        return 0;
-    }
-}
-";
-            var verifier = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: @"
-Position Equals for item '-1'
-Position Equals for item '-2'
-").VerifyDiagnostics();
-
-            verifier.VerifyIL("Program.Call1<T>",
-@"
-{
-  // Code size       52 (0x34)
-  .maxstack  2
-  .locals init (T V_0)
-  IL_0000:  ldarga.s   V_0
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
-  IL_0011:  brtrue.s   IL_001b
-  IL_0013:  ldobj      ""T""
-  IL_0018:  stloc.0
-  IL_0019:  ldloca.s   V_0
-  IL_001b:  ldarga.s   V_0
-  IL_001d:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0022:  box        ""int""
-  IL_0027:  constrained. ""T""
-  IL_002d:  callvirt   ""bool object.Equals(object)""
-  IL_0032:  pop
-  IL_0033:  ret
-}
-");
-
-            verifier.VerifyIL("Program.Call2<T>",
-@"
-{
-  // Code size       50 (0x32)
-  .maxstack  2
-  .locals init (T V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  ldtoken    ""T""
-  IL_0006:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000b:  call       ""bool System.Type.IsValueType.get""
-  IL_0010:  brtrue.s   IL_001a
-  IL_0012:  ldobj      ""T""
-  IL_0017:  stloc.0
-  IL_0018:  ldloca.s   V_0
-  IL_001a:  ldarg.0
-  IL_001b:  call       ""int Program.GetOffset<T>(ref T)""
-  IL_0020:  box        ""int""
-  IL_0025:  constrained. ""T""
-  IL_002b:  callvirt   ""bool object.Equals(object)""
-  IL_0030:  pop
-  IL_0031:  ret
-}
-");
-
-            var comp = CreateCompilation(source);
-            comp.MakeTypeMissing(WellKnownType.System_Type);
-            comp.VerifyEmitDiagnostics(
-                // (29,9): error CS0656: Missing compiler required member 'System.Type.GetTypeFromHandle'
-                //         item.Equals(GetOffset(ref item));
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "item").WithArguments("System.Type", "GetTypeFromHandle").WithLocation(29, 9),
-                // (34,9): error CS0656: Missing compiler required member 'System.Type.GetTypeFromHandle'
-                //         item.Equals(GetOffset(ref item));
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "item").WithArguments("System.Type", "GetTypeFromHandle").WithLocation(34, 9)
-                );
-
-            comp = CreateCompilation(source);
-            comp.MakeMemberMissing(WellKnownMember.System_Type__GetTypeFromHandle);
-            comp.VerifyEmitDiagnostics(
-                // (29,9): error CS0656: Missing compiler required member 'System.Type.GetTypeFromHandle'
-                //         item.Equals(GetOffset(ref item));
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "item").WithArguments("System.Type", "GetTypeFromHandle").WithLocation(29, 9),
-                // (34,9): error CS0656: Missing compiler required member 'System.Type.GetTypeFromHandle'
-                //         item.Equals(GetOffset(ref item));
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "item").WithArguments("System.Type", "GetTypeFromHandle").WithLocation(34, 9)
-                );
-
-            comp = CreateCompilation(source);
-            comp.MakeMemberMissing(WellKnownMember.System_Type__get_IsValueType);
-            comp.VerifyEmitDiagnostics(
-                // (29,9): error CS0656: Missing compiler required member 'System.Type.get_IsValueType'
-                //         item.Equals(GetOffset(ref item));
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "item").WithArguments("System.Type", "get_IsValueType").WithLocation(29, 9),
-                // (34,9): error CS0656: Missing compiler required member 'System.Type.get_IsValueType'
-                //         item.Equals(GetOffset(ref item));
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "item").WithArguments("System.Type", "get_IsValueType").WithLocation(34, 9)
-                );
-        }
-
-        [Fact]
-        [WorkItem(66162, "https://github.com/dotnet/roslyn/issues/66162")]
-        public void GenericTypeParameterAsReceiver_Call_Nullable_Async()
-        {
-            var source = @"
-using System;
-using System.Threading.Tasks;
-
-#pragma warning disable CS0659 // 'Item' overrides Object.Equals(object o) but does not override Object.GetHashCode()
-    
-struct Item
-{
-    public int Count;
-
-    public override bool Equals(object obj)
-    {
-        Console.WriteLine(""Position Equals for item '{0}'"", Count);
-        return base.Equals(obj);
-    }
-}
-
-class Program
-{
-    static async Task Main()
-    {
-        Item? item1 = new Item {Count = 1};
-        await Call1(item1);
-    }
-
-    static async Task Call1<T>(T item)
-    {
-        item.Equals(await GetOffsetAsync(GetOffset(ref item)));
-    }
-
-    static int value = 0;
-    static int GetOffset<T>(ref T item)
-    {
-        item = (T)(object)new Item {Count = --value};
-        return 0;
-    }
-
-#pragma warning disable CS1998 // This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
-    static async Task<int> GetOffsetAsync(int i)
-    {
-        return i;
-    }
-}
-";
-
-            var verifier = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: @"
-Position Equals for item '-1'
-").VerifyDiagnostics();
-
-            verifier.VerifyIL("Program.<Call1>d__1<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext",
-@"
-{
-  // Code size      247 (0xf7)
-  .maxstack  3
-  .locals init (int V_0,
-                int V_1,
-                System.Runtime.CompilerServices.TaskAwaiter<int> V_2,
-                System.Exception V_3)
-  IL_0000:  ldarg.0
-  IL_0001:  ldfld      ""int Program.<Call1>d__1<T>.<>1__state""
-  IL_0006:  stloc.0
-  .try
-  {
-    IL_0007:  ldloc.0
-    IL_0008:  brfalse.s  IL_0069
-    IL_000a:  ldtoken    ""T""
-    IL_000f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0014:  call       ""bool System.Type.IsValueType.get""
-    IL_0019:  brtrue.s   IL_0027
-    IL_001b:  ldarg.0
-    IL_001c:  ldarg.0
-    IL_001d:  ldfld      ""T Program.<Call1>d__1<T>.item""
-    IL_0022:  stfld      ""T Program.<Call1>d__1<T>.<>7__wrap1""
-    IL_0027:  ldarg.0
-    IL_0028:  ldflda     ""T Program.<Call1>d__1<T>.item""
-    IL_002d:  call       ""int Program.GetOffset<T>(ref T)""
-    IL_0032:  call       ""System.Threading.Tasks.Task<int> Program.GetOffsetAsync(int)""
-    IL_0037:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-    IL_003c:  stloc.2
-    IL_003d:  ldloca.s   V_2
-    IL_003f:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-    IL_0044:  brtrue.s   IL_0085
-    IL_0046:  ldarg.0
-    IL_0047:  ldc.i4.0
-    IL_0048:  dup
-    IL_0049:  stloc.0
-    IL_004a:  stfld      ""int Program.<Call1>d__1<T>.<>1__state""
-    IL_004f:  ldarg.0
-    IL_0050:  ldloc.2
-    IL_0051:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Call1>d__1<T>.<>u__1""
-    IL_0056:  ldarg.0
-    IL_0057:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Call1>d__1<T>.<>t__builder""
-    IL_005c:  ldloca.s   V_2
-    IL_005e:  ldarg.0
-    IL_005f:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, Program.<Call1>d__1<T>>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref Program.<Call1>d__1<T>)""
-    IL_0064:  leave      IL_00f6
-    IL_0069:  ldarg.0
-    IL_006a:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Call1>d__1<T>.<>u__1""
-    IL_006f:  stloc.2
-    IL_0070:  ldarg.0
-    IL_0071:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> Program.<Call1>d__1<T>.<>u__1""
-    IL_0076:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-    IL_007c:  ldarg.0
-    IL_007d:  ldc.i4.m1
-    IL_007e:  dup
-    IL_007f:  stloc.0
-    IL_0080:  stfld      ""int Program.<Call1>d__1<T>.<>1__state""
-    IL_0085:  ldloca.s   V_2
-    IL_0087:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-    IL_008c:  stloc.1
-    IL_008d:  ldtoken    ""T""
-    IL_0092:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0097:  call       ""bool System.Type.IsValueType.get""
-    IL_009c:  brtrue.s   IL_00a6
-    IL_009e:  ldarg.0
-    IL_009f:  ldflda     ""T Program.<Call1>d__1<T>.<>7__wrap1""
-    IL_00a4:  br.s       IL_00ac
-    IL_00a6:  ldarg.0
-    IL_00a7:  ldflda     ""T Program.<Call1>d__1<T>.item""
-    IL_00ac:  ldloc.1
-    IL_00ad:  box        ""int""
-    IL_00b2:  constrained. ""T""
-    IL_00b8:  callvirt   ""bool object.Equals(object)""
-    IL_00bd:  pop
-    IL_00be:  ldarg.0
-    IL_00bf:  ldflda     ""T Program.<Call1>d__1<T>.<>7__wrap1""
-    IL_00c4:  initobj    ""T""
-    IL_00ca:  leave.s    IL_00e3
-  }
-  catch System.Exception
-  {
-    IL_00cc:  stloc.3
-    IL_00cd:  ldarg.0
-    IL_00ce:  ldc.i4.s   -2
-    IL_00d0:  stfld      ""int Program.<Call1>d__1<T>.<>1__state""
-    IL_00d5:  ldarg.0
-    IL_00d6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Call1>d__1<T>.<>t__builder""
-    IL_00db:  ldloc.3
-    IL_00dc:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-    IL_00e1:  leave.s    IL_00f6
-  }
-  IL_00e3:  ldarg.0
-  IL_00e4:  ldc.i4.s   -2
-  IL_00e6:  stfld      ""int Program.<Call1>d__1<T>.<>1__state""
-  IL_00eb:  ldarg.0
-  IL_00ec:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<Call1>d__1<T>.<>t__builder""
-  IL_00f1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-  IL_00f6:  ret
-}
-");
-
-            var comp = CreateCompilation(source);
-            comp.MakeTypeMissing(WellKnownType.System_Type);
-            comp.VerifyEmitDiagnostics(
-                // (28,9): error CS0656: Missing compiler required member 'System.Type.GetTypeFromHandle'
-                //         item.Equals(await GetOffsetAsync(GetOffset(ref item)));
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "item.Equals(await GetOffsetAsync(GetOffset(ref item)))").WithArguments("System.Type", "GetTypeFromHandle").WithLocation(28, 9),
-                // (28,9): error CS0656: Missing compiler required member 'System.Type.GetTypeFromHandle'
-                //         item.Equals(await GetOffsetAsync(GetOffset(ref item)));
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "item.Equals(await GetOffsetAsync(GetOffset(ref item)))").WithArguments("System.Type", "GetTypeFromHandle").WithLocation(28, 9)
-                );
-
-            comp = CreateCompilation(source);
-            comp.MakeMemberMissing(WellKnownMember.System_Type__GetTypeFromHandle);
-            comp.VerifyEmitDiagnostics(
-                // (28,9): error CS0656: Missing compiler required member 'System.Type.GetTypeFromHandle'
-                //         item.Equals(await GetOffsetAsync(GetOffset(ref item)));
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "item.Equals(await GetOffsetAsync(GetOffset(ref item)))").WithArguments("System.Type", "GetTypeFromHandle").WithLocation(28, 9),
-                // (28,9): error CS0656: Missing compiler required member 'System.Type.GetTypeFromHandle'
-                //         item.Equals(await GetOffsetAsync(GetOffset(ref item)));
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "item.Equals(await GetOffsetAsync(GetOffset(ref item)))").WithArguments("System.Type", "GetTypeFromHandle").WithLocation(28, 9)
-                );
-
-            comp = CreateCompilation(source);
-            comp.MakeMemberMissing(WellKnownMember.System_Type__get_IsValueType);
-            comp.VerifyEmitDiagnostics(
-                // (28,9): error CS0656: Missing compiler required member 'System.Type.get_IsValueType'
-                //         item.Equals(await GetOffsetAsync(GetOffset(ref item)));
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "item.Equals(await GetOffsetAsync(GetOffset(ref item)))").WithArguments("System.Type", "get_IsValueType").WithLocation(28, 9),
-                // (28,9): error CS0656: Missing compiler required member 'System.Type.get_IsValueType'
-                //         item.Equals(await GetOffsetAsync(GetOffset(ref item)));
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "item.Equals(await GetOffsetAsync(GetOffset(ref item)))").WithArguments("System.Type", "get_IsValueType").WithLocation(28, 9)
-                );
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -11033,37 +11033,39 @@ logged = 4
   // Code size       88 (0x58)
   .maxstack  5
   .locals init (T& V_0,
-                T V_1,
-                T& V_2,
-                DummyHandler V_3)
+            T V_1,
+            T& V_2,
+            T V_3,
+            DummyHandler V_4)
   IL_0000:  ldarga.s   V_0
   IL_0002:  stloc.2
-  IL_0003:  ldtoken    ""T""
-  IL_0008:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000d:  call       ""bool System.Type.IsValueType.get""
-  IL_0012:  brtrue.s   IL_001f
-  IL_0014:  ldloc.2
-  IL_0015:  ldobj      ""T""
-  IL_001a:  stloc.1
-  IL_001b:  ldloca.s   V_1
-  IL_001d:  br.s       IL_0020
-  IL_001f:  ldloc.2
-  IL_0020:  stloc.0
-  IL_0021:  ldloc.0
-  IL_0022:  ldloca.s   V_3
-  IL_0024:  ldc.i4.4
-  IL_0025:  ldc.i4.1
-  IL_0026:  ldloc.0
-  IL_0027:  ldobj      ""T""
-  IL_002c:  box        ""T""
-  IL_0031:  call       ""DummyHandler..ctor(int, int, ILogger)""
-  IL_0036:  ldloca.s   V_3
-  IL_0038:  ldstr      ""log:""
-  IL_003d:  call       ""void DummyHandler.AppendLiteral(string)""
-  IL_0042:  ldloca.s   V_3
-  IL_0044:  ldc.i4.m1
-  IL_0045:  call       ""void DummyHandler.AppendFormatted<int>(int)""
-  IL_004a:  ldloc.3
+  IL_0003:  ldloca.s   V_3
+  IL_0005:  initobj    ""T""
+  IL_000b:  ldloc.3
+  IL_000c:  box        ""T""
+  IL_0011:  brtrue.s   IL_001e
+  IL_0013:  ldloc.2
+  IL_0014:  ldobj      ""T""
+  IL_0019:  stloc.1
+  IL_001a:  ldloca.s   V_1
+  IL_001c:  br.s       IL_001f
+  IL_001e:  ldloc.2
+  IL_001f:  stloc.0
+  IL_0020:  ldloc.0
+  IL_0021:  ldloca.s   V_4
+  IL_0023:  ldc.i4.4
+  IL_0024:  ldc.i4.1
+  IL_0025:  ldloc.0
+  IL_0026:  ldobj      ""T""
+  IL_002b:  box        ""T""
+  IL_0030:  call       ""DummyHandler..ctor(int, int, ILogger)""
+  IL_0035:  ldloca.s   V_4
+  IL_0037:  ldstr      ""log:""
+  IL_003c:  call       ""void DummyHandler.AppendLiteral(string)""
+  IL_0041:  ldloca.s   V_4
+  IL_0043:  ldc.i4.m1
+  IL_0044:  call       ""void DummyHandler.AppendFormatted<int>(int)""
+  IL_0049:  ldloc.s    V_4
   IL_004b:  constrained. ""T""
   IL_0051:  callvirt   ""void ILogger.Log(DummyHandler)""
   IL_0056:  ldarg.0
@@ -11108,37 +11110,39 @@ logged = 4
   // Code size       87 (0x57)
   .maxstack  5
   .locals init (T& V_0,
-                T V_1,
-                T& V_2,
-                DummyHandler V_3)
+            T V_1,
+            T& V_2,
+            T V_3,
+            DummyHandler V_4)
   IL_0000:  ldarg.0
   IL_0001:  stloc.2
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
-  IL_0011:  brtrue.s   IL_001e
-  IL_0013:  ldloc.2
-  IL_0014:  ldobj      ""T""
-  IL_0019:  stloc.1
-  IL_001a:  ldloca.s   V_1
-  IL_001c:  br.s       IL_001f
-  IL_001e:  ldloc.2
-  IL_001f:  stloc.0
-  IL_0020:  ldloc.0
-  IL_0021:  ldloca.s   V_3
-  IL_0023:  ldc.i4.4
-  IL_0024:  ldc.i4.1
-  IL_0025:  ldloc.0
-  IL_0026:  ldobj      ""T""
-  IL_002b:  box        ""T""
-  IL_0030:  call       ""DummyHandler..ctor(int, int, ILogger)""
-  IL_0035:  ldloca.s   V_3
-  IL_0037:  ldstr      ""log:""
-  IL_003c:  call       ""void DummyHandler.AppendLiteral(string)""
-  IL_0041:  ldloca.s   V_3
-  IL_0043:  ldc.i4.s   -3
-  IL_0045:  call       ""void DummyHandler.AppendFormatted<int>(int)""
-  IL_004a:  ldloc.3
+  IL_0002:  ldloca.s   V_3
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.3
+  IL_000b:  box        ""T""
+  IL_0010:  brtrue.s   IL_001d
+  IL_0012:  ldloc.2
+  IL_0013:  ldobj      ""T""
+  IL_0018:  stloc.1
+  IL_0019:  ldloca.s   V_1
+  IL_001b:  br.s       IL_001e
+  IL_001d:  ldloc.2
+  IL_001e:  stloc.0
+  IL_001f:  ldloc.0
+  IL_0020:  ldloca.s   V_4
+  IL_0022:  ldc.i4.4
+  IL_0023:  ldc.i4.1
+  IL_0024:  ldloc.0
+  IL_0025:  ldobj      ""T""
+  IL_002a:  box        ""T""
+  IL_002f:  call       ""DummyHandler..ctor(int, int, ILogger)""
+  IL_0034:  ldloca.s   V_4
+  IL_0036:  ldstr      ""log:""
+  IL_003b:  call       ""void DummyHandler.AppendLiteral(string)""
+  IL_0040:  ldloca.s   V_4
+  IL_0042:  ldc.i4.s   -3
+  IL_0044:  call       ""void DummyHandler.AppendFormatted<int>(int)""
+  IL_0049:  ldloc.s    V_4
   IL_004b:  constrained. ""T""
   IL_0051:  callvirt   ""void ILogger.Log(DummyHandler)""
   IL_0056:  ret
@@ -11283,16 +11287,18 @@ logged = 4
   // Code size      110 (0x6e)
   .maxstack  4
   .locals init (T& V_0,
-                T V_1,
-                T& V_2,
-                DummyHandler V_3,
-                DummyHandler V_4)
+            T V_1,
+            T& V_2,
+            DummyHandler V_3,
+            T V_4,
+            DummyHandler V_5)
   IL_0000:  ldarg.0
   IL_0001:  call       ""ref T Program.<<Main>$>g__get3|0_2<T>(ref T)""
   IL_0006:  stloc.2
-  IL_0007:  ldtoken    ""T""
-  IL_000c:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_0011:  call       ""bool System.Type.IsValueType.get""
+  IL_0007:  ldloca.s   V_4
+  IL_0009:  initobj    ""T""
+  IL_000f:  ldloc.s    V_4
+  IL_0011:  box        ""T""
   IL_0016:  brtrue.s   IL_0023
   IL_0018:  ldloc.2
   IL_0019:  ldobj      ""T""
@@ -11301,20 +11307,20 @@ logged = 4
   IL_0021:  br.s       IL_0024
   IL_0023:  ldloc.2
   IL_0024:  stloc.0
-  IL_0025:  ldloca.s   V_4
+  IL_0025:  ldloca.s   V_5
   IL_0027:  ldc.i4.4
   IL_0028:  ldc.i4.1
   IL_0029:  ldloc.0
   IL_002a:  ldobj      ""T""
   IL_002f:  box        ""T""
   IL_0034:  call       ""DummyHandler..ctor(int, int, ILogger)""
-  IL_0039:  ldloca.s   V_4
+  IL_0039:  ldloca.s   V_5
   IL_003b:  ldstr      ""log:""
   IL_0040:  call       ""void DummyHandler.AppendLiteral(string)""
-  IL_0045:  ldloca.s   V_4
+  IL_0045:  ldloca.s   V_5
   IL_0047:  ldc.i4.s   -3
   IL_0049:  call       ""void DummyHandler.AppendFormatted<int>(int)""
-  IL_004e:  ldloc.s    V_4
+  IL_004e:  ldloc.s    V_5
   IL_0050:  stloc.3
   IL_0051:  ldloc.0
   IL_0052:  ldloc.3

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/GenericConstraintTests.cs
@@ -1480,61 +1480,63 @@ B.M");
             compilation.VerifyIL("C<T1, T2>.M<U1, U2>(T1, T2, U1, U2)",
 @"
 {
-  // Code size      195 (0xc3)
+  // Code size      193 (0xc1)
   .maxstack  2
   .locals init (T1 V_0,
-                U1 V_1)
+            U1 V_1)
   IL_0000:  ldarga.s   V_0
-  IL_0002:  ldtoken    ""T1""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
-  IL_0011:  brtrue.s   IL_001b
-  IL_0013:  ldobj      ""T1""
-  IL_0018:  stloc.0
-  IL_0019:  ldloca.s   V_0
-  IL_001b:  ldarga.s   V_0
-  IL_001d:  constrained. ""T1""
-  IL_0023:  callvirt   ""object I.P.get""
-  IL_0028:  constrained. ""T1""
-  IL_002e:  callvirt   ""void I.P.set""
-  IL_0033:  ldarga.s   V_0
-  IL_0035:  constrained. ""T1""
-  IL_003b:  callvirt   ""void I.M()""
-  IL_0040:  ldarg.1
-  IL_0041:  box        ""T2""
-  IL_0046:  ldarg.1
-  IL_0047:  box        ""T2""
-  IL_004c:  callvirt   ""object A.P.get""
-  IL_0051:  callvirt   ""void A.P.set""
-  IL_0056:  ldarg.1
-  IL_0057:  box        ""T2""
-  IL_005c:  callvirt   ""void A.M()""
-  IL_0061:  ldarga.s   V_2
-  IL_0063:  ldtoken    ""U1""
-  IL_0068:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_006d:  call       ""bool System.Type.IsValueType.get""
-  IL_0072:  brtrue.s   IL_007c
-  IL_0074:  ldobj      ""U1""
-  IL_0079:  stloc.1
-  IL_007a:  ldloca.s   V_1
-  IL_007c:  ldarga.s   V_2
-  IL_007e:  constrained. ""U1""
-  IL_0084:  callvirt   ""object I.P.get""
-  IL_0089:  constrained. ""U1""
-  IL_008f:  callvirt   ""void I.P.set""
-  IL_0094:  ldarga.s   V_2
-  IL_0096:  constrained. ""U1""
-  IL_009c:  callvirt   ""void I.M()""
-  IL_00a1:  ldarg.3
-  IL_00a2:  box        ""U2""
-  IL_00a7:  ldarg.3
-  IL_00a8:  box        ""U2""
-  IL_00ad:  callvirt   ""object A.P.get""
-  IL_00b2:  callvirt   ""void A.P.set""
-  IL_00b7:  ldarg.3
-  IL_00b8:  box        ""U2""
-  IL_00bd:  callvirt   ""void A.M()""
-  IL_00c2:  ret
+  IL_0002:  ldloca.s   V_0
+  IL_0004:  initobj    ""T1""
+  IL_000a:  ldloc.0
+  IL_000b:  box        ""T1""
+  IL_0010:  brtrue.s   IL_001a
+  IL_0012:  ldobj      ""T1""
+  IL_0017:  stloc.0
+  IL_0018:  ldloca.s   V_0
+  IL_001a:  ldarga.s   V_0
+  IL_001c:  constrained. ""T1""
+  IL_0022:  callvirt   ""object I.P.get""
+  IL_0027:  constrained. ""T1""
+  IL_002d:  callvirt   ""void I.P.set""
+  IL_0032:  ldarga.s   V_0
+  IL_0034:  constrained. ""T1""
+  IL_003a:  callvirt   ""void I.M()""
+  IL_003f:  ldarg.1
+  IL_0040:  box        ""T2""
+  IL_0045:  ldarg.1
+  IL_0046:  box        ""T2""
+  IL_004b:  callvirt   ""object A.P.get""
+  IL_0050:  callvirt   ""void A.P.set""
+  IL_0055:  ldarg.1
+  IL_0056:  box        ""T2""
+  IL_005b:  callvirt   ""void A.M()""
+  IL_0060:  ldarga.s   V_2
+  IL_0062:  ldloca.s   V_1
+  IL_0064:  initobj    ""U1""
+  IL_006a:  ldloc.1
+  IL_006b:  box        ""U1""
+  IL_0070:  brtrue.s   IL_007a
+  IL_0072:  ldobj      ""U1""
+  IL_0077:  stloc.1
+  IL_0078:  ldloca.s   V_1
+  IL_007a:  ldarga.s   V_2
+  IL_007c:  constrained. ""U1""
+  IL_0082:  callvirt   ""object I.P.get""
+  IL_0087:  constrained. ""U1""
+  IL_008d:  callvirt   ""void I.P.set""
+  IL_0092:  ldarga.s   V_2
+  IL_0094:  constrained. ""U1""
+  IL_009a:  callvirt   ""void I.M()""
+  IL_009f:  ldarg.3
+  IL_00a0:  box        ""U2""
+  IL_00a5:  ldarg.3
+  IL_00a6:  box        ""U2""
+  IL_00ab:  callvirt   ""object A.P.get""
+  IL_00b0:  callvirt   ""void A.P.set""
+  IL_00b5:  ldarg.3
+  IL_00b6:  box        ""U2""
+  IL_00bb:  callvirt   ""void A.M()""
+  IL_00c0:  ret
 }");
         }
 
@@ -1587,27 +1589,28 @@ S[0]");
             compilation.VerifyIL("C.M<T, U>(T, U)",
 @"
 {
-  // Code size       62 (0x3e)
+  // Code size       61 (0x3d)
   .maxstack  4
   .locals init (T V_0)
   IL_0000:  ldarga.s   V_0
-  IL_0002:  ldtoken    ""T""
-  IL_0007:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_000c:  call       ""bool System.Type.IsValueType.get""
-  IL_0011:  brtrue.s   IL_001b
-  IL_0013:  ldobj      ""T""
-  IL_0018:  stloc.0
-  IL_0019:  ldloca.s   V_0
-  IL_001b:  ldc.i4.0
-  IL_001c:  box        ""int""
-  IL_0021:  ldarg.1
-  IL_0022:  box        ""U""
-  IL_0027:  ldc.i4.1
-  IL_0028:  box        ""int""
-  IL_002d:  callvirt   ""object A.this[object].get""
-  IL_0032:  constrained. ""T""
-  IL_0038:  callvirt   ""void I.this[object].set""
-  IL_003d:  ret
+  IL_0002:  ldloca.s   V_0
+  IL_0004:  initobj    ""T""
+  IL_000a:  ldloc.0
+  IL_000b:  box        ""T""
+  IL_0010:  brtrue.s   IL_001a
+  IL_0012:  ldobj      ""T""
+  IL_0017:  stloc.0
+  IL_0018:  ldloca.s   V_0
+  IL_001a:  ldc.i4.0
+  IL_001b:  box        ""int""
+  IL_0020:  ldarg.1
+  IL_0021:  box        ""U""
+  IL_0026:  ldc.i4.1
+  IL_0027:  box        ""int""
+  IL_002c:  callvirt   ""object A.this[object].get""
+  IL_0031:  constrained. ""T""
+  IL_0037:  callvirt   ""void I.this[object].set""
+  IL_003c:  ret
 }");
         }
 
@@ -4541,11 +4544,11 @@ class B
             compilation.VerifyIL("B.M1<T>(T)",
 @"
 {
-  // Code size      218 (0xda)
+  // Code size      216 (0xd8)
   .maxstack  4
   .locals init (int V_0,
-                T& V_1,
-                T V_2)
+            T& V_1,
+            T V_2)
   IL_0000:  ldarga.s   V_0
   IL_0002:  dup
   IL_0003:  constrained. ""T""
@@ -4571,51 +4574,53 @@ class B
   IL_003c:  ldarga.s   V_0
   IL_003e:  stloc.1
   IL_003f:  ldloc.1
-  IL_0040:  ldtoken    ""T""
-  IL_0045:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_004a:  call       ""bool System.Type.IsValueType.get""
-  IL_004f:  brtrue.s   IL_0059
-  IL_0051:  ldobj      ""T""
-  IL_0056:  stloc.2
-  IL_0057:  ldloca.s   V_2
-  IL_0059:  ldloc.1
-  IL_005a:  constrained. ""T""
-  IL_0060:  callvirt   ""int I.P.get""
-  IL_0065:  ldc.i4.2
-  IL_0066:  add
-  IL_0067:  constrained. ""T""
-  IL_006d:  callvirt   ""void I.P.set""
-  IL_0072:  ldarga.s   V_0
-  IL_0074:  stloc.1
-  IL_0075:  ldloc.1
-  IL_0076:  ldtoken    ""T""
-  IL_007b:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_0080:  call       ""bool System.Type.IsValueType.get""
-  IL_0085:  brtrue.s   IL_008f
-  IL_0087:  ldobj      ""T""
-  IL_008c:  stloc.2
-  IL_008d:  ldloca.s   V_2
+  IL_0040:  ldloca.s   V_2
+  IL_0042:  initobj    ""T""
+  IL_0048:  ldloc.2
+  IL_0049:  box        ""T""
+  IL_004e:  brtrue.s   IL_0058
+  IL_0050:  ldobj      ""T""
+  IL_0055:  stloc.2
+  IL_0056:  ldloca.s   V_2
+  IL_0058:  ldloc.1
+  IL_0059:  constrained. ""T""
+  IL_005f:  callvirt   ""int I.P.get""
+  IL_0064:  ldc.i4.2
+  IL_0065:  add
+  IL_0066:  constrained. ""T""
+  IL_006c:  callvirt   ""void I.P.set""
+  IL_0071:  ldarga.s   V_0
+  IL_0073:  stloc.1
+  IL_0074:  ldloc.1
+  IL_0075:  ldloca.s   V_2
+  IL_0077:  initobj    ""T""
+  IL_007d:  ldloc.2
+  IL_007e:  box        ""T""
+  IL_0083:  brtrue.s   IL_008d
+  IL_0085:  ldobj      ""T""
+  IL_008a:  stloc.2
+  IL_008b:  ldloca.s   V_2
+  IL_008d:  ldc.i4.0
+  IL_008e:  ldloc.1
   IL_008f:  ldc.i4.0
-  IL_0090:  ldloc.1
-  IL_0091:  ldc.i4.0
-  IL_0092:  constrained. ""T""
-  IL_0098:  callvirt   ""int I.this[int].get""
-  IL_009d:  ldc.i4.2
-  IL_009e:  add
-  IL_009f:  constrained. ""T""
-  IL_00a5:  callvirt   ""void I.this[int].set""
-  IL_00aa:  ldstr      ""{0}, {1}""
-  IL_00af:  ldarga.s   V_0
-  IL_00b1:  constrained. ""T""
-  IL_00b7:  callvirt   ""int I.P.get""
-  IL_00bc:  box        ""int""
-  IL_00c1:  ldarga.s   V_0
-  IL_00c3:  ldc.i4.0
-  IL_00c4:  constrained. ""T""
-  IL_00ca:  callvirt   ""int I.this[int].get""
-  IL_00cf:  box        ""int""
-  IL_00d4:  call       ""void System.Console.WriteLine(string, object, object)""
-  IL_00d9:  ret
+  IL_0090:  constrained. ""T""
+  IL_0096:  callvirt   ""int I.this[int].get""
+  IL_009b:  ldc.i4.2
+  IL_009c:  add
+  IL_009d:  constrained. ""T""
+  IL_00a3:  callvirt   ""void I.this[int].set""
+  IL_00a8:  ldstr      ""{0}, {1}""
+  IL_00ad:  ldarga.s   V_0
+  IL_00af:  constrained. ""T""
+  IL_00b5:  callvirt   ""int I.P.get""
+  IL_00ba:  box        ""int""
+  IL_00bf:  ldarga.s   V_0
+  IL_00c1:  ldc.i4.0
+  IL_00c2:  constrained. ""T""
+  IL_00c8:  callvirt   ""int I.this[int].get""
+  IL_00cd:  box        ""int""
+  IL_00d2:  call       ""void System.Console.WriteLine(string, object, object)""
+  IL_00d7:  ret
 }
 ");
             compilation.VerifyIL("B.M2<T>(T)",

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -55,7 +55,6 @@ namespace Microsoft.CodeAnalysis
         System_Type__GetTypeFromHandle,
         System_Type__Missing,
         System_Type__op_Equality,
-        System_Type__get_IsValueType,
 
         System_Reflection_AssemblyKeyFileAttribute__ctor,
         System_Reflection_AssemblyKeyNameAttribute__ctor,

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -365,13 +365,6 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Type,
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Type,
 
-                // System_Type__get_IsValueType
-                (byte)(MemberFlags.PropertyGet),                                                                            // Flags
-                (byte)WellKnownType.System_Type,                                                                            // DeclaringTypeId
-                0,                                                                                                          // Arity
-                    0,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean, // Return Type
-
                 // System_Reflection_AssemblyKeyFileAttribute__ctor
                 (byte)MemberFlags.Constructor,                                                                              // Flags
                 (byte)WellKnownType.System_Reflection_AssemblyKeyFileAttribute,                                             // DeclaringTypeId
@@ -3734,7 +3727,6 @@ namespace Microsoft.CodeAnalysis
                 "GetTypeFromHandle",                        // System_Type__GetTypeFromHandle
                 "Missing",                                  // System_Type__Missing
                 WellKnownMemberNames.EqualityOperatorName,  // System_Type__op_Equality
-                "get_IsValueType",                          // System_Type__get_IsValueType
                 ".ctor",                                    // System_Reflection_AssemblyKeyFileAttribute__ctor
                 ".ctor",                                    // System_Reflection_AssemblyKeyNameAttribute__ctor
                 "GetMethodFromHandle",                      // System_Reflection_MethodBase__GetMethodFromHandle

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbolBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EELocalSymbolBase.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Roslyn.Utilities;
 
@@ -53,14 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             get { return null; }
         }
 
-        internal sealed override LocalSymbol WithSynthesizedLocalKindAndSyntax(
-            SynthesizedLocalKind kind, SyntaxNode syntax
-#if DEBUG
-            ,
-            [CallerLineNumber] int createdAtLineNumber = 0,
-            [CallerFilePath] string createdAtFilePath = null
-#endif
-            )
+        internal sealed override LocalSymbol WithSynthesizedLocalKindAndSyntax(SynthesizedLocalKind kind, SyntaxNode syntax)
         {
             throw ExceptionUtilities.Unreachable();
         }


### PR DESCRIPTION
Reverts dotnet/roslyn#66311 due to https://github.com/dotnet/runtime/pull/80429#issuecomment-1381250767