### PR TITLE
Ensure no extension method applies to System.Void

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -745,7 +745,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 throw new ArgumentNullException(nameof(receiverType));
             }
 
-            if (!this.IsExtensionMethod || this.MethodKind == MethodKind.ReducedExtension)
+            if (!this.IsExtensionMethod || this.MethodKind == MethodKind.ReducedExtension || receiverType.IsVoidType())
             {
                 return null;
             }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -4102,6 +4102,9 @@ public static class C
 
             var reduced = extensionMethod.ReduceExtensionMethod(systemVoidType, null!);
             Assert.Null(reduced);
+
+            reduced = extensionMethod.ReduceExtensionMethod(systemVoidType, compilation);
+            Assert.Null(reduced);
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ExtensionMethodTests.cs
@@ -4079,5 +4079,29 @@ public static class C
 
             CompileAndVerify(source, validator: Validator, options: TestOptions.ReleaseDll);
         }
+
+        [Fact]
+        [WorkItem(65020, "https://github.com/dotnet/roslyn/issues/65020")]
+        public void ReduceExtensionsMethodOnReceiverTypeSystemVoid()
+        {
+            var source =
+@"static class C
+{
+    static void M(this object x)
+    {
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib40AndSystemCore(source);
+            compilation.VerifyDiagnostics();
+
+            var extensionMethod = compilation.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMember<MethodSymbol>("M");
+            Assert.True(extensionMethod.IsExtensionMethod);
+
+            var systemVoidType = compilation.GetSpecialType(SpecialType.System_Void);
+            Assert.Equal(SpecialType.System_Void, systemVoidType.SpecialType);
+
+            var reduced = extensionMethod.ReduceExtensionMethod(systemVoidType, null!);
+            Assert.Null(reduced);
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelLookupSymbolsAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelLookupSymbolsAPITests.vb
@@ -9,7 +9,6 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Imports Roslyn.Test.Utilities
-Imports Roslyn.Test.Utilities.TestMetadata
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
@@ -915,40 +914,6 @@ End Class
             result.Free()
         End Sub
 
-        <Fact>
-        Public Sub LookupExtensionMethodOnReceiverTypeSystemVoid()
-            Dim compilation = CompilationUtils.CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(
-<compilation>
-    <file name="a.vb"><![CDATA[
-Imports System
-Imports System.Runtime.CompilerServices
-Structure C
-    Public Sub M()
-        ' in M
-    End Sub
-End Structure
-Module E
-    <Extension()>
-    Friend Sub ExtMethod(o As ValueType)
-    End Sub
-End Module
-]]></file>
-</compilation>, {TestMetadata.Net40.SystemCore})
-
-            Dim tree = compilation.SyntaxTrees.Single()
-            Dim semanticModel = compilation.GetSemanticModel(tree)
-            Dim posInside As Integer = CompilationUtils.FindPositionFromText(tree, "' in M")
-
-            ' Lookup should return ExtMethod for object of type C
-            Dim actual_lookupSymbols = semanticModel.LookupSymbols(posInside, container:=compilation.GetTypeByMetadataName("C"), includeReducedExtensionMethods:=True)
-            Dim actual_lookupSymbols_as_string = actual_lookupSymbols.Select(Function(e) e.ToTestDisplayString())
-            Assert.Contains("Sub System.ValueType.ExtMethod()", actual_lookupSymbols_as_string)
-
-            ' Lookup should not return ExtMethod for object of System>Void, even though it's a ValueType
-            actual_lookupSymbols = semanticModel.LookupSymbols(posInside, container:=compilation.GetSpecialType(SpecialType.System_Void), includeReducedExtensionMethods:=True)
-            actual_lookupSymbols_as_string = actual_lookupSymbols.Select(Function(e) e.ToTestDisplayString())
-            Assert.DoesNotContain("Sub System.ValueType.ExtMethod()", actual_lookupSymbols_as_string)
-        End Sub
 #End Region
 
 #Region "Regression"

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
@@ -2553,9 +2553,7 @@ End Module
 ]]></file>
 </compilation>, {Net40.SystemCore})
 
-            Dim tree = compilation.SyntaxTrees.Single()
             Dim extensionMethod = DirectCast(compilation.GetSymbolsWithName("ExtMethod", SymbolFilter.Member).Single(), IMethodSymbol)
-
             Assert.NotNull(extensionMethod)
 
             Dim reducedMethodOnC = extensionMethod.ReduceExtensionMethod(compilation.GetTypeByMetadataName("C"))

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/ExtensionMethods/ExtensionMethodTests.vb
@@ -2535,6 +2535,36 @@ End Module
             CompileAndVerify(vb, expectedOutput:="5")
         End Sub
 
+        <Fact>
+        <WorkItem(65020, "https://github.com/dotnet/roslyn/issues/65020")>
+        Public Sub ReduceExtensionMethodOnReceiverTypeSystemVoid()
+            Dim compilation = CreateCompilationWithMscorlib40AndVBRuntimeAndReferences(
+<compilation>
+    <file name="a.vb"><![CDATA[
+Imports System
+Imports System.Runtime.CompilerServices
+Structure C
+End Structure
+Module E
+    <Extension()>
+    Friend Sub ExtMethod(o As ValueType)
+    End Sub
+End Module
+]]></file>
+</compilation>, {Net40.SystemCore})
+
+            Dim tree = compilation.SyntaxTrees.Single()
+            Dim extensionMethod = DirectCast(compilation.GetSymbolsWithName("ExtMethod", SymbolFilter.Member).Single(), IMethodSymbol)
+
+            Assert.NotNull(extensionMethod)
+
+            Dim reducedMethodOnC = extensionMethod.ReduceExtensionMethod(compilation.GetTypeByMetadataName("C"))
+            Assert.NotNull(reducedMethodOnC)
+            Assert.Equal("Sub System.ValueType.ExtMethod()", reducedMethodOnC.ToTestDisplayString())
+
+            Dim reducedMethodOnVoid = extensionMethod.ReduceExtensionMethod(compilation.GetSpecialType(SpecialType.System_Void))
+            Assert.Null(reducedMethodOnVoid)
+        End Sub
     End Class
 
 End Namespace

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -12021,6 +12021,28 @@ ref struct MyRefStruct { }
         }
 
         [Fact]
+        [WorkItem(65020, "https://github.com/dotnet/roslyn/issues/65020")]
+        public async Task DoNotProvideMemberOnSystemVoid()
+        {
+            var source = @"
+class C
+{
+    void M1(){}
+    void M2()
+    {
+        this.M1().$$
+    }
+}
+
+public static class Extension
+{
+    public static bool ExtMethod(this object x) => false;
+}
+";
+            await VerifyItemIsAbsentAsync(MakeMarkup(source), "ExtMethod");
+        }
+
+        [Fact]
         public async Task NoSymbolCompletionsInEnumBaseList()
         {
             var source = "enum E : $$";

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -437,6 +437,11 @@ internal partial class CSharpRecommendationService
             if (containerSymbol == null)
                 return default;
 
+            // We don't provide any member from System.Void (which is valid only in the context of typeof operation).
+            // Try to bail early to avoid unnecessary work even though compiler will handle this case for us.
+            if (containerSymbol is INamedTypeSymbol typeSymbol && typeSymbol.IsSystemVoid())
+                return default;
+
             Debug.Assert(!excludeInstance || !excludeStatic);
 
             // nameof(X.|

--- a/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
+++ b/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
@@ -273,6 +273,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
                     Return ImmutableArray(Of ISymbol).Empty
                 End If
 
+                ' We don't provide any member from System.Void (which is valid only in the context of typeof operation).
+                ' Try to bail early to avoid unnecessary work even though compiler will handle this case for us.
+                If container IsNot Nothing AndAlso container.Kind = SymbolKind.NamedType Then
+                    Dim typeContainer = DirectCast(container, INamedTypeSymbol)
+                    If typeContainer.IsSystemVoid() Then
+                        Return ImmutableArray(Of ISymbol).Empty
+                    End If
+                End If
+
                 Debug.Assert((Not excludeInstance OrElse Not excludeShared) OrElse
                          (inNameOfExpression AndAlso Not excludeInstance AndAlso Not excludeShared))
 


### PR DESCRIPTION
Fix https://github.com/dotnet/roslyn/issues/65020

This is not an issue in VB because there's already a single check for regular members and extension methods exist https://sourceroslyn.io/#Microsoft.CodeAnalysis.VisualBasic/Binding/Binder_Lookup.vb,1928