### PR TITLE
Catch exceptions when doing I/O to read the generator file version

### DIFF
--- a/src/Workspaces/Core/Portable/SourceGeneratorTelemetry/SourceGeneratorTelemetryCollectorWorkspaceService.cs
+++ b/src/Workspaces/Core/Portable/SourceGeneratorTelemetry/SourceGeneratorTelemetryCollectorWorkspaceService.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.SourceGeneratorTelemetry
@@ -25,7 +26,7 @@ namespace Microsoft.CodeAnalysis.SourceGeneratorTelemetry
 
                 if (Identity.AssemblyPath != null)
                 {
-                    FileVersion = FileVersionInfo.GetVersionInfo(Identity.AssemblyPath).FileVersion;
+                    FileVersion = IOUtilities.PerformIO(() => FileVersionInfo.GetVersionInfo(Identity.AssemblyPath).FileVersion, defaultValue: "(reading version threw exception)");
                 }
             }
 

--- a/src/Workspaces/CoreTest/SolutionTests/SourceGeneratorTelemetryCollectorWorkspaceServiceTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SourceGeneratorTelemetryCollectorWorkspaceServiceTests.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.SourceGeneratorTelemetry;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Roslyn.Test.Utilities.TestGenerators;
+using Xunit;
+using static Microsoft.CodeAnalysis.UnitTests.SolutionTestHelpers;
+using static Microsoft.CodeAnalysis.UnitTests.SolutionUtilities;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    [UseExportProvider]
+    public class SourceGeneratorTelemetryCollectorWorkspaceServiceTests
+    {
+        [Fact]
+        [WorkItem(1675665, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1675665")]
+        public async Task WithReferencesMethodCorrectlyUpdatesWithEqualReferences()
+        {
+            using var workspace = CreateWorkspace(additionalParts: new[] { typeof(TestSourceGeneratorTelemetryCollectorWorkspaceServiceFactory) });
+
+            var nonExistentFilePath = "Z:\\" + Guid.NewGuid().ToString();
+            var analyzerReference = new TestGeneratorReference(new SingleFileTestGenerator("// Hello World"), analyzerFilePath: nonExistentFilePath);
+
+            var project = AddEmptyProject(workspace.CurrentSolution)
+                .AddAnalyzerReference(analyzerReference);
+
+            _ = await project.GetCompilationAsync();
+        }
+
+        [ExportWorkspaceServiceFactory(typeof(ISourceGeneratorTelemetryCollectorWorkspaceService)), Shared]
+        [PartNotDiscoverable]
+        public class TestSourceGeneratorTelemetryCollectorWorkspaceServiceFactory : IWorkspaceServiceFactory
+        {
+            [ImportingConstructor]
+            [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+            public TestSourceGeneratorTelemetryCollectorWorkspaceServiceFactory()
+            {
+            }
+
+            public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
+            {
+                return new SourceGeneratorTelemetryCollectorWorkspaceService();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Sometimes when we do file I/O to read the generator version, we end up getting an exception if the file could no longer be read. In this case, just record there was an exception in telemetry.

Fixes [AB#1675665](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1675665)

Putting this into 17.6; the hit count is non-zero in 17.4/17.5 but it's pretty low, so no need to rush it.