### PR TITLE
Replace placeholder XXX SDK version

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes - DotNet 7.md
@@ -66,7 +66,7 @@ To workaround the overload resolution changes, use explicit types for the lambda
 
 ***Introduced in Visual Studio 2022 version 17.5***
 
-In .NET SDK XXX or earlier the following was erroneously allowed:
+In .NET SDK 7.0.100 or earlier the following was erroneously allowed:
 
 ```csharp
 var x = $"""


### PR DESCRIPTION
I've guessed the right version is 7.0.100 , based on line 95.  Let me know if it's not the right one and I'll update the PR!