### PR TITLE
Enable EnC file logging during VS Feedback recording and collect the logs

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -112,6 +112,7 @@
     <MicrosoftIdentityModelClientsActiveDirectoryVersion>3.13.8</MicrosoftIdentityModelClientsActiveDirectoryVersion>
     <MicrosoftInternalPerformanceCodeMarkersDesignTimeVersion>15.8.27812-alpha</MicrosoftInternalPerformanceCodeMarkersDesignTimeVersion>
     <MicrosoftInternalVisualStudioInteropVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioInteropVersion>
+    <MicrosoftInternalVisualStudioShellFrameworkVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioShellFrameworkVersion>
     <MicrosoftmacOSRefVersion>12.3.300-rc.3.83</MicrosoftmacOSRefVersion>
     <MicrosoftMetadataVisualizerVersion>1.0.0-beta3.21075.2</MicrosoftMetadataVisualizerVersion>
     <MicrosoftNETBuildExtensionsVersion>2.2.101</MicrosoftNETBuildExtensionsVersion>

--- a/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
@@ -61,6 +61,22 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             _sourceTextProvider = sourceTextProvider;
         }
 
+        public void SetFileLoggingDirectory(string? logDirectory)
+        {
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    var proxy = new RemoteEditAndContinueServiceProxy(WorkspaceProvider.Value.Workspace);
+                    await proxy.SetFileLoggingDirectoryAsync(logDirectory, CancellationToken.None).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // ignore
+                }
+            });
+        }
+
         private Solution GetCurrentCompileTimeSolution(Solution? currentDesignTimeSolution = null)
         {
             var workspace = WorkspaceProvider.Value.Workspace;

--- a/src/EditorFeatures/Test/EditAndContinue/TraceLogTests.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/TraceLogTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         [Fact]
         public void Write()
         {
-            var log = new TraceLog(5, "log", "File.log", logDirectory: null);
+            var log = new TraceLog(5, "log", "File.log");
 
             var projectId = ProjectId.CreateFromSerialized(Guid.Parse("5E40F37C-5AB3-495E-A3F2-4A244D177674"), debugName: "MyProject");
             var diagnostic = Diagnostic.Create(EditAndContinueDiagnosticDescriptors.GetDescriptor(EditAndContinueErrorCode.ErrorReadingFile), Location.None, "file", "error");

--- a/src/EditorFeatures/TestUtilities/EditAndContinue/MockEditAndContinueWorkspaceService.cs
+++ b/src/EditorFeatures/TestUtilities/EditAndContinue/MockEditAndContinueWorkspaceService.cs
@@ -84,5 +84,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
         public ValueTask<DebuggingSessionId> StartDebuggingSessionAsync(Solution solution, IManagedHotReloadService debuggerService, IPdbMatchingSourceTextProvider sourceTextProvider, ImmutableArray<DocumentId> captureMatchingDocuments, bool captureAllMatchingDocuments, bool reportDiagnostics, CancellationToken cancellationToken)
             => new((StartDebuggingSessionImpl ?? throw new NotImplementedException()).Invoke(solution, debuggerService, sourceTextProvider, captureMatchingDocuments, captureAllMatchingDocuments, reportDiagnostics));
+
+        public void SetFileLoggingDirectory(string? logDirectory)
+            => throw new NotImplementedException();
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
@@ -46,9 +46,15 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         static EditAndContinueWorkspaceService()
         {
+            Log = new(2048, "EnC", "Trace.log");
+            AnalysisLog = new(1024, "EnC", "Analysis.log");
+
             var logDir = GetLogDirectory();
-            Log = new(2048, "EnC", "Trace.log", logDir);
-            AnalysisLog = new(1024, "EnC", "Analysis.log", logDir);
+            if (logDir != null)
+            {
+                Log.SetLogDirectory(logDir);
+                AnalysisLog.SetLogDirectory(logDir);
+            }
         }
 
         private static string? GetLogDirectory()
@@ -68,6 +74,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 return null;
             }
+        }
+
+        public void SetFileLoggingDirectory(string? logDirectory)
+        {
+            Log.SetLogDirectory(logDirectory ?? GetLogDirectory());
         }
 
         private static CompilationOutputs GetCompilationOutputs(Project project)

--- a/src/Features/Core/Portable/EditAndContinue/IEditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/IEditAndContinueWorkspaceService.cs
@@ -28,5 +28,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         ValueTask<ImmutableArray<ImmutableArray<ActiveStatementSpan>>> GetBaseActiveStatementSpansAsync(DebuggingSessionId sessionId, Solution solution, ImmutableArray<DocumentId> documentIds, CancellationToken cancellationToken);
         ValueTask<ImmutableArray<ActiveStatementSpan>> GetAdjustedActiveStatementSpansAsync(DebuggingSessionId sessionId, TextDocument document, ActiveStatementSpanProvider activeStatementSpanProvider, CancellationToken cancellationToken);
+
+        void SetFileLoggingDirectory(string? logDirectory);
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/IRemoteEditAndContinueService.cs
@@ -51,5 +51,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
         ValueTask<bool?> IsActiveStatementInExceptionRegionAsync(Checksum solutionChecksum, DebuggingSessionId sessionId, ManagedInstructionId instructionId, CancellationToken cancellationToken);
         ValueTask<LinePositionSpan?> GetCurrentActiveStatementPositionAsync(Checksum solutionChecksum, RemoteServiceCallbackId callbackId, DebuggingSessionId sessionId, ManagedInstructionId instructionId, CancellationToken cancellationToken);
+
+        ValueTask SetFileLoggingDirectoryAsync(string? logDirectory, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/Remote/RemoteEditAndContinueServiceProxy.cs
+++ b/src/Features/Core/Portable/EditAndContinue/Remote/RemoteEditAndContinueServiceProxy.cs
@@ -242,6 +242,21 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             return data.ToDiagnostic(location, ImmutableArray<Location>.Empty);
         }
 
+        public async ValueTask SetFileLoggingDirectoryAsync(string? logDirectory, CancellationToken cancellationToken)
+        {
+            var client = await RemoteHostClient.TryGetClientAsync(Workspace, cancellationToken).ConfigureAwait(false);
+            if (client == null)
+            {
+                GetLocalService().SetFileLoggingDirectory(logDirectory);
+            }
+            else
+            {
+                await client.TryInvokeAsync<IRemoteEditAndContinueService>(
+                    (service, cancellationToken) => service.SetFileLoggingDirectoryAsync(logDirectory, cancellationToken),
+                    cancellationToken).ConfigureAwait(false);
+            }
+        }
+
         private sealed class LocalConnection : IDisposable
         {
             public static readonly LocalConnection Instance = new();

--- a/src/Features/Core/Portable/EditAndContinue/TraceLog.cs
+++ b/src/Features/Core/Portable/EditAndContinue/TraceLog.cs
@@ -112,22 +112,137 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 => (MessageFormat == null) ? "" : string.Format(MessageFormat, Args?.Select(a => a.GetDebuggerDisplay()).ToArray() ?? Array.Empty<object>());
         }
 
+        internal sealed class FileLogger
+        {
+            private readonly string _logDirectory;
+            private readonly TraceLog _traceLog;
+
+            public FileLogger(string logDirectory, TraceLog traceLog)
+            {
+                _logDirectory = logDirectory;
+                _traceLog = traceLog;
+            }
+
+            public void Append(Entry entry)
+            {
+                string? path = null;
+
+                try
+                {
+                    path = Path.Combine(_logDirectory, _traceLog._fileName);
+                    File.AppendAllLines(path, new[] { entry.GetDebuggerDisplay() });
+                }
+                catch (Exception e)
+                {
+                    _traceLog.AppendFileLoggingErrorInMemory(path, e);
+                }
+            }
+
+            private string CreateSessionDirectory(DebuggingSessionId sessionId, string relativePath)
+            {
+                Contract.ThrowIfNull(_logDirectory);
+                var directory = Path.Combine(_logDirectory, sessionId.Ordinal.ToString(), relativePath);
+                Directory.CreateDirectory(directory);
+                return directory;
+            }
+
+            private string MakeSourceFileLogPath(Document document, string suffix, UpdateId updateId, int? generation)
+            {
+                Debug.Assert(document.FilePath != null);
+                Debug.Assert(document.Project.FilePath != null);
+
+                var projectDir = PathUtilities.GetDirectoryName(document.Project.FilePath)!;
+                var documentDir = PathUtilities.GetDirectoryName(document.FilePath)!;
+                var extension = PathUtilities.GetExtension(document.FilePath);
+                var fileName = PathUtilities.GetFileName(document.FilePath, includeExtension: false);
+
+                var relativeDir = PathUtilities.IsSameDirectoryOrChildOf(documentDir, projectDir) ? PathUtilities.GetRelativePath(projectDir, documentDir) : documentDir;
+                relativeDir = relativeDir.Replace('\\', '_').Replace('/', '_');
+
+                var directory = CreateSessionDirectory(updateId.SessionId, Path.Combine(document.Project.Name, relativeDir));
+                return Path.Combine(directory, $"{fileName}.{updateId.Ordinal}.{generation?.ToString() ?? "-"}.{suffix}{extension}");
+            }
+
+            public void Write(DebuggingSessionId sessionId, ImmutableArray<byte> bytes, string directory, string fileName)
+            {
+                string? path = null;
+                try
+                {
+                    path = Path.Combine(CreateSessionDirectory(sessionId, directory), fileName);
+                    File.WriteAllBytes(path, bytes.ToArray());
+                }
+                catch (Exception e)
+                {
+                    _traceLog.AppendFileLoggingErrorInMemory(path, e);
+                }
+            }
+
+            public async ValueTask WriteAsync(Func<Stream, CancellationToken, ValueTask> writer, DebuggingSessionId sessionId, string directory, string fileName, CancellationToken cancellationToken)
+            {
+                string? path = null;
+                try
+                {
+                    path = Path.Combine(CreateSessionDirectory(sessionId, directory), fileName);
+                    using var file = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Write | FileShare.Delete);
+                    await writer(file, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    _traceLog.AppendFileLoggingErrorInMemory(path, e);
+                }
+            }
+
+            public async ValueTask WriteDocumentAsync(Document document, string fileNameSuffix, UpdateId updateId, int? generation, CancellationToken cancellationToken)
+            {
+                Debug.Assert(document.FilePath != null);
+
+                string? path = null;
+                try
+                {
+                    path = MakeSourceFileLogPath(document, fileNameSuffix, updateId, generation);
+                    var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                    using var file = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Write | FileShare.Delete);
+                    using var writer = new StreamWriter(file, text.Encoding ?? Encoding.UTF8);
+                    text.Write(writer, cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    _traceLog.AppendFileLoggingErrorInMemory(path, e);
+                }
+            }
+
+            public async ValueTask WriteDocumentChangeAsync(Document? oldDocument, Document? newDocument, UpdateId updateId, int? generation, CancellationToken cancellationToken)
+            {
+                if (oldDocument?.FilePath != null)
+                {
+                    await WriteDocumentAsync(oldDocument, fileNameSuffix: "old", updateId, generation, cancellationToken).ConfigureAwait(false);
+                }
+
+                if (newDocument?.FilePath != null)
+                {
+                    await WriteDocumentAsync(newDocument, fileNameSuffix: "new", updateId, generation, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
         private readonly Entry[] _log;
         private readonly string _id;
         private readonly string _fileName;
-        private readonly string? _logDirectory;
         private int _currentLine;
 
-        public TraceLog(int logSize, string id, string fileName, string? logDirectory)
+        public FileLogger? FileLog { get; private set; }
+
+        public TraceLog(int logSize, string id, string fileName)
         {
             _log = new Entry[logSize];
             _id = id;
             _fileName = fileName;
-            _logDirectory = logDirectory;
         }
 
-        public bool FileLoggingEnabled
-            => _logDirectory != null;
+        public void SetLogDirectory(string? logDirectory)
+        {
+            FileLog = (logDirectory != null) ? new FileLogger(logDirectory, this) : null;
+        }
 
         private void AppendInMemory(Entry entry)
         {
@@ -138,30 +253,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         private void AppendFileLoggingErrorInMemory(string? path, Exception e)
             => AppendInMemory(new Entry("Error writing log file '{0}': {1}", new[] { new Arg(path), new Arg(e.Message) }));
 
-        private void AppendToFile(Entry entry)
-        {
-            Debug.Assert(_logDirectory != null);
-            string? path = null;
-
-            try
-            {
-                path = Path.Combine(_logDirectory, _fileName);
-                File.AppendAllLines(path, new[] { entry.GetDebuggerDisplay() });
-            }
-            catch (Exception e)
-            {
-                AppendFileLoggingErrorInMemory(path, e);
-            }
-        }
-
         private void Append(Entry entry)
         {
             AppendInMemory(entry);
-
-            if (_logDirectory != null)
-            {
-                AppendToFile(entry);
-            }
+            FileLog?.Append(entry);
         }
 
         public void Write(string str)
@@ -180,92 +275,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             var entry = new Entry(format, args);
             Append(entry);
             Debug.WriteLine(entry.ToString(), _id);
-        }
-
-        private string CreateSessionDirectory(DebuggingSessionId sessionId, string relativePath)
-        {
-            Contract.ThrowIfNull(_logDirectory);
-            var directory = Path.Combine(_logDirectory, sessionId.Ordinal.ToString(), relativePath);
-            Directory.CreateDirectory(directory);
-            return directory;
-        }
-
-        private string MakeSourceFileLogPath(Document document, string suffix, UpdateId updateId, int? generation)
-        {
-            Debug.Assert(document.FilePath != null);
-            Debug.Assert(document.Project.FilePath != null);
-
-            var projectDir = PathUtilities.GetDirectoryName(document.Project.FilePath)!;
-            var documentDir = PathUtilities.GetDirectoryName(document.FilePath)!;
-            var extension = PathUtilities.GetExtension(document.FilePath);
-            var fileName = PathUtilities.GetFileName(document.FilePath, includeExtension: false);
-
-            var relativeDir = PathUtilities.IsSameDirectoryOrChildOf(documentDir, projectDir) ? PathUtilities.GetRelativePath(projectDir, documentDir) : documentDir;
-            relativeDir = relativeDir.Replace('\\', '_').Replace('/', '_');
-
-            var directory = CreateSessionDirectory(updateId.SessionId, Path.Combine(document.Project.Name, relativeDir));
-            return Path.Combine(directory, $"{fileName}.{updateId.Ordinal}.{generation?.ToString() ?? "-"}.{suffix}{extension}");
-        }
-
-        public void WriteToFile(DebuggingSessionId sessionId, ImmutableArray<byte> bytes, string directory, string fileName)
-        {
-            string? path = null;
-            try
-            {
-                path = Path.Combine(CreateSessionDirectory(sessionId, directory), fileName);
-                File.WriteAllBytes(path, bytes.ToArray());
-            }
-            catch (Exception e)
-            {
-                AppendFileLoggingErrorInMemory(path, e);
-            }
-        }
-
-        public async ValueTask WriteToFileAsync(Func<Stream, CancellationToken, ValueTask> writer, DebuggingSessionId sessionId, string directory, string fileName, CancellationToken cancellationToken)
-        {
-            string? path = null;
-            try
-            {
-                path = Path.Combine(CreateSessionDirectory(sessionId, directory), fileName);
-                using var file = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Write | FileShare.Delete);
-                await writer(file, cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                AppendFileLoggingErrorInMemory(path, e);
-            }
-        }
-
-        private async ValueTask WriteDocumentAsync(Document document, string fileNameSuffix, UpdateId updateId, int? generation, CancellationToken cancellationToken)
-        {
-            Debug.Assert(document.FilePath != null);
-
-            string? path = null;
-            try
-            {
-                path = MakeSourceFileLogPath(document, fileNameSuffix, updateId, generation);
-                var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-                using var file = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Write | FileShare.Delete);
-                using var writer = new StreamWriter(file, text.Encoding ?? Encoding.UTF8);
-                text.Write(writer, cancellationToken);
-            }
-            catch (Exception e)
-            {
-                AppendFileLoggingErrorInMemory(path, e);
-            }
-        }
-
-        public async ValueTask WriteDocumentChangeAsync(Document? oldDocument, Document? newDocument, UpdateId updateId, int? generation, CancellationToken cancellationToken)
-        {
-            if (oldDocument?.FilePath != null)
-            {
-                await WriteDocumentAsync(oldDocument, fileNameSuffix: "old", updateId, generation, cancellationToken).ConfigureAwait(false);
-            }
-
-            if (newDocument?.FilePath != null)
-            {
-                await WriteDocumentAsync(newDocument, fileNameSuffix: "new", updateId, generation, cancellationToken).ConfigureAwait(false);
-            }
         }
 
         internal TestAccessor GetTestAccessor()

--- a/src/VisualStudio/Core/Def/EditAndContinue/EditAndContinueFeedbackDiagnosticFileProvider.cs
+++ b/src/VisualStudio/Core/Def/EditAndContinue/EditAndContinueFeedbackDiagnosticFileProvider.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.Internal.VisualStudio.Shell.Embeddable.Feedback;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Newtonsoft.Json.Linq;
+using Task = System.Threading.Tasks.Task;
+using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.EditAndContinue;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.LanguageServices.EditAndContinue;
+
+[Export(typeof(IFeedbackDiagnosticFileProvider))]
+internal sealed class EditAndContinueFeedbackDiagnosticFileProvider : IFeedbackDiagnosticFileProvider
+{
+    /// <summary>
+    /// Name of the file displayed in VS Feedback UI.
+    /// See https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1714452.
+    /// </summary>
+    private const string ZipFileName = "source_files_and_binaries_updated_during_hot_reload.zip";
+
+    private const string VSFeedbackSemaphoreDir = @"Microsoft\VSFeedbackCollector";
+    private const string VSFeedbackSemaphoreFileName = "feedback.recording.json";
+
+    /// <summary>
+    /// VS Feedback creates a JSON file at the start of feedback session and deletes it when the session is over.
+    /// Watching the file is currently the only way to detect the feedback session.
+    /// </summary>
+    private readonly string _vsFeedbackSemaphoreFullPath;
+    private readonly FileSystemWatcher _vsFeedbackSemaphoreFileWatcher;
+
+    private readonly int _vsProcessId;
+    private readonly DateTime _vsProcessStartTime;
+    private readonly string _tempDir;
+
+    private volatile int _isLogCollectionInProgress;
+
+    private readonly EditAndContinueLanguageService _encService;
+
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public EditAndContinueFeedbackDiagnosticFileProvider(EditAndContinueLanguageService encService)
+    {
+        _encService = encService;
+
+        var vsProcess = Process.GetCurrentProcess();
+
+        _vsProcessId = vsProcess.Id;
+        _vsProcessStartTime = vsProcess.StartTime;
+
+        _tempDir = Path.GetTempPath();
+        var vsFeedbackTempDir = Path.Combine(_tempDir, VSFeedbackSemaphoreDir);
+        _vsFeedbackSemaphoreFullPath = Path.Combine(vsFeedbackTempDir, VSFeedbackSemaphoreFileName);
+
+        _vsFeedbackSemaphoreFileWatcher = new FileSystemWatcher(vsFeedbackTempDir, VSFeedbackSemaphoreFileName);
+        _vsFeedbackSemaphoreFileWatcher.Created += (_, _) => OnFeedbackSemaphoreCreatedOrChanged();
+        _vsFeedbackSemaphoreFileWatcher.Changed += (_, _) => OnFeedbackSemaphoreCreatedOrChanged();
+        _vsFeedbackSemaphoreFileWatcher.Deleted += (_, _) => OnFeedbackSemaphoreDeleted();
+
+        if (File.Exists(_vsFeedbackSemaphoreFullPath))
+        {
+            OnFeedbackSemaphoreCreatedOrChanged();
+        }
+
+        _vsFeedbackSemaphoreFileWatcher.EnableRaisingEvents = true;
+    }
+
+    /// <summary>
+    /// Reuse the same directory for multiple feedback sessions originating from the same VS instance.
+    /// Log files for different debugging sessions will be in separate subdirectories so they will not collide,
+    /// but the later feedback sessions will include all files logged for the previous sessions as well.
+    /// Also if the compression and/or uploading of the zip file is not finished by the time the new recording starts
+    /// we might not be able to write the new zip file to disk and the previous content might be uploaded instead.
+    /// See https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1716980
+    /// </summary>
+    private string GetLogDirectory()
+        => Path.Combine(Path.Combine(_tempDir, $"EnC_{_vsProcessId}", "Log"));
+
+    private string GetZipFilePath()
+        => Path.Combine(Path.Combine(_tempDir, $"EnC_{_vsProcessId}", ZipFileName));
+
+    public IReadOnlyCollection<string> GetFiles()
+        => new[] { GetZipFilePath() };
+
+    private void OnFeedbackSemaphoreCreatedOrChanged()
+    {
+        if (!IsLoggingEnabledForCurrentVisualStudioInstance(_vsFeedbackSemaphoreFullPath))
+        {
+            // The semaphore file was created for another VS instance.
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _isLogCollectionInProgress, 1, 0) == 0)
+        {
+            _encService.SetFileLoggingDirectory(GetLogDirectory());
+        }
+    }
+
+    private void OnFeedbackSemaphoreDeleted()
+    {
+        if (Interlocked.Exchange(ref _isLogCollectionInProgress, 0) == 1)
+        {
+            _encService.SetFileLoggingDirectory(logDirectory: null);
+
+            // Including the zip files in VS Feedback is currently on best effort basis.
+            // See https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1714439
+            Task.Run(() =>
+            {
+                try
+                {
+                    ZipFile.CreateFromDirectory(GetLogDirectory(), GetZipFilePath());
+                }
+                catch
+                {
+                }
+            });
+        }
+    }
+
+    private bool IsLoggingEnabledForCurrentVisualStudioInstance(string semaphoreFilePath)
+    {
+        try
+        {
+            if (_vsProcessStartTime > File.GetCreationTime(semaphoreFilePath))
+            {
+                // Semaphore file is older than the running instance of VS
+                return false;
+            }
+
+            // Check the contents of the semaphore file to see if it's for this instance of VS
+            var content = File.ReadAllText(semaphoreFilePath);
+            return JObject.Parse(content)["processIds"] is JContainer pidCollection && pidCollection.Values<int>().Contains(_vsProcessId);
+        }
+        catch
+        {
+            // Something went wrong opening or parsing the semaphore file - ignore it
+            return false;
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/EditAndContinue/EditAndContinueFeedbackDiagnosticFileProvider.cs
+++ b/src/VisualStudio/Core/Def/EditAndContinue/EditAndContinueFeedbackDiagnosticFileProvider.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
+++ b/src/VisualStudio/Core/Def/Microsoft.VisualStudio.LanguageServices.csproj
@@ -121,6 +121,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpVersion)" />
     <PackageReference Include="Microsoft.Internal.Performance.CodeMarkers.DesignTime" Version="$(MicrosoftInternalPerformanceCodeMarkersDesignTimeVersion)" />
     <PackageReference Include="Microsoft.Internal.VisualStudio.Interop" Version="$(MicrosoftInternalVisualStudioInteropVersion)" />
+    <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Framework" Version="$(MicrosoftInternalVisualStudioShellFrameworkVersion)" />
     <PackageReference Include="Microsoft.ServiceHub.Client" Version="$(MicrosoftServiceHubClientVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Debugger.Engine-implementation" Version="$(MicrosoftVisualStudioDebuggerEngineimplementationVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="$(MicrosoftVisualStudioDesignerInterfacesVersion)" />

--- a/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/EditAndContinue/RemoteEditAndContinueService.cs
@@ -234,5 +234,17 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 return await GetService().GetCurrentActiveStatementPositionAsync(sessionId, solution, CreateActiveStatementSpanProvider(callbackId), instructionId, cancellationToken).ConfigureAwait(false);
             }, cancellationToken);
         }
+
+        /// <summary>
+        /// Remote API.
+        /// </summary>
+        public ValueTask SetFileLoggingDirectoryAsync(string? logDirectory, CancellationToken cancellationToken)
+        {
+            return RunServiceAsync(cancellationToken =>
+            {
+                GetService().SetFileLoggingDirectory(logDirectory);
+                return default;
+            }, cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
Internal doc link

https://dev.azure.com/devdiv/DevDiv/_wiki/wikis/DevDiv.wiki/3928/Adding-log-files-through-IFeedbackDiagnosticFileProvider?anchor=adopting-teams

Turns out this does not work entirely end to end (the file is not uploaded to feedback), but at least it is created on disk and can be inspected, so this is still useful until the upload is fixed by the VS Feedback team.