### PR TITLE
Support generating conversion-operators from SyntaxGenerator

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -23,7 +23,7 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 {
     [ExportLanguageService(typeof(SyntaxGenerator), LanguageNames.CSharp), Shared]
-    internal class CSharpSyntaxGenerator : SyntaxGenerator
+    internal sealed class CSharpSyntaxGenerator : SyntaxGenerator
     {
         // A bit hacky, but we need to actually run ParseToken on the "nameof" text as there's no
         // other way to get a token back that has the appropriate internal bit set that indicates

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -49,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Editing
         {
             Assert.IsAssignableFrom<TSyntax>(node);
             var normalized = node.NormalizeWhitespace().ToFullString();
-            Assert.Equal(expectedText, normalized);
+            AssertEx.Equal(expectedText, normalized);
         }
 
         private static void VerifySyntaxRaw<TSyntax>(SyntaxNode node, string expectedText) where TSyntax : SyntaxNode
@@ -966,6 +967,25 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
             VerifySyntax<ConversionOperatorDeclarationSyntax>(
                 Generator.OperatorDeclaration(OperatorKind.ExplicitConversion, parameters, returnType),
                 "explicit operator bool (global::System.Int32 p0, global::System.String p1)\r\n{\r\n}");
+        }
+
+        [Fact]
+        public void TestConversionOperatorDeclaration()
+        {
+            var gcHandleType = _emptyCompilation.GetTypeByMetadataName(typeof(GCHandle).FullName);
+            var conversion = gcHandleType.GetMembers().OfType<IMethodSymbol>().Single(m =>
+                m.Name == WellKnownMemberNames.ExplicitConversionName && m.Parameters[0].Type.Equals(gcHandleType));
+
+            VerifySyntax<ConversionOperatorDeclarationSyntax>(
+                Generator.Declaration(conversion),
+                "public static explicit operator global::System.IntPtr(global::System.Runtime.InteropServices.GCHandle value)\r\n{\r\n}");
+
+            var doubleType = _emptyCompilation.GetSpecialType(SpecialType.System_Decimal);
+            conversion = doubleType.GetMembers().OfType<IMethodSymbol>().Single(m =>
+                m.Name == WellKnownMemberNames.ImplicitConversionName && m.Parameters[0].Type.Equals(_emptyCompilation.GetSpecialType(SpecialType.System_Byte)));
+            VerifySyntax<ConversionOperatorDeclarationSyntax>(
+                Generator.Declaration(conversion),
+                "public static implicit operator global::System.Decimal(global::System.Byte value)\r\n{\r\n}");
         }
 
         [Fact]

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -969,7 +969,7 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
                 "explicit operator bool (global::System.Int32 p0, global::System.String p1)\r\n{\r\n}");
         }
 
-        [Fact]
+        [Fact, WorkItem(65833, "https://github.com/dotnet/roslyn/issues/65833")]
         public void TestConversionOperatorDeclaration()
         {
             var gcHandleType = _emptyCompilation.GetTypeByMetadataName(typeof(GCHandle).FullName);

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -201,14 +201,12 @@ namespace Microsoft.CodeAnalysis.Editing
         }
 
         /// <summary>
-        /// Creates a method declaration matching an existing method symbol.
+        /// Creates a operator or conversion declaration matching an existing method symbol.
         /// </summary>
         public SyntaxNode OperatorDeclaration(IMethodSymbol method, IEnumerable<SyntaxNode>? statements = null)
         {
-            if (method.MethodKind != MethodKind.UserDefinedOperator)
-            {
+            if (method.MethodKind is not (MethodKind.UserDefinedOperator or MethodKind.Conversion))
                 throw new ArgumentException("Method is not an operator.");
-            }
 
             var decl = OperatorDeclaration(
                 GetOperatorKind(method),
@@ -579,7 +577,7 @@ namespace Microsoft.CodeAnalysis.Editing
                         case MethodKind.Ordinary:
                             return MethodDeclaration(method);
 
-                        case MethodKind.UserDefinedOperator:
+                        case MethodKind.UserDefinedOperator or MethodKind.Conversion:
                             return OperatorDeclaration(method);
                     }
 

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Globalization
+Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Shared.Extensions
 Imports Microsoft.CodeAnalysis.Test.Utilities
@@ -41,7 +42,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Editing
             Assert.IsAssignableFrom(GetType(TSyntax), type)
             Dim normalized = type.NormalizeWhitespace().ToFullString()
             Dim fixedExpectations = expectedText.Replace(vbCrLf, vbLf).Replace(vbLf, vbCrLf)
-            Assert.Equal(fixedExpectations, normalized)
+            AssertEx.Equal(fixedExpectations, normalized)
         End Sub
 
         Private Shared Sub VerifySyntaxRaw(Of TSyntax As SyntaxNode)(type As SyntaxNode, expectedText As String)
@@ -1056,6 +1057,26 @@ End Operator")
             VerifySyntax(Of OperatorBlockSyntax)(
                 Generator.OperatorDeclaration(OperatorKind.ExplicitConversion, parameters, returnType),
 "Narrowing Operator CType(p0 As System.Int32, p1 As System.String) As Boolean
+End Operator")
+        End Sub
+
+        <Fact>
+        Public Sub TestConversionOperatorDeclaration()
+            Dim gcHandleType = _emptyCompilation.GetTypeByMetadataName(GetType(GCHandle).FullName)
+            Dim Conversion = gcHandleType.GetMembers().OfType(Of IMethodSymbol)().Single(
+                Function(m) m.Name = WellKnownMemberNames.ExplicitConversionName AndAlso m.Parameters(0).Type.Equals(gcHandleType))
+
+            VerifySyntax(Of OperatorBlockSyntax)(
+                Generator.Declaration(Conversion),
+"Public Shared Narrowing Operator CType(value As Global.System.Runtime.InteropServices.GCHandle) As Global.System.IntPtr
+End Operator")
+
+            Dim doubleType = _emptyCompilation.GetSpecialType(SpecialType.System_Decimal)
+            Conversion = doubleType.GetMembers().OfType(Of IMethodSymbol)().Single(
+                Function(m) m.Name = WellKnownMemberNames.ImplicitConversionName AndAlso m.Parameters(0).Type.Equals(_emptyCompilation.GetSpecialType(SpecialType.System_Byte)))
+            VerifySyntax(Of OperatorBlockSyntax)(
+                Generator.Declaration(Conversion),
+"Public Shared Widening Operator CType(value As System.Byte) As System.Decimal
 End Operator")
         End Sub
 
@@ -2089,7 +2110,7 @@ Dim y As x")
                         Generator.Attribute("a")),
                     Generator.Attribute("b")),
 "<a>
-<b>
+                                                                                                                                                            <b>
 Dim y As x")
 
             VerifySyntax(Of MethodStatementSyntax)(
@@ -2190,7 +2211,7 @@ End Namespace
                         Generator.Attribute("a")),
                     Generator.Attribute("b")),
 "<Assembly:a>
-<Assembly:b>
+                                                                                                                                                                                                                <Assembly:b>
 Namespace n
 End Namespace
 ")
@@ -3589,7 +3610,7 @@ End Class")
                 Generator.InsertAttributes(declC, 0, Generator.Attribute("A")),
 "' Comment
 <A>
-<X, Y, Z>
+                                                                                                                                                                                                                                                                                                                                                                                                                                <X, Y, Z>
 Public Class C
 End Class")
 
@@ -3597,8 +3618,8 @@ End Class")
                 Generator.InsertAttributes(declC, 1, Generator.Attribute("A")),
 "' Comment
 <X>
-<A>
-<Y, Z>
+                                                                                                                                                                                                                                                                                                                                                                                                                                        <A>
+                                                                                                                                                                                                                                                                                                                                                                                                                                            <Y, Z>
 Public Class C
 End Class")
 
@@ -3606,8 +3627,8 @@ End Class")
                 Generator.InsertAttributes(declC, 2, Generator.Attribute("A")),
 "' Comment
 <X, Y>
-<A>
-<Z>
+                                                                                                                                                                                                                                                                                                                                                                                                                                                    <A>
+                                                                                                                                                                                                                                                                                                                                                                                                                                                        <Z>
 Public Class C
 End Class")
 
@@ -3615,7 +3636,7 @@ End Class")
                 Generator.InsertAttributes(declC, 3, Generator.Attribute("A")),
 "' Comment
 <X, Y, Z>
-<A>
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                <A>
 Public Class C
 End Class")
 

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -3,7 +3,6 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Globalization
-Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Shared.Extensions
 Imports Microsoft.CodeAnalysis.Test.Utilities
@@ -42,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Editing
             Assert.IsAssignableFrom(GetType(TSyntax), type)
             Dim normalized = type.NormalizeWhitespace().ToFullString()
             Dim fixedExpectations = expectedText.Replace(vbCrLf, vbLf).Replace(vbLf, vbCrLf)
-            AssertEx.Equal(fixedExpectations, normalized)
+            Assert.Equal(fixedExpectations, normalized)
         End Sub
 
         Private Shared Sub VerifySyntaxRaw(Of TSyntax As SyntaxNode)(type As SyntaxNode, expectedText As String)
@@ -2110,7 +2109,7 @@ Dim y As x")
                         Generator.Attribute("a")),
                     Generator.Attribute("b")),
 "<a>
-                                                                                                                                                            <b>
+<b>
 Dim y As x")
 
             VerifySyntax(Of MethodStatementSyntax)(
@@ -2211,7 +2210,7 @@ End Namespace
                         Generator.Attribute("a")),
                     Generator.Attribute("b")),
 "<Assembly:a>
-                                                                                                                                                                                                                <Assembly:b>
+<Assembly:b>
 Namespace n
 End Namespace
 ")
@@ -3610,7 +3609,7 @@ End Class")
                 Generator.InsertAttributes(declC, 0, Generator.Attribute("A")),
 "' Comment
 <A>
-                                                                                                                                                                                                                                                                                                                                                                                                                                <X, Y, Z>
+<X, Y, Z>
 Public Class C
 End Class")
 
@@ -3618,8 +3617,8 @@ End Class")
                 Generator.InsertAttributes(declC, 1, Generator.Attribute("A")),
 "' Comment
 <X>
-                                                                                                                                                                                                                                                                                                                                                                                                                                        <A>
-                                                                                                                                                                                                                                                                                                                                                                                                                                            <Y, Z>
+<A>
+<Y, Z>
 Public Class C
 End Class")
 
@@ -3627,8 +3626,8 @@ End Class")
                 Generator.InsertAttributes(declC, 2, Generator.Attribute("A")),
 "' Comment
 <X, Y>
-                                                                                                                                                                                                                                                                                                                                                                                                                                                    <A>
-                                                                                                                                                                                                                                                                                                                                                                                                                                                        <Z>
+<A>
+<Z>
 Public Class C
 End Class")
 
@@ -3636,7 +3635,7 @@ End Class")
                 Generator.InsertAttributes(declC, 3, Generator.Attribute("A")),
 "' Comment
 <X, Y, Z>
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                <A>
+<A>
 Public Class C
 End Class")
 

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -1060,7 +1060,7 @@ End Operator")
 End Operator")
         End Sub
 
-        <Fact>
+        <Fact, WorkItem(65833, "https://github.com/dotnet/roslyn/issues/65833")>
         Public Sub TestConversionOperatorDeclaration()
             Dim gcHandleType = _emptyCompilation.GetTypeByMetadataName(GetType(GCHandle).FullName)
             Dim Conversion = gcHandleType.GetMembers().OfType(Of IMethodSymbol)().Single(

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports System.Globalization
+Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Shared.Extensions
 Imports Microsoft.CodeAnalysis.Test.Utilities


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/65833.