### PR TITLE
Fix stepping UI delays

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTrackingServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTrackingServiceTests.cs
@@ -196,7 +196,7 @@ class C
 
             if (scheduleInitialTrackingBeforeOpenDoc)
             {
-                await trackingSession.TrackActiveSpansAsync(solution, CancellationToken.None);
+                await trackingSession.TrackActiveSpansAsync(solution);
 
                 var spans1 = trackingSession.Test_GetTrackingSpans();
                 AssertEx.Equal(new[]
@@ -223,7 +223,7 @@ class C
 
             if (!scheduleInitialTrackingBeforeOpenDoc)
             {
-                await trackingSession.TrackActiveSpansAsync(solution, CancellationToken.None);
+                await trackingSession.TrackActiveSpansAsync(solution);
 
                 var spans5 = trackingSession.Test_GetTrackingSpans();
                 AssertEx.Equal(new[]

--- a/src/EditorFeatures/Core/EditAndContinue/ActiveStatementTrackingService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/ActiveStatementTrackingService.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
@@ -37,13 +38,18 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         [ExportWorkspaceServiceFactory(typeof(IActiveStatementTrackingService), ServiceLayer.Editor), Shared]
         internal sealed class Factory : IWorkspaceServiceFactory
         {
+            private readonly IAsynchronousOperationListenerProvider _listenerProvider;
+
             [ImportingConstructor]
             [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-            public Factory() { }
+            public Factory(IAsynchronousOperationListenerProvider listenerProvider)
+                => _listenerProvider = listenerProvider;
 
             public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
-                => new ActiveStatementTrackingService(workspaceServices.Workspace);
+                => new ActiveStatementTrackingService(workspaceServices.Workspace, _listenerProvider.GetListener(FeatureAttribute.EditAndContinue));
         }
+
+        private readonly IAsynchronousOperationListener _listener;
 
         private TrackingSession? _session;
         private readonly Workspace _workspace;
@@ -53,12 +59,13 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// </summary>
         public event Action? TrackingChanged;
 
-        public ActiveStatementTrackingService(Workspace workspace)
+        public ActiveStatementTrackingService(Workspace workspace, IAsynchronousOperationListener listener)
         {
             _workspace = workspace;
+            _listener = listener;
         }
 
-        public async ValueTask StartTrackingAsync(Solution solution, IActiveStatementSpanProvider spanProvider, CancellationToken cancellationToken)
+        public void StartTracking(Solution solution, IActiveStatementSpanProvider spanProvider)
         {
             var newSession = new TrackingSession(_workspace, spanProvider);
             if (Interlocked.CompareExchange(ref _session, newSession, null) != null)
@@ -67,7 +74,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 Contract.Fail("Can only track active statements for a single edit session.");
             }
 
-            await newSession.TrackActiveSpansAsync(solution, cancellationToken).ConfigureAwait(false);
+            var token = _listener.BeginAsyncOperation(nameof(ActiveStatementTrackingService));
+            _ = newSession.TrackActiveSpansAsync(solution).CompletesAsyncOperation(token);
 
             TrackingChanged?.Invoke();
         }
@@ -145,12 +153,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
 
             private void DocumentOpened(object? sender, DocumentEventArgs e)
-                => _ = TrackActiveSpansAsync(e.Document, _cancellationSource.Token);
+                => _ = TrackActiveSpansAsync(e.Document);
 
-            private async Task TrackActiveSpansAsync(Document designTimeDocument, CancellationToken cancellationToken)
+            private async Task TrackActiveSpansAsync(Document designTimeDocument)
             {
                 try
                 {
+                    var cancellationToken = _cancellationSource.Token;
+
                     if (!designTimeDocument.DocumentState.SupportsEditAndContinue())
                     {
                         return;
@@ -176,10 +186,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 }
             }
 
-            internal async Task TrackActiveSpansAsync(Solution solution, CancellationToken cancellationToken)
+            internal async Task TrackActiveSpansAsync(Solution solution)
             {
                 try
                 {
+                    var cancellationToken = _cancellationSource.Token;
+
                     var openDocumentIds = _workspace.GetOpenDocumentIds().ToImmutableArray();
                     if (openDocumentIds.Length == 0)
                     {

--- a/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/EditAndContinueLanguageService.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
 using Microsoft.VisualStudio.Debugger.Contracts.HotReload;
 using Roslyn.Utilities;
@@ -145,8 +146,12 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
 
             // Start tracking after we entered break state so that break-state session is active.
-            // This is potentially costly operation but entering break state is non-blocking so it should be ok to await.
-            await GetActiveStatementTrackingService().StartTrackingAsync(solution, session, cancellationToken).ConfigureAwait(false);
+            // This is potentially costly operation as source generators might get invoked in OOP
+            // to determine the spans of all active statements.
+            // We start the operation but do not wait for it to complete.
+            // The tracking session is cancelled when we exit the break state.
+
+            GetActiveStatementTrackingService().StartTracking(solution, session);
         }
 
         public async ValueTask ExitBreakStateAsync(CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core/EditAndContinue/IActiveStatementTrackingService.cs
+++ b/src/EditorFeatures/Core/EditAndContinue/IActiveStatementTrackingService.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue;
 
 internal interface IActiveStatementTrackingService : IWorkspaceService
 {
-    ValueTask StartTrackingAsync(Solution solution, IActiveStatementSpanProvider spanProvider, CancellationToken cancellationToken);
+    void StartTracking(Solution solution, IActiveStatementSpanProvider spanProvider);
 
     void EndTracking();
 

--- a/src/Workspaces/Core/Portable/Shared/TestHooks/FeatureAttribute.cs
+++ b/src/Workspaces/Core/Portable/Shared/TestHooks/FeatureAttribute.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
         public const string DesignerAttributes = nameof(DesignerAttributes);
         public const string DiagnosticService = nameof(DiagnosticService);
         public const string DocumentOutline = nameof(DocumentOutline);
+        public const string EditAndContinue = nameof(EditAndContinue);
         public const string EncapsulateField = nameof(EncapsulateField);
         public const string ErrorList = nameof(ErrorList);
         public const string ErrorSquiggles = nameof(ErrorSquiggles);


### PR DESCRIPTION
Although `EnterBreakModeAsync` itself is non-blocking the debugger currently waits for completion of all calls to Roslyn before calling `HasChangesAsync`. Since `HasChangesAsync` is blocking UI thread any expensive operations run in  `EnterBreakModeAsync` will also end up blocking the UI.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1715570
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1597298
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1370311/