### PR TITLE
Gracefully handle negative endLine and endColumn values for build errors

### DIFF
--- a/src/VisualStudio/Core/Def/TaskList/ProjectExternalErrorReporter.cs
+++ b/src/VisualStudio/Core/Def/TaskList/ProjectExternalErrorReporter.cs
@@ -233,6 +233,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                 documentId = TryGetDocumentId(bstrFileName);
             }
 
+            if (iEndLine < 0)
+                iEndLine = iStartLine;
+            if (iEndColumn < 0)
+                iEndColumn = iStartColumn;
+
             var diagnostic = GetDiagnosticData(
                 documentId,
                 _projectId,


### PR DESCRIPTION
Fixes [AB#1643350](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1643350) VB legacy project system reports closed file errors with `-1` as the values for endLine and endColumn, which was leading to a silent exception when attempting to create error span leading to the reported build error being silently ignored and not reported in the error list. We now handle these values gracefully similar to negative startLine and startColumn values earlier in the same method.

Verified that the added integration test fails prior to the product fix.