### PR TITLE
Fix serialization of CSharpIdeCodeStyleOptions.Common options

### DIFF
--- a/src/Workspaces/CoreTest/Options/OptionsTestHelpers.cs
+++ b/src/Workspaces/CoreTest/Options/OptionsTestHelpers.cs
@@ -10,7 +10,9 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.NamingStyles;
 using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.UnitTests
@@ -109,5 +111,35 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
         public static IEnumerable<string?> GetApplicableLanguages(IOption option)
             => (option is IPerLanguageValuedOption) ? new[] { LanguageNames.CSharp, LanguageNames.VisualBasic } : new string?[] { null };
+
+        public static NamingStylePreferences GetNonDefaultNamingStylePreference()
+        {
+            var symbolSpecification = new SymbolSpecification(
+                Guid.NewGuid(),
+                "Name",
+                ImmutableArray.Create(new SymbolSpecification.SymbolKindOrTypeKind(TypeKind.Class)),
+                accessibilityList: default,
+                modifiers: default);
+
+            var namingStyle = new NamingStyle(
+                Guid.NewGuid(),
+                capitalizationScheme: Capitalization.PascalCase,
+                name: "Name",
+                prefix: "",
+                suffix: "",
+                wordSeparator: "");
+
+            var namingRule = new SerializableNamingRule()
+            {
+                SymbolSpecificationID = symbolSpecification.ID,
+                NamingStyleID = namingStyle.ID,
+                EnforcementLevel = ReportDiagnostic.Error
+            };
+
+            return new NamingStylePreferences(
+                ImmutableArray.Create(symbolSpecification),
+                ImmutableArray.Create(namingStyle),
+                ImmutableArray.Create(namingRule));
+        }
     }
 }

--- a/src/Workspaces/CoreTest/Remote/ServiceDescriptorTests.cs
+++ b/src/Workspaces/CoreTest/Remote/ServiceDescriptorTests.cs
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
                     },
                     PreferConditionalDelegateCall = new CodeStyleOption2<bool>(false, NotificationOption2.Error)
                 },
-                
+
                 new VisualBasicSyntaxFormattingOptions()
                 {
                     Common = SyntaxFormattingOptions.CommonOptions.Default with

--- a/src/Workspaces/CoreTest/Remote/ServiceDescriptorTests.cs
+++ b/src/Workspaces/CoreTest/Remote/ServiceDescriptorTests.cs
@@ -23,8 +23,10 @@ using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.CSharp.Simplification;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.DocumentHighlighting;
@@ -35,7 +37,11 @@ using Microsoft.CodeAnalysis.Indentation;
 using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.UnitTests;
+using Microsoft.CodeAnalysis.VisualBasic.CodeGeneration;
 using Microsoft.CodeAnalysis.VisualBasic.CodeStyle;
+using Microsoft.CodeAnalysis.VisualBasic.Formatting;
+using Microsoft.CodeAnalysis.VisualBasic.Simplification;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
@@ -239,13 +245,81 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
                 ExtractMethodGenerationOptions.GetDefault(languageServices),
 
                 // some non-default values:
+
+                new CSharpSyntaxFormattingOptions()
+                {
+                    Common = SyntaxFormattingOptions.CommonOptions.Default with
+                    {
+                        AccessibilityModifiersRequired = AccessibilityModifiersRequired.Always
+                    },
+                    Indentation = IndentationPlacement.SwitchSection
+                },
+
+                new CSharpSimplifierOptions()
+                {
+                    Common = SimplifierOptions.CommonOptions.Default with
+                    {
+                        QualifyFieldAccess = new CodeStyleOption2<bool>(true, NotificationOption2.Error)
+                    },
+                },
+
+                new CSharpCodeGenerationOptions()
+                {
+                    Common = CodeGenerationOptions.CommonOptions.Default with
+                    {
+                        NamingStyle = OptionsTestHelpers.GetNonDefaultNamingStylePreference()
+                    },
+                    PreferExpressionBodiedIndexers = new CodeStyleOption2<ExpressionBodyPreference>(ExpressionBodyPreference.WhenOnSingleLine, NotificationOption2.Error)
+                },
+
+                new CSharpSyntaxFormattingOptions()
+                {
+                    Common = SyntaxFormattingOptions.CommonOptions.Default with
+                    {
+                        AccessibilityModifiersRequired = AccessibilityModifiersRequired.Always
+                    },
+                    NewLines = NewLinePlacement.BeforeFinally
+                },
+
+                new CSharpIdeCodeStyleOptions()
+                {
+                    Common = IdeCodeStyleOptions.CommonOptions.Default with
+                    {
+                        AllowStatementImmediatelyAfterBlock = new CodeStyleOption2<bool>(true, NotificationOption2.Error)
+                    },
+                    PreferConditionalDelegateCall = new CodeStyleOption2<bool>(false, NotificationOption2.Error)
+                },
+                
+                new VisualBasicSyntaxFormattingOptions()
+                {
+                    Common = SyntaxFormattingOptions.CommonOptions.Default with
+                    {
+                        AccessibilityModifiersRequired = AccessibilityModifiersRequired.Always
+                    }
+                },
+
+                new VisualBasicSimplifierOptions()
+                {
+                    Common = SimplifierOptions.CommonOptions.Default with
+                    {
+                        QualifyFieldAccess = new CodeStyleOption2<bool>(true, NotificationOption2.Error)
+                    }
+                },
+
+                new VisualBasicCodeGenerationOptions()
+                {
+                    Common = CodeGenerationOptions.CommonOptions.Default with
+                    {
+                        NamingStyle = OptionsTestHelpers.GetNonDefaultNamingStylePreference()
+                    }
+                },
+
                 new VisualBasicIdeCodeStyleOptions(
                     new IdeCodeStyleOptions.CommonOptions()
                     {
                         AllowStatementImmediatelyAfterBlock = new CodeStyleOption2<bool>(false, NotificationOption2.Error)
                     },
                     PreferredModifierOrder: new CodeStyleOption2<string>("Public Private", NotificationOption2.Error))
-
             };
 
             foreach (var original in options)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Simplification/SimplifierOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Simplification/SimplifierOptions.cs
@@ -37,6 +37,7 @@ namespace Microsoft.CodeAnalysis.Simplification
             [DataMember] public CodeStyleOption2<bool> PreferPredefinedTypeKeywordInDeclaration { get; init; } = DefaultPreferPredefinedTypeKeyword;
         }
 
+        [DataMember]
         public CommonOptions Common { get; init; } = CommonOptions.Default;
 
         public CodeStyleOption2<bool> QualifyFieldAccess => Common.QualifyFieldAccess;


### PR DESCRIPTION
Adds missing `[DataMember]` attribute.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1712112

Regressed by https://github.com/dotnet/roslyn/pull/60888 in 17.3