### PR TITLE
Block instrumentation improvements

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CodeCoverageInstrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CodeCoverageInstrumenter.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -233,81 +234,84 @@ namespace Microsoft.CodeAnalysis.CSharp
                     methodBodyFactory.Literal(dynamicAnalysisSpans.Length)));
         }
 
-        public override BoundStatement? CreateBlockPrologue(BoundBlock original, out LocalSymbol? synthesizedLocal)
+        public override void InstrumentBlock(BoundBlock original, LocalRewriter rewriter, ref TemporaryArray<LocalSymbol> additionalLocals, out BoundStatement? prologue, out BoundStatement? epilogue)
         {
-            BoundStatement? previousPrologue = base.CreateBlockPrologue(original, out synthesizedLocal);
-            if (_methodBody == original)
+            base.InstrumentBlock(original, rewriter, ref additionalLocals, out var previousPrologue, out epilogue);
+
+            // only instrument method body block:
+            if (original != rewriter.CurrentMethodBody)
             {
-                _dynamicAnalysisSpans = _spansBuilder.ToImmutableAndFree();
-                // In the future there will be multiple analysis kinds.
-                const int analysisKind = 0;
-
-                ArrayTypeSymbol modulePayloadType =
-                    ArrayTypeSymbol.CreateCSharpArray(_methodBodyFactory.Compilation.Assembly, TypeWithAnnotations.Create(_payloadType));
-
-                // Synthesize the initialization of the instrumentation payload array, using concurrency-safe code:
-                //
-                // var payload = PID.PayloadRootField[methodIndex];
-                // if (payload == null)
-                //     payload = Instrumentation.CreatePayload(mvid, methodIndex, fileIndexOrIndices, ref PID.PayloadRootField[methodIndex], payloadLength);
-
-                BoundStatement payloadInitialization =
-                    _methodBodyFactory.Assignment(
-                        _methodBodyFactory.Local(_methodPayload),
-                        _methodBodyFactory.ArrayAccess(
-                            _methodBodyFactory.InstrumentationPayloadRoot(analysisKind, modulePayloadType),
-                            ImmutableArray.Create(_methodBodyFactory.MethodDefIndex(_method))));
-
-                BoundExpression mvid = _methodBodyFactory.ModuleVersionId();
-                BoundExpression methodToken = _methodBodyFactory.MethodDefIndex(_method);
-
-                BoundExpression payloadSlot =
-                    _methodBodyFactory.ArrayAccess(
-                        _methodBodyFactory.InstrumentationPayloadRoot(analysisKind, modulePayloadType),
-                        ImmutableArray.Create(_methodBodyFactory.MethodDefIndex(_method)));
-
-                BoundStatement createPayloadCall =
-                    GetCreatePayloadStatement(
-                        _dynamicAnalysisSpans,
-                        _methodBody.Syntax,
-                        _methodPayload,
-                        _createPayloadForMethodsSpanningSingleFile,
-                        _createPayloadForMethodsSpanningMultipleFiles,
-                        mvid,
-                        methodToken,
-                        payloadSlot,
-                        _methodBodyFactory,
-                        _debugDocumentProvider);
-
-                BoundExpression payloadNullTest =
-                    _methodBodyFactory.Binary(
-                        BinaryOperatorKind.ObjectEqual,
-                        _methodBodyFactory.SpecialType(SpecialType.System_Boolean),
-                        _methodBodyFactory.Local(_methodPayload),
-                        _methodBodyFactory.Null(_payloadType));
-
-                BoundStatement payloadIf = _methodBodyFactory.If(payloadNullTest, createPayloadCall);
-
-                Debug.Assert(synthesizedLocal == null);
-                synthesizedLocal = _methodPayload;
-
-                ArrayBuilder<BoundStatement> prologueStatements = ArrayBuilder<BoundStatement>.GetInstance(previousPrologue == null ? 3 : 4);
-                prologueStatements.Add(payloadInitialization);
-                prologueStatements.Add(payloadIf);
-                if (_methodEntryInstrumentation != null)
-                {
-                    prologueStatements.Add(_methodEntryInstrumentation);
-                }
-
-                if (previousPrologue != null)
-                {
-                    prologueStatements.Add(previousPrologue);
-                }
-
-                return _methodBodyFactory.StatementList(prologueStatements.ToImmutableAndFree());
+                prologue = previousPrologue;
+                return;
             }
 
-            return previousPrologue;
+            _dynamicAnalysisSpans = _spansBuilder.ToImmutableAndFree();
+            // In the future there will be multiple analysis kinds.
+            const int analysisKind = 0;
+
+            ArrayTypeSymbol modulePayloadType =
+                ArrayTypeSymbol.CreateCSharpArray(_methodBodyFactory.Compilation.Assembly, TypeWithAnnotations.Create(_payloadType));
+
+            // Synthesize the initialization of the instrumentation payload array, using concurrency-safe code:
+            //
+            // var payload = PID.PayloadRootField[methodIndex];
+            // if (payload == null)
+            //     payload = Instrumentation.CreatePayload(mvid, methodIndex, fileIndexOrIndices, ref PID.PayloadRootField[methodIndex], payloadLength);
+
+            BoundStatement payloadInitialization =
+                _methodBodyFactory.Assignment(
+                    _methodBodyFactory.Local(_methodPayload),
+                    _methodBodyFactory.ArrayAccess(
+                        _methodBodyFactory.InstrumentationPayloadRoot(analysisKind, modulePayloadType),
+                        ImmutableArray.Create(_methodBodyFactory.MethodDefIndex(_method))));
+
+            BoundExpression mvid = _methodBodyFactory.ModuleVersionId();
+            BoundExpression methodToken = _methodBodyFactory.MethodDefIndex(_method);
+
+            BoundExpression payloadSlot =
+                _methodBodyFactory.ArrayAccess(
+                    _methodBodyFactory.InstrumentationPayloadRoot(analysisKind, modulePayloadType),
+                    ImmutableArray.Create(_methodBodyFactory.MethodDefIndex(_method)));
+
+            BoundStatement createPayloadCall =
+                GetCreatePayloadStatement(
+                    _dynamicAnalysisSpans,
+                    _methodBody.Syntax,
+                    _methodPayload,
+                    _createPayloadForMethodsSpanningSingleFile,
+                    _createPayloadForMethodsSpanningMultipleFiles,
+                    mvid,
+                    methodToken,
+                    payloadSlot,
+                    _methodBodyFactory,
+                    _debugDocumentProvider);
+
+            BoundExpression payloadNullTest =
+                _methodBodyFactory.Binary(
+                    BinaryOperatorKind.ObjectEqual,
+                    _methodBodyFactory.SpecialType(SpecialType.System_Boolean),
+                    _methodBodyFactory.Local(_methodPayload),
+                    _methodBodyFactory.Null(_payloadType));
+
+            BoundStatement payloadIf = _methodBodyFactory.If(payloadNullTest, createPayloadCall);
+
+            additionalLocals.Add(_methodPayload);
+
+            var prologueStatements = ArrayBuilder<BoundStatement>.GetInstance(2 + (_methodEntryInstrumentation != null ? 1 : 0) + (previousPrologue != null ? 1 : 0));
+
+            prologueStatements.Add(payloadInitialization);
+            prologueStatements.Add(payloadIf);
+            if (_methodEntryInstrumentation != null)
+            {
+                prologueStatements.Add(_methodEntryInstrumentation);
+            }
+
+            if (previousPrologue != null)
+            {
+                prologueStatements.Add(previousPrologue);
+            }
+
+            prologue = _methodBodyFactory.StatementList(prologueStatements.ToImmutableAndFree());
         }
 
         public ImmutableArray<SourceSpan> DynamicAnalysisSpans => _dynamicAnalysisSpans;

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.Shared.Collections;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -77,14 +79,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Previous.InstrumentBreakStatement(original, rewritten);
         }
 
-        public override BoundStatement? CreateBlockPrologue(BoundBlock original, out Symbols.LocalSymbol? synthesizedLocal)
+        public override void InstrumentBlock(BoundBlock original, LocalRewriter rewriter, ref TemporaryArray<LocalSymbol> additionalLocals, out BoundStatement? prologue, out BoundStatement? epilogue)
         {
-            return Previous.CreateBlockPrologue(original, out synthesizedLocal);
-        }
-
-        public override BoundStatement? CreateBlockEpilogue(BoundBlock original)
-        {
-            return Previous.CreateBlockEpilogue(original);
+            Previous.InstrumentBlock(original, rewriter, ref additionalLocals, out prologue, out epilogue);
         }
 
         public override BoundExpression InstrumentDoStatementCondition(BoundDoStatement original, BoundExpression rewrittenCondition, SyntheticBoundNodeFactory factory)

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
@@ -5,7 +5,9 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
@@ -140,39 +142,36 @@ namespace Microsoft.CodeAnalysis.CSharp
             return AddSequencePoint(base.InstrumentYieldReturnStatement(original, rewritten));
         }
 
-        public override BoundStatement? CreateBlockPrologue(BoundBlock original, out Symbols.LocalSymbol? synthesizedLocal)
+        public override void InstrumentBlock(BoundBlock original, LocalRewriter rewriter, ref TemporaryArray<LocalSymbol> additionalLocals, out BoundStatement? prologue, out BoundStatement? epilogue)
         {
-            var previous = base.CreateBlockPrologue(original, out synthesizedLocal);
-            if (original.Syntax.Kind() == SyntaxKind.Block && !original.WasCompilerGenerated)
-            {
-                var oBspan = ((BlockSyntax)original.Syntax).OpenBraceToken.Span;
-                return new BoundSequencePointWithSpan(original.Syntax, previous, oBspan);
-            }
-            else if (previous != null)
-            {
-                return new BoundSequencePoint(original.Syntax, previous);
-            }
+            base.InstrumentBlock(original, rewriter, ref additionalLocals, out var previousPrologue, out var previousEpilogue);
 
-            return null;
-        }
+            prologue = previousPrologue;
+            epilogue = previousEpilogue;
 
-        public override BoundStatement? CreateBlockEpilogue(BoundBlock original)
-        {
-            var previous = base.CreateBlockEpilogue(original);
-
-            if (original.Syntax.Kind() == SyntaxKind.Block && !original.WasCompilerGenerated)
+            if (original.Syntax is BlockSyntax blockSyntax && !original.WasCompilerGenerated)
             {
+                prologue = new BoundSequencePointWithSpan(original.Syntax, previousPrologue, blockSyntax.OpenBraceToken.Span);
+
                 // no need to mark "}" on the outermost block
                 // as it cannot leave it normally. The block will have "return" at the end.
                 SyntaxNode? parent = original.Syntax.Parent;
                 if (parent == null || !(parent.IsAnonymousFunction() || parent is BaseMethodDeclarationSyntax))
                 {
-                    var cBspan = ((BlockSyntax)original.Syntax).CloseBraceToken.Span;
-                    return new BoundSequencePointWithSpan(original.Syntax, previous, cBspan);
+                    epilogue = new BoundSequencePointWithSpan(original.Syntax, previousEpilogue, blockSyntax.CloseBraceToken.Span);
                 }
             }
-
-            return previous;
+            else if (original == rewriter.CurrentMethodBody)
+            {
+                if (previousPrologue != null)
+                {
+                    prologue = new BoundSequencePoint(original.Syntax, previousPrologue);
+                }
+                else if (rewriter.Factory.TopLevelMethod is SynthesizedSimpleProgramEntryPointSymbol)
+                {
+                    prologue = BoundSequencePoint.CreateHidden();
+                }
+            }
         }
 
         public override BoundExpression InstrumentDoStatementCondition(BoundDoStatement original, BoundExpression rewrittenCondition, SyntheticBoundNodeFactory factory)

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
@@ -165,11 +165,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (previousPrologue != null)
                 {
-                    prologue = new BoundSequencePoint(original.Syntax, previousPrologue);
+                    prologue = BoundSequencePoint.CreateHidden(previousPrologue);
                 }
                 else if (rewriter.Factory.TopLevelMethod is SynthesizedSimpleProgramEntryPointSymbol)
                 {
                     prologue = BoundSequencePoint.CreateHidden();
+                }
+
+                if (previousEpilogue != null)
+                {
+                    epilogue = BoundSequencePoint.CreateHidden(previousEpilogue);
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
@@ -5,6 +5,8 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.Shared.Collections;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -53,20 +55,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Return a node that is associated with open brace of the block. Ok to return null.
+        /// Instruments <paramref name="original"/> block.
         /// </summary>
-        public virtual BoundStatement? CreateBlockPrologue(BoundBlock original, out Symbols.LocalSymbol? synthesizedLocal)
+        /// <param name="original">Original block.</param>
+        /// <param name="rewriter">Local rewriter.</param>
+        /// <param name="additionalLocals">Local symbols to be added to <see cref="BoundBlock.Locals"/> of the resulting block.</param>
+        /// <param name="prologue">Node to be added to the beginning of the statement list of the instrumented block.</param>
+        /// <param name="epilogue">Node to be added at the end of the statement list of the instrumented block.</param>
+        public virtual void InstrumentBlock(BoundBlock original, LocalRewriter rewriter, ref TemporaryArray<LocalSymbol> additionalLocals, out BoundStatement? prologue, out BoundStatement? epilogue)
         {
-            synthesizedLocal = null;
-            return null;
-        }
-
-        /// <summary>
-        /// Return a node that is associated with close brace of the block. Ok to return null.
-        /// </summary>
-        public virtual BoundStatement? CreateBlockEpilogue(BoundBlock original)
-        {
-            return null;
+            prologue = null;
+            epilogue = null;
         }
 
         public virtual BoundStatement InstrumentThrowStatement(BoundThrowStatement original, BoundStatement rewritten)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -144,6 +144,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal SyntheticBoundNodeFactory Factory
+            => _factory;
+
+        internal BoundStatement CurrentMethodBody
+            => _rootStatement;
+
         private InstrumentationState InstrumentationState
             => _factory.InstrumentationState!;
 
@@ -580,6 +586,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (initializer.Kind == BoundKind.Block)
                     {
                         var block = (BoundBlock)initializer;
+
                         var statement = RewriteExpressionStatement((BoundExpressionStatement)block.Statements.Single(), suppressInstrumentation: true);
                         Debug.Assert(statement is { });
                         statements.Add(block.Update(block.Locals, block.LocalFunctions, block.HasUnsafeModifier, ImmutableArray.Create(statement)));

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Block.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Block.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Shared.Collections;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -15,29 +17,23 @@ namespace Microsoft.CodeAnalysis.CSharp
             var builder = ArrayBuilder<BoundStatement>.GetInstance();
             VisitStatementSubList(builder, node.Statements);
 
-            if (!this.Instrument || (node != _rootStatement && (node.WasCompilerGenerated || node.Syntax.Kind() != SyntaxKind.Block)))
+            var additionalLocals = TemporaryArray<LocalSymbol>.Empty;
+
+            if (Instrument)
             {
-                return node.Update(node.Locals, node.LocalFunctions, node.HasUnsafeModifier, builder.ToImmutableAndFree());
+                Instrumenter.InstrumentBlock(node, this, ref additionalLocals, out var prologue, out var epilogue);
+                if (prologue != null)
+                {
+                    builder.Insert(0, prologue);
+                }
+
+                if (epilogue != null)
+                {
+                    builder.Add(epilogue);
+                }
             }
 
-            LocalSymbol? synthesizedLocal;
-            BoundStatement? prologue = Instrumenter.CreateBlockPrologue(node, out synthesizedLocal);
-            if (prologue != null)
-            {
-                builder.Insert(0, prologue);
-            }
-            else if (node == _rootStatement && _factory.TopLevelMethod is SynthesizedSimpleProgramEntryPointSymbol entryPoint)
-            {
-                builder.Insert(0, _factory.HiddenSequencePoint());
-            }
-
-            BoundStatement? epilogue = Instrumenter.CreateBlockEpilogue(node);
-            if (epilogue != null)
-            {
-                builder.Add(epilogue);
-            }
-
-            return new BoundBlock(node.Syntax, synthesizedLocal == null ? node.Locals : node.Locals.Add(synthesizedLocal), node.LocalFunctions, node.HasUnsafeModifier, builder.ToImmutableAndFree(), node.HasErrors);
+            return new BoundBlock(node.Syntax, node.Locals.AddRange(additionalLocals), node.LocalFunctions, node.HasUnsafeModifier, builder.ToImmutableAndFree(), node.HasErrors);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -2141,6 +2141,73 @@ True
 
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
             verifier.VerifyDiagnostics();
+
+            verifier.VerifyMethodBody("C..ctor", @"
+{
+  // Code size      120 (0x78)
+  .maxstack  5
+  .locals init (bool[] V_0)
+  // sequence point: <hidden>
+  IL_0000:  ldsfld     ""bool[][] <PrivateImplementationDetails>.PayloadRoot0""
+  IL_0005:  ldtoken    ""C..ctor()""
+  IL_000a:  ldelem.ref
+  IL_000b:  stloc.0
+  IL_000c:  ldloc.0
+  IL_000d:  brtrue.s   IL_0034
+  IL_000f:  ldsfld     ""System.Guid <PrivateImplementationDetails>.MVID""
+  IL_0014:  ldtoken    ""C..ctor()""
+  IL_0019:  ldtoken    Source Document 0
+  IL_001e:  ldsfld     ""bool[][] <PrivateImplementationDetails>.PayloadRoot0""
+  IL_0023:  ldtoken    ""C..ctor()""
+  IL_0028:  ldelema    ""bool[]""
+  IL_002d:  ldc.i4.5
+  IL_002e:  call       ""bool[] Microsoft.CodeAnalysis.Runtime.Instrumentation.CreatePayload(System.Guid, int, int, ref bool[], int)""
+  IL_0033:  stloc.0
+  IL_0034:  ldloc.0
+  IL_0035:  ldc.i4.0
+  IL_0036:  ldc.i4.1
+  IL_0037:  stelem.i1
+  // sequence point: int _x = Init();
+  IL_0038:  ldloc.0
+  IL_0039:  ldc.i4.1
+  IL_003a:  ldc.i4.1
+  IL_003b:  stelem.i1
+  IL_003c:  ldarg.0
+  IL_003d:  call       ""int C.Init()""
+  IL_0042:  stfld      ""int C._x""
+  // sequence point: int _y = Init() + 12;
+  IL_0047:  ldloc.0
+  IL_0048:  ldc.i4.2
+  IL_0049:  ldc.i4.1
+  IL_004a:  stelem.i1
+  IL_004b:  ldarg.0
+  IL_004c:  call       ""int C.Init()""
+  IL_0051:  ldc.i4.s   12
+  IL_0053:  add
+  IL_0054:  stfld      ""int C._y""
+  // sequence point: 15
+  IL_0059:  ldloc.0
+  IL_005a:  ldc.i4.3
+  IL_005b:  ldc.i4.1
+  IL_005c:  stelem.i1
+  IL_005d:  ldarg.0
+  IL_005e:  ldc.i4.s   15
+  IL_0060:  stfld      ""int C.<Prop1>k__BackingField""
+  // sequence point: C()
+  IL_0065:  ldarg.0
+  IL_0066:  call       ""object..ctor()""
+  // sequence point: _z = 12;
+  IL_006b:  ldloc.0
+  IL_006c:  ldc.i4.4
+  IL_006d:  ldc.i4.1
+  IL_006e:  stelem.i1
+  IL_006f:  ldarg.0
+  IL_0070:  ldc.i4.s   12
+  IL_0072:  stfld      ""int C._z""
+  // sequence point: }
+  IL_0077:  ret
+}
+");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -1027,6 +1027,87 @@ class C
 </symbols>");
         }
 
+        [Fact]
+        public void ConstructorsWithSharedInitializers()
+        {
+            var source = @"
+class B
+{
+    public B(int z) {}
+}
+
+class C : B
+{
+    int a = 1;
+    bool b = true;
+
+    C(int x)
+        : base(3)
+    {
+        a = x;
+    }
+    
+    C(bool y)
+        : base(4)
+    {
+        b = y;
+    }
+}
+
+";
+
+            var c = CompileAndVerify(source);
+
+            c.VerifyMethodBody("C..ctor(int)", @"
+{
+  // Code size       29 (0x1d)
+  .maxstack  2
+  // sequence point: int a = 1;
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.1
+  IL_0002:  stfld      ""int C.a""
+  // sequence point: bool b = true;
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.1
+  IL_0009:  stfld      ""bool C.b""
+  // sequence point: base(3)
+  IL_000e:  ldarg.0
+  IL_000f:  ldc.i4.3
+  IL_0010:  call       ""B..ctor(int)""
+  // sequence point: a = x;
+  IL_0015:  ldarg.0
+  IL_0016:  ldarg.1
+  IL_0017:  stfld      ""int C.a""
+  // sequence point: }
+  IL_001c:  ret
+}
+");
+            c.VerifyMethodBody("C..ctor(bool)", @"
+{
+  // Code size       29 (0x1d)
+  .maxstack  2
+  // sequence point: int a = 1;
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.1
+  IL_0002:  stfld      ""int C.a""
+  // sequence point: bool b = true;
+  IL_0007:  ldarg.0
+  IL_0008:  ldc.i4.1
+  IL_0009:  stfld      ""bool C.b""
+  // sequence point: base(4)
+  IL_000e:  ldarg.0
+  IL_000f:  ldc.i4.4
+  IL_0010:  call       ""B..ctor(int)""
+  // sequence point: b = y;
+  IL_0015:  ldarg.0
+  IL_0016:  ldarg.1
+  IL_0017:  stfld      ""bool C.b""
+  // sequence point: }
+  IL_001c:  ret
+}
+");
+        }
+
         /// <summary>
         /// Although the debugging info attached to DebuggerHidden method is not used by the debugger 
         /// (the debugger doesn't ever stop in the method) Dev11 emits the info and so do we.

--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.Shared.Collections;
 
 #if DEBUG
 using System.Linq;
@@ -732,6 +733,29 @@ namespace Microsoft.CodeAnalysis
         internal static ImmutableArray<T> Concat<T>(this ImmutableArray<T> first, T second)
         {
             return first.Add(second);
+        }
+
+        internal static ImmutableArray<T> AddRange<T>(this ImmutableArray<T> self, in TemporaryArray<T> items)
+        {
+            if (items.Count == 0)
+            {
+                return self;
+            }
+
+            if (items.Count == 1)
+            {
+                return self.Add(items[0]);
+            }
+
+            var builder = ArrayBuilder<T>.GetInstance(self.Length + items.Count);
+            builder.AddRange(self);
+
+            foreach (var item in items)
+            {
+                builder.Add(item);
+            }
+
+            return builder.ToImmutableAndFree();
         }
 
         internal static bool HasDuplicates<T>(this ImmutableArray<T> array, IEqualityComparer<T> comparer)


### PR DESCRIPTION
Simplifies block instrumentation and makes it composable (allows multiple instrumenters to add local variables).

Fixes sequence point applied to instrumentation prologue.