### PR TITLE
Fix handling of Regex classification when splitting to multiple lines 

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -155,8 +155,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                 // Since VS doesn't support multi-line spans/tokens, we need to break the span up into single-line spans.
                 if (startLine != endLine)
                 {
-                    spanIndex = ConvertToSingleLineSpan(
-                        text, classifiedSpans, updatedClassifiedSpans, spanIndex, span.ClassificationType,
+                    ConvertToSingleLineSpan(
+                        text, classifiedSpans, updatedClassifiedSpans, ref spanIndex, span.ClassificationType,
                         startLine, startOffset, endLine, endOffSet);
                 }
                 else
@@ -168,11 +168,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
 
             return updatedClassifiedSpans.ToArray();
 
-            static int ConvertToSingleLineSpan(
+            static void ConvertToSingleLineSpan(
                 SourceText text,
                 ClassifiedSpan[] originalClassifiedSpans,
                 ArrayBuilder<ClassifiedSpan> updatedClassifiedSpans,
-                int spanIndex,
+                ref int spanIndex,
                 string classificationType,
                 int startLine,
                 int startOffset,
@@ -181,8 +181,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
             {
                 var numLinesInSpan = endLine - startLine + 1;
                 Contract.ThrowIfTrue(numLinesInSpan < 1);
-
-                var updatedSpanIndex = spanIndex;
 
                 for (var currentLine = 0; currentLine < numLinesInSpan; currentLine++)
                 {
@@ -220,15 +218,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                     //     var x = @"one ""
                     //               two";
                     // The check below ensures we correctly return the spans in the correct order, i.e. 'one', '""', 'two'.
-                    while (updatedSpanIndex + 1 < originalClassifiedSpans.Length &&
-                        textSpan.Contains(originalClassifiedSpans[updatedSpanIndex + 1].TextSpan))
+                    while (spanIndex + 1 < originalClassifiedSpans.Length &&
+                        textSpan.Contains(originalClassifiedSpans[spanIndex + 1].TextSpan))
                     {
-                        updatedClassifiedSpans.Add(originalClassifiedSpans[updatedSpanIndex + 1]);
-                        updatedSpanIndex++;
+                        updatedClassifiedSpans.Add(originalClassifiedSpans[spanIndex + 1]);
+                        spanIndex++;
                     }
                 }
-
-                return updatedSpanIndex;
             }
         }
 

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -190,9 +190,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                     // Case 1: First line of span
                     if (currentLine == 0)
                     {
-                        var absoluteStartOffset = line.Start + startOffset;
-                        var spanLength = line.End - absoluteStartOffset;
-                        textSpan = new TextSpan(absoluteStartOffset, spanLength);
+                        var absoluteStart = line.Start + startOffset;
+
+                        // This start could be past the regular end of the line if it's within the newline character if we have a CRLF newline. In that case, just skip emitting a span for the LF.
+                        // One example where this could happen is an embedded regular expression that we're classifying; regular expression comments contained within a multi-line string
+                        // contain the carriage return but not the linefeed, so the linefeed could be the start of the next classification.
+                        textSpan = TextSpan.FromBounds(Math.Min(absoluteStart, line.End), line.End);
                     }
                     // Case 2: Any of the span's middle lines
                     else if (currentLine != numLinesInSpan - 1)

--- a/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/SemanticTokens/SemanticTokensHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -185,30 +186,31 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
 
                 for (var currentLine = 0; currentLine < numLinesInSpan; currentLine++)
                 {
-                    TextSpan? textSpan;
+                    TextSpan textSpan;
+                    var line = text.Lines[startLine + currentLine];
 
                     // Case 1: First line of span
                     if (currentLine == 0)
                     {
-                        var absoluteStartOffset = text.Lines[startLine].Start + startOffset;
-                        var spanLength = text.Lines[startLine].End - absoluteStartOffset;
+                        var absoluteStartOffset = line.Start + startOffset;
+                        var spanLength = line.End - absoluteStartOffset;
                         textSpan = new TextSpan(absoluteStartOffset, spanLength);
                     }
                     // Case 2: Any of the span's middle lines
                     else if (currentLine != numLinesInSpan - 1)
                     {
-                        textSpan = text.Lines[startLine + currentLine].Span;
+                        textSpan = line.Span;
                     }
                     // Case 3: Last line of span
                     else
                     {
-                        textSpan = new TextSpan(text.Lines[endLine].Start, endOffSet);
+                        textSpan = new TextSpan(line.Start, endOffSet);
                     }
 
                     // Omit 0-length spans created in this fashion.
-                    if (textSpan.Value.Length > 0)
+                    if (textSpan.Length > 0)
                     {
-                        var updatedClassifiedSpan = new ClassifiedSpan(textSpan.Value, classificationType);
+                        var updatedClassifiedSpan = new ClassifiedSpan(textSpan, classificationType);
                         updatedClassifiedSpans.Add(updatedClassifiedSpan);
                     }
 
@@ -219,7 +221,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.SemanticTokens
                     //               two";
                     // The check below ensures we correctly return the spans in the correct order, i.e. 'one', '""', 'two'.
                     while (updatedSpanIndex + 1 < originalClassifiedSpans.Length &&
-                        textSpan.Value.Contains(originalClassifiedSpans[updatedSpanIndex + 1].TextSpan))
+                        textSpan.Contains(originalClassifiedSpans[updatedSpanIndex + 1].TextSpan))
                     {
                         updatedClassifiedSpans.Add(originalClassifiedSpans[updatedSpanIndex + 1]);
                         updatedSpanIndex++;

--- a/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/AbstractSemanticTokensTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/AbstractSemanticTokensTests.cs
@@ -4,6 +4,7 @@
 
 #nullable enable
 
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -93,6 +94,25 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.SemanticTokens
                     $"Multi-line token of type {kind} found on line {currentLine} at character index {currentChar}. " +
                     $"The token ends at index {currentChar + tokenLength}, which exceeds the line length of {lineLength}.");
             }
+        }
+
+        /// <summary>
+        /// This converts the raw array form back to a slightly more readable form for the purposes of understanding the diff should a test
+        /// fail. This groups rows by five (so that way the diff can't desynced from the start of a new token), and also replaces the token index
+        /// back with the string again.
+        /// </summary>
+        protected static ImmutableArray<string> ConvertToReadableFormat(int[] data)
+        {
+            var convertedStringsBuilder = ImmutableArray.CreateBuilder<string>(data.Length / 5);
+
+            for (var i = 0; i < data.Length; i += 5)
+            {
+                var kind = SemanticTokensHelpers.TokenTypeToIndex.Single(kvp => kvp.Value == data[i + 3]).Key;
+
+                convertedStringsBuilder.Add($"{data[i]}, {data[i + 1]}, {data[i + 2]}, {kind}, {data[i + 4]}");
+            }
+
+            return convertedStringsBuilder.MoveToImmutable();
         }
     }
 }

--- a/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
@@ -186,7 +186,7 @@ three"";
         }
 
         [Fact]
-        public async Task TestGetSemanticTokensRange_StringLiteral_RazorAsync()
+        public async Task TestGetSemanticTokensRange_StringLiteral_IncludeSyntacticClassificationsAsync()
         {
             var markup =
 @"{|caret:|}class C
@@ -239,7 +239,7 @@ three"";
         }
 
         [Fact]
-        public async Task TestGetSemanticTokensRange_Regex_RazorAsync()
+        public async Task TestGetSemanticTokensRange_Regex_IncludeSyntacticClassificationsAsync()
         {
             var markup =
 @"{|caret:|}using System.Text.RegularExpressions;
@@ -294,6 +294,79 @@ class C
                        0,     1,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.RegexQuantifier],       0, // '*'
                        0,     1,     1,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.String],                 0, // '"'
                        0,     1,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // ')'
+                       0,     1,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // ';'
+                       1,     4,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // }
+                       1,     0,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // }
+                }
+            };
+
+            await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
+            AssertEx.Equal(ConvertToReadableFormat(expectedResults.Data), ConvertToReadableFormat(results));
+        }
+
+        [Fact]
+        [WorkItem(1710519, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1710519")]
+        public async Task TestGetSemanticTokensRange_RegexWithComment_IncludeSyntacticClassificationsAsync()
+        {
+            var markup =
+@"{|caret:|}using System.Text.RegularExpressions;
+
+class C
+{
+	void M()
+	{
+		var x = new Regex(@""(abc)* #comment
+                          "", RegexOptions.IgnorePatternWhitespace);
+    }
+}
+";
+
+            await using var testLspServer = await CreateTestLspServerAsync(markup);
+
+            var document = testLspServer.GetCurrentSolution().Projects.First().Documents.First();
+            var options = ClassificationOptions.Default;
+            var results = await SemanticTokensHelpers.ComputeSemanticTokensDataAsync(
+                document, SemanticTokensHelpers.TokenTypeToIndex, range: null, options, includeSyntacticClassifications: true, CancellationToken.None);
+
+            var expectedResults = new LSP.SemanticTokens
+            {
+                Data = new int[]
+                {
+                    // Line | Char | Len | Token type                                                                         | Modifier
+                       0,     0,     5,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Keyword],                0, // 'using'
+                       0,     6,     6,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.NamespaceName],         0, // 'System'
+                       0,     6,     1,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Operator],               0, // '.'
+                       0,     1,     4,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.NamespaceName],         0, // 'Text'
+                       0,     4,     1,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Operator],               0, // '.'
+                       0,     1,     18,   SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.NamespaceName],         0, // 'RegularExpressions'
+                       0,     18,    1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // ';'
+                       2,     0,     5,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Keyword],                0, // 'class'
+                       0,     6,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.ClassName],             0, // 'C'
+                       1,     0,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // '{'
+                       1,     1,     4,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Keyword],                0,  // 'void'
+                       0,     5,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.MethodName],            0, // 'M'
+                       0,     1,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // '('
+                       0,     1,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // ')'
+                       1,     1,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // '{'
+                       1,     2,     3,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Keyword],               0, // 'var'
+                       0,     4,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.LocalName],             0, // 'x'
+                       0,     2,     1,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Operator],               0, // '='
+                       0,     2,     3,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Keyword],                0, // 'new'
+                       0,     4,     5,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.ClassName],             0, // 'Regex'
+                       0,     5,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // '('
+                       0,     1,     2,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral], 0, // '@"'
+                       0,     2,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.RegexGrouping],         0, // '('
+                       0,     1,     3,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.RegexText],             0, // 'abc'
+                       0,     3,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.RegexGrouping],         0, // ')'
+                       0,     1,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.RegexQuantifier],       0, // '*'
+                       0,     1,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral], 0, // ' '
+                       0,     1,     9,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.RegexComment],          0, // '#comment'
+                       1,     0,     27,   SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.VerbatimStringLiteral], 0, // '"'
+                       0,     27,    1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // ','
+                       0,     2,     12,   SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.EnumName],              0, // 'RegexOptions'
+                       0,     12,    1,    SemanticTokensHelpers.TokenTypeToIndex[LSP.SemanticTokenTypes.Operator],               0, // '.'
+                       0,     1,     23,   SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.EnumMemberName],        0, // 'IgnorePatternWhitespace'
+                       0,     23,    1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // ')'
                        0,     1,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // ';'
                        1,     4,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // }
                        1,     0,     1,    SemanticTokensHelpers.TokenTypeToIndex[ClassificationTypeNames.Punctuation],           0, // }

--- a/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
@@ -79,7 +79,7 @@ static class C { }
             };
 
             await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
-            Assert.Equal(expectedResults.Data, results);
+            AssertEx.Equal(ConvertToReadableFormat(expectedResults.Data), ConvertToReadableFormat(results));
         }
 
         [Fact]
@@ -112,7 +112,7 @@ static class C { }
             };
 
             await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
-            Assert.Equal(expectedResults.Data, results);
+            AssertEx.Equal(ConvertToReadableFormat(expectedResults.Data), ConvertToReadableFormat(results));
         }
 
         [Fact]
@@ -149,7 +149,7 @@ three */ }
             };
 
             await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
-            Assert.Equal(expectedResults.Data, results);
+            AssertEx.Equal(ConvertToReadableFormat(expectedResults.Data), ConvertToReadableFormat(results));
         }
 
         [Fact]
@@ -182,7 +182,7 @@ three"";
             };
 
             await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results.Data!).ConfigureAwait(false);
-            Assert.Equal(expectedResults.Data, results.Data);
+            AssertEx.Equal(ConvertToReadableFormat(expectedResults.Data), ConvertToReadableFormat(results.Data));
         }
 
         [Fact]
@@ -235,7 +235,7 @@ three"";
             };
 
             await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
-            AssertEx.Equal(expectedResults.Data, results);
+            AssertEx.Equal(ConvertToReadableFormat(expectedResults.Data), ConvertToReadableFormat(results));
         }
 
         [Fact]
@@ -301,7 +301,7 @@ class C
             };
 
             await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
-            AssertEx.Equal(expectedResults.Data, results);
+            AssertEx.Equal(ConvertToReadableFormat(expectedResults.Data), ConvertToReadableFormat(results));
         }
 
         [Theory, MemberData(nameof(ClassificationTypeNamesToMatch))]

--- a/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/SemanticTokens/SemanticTokensRangeTests.cs
@@ -78,7 +78,7 @@ static class C { }
                 },
             };
 
-            await VerifyNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
+            await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
             Assert.Equal(expectedResults.Data, results);
         }
 
@@ -111,12 +111,12 @@ static class C { }
                 },
             };
 
-            await VerifyNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
+            await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
             Assert.Equal(expectedResults.Data, results);
         }
 
         [Fact]
-        public async Task TestGetSemanticTokensRange_MultiLineComment_RazorAsync()
+        public async Task TestGetSemanticTokensRange_MultiLineComment_IncludeSyntacticClassificationsAsync()
         {
             // Testing as a Razor doc so we get both syntactic + semantic results; otherwise the results would be empty.
             var markup =
@@ -148,7 +148,7 @@ three */ }
                 },
             };
 
-            await VerifyNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
+            await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
             Assert.Equal(expectedResults.Data, results);
         }
 
@@ -181,7 +181,7 @@ three"";
                 },
             };
 
-            await VerifyNoMultiLineTokens(testLspServer, results.Data!).ConfigureAwait(false);
+            await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results.Data!).ConfigureAwait(false);
             Assert.Equal(expectedResults.Data, results.Data);
         }
 
@@ -234,7 +234,7 @@ three"";
                 },
             };
 
-            await VerifyNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
+            await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
             AssertEx.Equal(expectedResults.Data, results);
         }
 
@@ -300,7 +300,7 @@ class C
                 }
             };
 
-            await VerifyNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
+            await VerifyBasicInvariantsAndNoMultiLineTokens(testLspServer, results).ConfigureAwait(false);
             AssertEx.Equal(expectedResults.Data, results);
         }
 


### PR DESCRIPTION
The Regex lexer considers that a comment ends at the linefeed character, so a CRLF ending means the carriage return is a part of the comment and the linefeed is whitespace. In the case of a Regex with IgnorePatternWhitespace, this meant that we'd classify the carriage return as the commend, and the linefeed as general string literal. When we tried to convert this to a multi-line span, we'd screw up since the span was starting in the middle of the linebreak.

An alternative fix here would be to change the Regex lexer, but:

1. There is a comment in the lexer saying we're matching the behavior of the actual runtime implementation, which seems like a good invariant to maintain.
2. This ensures we're robust against other embedded languages having the same issue.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1710519