### PR TITLE
CreateCompilation default option to detect 'unsafe' keyword

### DIFF
--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IParameterReferenceExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IParameterReferenceExpression.cs
@@ -490,7 +490,7 @@ IOperation:  (OperationKind.None, Type: System.Int32) (Syntax: '*x')
                 Diagnostic(ErrorCode.ERR_IllegalUnsafe, "M").WithLocation(4, 23)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<PrefixUnaryExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<PrefixUnaryExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, compilationOptions: TestOptions.ReleaseDll);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -525,7 +525,7 @@ IVariableDeclaratorOperation (Symbol: System.Int32* p) (OperationKind.VariableDe
                 Diagnostic(ErrorCode.ERR_IllegalUnsafe, "M").WithLocation(6, 24)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclaratorSyntax>(source, expectedOperationTree, expectedDiagnostics, compilationOptions: TestOptions.ReleaseDll);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -740,7 +740,7 @@ IOperation:  (OperationKind.None, Type: System.Int32*) (Syntax: 'stackalloc int[
                 Diagnostic(ErrorCode.ERR_IllegalUnsafe, "M").WithLocation(6, 24)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<StackAllocArrayCreationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, compilationOptions: TestOptions.ReleaseDll);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IVariableDeclaration.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IVariableDeclaration.cs
@@ -1436,7 +1436,7 @@ IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration
                 Diagnostic(ErrorCode.ERR_IllegalUnsafe, "unsafe").WithLocation(8, 9)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics, compilationOptions: TestOptions.ReleaseDll);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -1492,7 +1492,7 @@ IVariableDeclarationOperation (2 declarators) (OperationKind.VariableDeclaration
                 Diagnostic(ErrorCode.ERR_IllegalUnsafe, "unsafe").WithLocation(8, 9)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics, compilationOptions: TestOptions.ReleaseDll);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -1539,7 +1539,7 @@ IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration
                 Diagnostic(ErrorCode.WRN_UnreferencedField, "i1").WithArguments("Program.i1").WithLocation(4, 9)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics, compilationOptions: TestOptions.ReleaseDll);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -1597,7 +1597,7 @@ IVariableDeclarationOperation (2 declarators) (OperationKind.VariableDeclaration
                 Diagnostic(ErrorCode.WRN_UnreferencedField, "i1").WithArguments("Program.i1").WithLocation(4, 9)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics, compilationOptions: TestOptions.ReleaseDll);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -1642,7 +1642,7 @@ IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration
                 Diagnostic(ErrorCode.WRN_UnreferencedField, "i1").WithArguments("Program.i1").WithLocation(4, 9)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics, compilationOptions: TestOptions.ReleaseDll);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -1696,7 +1696,7 @@ IVariableDeclarationOperation (2 declarators) (OperationKind.VariableDeclaration
                 Diagnostic(ErrorCode.WRN_UnreferencedField, "i1").WithArguments("Program.i1").WithLocation(4, 9)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics, compilationOptions: TestOptions.ReleaseDll);
         }
 
         [CompilerTrait(CompilerFeature.IOperation)]
@@ -1754,7 +1754,7 @@ IVariableDeclarationOperation (2 declarators) (OperationKind.VariableDeclaration
                 Diagnostic(ErrorCode.WRN_UnreferencedField, "i2").WithArguments("Program.i2").WithLocation(4, 13)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics, compilationOptions: TestOptions.ReleaseDll);
         }
 
         [Fact]
@@ -1824,7 +1824,7 @@ IVariableDeclarationOperation (1 declarators) (OperationKind.VariableDeclaration
                 Diagnostic(ErrorCode.ERR_BadFixedInitType, "p1 = null").WithLocation(9, 64)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<VariableDeclarationSyntax>(source, expectedOperationTree, expectedDiagnostics, compilationOptions: TestOptions.ReleaseDll);
         }
 
         #endregion

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
@@ -1311,7 +1311,7 @@ IDynamicInvocationOperation (OperationKind.DynamicInvocation, Type: dynamic) (Sy
                 Diagnostic(ErrorCode.ERR_BadTypeArgument, "System.TypedReference").WithArguments("System.TypedReference").WithLocation(10, 14)
             };
 
-            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics);
+            VerifyOperationTreeAndDiagnosticsForTest<InvocationExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics, compilationOptions: TestOptions.ReleaseDll);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -1441,7 +1441,7 @@ class C
     }
 }";
 
-            var comp = CreateCompilation(source);
+            var comp = CreateCompilation(source, options: TestOptions.ReleaseDll);
             Assert.Empty(comp.GetDeclarationDiagnostics());
             comp.VerifyDiagnostics(
                 // (8,23): error CS0227: Unsafe code may only appear if compiling with /unsafe

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RecordStructTests.cs
@@ -726,7 +726,7 @@ static record struct S9;
 sealed record struct S10;
 ";
 
-            var comp = CreateCompilation(src);
+            var comp = CreateCompilation(src, options: TestOptions.ReleaseDll);
             comp.VerifyDiagnostics(
                 // (2,24): error CS0106: The modifier 'abstract' is not valid for this item
                 // abstract record struct S1;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -294,7 +294,7 @@ class C
 }
 ";
 
-            CreateCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            CreateCompilation(text).VerifyDiagnostics(
                 // (6,9): error CS1629: Unsafe code may not appear in iterators
                 Diagnostic(ErrorCode.ERR_IllegalInnerUnsafe, "unsafe"));
         }
@@ -358,7 +358,7 @@ unsafe class C
 }
 ";
 
-            CreateCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            CreateCompilation(text).VerifyDiagnostics(
                 // (10,32): warning CS0067: The event 'C.Event' is never used
                 //     unsafe event System.Action Event;
                 Diagnostic(ErrorCode.WRN_UnreferencedEvent, "Event").WithArguments("C.Event"));
@@ -1067,7 +1067,7 @@ class C : I
 }
 ";
 
-            CreateCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics();
+            CreateCompilation(text).VerifyDiagnostics();
         }
 
         [WorkItem(544417, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544417")]
@@ -8565,7 +8565,7 @@ class C<T>
     unsafe E* ptr;
 }
 ";
-            CreateCompilation(text, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+            CreateCompilation(text).VerifyDiagnostics(
                 // (5,15): warning CS0169: The field 'C<T>.ptr' is never used
                 //     unsafe E* ptr;
                 Diagnostic(ErrorCode.WRN_UnreferencedField, "ptr").WithArguments("C<T>.ptr"));
@@ -9167,7 +9167,7 @@ public class Test
     {
         int* pointer = &p;
     }
-}", options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
+}").VerifyDiagnostics(
                 // (6,24): error CS0212: You can only take the address of an unfixed expression inside of a fixed statement initializer
                 //         int* pointer = &p;
                 Diagnostic(ErrorCode.ERR_FixedNeeded, "&p").WithLocation(6, 24)
@@ -9282,7 +9282,7 @@ unsafe class C
         int* e = &(s.Buf[0]);
         int* f = &(s_f.Buf[0]);
     }
-}", options: TestOptions.UnsafeDebugDll).VerifyDiagnostics(
+}").VerifyDiagnostics(
                 // (12,25): error CS0213: You cannot use the fixed statement to take the address of an already fixed expression
                 //         fixed (int* a = &s.Buf[0]) { }
                 Diagnostic(ErrorCode.ERR_FixedNotNeeded, "&s.Buf[0]").WithLocation(12, 25),
@@ -9311,7 +9311,7 @@ namespace Interop
         public PROPVARIANT* pElems;
     }
 }";
-            var comp = CreateCompilation(csharp, options: TestOptions.UnsafeDebugDll);
+            var comp = CreateCompilation(csharp);
             comp.VerifyDiagnostics();
         }
     }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/StatementAttributeParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/StatementAttributeParsingTests.cs
@@ -4,6 +4,7 @@
 
 #nullable disable
 
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -1677,7 +1678,7 @@ class C
             }
             EOF();
 
-            CreateCompilation(test).GetDiagnostics().Verify(
+            CreateCompilation(test, options: TestOptions.ReleaseDll).GetDiagnostics().Verify(
                 // (4,17): error CS0227: Unsafe code may only appear if compiling with /unsafe
                 //     unsafe void Goo(int[] vals)
                 Diagnostic(ErrorCode.ERR_IllegalUnsafe, "Goo").WithLocation(4, 17),
@@ -1960,7 +1961,7 @@ class C
             }
             EOF();
 
-            CreateCompilation(test).GetDiagnostics().Verify(
+            CreateCompilation(test, options: TestOptions.ReleaseDll).GetDiagnostics().Verify(
                 // (6,9): error CS7014: Attributes are not valid in this context.
                 //         [A]unsafe { }
                 Diagnostic(ErrorCode.ERR_AttributesNotAllowed, "[A]").WithLocation(6, 9),

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -626,7 +626,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             type = "unsafe class C { delegate*<void> x; }";
 
-            CreateCompilation(type, parseOptions: TestOptions.Regular8).VerifyDiagnostics(
+            CreateCompilation(type, parseOptions: TestOptions.Regular8, options: TestOptions.ReleaseDll).VerifyDiagnostics(
                 // (1,14): error CS0227: Unsafe code may only appear if compiling with /unsafe
                 // unsafe class C { delegate*<void> x; }
                 Diagnostic(ErrorCode.ERR_IllegalUnsafe, "C").WithLocation(1, 14),
@@ -637,7 +637,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 // unsafe class C { delegate*<void> x; }
                 Diagnostic(ErrorCode.WRN_UnreferencedField, "x").WithArguments("C.x").WithLocation(1, 34));
 
-            CreateCompilation(type, parseOptions: TestOptions.Regular9).VerifyDiagnostics(
+            CreateCompilation(type, parseOptions: TestOptions.Regular9, options: TestOptions.ReleaseDll).VerifyDiagnostics(
                 // (1,14): error CS0227: Unsafe code may only appear if compiling with /unsafe
                 // unsafe class C { delegate*<void> x; }
                 Diagnostic(ErrorCode.ERR_IllegalUnsafe, "C").WithLocation(1, 14),


### PR DESCRIPTION
Small convenience: When options aren't specified, `CreateCompilation` can look for `unsafe` in the syntax to determine what options I need.