### PR TITLE
Annotate MS.CA and MS.CA.C# for trimming

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpFileSystemExtensions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpFileSystemExtensions.cs
@@ -28,6 +28,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <exception cref="ArgumentNullException">Compilation or path is null.</exception>
         /// <exception cref="ArgumentException">Path is empty or invalid.</exception>
         /// <exception cref="IOException">An error occurred while reading or writing a file.</exception>
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         public static EmitResult Emit(
             this CSharpCompilation compilation,
             string outputPath,

--- a/src/Compilers/CSharp/Portable/CSharpFileSystemExtensions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpFileSystemExtensions.cs
@@ -21,16 +21,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Also embedded in the output file.  Null to forego PDB generation.
         /// </param>
         /// <param name="xmlDocumentationPath">Path of the file to which the compilation's XML documentation will be written.  Null to forego XML generation.</param>
-        /// <param name="win32ResourcesPath">Path of the file from which the compilation's Win32 resources will be read (in RES format).  
+        /// <param name="win32ResourcesPath">Path of the file from which the compilation's Win32 resources will be read (in RES format).
         /// Null to indicate that there are none.</param>
         /// <param name="manifestResources">List of the compilation's managed resources.  Null to indicate that there are none.</param>
         /// <param name="cancellationToken">To cancel the emit process.</param>
         /// <exception cref="ArgumentNullException">Compilation or path is null.</exception>
         /// <exception cref="ArgumentException">Path is empty or invalid.</exception>
         /// <exception cref="IOException">An error occurred while reading or writing a file.</exception>
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         public static EmitResult Emit(
             this CSharpCompilation compilation,
             string outputPath,

--- a/src/Compilers/CSharp/Portable/CSharpFileSystemExtensions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpFileSystemExtensions.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using Microsoft.CodeAnalysis.Emit;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -330,6 +330,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return CommonCompiler.TryGetCompilerDiagnosticCode(diagnosticId, "CS", out code);
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
+#endif
         protected override void ResolveAnalyzersFromArguments(
             List<DiagnosticInfo> diagnostics,
             CommonMessageProvider messageProvider,

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -330,9 +330,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return CommonCompiler.TryGetCompilerDiagnosticCode(diagnosticId, "CS", out code);
         }
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
-#endif
         protected override void ResolveAnalyzersFromArguments(
             List<DiagnosticInfo> diagnostics,
             CommonMessageProvider messageProvider,

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -3438,6 +3438,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         internal override EmitDifferenceResult EmitDifference(
             EmitBaseline baseline,
             IEnumerable<SemanticEdit> edits,

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -3438,9 +3438,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         internal override EmitDifferenceResult EmitDifference(
             EmitBaseline baseline,
             IEnumerable<SemanticEdit> edits,

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
@@ -19,6 +19,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 {
     internal static class EmitHelpers
     {
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         internal static EmitDifferenceResult EmitDifference(
             CSharpCompilation compilation,
             EmitBaseline baseline,

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
@@ -19,9 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 {
     internal static class EmitHelpers
     {
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         internal static EmitDifferenceResult EmitDifference(
             CSharpCompilation compilation,
             EmitBaseline baseline,

--- a/src/Compilers/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.csproj
+++ b/src/Compilers/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.csproj
@@ -7,6 +7,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <GenerateMicrosoftCodeAnalysisCommitHashAttribute>true</GenerateMicrosoftCodeAnalysisCommitHashAttribute>
+    <IsTrimmable Condition="'$(TargetFramework)' != 'netstandard2.0'">true</IsTrimmable>
+    <EnableAotAnalyzer Condition="'$(TargetFramework)' != 'netstandard2.0'">true</EnableAotAnalyzer>
     <ApplyNgenOptimization Condition="'$(TargetFramework)' == 'netstandard2.0'">full</ApplyNgenOptimization>
 
     <!-- NuGet -->

--- a/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
@@ -425,19 +425,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(ObjectWriter.TypeCode.UInt32_10, ObjectWriter.TypeCode.UInt32_0 + 10);
         }
 
-        private void TestRoundTripType(Type type)
-        {
-            TestRoundTrip(type, (w, v) => w.WriteType(v), r => r.ReadType());
-        }
-
-        [Fact]
-        public void TestTypes()
-        {
-            TestRoundTripType(typeof(int));
-            TestRoundTripType(typeof(string));
-            TestRoundTripType(typeof(ObjectSerializationTests));
-        }
-
         private void TestRoundTripCompressedUint(uint value)
         {
             TestRoundTrip(value, (w, v) => ((ObjectWriter)w).WriteCompressedUInt(v), r => ((ObjectReader)r).ReadCompressedUInt());

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -10,7 +10,7 @@
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
 
     <!--
-      Prevent the generation of binding redirects as they are not respected by 
+      Prevent the generation of binding redirects as they are not respected by
       MSBuild. At the moment it's on by default due to arcade settings that we
       need to override here
 
@@ -57,6 +57,8 @@
     <Compile Include="..\Portable\InternalUtilities\NullableAttributes.cs" />
     <Compile Include="..\Portable\InternalUtilities\PlatformInformation.cs" />
     <Compile Include="..\Portable\InternalUtilities\ReflectionUtilities.cs" />
+    <Compile Include="..\Portable\InternalUtilities\DynamicallyAccessedMembersAttribute.cs" />
+    <Compile Include="..\Portable\InternalUtilities\RequiresUnreferencedCodeAttribute.cs" />
     <Compile Include="..\Portable\InternalUtilities\RoslynString.cs" />
     <Compile Include="..\Portable\InternalUtilities\UnicodeCharacterUtilities.cs" />
   </ItemGroup>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Build.Tasks.CodeAnalysis.csproj
@@ -57,6 +57,7 @@
     <Compile Include="..\Portable\InternalUtilities\NullableAttributes.cs" />
     <Compile Include="..\Portable\InternalUtilities\PlatformInformation.cs" />
     <Compile Include="..\Portable\InternalUtilities\ReflectionUtilities.cs" />
+    <Compile Include="..\Portable\InternalUtilities\TrimWarningMessages.cs" />
     <Compile Include="..\Portable\InternalUtilities\DynamicallyAccessedMembersAttribute.cs" />
     <Compile Include="..\Portable\InternalUtilities\RequiresUnreferencedCodeAttribute.cs" />
     <Compile Include="..\Portable\InternalUtilities\RoslynString.cs" />

--- a/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using Roslyn.Utilities;
 
@@ -36,6 +37,9 @@ namespace Microsoft.CodeAnalysis
         internal void StartSingleGeneratorRunTime(string generatorName, string assemblyPath, string id) => WriteEvent(3, generatorName, assemblyPath, id);
 
         [Event(4, Message = "Generator {0} ran for {2} ticks", Keywords = Keywords.Performance, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Task = Tasks.SingleGeneratorRunTime)]
+#if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026:'RequiresUnreferencedCodeAttribute'", Justification = "Only passes primitive types, which is safe according to the RUC message.")]
+#endif
         internal void StopSingleGeneratorRunTime(string generatorName, string assemblyPath, long elapsedTicks, string id) => WriteEvent(4, generatorName, assemblyPath, elapsedTicks, id);
     }
 }

--- a/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisEventSource.cs
@@ -37,9 +37,7 @@ namespace Microsoft.CodeAnalysis
         internal void StartSingleGeneratorRunTime(string generatorName, string assemblyPath, string id) => WriteEvent(3, generatorName, assemblyPath, id);
 
         [Event(4, Message = "Generator {0} ran for {2} ticks", Keywords = Keywords.Performance, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Task = Tasks.SingleGeneratorRunTime)]
-#if NET6_0_OR_GREATER
         [UnconditionalSuppressMessage("Trimming", "IL2026:'RequiresUnreferencedCodeAttribute'", Justification = "Only passes primitive types, which is safe according to the RUC message.")]
-#endif
         internal void StopSingleGeneratorRunTime(string generatorName, string assemblyPath, long elapsedTicks, string id) => WriteEvent(4, generatorName, assemblyPath, elapsedTicks, id);
     }
 }

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
@@ -453,6 +453,9 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="analyzerLoader">Load an assembly from a file path</param>
         /// <returns>Yields resolved <see cref="AnalyzerFileReference"/> or <see cref="UnresolvedAnalyzerReference"/>.</returns>
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
+#endif
         public IEnumerable<AnalyzerReference> ResolveAnalyzerReferences(IAnalyzerAssemblyLoader analyzerLoader)
         {
             foreach (CommandLineAnalyzerReference cmdLineReference in AnalyzerReferences)
@@ -462,6 +465,9 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
+#endif
         internal void ResolveAnalyzersFromArguments(
             string language,
             List<DiagnosticInfo> diagnostics,
@@ -556,6 +562,9 @@ namespace Microsoft.CodeAnalysis
             bool shouldIncludeAnalyzer(DiagnosticAnalyzer analyzer) => !skipAnalyzers || analyzer is DiagnosticSuppressor;
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
+#endif
         private AnalyzerFileReference? ResolveAnalyzerReference(CommandLineAnalyzerReference reference, IAnalyzerAssemblyLoader analyzerLoader)
         {
             string? resolvedPath = FileUtilities.ResolveRelativePath(reference.FilePath, basePath: null, baseDirectory: BaseDirectory, searchPaths: ReferencePaths, fileExists: File.Exists);

--- a/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineArguments.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis
         public string? PdbPath { get; internal set; }
 
         /// <summary>
-        /// Path of the file containing information linking the compilation to source server that stores 
+        /// Path of the file containing information linking the compilation to source server that stores
         /// a snapshot of the source code included in the compilation.
         /// </summary>
         public string? SourceLink { get; internal set; }
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis
         public ImmutableArray<Diagnostic> Errors { get; internal set; }
 
         /// <summary>
-        /// References to metadata supplied on the command line. 
+        /// References to metadata supplied on the command line.
         /// Includes assemblies specified via /r and netmodules specified via /addmodule.
         /// </summary>
         public ImmutableArray<CommandLineReference> MetadataReferences { get; internal set; }
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis
         public bool SkipAnalyzers { get; internal set; }
 
         /// <summary>
-        /// If true, prepend the command line header logo during 
+        /// If true, prepend the command line header logo during
         /// <see cref="CommonCompiler.Run"/>.
         /// </summary>
         public bool DisplayLogo { get; internal set; }
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis
         /// Source file paths.
         /// </summary>
         /// <remarks>
-        /// Includes files specified directly on command line as well as files matching patterns specified 
+        /// Includes files specified directly on command line as well as files matching patterns specified
         /// on command line using '*' and '?' wildcards or /recurse option.
         /// </remarks>
         public ImmutableArray<CommandLineSourceFile> SourceFiles { get; internal set; }
@@ -266,7 +266,7 @@ namespace Microsoft.CodeAnalysis
         /// Full path of a log of file paths accessed by the compiler, or null if file logging should be suppressed.
         /// </summary>
         /// <remarks>
-        /// Two log files will be created: 
+        /// Two log files will be created:
         /// One with path <see cref="TouchedFilesPath"/> and extension ".read" logging the files read,
         /// and second with path <see cref="TouchedFilesPath"/> and extension ".write" logging the files written to during compilation.
         /// </remarks>
@@ -314,9 +314,9 @@ namespace Microsoft.CodeAnalysis
         /// Returns a full path of the file that the compiler will generate the assembly to if compilation succeeds.
         /// </summary>
         /// <remarks>
-        /// The method takes <paramref name="outputFileName"/> rather than using the value of <see cref="OutputFileName"/> 
+        /// The method takes <paramref name="outputFileName"/> rather than using the value of <see cref="OutputFileName"/>
         /// since the latter might be unspecified, in which case actual output path can't be determined for C# command line
-        /// without creating a compilation and finding an entry point. VB does not allow <see cref="OutputFileName"/> to 
+        /// without creating a compilation and finding an entry point. VB does not allow <see cref="OutputFileName"/> to
         /// be unspecified.
         /// </remarks>
         public string GetOutputFilePath(string outputFileName)
@@ -330,13 +330,13 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Returns a full path of the PDB file that the compiler will generate the debug symbols to 
+        /// Returns a full path of the PDB file that the compiler will generate the debug symbols to
         /// if <see cref="EmitPdbFile"/> is true and the compilation succeeds.
         /// </summary>
         /// <remarks>
-        /// The method takes <paramref name="outputFileName"/> rather than using the value of <see cref="OutputFileName"/> 
+        /// The method takes <paramref name="outputFileName"/> rather than using the value of <see cref="OutputFileName"/>
         /// since the latter might be unspecified, in which case actual output path can't be determined for C# command line
-        /// without creating a compilation and finding an entry point. VB does not allow <see cref="OutputFileName"/> to 
+        /// without creating a compilation and finding an entry point. VB does not allow <see cref="OutputFileName"/> to
         /// be unspecified.
         /// </remarks>
         public string GetPdbFilePath(string outputFileName)
@@ -453,9 +453,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         /// <param name="analyzerLoader">Load an assembly from a file path</param>
         /// <returns>Yields resolved <see cref="AnalyzerFileReference"/> or <see cref="UnresolvedAnalyzerReference"/>.</returns>
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
-#endif
         public IEnumerable<AnalyzerReference> ResolveAnalyzerReferences(IAnalyzerAssemblyLoader analyzerLoader)
         {
             foreach (CommandLineAnalyzerReference cmdLineReference in AnalyzerReferences)
@@ -465,9 +463,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
-#endif
         internal void ResolveAnalyzersFromArguments(
             string language,
             List<DiagnosticInfo> diagnostics,
@@ -562,9 +558,7 @@ namespace Microsoft.CodeAnalysis
             bool shouldIncludeAnalyzer(DiagnosticAnalyzer analyzer) => !skipAnalyzers || analyzer is DiagnosticSuppressor;
         }
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
-#endif
         private AnalyzerFileReference? ResolveAnalyzerReference(CommandLineAnalyzerReference reference, IAnalyzerAssemblyLoader analyzerLoader)
         {
             string? resolvedPath = FileUtilities.ResolveRelativePath(reference.FilePath, basePath: null, baseDirectory: BaseDirectory, searchPaths: ReferencePaths, fileExists: File.Exists);

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -112,6 +112,9 @@ namespace Microsoft.CodeAnalysis
 
         protected abstract bool TryGetCompilerDiagnosticCode(string diagnosticId, out uint code);
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
+#endif
         protected abstract void ResolveAnalyzersFromArguments(
             List<DiagnosticInfo> diagnostics,
             CommonMessageProvider messageProvider,

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -678,6 +678,9 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// csc.exe and vbc.exe entry point.
         /// </summary>
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         public virtual int Run(TextWriter consoleOutput, CancellationToken cancellationToken = default)
         {
             var saveUICulture = CultureInfo.CurrentUICulture;
@@ -791,6 +794,9 @@ namespace Microsoft.CodeAnalysis
 
         private protected abstract GeneratorDriver CreateGeneratorDriver(ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider, ImmutableArray<AdditionalText> additionalTexts);
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         private int RunCore(TextWriter consoleOutput, ErrorLogger? errorLogger, CancellationToken cancellationToken)
         {
             Debug.Assert(!Arguments.IsScriptRunner);
@@ -967,6 +973,9 @@ namespace Microsoft.CodeAnalysis
         /// (parsing, binding, compile, emit), resulting in diagnostics
         /// and analyzer output.
         /// </summary>
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         private void CompileAndEmit(
             TouchedFileLogger? touchedFilesLogger,
             ref Compilation compilation,

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -112,9 +112,7 @@ namespace Microsoft.CodeAnalysis
 
         protected abstract bool TryGetCompilerDiagnosticCode(string diagnosticId, out uint code);
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
-#endif
         protected abstract void ResolveAnalyzersFromArguments(
             List<DiagnosticInfo> diagnostics,
             CommonMessageProvider messageProvider,
@@ -681,9 +679,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// csc.exe and vbc.exe entry point.
         /// </summary>
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         public virtual int Run(TextWriter consoleOutput, CancellationToken cancellationToken = default)
         {
             var saveUICulture = CultureInfo.CurrentUICulture;
@@ -797,9 +793,7 @@ namespace Microsoft.CodeAnalysis
 
         private protected abstract GeneratorDriver CreateGeneratorDriver(ParseOptions parseOptions, ImmutableArray<ISourceGenerator> generators, AnalyzerConfigOptionsProvider analyzerConfigOptionsProvider, ImmutableArray<AdditionalText> additionalTexts);
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         private int RunCore(TextWriter consoleOutput, ErrorLogger? errorLogger, CancellationToken cancellationToken)
         {
             Debug.Assert(!Arguments.IsScriptRunner);
@@ -976,9 +970,7 @@ namespace Microsoft.CodeAnalysis
         /// (parsing, binding, compile, emit), resulting in diagnostics
         /// and analyzer output.
         /// </summary>
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         private void CompileAndEmit(
             TouchedFileLogger? touchedFilesLogger,
             ref Compilation compilation,

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -3009,6 +3009,9 @@ namespace Microsoft.CodeAnalysis
         /// subsequent Edit and Continue.
         /// </summary>
         [Obsolete("UpdatedMethods is now part of EmitDifferenceResult, so you should use an overload that doesn't take it.")]
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         public EmitDifferenceResult EmitDifference(
             EmitBaseline baseline,
             IEnumerable<SemanticEdit> edits,
@@ -3029,6 +3032,9 @@ namespace Microsoft.CodeAnalysis
         /// subsequent Edit and Continue.
         /// </summary>
         [Obsolete("UpdatedMethods is now part of EmitDifferenceResult, so you should use an overload that doesn't take it.")]
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         public EmitDifferenceResult EmitDifference(
             EmitBaseline baseline,
             IEnumerable<SemanticEdit> edits,
@@ -3056,6 +3062,9 @@ namespace Microsoft.CodeAnalysis
         /// of the current compilation is returned as an EmitBaseline for use in a
         /// subsequent Edit and Continue.
         /// </summary>
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         public EmitDifferenceResult EmitDifference(
             EmitBaseline baseline,
             IEnumerable<SemanticEdit> edits,
@@ -3102,6 +3111,9 @@ namespace Microsoft.CodeAnalysis
         }
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         internal abstract EmitDifferenceResult EmitDifference(
             EmitBaseline baseline,
             IEnumerable<SemanticEdit> edits,

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2623,6 +2623,9 @@ namespace Microsoft.CodeAnalysis
 
         // 1.0 BACKCOMPAT OVERLOAD -- DO NOT TOUCH
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         public EmitResult Emit(
             Stream peStream,
             Stream? pdbStream,
@@ -2647,6 +2650,9 @@ namespace Microsoft.CodeAnalysis
 
         // 1.3 BACKCOMPAT OVERLOAD -- DO NOT TOUCH
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         public EmitResult Emit(
             Stream peStream,
             Stream pdbStream,
@@ -2671,6 +2677,9 @@ namespace Microsoft.CodeAnalysis
         }
 
         // 2.0 BACKCOMPAT OVERLOAD -- DO NOT TOUCH
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         public EmitResult Emit(
             Stream peStream,
             Stream? pdbStream,
@@ -2732,6 +2741,9 @@ namespace Microsoft.CodeAnalysis
         /// Only supported when emitting Portable PDBs.
         /// </param>
         /// <param name="cancellationToken">To cancel the emit process.</param>
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         public EmitResult Emit(
             Stream peStream,
             Stream? pdbStream = null,
@@ -2760,6 +2772,9 @@ namespace Microsoft.CodeAnalysis
                 cancellationToken);
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         internal EmitResult Emit(
             Stream peStream,
             Stream? pdbStream,
@@ -2877,6 +2892,9 @@ namespace Microsoft.CodeAnalysis
         /// This overload is only intended to be directly called by tests that want to pass <paramref name="testData"/>.
         /// The map is used for storing a list of methods and their associated IL.
         /// </summary>
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         internal EmitResult Emit(
             Stream peStream,
             Stream? metadataPEStream,
@@ -3156,6 +3174,9 @@ namespace Microsoft.CodeAnalysis
 
         internal bool IsEmitDeterministic => this.Options.Deterministic;
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         internal bool SerializeToPeStream(
             CommonPEModuleBuilder moduleBeingBuilt,
             EmitStreamProvider peStreamProvider,
@@ -3308,6 +3329,9 @@ namespace Microsoft.CodeAnalysis
             return auxStream;
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         internal static bool SerializePeToStream(
             CommonPEModuleBuilder moduleBeingBuilt,
             DiagnosticBag metadataDiagnostics,
@@ -3371,6 +3395,9 @@ namespace Microsoft.CodeAnalysis
             return true;
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         internal EmitBaseline? SerializeToDeltaStreams(
             CommonPEModuleBuilder moduleBeingBuilt,
             EmitBaseline baseline,

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -2623,9 +2623,7 @@ namespace Microsoft.CodeAnalysis
 
         // 1.0 BACKCOMPAT OVERLOAD -- DO NOT TOUCH
         [EditorBrowsable(EditorBrowsableState.Never)]
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         public EmitResult Emit(
             Stream peStream,
             Stream? pdbStream,
@@ -2650,9 +2648,7 @@ namespace Microsoft.CodeAnalysis
 
         // 1.3 BACKCOMPAT OVERLOAD -- DO NOT TOUCH
         [EditorBrowsable(EditorBrowsableState.Never)]
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         public EmitResult Emit(
             Stream peStream,
             Stream pdbStream,
@@ -2677,9 +2673,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         // 2.0 BACKCOMPAT OVERLOAD -- DO NOT TOUCH
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         public EmitResult Emit(
             Stream peStream,
             Stream? pdbStream,
@@ -2741,9 +2735,7 @@ namespace Microsoft.CodeAnalysis
         /// Only supported when emitting Portable PDBs.
         /// </param>
         /// <param name="cancellationToken">To cancel the emit process.</param>
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         public EmitResult Emit(
             Stream peStream,
             Stream? pdbStream = null,
@@ -2772,9 +2764,7 @@ namespace Microsoft.CodeAnalysis
                 cancellationToken);
         }
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         internal EmitResult Emit(
             Stream peStream,
             Stream? pdbStream,
@@ -2892,9 +2882,7 @@ namespace Microsoft.CodeAnalysis
         /// This overload is only intended to be directly called by tests that want to pass <paramref name="testData"/>.
         /// The map is used for storing a list of methods and their associated IL.
         /// </summary>
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         internal EmitResult Emit(
             Stream peStream,
             Stream? metadataPEStream,
@@ -3009,9 +2997,7 @@ namespace Microsoft.CodeAnalysis
         /// subsequent Edit and Continue.
         /// </summary>
         [Obsolete("UpdatedMethods is now part of EmitDifferenceResult, so you should use an overload that doesn't take it.")]
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         public EmitDifferenceResult EmitDifference(
             EmitBaseline baseline,
             IEnumerable<SemanticEdit> edits,
@@ -3032,9 +3018,7 @@ namespace Microsoft.CodeAnalysis
         /// subsequent Edit and Continue.
         /// </summary>
         [Obsolete("UpdatedMethods is now part of EmitDifferenceResult, so you should use an overload that doesn't take it.")]
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         public EmitDifferenceResult EmitDifference(
             EmitBaseline baseline,
             IEnumerable<SemanticEdit> edits,
@@ -3062,9 +3046,7 @@ namespace Microsoft.CodeAnalysis
         /// of the current compilation is returned as an EmitBaseline for use in a
         /// subsequent Edit and Continue.
         /// </summary>
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         public EmitDifferenceResult EmitDifference(
             EmitBaseline baseline,
             IEnumerable<SemanticEdit> edits,
@@ -3111,9 +3093,7 @@ namespace Microsoft.CodeAnalysis
         }
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         internal abstract EmitDifferenceResult EmitDifference(
             EmitBaseline baseline,
             IEnumerable<SemanticEdit> edits,
@@ -3186,9 +3166,7 @@ namespace Microsoft.CodeAnalysis
 
         internal bool IsEmitDeterministic => this.Options.Deterministic;
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         internal bool SerializeToPeStream(
             CommonPEModuleBuilder moduleBeingBuilt,
             EmitStreamProvider peStreamProvider,
@@ -3341,9 +3319,7 @@ namespace Microsoft.CodeAnalysis
             return auxStream;
         }
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         internal static bool SerializePeToStream(
             CommonPEModuleBuilder moduleBeingBuilt,
             DiagnosticBag metadataDiagnostics,
@@ -3407,9 +3383,7 @@ namespace Microsoft.CodeAnalysis
             return true;
         }
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         internal EmitBaseline? SerializeToDeltaStreams(
             CommonPEModuleBuilder moduleBeingBuilt,
             EmitBaseline baseline,

--- a/src/Compilers/Core/Portable/DiaSymReader/SymUnmanagedFactory.cs
+++ b/src/Compilers/Core/Portable/DiaSymReader/SymUnmanagedFactory.cs
@@ -8,6 +8,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.DiaSymReader
@@ -163,6 +164,9 @@ namespace Microsoft.DiaSymReader
             return lazyType;
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         internal static object CreateObject(bool createReader, bool useAlternativeLoadPath, bool useComRegistry, out string moduleName, out Exception loadException)
         {
             object instance = null;

--- a/src/Compilers/Core/Portable/DiaSymReader/SymUnmanagedFactory.cs
+++ b/src/Compilers/Core/Portable/DiaSymReader/SymUnmanagedFactory.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
+using Roslyn.Utilities;
 
 namespace Microsoft.DiaSymReader
 {

--- a/src/Compilers/Core/Portable/DiaSymReader/SymUnmanagedFactory.cs
+++ b/src/Compilers/Core/Portable/DiaSymReader/SymUnmanagedFactory.cs
@@ -164,9 +164,7 @@ namespace Microsoft.DiaSymReader
             return lazyType;
         }
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         internal static object CreateObject(bool createReader, bool useAlternativeLoadPath, bool useComRegistry, out string moduleName, out Exception loadException)
         {
             object instance = null;

--- a/src/Compilers/Core/Portable/DiaSymReader/Writer/SymUnmanagedWriterFactory.cs
+++ b/src/Compilers/Core/Portable/DiaSymReader/Writer/SymUnmanagedWriterFactory.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis;
 
 namespace Microsoft.DiaSymReader
 {
@@ -29,6 +30,9 @@ namespace Microsoft.DiaSymReader
         /// <exception cref="ArgumentNullException"><paramref name="metadataProvider"/>is null.</exception>
         /// <exception cref="DllNotFoundException">The SymWriter implementation is not available or failed to load.</exception>
         /// <exception cref="SymUnmanagedWriterException">Error creating the PDB writer. See inner exception for root cause.</exception>
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         public static SymUnmanagedWriter CreateWriter(
             ISymWriterMetadataProvider metadataProvider,
             SymUnmanagedWriterCreationOptions options = SymUnmanagedWriterCreationOptions.Default)

--- a/src/Compilers/Core/Portable/DiaSymReader/Writer/SymUnmanagedWriterFactory.cs
+++ b/src/Compilers/Core/Portable/DiaSymReader/Writer/SymUnmanagedWriterFactory.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis;
+using Roslyn.Utilities;
 
 namespace Microsoft.DiaSymReader
 {

--- a/src/Compilers/Core/Portable/DiaSymReader/Writer/SymUnmanagedWriterFactory.cs
+++ b/src/Compilers/Core/Portable/DiaSymReader/Writer/SymUnmanagedWriterFactory.cs
@@ -19,20 +19,18 @@ namespace Microsoft.DiaSymReader
         /// <param name="options">Options.</param>
         /// <remarks>
         /// Tries to load the implementation of the PDB writer from Microsoft.DiaSymReader.Native.{platform}.dll library first.
-        /// It searches for this library in the directory Microsoft.DiaSymReader.dll is loaded from, 
+        /// It searches for this library in the directory Microsoft.DiaSymReader.dll is loaded from,
         /// the application directory, the %WinDir%\System32 directory, and user directories in the DLL search path, in this order.
         /// If not found in the above locations and <see cref="SymUnmanagedWriterCreationOptions.UseAlternativeLoadPath"/> option is specified
         /// the directory specified by MICROSOFT_DIASYMREADER_NATIVE_ALT_LOAD_PATH environment variable is also searched.
-        /// If the Microsoft.DiaSymReader.Native.{platform}.dll library can't be found and <see cref="SymUnmanagedWriterCreationOptions.UseComRegistry"/> 
-        /// option is specified checks if the PDB reader is available from a globally registered COM object. This COM object is provided 
+        /// If the Microsoft.DiaSymReader.Native.{platform}.dll library can't be found and <see cref="SymUnmanagedWriterCreationOptions.UseComRegistry"/>
+        /// option is specified checks if the PDB reader is available from a globally registered COM object. This COM object is provided
         /// by .NET Framework and has limited functionality (features like determinism and source link are not supported).
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="metadataProvider"/>is null.</exception>
         /// <exception cref="DllNotFoundException">The SymWriter implementation is not available or failed to load.</exception>
         /// <exception cref="SymUnmanagedWriterException">Error creating the PDB writer. See inner exception for root cause.</exception>
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         public static SymUnmanagedWriter CreateWriter(
             ISymWriterMetadataProvider metadataProvider,
             SymUnmanagedWriterCreationOptions options = SymUnmanagedWriterCreationOptions.Default)

--- a/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/LocalizableResourceString.cs
@@ -21,11 +21,6 @@ namespace Microsoft.CodeAnalysis
         private readonly Type _resourceSource;
         private readonly string[] _formatArguments;
 
-        static LocalizableResourceString()
-        {
-            ObjectBinder.RegisterTypeReader(typeof(LocalizableResourceString), reader => new LocalizableResourceString(reader));
-        }
-
         /// <summary>
         /// Creates a localizable resource string with no formatting arguments.
         /// </summary>
@@ -70,29 +65,6 @@ namespace Microsoft.CodeAnalysis
             _nameOfLocalizableResource = nameOfLocalizableResource;
             _resourceSource = resourceSource;
             _formatArguments = formatArguments;
-        }
-
-        private LocalizableResourceString(ObjectReader reader)
-        {
-            _resourceSource = reader.ReadType();
-            _nameOfLocalizableResource = reader.ReadString();
-            _resourceManager = new ResourceManager(_resourceSource);
-
-            var length = reader.ReadInt32();
-            if (length == 0)
-            {
-                _formatArguments = Array.Empty<string>();
-            }
-            else
-            {
-                var argumentsBuilder = ArrayBuilder<string>.GetInstance(length);
-                for (int i = 0; i < length; i++)
-                {
-                    argumentsBuilder.Add(reader.ReadString());
-                }
-
-                _formatArguments = argumentsBuilder.ToArrayAndFree();
-            }
         }
 
         bool IObjectWritable.ShouldReuseInSerialization => false;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
@@ -15,6 +15,9 @@ using System.Runtime.Loader;
 
 namespace Microsoft.CodeAnalysis
 {
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
+#endif
     internal partial class AnalyzerAssemblyLoader
     {
         private readonly AssemblyLoadContext _compilerLoadContext;
@@ -70,6 +73,9 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
+#endif
         internal sealed class DirectoryLoadContext : AssemblyLoadContext
         {
             internal string Directory { get; }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Core.cs
@@ -15,9 +15,7 @@ using System.Runtime.Loader;
 
 namespace Microsoft.CodeAnalysis
 {
-#if NET6_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
-#endif
     internal partial class AnalyzerAssemblyLoader
     {
         private readonly AssemblyLoadContext _compilerLoadContext;
@@ -73,9 +71,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
-#endif
         internal sealed class DirectoryLoadContext : AssemblyLoadContext
         {
             internal string Directory { get; }
@@ -115,7 +111,7 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 // Next prefer registered dependencies from other directories. Ideally this would not
-                // be necessary but msbuild target defaults have caused a number of customers to 
+                // be necessary but msbuild target defaults have caused a number of customers to
                 // fall into this path. See discussion here for where it comes up
                 // https://github.com/dotnet/roslyn/issues/56442
                 if (_loader.GetBestPath(assemblyName) is string bestRealPath)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -13,6 +13,12 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
+    internal static class TrimWarningMessages
+    {
+        internal const string AnalyzerReflectionLoadMessage = "Loading analyzers via reflection is not supported when trimming.";
+        internal const string NativePdbsNotSupported = "Native PDBs use built-in COM, which is not supported when trimming";
+    }
+
     /// <summary>
     /// The base implementation for <see cref="IAnalyzerAssemblyLoader"/>. This type provides caching and tracking of inputs given
     /// to <see cref="AddDependencyLocation(string)"/>.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.cs
@@ -13,12 +13,6 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
-    internal static class TrimWarningMessages
-    {
-        internal const string AnalyzerReflectionLoadMessage = "Loading analyzers via reflection is not supported when trimming.";
-        internal const string NativePdbsNotSupported = "Native PDBs use built-in COM, which is not supported when trimming";
-    }
-
     /// <summary>
     /// The base implementation for <see cref="IAnalyzerAssemblyLoader"/>. This type provides caching and tracking of inputs given
     /// to <see cref="AddDependencyLocation(string)"/>.
@@ -40,8 +34,8 @@ namespace Microsoft.CodeAnalysis
         private readonly Dictionary<string, (AssemblyName? AssemblyName, string RealAssemblyPath)?> _analyzerAssemblyInfoMap = new();
 
         /// <summary>
-        /// Maps analyzer dependency simple names to the set of original full paths it was loaded from. This _only_ 
-        /// tracks the paths provided to the analyzer as it's a place to look for indirect loads. 
+        /// Maps analyzer dependency simple names to the set of original full paths it was loaded from. This _only_
+        /// tracks the paths provided to the analyzer as it's a place to look for indirect loads.
         /// </summary>
         /// <remarks>
         /// Access must be guarded by <see cref="_guard"/>
@@ -59,8 +53,8 @@ namespace Microsoft.CodeAnalysis
         private partial Assembly Load(AssemblyName assemblyName, string assemblyOriginalPath);
 
         /// <summary>
-        /// Determines if the <paramref name="candidateName"/> satisfies the request for 
-        /// <paramref name="requestedName"/>. This is partial'd out as each runtime has a different 
+        /// Determines if the <paramref name="candidateName"/> satisfies the request for
+        /// <paramref name="requestedName"/>. This is partial'd out as each runtime has a different
         /// definition of matching name.
         /// </summary>
         private partial bool IsMatch(AssemblyName requestedName, AssemblyName candidateName);
@@ -91,7 +85,7 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 // This type assumses the file system is static for the duration of the
-                // it's instance. Repeated calls to this method, even if the underlying 
+                // it's instance. Repeated calls to this method, even if the underlying
                 // file system contents, should reuse the results of the first call.
                 _ = _analyzerAssemblyInfoMap.TryAdd(fullPath, null);
             }
@@ -120,7 +114,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Get the <see cref="AssemblyName"/> and the path it should be loaded from for the given original 
+        /// Get the <see cref="AssemblyName"/> and the path it should be loaded from for the given original
         /// analyzer path
         /// </summary>
         /// <remarks>
@@ -151,8 +145,8 @@ namespace Microsoft.CodeAnalysis
             }
             catch
             {
-                // The above can fail when the assembly doesn't exist because it's corrupted, 
-                // doesn't exist on disk, or is a native DLL. Those failures are handled when 
+                // The above can fail when the assembly doesn't exist because it's corrupted,
+                // doesn't exist on disk, or is a native DLL. Those failures are handled when
                 // the actual load is attempted. Just record the failure now.
                 assemblyName = null;
             }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -28,6 +28,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     /// 
     /// If you need to manage the lifetime of the analyzer reference (and the file stream) explicitly use <see cref="AnalyzerImageReference"/>.
     /// </remarks>
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
+#endif
     public sealed class AnalyzerFileReference : AnalyzerReference, IEquatable<AnalyzerReference>
     {
         private delegate IEnumerable<string> AttributeLanguagesFunc(PEModule module, CustomAttributeHandle attribute);
@@ -347,6 +350,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
+#endif
         private sealed class Extensions<TExtension>
             where TExtension : class
         {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerFileReference.cs
@@ -23,14 +23,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     /// Represents analyzers stored in an analyzer assembly file.
     /// </summary>
     /// <remarks>
-    /// Analyzer are read from the file, owned by the reference, and doesn't change 
+    /// Analyzer are read from the file, owned by the reference, and doesn't change
     /// since the reference is accessed until the reference object is garbage collected.
-    /// 
+    ///
     /// If you need to manage the lifetime of the analyzer reference (and the file stream) explicitly use <see cref="AnalyzerImageReference"/>.
     /// </remarks>
-#if NET6_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
-#endif
     public sealed class AnalyzerFileReference : AnalyzerReference, IEquatable<AnalyzerReference>
     {
         private delegate IEnumerable<string> AttributeLanguagesFunc(PEModule module, CustomAttributeHandle attribute);
@@ -350,9 +348,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
-#endif
         private sealed class Extensions<TExtension>
             where TExtension : class
         {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
@@ -13,6 +13,9 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
+#endif
     internal sealed class DefaultAnalyzerAssemblyLoader : AnalyzerAssemblyLoader
     {
 #if NETCOREAPP

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DefaultAnalyzerAssemblyLoader.cs
@@ -13,9 +13,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
-#if NET6_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
-#endif
     internal sealed class DefaultAnalyzerAssemblyLoader : AnalyzerAssemblyLoader
     {
 #if NETCOREAPP

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -16,6 +16,9 @@ using System.Runtime.Loader;
 
 namespace Microsoft.CodeAnalysis
 {
+#if NET6_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
+#endif
     internal sealed class ShadowCopyAnalyzerAssemblyLoader : AnalyzerAssemblyLoader
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Roslyn.Utilities;
 
 #if NETCOREAPP
 using System.Runtime.Loader;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -16,9 +16,7 @@ using System.Runtime.Loader;
 
 namespace Microsoft.CodeAnalysis
 {
-#if NET6_0_OR_GREATER
     [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.AnalyzerReflectionLoadMessage)]
-#endif
     internal sealed class ShadowCopyAnalyzerAssemblyLoader : AnalyzerAssemblyLoader
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/TrimWarningMessages.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/TrimWarningMessages.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CodeAnalysis;
+
+internal static class TrimWarningMessages
+{
+    internal const string AnalyzerReflectionLoadMessage = "Loading analyzers via reflection is not supported when trimming.";
+    internal const string NativePdbsNotSupported = "Native PDBs use built-in COM, which is not supported when trimming";
+}

--- a/src/Compilers/Core/Portable/FileSystemExtensions.cs
+++ b/src/Compilers/Core/Portable/FileSystemExtensions.cs
@@ -29,6 +29,9 @@ namespace Microsoft.CodeAnalysis
         /// <exception cref="ArgumentNullException">Compilation or path is null.</exception>
         /// <exception cref="ArgumentException">Path is empty or invalid.</exception>
         /// <exception cref="IOException">An error occurred while reading or writing a file.</exception>
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         public static EmitResult Emit(
             this Compilation compilation,
             string outputPath,

--- a/src/Compilers/Core/Portable/FileSystemExtensions.cs
+++ b/src/Compilers/Core/Portable/FileSystemExtensions.cs
@@ -22,16 +22,14 @@ namespace Microsoft.CodeAnalysis
         /// Also embedded in the output file.  Null to forego PDB generation.
         /// </param>
         /// <param name="xmlDocPath">Path of the file to which the compilation's XML documentation will be written.  Null to forego XML generation.</param>
-        /// <param name="win32ResourcesPath">Path of the file from which the compilation's Win32 resources will be read (in RES format).  
+        /// <param name="win32ResourcesPath">Path of the file from which the compilation's Win32 resources will be read (in RES format).
         /// Null to indicate that there are none.</param>
         /// <param name="manifestResources">List of the compilation's managed resources.  Null to indicate that there are none.</param>
         /// <param name="cancellationToken">To cancel the emit process.</param>
         /// <exception cref="ArgumentNullException">Compilation or path is null.</exception>
         /// <exception cref="ArgumentException">Path is empty or invalid.</exception>
         /// <exception cref="IOException">An error occurred while reading or writing a file.</exception>
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         public static EmitResult Emit(
             this Compilation compilation,
             string outputPath,

--- a/src/Compilers/Core/Portable/InternalUtilities/DynamicallyAccessedMembersAttribute.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/DynamicallyAccessedMembersAttribute.cs
@@ -1,0 +1,119 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if !NET5_0_OR_GREATER
+
+using System;
+
+namespace System.Diagnostics.CodeAnalysis;
+
+[AttributeUsage(
+    AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+    AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method |
+    AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+    Inherited = false)]
+internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+    /// with the specified member types.
+    /// </summary>
+    /// <param name="memberTypes">The types of members dynamically accessed.</param>
+    public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+    {
+        MemberTypes = memberTypes;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+    /// of members dynamically accessed.
+    /// </summary>
+    public DynamicallyAccessedMemberTypes MemberTypes { get; }
+}
+
+[Flags]
+internal enum DynamicallyAccessedMemberTypes
+{
+    /// <summary>
+    /// Specifies no members.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Specifies the default, parameterless public constructor.
+    /// </summary>
+    PublicParameterlessConstructor = 0x0001,
+
+    /// <summary>
+    /// Specifies all public constructors.
+    /// </summary>
+    PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+
+    /// <summary>
+    /// Specifies all non-public constructors.
+    /// </summary>
+    NonPublicConstructors = 0x0004,
+
+    /// <summary>
+    /// Specifies all public methods.
+    /// </summary>
+    PublicMethods = 0x0008,
+
+    /// <summary>
+    /// Specifies all non-public methods.
+    /// </summary>
+    NonPublicMethods = 0x0010,
+
+    /// <summary>
+    /// Specifies all public fields.
+    /// </summary>
+    PublicFields = 0x0020,
+
+    /// <summary>
+    /// Specifies all non-public fields.
+    /// </summary>
+    NonPublicFields = 0x0040,
+
+    /// <summary>
+    /// Specifies all public nested types.
+    /// </summary>
+    PublicNestedTypes = 0x0080,
+
+    /// <summary>
+    /// Specifies all non-public nested types.
+    /// </summary>
+    NonPublicNestedTypes = 0x0100,
+
+    /// <summary>
+    /// Specifies all public properties.
+    /// </summary>
+    PublicProperties = 0x0200,
+
+    /// <summary>
+    /// Specifies all non-public properties.
+    /// </summary>
+    NonPublicProperties = 0x0400,
+
+    /// <summary>
+    /// Specifies all public events.
+    /// </summary>
+    PublicEvents = 0x0800,
+
+    /// <summary>
+    /// Specifies all non-public events.
+    /// </summary>
+    NonPublicEvents = 0x1000,
+
+    /// <summary>
+    /// Specifies all interfaces implemented by the type.
+    /// </summary>
+    Interfaces = 0x2000,
+
+    /// <summary>
+    /// Specifies all members.
+    /// </summary>
+    All = ~None
+}
+
+#endif

--- a/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
@@ -72,6 +72,9 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// This file is in linked into multiple layers, but we want to ensure that all layers have the same copy.
         /// This lets us copy the handler in this instance into the same in another instance.
         /// </remarks>
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Gets type by name")]
+#endif
         public static void CopyHandlerTo(Assembly assembly)
         {
             var targetType = assembly.GetType(typeof(FatalError).FullName!, throwOnError: true)!;

--- a/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// This file is in linked into multiple layers, but we want to ensure that all layers have the same copy.
         /// This lets us copy the handler in this instance into the same in another instance.
         /// </remarks>
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Gets type by name")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.LoadsTypeByName)]
         public static void CopyHandlerTo(Assembly assembly)
         {
             var targetType = assembly.GetType(typeof(FatalError).FullName!, throwOnError: true)!;

--- a/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FatalError.cs
@@ -72,9 +72,7 @@ namespace Microsoft.CodeAnalysis.ErrorReporting
         /// This file is in linked into multiple layers, but we want to ensure that all layers have the same copy.
         /// This lets us copy the handler in this instance into the same in another instance.
         /// </remarks>
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Gets type by name")]
-#endif
         public static void CopyHandlerTo(Assembly assembly)
         {
             var targetType = assembly.GetType(typeof(FatalError).FullName!, throwOnError: true)!;

--- a/src/Compilers/Core/Portable/InternalUtilities/ReflectionUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ReflectionUtilities.cs
@@ -15,6 +15,9 @@ namespace Roslyn.Utilities
     {
         private static readonly Type Missing = typeof(void);
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Loading arbitrary type by name")]
+#endif
         public static Type? TryGetType(string assemblyQualifiedName)
         {
             try
@@ -28,6 +31,9 @@ namespace Roslyn.Utilities
             }
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Loading arbitrary type by name")]
+#endif
         public static Type? TryGetType([NotNull] ref Type? lazyType, string assemblyQualifiedName)
         {
             if (lazyType == null)
@@ -42,6 +48,9 @@ namespace Roslyn.Utilities
         /// Find a <see cref="Type"/> instance by first probing the contract name and then the name as it
         /// would exist in mscorlib.  This helps satisfy both the CoreCLR and Desktop scenarios. 
         /// </summary>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Loading arbitrary type by name")]
+#endif
         public static Type? GetTypeFromEither(string contractName, string desktopName)
         {
             var type = TryGetType(contractName);
@@ -54,6 +63,9 @@ namespace Roslyn.Utilities
             return type;
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Loading arbitrary type by name")]
+#endif
         public static Type? GetTypeFromEither([NotNull] ref Type? lazyType, string contractName, string desktopName)
         {
             if (lazyType == null)
@@ -94,12 +106,20 @@ namespace Roslyn.Utilities
             return null;
         }
 
-        internal static MethodInfo? GetDeclaredMethod(this TypeInfo typeInfo, string name, params Type[] paramTypes)
+        internal static MethodInfo? GetDeclaredMethod(
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
+#endif
+            this TypeInfo typeInfo, string name, params Type[] paramTypes)
         {
             return FindItem(typeInfo.GetDeclaredMethods(name), paramTypes);
         }
 
-        internal static ConstructorInfo? GetDeclaredConstructor(this TypeInfo typeInfo, params Type[] paramTypes)
+        internal static ConstructorInfo? GetDeclaredConstructor(
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+#endif
+            this TypeInfo typeInfo, params Type[] paramTypes)
         {
             return FindItem(typeInfo.DeclaredConstructors, paramTypes);
         }

--- a/src/Compilers/Core/Portable/InternalUtilities/ReflectionUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ReflectionUtilities.cs
@@ -15,9 +15,7 @@ namespace Roslyn.Utilities
     {
         private static readonly Type Missing = typeof(void);
 
-#if NET6_0_OR_GREATER
         [RequiresUnreferencedCode("Loading arbitrary type by name")]
-#endif
         public static Type? TryGetType(string assemblyQualifiedName)
         {
             try
@@ -31,9 +29,7 @@ namespace Roslyn.Utilities
             }
         }
 
-#if NET6_0_OR_GREATER
         [RequiresUnreferencedCode("Loading arbitrary type by name")]
-#endif
         public static Type? TryGetType([NotNull] ref Type? lazyType, string assemblyQualifiedName)
         {
             if (lazyType == null)
@@ -46,11 +42,9 @@ namespace Roslyn.Utilities
 
         /// <summary>
         /// Find a <see cref="Type"/> instance by first probing the contract name and then the name as it
-        /// would exist in mscorlib.  This helps satisfy both the CoreCLR and Desktop scenarios. 
+        /// would exist in mscorlib.  This helps satisfy both the CoreCLR and Desktop scenarios.
         /// </summary>
-#if NET6_0_OR_GREATER
         [RequiresUnreferencedCode("Loading arbitrary type by name")]
-#endif
         public static Type? GetTypeFromEither(string contractName, string desktopName)
         {
             var type = TryGetType(contractName);
@@ -63,9 +57,7 @@ namespace Roslyn.Utilities
             return type;
         }
 
-#if NET6_0_OR_GREATER
         [RequiresUnreferencedCode("Loading arbitrary type by name")]
-#endif
         public static Type? GetTypeFromEither([NotNull] ref Type? lazyType, string contractName, string desktopName)
         {
             if (lazyType == null)
@@ -107,18 +99,14 @@ namespace Roslyn.Utilities
         }
 
         internal static MethodInfo? GetDeclaredMethod(
-#if NET6_0_OR_GREATER
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]
-#endif
             this TypeInfo typeInfo, string name, params Type[] paramTypes)
         {
             return FindItem(typeInfo.GetDeclaredMethods(name), paramTypes);
         }
 
         internal static ConstructorInfo? GetDeclaredConstructor(
-#if NET6_0_OR_GREATER
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-#endif
             this TypeInfo typeInfo, params Type[] paramTypes)
         {
             return FindItem(typeInfo.DeclaredConstructors, paramTypes);

--- a/src/Compilers/Core/Portable/InternalUtilities/ReflectionUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ReflectionUtilities.cs
@@ -15,7 +15,7 @@ namespace Roslyn.Utilities
     {
         private static readonly Type Missing = typeof(void);
 
-        [RequiresUnreferencedCode("Loading arbitrary type by name")]
+        [RequiresUnreferencedCode(TrimWarningMessages.LoadsTypeByName)]
         public static Type? TryGetType(string assemblyQualifiedName)
         {
             try
@@ -29,7 +29,7 @@ namespace Roslyn.Utilities
             }
         }
 
-        [RequiresUnreferencedCode("Loading arbitrary type by name")]
+        [RequiresUnreferencedCode(TrimWarningMessages.LoadsTypeByName)]
         public static Type? TryGetType([NotNull] ref Type? lazyType, string assemblyQualifiedName)
         {
             if (lazyType == null)
@@ -44,7 +44,7 @@ namespace Roslyn.Utilities
         /// Find a <see cref="Type"/> instance by first probing the contract name and then the name as it
         /// would exist in mscorlib.  This helps satisfy both the CoreCLR and Desktop scenarios.
         /// </summary>
-        [RequiresUnreferencedCode("Loading arbitrary type by name")]
+        [RequiresUnreferencedCode(TrimWarningMessages.LoadsTypeByName)]
         public static Type? GetTypeFromEither(string contractName, string desktopName)
         {
             var type = TryGetType(contractName);
@@ -57,7 +57,7 @@ namespace Roslyn.Utilities
             return type;
         }
 
-        [RequiresUnreferencedCode("Loading arbitrary type by name")]
+        [RequiresUnreferencedCode(TrimWarningMessages.LoadsTypeByName)]
         public static Type? GetTypeFromEither([NotNull] ref Type? lazyType, string contractName, string desktopName)
         {
             if (lazyType == null)

--- a/src/Compilers/Core/Portable/InternalUtilities/RequiresUnreferencedCodeAttribute.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/RequiresUnreferencedCodeAttribute.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if !NET5_0_OR_GREATER
+namespace System.Diagnostics.CodeAnalysis;
+
+internal sealed class RequiresUnreferencedCodeAttribute : Attribute
+{
+    public RequiresUnreferencedCodeAttribute(string message) { }
+}
+#endif

--- a/src/Compilers/Core/Portable/InternalUtilities/RoslynLazyInitializer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/RoslynLazyInitializer.cs
@@ -13,9 +13,9 @@ namespace Roslyn.Utilities
         /// <inheritdoc cref="LazyInitializer.EnsureInitialized{T}(ref T)"/>
         public static T EnsureInitialized<
 #if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 #endif
-            T>([NotNull] ref T? target) where T : class
+        T>([NotNull] ref T? target) where T : class
             => LazyInitializer.EnsureInitialized<T>(ref target!);
 
         /// <inheritdoc cref="LazyInitializer.EnsureInitialized{T}(ref T, Func{T})"/>
@@ -25,9 +25,9 @@ namespace Roslyn.Utilities
         /// <inheritdoc cref="LazyInitializer.EnsureInitialized{T}(ref T, ref bool, ref object)"/>
         public static T EnsureInitialized<
 #if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 #endif
-            T>([NotNull] ref T? target, ref bool initialized, [NotNullIfNotNull(nameof(syncLock))] ref object? syncLock)
+        T>([NotNull] ref T? target, ref bool initialized, [NotNullIfNotNull(nameof(syncLock))] ref object? syncLock)
             => LazyInitializer.EnsureInitialized<T>(ref target!, ref initialized, ref syncLock);
 
         /// <inheritdoc cref="LazyInitializer.EnsureInitialized{T}(ref T, ref bool, ref object, Func{T})"/>

--- a/src/Compilers/Core/Portable/InternalUtilities/RoslynLazyInitializer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/RoslynLazyInitializer.cs
@@ -11,7 +11,11 @@ namespace Roslyn.Utilities
     internal static class RoslynLazyInitializer
     {
         /// <inheritdoc cref="LazyInitializer.EnsureInitialized{T}(ref T)"/>
-        public static T EnsureInitialized<T>([NotNull] ref T? target) where T : class
+        public static T EnsureInitialized<
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            T>([NotNull] ref T? target) where T : class
             => LazyInitializer.EnsureInitialized<T>(ref target!);
 
         /// <inheritdoc cref="LazyInitializer.EnsureInitialized{T}(ref T, Func{T})"/>
@@ -19,7 +23,11 @@ namespace Roslyn.Utilities
             => LazyInitializer.EnsureInitialized<T>(ref target!, valueFactory);
 
         /// <inheritdoc cref="LazyInitializer.EnsureInitialized{T}(ref T, ref bool, ref object)"/>
-        public static T EnsureInitialized<T>([NotNull] ref T? target, ref bool initialized, [NotNullIfNotNull(nameof(syncLock))] ref object? syncLock)
+        public static T EnsureInitialized<
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+#endif
+            T>([NotNull] ref T? target, ref bool initialized, [NotNullIfNotNull(nameof(syncLock))] ref object? syncLock)
             => LazyInitializer.EnsureInitialized<T>(ref target!, ref initialized, ref syncLock);
 
         /// <inheritdoc cref="LazyInitializer.EnsureInitialized{T}(ref T, ref bool, ref object, Func{T})"/>

--- a/src/Compilers/Core/Portable/InternalUtilities/RoslynLazyInitializer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/RoslynLazyInitializer.cs
@@ -12,9 +12,7 @@ namespace Roslyn.Utilities
     {
         /// <inheritdoc cref="LazyInitializer.EnsureInitialized{T}(ref T)"/>
         public static T EnsureInitialized<
-#if NET6_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
-#endif
         T>([NotNull] ref T? target) where T : class
             => LazyInitializer.EnsureInitialized<T>(ref target!);
 
@@ -24,9 +22,7 @@ namespace Roslyn.Utilities
 
         /// <inheritdoc cref="LazyInitializer.EnsureInitialized{T}(ref T, ref bool, ref object)"/>
         public static T EnsureInitialized<
-#if NET6_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
-#endif
         T>([NotNull] ref T? target, ref bool initialized, [NotNullIfNotNull(nameof(syncLock))] ref object? syncLock)
             => LazyInitializer.EnsureInitialized<T>(ref target!, ref initialized, ref syncLock);
 

--- a/src/Compilers/Core/Portable/InternalUtilities/TrimWarningMessages.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/TrimWarningMessages.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.CodeAnalysis;
+namespace Roslyn.Utilities;
 
 internal static class TrimWarningMessages
 {
     internal const string AnalyzerReflectionLoadMessage = "Loading analyzers via reflection is not supported when trimming.";
-    internal const string NativePdbsNotSupported = "Native PDBs use built-in COM, which is not supported when trimming";
+    internal const string NativePdbsNotSupported = "Native PDBs use built-in COM, which is not supported when trimming.";
+    internal const string LoadsTypeByName = "Loading types by name is not supported when trimming.";
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/UICultureUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/UICultureUtilities.cs
@@ -11,127 +11,23 @@ namespace Roslyn.Utilities
 {
     internal static class UICultureUtilities
     {
-        // TODO (DevDiv 1117307): Replace with CultureInfo.CurrentUICulture.set when available.
-        private const string currentUICultureName = "CurrentUICulture";
-        private static readonly Action<CultureInfo>? s_setCurrentUICulture;
-
-        private static bool TryGetCurrentUICultureSetter([NotNullWhen(returnValue: true)] out Action<CultureInfo>? setter)
-        {
-            const string cultureInfoTypeName = "System.Globalization.CultureInfo";
-            const string cultureInfoTypeNameGlobalization = cultureInfoTypeName + ", System.Globalization, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
-
-            try
-            {
-                var type = Type.GetType(cultureInfoTypeNameGlobalization) ?? typeof(object).GetTypeInfo().Assembly.GetType(cultureInfoTypeName);
-                if ((object?)type == null)
-                {
-                    setter = null;
-                    return false;
-                }
-
-                var currentUICultureSetter = type.GetTypeInfo().GetDeclaredProperty(currentUICultureName)?.SetMethod;
-                if ((object?)currentUICultureSetter == null || !currentUICultureSetter.IsStatic || currentUICultureSetter.ContainsGenericParameters || currentUICultureSetter.ReturnType != typeof(void))
-                {
-                    setter = null;
-                    return false;
-                }
-
-                var parameters = currentUICultureSetter.GetParameters();
-                if (parameters.Length != 1 || parameters[0].ParameterType != typeof(CultureInfo))
-                {
-                    setter = null;
-                    return false;
-                }
-
-                setter = (Action<CultureInfo>)currentUICultureSetter.CreateDelegate(typeof(Action<CultureInfo>));
-                return true;
-            }
-            catch
-            {
-                setter = null;
-                return false;
-            }
-        }
-
-        private static bool TryGetCurrentThreadUICultureSetter([NotNullWhen(returnValue: true)] out Action<CultureInfo>? setter)
-        {
-            const string threadTypeName = "System.Threading.Thread";
-            const string currentThreadName = "CurrentThread";
-
-            try
-            {
-                var type = typeof(object).GetTypeInfo().Assembly.GetType(threadTypeName);
-                if (type is null)
-                {
-                    setter = null;
-                    return false;
-                }
-
-                var typeInfo = type.GetTypeInfo();
-                var currentThreadGetter = typeInfo.GetDeclaredProperty(currentThreadName)?.GetMethod;
-                if ((object?)currentThreadGetter == null || !currentThreadGetter.IsStatic || currentThreadGetter.ContainsGenericParameters || currentThreadGetter.ReturnType != type || currentThreadGetter.GetParameters().Length != 0)
-                {
-                    setter = null;
-                    return false;
-                }
-
-                var currentUICultureSetter = typeInfo.GetDeclaredProperty(currentUICultureName)?.SetMethod;
-                if ((object?)currentUICultureSetter == null || currentUICultureSetter.IsStatic || currentUICultureSetter.ContainsGenericParameters || currentUICultureSetter.ReturnType != typeof(void))
-                {
-                    setter = null;
-                    return false;
-                }
-
-                var parameters = currentUICultureSetter.GetParameters();
-                if (parameters.Length != 1 || parameters[0].ParameterType != typeof(CultureInfo))
-                {
-                    setter = null;
-                    return false;
-                }
-
-                setter = culture =>
-                {
-                    currentUICultureSetter.Invoke(currentThreadGetter.Invoke(null, null), new[] { culture });
-                };
-                return true;
-            }
-            catch
-            {
-                setter = null;
-                return false;
-            }
-        }
-
-        static UICultureUtilities()
-        {
-            if (!TryGetCurrentUICultureSetter(out s_setCurrentUICulture) &&
-                !TryGetCurrentThreadUICultureSetter(out s_setCurrentUICulture))
-            {
-                s_setCurrentUICulture = null;
-            }
-        }
 
         public static Action WithCurrentUICulture(Action action)
         {
-            if (s_setCurrentUICulture == null)
-            {
-                return action;
-            }
-
             var savedCulture = CultureInfo.CurrentUICulture;
             return () =>
             {
                 var currentCulture = CultureInfo.CurrentUICulture;
                 if (currentCulture != savedCulture)
                 {
-                    s_setCurrentUICulture(savedCulture);
+                    CultureInfo.CurrentUICulture = savedCulture;
                     try
                     {
                         action();
                     }
                     finally
                     {
-                        s_setCurrentUICulture(currentCulture);
+                        CultureInfo.CurrentUICulture = currentCulture;
                     }
                 }
                 else
@@ -143,25 +39,20 @@ namespace Roslyn.Utilities
 
         public static Action<T> WithCurrentUICulture<T>(Action<T> action)
         {
-            if (s_setCurrentUICulture == null)
-            {
-                return action;
-            }
-
             var savedCulture = CultureInfo.CurrentUICulture;
             return param =>
             {
                 var currentCulture = CultureInfo.CurrentUICulture;
                 if (currentCulture != savedCulture)
                 {
-                    s_setCurrentUICulture(savedCulture);
+                    CultureInfo.CurrentUICulture = savedCulture;
                     try
                     {
                         action(param);
                     }
                     finally
                     {
-                        s_setCurrentUICulture(currentCulture);
+                        CultureInfo.CurrentUICulture = currentCulture;
                     }
                 }
                 else
@@ -173,25 +64,20 @@ namespace Roslyn.Utilities
 
         public static Func<T> WithCurrentUICulture<T>(Func<T> func)
         {
-            if (s_setCurrentUICulture == null)
-            {
-                return func;
-            }
-
             var savedCulture = CultureInfo.CurrentUICulture;
             return () =>
             {
                 var currentCulture = CultureInfo.CurrentUICulture;
                 if (currentCulture != savedCulture)
                 {
-                    s_setCurrentUICulture(savedCulture);
+                    CultureInfo.CurrentUICulture = savedCulture;
                     try
                     {
                         return func();
                     }
                     finally
                     {
-                        s_setCurrentUICulture(currentCulture);
+                        CultureInfo.CurrentUICulture = currentCulture;
                     }
                 }
                 else

--- a/src/Compilers/Core/Portable/InternalUtilities/UnconditionalSuppressMessageAttribute.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/UnconditionalSuppressMessageAttribute.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if !NET5_0_OR_GREATER
+
+using System;
+
+namespace System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Suppresses reporting of a specific rule violation, allowing multiple suppressions on a
+/// single code artifact.
+/// </summary>
+/// <remarks>
+/// <see cref="UnconditionalSuppressMessageAttribute"/> is different than
+/// <see cref="SuppressMessageAttribute"/> in that it doesn't have a
+/// <see cref="ConditionalAttribute"/>. So it is always preserved in the compiled assembly.
+/// </remarks>
+[AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+internal sealed class UnconditionalSuppressMessageAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnconditionalSuppressMessageAttribute"/>
+    /// class, specifying the category of the tool and the identifier for an analysis rule.
+    /// </summary>
+    /// <param name="category">The category for the attribute.</param>
+    /// <param name="checkId">The identifier of the analysis rule the attribute applies to.</param>
+    public UnconditionalSuppressMessageAttribute(string category, string checkId)
+    {
+        Category = category;
+        CheckId = checkId;
+    }
+
+    /// <summary>
+    /// Gets the category identifying the classification of the attribute.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="Category"/> property describes the tool or tool analysis category
+    /// for which a message suppression attribute applies.
+    /// </remarks>
+    public string Category { get; }
+
+    /// <summary>
+    /// Gets the identifier of the analysis tool rule to be suppressed.
+    /// </summary>
+    /// <remarks>
+    /// Concatenated together, the <see cref="Category"/> and <see cref="CheckId"/>
+    /// properties form a unique check identifier.
+    /// </remarks>
+    public string CheckId { get; }
+
+    /// <summary>
+    /// Gets or sets the scope of the code that is relevant for the attribute.
+    /// </summary>
+    /// <remarks>
+    /// The Scope property is an optional argument that specifies the metadata scope for which
+    /// the attribute is relevant.
+    /// </remarks>
+    public string? Scope { get; set; }
+
+    /// <summary>
+    /// Gets or sets a fully qualified path that represents the target of the attribute.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="Target"/> property is an optional argument identifying the analysis target
+    /// of the attribute. An example value is "System.IO.Stream.ctor():System.Void".
+    /// Because it is fully qualified, it can be long, particularly for targets such as parameters.
+    /// The analysis tool user interface should be capable of automatically formatting the parameter.
+    /// </remarks>
+    public string? Target { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional argument expanding on exclusion criteria.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="MessageId "/> property is an optional argument that specifies additional
+    /// exclusion where the literal metadata target is not sufficiently precise. For example,
+    /// the <see cref="UnconditionalSuppressMessageAttribute"/> cannot be applied within a method,
+    /// and it may be desirable to suppress a violation against a statement in the method that will
+    /// give a rule violation, but not against all statements in the method.
+    /// </remarks>
+    public string? MessageId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the justification for suppressing the code analysis message.
+    /// </summary>
+    public string? Justification { get; set; }
+}
+#endif

--- a/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj
@@ -9,6 +9,8 @@
     <DefineConstants>$(DefineConstants);COMPILERCORE</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <ApplyNgenOptimization Condition="'$(TargetFramework)' == 'netstandard2.0'">full</ApplyNgenOptimization>
+    <IsTrimmable Condition="'$(TargetFramework)' != 'netstandard2.0'">true</IsTrimmable>
+    <EnableAotAnalyzer Condition="'$(TargetFramework)' != 'netstandard2.0'">true</EnableAotAnalyzer>
     <GeneratePerformanceSensitiveAttribute>true</GeneratePerformanceSensitiveAttribute>
 
     <!-- NuGet -->

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -514,6 +514,9 @@ namespace Microsoft.Cci
             }
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         public void SetMetadataEmitter(MetadataWriter metadataWriter)
         {
             // Do not look for COM registered diasymreader when determinism is needed as it doesn't support it.

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -514,9 +514,7 @@ namespace Microsoft.Cci
             }
         }
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         public void SetMetadataEmitter(MetadataWriter metadataWriter)
         {
             // Do not look for COM registered diasymreader when determinism is needed as it doesn't support it.

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -1684,6 +1684,9 @@ namespace Microsoft.Cci
             };
         }
 
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         public void WriteMetadataAndIL(PdbWriter nativePdbWriterOpt, Stream metadataStream, Stream ilStream, Stream portablePdbStreamOpt, out MetadataSizes metadataSizes)
         {
             Debug.Assert(nativePdbWriterOpt == null ^ portablePdbStreamOpt == null);

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -1684,9 +1684,7 @@ namespace Microsoft.Cci
             };
         }
 
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         public void WriteMetadataAndIL(PdbWriter nativePdbWriterOpt, Stream metadataStream, Stream ilStream, Stream portablePdbStreamOpt, out MetadataSizes metadataSizes)
         {
             Debug.Assert(nativePdbWriterOpt == null ^ portablePdbStreamOpt == null);

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Cci
 
     internal static class PeWriter
     {
+#if NET6_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
+#endif
         internal static bool WritePeToStream(
             EmitContext context,
             CommonMessageProvider messageProvider,

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -35,9 +35,7 @@ namespace Microsoft.Cci
 
     internal static class PeWriter
     {
-#if NET6_0_OR_GREATER
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(TrimWarningMessages.NativePdbsNotSupported)]
-#endif
         internal static bool WritePeToStream(
             EmitContext context,
             CommonMessageProvider messageProvider,
@@ -209,8 +207,8 @@ namespace Microsoft.Cci
 
                     if (!portablePdbContentHash.IsDefault)
                     {
-                        // Emit PDB Checksum entry for Portable and Embedded PDBs. The checksum is not as useful when the PDB is embedded, 
-                        // however it allows the client to efficiently validate a standalone Portable PDB that 
+                        // Emit PDB Checksum entry for Portable and Embedded PDBs. The checksum is not as useful when the PDB is embedded,
+                        // however it allows the client to efficiently validate a standalone Portable PDB that
                         // has been extracted from Embedded PDB and placed next to the PE file.
                         debugDirectoryBuilder.AddPdbChecksumEntry(context.Module.PdbChecksumAlgorithm.Name, portablePdbContentHash);
                     }

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -21,6 +21,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.DiaSymReader;
+using Roslyn.Utilities;
 using static Microsoft.CodeAnalysis.SigningUtilities;
 using EmitContext = Microsoft.CodeAnalysis.Emit.EmitContext;
 

--- a/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/ObjectReader.cs
@@ -657,12 +657,6 @@ namespace Roslyn.Utilities
             return array;
         }
 
-        public Type ReadType()
-        {
-            _reader.ReadByte();
-            return Type.GetType(ReadString());
-        }
-
         private Type ReadTypeAfterTag()
             => _binderSnapshot.GetTypeFromId(this.ReadInt32());
 

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/Microsoft.CodeAnalysis.ResultProvider.csproj
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/Microsoft.CodeAnalysis.ResultProvider.csproj
@@ -40,6 +40,9 @@
     <Compile Include="..\..\..\..\..\Compilers\Core\Portable\InternalUtilities\ReflectionUtilities.cs">
       <Link>Compiler\InternalUtilities\ReflectionUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\..\..\Compilers\Core\Portable\InternalUtilities\TrimWarningMessages.cs">
+      <Link>Compiler\InternalUtilities\TrimWarningMessages.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\..\..\Compilers\Core\Portable\InternalUtilities\RequiresUnreferencedCodeAttribute.cs">
       <Link>Compiler\InternalUtilities\RequiresUnreferencedCodeAttribute.cs</Link>
     </Compile>

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/Microsoft.CodeAnalysis.ResultProvider.csproj
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Portable/Microsoft.CodeAnalysis.ResultProvider.csproj
@@ -19,6 +19,9 @@
     <Compile Include="..\..\..\..\..\Compilers\Core\Portable\InternalUtilities\Debug.cs">
       <Link>Compiler\InternalUtilities\Debug.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\..\..\Compilers\Core\Portable\InternalUtilities\DynamicallyAccessedMembersAttribute.cs">
+      <Link>Compiler\InternalUtilities\DynamicallyAccessedMembersAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\..\..\Compilers\Core\Portable\InternalUtilities\FailFast.cs">
       <Link>Compiler\InternalUtilities\FailFast.cs</Link>
     </Compile>
@@ -36,6 +39,9 @@
     </Compile>
     <Compile Include="..\..\..\..\..\Compilers\Core\Portable\InternalUtilities\ReflectionUtilities.cs">
       <Link>Compiler\InternalUtilities\ReflectionUtilities.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\..\Compilers\Core\Portable\InternalUtilities\RequiresUnreferencedCodeAttribute.cs">
+      <Link>Compiler\InternalUtilities\RequiresUnreferencedCodeAttribute.cs</Link>
     </Compile>
     <Compile Include="..\..\..\..\..\Dependencies\PooledObjects\ObjectPool`1.cs">
       <Link>Compiler\InternalUtilities\ObjectPool`1.cs</Link>

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Microsoft.CodeAnalysis.ResultProvider.Utilities.csproj
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Microsoft.CodeAnalysis.ResultProvider.Utilities.csproj
@@ -51,8 +51,8 @@
     <Compile Include="..\..\..\..\Compilers\Core\Portable\InternalUtilities\ReflectionUtilities.cs">
       <Link>Compiler\InternalUtilities\ReflectionUtilities.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\..\Compilers\Core\Portable\InternalUtilities\ReflectionUtilities.cs">
-      <Link>Compiler\InternalUtilities\ReflectionUtilities.cs</Link>
+    <Compile Include="..\..\..\..\Compilers\Core\Portable\InternalUtilities\TrimWarningMessages.cs">
+      <Link>Compiler\InternalUtilities\TrimWarningMessages.cs</Link>
     </Compile>
     <Compile Include="..\..\..\..\Dependencies\PooledObjects\ObjectPool`1.cs">
       <Link>Compiler\InternalUtilities\ObjectPool`1.cs</Link>

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Microsoft.CodeAnalysis.ResultProvider.Utilities.csproj
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Microsoft.CodeAnalysis.ResultProvider.Utilities.csproj
@@ -30,6 +30,9 @@
     <Compile Include="..\..\..\..\Compilers\Core\Portable\InternalUtilities\Debug.cs">
       <Link>Compiler\InternalUtilities\Debug.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\..\Compilers\Core\Portable\InternalUtilities\DynamicallyAccessedMembersAttribute.cs">
+      <Link>Compiler\InternalUtilities\DynamicallyAccessedMembersAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\..\Compilers\Core\Portable\InternalUtilities\FailFast.cs">
       <Link>Compiler\InternalUtilities\FailFast.cs</Link>
     </Compile>
@@ -44,6 +47,9 @@
     </Compile>
     <Compile Include="..\..\..\..\Compilers\Core\Portable\InternalUtilities\NullableAttributes.cs">
       <Link>Compiler\InternalUtilities\NullableAttributes.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\..\Compilers\Core\Portable\InternalUtilities\ReflectionUtilities.cs">
+      <Link>Compiler\InternalUtilities\ReflectionUtilities.cs</Link>
     </Compile>
     <Compile Include="..\..\..\..\Compilers\Core\Portable\InternalUtilities\ReflectionUtilities.cs">
       <Link>Compiler\InternalUtilities\ReflectionUtilities.cs</Link>

--- a/src/ExpressionEvaluator/Core/Test/ResultProvider/Microsoft.CodeAnalysis.ResultProvider.Utilities.csproj
+++ b/src/ExpressionEvaluator/Core/Test/ResultProvider/Microsoft.CodeAnalysis.ResultProvider.Utilities.csproj
@@ -51,6 +51,9 @@
     <Compile Include="..\..\..\..\Compilers\Core\Portable\InternalUtilities\ReflectionUtilities.cs">
       <Link>Compiler\InternalUtilities\ReflectionUtilities.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\..\Compilers\Core\Portable\InternalUtilities\RequiresUnreferencedCodeAttribute.cs">
+      <Link>Compiler\InternalUtilities\RequiresUnreferencedCodeAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\..\Compilers\Core\Portable\InternalUtilities\TrimWarningMessages.cs">
       <Link>Compiler\InternalUtilities\TrimWarningMessages.cs</Link>
     </Compile>

--- a/src/Interactive/Host/Microsoft.CodeAnalysis.InteractiveHost.csproj
+++ b/src/Interactive/Host/Microsoft.CodeAnalysis.InteractiveHost.csproj
@@ -50,6 +50,7 @@
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\SemaphoreSlimExtensions.cs" Link="Utilities\SemaphoreSlimExtensions.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\ExceptionUtilities.cs" Link="Utilities\ExceptionUtilities.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\FailFast.cs" Link="Utilities\FailFast.cs" />
+    <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\RequiresUnreferencedCodeAttribute.cs" Link="Utilities\RequiresUnreferencedCodeAttribute.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\FatalError.cs" Link="Utilities\FatalError.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\FileNameUtilities.cs" Link="Utilities\FileNameUtilities.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\PlatformInformation.cs" Link="Utilities\PlatformInformation.cs" />

--- a/src/Interactive/Host/Microsoft.CodeAnalysis.InteractiveHost.csproj
+++ b/src/Interactive/Host/Microsoft.CodeAnalysis.InteractiveHost.csproj
@@ -51,6 +51,7 @@
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\ExceptionUtilities.cs" Link="Utilities\ExceptionUtilities.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\FailFast.cs" Link="Utilities\FailFast.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\RequiresUnreferencedCodeAttribute.cs" Link="Utilities\RequiresUnreferencedCodeAttribute.cs" />
+    <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\TrimWarningMessages.cs" Link="Utilities\TrimWarningMessages.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\FatalError.cs" Link="Utilities\FatalError.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\FileNameUtilities.cs" Link="Utilities\FileNameUtilities.cs" />
     <Compile Include="..\..\Compilers\Core\Portable\InternalUtilities\PlatformInformation.cs" Link="Utilities\PlatformInformation.cs" />

--- a/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
   <ItemGroup Label="Linked Files">
     <Compile Remove="Storage\SQLite\**\*.cs" Condition="'$(DotNetBuildFromSource)' == 'true'" />
+    <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\TrimWarningMessages.cs" Link="Diagnostics\CompilerShared\AnalyzerAssemblyLoader.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\AnalyzerAssemblyLoader.cs" Link="Diagnostics\CompilerShared\AnalyzerAssemblyLoader.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\AnalyzerAssemblyLoader.Core.cs" Link="Diagnostics\CompilerShared\AnalyzerAssemblyLoader.Core.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\AnalyzerAssemblyLoader.Desktop.cs" Link="Diagnostics\CompilerShared\AnalyzerAssemblyLoader.Desktop.cs" />

--- a/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Microsoft.CodeAnalysis.Workspaces.csproj
@@ -31,7 +31,6 @@
   </ItemGroup>
   <ItemGroup Label="Linked Files">
     <Compile Remove="Storage\SQLite\**\*.cs" Condition="'$(DotNetBuildFromSource)' == 'true'" />
-    <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\TrimWarningMessages.cs" Link="Diagnostics\CompilerShared\AnalyzerAssemblyLoader.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\AnalyzerAssemblyLoader.cs" Link="Diagnostics\CompilerShared\AnalyzerAssemblyLoader.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\AnalyzerAssemblyLoader.Core.cs" Link="Diagnostics\CompilerShared\AnalyzerAssemblyLoader.Core.cs" />
     <Compile Include="..\..\..\Compilers\Core\Portable\DiagnosticAnalyzer\AnalyzerAssemblyLoader.Desktop.cs" Link="Diagnostics\CompilerShared\AnalyzerAssemblyLoader.Desktop.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -184,6 +184,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\ReflectionUtilities.cs">
       <Link>InternalUtilities\ReflectionUtilities.cs</Link>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\TrimWarningMessages.cs">
+      <Link>InternalUtilities\ReflectionUtilities.cs</Link>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\RequiresUnreferencedCodeAttribute.cs">
       <Link>InternalUtilities\RequiresUnreferencedCodeAttribute.cs</Link>
     </Compile>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CompilerExtensions.projitems
@@ -105,6 +105,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\DocumentationCommentXmlNames.cs">
       <Link>InternalUtilities\DocumentationCommentXmlNames.cs</Link>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\DynamicallyAccessedMembersAttribute.cs">
+      <Link>InternalUtilities\DynamicallyAccessedMembersAttribute.cs</Link>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\EncodingExtensions.cs">
       <Link>InternalUtilities\EncodingExtensions.cs</Link>
     </Compile>
@@ -180,6 +183,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\ReflectionUtilities.cs">
       <Link>InternalUtilities\ReflectionUtilities.cs</Link>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\RequiresUnreferencedCodeAttribute.cs">
+      <Link>InternalUtilities\RequiresUnreferencedCodeAttribute.cs</Link>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\..\Compilers\Core\Portable\InternalUtilities\UnicodeCharacterUtilities.cs">
       <Link>InternalUtilities\UnicodeCharacterUtilities.cs</Link>


### PR DESCRIPTION
Brief description of trimming analysis: when trimming an application, the libraries should be annotated to be trim-compatible or, if that's not possible, to alert the user which APIs will not be compatible with trimming.

Almost all of MS.CA and MS.CA.CSharp are already trimming compatible, it is only native PDB writing which has problems (because it uses built-in COM support, which is basically reflection). The native PDB writing could eventually be moved to use COM wrappers and be made trim-compatible, but right now I've simply marked the APIs incompatible. There are still plenty of useful APIs for consumers, including all the syntax and binding APIs, that don't use PDB emit.