### PR TITLE
Make SymbolDisplay show nullable enum values as enums

### DIFF
--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IArgument.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IArgument.cs
@@ -4064,7 +4064,7 @@ class C
             string expectedOperationTree = @"
 IExpressionStatementOperation (OperationKind.ExpressionStatement, Type: null) (Syntax: 'M0();')
   Expression: 
-    IInvocationOperation ( void C.M0([E? e = 1])) (OperationKind.Invocation, Type: System.Void) (Syntax: 'M0()')
+    IInvocationOperation ( void C.M0([E? e = E.E1])) (OperationKind.Invocation, Type: System.Void) (Syntax: 'M0()')
       Instance Receiver: 
         IInstanceReferenceOperation (ReferenceKind: ContainingTypeInstance) (OperationKind.InstanceReference, Type: C, IsImplicit) (Syntax: 'M0')
       Arguments(1):

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -3998,6 +3998,112 @@ struct S
         }
 
         [Fact]
+        public void DefaultParameterValues_NullableEnum()
+        {
+            var text = @"
+[System.FlagsAttribute]
+enum E : sbyte
+{
+    A = -2,
+    A1 = -2,
+    B = 1,
+    B1 = 1,
+    C = 0,
+    C1 = 0,
+}
+
+struct S
+{
+    void P(E? e = null, E? f = E.A, E? g = E.A | E.B, E? h = (E)(-3))
+    {
+    }
+}";
+
+            Func<NamespaceSymbol, Symbol> findSymbol = global =>
+                global.GetMember<NamedTypeSymbol>("S").GetMember<MethodSymbol>("P");
+
+            var format =
+             new SymbolDisplayFormat(
+                 globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Included,
+                 genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+                 memberOptions:
+                     SymbolDisplayMemberOptions.IncludeParameters |
+                     SymbolDisplayMemberOptions.IncludeType |
+                     SymbolDisplayMemberOptions.IncludeContainingType,
+                 parameterOptions:
+                     SymbolDisplayParameterOptions.IncludeName |
+                     SymbolDisplayParameterOptions.IncludeType |
+                     SymbolDisplayParameterOptions.IncludeParamsRefOut |
+                     SymbolDisplayParameterOptions.IncludeDefaultValue,
+                 localOptions: SymbolDisplayLocalOptions.IncludeType,
+                 miscellaneousOptions:
+                     SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers |
+                     SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+
+            TestSymbolDescription(text, findSymbol,
+                format,
+                @"void S.P(E? e = null, E? f = E.A, E? g = E.A | E.B, E? h = (E)-3)",
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.StructName,
+                SymbolDisplayPartKind.Punctuation, //.
+                SymbolDisplayPartKind.MethodName,
+                SymbolDisplayPartKind.Punctuation, //(
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation, //?
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation, //=
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation, //,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation, //?
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation, //=
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation, //.
+                SymbolDisplayPartKind.EnumMemberName,
+                SymbolDisplayPartKind.Punctuation, //,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation, //?
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation, //=
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation, //.
+                SymbolDisplayPartKind.EnumMemberName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation, //|
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation, //.
+                SymbolDisplayPartKind.EnumMemberName,
+                SymbolDisplayPartKind.Punctuation, //,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation, //?
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation, // =
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation, // (
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation, // )
+                SymbolDisplayPartKind.NumericLiteral,
+                SymbolDisplayPartKind.Punctuation); //)
+        }
+
+        [Fact]
         public void TestConstantFieldValue()
         {
             var text =

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -4014,7 +4014,7 @@ enum E : sbyte
 
 struct S
 {
-    void P(E? e = null, E? f = E.A, E? g = E.A | E.B, E? h = (E)(-3))
+    void P(E? e = null, E? f = E.A, E? g = E.A | E.B, E?h = 0, E? i = (E)(-3))
     {
     }
 }";
@@ -4042,7 +4042,7 @@ struct S
 
             TestSymbolDescription(text, findSymbol,
                 format,
-                @"void S.P(E? e = null, E? f = E.A, E? g = E.A | E.B, E? h = (E)-3)",
+                @"void S.P(E? e = null, E? f = E.A, E? g = E.A | E.B, E? h = E.C, E? i = (E)-3)",
                 SymbolDisplayPartKind.Keyword,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.StructName,
@@ -4083,6 +4083,18 @@ struct S
                 SymbolDisplayPartKind.EnumMemberName,
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.Punctuation, //|
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation, //.
+                SymbolDisplayPartKind.EnumMemberName,
+                SymbolDisplayPartKind.Punctuation, //,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation, //?
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation, //=
                 SymbolDisplayPartKind.Space,
                 SymbolDisplayPartKind.EnumName,
                 SymbolDisplayPartKind.Punctuation, //.

--- a/src/Compilers/Core/Portable/SymbolDisplay/AbstractSymbolDisplayVisitor.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/AbstractSymbolDisplayVisitor.cs
@@ -90,7 +90,10 @@ namespace Microsoft.CodeAnalysis.SymbolDisplay
         {
             Debug.Assert(constantValue != null);
 
-            type = TryUnwrapNullableStruct(type);
+            if (ITypeSymbolHelpers.IsNullableType(type))
+            {
+                type = ITypeSymbolHelpers.GetNullableUnderlyingType(type);
+            }
 
             if (type.TypeKind == TypeKind.Enum)
             {
@@ -121,23 +124,6 @@ namespace Microsoft.CodeAnalysis.SymbolDisplay
                 // the literal value of the enum.
                 AddNonFlagsEnumConstantValue(enumType, constantValue);
             }
-        }
-
-        /// <summary>
-        /// Attemps to unwrap the underlying type if the given type is <see cref="System.Nullable{T}"/>
-        /// </summary>
-        private static ITypeSymbol TryUnwrapNullableStruct(ITypeSymbol typeSymbol)
-        {
-            if (typeSymbol.TypeKind != TypeKind.Struct)
-                return typeSymbol;
-
-            var namedTypeSymbol = (INamedTypeSymbol)typeSymbol;
-            if (namedTypeSymbol.IsGenericType && namedTypeSymbol.ConstructedFrom.SpecialType == SpecialType.System_Nullable_T)
-            {
-                return namedTypeSymbol.TypeArguments[0];
-            }
-
-            return typeSymbol;
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/SymbolDisplay/AbstractSymbolDisplayVisitor.cs
+++ b/src/Compilers/Core/Portable/SymbolDisplay/AbstractSymbolDisplayVisitor.cs
@@ -89,6 +89,9 @@ namespace Microsoft.CodeAnalysis.SymbolDisplay
         protected void AddNonNullConstantValue(ITypeSymbol type, object constantValue, bool preferNumericValueOrExpandedFlagsForEnum = false)
         {
             Debug.Assert(constantValue != null);
+
+            type = TryUnwrapNullableStruct(type);
+
             if (type.TypeKind == TypeKind.Enum)
             {
                 AddEnumConstantValue((INamedTypeSymbol)type, constantValue, preferNumericValueOrExpandedFlagsForEnum);
@@ -118,6 +121,23 @@ namespace Microsoft.CodeAnalysis.SymbolDisplay
                 // the literal value of the enum.
                 AddNonFlagsEnumConstantValue(enumType, constantValue);
             }
+        }
+
+        /// <summary>
+        /// Attemps to unwrap the underlying type if the given type is <see cref="System.Nullable{T}"/>
+        /// </summary>
+        private static ITypeSymbol TryUnwrapNullableStruct(ITypeSymbol typeSymbol)
+        {
+            if (typeSymbol.TypeKind != TypeKind.Struct)
+                return typeSymbol;
+
+            var namedTypeSymbol = (INamedTypeSymbol)typeSymbol;
+            if (namedTypeSymbol.IsGenericType && namedTypeSymbol.ConstructedFrom.SpecialType == SpecialType.System_Nullable_T)
+            {
+                return namedTypeSymbol.TypeArguments[0];
+            }
+
+            return typeSymbol;
         }
 
         /// <summary>

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/SymbolDisplayTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolDisplay/SymbolDisplayTests.vb
@@ -2897,6 +2897,283 @@ End Class
         End Sub
 
         <Fact()>
+        Public Sub TestOptionalParameterValue_Enum()
+            Dim text =
+<compilation>
+    <file name="a.vb">
+Imports Microsoft.VisualBasic
+
+Enum E
+    A = 1
+    B = 2
+    C = 4
+End Enum
+
+Class C
+    Sub M(Optional a As E = 0, Optional b As E = 1, Optional c As E = 2)
+    End Sub
+End Class
+            </file>
+</compilation>
+
+            Dim findSymbol =
+                Function(globalns As NamespaceSymbol) globalns _
+                    .GetMember(Of NamedTypeSymbol)("C") _
+                    .GetMember(Of MethodSymbol)("M")
+
+            Dim format = New SymbolDisplayFormat(
+                memberOptions:=SymbolDisplayMemberOptions.IncludeParameters,
+                parameterOptions:=
+                    SymbolDisplayParameterOptions.IncludeParamsRefOut Or
+                    SymbolDisplayParameterOptions.IncludeType Or
+                    SymbolDisplayParameterOptions.IncludeName Or
+                    SymbolDisplayParameterOptions.IncludeDefaultValue)
+
+            TestSymbolDescription(
+                text,
+                findSymbol,
+                format,
+                "M(a As E = 0, b As E = A, c As E = B)",
+                {
+                SymbolDisplayPartKind.MethodName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.NumericLiteral,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumMemberName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumMemberName,
+                SymbolDisplayPartKind.Punctuation
+                })
+        End Sub
+
+        <Fact()>
+        Public Sub TestOptionalParameterValue_FlagsEnum()
+            Dim text =
+<compilation>
+    <file name="a.vb">
+Imports Microsoft.VisualBasic
+&lt;System.FlagsAttribute&gt;
+Enum E
+    A = 1
+    B = 2
+    C = 4
+    D = A Or B Or C
+End Enum
+
+Class C
+    Sub M(Optional a As E = 0, Optional b As E = E.A, Optional c As E = E.A Or E.B, Optional d As E = E.A Or E.B Or E.C)
+    End Sub
+End Class
+            </file>
+</compilation>
+
+            Dim findSymbol =
+                Function(globalns As NamespaceSymbol) globalns _
+                    .GetMember(Of NamedTypeSymbol)("C") _
+                    .GetMember(Of MethodSymbol)("M")
+
+            Dim format = New SymbolDisplayFormat(
+                memberOptions:=SymbolDisplayMemberOptions.IncludeParameters,
+                parameterOptions:=
+                    SymbolDisplayParameterOptions.IncludeParamsRefOut Or
+                    SymbolDisplayParameterOptions.IncludeType Or
+                    SymbolDisplayParameterOptions.IncludeName Or
+                    SymbolDisplayParameterOptions.IncludeDefaultValue)
+
+            TestSymbolDescription(
+                text,
+                findSymbol,
+                format,
+                "M(a As E = 0, b As E = A, c As E = A Or B, d As E = D)",
+                {
+                SymbolDisplayPartKind.MethodName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.NumericLiteral,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumMemberName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumMemberName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumMemberName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumMemberName,
+                SymbolDisplayPartKind.Punctuation
+                })
+        End Sub
+
+        <Fact()>
+        Public Sub TestOptionalParameterValue_NullableEnum()
+            Dim text =
+<compilation>
+    <file name="a.vb">
+Imports Microsoft.VisualBasic
+&lt;System.FlagsAttribute&gt;
+Enum E
+    A = 1
+    B = 2
+    C = 4
+    D = A Or B Or C
+End Enum
+
+Class C
+    Sub M(Optional a As E? = 0, Optional b As E? = E.A, Optional c As E? = E.A Or E.B, Optional d As E? = E.A Or E.B Or E.C, Optional e As E? = Nothing)
+    End Sub
+End Class
+            </file>
+</compilation>
+
+            Dim findSymbol =
+                Function(globalns As NamespaceSymbol) globalns _
+                    .GetMember(Of NamedTypeSymbol)("C") _
+                    .GetMember(Of MethodSymbol)("M")
+
+            Dim format = New SymbolDisplayFormat(
+                miscellaneousOptions:=SymbolDisplayMiscellaneousOptions.UseSpecialTypes,
+                memberOptions:=SymbolDisplayMemberOptions.IncludeParameters,
+                parameterOptions:=
+                    SymbolDisplayParameterOptions.IncludeParamsRefOut Or
+                    SymbolDisplayParameterOptions.IncludeType Or
+                    SymbolDisplayParameterOptions.IncludeName Or
+                    SymbolDisplayParameterOptions.IncludeDefaultValue)
+
+            TestSymbolDescription(
+                text,
+                findSymbol,
+                format,
+                "M(a As E? = 0, b As E? = A, c As E? = A Or B, d As E? = D, e As E? = Nothing)",
+                {
+                SymbolDisplayPartKind.MethodName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.NumericLiteral,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumMemberName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumMemberName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumMemberName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumMemberName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.ParameterName,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.EnumName,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Punctuation,
+                SymbolDisplayPartKind.Space,
+                SymbolDisplayPartKind.Keyword,
+                SymbolDisplayPartKind.Punctuation
+                })
+        End Sub
+
+        <Fact()>
         Public Sub TestOptionalParameterValue_InvariantCulture1()
             Dim text =
 <compilation>


### PR DESCRIPTION
Fixes #66514

Shows nullable enum values as enums instead of numbers