### PR TITLE
Fix property initialization issue in KeyValueLogMessage

### DIFF
--- a/src/Workspaces/Core/Portable/Log/KeyValueLogMessage.cs
+++ b/src/Workspaces/Core/Portable/Log/KeyValueLogMessage.cs
@@ -160,9 +160,11 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         private void EnsureMap()
         {
             // always create _map
-            _lazyMap ??= SharedPools.Default<Dictionary<string, object?>>().AllocateAndClear();
-
-            _propertySetter?.Invoke(_lazyMap);
+            if (_lazyMap == null)
+            {
+                _lazyMap = SharedPools.Default<Dictionary<string, object?>>().AllocateAndClear();
+                _propertySetter?.Invoke(_lazyMap);
+            }
         }
     }
 


### PR DESCRIPTION
The EnsureMap() method is supposed to create the property map if it has not been created before. However, even though the method creates the map only once, it always invokes the property initialization callback. In the best case, this results on code being unnecessarily executed twice. In the worst case, it may result on an exception if the callback uses the Dictionary.Add method to update the property dictionary (since it will find duplicates).

Specifically, this fixes an exception I'm seeing in VS for Mac:

```
System.ArgumentException: An item with the same key has already been added. Key: ProcessDocument.Maximum
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at Microsoft.CodeAnalysis.Internal.Log.StatisticResult.WriteTelemetryPropertiesTo(Dictionary`2 properties, String prefix) in /_/src/Workspaces/Core/Portable/Log/StatisticResult.cs:line 91
   at Microsoft.CodeAnalysis.SolutionCrawler.SolutionCrawlerLogger.<>c__DisplayClass44_0.<LogIncrementalAnalyzerProcessorStatistics>b__0(Dictionary`2 m) in /_/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerLogger.cs:line 218
   at Microsoft.CodeAnalysis.Internal.Log.KeyValueLogMessage.get_ContainsProperty() in /_/src/Workspaces/Core/Portable/Log/KeyValueLogMessage.cs:line 70
   at Xamarin.Ide.RoslynTelemetry.VSTelemetryLogger.AppendProperties[T](T event, FunctionId functionId, KeyValueLogMessage logMessage) in /Users/lluis/prog/work/vsmac/vmain/main/src/addins/Xamarin.Ide/Xamarin.Ide/Xamarin.Ide.RoslynTelemetry/VSTelemetryLogger.cs:line 137
   at Xamarin.Ide.RoslynTelemetry.VSTelemetryLogger.CreateTelemetryEvent(FunctionId functionId, KeyValueLogMessage logMessage) in /Users/lluis/prog/work/vsmac/vmain/main/src/addins/Xamarin.Ide/Xamarin.Ide/Xamarin.Ide.RoslynTelemetry/VSTelemetryLogger.cs:line 131
   at Xamarin.Ide.RoslynTelemetry.VSTelemetryLogger.Log(FunctionId functionId, LogMessage logMessage) in /Users/lluis/prog/work/vsmac/vmain/main/src/addins/Xamarin.Ide/Xamarin.Ide/Xamarin.Ide.RoslynTelemetry/VSTelemetryLogger.cs:line 41
```