### PR TITLE
Add VerifyMethodBody helper as a replacement of VerifyIL

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -3176,8 +3176,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // testData is only passed when running tests.
             if (testData != null)
             {
-                moduleBeingBuilt.SetMethodTestData(testData.Methods);
-                testData.Module = moduleBeingBuilt;
+                moduleBeingBuilt.SetTestData(testData);
             }
 
             return moduleBeingBuilt;

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1594,10 +1594,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 // We will only save the IL builders when running tests.
-                if (moduleBuilder.SaveTestData)
-                {
-                    moduleBuilder.SetMethodTestData(method, builder.GetSnapshot());
-                }
+                moduleBuilder.TestData?.SetMethodILBuilder(method, builder.GetSnapshot());
 
                 var stateMachineHoistedLocalSlots = default(ImmutableArray<EncHoistedLocalInfo>);
                 var stateMachineAwaiterSlots = default(ImmutableArray<Cci.ITypeReference>);

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/EmitHelpers.cs
@@ -64,8 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
             if (testData != null)
             {
-                moduleBeingBuilt.SetMethodTestData(testData.Methods);
-                testData.Module = moduleBeingBuilt;
+                moduleBeingBuilt.SetTestData(testData);
             }
 
             var definitionMap = moduleBeingBuilt.PreviousDefinitions;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -5728,94 +5728,102 @@ public class C {
             var comp = CSharpTestBase.CreateCompilation(source, options: TestOptions.ReleaseDll);
             comp.VerifyEmitDiagnostics();
             var verifier = CompileAndVerify(comp);
-            verifier.VerifyIL("C.<M>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", source: source, expectedIL: @"
-    {
-      // Code size      176 (0xb0)
-      .maxstack  3
-      .locals init (int V_0,
-                    C V_1,
-                    int? V_2,
-                    int V_3,
-                    System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
-                    System.Exception V_5)
-      IL_0000:  ldarg.0
-      IL_0001:  ldfld      ""int C.<M>d__1.<>1__state""
-      IL_0006:  stloc.0
-      IL_0007:  ldarg.0
-      IL_0008:  ldfld      ""C C.<M>d__1.<>4__this""
-      IL_000d:  stloc.1
-      .try
-      {
-        IL_000e:  ldloc.0
-        IL_000f:  brfalse.s  IL_0062
-        IL_0011:  ldarg.0
-        IL_0012:  ldfld      ""int? C.<M>d__1.val""
-        IL_0017:  stloc.2
-        IL_0018:  ldloca.s   V_2
-        IL_001a:  call       ""bool int?.HasValue.get""
-        IL_001f:  brfalse.s  IL_002b
-        IL_0021:  ldloca.s   V_2
-        IL_0023:  call       ""int int?.GetValueOrDefault()""
-        IL_0028:  stloc.3
-        IL_0029:  br.s       IL_0087
-        IL_002b:  ldloc.1
-        IL_002c:  call       ""System.Threading.Tasks.Task<int> C.Get()""
-        IL_0031:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
-        IL_0036:  stloc.s    V_4
-        IL_0038:  ldloca.s   V_4
-        IL_003a:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
-        IL_003f:  brtrue.s   IL_007f
-        IL_0041:  ldarg.0
-        IL_0042:  ldc.i4.0
-        IL_0043:  dup
-        IL_0044:  stloc.0
-        IL_0045:  stfld      ""int C.<M>d__1.<>1__state""
-        IL_004a:  ldarg.0
-        IL_004b:  ldloc.s    V_4
-        IL_004d:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<M>d__1.<>u__1""
-        IL_0052:  ldarg.0
-        IL_0053:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M>d__1.<>t__builder""
-        IL_0058:  ldloca.s   V_4
-        IL_005a:  ldarg.0
-        IL_005b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<M>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<M>d__1)""
-        IL_0060:  leave.s    IL_00af
-        IL_0062:  ldarg.0
-        IL_0063:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<M>d__1.<>u__1""
-        IL_0068:  stloc.s    V_4
-        IL_006a:  ldarg.0
-        IL_006b:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<M>d__1.<>u__1""
-        IL_0070:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
-        IL_0076:  ldarg.0
-        IL_0077:  ldc.i4.m1
-        IL_0078:  dup
-        IL_0079:  stloc.0
-        IL_007a:  stfld      ""int C.<M>d__1.<>1__state""
-        IL_007f:  ldloca.s   V_4
-        IL_0081:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
-        IL_0086:  stloc.3
-        IL_0087:  ldloc.3
-        IL_0088:  ldc.i4.1
-        IL_0089:  pop
-        IL_008a:  pop
-        IL_008b:  ldsfld     ""string string.Empty""
-        IL_0090:  newobj     ""System.NotImplementedException..ctor(string)""
-        IL_0095:  throw
-      }
-      catch System.Exception
-      {
-        IL_0096:  stloc.s    V_5
-        IL_0098:  ldarg.0
-        IL_0099:  ldc.i4.s   -2
-        IL_009b:  stfld      ""int C.<M>d__1.<>1__state""
-        IL_00a0:  ldarg.0
-        IL_00a1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M>d__1.<>t__builder""
-        IL_00a6:  ldloc.s    V_5
-        IL_00a8:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-        IL_00ad:  leave.s    IL_00af
-      }
-      IL_00af:  ret
-    }
-");
+            verifier.VerifyMethodBody("C.<M>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
+{
+  // Code size      176 (0xb0)
+  .maxstack  3
+  .locals init (int V_0,
+                C V_1,
+                int? V_2,
+                int V_3,
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
+                System.Exception V_5)
+  // sequence point: <hidden>
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<M>d__1.<>1__state""
+  IL_0006:  stloc.0
+  IL_0007:  ldarg.0
+  IL_0008:  ldfld      ""C C.<M>d__1.<>4__this""
+  IL_000d:  stloc.1
+  .try
+  {
+    // sequence point: <hidden>
+    IL_000e:  ldloc.0
+    IL_000f:  brfalse.s  IL_0062
+    // sequence point: switch (val ?? await Get())
+    IL_0011:  ldarg.0
+    IL_0012:  ldfld      ""int? C.<M>d__1.val""
+    IL_0017:  stloc.2
+    IL_0018:  ldloca.s   V_2
+    IL_001a:  call       ""bool int?.HasValue.get""
+    IL_001f:  brfalse.s  IL_002b
+    IL_0021:  ldloca.s   V_2
+    IL_0023:  call       ""int int?.GetValueOrDefault()""
+    IL_0028:  stloc.3
+    IL_0029:  br.s       IL_0087
+    IL_002b:  ldloc.1
+    IL_002c:  call       ""System.Threading.Tasks.Task<int> C.Get()""
+    IL_0031:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_0036:  stloc.s    V_4
+    // sequence point: <hidden>
+    IL_0038:  ldloca.s   V_4
+    IL_003a:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_003f:  brtrue.s   IL_007f
+    IL_0041:  ldarg.0
+    IL_0042:  ldc.i4.0
+    IL_0043:  dup
+    IL_0044:  stloc.0
+    IL_0045:  stfld      ""int C.<M>d__1.<>1__state""
+    // async: yield
+    IL_004a:  ldarg.0
+    IL_004b:  ldloc.s    V_4
+    IL_004d:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<M>d__1.<>u__1""
+    IL_0052:  ldarg.0
+    IL_0053:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M>d__1.<>t__builder""
+    IL_0058:  ldloca.s   V_4
+    IL_005a:  ldarg.0
+    IL_005b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<M>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<M>d__1)""
+    IL_0060:  leave.s    IL_00af
+    // async: resume
+    IL_0062:  ldarg.0
+    IL_0063:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<M>d__1.<>u__1""
+    IL_0068:  stloc.s    V_4
+    IL_006a:  ldarg.0
+    IL_006b:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<M>d__1.<>u__1""
+    IL_0070:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0076:  ldarg.0
+    IL_0077:  ldc.i4.m1
+    IL_0078:  dup
+    IL_0079:  stloc.0
+    IL_007a:  stfld      ""int C.<M>d__1.<>1__state""
+    IL_007f:  ldloca.s   V_4
+    IL_0081:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_0086:  stloc.3
+    IL_0087:  ldloc.3
+    // sequence point: <hidden>
+    IL_0088:  ldc.i4.1
+    IL_0089:  pop
+    IL_008a:  pop
+    // sequence point: throw new NotImplementedException(string.Empty);
+    IL_008b:  ldsfld     ""string string.Empty""
+    IL_0090:  newobj     ""System.NotImplementedException..ctor(string)""
+    IL_0095:  throw
+  }
+  catch System.Exception
+  {
+    // sequence point: <hidden>
+    IL_0096:  stloc.s    V_5
+    IL_0098:  ldarg.0
+    IL_0099:  ldc.i4.s   -2
+    IL_009b:  stfld      ""int C.<M>d__1.<>1__state""
+    IL_00a0:  ldarg.0
+    IL_00a1:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder C.<M>d__1.<>t__builder""
+    IL_00a6:  ldloc.s    V_5
+    IL_00a8:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
+    IL_00ad:  leave.s    IL_00af
+  }
+  IL_00af:  ret
+}");
         }
 
         [Fact, WorkItem(46843, "https://github.com/dotnet/roslyn/issues/46843")]

--- a/src/Compilers/Core/Portable/CodeGen/CompilationTestData.cs
+++ b/src/Compilers/Core/Portable/CodeGen/CompilationTestData.cs
@@ -2,13 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Cci;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Symbols;
 using Microsoft.DiaSymReader;
+using Roslyn.Utilities;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 
@@ -34,14 +37,28 @@ namespace Microsoft.CodeAnalysis.CodeGen
         // The emitted module.
         public CommonPEModuleBuilder? Module;
 
+        // MetadataWriter used to emit metadata
+        public MetadataWriter? MetadataWriter { get; private set; }
+
         public Func<ISymWriterMetadataProvider, SymUnmanagedWriter>? SymWriterFactory;
+
+        private ImmutableDictionary<string, MethodData>? _lazyMethodsByName;
+
+        public void SetMetadataWriter(MetadataWriter writer)
+        {
+            Debug.Assert(MetadataWriter == null);
+            MetadataWriter = writer;
+        }
+
+        public void SetMethodILBuilder(IMethodSymbolInternal method, ILBuilder builder)
+        {
+            Methods.Add(method, new MethodData(builder, method));
+        }
 
         public ILBuilder GetIL(Func<IMethodSymbolInternal, bool> predicate)
         {
             return Methods.Single(p => predicate(p.Key)).Value.ILBuilder;
         }
-
-        private ImmutableDictionary<string, MethodData>? _lazyMethodsByName;
 
         // Returns map indexed by name for those methods that have a unique name.
         public ImmutableDictionary<string, MethodData> GetMethodsByName()

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -3407,6 +3407,8 @@ namespace Microsoft.CodeAnalysis
                         changes,
                         cancellationToken);
 
+                    moduleBeingBuilt.TestData?.SetMetadataWriter(writer);
+
                     writer.WriteMetadataAndIL(
                         nativePdbWriter,
                         metadataStream,

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -44,8 +44,8 @@ namespace Microsoft.CodeAnalysis.Emit
         private ImmutableArray<Cci.ManagedResource> _lazyManagedResources;
         private IEnumerable<EmbeddedText> _embeddedTexts = SpecializedCollections.EmptyEnumerable<EmbeddedText>();
 
-        // Only set when running tests to allow realized IL for a given method to be looked up by method.
-        internal ConcurrentDictionary<IMethodSymbolInternal, CompilationTestData.MethodData> TestData { get; private set; }
+        // Only set when running tests to allow inspection of the emitted data.
+        internal CompilationTestData TestData { get; private set; }
 
         internal EmitOptions EmitOptions { get; }
 
@@ -504,17 +504,11 @@ namespace Microsoft.CodeAnalysis.Emit
             }
         }
 
-        internal bool SaveTestData => TestData != null;
-
-        internal void SetMethodTestData(IMethodSymbolInternal method, ILBuilder builder)
-        {
-            TestData.Add(method, new CompilationTestData.MethodData(builder, method));
-        }
-
-        internal void SetMethodTestData(ConcurrentDictionary<IMethodSymbolInternal, CompilationTestData.MethodData> methods)
+        internal void SetTestData(CompilationTestData testData)
         {
             Debug.Assert(TestData == null);
-            TestData = methods;
+            TestData = testData;
+            testData.Module = this;
         }
 
         public int GetTypeDefinitionGeneration(Cci.INamedTypeDefinition typeDef)

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Cci
 
             var properties = context.Module.SerializationProperties;
 
+            context.Module.TestData?.SetMetadataWriter(mdWriter);
             nativePdbWriterOpt?.SetMetadataEmitter(mdWriter);
 
             // Since we are producing a full assembly, we should not have a module version ID

--- a/src/Compilers/Test/Core/Compilation/CompilationDifference.cs
+++ b/src/Compilers/Test/Core/Compilation/CompilationDifference.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.CompilerServices;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Emit;
@@ -90,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             if (!methodToken.IsNil)
             {
                 string actualPdb = PdbToXmlConverter.DeltaPdbToXml(new ImmutableMemoryStream(PdbDelta), new[] { MetadataTokens.GetToken(methodToken) });
-                sequencePointMarkers = ILValidation.GetSequencePointMarkers(actualPdb);
+                sequencePointMarkers = ILValidation.GetSequencePointMarkers(XElement.Parse(actualPdb));
 
                 Assert.True(sequencePointMarkers.Count > 0, $"No sequence points found in:{Environment.NewLine}{actualPdb}");
             }

--- a/src/Compilers/Test/Core/Metadata/ILValidation.cs
+++ b/src/Compilers/Test/Core/Metadata/ILValidation.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -17,9 +18,13 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Xml;
+using System.Xml.Linq;
 using Microsoft.Cci;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.DiaSymReader.Tools;
 using Microsoft.Metadata.Tools;
+using Xunit;
 
 namespace Roslyn.Test.Utilities
 {
@@ -320,106 +325,122 @@ namespace Roslyn.Test.Utilities
             }
         }
 
-        public static Dictionary<int, string> GetSequencePointMarkers(string pdbXml, string source = null)
-        {
-            var doc = new XmlDocument() { XmlResolver = null };
-            using (var reader = new XmlTextReader(new StringReader(pdbXml)) { DtdProcessing = DtdProcessing.Prohibit })
-            {
-                doc.Load(reader);
-            }
+        /// <summary>
+        /// Returns "method" element with a specified token.
+        /// <see cref="PdbToXmlOptions.IncludeTokens"/> must be set to include "token" attributes in "method" elements.
+        /// </summary>
+        public static XElement GetMethodElement(XElement document, int methodToken)
+            => (from e in document.DescendantsAndSelf()
+                where e.Name == "method"
+                let xmlTokenValue = e.Attribute("token")?.Value
+                where xmlTokenValue != null &&
+                      xmlTokenValue.StartsWith("0x") &&
+                      Convert.ToInt32(xmlTokenValue[2..], 16) == methodToken
+                select e).SingleOrDefault();
 
+        public static ImmutableDictionary<string, string> GetDocumentIdToPathMap(XElement document)
+            => document
+                .Descendants().Where(e => e.Name == "files").Single()
+                .Descendants().ToImmutableDictionary(e => e.Attribute("id").Value, e => e.Attribute("name").Value);
+
+        public static Dictionary<int, string> GetSequencePointMarkers(XElement methodXml)
+        {
             var result = new Dictionary<int, string>();
 
-            if (source == null)
+            void add(int key, string value)
+                => result[key] = result.TryGetValue(key, out var existing) ? existing + value : value;
+
+            foreach (var e in methodXml.Descendants())
             {
-                static void Add(Dictionary<int, string> dict, int key, string value)
-                    => dict[key] = dict.TryGetValue(key, out var found) ? found + value : value;
-
-                foreach (XmlNode entry in doc.GetElementsByTagName("sequencePoints"))
+                if (e.Name == "entry" && e.Parent.Name == "sequencePoints")
                 {
-                    foreach (XmlElement item in entry.ChildNodes)
-                    {
-                        Add(result,
-                            Convert.ToInt32(item.GetAttribute("offset"), 16),
-                            (item.GetAttribute("hidden") == "true") ? "~" : "-");
-                    }
-                }
-
-                foreach (XmlNode entry in doc.GetElementsByTagName("asyncInfo"))
-                {
-                    foreach (XmlElement item in entry.ChildNodes)
-                    {
-                        if (item.Name == "await")
-                        {
-                            Add(result, Convert.ToInt32(item.GetAttribute("yield"), 16), "<");
-                            Add(result, Convert.ToInt32(item.GetAttribute("resume"), 16), ">");
-                        }
-                        else if (item.Name == "catchHandler")
-                        {
-                            Add(result, Convert.ToInt32(item.GetAttribute("offset"), 16), "$");
-                        }
-                    }
+                    add(Convert.ToInt32(e.Attribute("offset").Value, 16), (e.Attribute("hidden")?.Value == "true") ? "~" : "-");
                 }
             }
-            else
+
+            foreach (var e in methodXml.Descendants())
             {
-                static void AddTextual(Dictionary<int, string> dict, int key, string value)
-                    => dict[key] = dict.TryGetValue(key, out var found) ? found + ", " + value : "// " + value;
-
-                foreach (XmlNode entry in doc.GetElementsByTagName("asyncInfo"))
+                if (e.Name == "await" && e.Parent.Name == "asyncInfo")
                 {
-                    foreach (XmlElement item in entry.ChildNodes)
-                    {
-                        if (item.Name == "await")
-                        {
-                            AddTextual(result, Convert.ToInt32(item.GetAttribute("yield"), 16), "async: yield");
-                            AddTextual(result, Convert.ToInt32(item.GetAttribute("resume"), 16), "async: resume");
-                        }
-                        else if (item.Name == "catchHandler")
-                        {
-                            AddTextual(result, Convert.ToInt32(item.GetAttribute("offset"), 16), "async: catch handler");
-                        }
-                    }
+                    add(Convert.ToInt32(e.Attribute("yield").Value, 16), "<");
+                    add(Convert.ToInt32(e.Attribute("resume").Value, 16), ">");
                 }
-
-                var sourceLines = source.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
-
-                foreach (XmlNode entry in doc.GetElementsByTagName("sequencePoints"))
+                else if (e.Name == "catchHandler" && e.Parent.Name == "asyncInfo")
                 {
-                    foreach (XmlElement item in entry.ChildNodes)
-                    {
-                        AddTextual(result, Convert.ToInt32(item.GetAttribute("offset"), 16), "sequence point: " + SnippetFromSpan(sourceLines, item));
-                    }
+                    add(Convert.ToInt32(e.Attribute("offset").Value, 16), "$");
                 }
             }
 
             return result;
         }
 
-        private static string SnippetFromSpan(string[] lines, XmlElement span)
+        public static Dictionary<int, string> GetSequencePointMarkers(XElement methodXml, Func<string, SourceText> getSource)
         {
-            if (span.GetAttribute("hidden") == "true")
+            var result = new Dictionary<int, string>();
+
+            void add(int key, string value)
+                => result[key] = result.TryGetValue(key, out var existing) ? existing + ", " + value : "// " + value;
+
+            foreach (var e in methodXml.Descendants())
+            {
+                if (e.Name == "await" && e.Parent.Name == "asyncInfo")
+                {
+                    add(Convert.ToInt32(e.Attribute("yield").Value, 16), "async: yield");
+                    add(Convert.ToInt32(e.Attribute("resume").Value, 16), "async: resume");
+                }
+                else if (e.Name == "catchHandler" && e.Parent.Name == "asyncInfo")
+                {
+                    add(Convert.ToInt32(e.Attribute("offset").Value, 16), "async: catch handler");
+                }
+            }
+
+            foreach (var e in methodXml.Descendants())
+            {
+                if (e.Name == "entry" && e.Parent.Name == "sequencePoints")
+                {
+                    var documentId = e.Attribute("document").Value;
+                    
+                    var source = getSource(documentId);
+                    Assert.NotNull(source);
+
+                    add(Convert.ToInt32(e.Attribute("offset").Value, 16), "sequence point: " + SnippetFromSpan(source, e));
+                }
+            }
+
+            return result;
+        }
+
+        private static string SnippetFromSpan(SourceText text, XElement sequencePointXml)
+        {
+            if (sequencePointXml.Attribute("hidden")?.Value == "true")
             {
                 return "<hidden>";
             }
 
-            var startLine = Convert.ToInt32(span.GetAttribute("startLine"));
-            var startColumn = Convert.ToInt32(span.GetAttribute("startColumn"));
-            var endLine = Convert.ToInt32(span.GetAttribute("endLine"));
-            var endColumn = Convert.ToInt32(span.GetAttribute("endColumn"));
+            var lines = text.Lines;
+
+            var startLine = Convert.ToInt32(sequencePointXml.Attribute("startLine").Value);
+            var startColumn = Convert.ToInt32(sequencePointXml.Attribute("startColumn").Value);
+            var endLine = Convert.ToInt32(sequencePointXml.Attribute("endLine").Value);
+            var endColumn = Convert.ToInt32(sequencePointXml.Attribute("endColumn").Value);
+
+            var lineSpan = new LinePositionSpan(new(startLine, startColumn), new(endLine, endColumn));
+            var span = text.Lines.GetTextSpan(lineSpan);
+            var subtext = text.GetSubText(span);
+
             if (startLine == endLine)
             {
-                return lines[startLine - 1].Substring(startColumn - 1, endColumn - startColumn);
+                return subtext.ToString();
             }
 
             static string TruncateStart(string text, int maxLength)
-                => (text.Length < maxLength) ? text : text.Substring(0, maxLength);
+                => (text.Length < maxLength) ? text : text[..maxLength];
 
             static string TruncateEnd(string text, int maxLength)
                 => (text.Length < maxLength) ? text : text.Substring(text.Length - maxLength - 1, maxLength);
 
-            var start = lines[startLine - 1].Substring(startColumn - 1);
-            var end = lines[endLine - 1].Substring(0, endColumn - 1);
+            var start = subtext.Lines[0].ToString()[(startColumn - 1)..];
+            var end = subtext.Lines[^1].ToString()[..(endColumn - 1)];
             return TruncateStart(start, 12) + " ... " + TruncateEnd(end, 12);
         }
     }

--- a/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/MethodCompiler.vb
@@ -1657,9 +1657,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 ' We will only save the IL builders when running tests.
-                If moduleBuilder.SaveTestData Then
-                    moduleBuilder.SetMethodTestData(method, builder.GetSnapshot())
-                End If
+                moduleBuilder.TestData?.SetMethodILBuilder(method, builder.GetSnapshot())
 
                 Dim stateMachineHoistedLocalSlots As ImmutableArray(Of EncHoistedLocalInfo) = Nothing
                 Dim stateMachineAwaiterSlots As ImmutableArray(Of Cci.ITypeReference) = Nothing

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -2430,8 +2430,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If testData IsNot Nothing Then
-                moduleBeingBuilt.SetMethodTestData(testData.Methods)
-                testData.Module = moduleBeingBuilt
+                moduleBeingBuilt.SetTestData(testData)
             End If
 
             Return moduleBeingBuilt

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/EmitHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/EmitHelpers.vb
@@ -57,8 +57,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             End Try
 
             If testData IsNot Nothing Then
-                moduleBeingBuilt.SetMethodTestData(testData.Methods)
-                testData.Module = moduleBeingBuilt
+                moduleBeingBuilt.SetTestData(testData)
             End If
 
             Dim definitionMap = moduleBeingBuilt.PreviousDefinitions

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EEAssemblyBuilder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EEAssemblyBuilder.cs
@@ -42,8 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
             if (testData != null)
             {
-                this.SetMethodTestData(testData.Methods);
-                testData.Module = this;
+                SetTestData(testData);
             }
         }
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EEAssemblyBuilder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EEAssemblyBuilder.vb
@@ -43,8 +43,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Me.Methods = methods
 
             If testData IsNot Nothing Then
-                SetMethodTestData(testData.Methods)
-                testData.Module = Me
+                SetTestData(testData)
             End If
         End Sub
 


### PR DESCRIPTION
VerifyMethodBody verifies both IL and sequence points without requiring to specify sequencePoints and source arguments like VerifyIL. Instead of looking up method in the PDB by its metadata name it uses method token. The tokens are made available via TestData by exposing MetadataWriter used for emit. The source is retrieved from the compilation using the document name stored in the PDB.