### PR TITLE
Correctly emit accessibility when generating properties via `SyntaxGenerator`

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -355,7 +355,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return PropertyDeclaration(name, type, getAccessor, setAccessor, accessibility, modifiers);
         }
 
-        internal override SyntaxNode PropertyDeclaration(
+        private protected override SyntaxNode PropertyDeclaration(
             string name,
             SyntaxNode type,
             SyntaxNode? getAccessor,

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -343,21 +343,33 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             IEnumerable<SyntaxNode>? getAccessorStatements,
             IEnumerable<SyntaxNode>? setAccessorStatements)
         {
+            SyntaxNode? getAccessor = null;
+            SyntaxNode? setAccessor = null;
+
+            if (!modifiers.IsWriteOnly)
+                getAccessor = AccessorDeclaration(SyntaxKind.GetAccessorDeclaration, modifiers.IsAbstract ? null : getAccessorStatements);
+
+            if (!modifiers.IsReadOnly)
+                setAccessor = AccessorDeclaration(SyntaxKind.SetAccessorDeclaration, modifiers.IsAbstract ? null : setAccessorStatements);
+
+            return PropertyDeclaration(name, type, getAccessor, setAccessor, accessibility, modifiers);
+        }
+
+        internal override SyntaxNode PropertyDeclaration(
+            string name,
+            SyntaxNode type,
+            SyntaxNode? getAccessor,
+            SyntaxNode? setAccessor,
+            Accessibility accessibility = Accessibility.NotApplicable,
+            DeclarationModifiers modifiers = default)
+        {
             var accessors = new List<AccessorDeclarationSyntax>();
-            var hasGetter = !modifiers.IsWriteOnly;
-            var hasSetter = !modifiers.IsReadOnly;
 
-            if (modifiers.IsAbstract)
-            {
-                getAccessorStatements = null;
-                setAccessorStatements = null;
-            }
+            if (getAccessor is not null)
+                accessors.Add((AccessorDeclarationSyntax)getAccessor);
 
-            if (hasGetter)
-                accessors.Add(AccessorDeclaration(SyntaxKind.GetAccessorDeclaration, getAccessorStatements));
-
-            if (hasSetter)
-                accessors.Add(AccessorDeclaration(SyntaxKind.SetAccessorDeclaration, setAccessorStatements));
+            if (setAccessor is not null)
+                accessors.Add((AccessorDeclarationSyntax)setAccessor);
 
             var actualModifiers = modifiers - (DeclarationModifiers.ReadOnly | DeclarationModifiers.WriteOnly);
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -360,8 +360,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             SyntaxNode type,
             SyntaxNode? getAccessor,
             SyntaxNode? setAccessor,
-            Accessibility accessibility = Accessibility.NotApplicable,
-            DeclarationModifiers modifiers = default)
+            Accessibility accessibility,
+            DeclarationModifiers modifiers)
         {
             var accessors = new List<AccessorDeclarationSyntax>();
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -365,11 +365,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         {
             var accessors = new List<AccessorDeclarationSyntax>();
 
-            if (getAccessor is not null)
-                accessors.Add((AccessorDeclarationSyntax)getAccessor);
-
-            if (setAccessor is not null)
-                accessors.Add((AccessorDeclarationSyntax)setAccessor);
+            accessors.AddIfNotNull((AccessorDeclarationSyntax?)getAccessor);
+            accessors.AddIfNotNull((AccessorDeclarationSyntax?)setAccessor);
 
             var actualModifiers = modifiers - (DeclarationModifiers.ReadOnly | DeclarationModifiers.WriteOnly);
 

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -2305,6 +2305,42 @@ public class C { } // end").Members[0];
                 """);
         }
 
+        [Fact, WorkItem(66379, "https://github.com/dotnet/roslyn/issues/66379")]
+        public void TestPropertyDeclarationFromSymbol1()
+        {
+            var compilation = _emptyCompilation.AddSyntaxTrees(SyntaxFactory.ParseSyntaxTree("""
+                class C
+                {
+                    public int Prop { get; protected set; }
+                }
+                """));
+
+            var type = compilation.GetTypeByMetadataName("C");
+            var property = type.GetMembers("Prop").Single();
+
+            VerifySyntax<PropertyDeclarationSyntax>(
+                Generator.Declaration(property),
+                "public global::System.Int32 Prop { get; protected set; }");
+        }
+
+        [Fact, WorkItem(66379, "https://github.com/dotnet/roslyn/issues/66379")]
+        public void TestPropertyDeclarationFromSymbol2()
+        {
+            var compilation = _emptyCompilation.AddSyntaxTrees(SyntaxFactory.ParseSyntaxTree("""
+                class C
+                {
+                    public int Prop { protected get; set; }
+                }
+                """));
+
+            var type = compilation.GetTypeByMetadataName("C");
+            var property = type.GetMembers("Prop").Single();
+
+            VerifySyntax<PropertyDeclarationSyntax>(
+                Generator.Declaration(property),
+                "public global::System.Int32 Prop { protected get; set; }");
+        }
+
         #endregion
 
         #region Add/Insert/Remove/Get declarations & members/elements

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.Editing
                     DeclarationModifiers.From(property));
         }
 
-        internal abstract SyntaxNode PropertyDeclaration(
+        private protected abstract SyntaxNode PropertyDeclaration(
             string name,
             SyntaxNode type,
             SyntaxNode? getAccessor,

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -279,7 +279,7 @@ namespace Microsoft.CodeAnalysis.Editing
         /// </summary>
         public SyntaxNode ParameterDeclaration(IParameterSymbol symbol, SyntaxNode? initializer = null)
         {
-            var parameter = ParameterDeclaration(
+            return ParameterDeclaration(
                 symbol.Name,
                 TypeExpression(symbol.Type),
                 initializer is not null ? initializer :
@@ -287,8 +287,6 @@ namespace Microsoft.CodeAnalysis.Editing
                 symbol.RefKind,
                 isExtension: symbol is { Ordinal: 0, ContainingSymbol: IMethodSymbol { IsExtensionMethod: true } },
                 symbol.IsParams);
-
-            return parameter;
         }
 
         private protected abstract SyntaxNode GenerateExpression(ITypeSymbol? type, object? value, bool canUseFieldReference);
@@ -322,14 +320,41 @@ namespace Microsoft.CodeAnalysis.Editing
             IEnumerable<SyntaxNode>? getAccessorStatements = null,
             IEnumerable<SyntaxNode>? setAccessorStatements = null)
         {
+            var propertyAccessibility = property.DeclaredAccessibility;
+            var getMethodSymbol = property.GetMethod;
+            var setMethodSymbol = property.SetMethod;
+
+            SyntaxNode? getAccessor = null;
+            SyntaxNode? setAccessor = null;
+
+            if (getMethodSymbol is not null)
+            {
+                var getMethodAccessibility = getMethodSymbol.DeclaredAccessibility;
+                getAccessor = GetAccessorDeclaration(getMethodAccessibility < propertyAccessibility ? getMethodAccessibility : Accessibility.NotApplicable, getAccessorStatements);
+            }
+
+            if (setMethodSymbol is not null)
+            {
+                var setMethodAccessibility = setMethodSymbol.DeclaredAccessibility;
+                setAccessor = SetAccessorDeclaration(setMethodAccessibility < propertyAccessibility ? setMethodAccessibility : Accessibility.NotApplicable, setAccessorStatements);
+            }
+
             return PropertyDeclaration(
                     property.Name,
                     TypeExpression(property.Type),
-                    property.DeclaredAccessibility,
-                    DeclarationModifiers.From(property),
-                    getAccessorStatements,
-                    setAccessorStatements);
+                    getAccessor,
+                    setAccessor,
+                    propertyAccessibility,
+                    DeclarationModifiers.From(property));
         }
+
+        internal abstract SyntaxNode PropertyDeclaration(
+            string name,
+            SyntaxNode type,
+            SyntaxNode? getAccessor,
+            SyntaxNode? setAccessor,
+            Accessibility accessibility = Accessibility.NotApplicable,
+            DeclarationModifiers modifiers = default);
 
         public SyntaxNode WithAccessorDeclarations(SyntaxNode declaration, params SyntaxNode[] accessorDeclarations)
             => WithAccessorDeclarations(declaration, (IEnumerable<SyntaxNode>)accessorDeclarations);

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -353,8 +353,8 @@ namespace Microsoft.CodeAnalysis.Editing
             SyntaxNode type,
             SyntaxNode? getAccessor,
             SyntaxNode? setAccessor,
-            Accessibility accessibility = Accessibility.NotApplicable,
-            DeclarationModifiers modifiers = default);
+            Accessibility accessibility,
+            DeclarationModifiers modifiers);
 
         public SyntaxNode WithAccessorDeclarations(SyntaxNode declaration, params SyntaxNode[] accessorDeclarations)
             => WithAccessorDeclarations(declaration, (IEnumerable<SyntaxNode>)accessorDeclarations);

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -986,11 +986,28 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Optional getAccessorStatements As IEnumerable(Of SyntaxNode) = Nothing,
             Optional setAccessorStatements As IEnumerable(Of SyntaxNode) = Nothing) As SyntaxNode
 
+            Return PropertyDeclaration(
+                identifier,
+                type,
+                If(Not modifiers.IsWriteOnly, CreateGetAccessorBlock(getAccessorStatements), Nothing),
+                If(Not modifiers.IsReadOnly, CreateSetAccessorBlock(type, setAccessorStatements), Nothing),
+                accessibility,
+                modifiers)
+        End Function
+
+        Friend Overrides Function PropertyDeclaration(
+            name As String,
+            type As SyntaxNode,
+            getAccessor As SyntaxNode,
+            setAccessor As SyntaxNode,
+            Optional accessibility As Accessibility = Accessibility.NotApplicable,
+            Optional modifiers As DeclarationModifiers = Nothing) As SyntaxNode
+
             Dim asClause = SyntaxFactory.SimpleAsClause(DirectCast(type, TypeSyntax))
             Dim statement = SyntaxFactory.PropertyStatement(
                 attributeLists:=Nothing,
                 modifiers:=GetModifierList(accessibility, modifiers And s_propertyModifiers, declaration:=Nothing, DeclarationKind.Property),
-                identifier:=identifier.ToIdentifierToken(),
+                identifier:=name.ToIdentifierToken(),
                 parameterList:=Nothing,
                 asClause:=asClause,
                 initializer:=Nothing,
@@ -1001,12 +1018,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Else
                 Dim accessors = New List(Of AccessorBlockSyntax)
 
-                If Not modifiers.IsWriteOnly Then
-                    accessors.Add(CreateGetAccessorBlock(getAccessorStatements))
+                If getAccessor IsNot Nothing Then
+                    accessors.Add(DirectCast(getAccessor, AccessorBlockSyntax))
                 End If
 
-                If Not modifiers.IsReadOnly Then
-                    accessors.Add(CreateSetAccessorBlock(type, setAccessorStatements))
+                If setAccessor IsNot Nothing Then
+                    accessors.Add(DirectCast(setAccessor, AccessorBlockSyntax))
                 End If
 
                 Return SyntaxFactory.PropertyBlock(

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -1018,13 +1018,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Else
                 Dim accessors = New List(Of AccessorBlockSyntax)
 
-                If getAccessor IsNot Nothing Then
-                    accessors.Add(DirectCast(getAccessor, AccessorBlockSyntax))
-                End If
-
-                If setAccessor IsNot Nothing Then
-                    accessors.Add(DirectCast(setAccessor, AccessorBlockSyntax))
-                End If
+                accessors.AddIfNotNull(DirectCast(getAccessor, AccessorBlockSyntax))
+                accessors.AddIfNotNull(DirectCast(setAccessor, AccessorBlockSyntax))
 
                 Return SyntaxFactory.PropertyBlock(
                     propertyStatement:=statement,

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -1000,8 +1000,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             type As SyntaxNode,
             getAccessor As SyntaxNode,
             setAccessor As SyntaxNode,
-            Optional accessibility As Accessibility = Accessibility.NotApplicable,
-            Optional modifiers As DeclarationModifiers = Nothing) As SyntaxNode
+            accessibility As Accessibility,
+            modifiers As DeclarationModifiers) As SyntaxNode
 
             Dim asClause = SyntaxFactory.SimpleAsClause(DirectCast(type, TypeSyntax))
             Dim statement = SyntaxFactory.PropertyStatement(

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -995,7 +995,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                 modifiers)
         End Function
 
-        Friend Overrides Function PropertyDeclaration(
+        Private Protected Overrides Function PropertyDeclaration(
             name As String,
             type As SyntaxNode,
             getAccessor As SyntaxNode,

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -2347,6 +2347,58 @@ End Class"))
 "Public Sub M(ParamArray arr As System.Int32())
 End Sub")
         End Sub
+
+        <Fact, WorkItem(66379, "https://github.com/dotnet/roslyn/issues/66379")>
+        Public Sub TestPropertyDeclarationFromSymbol1()
+            Dim compilation = _emptyCompilation.AddSyntaxTrees(SyntaxFactory.ParseSyntaxTree(
+"Class C
+    Public Property Prop As Integer
+        Get
+        End Get
+
+        Protected Set
+        End Set
+    End Property
+End Class"))
+
+            Dim type = compilation.GetTypeByMetadataName("C")
+            Dim method = type.GetMembers("Prop").Single()
+
+            VerifySyntax(Of PropertyBlockSyntax)(Generator.Declaration(method),
+"Public Property Prop As System.Int32
+    Get
+    End Get
+
+    Protected Set
+    End Set
+End Property")
+        End Sub
+
+        <Fact, WorkItem(66379, "https://github.com/dotnet/roslyn/issues/66379")>
+        Public Sub TestPropertyDeclarationFromSymbol2()
+            Dim compilation = _emptyCompilation.AddSyntaxTrees(SyntaxFactory.ParseSyntaxTree(
+"Class C
+    Public Property Prop As Integer
+        Protected Get
+        End Get
+
+        Set
+        End Set
+    End Property
+End Class"))
+
+            Dim type = compilation.GetTypeByMetadataName("C")
+            Dim method = type.GetMembers("Prop").Single()
+
+            VerifySyntax(Of PropertyBlockSyntax)(Generator.Declaration(method),
+"Public Property Prop As System.Int32
+    Protected Get
+    End Get
+
+    Set
+    End Set
+End Property")
+        End Sub
 #End Region
 
 #Region "Add/Insert/Remove/Get/Set members & elements"


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/66379
Fixes https://github.com/dotnet/arcade/issues/11935