### PR TITLE
List patterns: Add initial support for enumerables

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -292,8 +292,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundSlicePattern:
                     output = input;
                     return Tests.True.Instance;
-                case BoundListPattern list:
+                case BoundIndexableListPattern list:
                     return MakeTestsAndBindingsForListPattern(input, list, out output, bindings);
+                case BoundEnumerableListPattern list:
+                    return MakeTestsAndBindingsForEnumerableListPattern(input, list, out output, bindings);
                 case BoundRecursivePattern recursive:
                     return MakeTestsAndBindingsForRecursivePattern(input, recursive, out output, bindings);
                 case BoundITuplePattern iTuple:
@@ -310,6 +312,75 @@ namespace Microsoft.CodeAnalysis.CSharp
                 default:
                     throw ExceptionUtilities.UnexpectedValue(pattern.Kind);
             }
+        }
+
+        private Tests MakeTestsAndBindingsForEnumerableListPattern(BoundDagTemp input, BoundEnumerableListPattern list, out BoundDagTemp output, ArrayBuilder<BoundPatternBinding> bindings)
+        {
+            var syntax = list.Syntax;
+            var subpatterns = list.Subpatterns;
+            var tests = ArrayBuilder<Tests>.GetInstance();
+            output = input = MakeConvertToType(input, list.Syntax, list.NarrowedType, isExplicitTest: false, tests);
+
+            if (list.HasErrors)
+            {
+                tests.Add(new Tests.One(new BoundDagTypeTest(list.Syntax, ErrorType(), input, hasErrors: true)));
+            }
+            else if (subpatterns is [BoundSlicePattern { Pattern: null }])
+            {
+            }
+            else
+            {
+                var enumeratorEvaluation = new BoundDagEnumeratorEvaluation(syntax, list.GetEnumeratorMethod, list.ElementType, input);
+                // PROTOTYPE: Will be only used to call Dispose during lowering
+                // var enumeratorTemp = new BoundDagTemp(syntax, list.GetEnumeratorMethod.ReturnType, enumeratorEvaluation, index: 0);
+                var bufferType = _compilation.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_Buffer_T).Construct(list.ElementType);
+                var bufferTemp = new BoundDagTemp(syntax, bufferType, enumeratorEvaluation, index: 1);
+
+                tests.Add(new Tests.One(enumeratorEvaluation));
+
+                // PROTOTYPE: tests.Add(!input.TryGetNonEnumeratedCount || count >=/== N)
+                // PROTOTYPE: Could result in suboptimal codegen, as an alternative, it could use Buffer.ProbeCount(N) or some such
+
+                int index = 0;
+                foreach (BoundPattern subpattern in subpatterns)
+                {
+                    if (subpattern is BoundSlicePattern slice)
+                    {
+                        index -= subpatterns.Length - 1;
+
+                        if (slice.Pattern is not null)
+                        {
+                            // PROTOTYPE: Use Buffer.Slice?
+                            // PROTOTYPE: Could return Span/IEnumerable or both and select using explicit type [.. ROS<int>] which is also considered for arrays
+                            throw new NotImplementedException();
+                        }
+
+                        continue;
+                    }
+
+                    var elementEvaluation = new BoundDagElementEvaluation(subpattern.Syntax, index++, list.ElementType, bufferTemp);
+                    var successTemp = new BoundDagTemp(syntax, _compilation.GetSpecialType(SpecialType.System_Boolean), elementEvaluation, index: 0);
+                    var elementTemp = new BoundDagTemp(syntax, list.ElementType, elementEvaluation, index: 1);
+                    tests.Add(new Tests.One(elementEvaluation));
+                    tests.Add(new Tests.One(new BoundDagValueTest(subpattern.Syntax, ConstantValue.True, successTemp)));
+                    tests.Add(MakeTestsAndBindings(elementTemp, subpattern, bindings));
+                }
+
+                if (!list.HasSlice)
+                {
+                    var elementEvaluation = new BoundDagElementEvaluation(syntax, index, list.ElementType, bufferTemp);
+                    var successTemp = new BoundDagTemp(syntax, _compilation.GetSpecialType(SpecialType.System_Boolean), elementEvaluation, index: 0);
+                    tests.Add(new Tests.One(elementEvaluation));
+                    tests.Add(new Tests.One(new BoundDagValueTest(syntax, ConstantValue.False, successTemp)));
+                }
+            }
+
+            if (list.VariableAccess is not null)
+            {
+                bindings.Add(new BoundPatternBinding(list.VariableAccess, input));
+            }
+
+            return Tests.AndSequence.Create(tests);
         }
 
         private Tests MakeTestsAndBindingsForITuplePattern(

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_ListPatterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder_ListPatterns.cs
@@ -10,7 +10,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal sealed partial class DecisionDagBuilder
     {
-        private Tests MakeTestsAndBindingsForListPattern(BoundDagTemp input, BoundListPattern list, out BoundDagTemp output, ArrayBuilder<BoundPatternBinding> bindings)
+        // PROTOTYPE: Move to DecisionDagBuilder. This is not the whole thing anyways.
+        private Tests MakeTestsAndBindingsForListPattern(BoundDagTemp input, BoundIndexableListPattern list, out BoundDagTemp output, ArrayBuilder<BoundPatternBinding> bindings)
         {
             Debug.Assert(input.Type.IsErrorType() || list.HasErrors || list.InputType.IsErrorType() ||
                          input.Type.Equals(list.InputType, TypeCompareKind.AllIgnoreOptions) &&

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -508,10 +508,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public override BoundNode? VisitListPattern(BoundListPattern node)
+        public override BoundNode? VisitEnumerableListPattern(BoundEnumerableListPattern node)
         {
             SetPatternLocalScopes(node);
-            return base.VisitListPattern(node);
+            return base.VisitEnumerableListPattern(node);
+        }
+
+        public override BoundNode? VisitIndexableListPattern(BoundIndexableListPattern node)
+        {
+            SetPatternLocalScopes(node);
+            return base.VisitIndexableListPattern(node);
         }
 
         public override BoundNode? VisitRecursivePattern(BoundRecursivePattern node)

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDagEvaluation.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDagEvaluation.cs
@@ -42,6 +42,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     BoundDagSliceEvaluation e => getSymbolFromIndexerAccess(e.IndexerAccess),
                     BoundDagIndexerEvaluation e => getSymbolFromIndexerAccess(e.IndexerAccess),
                     BoundDagAssignmentEvaluation => null,
+                    BoundDagEnumeratorEvaluation e => e.GetEnumeratorMethod,
+                    BoundDagElementEvaluation e => e.ElementType,
                     _ => throw ExceptionUtilities.UnexpectedValue(this.Kind)
                 };
 
@@ -129,6 +131,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         private partial void Validate()
         {
             Debug.Assert(IndexerAccess is BoundIndexerAccess or BoundImplicitIndexerAccess or BoundArrayAccess);
+        }
+    }
+
+    partial class BoundDagElementEvaluation
+    {
+        public override int GetHashCode() => base.GetHashCode() ^ this.Index;
+        public override bool IsEquivalentTo(BoundDagEvaluation obj)
+        {
+            return base.IsEquivalentTo(obj) &&
+                this.Index == ((BoundDagElementEvaluation)obj).Index;
         }
     }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDagTemp.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDagTemp.cs
@@ -48,6 +48,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 #if DEBUG
         internal new string GetDebuggerDisplay()
         {
+            // PROTOTYPE: Handle new evaluation nodes
+
             var name = Source?.Id switch
             {
                 -1 => "<uninitialized>",

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundIndexableListPattern.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundIndexableListPattern.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    internal partial class BoundListPattern
+    internal partial class BoundIndexableListPattern
     {
         private partial void Validate()
         {

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1549,6 +1549,14 @@
     <Field Name="Property" Type="PropertySymbol" Null="disallow"/>
     <Field Name="Index" Type="int"/>
   </Node>
+  <Node Name="BoundDagElementEvaluation" Base="BoundDagEvaluation">
+    <Field Name="Index" Type="int"/>
+    <Field Name="ElementType" Type="TypeSymbol"/>
+  </Node>
+  <Node Name="BoundDagEnumeratorEvaluation" Base="BoundDagEvaluation">
+    <Field Name="GetEnumeratorMethod" Type="MethodSymbol"/>
+    <Field Name="ElementType" Type="TypeSymbol"/>
+  </Node>
 
   <Node Name="BoundDagIndexerEvaluation" Base="BoundDagEvaluation" HasValidate="true">
     <Field Name="IndexerType" Type="TypeSymbol"/>
@@ -2275,9 +2283,15 @@
     <Field Name="IsExplicitNotNullTest" Type="bool"/>
   </Node>
 
-  <Node Name="BoundListPattern" Base="BoundObjectPattern" HasValidate="true">
+  <AbstractNode Name="BoundListPattern" Base="BoundObjectPattern">
     <Field Name="Subpatterns" Type="ImmutableArray&lt;BoundPattern&gt;" Null="disallow"/>
     <Field Name="HasSlice" Type="bool"/>
+  </AbstractNode>
+  <Node Name="BoundEnumerableListPattern" Base="BoundListPattern">
+    <Field Name="GetEnumeratorMethod" Type="MethodSymbol"/>
+    <Field Name="ElementType" Type="TypeSymbol"/>
+  </Node>
+  <Node Name="BoundIndexableListPattern" Base="BoundListPattern" HasValidate="true">
     <Field Name="LengthAccess" Type="BoundExpression?" SkipInVisitor="true"/>
 
     <!--

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowsOutWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowsOutWalker.cs
@@ -117,7 +117,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 switch (node.Kind)
                 {
-                    case BoundKind.ListPattern:
+                    case BoundKind.IndexableListPattern:
+                    case BoundKind.EnumerableListPattern:
                     case BoundKind.RecursivePattern:
                     case BoundKind.DeclarationPattern:
                         {

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DefiniteAssignment.cs
@@ -1447,7 +1447,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             switch (node.Kind)
             {
-                case BoundKind.ListPattern:
+                case BoundKind.IndexableListPattern:
+                case BoundKind.EnumerableListPattern:
                 case BoundKind.RecursivePattern:
                 case BoundKind.DeclarationPattern:
                     {
@@ -1845,7 +1846,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                             break;
                         }
-                    case BoundKind.ListPattern:
+                    case BoundKind.IndexableListPattern:
+                    case BoundKind.EnumerableListPattern:
                         {
                             var pat = (BoundListPattern)pattern;
                             foreach (BoundPattern p in pat.Subpatterns)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.DebugVerifier.cs
@@ -223,7 +223,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            public override BoundNode? VisitListPattern(BoundListPattern node)
+            public override BoundNode? VisitIndexableListPattern(BoundIndexableListPattern node)
+            {
+                return VisitListPattern(node);
+            }
+
+            public override BoundNode? VisitEnumerableListPattern(BoundEnumerableListPattern node)
+            {
+                return VisitListPattern(node);
+            }
+
+            private BoundNode? VisitListPattern(BoundListPattern node)
             {
                 VisitList(node.Subpatterns);
                 Visit(node.VariableAccess);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker_Patterns.cs
@@ -83,8 +83,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             Visit(node.Pattern);
             return null;
         }
+        
+        public override BoundNode VisitIndexableListPattern(BoundIndexableListPattern node)
+        {
+            return VisitListPattern(node);
+        }
 
-        public override BoundNode VisitListPattern(BoundListPattern node)
+        public override BoundNode VisitEnumerableListPattern(BoundEnumerableListPattern node)
+        {
+            return VisitListPattern(node);
+        }
+        
+        private BoundNode VisitListPattern(BoundListPattern node)
         {
             VisitAndUnsplitAll(node.Subpatterns);
             Visit(node.VariableAccess);
@@ -500,6 +510,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     }
                                 case BoundDagIndexEvaluation e:
                                     addTemp(e, e.Property.Type);
+                                    break;
+                                case BoundDagElementEvaluation e:
+                                    addTemp(e, this.compilation.GetSpecialType(SpecialType.System_Boolean), index: 0);
+                                    addTemp(e, e.ElementType, index: 1);
+                                    break;
+                                case BoundDagEnumeratorEvaluation e:
+                                    addTemp(e, e.GetEnumeratorMethod.ReturnType, index: 0);
+                                    addTemp(e, compilation.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_Buffer_T).Construct(e.ElementType), index: 1);
                                     break;
                                 case BoundDagIndexerEvaluation e:
                                     {

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -159,6 +159,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         DagFieldEvaluation,
         DagPropertyEvaluation,
         DagIndexEvaluation,
+        DagElementEvaluation,
+        DagEnumeratorEvaluation,
         DagIndexerEvaluation,
         DagSliceEvaluation,
         DagAssignmentEvaluation,
@@ -221,7 +223,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         DiscardPattern,
         DeclarationPattern,
         RecursivePattern,
-        ListPattern,
+        EnumerableListPattern,
+        IndexableListPattern,
         SlicePattern,
         ITuplePattern,
         PositionalSubpattern,
@@ -5254,6 +5257,69 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
+    internal sealed partial class BoundDagElementEvaluation : BoundDagEvaluation
+    {
+        public BoundDagElementEvaluation(SyntaxNode syntax, int index, TypeSymbol elementType, BoundDagTemp input, bool hasErrors = false)
+            : base(BoundKind.DagElementEvaluation, syntax, input, hasErrors || input.HasErrors())
+        {
+
+            RoslynDebug.Assert(elementType is object, "Field 'elementType' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(input is object, "Field 'input' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+
+            this.Index = index;
+            this.ElementType = elementType;
+        }
+
+        public int Index { get; }
+        public TypeSymbol ElementType { get; }
+
+        [DebuggerStepThrough]
+        public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitDagElementEvaluation(this);
+
+        public BoundDagElementEvaluation Update(int index, TypeSymbol elementType, BoundDagTemp input)
+        {
+            if (index != this.Index || !TypeSymbol.Equals(elementType, this.ElementType, TypeCompareKind.ConsiderEverything) || input != this.Input)
+            {
+                var result = new BoundDagElementEvaluation(this.Syntax, index, elementType, input, this.HasErrors);
+                result.CopyAttributes(this);
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundDagEnumeratorEvaluation : BoundDagEvaluation
+    {
+        public BoundDagEnumeratorEvaluation(SyntaxNode syntax, MethodSymbol getEnumeratorMethod, TypeSymbol elementType, BoundDagTemp input, bool hasErrors = false)
+            : base(BoundKind.DagEnumeratorEvaluation, syntax, input, hasErrors || input.HasErrors())
+        {
+
+            RoslynDebug.Assert(getEnumeratorMethod is object, "Field 'getEnumeratorMethod' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(elementType is object, "Field 'elementType' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(input is object, "Field 'input' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+
+            this.GetEnumeratorMethod = getEnumeratorMethod;
+            this.ElementType = elementType;
+        }
+
+        public MethodSymbol GetEnumeratorMethod { get; }
+        public TypeSymbol ElementType { get; }
+
+        [DebuggerStepThrough]
+        public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitDagEnumeratorEvaluation(this);
+
+        public BoundDagEnumeratorEvaluation Update(MethodSymbol getEnumeratorMethod, TypeSymbol elementType, BoundDagTemp input)
+        {
+            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(getEnumeratorMethod, this.GetEnumeratorMethod) || !TypeSymbol.Equals(elementType, this.ElementType, TypeCompareKind.ConsiderEverything) || input != this.Input)
+            {
+                var result = new BoundDagEnumeratorEvaluation(this.Syntax, getEnumeratorMethod, elementType, input, this.HasErrors);
+                result.CopyAttributes(this);
+                return result;
+            }
+            return this;
+        }
+    }
+
     internal sealed partial class BoundDagIndexerEvaluation : BoundDagEvaluation
     {
         public BoundDagIndexerEvaluation(SyntaxNode syntax, TypeSymbol indexerType, BoundDagTemp lengthTemp, int index, BoundExpression indexerAccess, BoundListPatternReceiverPlaceholder receiverPlaceholder, BoundListPatternIndexPlaceholder argumentPlaceholder, BoundDagTemp input, bool hasErrors = false)
@@ -7684,10 +7750,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal sealed partial class BoundListPattern : BoundObjectPattern
+    internal abstract partial class BoundListPattern : BoundObjectPattern
     {
-        public BoundListPattern(SyntaxNode syntax, ImmutableArray<BoundPattern> subpatterns, bool hasSlice, BoundExpression? lengthAccess, BoundExpression? indexerAccess, BoundListPatternReceiverPlaceholder? receiverPlaceholder, BoundListPatternIndexPlaceholder? argumentPlaceholder, Symbol? variable, BoundExpression? variableAccess, TypeSymbol inputType, TypeSymbol narrowedType, bool hasErrors = false)
-            : base(BoundKind.ListPattern, syntax, variable, variableAccess, inputType, narrowedType, hasErrors || subpatterns.HasErrors() || lengthAccess.HasErrors() || indexerAccess.HasErrors() || receiverPlaceholder.HasErrors() || argumentPlaceholder.HasErrors() || variableAccess.HasErrors())
+        protected BoundListPattern(BoundKind kind, SyntaxNode syntax, ImmutableArray<BoundPattern> subpatterns, bool hasSlice, Symbol? variable, BoundExpression? variableAccess, TypeSymbol inputType, TypeSymbol narrowedType, bool hasErrors = false)
+            : base(kind, syntax, variable, variableAccess, inputType, narrowedType, hasErrors)
         {
 
             RoslynDebug.Assert(!subpatterns.IsDefault, "Field 'subpatterns' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
@@ -7696,6 +7762,56 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             this.Subpatterns = subpatterns;
             this.HasSlice = hasSlice;
+        }
+
+        public ImmutableArray<BoundPattern> Subpatterns { get; }
+        public bool HasSlice { get; }
+    }
+
+    internal sealed partial class BoundEnumerableListPattern : BoundListPattern
+    {
+        public BoundEnumerableListPattern(SyntaxNode syntax, MethodSymbol getEnumeratorMethod, TypeSymbol elementType, ImmutableArray<BoundPattern> subpatterns, bool hasSlice, Symbol? variable, BoundExpression? variableAccess, TypeSymbol inputType, TypeSymbol narrowedType, bool hasErrors = false)
+            : base(BoundKind.EnumerableListPattern, syntax, subpatterns, hasSlice, variable, variableAccess, inputType, narrowedType, hasErrors || subpatterns.HasErrors() || variableAccess.HasErrors())
+        {
+
+            RoslynDebug.Assert(getEnumeratorMethod is object, "Field 'getEnumeratorMethod' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(elementType is object, "Field 'elementType' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(!subpatterns.IsDefault, "Field 'subpatterns' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(inputType is object, "Field 'inputType' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(narrowedType is object, "Field 'narrowedType' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+
+            this.GetEnumeratorMethod = getEnumeratorMethod;
+            this.ElementType = elementType;
+        }
+
+        public MethodSymbol GetEnumeratorMethod { get; }
+        public TypeSymbol ElementType { get; }
+
+        [DebuggerStepThrough]
+        public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitEnumerableListPattern(this);
+
+        public BoundEnumerableListPattern Update(MethodSymbol getEnumeratorMethod, TypeSymbol elementType, ImmutableArray<BoundPattern> subpatterns, bool hasSlice, Symbol? variable, BoundExpression? variableAccess, TypeSymbol inputType, TypeSymbol narrowedType)
+        {
+            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(getEnumeratorMethod, this.GetEnumeratorMethod) || !TypeSymbol.Equals(elementType, this.ElementType, TypeCompareKind.ConsiderEverything) || subpatterns != this.Subpatterns || hasSlice != this.HasSlice || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(variable, this.Variable) || variableAccess != this.VariableAccess || !TypeSymbol.Equals(inputType, this.InputType, TypeCompareKind.ConsiderEverything) || !TypeSymbol.Equals(narrowedType, this.NarrowedType, TypeCompareKind.ConsiderEverything))
+            {
+                var result = new BoundEnumerableListPattern(this.Syntax, getEnumeratorMethod, elementType, subpatterns, hasSlice, variable, variableAccess, inputType, narrowedType, this.HasErrors);
+                result.CopyAttributes(this);
+                return result;
+            }
+            return this;
+        }
+    }
+
+    internal sealed partial class BoundIndexableListPattern : BoundListPattern
+    {
+        public BoundIndexableListPattern(SyntaxNode syntax, BoundExpression? lengthAccess, BoundExpression? indexerAccess, BoundListPatternReceiverPlaceholder? receiverPlaceholder, BoundListPatternIndexPlaceholder? argumentPlaceholder, ImmutableArray<BoundPattern> subpatterns, bool hasSlice, Symbol? variable, BoundExpression? variableAccess, TypeSymbol inputType, TypeSymbol narrowedType, bool hasErrors = false)
+            : base(BoundKind.IndexableListPattern, syntax, subpatterns, hasSlice, variable, variableAccess, inputType, narrowedType, hasErrors || lengthAccess.HasErrors() || indexerAccess.HasErrors() || receiverPlaceholder.HasErrors() || argumentPlaceholder.HasErrors() || subpatterns.HasErrors() || variableAccess.HasErrors())
+        {
+
+            RoslynDebug.Assert(!subpatterns.IsDefault, "Field 'subpatterns' cannot be null (use Null=\"allow\" in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(inputType is object, "Field 'inputType' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+            RoslynDebug.Assert(narrowedType is object, "Field 'narrowedType' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
+
             this.LengthAccess = lengthAccess;
             this.IndexerAccess = indexerAccess;
             this.ReceiverPlaceholder = receiverPlaceholder;
@@ -7706,21 +7822,19 @@ namespace Microsoft.CodeAnalysis.CSharp
         [Conditional("DEBUG")]
         private partial void Validate();
 
-        public ImmutableArray<BoundPattern> Subpatterns { get; }
-        public bool HasSlice { get; }
         public BoundExpression? LengthAccess { get; }
         public BoundExpression? IndexerAccess { get; }
         public BoundListPatternReceiverPlaceholder? ReceiverPlaceholder { get; }
         public BoundListPatternIndexPlaceholder? ArgumentPlaceholder { get; }
 
         [DebuggerStepThrough]
-        public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitListPattern(this);
+        public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitIndexableListPattern(this);
 
-        public BoundListPattern Update(ImmutableArray<BoundPattern> subpatterns, bool hasSlice, BoundExpression? lengthAccess, BoundExpression? indexerAccess, BoundListPatternReceiverPlaceholder? receiverPlaceholder, BoundListPatternIndexPlaceholder? argumentPlaceholder, Symbol? variable, BoundExpression? variableAccess, TypeSymbol inputType, TypeSymbol narrowedType)
+        public BoundIndexableListPattern Update(BoundExpression? lengthAccess, BoundExpression? indexerAccess, BoundListPatternReceiverPlaceholder? receiverPlaceholder, BoundListPatternIndexPlaceholder? argumentPlaceholder, ImmutableArray<BoundPattern> subpatterns, bool hasSlice, Symbol? variable, BoundExpression? variableAccess, TypeSymbol inputType, TypeSymbol narrowedType)
         {
-            if (subpatterns != this.Subpatterns || hasSlice != this.HasSlice || lengthAccess != this.LengthAccess || indexerAccess != this.IndexerAccess || receiverPlaceholder != this.ReceiverPlaceholder || argumentPlaceholder != this.ArgumentPlaceholder || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(variable, this.Variable) || variableAccess != this.VariableAccess || !TypeSymbol.Equals(inputType, this.InputType, TypeCompareKind.ConsiderEverything) || !TypeSymbol.Equals(narrowedType, this.NarrowedType, TypeCompareKind.ConsiderEverything))
+            if (lengthAccess != this.LengthAccess || indexerAccess != this.IndexerAccess || receiverPlaceholder != this.ReceiverPlaceholder || argumentPlaceholder != this.ArgumentPlaceholder || subpatterns != this.Subpatterns || hasSlice != this.HasSlice || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(variable, this.Variable) || variableAccess != this.VariableAccess || !TypeSymbol.Equals(inputType, this.InputType, TypeCompareKind.ConsiderEverything) || !TypeSymbol.Equals(narrowedType, this.NarrowedType, TypeCompareKind.ConsiderEverything))
             {
-                var result = new BoundListPattern(this.Syntax, subpatterns, hasSlice, lengthAccess, indexerAccess, receiverPlaceholder, argumentPlaceholder, variable, variableAccess, inputType, narrowedType, this.HasErrors);
+                var result = new BoundIndexableListPattern(this.Syntax, lengthAccess, indexerAccess, receiverPlaceholder, argumentPlaceholder, subpatterns, hasSlice, variable, variableAccess, inputType, narrowedType, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -8618,6 +8732,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitDagPropertyEvaluation((BoundDagPropertyEvaluation)node, arg);
                 case BoundKind.DagIndexEvaluation:
                     return VisitDagIndexEvaluation((BoundDagIndexEvaluation)node, arg);
+                case BoundKind.DagElementEvaluation:
+                    return VisitDagElementEvaluation((BoundDagElementEvaluation)node, arg);
+                case BoundKind.DagEnumeratorEvaluation:
+                    return VisitDagEnumeratorEvaluation((BoundDagEnumeratorEvaluation)node, arg);
                 case BoundKind.DagIndexerEvaluation:
                     return VisitDagIndexerEvaluation((BoundDagIndexerEvaluation)node, arg);
                 case BoundKind.DagSliceEvaluation:
@@ -8742,8 +8860,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return VisitDeclarationPattern((BoundDeclarationPattern)node, arg);
                 case BoundKind.RecursivePattern:
                     return VisitRecursivePattern((BoundRecursivePattern)node, arg);
-                case BoundKind.ListPattern:
-                    return VisitListPattern((BoundListPattern)node, arg);
+                case BoundKind.EnumerableListPattern:
+                    return VisitEnumerableListPattern((BoundEnumerableListPattern)node, arg);
+                case BoundKind.IndexableListPattern:
+                    return VisitIndexableListPattern((BoundIndexableListPattern)node, arg);
                 case BoundKind.SlicePattern:
                     return VisitSlicePattern((BoundSlicePattern)node, arg);
                 case BoundKind.ITuplePattern:
@@ -8927,6 +9047,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual R VisitDagFieldEvaluation(BoundDagFieldEvaluation node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitDagPropertyEvaluation(BoundDagPropertyEvaluation node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitDagIndexEvaluation(BoundDagIndexEvaluation node, A arg) => this.DefaultVisit(node, arg);
+        public virtual R VisitDagElementEvaluation(BoundDagElementEvaluation node, A arg) => this.DefaultVisit(node, arg);
+        public virtual R VisitDagEnumeratorEvaluation(BoundDagEnumeratorEvaluation node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitDagIndexerEvaluation(BoundDagIndexerEvaluation node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitDagSliceEvaluation(BoundDagSliceEvaluation node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitDagAssignmentEvaluation(BoundDagAssignmentEvaluation node, A arg) => this.DefaultVisit(node, arg);
@@ -8989,7 +9111,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual R VisitDiscardPattern(BoundDiscardPattern node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitDeclarationPattern(BoundDeclarationPattern node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitRecursivePattern(BoundRecursivePattern node, A arg) => this.DefaultVisit(node, arg);
-        public virtual R VisitListPattern(BoundListPattern node, A arg) => this.DefaultVisit(node, arg);
+        public virtual R VisitEnumerableListPattern(BoundEnumerableListPattern node, A arg) => this.DefaultVisit(node, arg);
+        public virtual R VisitIndexableListPattern(BoundIndexableListPattern node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitSlicePattern(BoundSlicePattern node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitITuplePattern(BoundITuplePattern node, A arg) => this.DefaultVisit(node, arg);
         public virtual R VisitPositionalSubpattern(BoundPositionalSubpattern node, A arg) => this.DefaultVisit(node, arg);
@@ -9151,6 +9274,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual BoundNode? VisitDagFieldEvaluation(BoundDagFieldEvaluation node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitDagPropertyEvaluation(BoundDagPropertyEvaluation node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitDagIndexEvaluation(BoundDagIndexEvaluation node) => this.DefaultVisit(node);
+        public virtual BoundNode? VisitDagElementEvaluation(BoundDagElementEvaluation node) => this.DefaultVisit(node);
+        public virtual BoundNode? VisitDagEnumeratorEvaluation(BoundDagEnumeratorEvaluation node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitDagIndexerEvaluation(BoundDagIndexerEvaluation node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitDagSliceEvaluation(BoundDagSliceEvaluation node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitDagAssignmentEvaluation(BoundDagAssignmentEvaluation node) => this.DefaultVisit(node);
@@ -9213,7 +9338,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual BoundNode? VisitDiscardPattern(BoundDiscardPattern node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitDeclarationPattern(BoundDeclarationPattern node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitRecursivePattern(BoundRecursivePattern node) => this.DefaultVisit(node);
-        public virtual BoundNode? VisitListPattern(BoundListPattern node) => this.DefaultVisit(node);
+        public virtual BoundNode? VisitEnumerableListPattern(BoundEnumerableListPattern node) => this.DefaultVisit(node);
+        public virtual BoundNode? VisitIndexableListPattern(BoundIndexableListPattern node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitSlicePattern(BoundSlicePattern node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitITuplePattern(BoundITuplePattern node) => this.DefaultVisit(node);
         public virtual BoundNode? VisitPositionalSubpattern(BoundPositionalSubpattern node) => this.DefaultVisit(node);
@@ -9807,6 +9933,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Visit(node.Input);
             return null;
         }
+        public override BoundNode? VisitDagElementEvaluation(BoundDagElementEvaluation node)
+        {
+            this.Visit(node.Input);
+            return null;
+        }
+        public override BoundNode? VisitDagEnumeratorEvaluation(BoundDagEnumeratorEvaluation node)
+        {
+            this.Visit(node.Input);
+            return null;
+        }
         public override BoundNode? VisitDagIndexerEvaluation(BoundDagIndexerEvaluation node)
         {
             this.Visit(node.LengthTemp);
@@ -10122,7 +10258,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Visit(node.VariableAccess);
             return null;
         }
-        public override BoundNode? VisitListPattern(BoundListPattern node)
+        public override BoundNode? VisitEnumerableListPattern(BoundEnumerableListPattern node)
+        {
+            this.VisitList(node.Subpatterns);
+            this.Visit(node.VariableAccess);
+            return null;
+        }
+        public override BoundNode? VisitIndexableListPattern(BoundIndexableListPattern node)
         {
             this.VisitList(node.Subpatterns);
             this.Visit(node.VariableAccess);
@@ -11010,6 +11152,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
             return node.Update(node.Property, node.Index, input);
         }
+        public override BoundNode? VisitDagElementEvaluation(BoundDagElementEvaluation node)
+        {
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
+            TypeSymbol? elementType = this.VisitType(node.ElementType);
+            return node.Update(node.Index, elementType, input);
+        }
+        public override BoundNode? VisitDagEnumeratorEvaluation(BoundDagEnumeratorEvaluation node)
+        {
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
+            TypeSymbol? elementType = this.VisitType(node.ElementType);
+            return node.Update(node.GetEnumeratorMethod, elementType, input);
+        }
         public override BoundNode? VisitDagIndexerEvaluation(BoundDagIndexerEvaluation node)
         {
             BoundDagTemp lengthTemp = (BoundDagTemp)this.Visit(node.LengthTemp);
@@ -11428,17 +11582,26 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol? narrowedType = this.VisitType(node.NarrowedType);
             return node.Update(declaredType, node.DeconstructMethod, deconstruction, properties, node.IsExplicitNotNullTest, node.Variable, variableAccess, inputType, narrowedType);
         }
-        public override BoundNode? VisitListPattern(BoundListPattern node)
+        public override BoundNode? VisitEnumerableListPattern(BoundEnumerableListPattern node)
         {
             ImmutableArray<BoundPattern> subpatterns = this.VisitList(node.Subpatterns);
+            BoundExpression? variableAccess = (BoundExpression?)this.Visit(node.VariableAccess);
+            TypeSymbol? elementType = this.VisitType(node.ElementType);
+            TypeSymbol? inputType = this.VisitType(node.InputType);
+            TypeSymbol? narrowedType = this.VisitType(node.NarrowedType);
+            return node.Update(node.GetEnumeratorMethod, elementType, subpatterns, node.HasSlice, node.Variable, variableAccess, inputType, narrowedType);
+        }
+        public override BoundNode? VisitIndexableListPattern(BoundIndexableListPattern node)
+        {
             BoundExpression? lengthAccess = node.LengthAccess;
             BoundExpression? indexerAccess = node.IndexerAccess;
             BoundListPatternReceiverPlaceholder? receiverPlaceholder = node.ReceiverPlaceholder;
             BoundListPatternIndexPlaceholder? argumentPlaceholder = node.ArgumentPlaceholder;
+            ImmutableArray<BoundPattern> subpatterns = this.VisitList(node.Subpatterns);
             BoundExpression? variableAccess = (BoundExpression?)this.Visit(node.VariableAccess);
             TypeSymbol? inputType = this.VisitType(node.InputType);
             TypeSymbol? narrowedType = this.VisitType(node.NarrowedType);
-            return node.Update(subpatterns, node.HasSlice, lengthAccess, indexerAccess, receiverPlaceholder, argumentPlaceholder, node.Variable, variableAccess, inputType, narrowedType);
+            return node.Update(lengthAccess, indexerAccess, receiverPlaceholder, argumentPlaceholder, subpatterns, node.HasSlice, node.Variable, variableAccess, inputType, narrowedType);
         }
         public override BoundNode? VisitSlicePattern(BoundSlicePattern node)
         {
@@ -12955,6 +13118,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             return node.Update(property, node.Index, input);
         }
 
+        public override BoundNode? VisitDagElementEvaluation(BoundDagElementEvaluation node)
+        {
+            TypeSymbol elementType = GetUpdatedSymbol(node, node.ElementType);
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
+            return node.Update(node.Index, elementType, input);
+        }
+
+        public override BoundNode? VisitDagEnumeratorEvaluation(BoundDagEnumeratorEvaluation node)
+        {
+            MethodSymbol getEnumeratorMethod = GetUpdatedSymbol(node, node.GetEnumeratorMethod);
+            TypeSymbol elementType = GetUpdatedSymbol(node, node.ElementType);
+            BoundDagTemp input = (BoundDagTemp)this.Visit(node.Input);
+            return node.Update(getEnumeratorMethod, elementType, input);
+        }
+
         public override BoundNode? VisitDagIndexerEvaluation(BoundDagIndexerEvaluation node)
         {
             TypeSymbol indexerType = GetUpdatedSymbol(node, node.IndexerType);
@@ -13932,18 +14110,30 @@ namespace Microsoft.CodeAnalysis.CSharp
             return node.Update(declaredType, deconstructMethod, deconstruction, properties, node.IsExplicitNotNullTest, variable, variableAccess, inputType, narrowedType);
         }
 
-        public override BoundNode? VisitListPattern(BoundListPattern node)
+        public override BoundNode? VisitEnumerableListPattern(BoundEnumerableListPattern node)
         {
+            MethodSymbol getEnumeratorMethod = GetUpdatedSymbol(node, node.GetEnumeratorMethod);
+            TypeSymbol elementType = GetUpdatedSymbol(node, node.ElementType);
             Symbol? variable = GetUpdatedSymbol(node, node.Variable);
             TypeSymbol inputType = GetUpdatedSymbol(node, node.InputType);
             TypeSymbol narrowedType = GetUpdatedSymbol(node, node.NarrowedType);
             ImmutableArray<BoundPattern> subpatterns = this.VisitList(node.Subpatterns);
+            BoundExpression? variableAccess = (BoundExpression?)this.Visit(node.VariableAccess);
+            return node.Update(getEnumeratorMethod, elementType, subpatterns, node.HasSlice, variable, variableAccess, inputType, narrowedType);
+        }
+
+        public override BoundNode? VisitIndexableListPattern(BoundIndexableListPattern node)
+        {
+            Symbol? variable = GetUpdatedSymbol(node, node.Variable);
+            TypeSymbol inputType = GetUpdatedSymbol(node, node.InputType);
+            TypeSymbol narrowedType = GetUpdatedSymbol(node, node.NarrowedType);
             BoundExpression? lengthAccess = node.LengthAccess;
             BoundExpression? indexerAccess = node.IndexerAccess;
             BoundListPatternReceiverPlaceholder? receiverPlaceholder = node.ReceiverPlaceholder;
             BoundListPatternIndexPlaceholder? argumentPlaceholder = node.ArgumentPlaceholder;
+            ImmutableArray<BoundPattern> subpatterns = this.VisitList(node.Subpatterns);
             BoundExpression? variableAccess = (BoundExpression?)this.Visit(node.VariableAccess);
-            return node.Update(subpatterns, node.HasSlice, lengthAccess, indexerAccess, receiverPlaceholder, argumentPlaceholder, variable, variableAccess, inputType, narrowedType);
+            return node.Update(lengthAccess, indexerAccess, receiverPlaceholder, argumentPlaceholder, subpatterns, node.HasSlice, variable, variableAccess, inputType, narrowedType);
         }
 
         public override BoundNode? VisitSlicePattern(BoundSlicePattern node)
@@ -15344,6 +15534,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );
+        public override TreeDumperNode VisitDagElementEvaluation(BoundDagElementEvaluation node, object? arg) => new TreeDumperNode("dagElementEvaluation", null, new TreeDumperNode[]
+        {
+            new TreeDumperNode("index", node.Index, null),
+            new TreeDumperNode("elementType", node.ElementType, null),
+            new TreeDumperNode("input", null, new TreeDumperNode[] { Visit(node.Input, null) }),
+            new TreeDumperNode("hasErrors", node.HasErrors, null)
+        }
+        );
+        public override TreeDumperNode VisitDagEnumeratorEvaluation(BoundDagEnumeratorEvaluation node, object? arg) => new TreeDumperNode("dagEnumeratorEvaluation", null, new TreeDumperNode[]
+        {
+            new TreeDumperNode("getEnumeratorMethod", node.GetEnumeratorMethod, null),
+            new TreeDumperNode("elementType", node.ElementType, null),
+            new TreeDumperNode("input", null, new TreeDumperNode[] { Visit(node.Input, null) }),
+            new TreeDumperNode("hasErrors", node.HasErrors, null)
+        }
+        );
         public override TreeDumperNode VisitDagIndexerEvaluation(BoundDagIndexerEvaluation node, object? arg) => new TreeDumperNode("dagIndexerEvaluation", null, new TreeDumperNode[]
         {
             new TreeDumperNode("indexerType", node.IndexerType, null),
@@ -16013,14 +16219,27 @@ namespace Microsoft.CodeAnalysis.CSharp
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );
-        public override TreeDumperNode VisitListPattern(BoundListPattern node, object? arg) => new TreeDumperNode("listPattern", null, new TreeDumperNode[]
+        public override TreeDumperNode VisitEnumerableListPattern(BoundEnumerableListPattern node, object? arg) => new TreeDumperNode("enumerableListPattern", null, new TreeDumperNode[]
         {
+            new TreeDumperNode("getEnumeratorMethod", node.GetEnumeratorMethod, null),
+            new TreeDumperNode("elementType", node.ElementType, null),
             new TreeDumperNode("subpatterns", null, from x in node.Subpatterns select Visit(x, null)),
             new TreeDumperNode("hasSlice", node.HasSlice, null),
+            new TreeDumperNode("variable", node.Variable, null),
+            new TreeDumperNode("variableAccess", null, new TreeDumperNode[] { Visit(node.VariableAccess, null) }),
+            new TreeDumperNode("inputType", node.InputType, null),
+            new TreeDumperNode("narrowedType", node.NarrowedType, null),
+            new TreeDumperNode("hasErrors", node.HasErrors, null)
+        }
+        );
+        public override TreeDumperNode VisitIndexableListPattern(BoundIndexableListPattern node, object? arg) => new TreeDumperNode("indexableListPattern", null, new TreeDumperNode[]
+        {
             new TreeDumperNode("lengthAccess", null, new TreeDumperNode[] { Visit(node.LengthAccess, null) }),
             new TreeDumperNode("indexerAccess", null, new TreeDumperNode[] { Visit(node.IndexerAccess, null) }),
             new TreeDumperNode("receiverPlaceholder", null, new TreeDumperNode[] { Visit(node.ReceiverPlaceholder, null) }),
             new TreeDumperNode("argumentPlaceholder", null, new TreeDumperNode[] { Visit(node.ArgumentPlaceholder, null) }),
+            new TreeDumperNode("subpatterns", null, from x in node.Subpatterns select Visit(x, null)),
+            new TreeDumperNode("hasSlice", node.HasSlice, null),
             new TreeDumperNode("variable", node.Variable, null),
             new TreeDumperNode("variableAccess", null, new TreeDumperNode[] { Visit(node.VariableAccess, null) }),
             new TreeDumperNode("inputType", node.InputType, null),

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
@@ -67,6 +67,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         case BoundLeafDecisionDagNode n:
                             return n.Label == whenTrueLabel;
                         case BoundEvaluationDecisionDagNode e:
+                            // PROTOTYPE: Only if enumerator needs disposal
+                            if (e.Evaluation is BoundDagEnumeratorEvaluation)
+                                return false;
                             node = e.Next;
                             break;
                         case BoundTestDecisionDagNode t:

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -237,8 +237,8 @@ namespace Microsoft.CodeAnalysis.Operations
                     return CreateBoundTypePatternOperation((BoundTypePattern)boundNode);
                 case BoundKind.SlicePattern:
                     return CreateBoundSlicePatternOperation((BoundSlicePattern)boundNode);
-                case BoundKind.ListPattern:
-                    return CreateBoundListPatternOperation((BoundListPattern)boundNode);
+                case BoundKind.IndexableListPattern:
+                    return CreateBoundListPatternOperation((BoundIndexableListPattern)boundNode);
                 case BoundKind.SwitchStatement:
                     return CreateBoundSwitchStatementOperation((BoundSwitchStatement)boundNode);
                 case BoundKind.SwitchLabel:
@@ -2498,7 +2498,7 @@ namespace Microsoft.CodeAnalysis.Operations
                 isImplicit: boundNode.WasCompilerGenerated);
         }
 
-        private IOperation CreateBoundListPatternOperation(BoundListPattern boundNode)
+        private IOperation CreateBoundListPatternOperation(BoundIndexableListPattern boundNode)
         {
             return new ListPatternOperation(
                 lengthSymbol: Binder.GetPropertySymbol(boundNode.LengthAccess, out _, out _).GetPublicSymbol(),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -633,6 +633,7 @@ namespace System
                     case WellKnownType.System_Runtime_CompilerServices_CompilerFeatureRequiredAttribute:
                     case WellKnownType.System_Diagnostics_CodeAnalysis_UnscopedRefAttribute:
                     case WellKnownType.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute:
+                    case WellKnownType.System_Runtime_CompilerServices_Buffer_T:
                         // Not yet in the platform.
                         continue;
                     case WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation:
@@ -1001,6 +1002,8 @@ namespace System
                     case WellKnownMember.System_Diagnostics_CodeAnalysis_UnscopedRefAttribute__ctor:
                     case WellKnownMember.System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute__ctor:
                     case WellKnownMember.System_Runtime_CompilerServices_RuntimeHelpers__CreateSpanRuntimeFieldHandle:
+                    case WellKnownMember.System_Runtime_CompilerServices_Buffer_T__ctor:
+                    case WellKnownMember.System_Runtime_CompilerServices_Buffer_T__TryGetElementAt:
                         // Not yet in the platform.
                         continue;
                     case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayloadForMethodsSpanningSingleFile:

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -536,6 +536,10 @@ namespace Microsoft.CodeAnalysis
         System_MissingMethodException__ctor,
         System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute__ctor,
 
+        System_Runtime_CompilerServices_Buffer_T__ctor,
+        // PROTOTYPE: Split into TryGetFromStart/TryGetFromEnd
+        System_Runtime_CompilerServices_Buffer_T__TryGetElementAt,
+
         Count
 
         // Remember to update the AllWellKnownTypeMembers tests when making changes here

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -3679,6 +3679,27 @@ namespace Microsoft.CodeAnalysis
                     1,                                                                                                                       // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,                                                       // Return Type
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Type,
+
+                // System_Runtime_CompilerServices_Buffer_T__ctor
+                (byte)MemberFlags.Constructor,                                                                                               // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_Buffer_T - WellKnownType.ExtSentinel), // DeclaringTypeId
+                0,                                                                                                                           // Arity
+                    1,                                                                                                                       // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,                                                       // Return Type
+                    (byte)SignatureTypeCode.GenericTypeInstance,
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Collections_Generic_IEnumerator_T,
+                    1,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,
+                    // PROTOTYPE: int/Span<T> bufferFromStart, int/Span<T> bufferFromEnd
+
+                // System_Runtime_CompilerServices_Buffer_T__TryGetElementAt
+                (byte)MemberFlags.Method,                                                                                                    // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_Buffer_T - WellKnownType.ExtSentinel), // DeclaringTypeId
+                0,                                                                                                                           // Arity
+                    2,                                                                                                                       // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean,                                                    // Return Type
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
+                    (byte)SignatureTypeCode.ByReference, (byte)SignatureTypeCode.GenericTypeParameter, 0,
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -4139,6 +4160,8 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_Diagnostics_CodeAnalysis_UnscopedRefAttribute__ctor
                 ".ctor",                                    // System_MissingMethodException__ctor
                 ".ctor",                                    // System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute
+                ".ctor",                                    // System_Runtime_CompilerServices_Buffer_T__ctor
+                "TryGetElementAt",                          // System_Runtime_CompilerServices_Buffer_T__TryGetElementAt
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -329,6 +329,9 @@ namespace Microsoft.CodeAnalysis
         System_MissingMethodException,
         System_Runtime_CompilerServices_MetadataUpdateOriginalTypeAttribute,
 
+        // PROTOTYPE: Should probably embedded into the compilation
+        System_Runtime_CompilerServices_Buffer_T,
+
         NextAvailable,
         // Remember to update the AllWellKnownTypes tests when making changes here
     }
@@ -346,7 +349,7 @@ namespace Microsoft.CodeAnalysis
         /// that we could use ids to index into the array
         /// </summary>
         /// <remarks></remarks>
-        private static readonly string[] s_metadataNames = new string[]
+        private static readonly string[] s_metadataNames = new string[Count]
         {
             "System.Math",
             "System.Array",
@@ -647,6 +650,7 @@ namespace Microsoft.CodeAnalysis
             "System.Diagnostics.CodeAnalysis.UnscopedRefAttribute",
             "System.MissingMethodException",
             "System.Runtime.CompilerServices.MetadataUpdateOriginalTypeAttribute",
+            "System.Runtime.CompilerServices.Buffer`1"
         };
 
         private static readonly Dictionary<string, WellKnownType> s_nameToTypeIdMap = new Dictionary<string, WellKnownType>((int)Count);


### PR DESCRIPTION
This deviates from the [draft spec](https://github.com/dotnet/csharplang/blob/main/proposals/list-patterns-enumerables.md) in a few ways, in particular:

- Removal of `Last()`: a negated test for the next index is used instead. As a plus, the result can be used elsewhere.
- Removal of `Count()`: we use a `Try` method for trailing elements as well which includes the count check.

This should fairly simplify the analysis for subsumption checking, explainer, etc.

Note: this only covers `IEnumerable<T>` at the moment.