### PR TITLE
Do not restrict field locations to the same document for "Replace with autoproperty" refactoring

### DIFF
--- a/src/EditorFeatures/Test2/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/UseAutoProperty/UseAutoPropertyTests.vb
@@ -145,5 +145,100 @@ partial class C
                     Next
                 End Function)
         End Function
+
+        <Fact, WorkItem(66320, "https://github.com/dotnet/roslyn/issues/66320")>
+        Public Async Function TestChangeReferencesInMultipleFiles_CSharp() As Task
+            Dim input =
+                <Workspace>
+                    <Project Language='C#' AssemblyName='CSharpAssembly1' CommonReferences='true'>
+                        <Document FilePath='Test1.cs'>
+partial class C
+{
+    private int test = 0;
+
+    public int $$TestProp { get => test; set => test = value; }
+}
+                        </Document>
+                        <Document FilePath='Test2.cs'>
+partial class C
+{
+    private void Bla()
+    {
+        Console.WriteLine(test);
+    }
+}
+                        </Document>
+                    </Project>
+                </Workspace>
+
+            Await TestAsync(input, fileNameToExpected:=
+                 New Dictionary(Of String, String) From {
+                    {"Test1.cs",
+<text>
+partial class C
+{
+    public int TestProp { get; set; } = 0;
+}
+</text>.Value.Trim()},
+                    {"Test2.cs",
+<text>
+partial class C
+{
+    private void Bla()
+    {
+        Console.WriteLine(TestProp);
+    }
+}
+</text>.Value.Trim()}
+                })
+        End Function
+
+        <Fact>
+        Public Async Function TestChangeReferencesInMultipleFiles_VisualBasic() As Task
+            Dim input =
+                <Workspace>
+                    <Project Language='Visual Basic' AssemblyName='CSharpAssembly1' CommonReferences='true'>
+                        <Document FilePath='Test1.vb'>
+partial class C
+    dim $$test as Integer
+
+    property TestProp as Integer
+        get
+            return test
+        end get
+        set(value as Integer)
+            test = value
+        end set
+    end property
+end class
+                        </Document>
+                        <Document FilePath='Test2.vb'>
+partial class C
+    private sub Bla()
+        Console.WriteLine(test)
+    end sub
+end class
+                        </Document>
+                    </Project>
+                </Workspace>
+
+            Await TestAsync(input, fileNameToExpected:=
+                 New Dictionary(Of String, String) From {
+                    {"Test1.vb",
+<text>
+partial class C
+    property TestProp as Integer
+end class
+</text>.Value.Trim()},
+                    {"Test2.vb",
+<text>
+partial class C
+    private sub Bla()
+        Console.WriteLine(TestProp)
+    end sub
+end class
+</text>.Value.Trim()}
+                })
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
@@ -18,7 +18,6 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.Rename;
-using Microsoft.CodeAnalysis.Rename.ConflictEngine;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -133,7 +132,6 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
 
             var filteredLocations = fieldLocations.Filter(
                 (documentId, span) =>
-                    fieldDocument.Id == documentId &&
                     !span.IntersectsWith(declaratorLocation.SourceSpan) &&
                     CanEditDocument(solution, documentId, linkedFiles, canEdit));
 

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
 
             var filteredLocations = fieldLocations.Filter(
                 (documentId, span) =>
-                    !span.IntersectsWith(declaratorLocation.SourceSpan) &&
+                    fieldDocument.Id == documentId ? !span.IntersectsWith(declaratorLocation.SourceSpan) : true && // The span check only makes sense if we are in the same file
                     CanEditDocument(solution, documentId, linkedFiles, canEdit));
 
             var resolution = await filteredLocations.ResolveConflictsAsync(


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/66320