### PR TITLE
Don't overwrite binary logs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -222,13 +222,13 @@ stages:
         displayName: Restore
         inputs:
           filePath: eng/build.ps1
-          arguments: -configuration Release -prepareMachine -ci -restore -binaryLog
+          arguments: -configuration Release -prepareMachine -ci -restore -binaryLogName Restore.binlog 
 
       - task: PowerShell@2
         displayName: Build
         inputs:
           filePath: eng/build.ps1
-          arguments: -configuration Release -prepareMachine -ci -build -pack -publish -sign -binaryLog
+          arguments: -configuration Release -prepareMachine -ci -build -pack -publish -sign -binaryLogName Build.binlog
 
       - script: $(Build.SourcesDirectory)\artifacts\bin\BuildBoss\Release\net472\BuildBoss.exe  -r "$(Build.SourcesDirectory)/" -c Release -p Roslyn.sln
         displayName: Validate Build Artifacts
@@ -326,7 +326,7 @@ stages:
         displayName: Restore
         inputs:
           filePath: eng/build.ps1
-          arguments: -configuration Debug -prepareMachine -ci -restore -binaryLog
+          arguments: -configuration Debug -prepareMachine -ci -restore -binaryLogName Restore.binlog
 
       - powershell: .\eng\test-rebuild.ps1 -ci -configuration Release
         displayName: Run BuildValidator

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,7 +207,7 @@ stages:
           - src/Compilers/*
           - src/Dependencies/*
 
-  - job: Correctness_Build_Artifacts
+ - job: Correctness_Build_Artifacts
     dependsOn: Determine_Changes
     pool:
       name: NetCore-Public

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,7 +207,7 @@ stages:
           - src/Compilers/*
           - src/Dependencies/*
 
- - job: Correctness_Build_Artifacts
+  - job: Correctness_Build_Artifacts
     dependsOn: Determine_Changes
     pool:
       name: NetCore-Public

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -710,6 +710,8 @@ try {
     exit 1
   }
 
+  Set-PSDebug -Trace 1
+
   $regKeyProperty = Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem -Name "LongPathsEnabled" -ErrorAction Ignore
   if (($null -eq $regKeyProperty) -or ($regKeyProperty.LongPathsEnabled -ne 1)) {
     Write-Host "LongPath is not enabled, you may experience build errors. You can avoid these by enabling LongPath with `"reg ADD HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1`""

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -259,8 +259,11 @@ function BuildSolution() {
   $generateDocumentationFile = if ($skipDocumentation) { "/p:GenerateDocumentationFile=false" } else { "" }
   $roslynUseHardLinks = if ($ci) { "/p:ROSLYNUSEHARDLINKS=true" } else { "" }
 
-  # temp disable RestoreUseStaticGraphEvaluation to work around this NuGet issue 
+  # Temporarily disable RestoreUseStaticGraphEvaluation to work around this NuGet issue 
+  # in our CI builds
   # https://github.com/NuGet/Home/issues/12373
+  $restoreUseStaticGraphEvaluation = if ($ci) { $false } else { $true }
+
   try {
     MSBuild $toolsetBuildProj `
       $bl `
@@ -280,7 +283,7 @@ function BuildSolution() {
       /p:TreatWarningsAsErrors=$warnAsError `
       /p:EnableNgenOptimization=$applyOptimizationData `
       /p:IbcOptimizationDataDir=$ibcDir `
-      /p:RestoreUseStaticGraphEvaluation=false `
+      /p:RestoreUseStaticGraphEvaluation=$restoreUseStaticGraphEvaluation `
       /p:VisualStudioIbcDrop=$ibcDropName `
       /p:VisualStudioDropAccessToken=$officialVisualStudioDropAccessToken `
       $suppressExtensionDeployment `

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -776,7 +776,7 @@ try {
   catch
   {
     if ($ci) {
-      Write-LogIssue -Type "error" -Message "(NETCORE_ENGINEERING_TELEMETRY=Build) Tests failed"
+      Write-LogIssue -Type "error" -Message "(NETCORE_ENGINEERING_TELEMETRY=Test) Tests failed"
     }
     throw $_
   }

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -224,15 +224,13 @@ function BuildSolution() {
   Write-Host "$($solution):"
 
   $bl = ""
-  if (binaryLog) {
+  if ($binaryLog) {
     $binaryLogPath = Join-Path $LogDir $binaryLogName
     $bl = "/bl:" + $binaryLogPath
-    if ($ci -and Test-Path $binaryLogPath) {
+    if ($ci -and (Test-Path $binaryLogPath)) {
       Write-LogIssue -Type "warning" -Message "Overwriting binary log file $($binaryLogPath)"
     }
-
   }
-  $bl = if ($binaryLog) { "/bl:" + (Join-Path $LogDir $binaryLogName) } else { "" }
 
   if ($buildServerLog) {
     ${env:ROSLYNCOMMANDLINELOGFILE} = Join-Path $LogDir "Build.Server.log"

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -259,6 +259,8 @@ function BuildSolution() {
   $generateDocumentationFile = if ($skipDocumentation) { "/p:GenerateDocumentationFile=false" } else { "" }
   $roslynUseHardLinks = if ($ci) { "/p:ROSLYNUSEHARDLINKS=true" } else { "" }
 
+  # temp disable RestoreUseStaticGraphEvaluation to work around this NuGet issue 
+  # https://github.com/NuGet/Home/issues/12373
   try {
     MSBuild $toolsetBuildProj `
       $bl `
@@ -278,7 +280,7 @@ function BuildSolution() {
       /p:TreatWarningsAsErrors=$warnAsError `
       /p:EnableNgenOptimization=$applyOptimizationData `
       /p:IbcOptimizationDataDir=$ibcDir `
-      /p:RestoreUseStaticGraphEvaluation=true `
+      /p:RestoreUseStaticGraphEvaluation=false `
       /p:VisualStudioIbcDrop=$ibcDropName `
       /p:VisualStudioDropAccessToken=$officialVisualStudioDropAccessToken `
       $suppressExtensionDeployment `
@@ -709,8 +711,6 @@ try {
     Write-Host "PowerShell version must be 5 or greater (version $($PSVersionTable.PSVersion) detected)"
     exit 1
   }
-
-  Set-PSDebug -Trace 1
 
   $regKeyProperty = Get-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem -Name "LongPathsEnabled" -ErrorAction Ignore
   if (($null -eq $regKeyProperty) -or ($regKeyProperty.LongPathsEnabled -ne 1)) {

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -180,7 +180,7 @@ function Process-Arguments() {
   }
 
   if ($binaryLog -and ($binaryLogName -eq "")) {
-    $binaryLogName = "Build.binlog"
+    $script:binaryLogName = "Build.binlog"
   }
 
   $anyUnit = $testDesktop -or $testCoreClr


### PR DESCRIPTION
Several of our legs were calling `build.ps1 -binaryLog` in a row and that re-uses the binary log file name which causes an overwrite. This change allows us to specify the name and adds a warning if we do accidentally overwrite in the future.