### PR TITLE
Update Project.HasSuccessfullyLoadedAsync logic

### DIFF
--- a/src/Analyzers/VisualBasic/Tests/UnsealClass/UnsealClassTests.vb
+++ b/src/Analyzers/VisualBasic/Tests/UnsealClass/UnsealClassTests.vb
@@ -143,7 +143,7 @@ end class")
         Public Async Function RemovedFromAllPartialClassDeclarationsAcrossFiles() As Task
             Await TestInRegularAndScriptAsync(
 <Workspace>
-    <Project Language="Visual Basic">
+    <Project Language="Visual Basic" CommonReferences="true">
         <Document>
 partial public notinheritable class C
 end class
@@ -162,7 +162,7 @@ end class
     </Project>
 </Workspace>.ToString(),
 <Workspace>
-    <Project Language="Visual Basic">
+    <Project Language="Visual Basic" CommonReferences="true">
         <Document>
 partial public class C
 end class

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateType/GenerateTypeTests.cs
@@ -5414,7 +5414,7 @@ new TestParameters(options: Option(CodeStyleOptions2.FileHeaderTemplate, "I am a
             await TestInRegularAndScriptAsync(
     $@"
 <Workspace>
-    <Project Language=""C#"" CommonReferences=""false"">
+    <Project Language=""C#"" CommonReferencesMinCorlib=""true"">
         <Document><![CDATA[
 class C
 {{
@@ -5446,9 +5446,9 @@ class C
 
 internal class Class
 {{
-    private global::System.Object method;
+    private object method;
 
-    public Class(global::System.Object method)
+    public Class(object method)
     {{
         this.method = method;
     }}

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UpgradeProject/UpgradeProjectTests.cs
@@ -362,7 +362,7 @@ class Program
         {
             await TestLanguageVersionUpgradedAsync(
 @"<Workspace>
-    <Project Language=""C#"" LanguageVersion=""6"">
+    <Project Language=""C#"" LanguageVersion=""6"" CommonReferences=""true"">
         <Document>
 class C
 {
@@ -373,9 +373,9 @@ class C
 }
         </Document>
     </Project>
-    <Project Language=""C#"" LanguageVersion=""6"">
+    <Project Language=""C#"" LanguageVersion=""6"" CommonReferences=""true"">
     </Project>
-    <Project Language=""C#"" LanguageVersion=""7"">
+    <Project Language=""C#"" LanguageVersion=""7"" CommonReferences=""true"">
     </Project>
     <Project Language=""Visual Basic"">
     </Project>
@@ -390,7 +390,7 @@ class C
         {
             await TestLanguageVersionUpgradedAsync(
 @"<Workspace>
-    <Project Language=""C#"" LanguageVersion=""6"">
+    <Project Language=""C#"" LanguageVersion=""6"" CommonReferences=""true"">
         <Document>
 class C
 {
@@ -398,11 +398,11 @@ class C
 }
         </Document>
     </Project>
-    <Project Language=""C#"" LanguageVersion=""6"">
+    <Project Language=""C#"" LanguageVersion=""6"" CommonReferences=""true"">
     </Project>
-    <Project Language=""C#"" LanguageVersion=""7"">
+    <Project Language=""C#"" LanguageVersion=""7"" CommonReferences=""true"">
     </Project>
-    <Project Language=""Visual Basic"">
+    <Project Language=""Visual Basic"" CommonReferences=""true"">
     </Project>
 </Workspace>",
                 LanguageVersion.CSharp8,
@@ -444,18 +444,18 @@ class C
         {
             await TestLanguageVersionUpgradedAsync(
 @"<Workspace>
-    <Project Language=""C#"" LanguageVersion=""6"">
+    <Project Language=""C#"" LanguageVersion=""6"" CommonReferences=""true"">
         <Document>
 [|System.Console.WriteLine();|]
         </Document>
     </Project>
-    <Project Language=""C#"" LanguageVersion=""6"">
+    <Project Language=""C#"" LanguageVersion=""6"" CommonReferences=""true"">
     </Project>
-    <Project Language=""C#"" LanguageVersion=""7"">
+    <Project Language=""C#"" LanguageVersion=""7"" CommonReferences=""true"">
     </Project>
-    <Project Language=""C#"" LanguageVersion=""8"">
+    <Project Language=""C#"" LanguageVersion=""8"" CommonReferences=""true"">
     </Project>
-    <Project Language=""Visual Basic"">
+    <Project Language=""Visual Basic"" CommonReferences=""true"">
     </Project>
 </Workspace>",
                 LanguageVersion.CSharp9,
@@ -469,7 +469,7 @@ class C
             await TestExactActionSetOfferedAsync(
 
 @"<Workspace>
-    <Project Language=""C#"" LanguageVersion=""6"">
+    <Project Language=""C#"" LanguageVersion=""6"" CommonReferences=""true"">
         <Document>
 class C
 {
@@ -480,9 +480,9 @@ class C
 }
         </Document>
     </Project>
-    <Project Language=""C#"" LanguageVersion=""7"">
+    <Project Language=""C#"" LanguageVersion=""7"" CommonReferences=""true"">
     </Project>
-    <Project Language=""C#"" LanguageVersion=""6"">
+    <Project Language=""C#"" LanguageVersion=""6"" CommonReferences=""true"">
     </Project>
 </Workspace>",
                 new[] {
@@ -527,7 +527,7 @@ class C
             await TestExactActionSetOfferedAsync(
 
 @"<Workspace>
-    <Project Language=""C#"" LanguageVersion=""6"">
+    <Project Language=""C#"" LanguageVersion=""6"" CommonReferences=""true"">
         <Document>
 class C
 {
@@ -538,7 +538,7 @@ class C
 }
         </Document>
     </Project>
-    <Project Language=""Visual Basic"">
+    <Project Language=""Visual Basic"" CommonReferences=""true"">
     </Project>
 </Workspace>",
                 new[] {
@@ -552,7 +552,7 @@ class C
             await TestExactActionSetOfferedAsync(
 
 @"<Workspace>
-    <Project Language=""C#"" LanguageVersion=""6"">
+    <Project Language=""C#"" LanguageVersion=""6"" CommonReferences=""true"">
         <Document>
 class C
 {
@@ -563,9 +563,9 @@ class C
 }
         </Document>
     </Project>
-    <Project Language=""C#"" LanguageVersion=""7"">
+    <Project Language=""C#"" LanguageVersion=""7"" CommonReferences=""true"">
     </Project>
-    <Project Language=""Visual Basic"">
+    <Project Language=""Visual Basic"" CommonReferences=""true"">
     </Project>
 </Workspace>",
                 new[] {
@@ -608,7 +608,7 @@ class C
             await TestExactActionSetOfferedAsync(
 
 @"<Workspace>
-    <Project Language=""C#"" LanguageVersion=""6"">
+    <Project Language=""C#"" LanguageVersion=""6"" CommonReferences=""true"">
         <Document>
 class C
 {
@@ -616,9 +616,9 @@ class C
 }
         </Document>
     </Project>
-    <Project Language=""C#"" LanguageVersion=""8"">
+    <Project Language=""C#"" LanguageVersion=""8"" CommonReferences=""true"">
     </Project>
-    <Project Language=""Visual Basic"">
+    <Project Language=""Visual Basic"" CommonReferences=""true"">
     </Project>
 </Workspace>",
             new[] {

--- a/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateConstructor/GenerateConstructorTests.cs
@@ -3639,7 +3639,7 @@ class P {
             await TestInRegularAndScriptAsync(
     $@"
 <Workspace>
-    <Project Language=""C#"" CommonReferences=""false"">
+    <Project Language=""C#"" CommonReferencesMinCorlib=""true"">
         <Document><![CDATA[
 class C
 {{
@@ -3675,9 +3675,9 @@ class C
 
 internal class Class
 {{
-    private global::System.Object method;
+    private object method;
 
-    public Class(global::System.Object method)
+    public Class(object method)
     {{
         this.method = method;
     }}

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
@@ -54,6 +54,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         private const string CommonReferencesNetCoreAppName = "CommonReferencesNetCoreApp";
         private const string CommonReferencesNet6Name = "CommonReferencesNet6";
         private const string CommonReferencesNetStandard20Name = "CommonReferencesNetStandard20";
+        private const string CommonReferencesMinCorlibName = "CommonReferencesMinCorlib";
         private const string ReferencesOnDiskAttributeName = "ReferencesOnDisk";
         private const string FilePathAttributeName = "FilePath";
         private const string FoldersAttributeName = "Folders";

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -1117,6 +1117,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 references = TargetFrameworkUtil.GetReferences(TargetFramework.Net60).ToList();
             }
 
+            var mincorlib = element.Attribute(CommonReferencesMinCorlibName);
+            if (mincorlib != null &&
+                ((bool?)mincorlib).HasValue &&
+                ((bool?)mincorlib).Value)
+            {
+                references = new List<MetadataReference> { TestBase.MinCorlibRef };
+            }
+
             return references;
         }
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
@@ -4408,7 +4408,7 @@ End Namespace")
         Public Async Function TestAcrossFiles() As Task
             Await TestInRegularAndScriptAsync(
 "<Workspace>
-    <Project Language=""Visual Basic"">
+    <Project Language=""Visual Basic"" CommonReferences=""true"">
         <Document>
 Public Class DataContainer
     Property PossibleInProcessTests As string
@@ -4462,6 +4462,7 @@ Public Class DataContainer
     End Sub
 
     Friend Sub ArbitraryPositionMethod()
+        Throw New NotImplementedException()
     End Sub
 
     Function Bazz() As Object

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.CompilationTracker.cs
@@ -703,8 +703,13 @@ namespace Microsoft.CodeAnalysis
             {
                 try
                 {
-                    // if HasAllInformation is false, then this project is always not completed.
-                    var hasSuccessfullyLoaded = this.ProjectState.HasAllInformation;
+                    // Project is complete only if the following are all true:
+                    //  1. HasAllInformation flag is set for the project
+                    //  2. Either the project has non-zero metadata references OR this is the corlib project.
+                    //     For the latter, we use a heuristic if the underlying compilation defines "System.Object" type.
+                    var hasSuccessfullyLoaded = this.ProjectState.HasAllInformation &&
+                        (this.ProjectState.MetadataReferences.Count > 0 ||
+                         compilationWithoutGenerators.GetTypeByMetadataName("System.Object") != null);
 
                     var newReferences = new List<MetadataReference>();
                     var metadataReferenceToProjectId = new Dictionary<MetadataReference, ProjectId>();


### PR DESCRIPTION
Fixes [AB#1674516](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1674516)
Fixes [AB#1710989](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1710989)
Fixes [AB#1665787](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1665787)
 Fixes spurious missing corlib types errors in the error list on loading any decently large solution, such as Roslyn.sln itself. These errors stay in the error list for few seconds before metadata references get added to the project

Our current logic in the CompilationTracker to determine `hasSuccessfullyLoaded` for the project relies on the `ProjectState.HasAllInformation` flag to determine if the project has loaded successfully. Additionally, we try to convert the project references to metadata references, and failing such a conversion, we reset `hasSuccessfullyLoaded` to false. However, there seem to be cases during project load where `ProjectState.HasAllInformation` is true, but metadata references haven't yet been added to the project, leading to hundreds of spurious missing type errors for corlib types such as object, int, string, etc.

This PR updates the logic for `hasSuccessfullyLoaded` to also check if the project either has non-zero metadata references or is the corlib itself (defines `System.Object`). I confirmed that this fixes all the repro cases/bugs cited above. I no longer see any spurious errors in the error list or squiggles in the editor for all these scenarios.