### PR TITLE
Warn for calls in top-level statements that could be awaited

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
@@ -123,8 +123,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            return GetAwaitableExpressionInfo(expression,
-                getAwaiterArgument: new BoundAwaitableValuePlaceholder(syntax, expression.Type),
+            return GetAwaitableExpressionInfo(expression, getAwaiterGetResultCall: out _,
                 node: syntax, diagnostics: BindingDiagnosticBag.Discarded);
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
@@ -125,7 +125,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return GetAwaitableExpressionInfo(expression,
                 getAwaiterArgument: new BoundAwaitableValuePlaceholder(syntax, expression.Type),
-                isDynamic: out _, getAwaiter: out _, isCompleted: out _, getResult: out _, getAwaiterGetResultCall: out _,
                 node: syntax, diagnostics: BindingDiagnosticBag.Discarded);
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
@@ -131,7 +131,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 #pragma warning disable format
                     return bag.DiagnosticBag.AsEnumerableWithoutResolution().All(d =>
                         d.Severity != DiagnosticSeverity.Error ||
-                        d is { Code: (int)ErrorCode.ERR_BadAwaitWithoutAsync or (int)ErrorCode.ERR_BadAwaitWithoutVoidAsyncMethod });
+                        d is { Code: (int)ErrorCode.ERR_BadAwaitWithoutAsync or
+                            (int)ErrorCode.ERR_BadAwaitWithoutVoidAsyncMethod or
+                            (int)ErrorCode.ERR_BadAwaitWithoutAsyncMethod });
 #pragma warning restore format
                 }
                 finally

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
@@ -123,8 +123,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            var placeholder = new BoundAwaitableValuePlaceholder(syntax, expression.Type);
-            return GetAwaitableExpressionInfo(expression: placeholder, getAwaiterArgument: placeholder,
+            return GetAwaitableExpressionInfo(expression,
+                getAwaiterArgument: new BoundAwaitableValuePlaceholder(syntax, expression.Type),
                 isDynamic: out _, getAwaiter: out _, isCompleted: out _, getResult: out _, getAwaiterGetResultCall: out _,
                 node: syntax, diagnostics: BindingDiagnosticBag.Discarded);
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
@@ -25,12 +25,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return BindAwait(expression, node, diagnostics);
         }
 
-        private BoundAwaitExpression BindAwait(BoundExpression expression, SyntaxNode node, BindingDiagnosticBag diagnostics)
+        private BoundAwaitExpression BindAwait(BoundExpression expression, SyntaxNode node, BindingDiagnosticBag diagnostics,
+            bool skipAsyncContextCheck = false)
         {
             bool hasErrors = false;
             var placeholder = new BoundAwaitableValuePlaceholder(expression.Syntax, expression.Type);
 
-            ReportBadAwaitDiagnostics(node, node.Location, diagnostics, ref hasErrors);
+            ReportBadAwaitDiagnostics(node, node.Location, diagnostics, ref hasErrors, skipAsyncContextCheck);
             var info = BindAwaitInfo(placeholder, node, diagnostics, ref hasErrors, expressionOpt: expression);
 
             // Spec 7.7.7.2:
@@ -42,9 +43,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundAwaitExpression(node, expression, info, awaitExpressionType, hasErrors);
         }
 
-        internal void ReportBadAwaitDiagnostics(SyntaxNode node, Location location, BindingDiagnosticBag diagnostics, ref bool hasErrors)
+        internal void ReportBadAwaitDiagnostics(SyntaxNode node, Location location, BindingDiagnosticBag diagnostics,
+            ref bool hasErrors, bool skipAsyncContextCheck = false)
         {
-            hasErrors |= ReportBadAwaitWithoutAsync(location, diagnostics);
+            if (!skipAsyncContextCheck)
+            {
+                hasErrors |= ReportBadAwaitWithoutAsync(location, diagnostics);
+            }
+
             hasErrors |= ReportBadAwaitContext(node, location, diagnostics);
         }
 
@@ -116,12 +122,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
-            // Could we bind await on this expression (ignoring whether we are in async context)?
-            var syntax = expression.Syntax;
-            var placeholder = new BoundAwaitableValuePlaceholder(syntax, expression.Type);
-            bool hasErrors = ReportBadAwaitContext(syntax, syntax.Location, BindingDiagnosticBag.Discarded);
-            _ = BindAwaitInfo(placeholder, syntax, BindingDiagnosticBag.Discarded, ref hasErrors, expressionOpt: expression);
-            return !hasErrors;
+            var boundAwait = BindAwait(expression, expression.Syntax, BindingDiagnosticBag.Discarded, skipAsyncContextCheck: true);
+            return !boundAwait.HasAnyErrors;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
@@ -3957,6 +3957,9 @@ public class C : I
                 //         Action a8 = async () => { await Task.Yield(); i.MAsync(); }; // 18
                 Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(42, 55)
                 );
+
+            var entryPoint = SynthesizedSimpleProgramEntryPointSymbol.GetSimpleProgramEntryPoint(comp);
+            Assert.Equal("System.Threading.Tasks.Task", entryPoint.ReturnType.ToTestDisplayString());
         }
 
         [Fact, WorkItem(64964, "https://github.com/dotnet/roslyn/issues/64964")]
@@ -4008,6 +4011,9 @@ public class C : I
                 // i.MAsync(); // 5
                 Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(12, 1)
                 );
+
+            var entryPoint = SynthesizedSimpleProgramEntryPointSymbol.GetSimpleProgramEntryPoint(comp);
+            Assert.Equal("System.Threading.Tasks.Task", entryPoint.ReturnType.ToTestDisplayString());
         }
 
         [Fact, WorkItem(64964, "https://github.com/dotnet/roslyn/issues/64964")]
@@ -4059,6 +4065,9 @@ public class C : I
                 // i.MAsync(); // 5
                 Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(12, 1)
                 );
+
+            var entryPoint = SynthesizedSimpleProgramEntryPointSymbol.GetSimpleProgramEntryPoint(comp);
+            Assert.Equal("System.Void", entryPoint.ReturnType.ToTestDisplayString());
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
@@ -3838,5 +3838,227 @@ class C
             var compilation = CreateCompilationWithMscorlib45(source, references: new[] { reference });
             compilation.VerifyEmitDiagnostics();
         }
+
+        [Fact, WorkItem(64964, "https://github.com/dotnet/roslyn/issues/64964")]
+        public void UnobservedAwaitableExpression_AsyncTopLevelStatement()
+        {
+            var src = """
+using System;
+using System.Threading.Tasks;
+
+await Task.Yield();
+
+C c = new C();
+c.M(); // 1
+c.MAsync(); // 2
+Action a1 = () => c.M();
+Action a2 = async () => { await Task.Yield(); c.M(); }; // 3
+Action a3 = () => c.MAsync(); // 4
+Action a4 = async () => { await Task.Yield(); c.MAsync(); }; // 5
+
+I i = new C();
+i.M(); // 6
+i.MAsync(); // 7
+Action a5 = () => i.M();
+Action a6 = async () => { await Task.Yield(); i.M(); }; // 8
+Action a7 = () => i.MAsync();
+Action a8 = async () => { await Task.Yield(); i.MAsync(); }; // 9
+
+public class D
+{
+    public async Task M2()
+    {
+        await Task.Yield();
+
+        C c = new C();
+        c.M(); // 10
+        c.MAsync(); // 11
+        Action a1 = () => c.M();
+        Action a2 = async () => { await Task.Yield(); c.M(); }; // 12
+        Action a3 = () => c.MAsync(); // 13
+        Action a4 = async () => { await Task.Yield(); c.MAsync(); }; // 14
+
+        I i = new C();
+        i.M(); // 15
+        i.MAsync(); // 16
+        Action a5 = () => i.M();
+        Action a6 = async () => { await Task.Yield(); i.M(); }; // 17
+        Action a7 = () => i.MAsync();
+        Action a8 = async () => { await Task.Yield(); i.MAsync(); }; // 18
+    }
+}
+
+public interface I
+{
+    Task M();
+    Task MAsync();
+}
+
+public class C : I
+{
+    public Task M() => throw null;
+    public async Task MAsync() => await Task.Yield();
+}
+""";
+            var comp = CreateCompilation(src);
+            comp.VerifyDiagnostics(
+                // (7,1): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // c.M(); // 1
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.M()").WithLocation(7, 1),
+                // (8,1): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // c.MAsync(); // 2
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(8, 1),
+                // (10,47): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // Action a2 = async () => { await Task.Yield(); c.M(); }; // 3
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.M()").WithLocation(10, 47),
+                // (11,19): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // Action a3 = () => c.MAsync(); // 4
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(11, 19),
+                // (12,47): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // Action a4 = async () => { await Task.Yield(); c.MAsync(); }; // 5
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(12, 47),
+                // (15,1): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // i.M(); // 6
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.M()").WithLocation(15, 1),
+                // (16,1): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // i.MAsync(); // 7
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(16, 1),
+                // (18,47): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // Action a6 = async () => { await Task.Yield(); i.M(); }; // 8
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.M()").WithLocation(18, 47),
+                // (20,47): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // Action a8 = async () => { await Task.Yield(); i.MAsync(); }; // 9
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(20, 47),
+                // (29,9): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                //         c.M(); // 10
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.M()").WithLocation(29, 9),
+                // (30,9): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                //         c.MAsync(); // 11
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(30, 9),
+                // (32,55): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                //         Action a2 = async () => { await Task.Yield(); c.M(); }; // 12
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.M()").WithLocation(32, 55),
+                // (33,27): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                //         Action a3 = () => c.MAsync(); // 13
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(33, 27),
+                // (34,55): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                //         Action a4 = async () => { await Task.Yield(); c.MAsync(); }; // 14
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(34, 55),
+                // (37,9): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                //         i.M(); // 15
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.M()").WithLocation(37, 9),
+                // (38,9): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                //         i.MAsync(); // 16
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(38, 9),
+                // (40,55): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                //         Action a6 = async () => { await Task.Yield(); i.M(); }; // 17
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.M()").WithLocation(40, 55),
+                // (42,55): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                //         Action a8 = async () => { await Task.Yield(); i.MAsync(); }; // 18
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(42, 55)
+                );
+        }
+
+        [Fact, WorkItem(64964, "https://github.com/dotnet/roslyn/issues/64964")]
+        public void UnobservedAwaitableExpression_NonAsyncTopLevelStatements_Task()
+        {
+            var src = """
+using System;
+using System.Threading.Tasks;
+
+C c = new C();
+c.M(); // 1
+c.MAsync(); // 2
+Action a1 = () => c.M();
+Action a2 = () => c.MAsync(); // 3
+
+I i = new C();
+i.M(); // 4
+i.MAsync(); // 5
+Action a3 = () => i.M();
+Action a4 = () => i.MAsync();
+
+public interface I
+{
+    Task M();
+    Task MAsync();
+}
+
+public class C : I
+{
+    public Task M() => throw null;
+    public async Task MAsync() => await Task.Yield();
+}
+""";
+            var comp = CreateCompilation(src);
+            comp.VerifyDiagnostics(
+                // (5,1): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // c.M(); // 1
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.M()").WithLocation(5, 1),
+                // (6,1): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // c.MAsync(); // 2
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(6, 1),
+                // (8,19): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // Action a2 = () => c.MAsync(); // 3
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(8, 19),
+                // (11,1): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // i.M(); // 4
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.M()").WithLocation(11, 1),
+                // (12,1): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // i.MAsync(); // 5
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(12, 1)
+                );
+        }
+
+        [Fact, WorkItem(64964, "https://github.com/dotnet/roslyn/issues/64964")]
+        public void UnobservedAwaitableExpression_NonAsyncTopLevelStatements_TaskT()
+        {
+            var src = """
+using System;
+using System.Threading.Tasks;
+
+C c = new C();
+c.M(); // 1
+c.MAsync(); // 2
+Action a1 = () => c.M();
+Action a2 = () => c.MAsync(); // 3
+
+I i = new C();
+i.M(); // 4
+i.MAsync(); // 5
+Action a3 = () => i.M();
+Action a4 = () => i.MAsync(); // 6
+
+public interface I
+{
+    Task<int> M();
+    Task<int> MAsync();
+}
+
+public class C : I
+{
+    public Task<int> M() => throw null;
+    public async Task<int> MAsync() { await Task.Yield(); throw null; }
+}
+""";
+            var comp = CreateCompilation(src);
+            comp.VerifyDiagnostics(
+                // (5,1): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // c.M(); // 1
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.M()").WithLocation(5, 1),
+                // (6,1): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // c.MAsync(); // 2
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(6, 1),
+                // (8,19): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // Action a2 = () => c.MAsync(); // 3
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(8, 19),
+                // (11,1): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // i.M(); // 4
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.M()").WithLocation(11, 1),
+                // (12,1): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // i.MAsync(); // 5
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(12, 1)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
@@ -4013,7 +4013,7 @@ public class C : I
                 );
 
             var entryPoint = SynthesizedSimpleProgramEntryPointSymbol.GetSimpleProgramEntryPoint(comp);
-            Assert.Equal("System.Threading.Tasks.Task", entryPoint.ReturnType.ToTestDisplayString());
+            Assert.Equal("System.Void", entryPoint.ReturnType.ToTestDisplayString());
         }
 
         [Fact, WorkItem(64964, "https://github.com/dotnet/roslyn/issues/64964")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTests.cs
@@ -3839,10 +3839,10 @@ class C
             compilation.VerifyEmitDiagnostics();
         }
 
-        [Fact, WorkItem(64964, "https://github.com/dotnet/roslyn/issues/64964")]
-        public void UnobservedAwaitableExpression_AsyncTopLevelStatement()
+        [Theory, CombinatorialData, WorkItem(64964, "https://github.com/dotnet/roslyn/issues/64964")]
+        public void UnobservedAwaitableExpression_AsyncTopLevelStatement(bool voidReturn)
         {
-            var src = """
+            var src = $$"""
 using System;
 using System.Threading.Tasks;
 
@@ -3863,6 +3863,8 @@ Action a5 = () => i.M();
 Action a6 = async () => { await Task.Yield(); i.M(); }; // 8
 Action a7 = () => i.MAsync();
 Action a8 = async () => { await Task.Yield(); i.MAsync(); }; // 9
+
+{{(voidReturn ? "" : "return 42;")}}
 
 public class D
 {
@@ -3929,43 +3931,43 @@ public class C : I
                 // (20,47): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
                 // Action a8 = async () => { await Task.Yield(); i.MAsync(); }; // 9
                 Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(20, 47),
-                // (29,9): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                // (31,9): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
                 //         c.M(); // 10
-                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.M()").WithLocation(29, 9),
-                // (30,9): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.M()").WithLocation(31, 9),
+                // (32,9): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
                 //         c.MAsync(); // 11
-                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(30, 9),
-                // (32,55): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
-                //         Action a2 = async () => { await Task.Yield(); c.M(); }; // 12
-                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.M()").WithLocation(32, 55),
-                // (33,27): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
-                //         Action a3 = () => c.MAsync(); // 13
-                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(33, 27),
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(32, 9),
                 // (34,55): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                //         Action a2 = async () => { await Task.Yield(); c.M(); }; // 12
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.M()").WithLocation(34, 55),
+                // (35,27): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                //         Action a3 = () => c.MAsync(); // 13
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(35, 27),
+                // (36,55): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
                 //         Action a4 = async () => { await Task.Yield(); c.MAsync(); }; // 14
-                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(34, 55),
-                // (37,9): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(36, 55),
+                // (39,9): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
                 //         i.M(); // 15
-                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.M()").WithLocation(37, 9),
-                // (38,9): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.M()").WithLocation(39, 9),
+                // (40,9): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
                 //         i.MAsync(); // 16
-                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(38, 9),
-                // (40,55): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
-                //         Action a6 = async () => { await Task.Yield(); i.M(); }; // 17
-                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.M()").WithLocation(40, 55),
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(40, 9),
                 // (42,55): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                //         Action a6 = async () => { await Task.Yield(); i.M(); }; // 17
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.M()").WithLocation(42, 55),
+                // (44,55): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
                 //         Action a8 = async () => { await Task.Yield(); i.MAsync(); }; // 18
-                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(42, 55)
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(44, 55)
                 );
 
             var entryPoint = SynthesizedSimpleProgramEntryPointSymbol.GetSimpleProgramEntryPoint(comp);
-            Assert.Equal("System.Threading.Tasks.Task", entryPoint.ReturnType.ToTestDisplayString());
+            Assert.Equal(voidReturn ? "System.Threading.Tasks.Task" : "System.Threading.Tasks.Task<System.Int32>", entryPoint.ReturnType.ToTestDisplayString());
         }
 
-        [Fact, WorkItem(64964, "https://github.com/dotnet/roslyn/issues/64964")]
-        public void UnobservedAwaitableExpression_NonAsyncTopLevelStatements_Task()
+        [Theory, CombinatorialData, WorkItem(64964, "https://github.com/dotnet/roslyn/issues/64964")]
+        public void UnobservedAwaitableExpression_NonAsyncTopLevelStatements_Task(bool voidReturn)
         {
-            var src = """
+            var src = $$"""
 using System;
 using System.Threading.Tasks;
 
@@ -3980,6 +3982,15 @@ i.M(); // 4
 i.MAsync(); // 5
 Action a3 = () => i.M();
 Action a4 = () => i.MAsync();
+
+object o = null;
+lock(o)
+{
+    c.M();
+    c.MAsync(); // 6
+}
+
+{{(voidReturn ? "" : "return 42;")}}
 
 public interface I
 {
@@ -4009,17 +4020,20 @@ public class C : I
                 Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.M()").WithLocation(11, 1),
                 // (12,1): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
                 // i.MAsync(); // 5
-                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(12, 1)
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "i.MAsync()").WithLocation(12, 1),
+                // (20,5): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
+                //     c.MAsync(); // 6
+                Diagnostic(ErrorCode.WRN_UnobservedAwaitableExpression, "c.MAsync()").WithLocation(20, 5)
                 );
 
             var entryPoint = SynthesizedSimpleProgramEntryPointSymbol.GetSimpleProgramEntryPoint(comp);
-            Assert.Equal("System.Void", entryPoint.ReturnType.ToTestDisplayString());
+            Assert.Equal(voidReturn ? "System.Void" : "System.Int32", entryPoint.ReturnType.ToTestDisplayString());
         }
 
-        [Fact, WorkItem(64964, "https://github.com/dotnet/roslyn/issues/64964")]
-        public void UnobservedAwaitableExpression_NonAsyncTopLevelStatements_TaskT()
+        [Theory, CombinatorialData, WorkItem(64964, "https://github.com/dotnet/roslyn/issues/64964")]
+        public void UnobservedAwaitableExpression_NonAsyncTopLevelStatements_TaskT(bool voidReturn)
         {
-            var src = """
+            var src = $$"""
 using System;
 using System.Threading.Tasks;
 
@@ -4034,6 +4048,8 @@ i.M(); // 4
 i.MAsync(); // 5
 Action a3 = () => i.M();
 Action a4 = () => i.MAsync(); // 6
+
+{{(voidReturn ? "" : "return 42;")}}
 
 public interface I
 {
@@ -4067,7 +4083,7 @@ public class C : I
                 );
 
             var entryPoint = SynthesizedSimpleProgramEntryPointSymbol.GetSimpleProgramEntryPoint(comp);
-            Assert.Equal("System.Void", entryPoint.ReturnType.ToTestDisplayString());
+            Assert.Equal(voidReturn ? "System.Void" : "System.Int32", entryPoint.ReturnType.ToTestDisplayString());
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/64964