### PR TITLE
Increase output in /shared logging

### DIFF
--- a/src/Compilers/CSharp/csc/Program.cs
+++ b/src/Compilers/CSharp/csc/Program.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
             ExitingTraceListener.Install(logger);
 #endif
 
-            return BuildClient.Run(args, RequestLanguage.CSharpCompile, Csc.Run, BuildClient.GetCompileOnServerFunc(logger));
+            return BuildClient.Run(args, RequestLanguage.CSharpCompile, Csc.Run, BuildClient.GetCompileOnServerFunc(logger), logger);
         }
 
         public static int Run(string[] args, string clientDir, string workingDir, string sdkDir, string tempDir, TextWriter textWriter, IAnalyzerAssemblyLoader analyzerLoader)

--- a/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/BuildClientTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 language ??= RequestLanguage.CSharpCompile;
                 compileFunc ??= delegate { return 0; };
                 compileOnServerFunc ??= delegate { throw new InvalidOperationException(); };
-                return new BuildClient(language.Value, compileFunc, compileOnServerFunc);
+                return new BuildClient(_logger, language.Value, compileFunc, compileOnServerFunc);
             }
 
             private ServerData CreateServer(string pipeName)

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                     cancellationToken);
 
             var compileFunc = GetCompileFunc(language);
-            return new BuildClient(language, compileFunc, compileOnServerFunc);
+            return new BuildClient(logger, language, compileFunc, compileOnServerFunc);
         }
 
         internal static CompileFunc GetCompileFunc(RequestLanguage language)

--- a/src/Compilers/VisualBasic/vbc/Program.cs
+++ b/src/Compilers/VisualBasic/vbc/Program.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
             ExitingTraceListener.Install(logger);
 #endif
 
-            return BuildClient.Run(args, RequestLanguage.VisualBasicCompile, Vbc.Run, BuildClient.GetCompileOnServerFunc(logger));
+            return BuildClient.Run(args, RequestLanguage.VisualBasicCompile, Vbc.Run, BuildClient.GetCompileOnServerFunc(logger), logger);
         }
 
         public static int Run(string[] args, string clientDir, string workingDir, string sdkDir, string tempDir, TextWriter textWriter, IAnalyzerAssemblyLoader analyzerLoader)


### PR DESCRIPTION
I've been working with customers that are seeing build hangs. Their build setup is not a typical .NET build in that they use `csc` to drive the compiler server via `/shared` where as typical builds use our MSBuild task.

When I revapmed the compiler server logging code a while back I didn't put enough logging in here. That means once the server request is completed there is no more logging client side and we lose track of the call. Adding logging here so we can continue to follow the request as control goes back to the client