### PR TITLE
Fix "MoveStaticMembers" for VB with invalid member

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/MoveStaticMembers/VisualBasicMoveStaticMembersTests.vb
@@ -5,6 +5,8 @@
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.MoveStaticMembers
 Imports Microsoft.CodeAnalysis.Test.Utilities.MoveStaticMembers
+Imports Microsoft.CodeAnalysis.Testing
+Imports Microsoft.CodeAnalysis.Testing.Verifiers
 Imports VerifyVB = Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions.VisualBasicCodeRefactoringVerifier(Of
     Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.MoveStaticMembers.VisualBasicMoveStaticMembersRefactoringProvider)
 
@@ -3018,6 +3020,24 @@ End Namespace"
             Await TestNoRefactoringAsync(initialMarkup)
         End Function
 
+#End Region
+
+#Region "Invalid Code Tests"
+        <Fact>
+        <WorkItem(66489, "https://github.com/dotnet/roslyn/issues/66489")>
+        Public Async Function TestCSharpCodeInVB() As Task
+            Dim initialMarkup = "
+                CompoundInstrumenter compound [||]"
+            Dim testRun = New Test("", ImmutableArray(Of String).Empty, "") With
+            {
+                .TestCode = initialMarkup,
+                .FixedCode = initialMarkup
+            }
+
+            testRun.TestState.ExpectedDiagnostics.Add(DiagnosticResult.CompilerError("BC30188").WithSpan(2, 17, 2, 37))
+            testRun.TestState.ExpectedDiagnostics.Add(DiagnosticResult.CompilerError("BC30195").WithSpan(2, 38, 2, 46))
+            Await testRun.RunAsync()
+        End Function
 #End Region
 
         Private Class Test

--- a/src/Features/Core/Portable/MoveStaticMembers/AbstractMoveStaticMembersRefactoringProvider.cs
+++ b/src/Features/Core/Portable/MoveStaticMembers/AbstractMoveStaticMembersRefactoringProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.MoveStaticMembers
 
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var memberNodeSymbolPairs = selectedMemberNodes
-                .SelectAsArray(m => (node: m, symbol: semanticModel.GetRequiredDeclaredSymbol(m, cancellationToken)))
+                .SelectAsArray(m => (node: m, symbol: semanticModel.GetDeclaredSymbol(m, cancellationToken)))
                 // Use same logic as pull members up for determining if a selected member
                 // is valid to be moved into a base
                 .WhereAsArray(pair => MemberAndDestinationValidator.IsMemberValid(pair.symbol) && pair.symbol.IsStatic);
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.MoveStaticMembers
                 return;
             }
 
-            var selectedMembers = memberNodeSymbolPairs.SelectAsArray(pair => pair.symbol);
+            var selectedMembers = memberNodeSymbolPairs.SelectAsArray(pair => pair.symbol!);
 
             var containingType = selectedMembers.First().ContainingType;
             Contract.ThrowIfNull(containingType);

--- a/src/Features/Core/Portable/PullMemberUp/MemberAndDestinationValidator.cs
+++ b/src/Features/Core/Portable/PullMemberUp/MemberAndDestinationValidator.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.PullMemberUp
             // Don't provide any refactoring option if the destination is not in source.
             // If the destination is generated code, also don't provide refactoring since we can't make sure if we won't break it.
             var isDestinationInSourceAndNotGeneratedCode =
-                destination.Locations.Any(static (location, arg) => location.IsInSource && !arg.solution.GetDocument(location.SourceTree).IsGeneratedCode(arg.cancellationToken), (solution, cancellationToken));
+                destination.Locations.Any(static (location, arg) => location.IsInSource && !arg.solution.GetRequiredDocument(location.SourceTree).IsGeneratedCode(arg.cancellationToken), (solution, cancellationToken));
             return isDestinationInSourceAndNotGeneratedCode;
         }
 

--- a/src/Features/Core/Portable/PullMemberUp/MemberAndDestinationValidator.cs
+++ b/src/Features/Core/Portable/PullMemberUp/MemberAndDestinationValidator.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.  
 
-#nullable disable
-
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -27,8 +26,13 @@ namespace Microsoft.CodeAnalysis.PullMemberUp
             return isDestinationInSourceAndNotGeneratedCode;
         }
 
-        public static bool IsMemberValid(ISymbol member)
+        public static bool IsMemberValid([NotNullWhen(true)] ISymbol? member)
         {
+            if (member is null)
+            {
+                return false;
+            }
+
             if (member.IsImplicitlyDeclared)
             {
                 return false;

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/MoveStaticMembers/VisualBasicMoveStaticMembersRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/MoveStaticMembers/VisualBasicMoveStaticMembersRefactoringProvider.vb
@@ -13,10 +13,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.MoveStaticMembers
     Friend Class VisualBasicMoveStaticMembersRefactoringProvider
         Inherits AbstractMoveStaticMembersRefactoringProvider
 
-#Disable Warning RS0033 ' Importing constructor should be marked with 'ObsoleteAttribute'
         <ImportingConstructor>
+        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
         Public Sub New()
-#Enable Warning RS0033 ' Importing constructor should be marked with 'ObsoleteAttribute'
             MyBase.New()
         End Sub
 

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/MoveStaticMembers/VisualBasicMoveStaticMembersRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/MoveStaticMembers/VisualBasicMoveStaticMembersRefactoringProvider.vb
@@ -13,9 +13,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeRefactorings.MoveStaticMembers
     Friend Class VisualBasicMoveStaticMembersRefactoringProvider
         Inherits AbstractMoveStaticMembersRefactoringProvider
 
+#Disable Warning RS0033 ' Importing constructor should be marked with 'ObsoleteAttribute'
         <ImportingConstructor>
-        <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
         Public Sub New()
+#Enable Warning RS0033 ' Importing constructor should be marked with 'ObsoleteAttribute'
             MyBase.New()
         End Sub
 


### PR DESCRIPTION
Don't error if a member isn't found relating to code. 

Fixes #66489 
