### PR TITLE
Improve type-inferrer results by looking at future usages of a variable.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -9148,5 +9148,104 @@ abstract class Barry
     protected abstract void Goo(Action<object> action, object arg);
 }");
         }
+
+        [Fact, WorkItem(44861, "https://github.com/dotnet/roslyn/issues/44861")]
+        public async Task GenerateBasedOnFutureUsage1()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    int M()
+    {
+        var v = [|NewExpr()|];
+        return v;
+    }
+}",
+@"using System;
+
+class C
+{
+    int M()
+    {
+        var v = [|NewExpr()|];
+        return v;
+    }
+
+    private int NewExpr()
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
+        [Fact, WorkItem(44861, "https://github.com/dotnet/roslyn/issues/44861")]
+        public async Task GenerateBasedOnFutureUsage2()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    int M()
+    {
+        var v = [|NewExpr()|];
+        if (v)
+        {
+        }
+    }
+}",
+@"using System;
+
+class C
+{
+    int M()
+    {
+        var v = [|NewExpr()|];
+        if (v)
+        {
+        }
+    }
+
+    private bool NewExpr()
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
+        [Fact, WorkItem(44861, "https://github.com/dotnet/roslyn/issues/44861")]
+        public async Task GenerateBasedOnFutureUsage3()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    int M()
+    {
+        var v = [|NewExpr()|];
+        var x = v;
+        return x;
+    }
+}",
+@"using System;
+
+class C
+{
+    int M()
+    {
+        var v = [|NewExpr()|];
+        var x = v;
+        return x;
+    }
+
+    private int NewExpr()
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -9247,5 +9247,40 @@ class C
     }
 }");
         }
+
+        [Fact, WorkItem(44861, "https://github.com/dotnet/roslyn/issues/44861")]
+        public async Task GenerateBasedOnFutureUsage4()
+        {
+            await TestInRegularAndScriptAsync(
+@"using System;
+
+class C
+{
+    int M()
+    {
+        var (x, y) = [|NewExpr()|];
+        Goo(x, y);
+    }
+
+    void Goo(string x, int y) { }
+}",
+@"using System;
+
+class C
+{
+    int M()
+    {
+        var (x, y) = [|NewExpr()|];
+        Goo(x, y);
+    }
+
+    private (string x, int y) NewExpr()
+    {
+        throw new NotImplementedException();
+    }
+
+    void Goo(string x, int y) { }
+}");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/44861

Improves cases, for example, like when assigning to a `var`.  We'll now look at how that variable is used later in the method to determine what type to generate.  Should help reduce the number of times that we end up generating `object` as a fallback result