### PR TITLE
Fix XmlDocumentationProvider to return the entire XML node

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
+++ b/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
@@ -77,11 +77,7 @@ namespace Microsoft.CodeAnalysis
                         foreach (var e in doc.Descendants("member"))
                         {
                             if (e.Attribute("name") != null)
-                            {
-                                using var reader = e.CreateReader();
-                                reader.MoveToContent();
-                                comments[e.Attribute("name").Value] = reader.ReadInnerXml();
-                            }
+                                comments[e.Attribute("name").Value] = e.ToString();
                         }
 
                         _docComments = comments;

--- a/src/Workspaces/CoreTest/UtilityTest/XmlDocumentationProviderTests.cs
+++ b/src/Workspaces/CoreTest/UtilityTest/XmlDocumentationProviderTests.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public class XmlDocumentationProviderTests
+    {
+        [Fact]
+        public void XmlDocumentationProviderReturnsEntireMemberNode()
+        {
+            var roslynCompilersLocation = typeof(Compilation).Assembly.Location;
+            var roslynCompilersXmlFilePath = Path.ChangeExtension(roslynCompilersLocation, ".xml");
+            var documentationProvider = XmlDocumentationProvider.CreateFromBytes(Encoding.UTF8.GetBytes("""
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>Microsoft.CodeAnalysis</name>
+    </assembly>
+    <members>
+        <member name="T:Microsoft.CodeAnalysis.AdditionalTextFile">
+            <summary>
+            Represents a non source code file.
+            </summary>
+        </member>
+    </members>
+</doc>
+"""));
+            var portableExecutableReference = MetadataReference.CreateFromFile(roslynCompilersLocation, documentation: documentationProvider);
+
+            var compilation = CSharpCompilation.Create(nameof(XmlDocumentationProviderReturnsEntireMemberNode), references: new[] { portableExecutableReference });
+
+            // Verify we can parse it and it contains a single node
+            var xml = compilation.GetTypeByMetadataName("Microsoft.CodeAnalysis.AdditionalTextFile")!.GetDocumentationCommentXml();
+            AssertEx.NotNull(xml);
+            var xmlDocument = XDocument.Parse(xml);
+            Assert.Equal("member", xmlDocument.Root!.Name.LocalName);
+            Assert.Equal("T:Microsoft.CodeAnalysis.AdditionalTextFile", xmlDocument.Root!.Attribute("name")!.Value);
+        }
+    }
+}


### PR DESCRIPTION
Every other implementation of XmlDocumentationProvider we have returns the <member> XML node when returning the XML for a symbol, but this was returning the inner contents. This still works in practice, but we have code that assumes the contents are a regular XML document which ends up throwing exceptions and then catching them with workarounds.