### PR TITLE
Add some EE and EnC tests for primary constructors

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -18540,5 +18540,228 @@ System.Console.Write(1);
         }
 
         #endregion
+
+        #region Primary Constructors
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_01([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = keyword + " C() { void M() { } }";
+            var src2 = keyword + " C() { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, keyword + " C", FeaturesResources.method));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_02([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = keyword + " C() { }";
+            var src2 = keyword + " C() { void M() { } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "void M()", FeaturesResources.method));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_03([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = keyword + " C() { void M() { } }";
+            var src2 = keyword + " C() { void M() { ToString(); } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Update, "void M()", FeaturesResources.method));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_04([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = keyword + " C(int a) { }";
+            var src2 = keyword + " C(int a, int b) { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "int b", FeaturesResources.parameter));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_05([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = keyword + " C(int a, int b) { }";
+            var src2 = keyword + " C(int a) { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, keyword + " C", FeaturesResources.parameter));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_06([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = keyword + " C { }";
+            var src2 = keyword + " C() { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_07([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = keyword + " C() { }";
+            var src2 = keyword + " C { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_08([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = keyword + " C() { }";
+            var src2 = keyword + " C(int b) { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "int b", FeaturesResources.parameter));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_09([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = keyword + " C(int b) { }";
+            var src2 = keyword + " C() { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, keyword + " C", FeaturesResources.parameter));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_10([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = keyword + " C { }";
+            var src2 = keyword + " C(int b) { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "int b", FeaturesResources.parameter));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_11([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = keyword + " C(int b) { }";
+            var src2 = keyword + " C { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, keyword + " C", FeaturesResources.parameter));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_12([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = "partial " + keyword + " C(); partial " + keyword + " C { void M() { } }";
+            var src2 = "partial " + keyword + " C(); partial " + keyword + " C { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Delete, "partial " + keyword + " C", FeaturesResources.method));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_13([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = "partial " + keyword + " C(); partial " + keyword + " C { }";
+            var src2 = "partial " + keyword + " C(); partial " + keyword + " C { void M() { } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Insert, "void M()", FeaturesResources.method));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_14([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = "partial " + keyword + " C(); partial " + keyword + " C { void M() { } }";
+            var src2 = "partial " + keyword + " C(); partial " + keyword + " C { void M() { ToString(); } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Update, "void M()", FeaturesResources.method));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_15([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = "partial " + keyword + " C(); partial " + keyword + " C { void M() { } }";
+            var src2 = "partial " + keyword + " C {} partial " + keyword + " C { void M() { ToString(); } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Update, "void M()", FeaturesResources.method));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_16([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = "partial " + keyword + " C {} partial " + keyword + " C { void M() { } }";
+            var src2 = "partial " + keyword + " C(); partial " + keyword + " C { void M() { ToString(); } }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Update, "void M()", FeaturesResources.method));
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public void PrimaryConstructors_17([CombinatorialValues("class", "struct")] string keyword)
+        {
+            var src1 = keyword + " C(int a) { }";
+            var src2 = keyword + " C(long a) { }";
+
+            var edits = GetTopEdits(src1, src2);
+
+            edits.VerifySemanticDiagnostics(
+                Diagnostic(RudeEditKind.Update, "long a", FeaturesResources.parameter));
+        }
+
+        #endregion
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTests.cs
@@ -7009,5 +7009,405 @@ class Program
 }
 """);
         }
+
+        [Fact]
+        public void PrimaryConstructors_01_EvaluateCapturedParameterInsideCapturingInstanceMethod()
+        {
+            var source =
+@"class C(int y)
+{
+    int M()
+    {
+        return y;
+    }
+}";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C.M",
+                expr: "y",
+                resultProperties: out _,
+                error: out string error);
+
+            // PROTOTYPE(PrimaryConstructors): There should be no error and IL should refer to a field 
+            Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
+            //            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            //@"{
+            //}");
+        }
+
+        [Fact]
+        public void PrimaryConstructors_02_EvaluateCapturedParameterInsideNonCapturingInstanceMethod()
+        {
+            var source =
+@"class C(int y)
+{
+    int M1()
+    {
+        return y;
+    }
+
+    void M2()
+    {
+    }
+}";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C.M2",
+                expr: "y",
+                resultProperties: out _,
+                error: out string error);
+
+            // PROTOTYPE(PrimaryConstructors): There should be no error and IL should refer to a field 
+            Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
+            //            testData.GetMethodData("<>x.<>m0").VerifyIL(
+            //@"{
+            //}");
+        }
+
+        [Fact]
+        public void PrimaryConstructors_03_EvaluateCapturedParameterInsideInstanceConstructor()
+        {
+            var source =
+@"class C(int y)
+{
+    C() : this(1)
+    {
+    }
+
+    int M()
+    {
+        return y;
+    }
+}";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C..ctor()",
+                expr: "y",
+                resultProperties: out _,
+                error: out string error);
+
+            // PROTOTYPE(PrimaryConstructors): Probably should report 
+            // error CS9500: Cannot use primary constructor parameter 'int y' in this context.
+            Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
+        }
+
+        [Fact]
+        public void PrimaryConstructors_04_EvaluateCapturedParameterInsideInstanceConstructorInitializer()
+        {
+            var source =
+@"class C(int y)
+{
+    C() :
+#line 100
+          this(1)
+#line 200
+    {
+    }
+
+    int M()
+    {
+        return y;
+    }
+}";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C..ctor()",
+                atLineNumber: 100,
+                expr: "y",
+                resultProperties: out _,
+                error: out string error);
+
+            // PROTOTYPE(PrimaryConstructors): Probably should report 
+            // error CS9500: Cannot use primary constructor parameter 'int y' in this context.
+            Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
+        }
+
+        [Fact]
+        public void PrimaryConstructors_05_EvaluateNotCapturedParameterInsideInstanceMethod()
+        {
+            var source =
+@"class C(int y)
+{
+    void M()
+    {
+    }
+}";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C.M",
+                expr: "y",
+                resultProperties: out _,
+                error: out string error);
+
+            Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
+        }
+
+        [Fact]
+        public void PrimaryConstructors_06_EvaluateNotCapturedParameterInsideInstanceConstructor()
+        {
+            var source =
+@"class C(int y)
+{
+    C() : this(1)
+    {
+    }
+}";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C..ctor()",
+                expr: "y",
+                resultProperties: out _,
+                error: out string error);
+
+            Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
+        }
+
+        [Fact]
+        public void PrimaryConstructors_07_EvaluateNotCapturedParameterInsideInstanceConstructorInitializer()
+        {
+            var source =
+@"class C(int y)
+{
+    C() :
+#line 100
+          this(1)
+#line 200
+    {
+    }
+}";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C..ctor()",
+                atLineNumber: 100,
+                expr: "y",
+                resultProperties: out _,
+                error: out string error);
+
+            Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
+        }
+
+        [Fact]
+        public void PrimaryConstructors_08_EvaluateCapturedParameterInsideInstanceFieldInitializer()
+        {
+            var source =
+@"class C(int y)
+{
+#line 100
+    int Y = y;
+#line 200
+    int M() => y;
+}";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C..ctor",
+                atLineNumber: 100,
+                expr: "y");
+
+            // PROTOTYPE(PrimaryConstructors): Should acces the field instead.
+            testData.GetMethodData("<>x.<>m0").VerifyIL(
+@"
+{
+  // Code size        2 (0x2)
+  .maxstack  1
+  IL_0000:  ldarg.1
+  IL_0001:  ret
+}");
+        }
+
+        [Fact]
+        public void PrimaryConstructors_09_EvaluateCapturedParameterInsidePrimaryConstructorInitializer()
+        {
+            var source =
+@"class C(int y) : 
+#line 100
+                   Base(1)
+#line 200
+{
+    int M() => y;
+}
+
+class Base(int x);
+";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C..ctor",
+                atLineNumber: 100,
+                expr: "y");
+
+            // PROTOTYPE(PrimaryConstructors): Should acces the field instead.
+            testData.GetMethodData("<>x.<>m0").VerifyIL(
+@"
+{
+  // Code size        2 (0x2)
+  .maxstack  1
+  IL_0000:  ldarg.1
+  IL_0001:  ret
+}");
+        }
+
+        [Fact]
+        public void PrimaryConstructors_10_EvaluateNotCapturedParameterInsideInstanceFieldInitializer()
+        {
+            var source =
+@"class C(int y)
+{
+#line 100
+    int Y = y;
+}";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C..ctor",
+                atLineNumber: 100,
+                expr: "y");
+
+            testData.GetMethodData("<>x.<>m0").VerifyIL(
+@"
+{
+  // Code size        2 (0x2)
+  .maxstack  1
+  IL_0000:  ldarg.1
+  IL_0001:  ret
+}");
+        }
+
+        [Fact]
+        public void PrimaryConstructors_11_EvaluateNotCapturedParameterInsidePrimaryConstructorInitializer()
+        {
+            var source =
+@"class C(int y) : 
+#line 100
+                   Base(1)
+#line 200
+{
+}
+
+class Base(int x);
+";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C..ctor",
+                atLineNumber: 100,
+                expr: "y");
+
+            testData.GetMethodData("<>x.<>m0").VerifyIL(
+@"
+{
+  // Code size        2 (0x2)
+  .maxstack  1
+  IL_0000:  ldarg.1
+  IL_0001:  ret
+}");
+        }
+
+        [Fact]
+        public void PrimaryConstructors_12_EvaluateCapturedParameterInsideStaticMethod()
+        {
+            var source =
+@"class C(int y)
+{
+    int M1()
+    {
+        return y;
+    }
+
+    static void M2()
+    {
+    }
+}";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C.M2",
+                expr: "y",
+                resultProperties: out _,
+                error: out string error);
+
+            // PROTOTYPE(PrimaryConstructors): Probably should report 
+            // error CS9500: Cannot use primary constructor parameter 'int y' in this context.
+            Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
+        }
+
+        [Fact]
+        public void PrimaryConstructors_13_EvaluateNotCapturedParameterInsideStaticMethod()
+        {
+            var source =
+@"class C(int y)
+{
+    static void M()
+    {
+    }
+}";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C.M",
+                expr: "y",
+                resultProperties: out _,
+                error: out string error);
+
+            // PROTOTYPE(PrimaryConstructors): Probably should report 
+            // error CS9500: Cannot use primary constructor parameter 'int y' in this context.
+            Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
+        }
+
+        [Fact]
+        public void PrimaryConstructors_14_EvaluateCapturedParameterInsideStaticFieldInitializer()
+        {
+            var source =
+@"class C(int y)
+{
+#line 100
+    static int Y = 1;
+#line 200
+    int M() => y;
+}";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C..cctor",
+                atLineNumber: 100,
+                expr: "y",
+                resultProperties: out _,
+                error: out string error);
+
+            // PROTOTYPE(PrimaryConstructors): Probably should report 
+            // error CS9500: Cannot use primary constructor parameter 'int y' in this context.
+            Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
+        }
+
+        [Fact]
+        public void PrimaryConstructors_15_EvaluateNotCapturedParameterInsideStaticFieldInitializer()
+        {
+            var source =
+@"class C(int y)
+{
+#line 100
+    static int Y = 1;
+#line 200
+}";
+            var testData = Evaluate(
+                source,
+                OutputKind.DynamicallyLinkedLibrary,
+                methodName: "C..cctor",
+                atLineNumber: 100,
+                expr: "y",
+                resultProperties: out _,
+                error: out string error);
+
+            // PROTOTYPE(PrimaryConstructors): Probably should report 
+            // error CS9500: Cannot use primary constructor parameter 'int y' in this context.
+            Assert.Equal("error CS0103: The name 'y' does not exist in the current context", error);
+        }
     }
 }

--- a/src/ExpressionEvaluator/CSharp/Test/ResultProvider/FullNameTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ResultProvider/FullNameTests.cs
@@ -962,6 +962,7 @@ namespace @namespace
             Assert.Equal("myClass", fullNameProvider.GetClrNameForField(inspectionContext, new DkmClrRuntimeInstance(assembly).Modules[0], fieldToken));
         }
 
+        // PROTOTYPE(PrimaryConstructors): should clone this test for parameter backing field
         [Fact]
         public void MangledName_SimplifyBackingField()
         {

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -3086,5 +3086,54 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         }
 
         #endregion
+
+        protected override bool IsRudeEditDueToPrimaryConstructor(ISymbol symbol, CancellationToken cancellationToken)
+        {
+            switch (symbol.Kind)
+            {
+                case SymbolKind.NamedType:
+                    break;
+
+                case SymbolKind.Parameter:
+                    {
+                        var container = symbol.ContainingSymbol;
+
+                        if (container is IMethodSymbol { IsImplicitlyDeclared: false, MethodKind: MethodKind.Constructor })
+                        {
+                            foreach (var syntaxReference in container.DeclaringSyntaxReferences)
+                            {
+                                if (syntaxReference.GetSyntax(cancellationToken) is
+                                    ClassDeclarationSyntax { ParameterList: not null } or
+                                    StructDeclarationSyntax { ParameterList: not null })
+                                {
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    break;
+
+                default:
+                    {
+                        var container = symbol.ContainingSymbol;
+
+                        if (container is { Kind: SymbolKind.NamedType, IsImplicitlyDeclared: false })
+                        {
+                            foreach (var syntaxReference in container.DeclaringSyntaxReferences)
+                            {
+                                if (syntaxReference.GetSyntax(cancellationToken) is
+                                    ClassDeclarationSyntax { ParameterList: not null } or
+                                    StructDeclarationSyntax { ParameterList: not null })
+                                {
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    break;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -2394,6 +2394,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             }
         }
 
+        protected virtual bool IsRudeEditDueToPrimaryConstructor(ISymbol symbol, CancellationToken cancellationToken)
+        {
+            return false;
+        }
+
         private async Task<ImmutableArray<SemanticEditInfo>> AnalyzeSemanticsAsync(
             EditScript<SyntaxNode> editScript,
             IReadOnlyDictionary<SyntaxNode, EditKind> editMap,
@@ -2592,6 +2597,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                     Contract.ThrowIfNull(oldSymbol);
                                     Contract.ThrowIfNull(oldDeclaration);
 
+                                    if (IsRudeEditDueToPrimaryConstructor(oldSymbol, cancellationToken))
+                                    {
+                                        // PROTOTYPE(PrimaryConstructors): Disable edits for now
+                                        diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.Delete, GetDeletedNodeDiagnosticSpan(editScript.Match.Matches, oldDeclaration),
+                                                                               oldDeclaration, new[] { GetDisplayName(oldDeclaration, EditKind.Delete) }));
+                                        continue;
+                                    }
+
                                     var activeStatementIndices = GetOverlappingActiveStatements(oldDeclaration, oldActiveStatements);
                                     var hasActiveStatement = activeStatementIndices.Any();
 
@@ -2759,6 +2772,14 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                                     Contract.ThrowIfNull(newModel);
                                     Contract.ThrowIfNull(newSymbol);
                                     Contract.ThrowIfNull(newDeclaration);
+
+                                    if (IsRudeEditDueToPrimaryConstructor(newSymbol, cancellationToken))
+                                    {
+                                        // PROTOTYPE(PrimaryConstructors): Disable edits for now
+                                        diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.Insert, GetDiagnosticSpan(newDeclaration, EditKind.Insert),
+                                                                               newDeclaration, new[] { GetDisplayName(newDeclaration, EditKind.Insert) }));
+                                        continue;
+                                    }
 
                                     syntaxMap = null;
 
@@ -3024,6 +3045,15 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                                     Contract.ThrowIfNull(oldDeclaration);
                                     Contract.ThrowIfNull(newDeclaration);
+
+                                    if (IsRudeEditDueToPrimaryConstructor(oldSymbol, cancellationToken) ||
+                                        IsRudeEditDueToPrimaryConstructor(newSymbol, cancellationToken))
+                                    {
+                                        // PROTOTYPE(PrimaryConstructors): Disable edits for now
+                                        diagnostics.Add(new RudeEditDiagnostic(RudeEditKind.Update, GetDiagnosticSpan(newDeclaration, EditKind.Update),
+                                                                               newDeclaration, new[] { GetDisplayName(newDeclaration, EditKind.Update) }));
+                                        continue;
+                                    }
 
                                     var oldBody = TryGetDeclarationBody(oldDeclaration);
                                     if (oldBody != null)


### PR DESCRIPTION
This change also flags as rude EnC edits that might result in changes around captured primary constructor parameters:
- Adding a capture
- Removing a capture
- Changing type of a captured parameter
- Etc.

The check is not meant to be able to accurately detect “safe” edits. The primary goal is to not let “unsafe” edits through.