### PR TITLE
Enable publishing from a dev branch

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -165,6 +165,16 @@
       "vsMajorVersion": 17,
       "insertionCreateDraftPR": true,
       "insertionTitlePrefix": "[Validation]"
+    },
+    "dev/jjonescz/razor-ea": {
+      "nugetKind": [
+        "Shipping",
+        "NonShipping"
+      ],
+      "vsBranch": "main",
+      "vsMajorVersion": 17,
+      "insertionCreateDraftPR": true,
+      "insertionTitlePrefix": "[Validation]"
     }
   }
 }


### PR DESCRIPTION
Attempting to publish NuPkg files from a dev branch to avoid the need to insert into release/dev17.5.

For reviewers. The intent here is *solely* to put our assets onto our AzDO NuGet feeds for consumption from razor. This branch is already mirror'd to AzDO, I can build it, we just need the assets on our package feeds so we can consume them for next month. Once 17.6 preview builds are available we can shift back to consuming `main` from roslyn.