### PR TITLE
Don't overwrite binary logs in CI

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -229,6 +229,7 @@ function BuildSolution() {
     $bl = "/bl:" + $binaryLogPath
     if ($ci -and (Test-Path $binaryLogPath)) {
       Write-LogIssue -Type "error" -Message "Overwriting binary log file $($binaryLogPath)"
+      throw "Overwriting binary log files"
     }
   }
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -228,7 +228,7 @@ function BuildSolution() {
     $binaryLogPath = Join-Path $LogDir $binaryLogName
     $bl = "/bl:" + $binaryLogPath
     if ($ci -and (Test-Path $binaryLogPath)) {
-      Write-LogIssue -Type "warning" -Message "Overwriting binary log file $($binaryLogPath)"
+      Write-LogIssue -Type "error" -Message "Overwriting binary log file $($binaryLogPath)"
     }
   }
 

--- a/eng/pipelines/build-windows-job.yml
+++ b/eng/pipelines/build-windows-job.yml
@@ -42,13 +42,13 @@ jobs:
       displayName: Restore
       inputs:
         filePath: eng/build.ps1
-        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -restore -binaryLog ${{ parameters.restoreArguments }}
+        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -restore -binaryLogName Restore.binlog ${{ parameters.restoreArguments }}
 
     - task: PowerShell@2
       displayName: Build
       inputs:
         filePath: eng/build.ps1
-        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -build -binaryLog -skipDocumentation ${{ parameters.buildArguments }}
+        arguments: -configuration ${{ parameters.configuration }} -prepareMachine -ci -build -binaryLogName Build.binlog -skipDocumentation ${{ parameters.buildArguments }}
 
     - task: PowerShell@2
       displayName: Prepare Unit Tests


### PR DESCRIPTION
This will make it an error whenever we overwrite a binary log during CI. Doing so means we've lost one of our main tools for investigating build failures. Turning this into an error so we don't make the mistake again.