### PR TITLE
⚡️Share AssemblyloadTestFixture on Framework

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Analyzers/AnalyzerFileReferenceTests.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void TestLoadErrors3()
         {
-            AnalyzerFileReference reference = CreateAnalyzerFileReference(_testFixture.Alpha.Path);
+            AnalyzerFileReference reference = CreateAnalyzerFileReference(_testFixture.Alpha);
 
             List<AnalyzerLoadFailureEventArgs> errors = new List<AnalyzerLoadFailureEventArgs>();
             EventHandler<AnalyzerLoadFailureEventArgs> errorHandler = (o, e) => errors.Add(e);
@@ -196,8 +196,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void BadAnalyzerReference_DisplayName()
         {
             var directory = Temp.CreateDirectory();
-            var textFile = directory.CreateFile("Goo.txt").WriteAllText("I am the very model of a modern major general.");
-            AnalyzerFileReference reference = CreateAnalyzerFileReference(textFile.Path);
+            var textFile = directory.CreateFile("Goo.txt").WriteAllText("I am the very model of a modern major general.").Path;
+            AnalyzerFileReference reference = CreateAnalyzerFileReference(textFile);
 
             Assert.Equal(expected: "Goo", actual: reference.Display);
         }
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void ValidAnalyzerReference_DisplayName()
         {
-            AnalyzerFileReference reference = CreateAnalyzerFileReference(_testFixture.Alpha.Path);
+            AnalyzerFileReference reference = CreateAnalyzerFileReference(_testFixture.Alpha);
 
             Assert.Equal(expected: "Alpha", actual: reference.Display);
         }
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [WorkItem(2782, "https://github.com/dotnet/roslyn/issues/2782")]
         public void ValidAnalyzerReference_Id()
         {
-            AnalyzerFileReference reference = CreateAnalyzerFileReference(_testFixture.Alpha.Path);
+            AnalyzerFileReference reference = CreateAnalyzerFileReference(_testFixture.Alpha);
 
             AssemblyIdentity.TryParseDisplayName("Alpha, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", out var expectedIdentity);
 
@@ -228,8 +228,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         public void BadAnalyzerReference_Id()
         {
             var directory = Temp.CreateDirectory();
-            var textFile = directory.CreateFile("Goo.txt").WriteAllText("I am the very model of a modern major general.");
-            AnalyzerFileReference reference = CreateAnalyzerFileReference(textFile.Path);
+            var textFile = directory.CreateFile("Goo.txt").WriteAllText("I am the very model of a modern major general.").Path;
+            AnalyzerFileReference reference = CreateAnalyzerFileReference(textFile);
 
             Assert.Equal(expected: "Goo", actual: reference.Id);
         }
@@ -238,7 +238,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [WorkItem(1032909, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1032909")]
         public void TestFailedLoadDoesntCauseNoAnalyzersWarning()
         {
-            AnalyzerFileReference reference = CreateAnalyzerFileReference(_testFixture.FaultyAnalyzer.Path);
+            AnalyzerFileReference reference = CreateAnalyzerFileReference(_testFixture.FaultyAnalyzer);
 
             List<AnalyzerLoadFailureEventArgs> errors = new List<AnalyzerLoadFailureEventArgs>();
             EventHandler<AnalyzerLoadFailureEventArgs> errorHandler = (o, e) => errors.Add(e);
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [WorkItem(1032909, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1032909")]
         public void TestReferencingFakeCompiler()
         {
-            AnalyzerFileReference reference = CreateAnalyzerFileReference(_testFixture.AnalyzerWithFakeCompilerDependency.Path);
+            AnalyzerFileReference reference = CreateAnalyzerFileReference(_testFixture.AnalyzerWithFakeCompilerDependency);
 
             List<AnalyzerLoadFailureEventArgs> errors = new List<AnalyzerLoadFailureEventArgs>();
             EventHandler<AnalyzerLoadFailureEventArgs> errorHandler = (o, e) => errors.Add(e);
@@ -278,7 +278,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [WorkItem(1032909, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1032909")]
         public void TestReferencingLaterFakeCompiler()
         {
-            AnalyzerFileReference reference = CreateAnalyzerFileReference(_testFixture.AnalyzerWithLaterFakeCompilerDependency.Path);
+            AnalyzerFileReference reference = CreateAnalyzerFileReference(_testFixture.AnalyzerWithLaterFakeCompilerDependency);
 
             List<AnalyzerLoadFailureEventArgs> errors = new List<AnalyzerLoadFailureEventArgs>();
             EventHandler<AnalyzerLoadFailureEventArgs> errorHandler = (o, e) => errors.Add(e);
@@ -316,7 +316,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var compiler = new AnalyzerLoaderMockCSharpCompiler(
                 CSharpCommandLineParser.Default,
                 responseFile: null,
-                args: new[] { "/nologo", $@"/analyzer:""{_testFixture.AnalyzerWithLaterFakeCompilerDependency.Path}""", "/nostdlib", $@"/r:""{corlib.Path}""", "/out:something.dll", source.Path },
+                args: new[] { "/nologo", $@"/analyzer:""{_testFixture.AnalyzerWithLaterFakeCompilerDependency}""", "/nostdlib", $@"/r:""{corlib}""", "/out:something.dll", source.Path },
                 new BuildPaths(clientDir: directory.Path, workingDir: directory.Path, sdkDir: null, tempDir: null),
                 additionalReferenceDirectories: null,
                 new DefaultAnalyzerAssemblyLoader());
@@ -325,7 +325,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var result = compiler.Run(writer);
             Assert.Equal(0, result);
             AssertEx.Equal($"""
-                warning CS9057: The analyzer assembly '{_testFixture.AnalyzerWithLaterFakeCompilerDependency.Path}' references version '100.0.0.0' of the compiler, which is newer than the currently running version '{typeof(DefaultAnalyzerAssemblyLoader).Assembly.GetName().Version}'.
+                warning CS9057: The analyzer assembly '{_testFixture.AnalyzerWithLaterFakeCompilerDependency}' references version '100.0.0.0' of the compiler, which is newer than the currently running version '{typeof(DefaultAnalyzerAssemblyLoader).Assembly.GetName().Version}'.
                 in.cs(1,5): warning CS0219: The variable 'x' is assigned but its value is never used
 
                 """, writer.ToString());
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var compiler = new AnalyzerLoaderMockCSharpCompiler(
                 CSharpCommandLineParser.Default,
                 responseFile: null,
-                args: new[] { "/nologo", $@"/analyzer:""{_testFixture.AnalyzerWithFakeCompilerDependency.Path}""", $@"/analyzer:""{_testFixture.AnalyzerWithFakeCompilerDependency.Path}""", "/nostdlib", $@"/r:""{corlib.Path}""", "/out:something.dll", source.Path },
+                args: new[] { "/nologo", $@"/analyzer:""{_testFixture.AnalyzerWithFakeCompilerDependency}""", $@"/analyzer:""{_testFixture.AnalyzerWithFakeCompilerDependency}""", "/nostdlib", $@"/r:""{corlib}""", "/out:something.dll", source.Path },
                 new BuildPaths(clientDir: directory.Path, workingDir: directory.Path, sdkDir: null, tempDir: null),
                 additionalReferenceDirectories: null,
                 new DefaultAnalyzerAssemblyLoader());
@@ -354,8 +354,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var result = compiler.Run(writer);
             Assert.Equal(0, result);
             AssertEx.Equal($"""
-                warning CS9067: Analyzer reference '{_testFixture.AnalyzerWithFakeCompilerDependency.Path}' specified multiple times
-                warning CS8032: An instance of analyzer Analyzer cannot be created from {_testFixture.AnalyzerWithFakeCompilerDependency.Path} : Method 'get_SupportedDiagnostics' in type 'Analyzer' from assembly 'AnalyzerWithFakeCompilerDependency, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' does not have an implementation..
+                warning CS9067: Analyzer reference '{_testFixture.AnalyzerWithFakeCompilerDependency}' specified multiple times
+                warning CS8032: An instance of analyzer Analyzer cannot be created from {_testFixture.AnalyzerWithFakeCompilerDependency} : Method 'get_SupportedDiagnostics' in type 'Analyzer' from assembly 'AnalyzerWithFakeCompilerDependency, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' does not have an implementation..
                 in.cs(1,5): warning CS0219: The variable 'x' is assigned but its value is never used
 
                 """, writer.ToString());

--- a/src/Compilers/Core/CodeAnalysisTest/AssemblyUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AssemblyUtilitiesTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
             var results = AssemblyUtilities.FindAssemblySet(alphaDll);
 
-            AssertEx.SetEqual(new[] { alphaDll, gammaDll}, results, StringComparer.OrdinalIgnoreCase);
+            AssertEx.SetEqual(new[] { alphaDll, gammaDll }, results, StringComparer.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void IdentifyMissingDependencies_MultipleMissing()
         {
-            var results = AssemblyUtilities.IdentifyMissingDependencies(_testFixture.Alpha, new[] { _testFixture.Alpha}).Select(identity => identity.Name);
+            var results = AssemblyUtilities.IdentifyMissingDependencies(_testFixture.Alpha, new[] { _testFixture.Alpha }).Select(identity => identity.Name);
 
             AssertEx.SetEqual(new[] { "netstandard", "Gamma" }, results);
         }

--- a/src/Compilers/Core/CodeAnalysisTest/AssemblyUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/AssemblyUtilitiesTests.cs
@@ -33,10 +33,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var directory = Temp.CreateDirectory();
 
-            var alphaDll = directory.CopyFile(_testFixture.Alpha.Path);
-            var results = AssemblyUtilities.FindAssemblySet(alphaDll.Path);
+            var alphaDll = directory.CopyFile(_testFixture.Alpha).Path;
+            var results = AssemblyUtilities.FindAssemblySet(alphaDll);
 
-            AssertEx.SetEqual(new[] { alphaDll.Path }, results);
+            AssertEx.SetEqual(new[] { alphaDll }, results);
         }
 
         [Fact]
@@ -44,11 +44,11 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var directory = Temp.CreateDirectory();
 
-            var alphaDll = directory.CopyFile(_testFixture.Alpha.Path);
-            var betaDll = directory.CopyFile(_testFixture.Beta.Path);
-            var results = AssemblyUtilities.FindAssemblySet(alphaDll.Path);
+            var alphaDll = directory.CopyFile(_testFixture.Alpha).Path;
+            var betaDll = directory.CopyFile(_testFixture.Beta).Path;
+            var results = AssemblyUtilities.FindAssemblySet(alphaDll);
 
-            AssertEx.SetEqual(new[] { alphaDll.Path }, results);
+            AssertEx.SetEqual(new[] { alphaDll }, results);
         }
 
         [Fact]
@@ -56,33 +56,33 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var directory = Temp.CreateDirectory();
 
-            var alphaDll = directory.CopyFile(_testFixture.Alpha.Path);
-            var gammaDll = directory.CopyFile(_testFixture.Gamma.Path);
+            var alphaDll = directory.CopyFile(_testFixture.Alpha).Path;
+            var gammaDll = directory.CopyFile(_testFixture.Gamma).Path;
 
-            var results = AssemblyUtilities.FindAssemblySet(alphaDll.Path);
+            var results = AssemblyUtilities.FindAssemblySet(alphaDll);
 
-            AssertEx.SetEqual(new[] { alphaDll.Path, gammaDll.Path }, results, StringComparer.OrdinalIgnoreCase);
+            AssertEx.SetEqual(new[] { alphaDll, gammaDll}, results, StringComparer.OrdinalIgnoreCase);
         }
 
         [Fact]
         public void FindAssemblySet_TransitiveDependencies()
         {
-            var results = AssemblyUtilities.FindAssemblySet(_testFixture.Alpha.Path);
+            var results = AssemblyUtilities.FindAssemblySet(_testFixture.Alpha);
 
             AssertEx.SetEqual(new[]
             {
-                _testFixture.Alpha.Path,
-                _testFixture.Gamma.Path,
-                _testFixture.Delta1.Path
+                _testFixture.Alpha,
+                _testFixture.Gamma,
+                _testFixture.Delta1
             }, results, StringComparer.OrdinalIgnoreCase);
         }
 
         [Fact]
         public void ReadMVid()
         {
-            var assembly = Assembly.Load(File.ReadAllBytes(_testFixture.Alpha.Path));
+            var assembly = Assembly.Load(File.ReadAllBytes(_testFixture.Alpha));
 
-            var result = AssemblyUtilities.ReadMvid(_testFixture.Alpha.Path);
+            var result = AssemblyUtilities.ReadMvid(_testFixture.Alpha);
 
             Assert.Equal(expected: assembly.ManifestModule.ModuleVersionId, actual: result);
         }
@@ -92,9 +92,9 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var directory = Temp.CreateDirectory();
 
-            var assemblyFile = directory.CreateFile("FakeAssembly.dll");
+            var assemblyFile = directory.CreateFile("FakeAssembly.dll").Path;
 
-            var results = AssemblyUtilities.FindSatelliteAssemblies(assemblyFile.Path);
+            var results = AssemblyUtilities.FindSatelliteAssemblies(assemblyFile);
 
             Assert.Empty(results);
         }
@@ -104,10 +104,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var directory = Temp.CreateDirectory();
 
-            var assemblyFile = directory.CreateFile("FakeAssembly.dll");
-            var satelliteFile = directory.CreateFile("FakeAssembly.resources.dll");
+            var assemblyFile = directory.CreateFile("FakeAssembly.dll").Path;
+            var satelliteFile = directory.CreateFile("FakeAssembly.resources.dll").Path;
 
-            var results = AssemblyUtilities.FindSatelliteAssemblies(assemblyFile.Path);
+            var results = AssemblyUtilities.FindSatelliteAssemblies(assemblyFile);
 
             Assert.Empty(results);
         }
@@ -117,12 +117,12 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var directory = Temp.CreateDirectory();
 
-            var assemblyFile = directory.CreateFile("FakeAssembly.dll");
-            var satelliteFile = directory.CreateDirectory("de").CreateFile("FakeAssembly.resources.dll");
+            var assemblyFile = directory.CreateFile("FakeAssembly.dll").Path;
+            var satelliteFile = directory.CreateDirectory("de").CreateFile("FakeAssembly.resources.dll").Path;
 
-            var results = AssemblyUtilities.FindSatelliteAssemblies(assemblyFile.Path);
+            var results = AssemblyUtilities.FindSatelliteAssemblies(assemblyFile);
 
-            AssertEx.SetEqual(new[] { satelliteFile.Path }, results, StringComparer.OrdinalIgnoreCase);
+            AssertEx.SetEqual(new[] { satelliteFile }, results, StringComparer.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -130,12 +130,12 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var directory = Temp.CreateDirectory();
 
-            var assemblyFile = directory.CreateFile("FakeAssembly.dll");
-            var satelliteFile = directory.CreateDirectory("de").CreateDirectory("FakeAssembly.resources").CreateFile("FakeAssembly.resources.dll");
+            var assemblyFile = directory.CreateFile("FakeAssembly.dll").Path;
+            var satelliteFile = directory.CreateDirectory("de").CreateDirectory("FakeAssembly.resources").CreateFile("FakeAssembly.resources.dll").Path;
 
-            var results = AssemblyUtilities.FindSatelliteAssemblies(assemblyFile.Path);
+            var results = AssemblyUtilities.FindSatelliteAssemblies(assemblyFile);
 
-            AssertEx.SetEqual(new[] { satelliteFile.Path }, results, StringComparer.OrdinalIgnoreCase);
+            AssertEx.SetEqual(new[] { satelliteFile }, results, StringComparer.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -143,13 +143,13 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var directory = Temp.CreateDirectory();
 
-            var assemblyFile = directory.CreateFile("FakeAssembly.dll");
-            var satelliteFileDE = directory.CreateDirectory("de").CreateFile("FakeAssembly.resources.dll");
-            var satelliteFileFR = directory.CreateDirectory("fr").CreateFile("FakeAssembly.resources.dll");
+            var assemblyFile = directory.CreateFile("FakeAssembly.dll").Path;
+            var satelliteFileDE = directory.CreateDirectory("de").CreateFile("FakeAssembly.resources.dll").Path;
+            var satelliteFileFR = directory.CreateDirectory("fr").CreateFile("FakeAssembly.resources.dll").Path;
 
-            var results = AssemblyUtilities.FindSatelliteAssemblies(assemblyFile.Path);
+            var results = AssemblyUtilities.FindSatelliteAssemblies(assemblyFile);
 
-            AssertEx.SetEqual(new[] { satelliteFileDE.Path, satelliteFileFR.Path }, results, StringComparer.OrdinalIgnoreCase);
+            AssertEx.SetEqual(new[] { satelliteFileDE, satelliteFileFR }, results, StringComparer.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -157,10 +157,10 @@ namespace Microsoft.CodeAnalysis.UnitTests
         {
             var directory = Temp.CreateDirectory();
 
-            var assemblyFile = directory.CreateFile("FakeAssembly.dll");
-            var satelliteFile = directory.CreateDirectory("de").CreateDirectory("OtherAssembly.resources").CreateFile("FakeAssembly.resources.dll");
+            var assemblyFile = directory.CreateFile("FakeAssembly.dll").Path;
+            var satelliteFile = directory.CreateDirectory("de").CreateDirectory("OtherAssembly.resources").CreateFile("FakeAssembly.resources.dll").Path;
 
-            var results = AssemblyUtilities.FindSatelliteAssemblies(assemblyFile.Path);
+            var results = AssemblyUtilities.FindSatelliteAssemblies(assemblyFile);
 
             Assert.Equal(expected: 0, actual: results.Length);
         }
@@ -168,7 +168,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void IdentifyMissingDependencies_OnlyNetstandardMissing()
         {
-            var results = AssemblyUtilities.IdentifyMissingDependencies(_testFixture.Alpha.Path, new[] { _testFixture.Alpha.Path, _testFixture.Gamma.Path, _testFixture.Delta1.Path });
+            var results = AssemblyUtilities.IdentifyMissingDependencies(_testFixture.Alpha, new[] { _testFixture.Alpha, _testFixture.Gamma, _testFixture.Delta1 });
 
             Assert.Equal(expected: 1, actual: results.Length);
             Assert.Equal(expected: "netstandard", actual: results[0].Name);
@@ -177,7 +177,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void IdentifyMissingDependencies_MultipleMissing()
         {
-            var results = AssemblyUtilities.IdentifyMissingDependencies(_testFixture.Alpha.Path, new[] { _testFixture.Alpha.Path }).Select(identity => identity.Name);
+            var results = AssemblyUtilities.IdentifyMissingDependencies(_testFixture.Alpha, new[] { _testFixture.Alpha}).Select(identity => identity.Name);
 
             AssertEx.SetEqual(new[] { "netstandard", "Gamma" }, results);
         }
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void GetAssemblyIdentity()
         {
-            var result = AssemblyUtilities.GetAssemblyIdentity(_testFixture.Alpha.Path);
+            var result = AssemblyUtilities.GetAssemblyIdentity(_testFixture.Alpha);
             Assert.Equal(expected: "Alpha", actual: result.Name);
         }
     }

--- a/src/Compilers/Core/CodeAnalysisTest/InvokeUtil.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InvokeUtil.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             finally
             {
                 loader.UnloadAll();
-                testOutputHelper.WriteLine($"Test fixture root: {fixture.TempDirectory.Path}");
+                testOutputHelper.WriteLine($"Test fixture root: {fixture.TempDirectory}");
 
                 foreach (var context in loader.GetDirectoryLoadContextsSnapshot())
                 {
@@ -88,9 +88,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
 
     public sealed class InvokeUtil : MarshalByRefObject
     {
-        public void Exec(ITestOutputHelper testOutputHelper, bool shadowLoad, string typeName, string methodName)
+        public void Exec(ITestOutputHelper testOutputHelper, AssemblyLoadTestFixture fixture, bool shadowLoad, string typeName, string methodName)
         {
-            using var fixture = new AssemblyLoadTestFixture();
             using var tempRoot = new TempRoot();
             AnalyzerAssemblyLoader loader = shadowLoad
                 ? new ShadowCopyAnalyzerAssemblyLoader(tempRoot.CreateDirectory().Path)
@@ -107,7 +106,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
             finally
             {
-                testOutputHelper.WriteLine($"Test fixture root: {fixture.TempDirectory.Path}");
+                testOutputHelper.WriteLine($"Test fixture root: {fixture.TempDirectory}");
 
                 testOutputHelper.WriteLine($"Loaded Assemblies");
                 foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().OrderByDescending(x => x.FullName))

--- a/src/Compilers/Server/VBCSCompilerTests/AnalyzerConsistencyCheckerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/AnalyzerConsistencyCheckerTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         public void MissingReference()
         {
             var directory = Temp.CreateDirectory();
-            var alphaDll = directory.CopyFile(TestFixture.Alpha.Path);
+            var alphaDll = directory.CopyFile(TestFixture.Alpha);
 
             var analyzerReferences = ImmutableArray.Create(new CommandLineAnalyzerReference("Alpha.dll"));
             var result = AnalyzerConsistencyChecker.Check(directory.Path, analyzerReferences, new InMemoryAssemblyLoader(), Logger);
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                 new CommandLineAnalyzerReference("Gamma.dll"),
                 new CommandLineAnalyzerReference("Delta.dll"));
 
-            var result = AnalyzerConsistencyChecker.Check(Path.GetDirectoryName(TestFixture.Alpha.Path), analyzerReferences, new InMemoryAssemblyLoader(), Logger);
+            var result = AnalyzerConsistencyChecker.Check(Path.GetDirectoryName(TestFixture.Alpha), analyzerReferences, new InMemoryAssemblyLoader(), Logger);
             Assert.True(result);
         }
 
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         public void AssemblyLoadException()
         {
             var directory = Temp.CreateDirectory();
-            directory.CopyFile(TestFixture.Delta1.Path);
+            directory.CopyFile(TestFixture.Delta1);
 
             var analyzerReferences = ImmutableArray.Create(
                 new CommandLineAnalyzerReference("Delta.dll"));

--- a/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
+++ b/src/Compilers/Test/Core/AssemblyLoadTestFixture.cs
@@ -15,100 +15,100 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
-    public sealed class AssemblyLoadTestFixture : IDisposable
+    public sealed class AssemblyLoadTestFixture : MarshalByRefObject, IDisposable
     {
         private readonly TempRoot _temp;
         private readonly TempDirectory _directory;
 
-        public TempDirectory TempDirectory => _directory;
+        public string TempDirectory => _directory.Path;
 
         /// <summary>
         /// An assembly with no references, assembly version 1.
         /// </summary>
-        public TempFile Delta1 { get; }
+        public string Delta1 { get; }
 
         /// <summary>
         /// An assembly with no references, assembly version 1, and public signed.
         /// </summary>
-        public TempFile DeltaPublicSigned1 { get; }
+        public string DeltaPublicSigned1 { get; }
 
         /// <summary>
         /// An assembly with a reference to <see cref="Delta1"/>.
         /// </summary>
-        public TempFile Gamma { get; }
+        public string Gamma { get; }
 
         /// <summary>
         /// An assembly with a reference to <see cref="DeltaPublicSigned1"/>.
         /// </summary>
-        public TempFile GammaReferencingPublicSigned { get; }
+        public string GammaReferencingPublicSigned { get; }
 
         /// <summary>
         /// An assembly with a reference to <see cref="Gamma"/>.
         /// </summary>
-        public TempFile Beta { get; }
+        public string Beta { get; }
 
         /// <summary>
         /// An assembly with a reference to <see cref="Gamma"/>.
         /// </summary>
-        public TempFile Alpha { get; }
+        public string Alpha { get; }
 
         /// <summary>
         /// An assembly with no references, assembly version 2.
         /// </summary>
-        public TempFile Delta2 { get; }
+        public string Delta2 { get; }
 
         /// <summary>
         /// An assembly with no references, assembly version 2, and public signed.
         /// </summary>
-        public TempFile DeltaPublicSigned2 { get; }
+        public string DeltaPublicSigned2 { get; }
 
         /// <summary>
         /// An assembly with a reference to <see cref="Delta2"/>.
         /// </summary>
-        public TempFile Epsilon { get; }
+        public string Epsilon { get; }
 
         /// <summary>
         /// An assembly with a reference to <see cref="DeltaPublicSigned2"/>.
         /// </summary>
-        public TempFile EpsilonReferencingPublicSigned { get; }
+        public string EpsilonReferencingPublicSigned { get; }
 
         /// <summary>
         /// An assembly with no references, assembly version 2. The implementation however is different than
         /// <see cref="Delta2"/> so we can test having two assemblies that look the same but aren't.
         /// </summary>
-        public TempFile Delta2B { get; }
+        public string Delta2B { get; }
 
         /// <summary>
         /// An assembly with no references, assembly version 3.
         /// </summary>
-        public TempFile Delta3 { get; }
+        public string Delta3 { get; }
 
-        public TempFile UserSystemCollectionsImmutable { get; }
+        public string UserSystemCollectionsImmutable { get; }
 
         /// <summary>
         /// An analyzer which uses members in its referenced version of System.Collections.Immutable
         /// that are not present in the compiler's version of System.Collections.Immutable.
         /// </summary>
-        public TempFile AnalyzerReferencesSystemCollectionsImmutable1 { get; }
+        public string AnalyzerReferencesSystemCollectionsImmutable1 { get; }
 
         /// <summary>
         /// An analyzer which uses members in its referenced version of System.Collections.Immutable
         /// which have different behavior than the same members in compiler's version of System.Collections.Immutable.
         /// </summary>
-        public TempFile AnalyzerReferencesSystemCollectionsImmutable2 { get; }
+        public string AnalyzerReferencesSystemCollectionsImmutable2 { get; }
 
-        public TempFile AnalyzerReferencesDelta1 { get; }
+        public string AnalyzerReferencesDelta1 { get; }
 
-        public TempFile FaultyAnalyzer { get; }
+        public string FaultyAnalyzer { get; }
 
-        public TempFile AnalyzerWithDependency { get; }
-        public TempFile AnalyzerDependency { get; }
+        public string AnalyzerWithDependency { get; }
+        public string AnalyzerDependency { get; }
 
-        public TempFile AnalyzerWithNativeDependency { get; }
+        public string AnalyzerWithNativeDependency { get; }
 
-        public TempFile AnalyzerWithFakeCompilerDependency { get; }
+        public string AnalyzerWithFakeCompilerDependency { get; }
 
-        public TempFile AnalyzerWithLaterFakeCompilerDependency { get; }
+        public string AnalyzerWithLaterFakeCompilerDependency { get; }
 
         public AssemblyLoadTestFixture()
         {
@@ -134,7 +134,7 @@ namespace Delta
 ";
 
             Delta1 = GenerateDll("Delta", _directory, Delta1Source);
-            var delta1Reference = MetadataReference.CreateFromFile(Delta1.Path);
+            var delta1Reference = MetadataReference.CreateFromFile(Delta1);
             DeltaPublicSigned1 = GenerateDll("DeltaPublicSigned", _directory.CreateDirectory("Delta1PublicSigned"), Delta1Source, publicKeyOpt: SigningTestHelpers.PublicKey);
 
             const string GammaSource = @"
@@ -155,9 +155,9 @@ namespace Gamma
 }
 ";
             Gamma = GenerateDll("Gamma", _directory, GammaSource, delta1Reference);
-            GammaReferencingPublicSigned = GenerateDll("GammaReferencingPublicSigned", _directory.CreateDirectory("GammaReferencingPublicSigned"), GammaSource, MetadataReference.CreateFromFile(DeltaPublicSigned1.Path));
+            GammaReferencingPublicSigned = GenerateDll("GammaReferencingPublicSigned", _directory.CreateDirectory("GammaReferencingPublicSigned"), GammaSource, MetadataReference.CreateFromFile(DeltaPublicSigned1));
 
-            var gammaReference = MetadataReference.CreateFromFile(Gamma.Path);
+            var gammaReference = MetadataReference.CreateFromFile(Gamma);
             Beta = GenerateDll("Beta", _directory, @"
 using System.Text;
 using Gamma;
@@ -216,7 +216,7 @@ namespace Delta
             var v2PublicSignedDirectory = _directory.CreateDirectory("Version2PublicSigned");
             DeltaPublicSigned2 = GenerateDll("DeltaPublicSigned", v2PublicSignedDirectory, Delta2Source, publicKeyOpt: SigningTestHelpers.PublicKey);
 
-            var delta2Reference = MetadataReference.CreateFromFile(Delta2.Path);
+            var delta2Reference = MetadataReference.CreateFromFile(Delta2);
 
             const string EpsilonSource = @"
 using System.Text;
@@ -236,7 +236,7 @@ namespace Epsilon
 }
 ";
             Epsilon = GenerateDll("Epsilon", v2Directory, EpsilonSource, delta2Reference);
-            EpsilonReferencingPublicSigned = GenerateDll("EpsilonReferencingPublicSigned", v2PublicSignedDirectory, EpsilonSource, MetadataReference.CreateFromFile(DeltaPublicSigned2.Path));
+            EpsilonReferencingPublicSigned = GenerateDll("EpsilonReferencingPublicSigned", v2PublicSignedDirectory, EpsilonSource, MetadataReference.CreateFromFile(DeltaPublicSigned2));
 
             var v2BDirectory = _directory.CreateDirectory("Version2B");
             Delta2B = GenerateDll("Delta", v2BDirectory, @"
@@ -296,7 +296,7 @@ namespace System.Collections.Immutable
 }
 ", compilerReference);
 
-            var userSystemCollectionsImmutableReference = MetadataReference.CreateFromFile(UserSystemCollectionsImmutable.Path);
+            var userSystemCollectionsImmutableReference = MetadataReference.CreateFromFile(UserSystemCollectionsImmutable);
             AnalyzerReferencesSystemCollectionsImmutable1 = GenerateDll("AnalyzerUsesSystemCollectionsImmutable1", sciUserDirectory, @"
 using System.Text;
 using System.Collections.Immutable;
@@ -324,7 +324,7 @@ public class Analyzer
 ", userSystemCollectionsImmutableReference, compilerReference);
 
             var analyzerReferencesDelta1Directory = _directory.CreateDirectory("AnalyzerReferencesDelta1");
-            var delta1InAnalyzerReferencesDelta1 = analyzerReferencesDelta1Directory.CopyFile(Delta1.Path);
+            var delta1InAnalyzerReferencesDelta1 = analyzerReferencesDelta1Directory.CopyFile(Delta1);
 
             AnalyzerReferencesDelta1 = GenerateDll("AnalyzerReferencesDelta1", _directory, @"
 using System.Text;
@@ -375,7 +375,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 public sealed class TestAnalyzer : AbstractTestAnalyzer
 {
     private static string SomeString2 = AbstractTestAnalyzer.SomeString;
-}", realSciReference, compilerReference, MetadataReference.CreateFromFile(AnalyzerDependency.Path));
+}", realSciReference, compilerReference, MetadataReference.CreateFromFile(AnalyzerDependency));
 
             AnalyzerWithNativeDependency = GenerateDll("AnalyzerWithNativeDependency", _directory, @"
 using System;
@@ -413,7 +413,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     }
 }
 ");
-            var fakeCompilerReference = MetadataReference.CreateFromFile(fakeCompilerAssembly.Path);
+            var fakeCompilerReference = MetadataReference.CreateFromFile(fakeCompilerAssembly);
             AnalyzerWithFakeCompilerDependency = GenerateDll("AnalyzerWithFakeCompilerDependency", analyzerWithFakeCompilerDependencyDirectory, @"
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -441,7 +441,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     }
 }
 ");
-            var laterCompilerReference = MetadataReference.CreateFromFile(laterFakeCompilerAssembly.Path);
+            var laterCompilerReference = MetadataReference.CreateFromFile(laterFakeCompilerAssembly);
             AnalyzerWithLaterFakeCompilerDependency = GenerateDll("AnalyzerWithLaterFakeCompilerDependency", analyzerWithLaterFakeCompileDirectory, @"
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -451,12 +451,12 @@ public class Analyzer : DiagnosticAnalyzer
 }", laterCompilerReference);
         }
 
-        private static TempFile GenerateDll(string assemblyName, TempDirectory directory, string csSource, params MetadataReference[] additionalReferences)
+        private static string GenerateDll(string assemblyName, TempDirectory directory, string csSource, params MetadataReference[] additionalReferences)
         {
             return GenerateDll(assemblyName, directory, csSource, publicKeyOpt: default, additionalReferences);
         }
 
-        private static TempFile GenerateDll(string assemblyName, TempDirectory directory, string csSource, ImmutableArray<byte> publicKeyOpt, params MetadataReference[] additionalReferences)
+        private static string GenerateDll(string assemblyName, TempDirectory directory, string csSource, ImmutableArray<byte> publicKeyOpt, params MetadataReference[] additionalReferences)
         {
             CSharpCompilationOptions options = new(OutputKind.DynamicallyLinkedLibrary, warningLevel: Diagnostic.MaxWarningLevel);
 
@@ -485,7 +485,7 @@ public class Analyzer : DiagnosticAnalyzer
             var fileInfo = new FileInfo(tempFile.Path);
             fileInfo.IsReadOnly = true;
 
-            return tempFile;
+            return tempFile.Path;
         }
 
         public void Dispose()

--- a/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/SnapshotSerializationTests.cs
@@ -478,8 +478,8 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             var dir = temp.CreateDirectory();
 
             // create two analyzer assembly files whose content is identical but path is different:
-            var file1 = dir.CreateFile("analyzer1.dll").CopyContentFrom(_testFixture.FaultyAnalyzer.Path);
-            var file2 = dir.CreateFile("analyzer2.dll").CopyContentFrom(_testFixture.FaultyAnalyzer.Path);
+            var file1 = dir.CreateFile("analyzer1.dll").CopyContentFrom(_testFixture.FaultyAnalyzer);
+            var file2 = dir.CreateFile("analyzer2.dll").CopyContentFrom(_testFixture.FaultyAnalyzer);
 
             var analyzer1 = new AnalyzerFileReference(file1.Path, TestAnalyzerAssemblyLoader.LoadNotImplemented);
             var analyzer2 = new AnalyzerFileReference(file2.Path, TestAnalyzerAssemblyLoader.LoadNotImplemented);

--- a/src/Workspaces/Remote/ServiceHubTest/RemoteAnalyzerAssemblyLoaderTests.cs
+++ b/src/Workspaces/Remote/ServiceHubTest/RemoteAnalyzerAssemblyLoaderTests.cs
@@ -26,8 +26,8 @@ namespace Microsoft.CodeAnalysis.Remote.UnitTests
             // Try to load MS.CA.Remote.ServiceHub.dll as an analyzer assembly via RemoteAnalyzerAssemblyLoader
             // since it's not one of the special assemblies listed in RemoteAnalyzerAssemblyLoader,
             // RemoteAnalyzerAssemblyLoader should loaded in a spearate DirectoryLoadContext. 
-            loader.AddDependencyLocation(testFixture.Delta1.Path);
-            var remoteAssemblyLoadedViaRemoteLoader = loader.LoadFromPath(testFixture.Delta1.Path);
+            loader.AddDependencyLocation(testFixture.Delta1);
+            var remoteAssemblyLoadedViaRemoteLoader = loader.LoadFromPath(testFixture.Delta1);
 
             var alc1 = AssemblyLoadContext.GetLoadContext(remoteAssemblyInCurrentAlc);
             var alc2 = AssemblyLoadContext.GetLoadContext(remoteAssemblyLoadedViaRemoteLoader);


### PR DESCRIPTION
This moves `AssemblyLoadTestFixture` to be a `MarshalByRefObject`. That means we can have a single instance that is shared amongst all of the `AppDomain` that we create in our tests. This significantly improves performance of our tests because it removes loads of redundant compilations from the test run.

In order to make it `MarshalByRefObject` I had to switch the API of the type to have types that can travel across the `AppDomain` boundary. Primarily that means moving from a `TempFile` return to `string`. That was very simple in the type but resulted in a lot of `.Path` deletion in other parts of the code base.

The change is highly mechanical in nature 🙁