### PR TITLE
Revert "Record added node output states as new"

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -967,7 +967,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
 
             values = ImmutableArray.Create(1, 2, 3);
 
-            // second time we'll see that the "Input" step is modified, but the outputs of the "SelectMany" step are new.
+            // second time we'll see that the "Input" step is modified, but the outputs of the "SelectMany" step are modified.
             dstBuilder = GetBuilder(dstBuilder.ToImmutable(), trackIncrementalGeneratorSteps: true);
             var table = dstBuilder.GetLatestStateTableForNode(transformNode);
 
@@ -979,7 +979,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
 
             Assert.All(step.Outputs, output =>
             {
-                Assert.Equal(IncrementalStepRunReason.New, output.Reason);
+                Assert.Equal(IncrementalStepRunReason.Modified, output.Reason);
             });
         }
 

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -406,7 +406,7 @@ namespace Microsoft.CodeAnalysis
                     (EntryState.Cached, EntryState.Cached) => IncrementalStepRunReason.Cached,
                     (EntryState.Removed, EntryState.Removed) => IncrementalStepRunReason.Removed,
                     (EntryState.Modified, EntryState.Removed) => IncrementalStepRunReason.Removed,
-                    (EntryState.Modified, EntryState.Added) => IncrementalStepRunReason.New,
+                    (EntryState.Modified, EntryState.Added) => IncrementalStepRunReason.Modified,
                     _ => throw ExceptionUtilities.UnexpectedValue((inputState, outputState))
                 };
             }


### PR DESCRIPTION
Reverts dotnet/roslyn#61575 - it broke CI