### PR TITLE
Do not suggest replacing lambda with method group if the invoked mehod has `Conditional` attribute

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryLambdaExpression/CSharpRemoveUnnecessaryLambdaExpressionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/RemoveUnnecessaryLambdaExpression/CSharpRemoveUnnecessaryLambdaExpressionDiagnosticAnalyzer.cs
@@ -170,6 +170,10 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryLambdaExpression
                     return;
             }
 
+            // If invoked method is conditional, converting lambda to method group produces compiler error
+            if (invokedMethod.GetAttributes().Any(a => Equals(a.AttributeClass, compilation.ConditionalAttribute())))
+                return;
+
             // Semantically, this looks good to go.  Now, do an actual speculative replacement to ensure that the
             // non-invoked method reference refers to the same method symbol, and that it converts to the same type that
             // the lambda was.

--- a/src/Analyzers/CSharp/Tests/RemoveUnnecessaryLambdaExpression/RemoveUnnecessaryLambdaExpressionTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnnecessaryLambdaExpression/RemoveUnnecessaryLambdaExpressionTests.cs
@@ -1539,5 +1539,27 @@ public partial class C
     private static void M2(Action<string> a) { }
 }");
         }
+
+        [Fact, WorkItem(63464, "https://github.com/dotnet/roslyn/issues/63464")]
+        public async Task TestNotWithConditionalAttribute()
+        {
+            await TestMissingInRegularAndScriptAsync("""
+                using System;
+                using System.Diagnostics;
+
+                public class C
+                {
+                    internal void M1()
+                    {
+                        M2(x => M3(x));
+                    }
+
+                    [Conditional("DEBUG")]
+                    internal void M3(string s) { }
+
+                    private static void M2(Action<string> a) { }
+                }
+                """);
+        }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/63464