### PR TITLE
Enable MSBuild COMM log

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -227,6 +227,9 @@ function BuildSolution() {
       throw "Overwriting binary log files"
     }
 
+  }
+
+  if ($ci) {
     ${env:ROSLYNCOMMANDLINELOGFILE} = Join-Path $LogDir "Build.Server.log"
     ${env:MSBUILDDEBUGCOMM} = 1
     ${env:MSBUILDDEBUGPATH} = Join-Path $LogDir "MSbuild.Comm.log"
@@ -293,7 +296,6 @@ function BuildSolution() {
     ${env:MSBUILDDEBUGPATH} = $null
   }
 }
-
 
 # Get the branch that produced the IBC data this build is going to consume.
 # IBC data are only merged in official built, but we want to test some of the logic in CI builds as well.

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -35,7 +35,6 @@ param (
   [string]$bootstrapConfiguration = "Release",
   [switch][Alias('bl')]$binaryLog,
   [string]$binaryLogName = "",
-  [switch]$buildServerLog,
   [switch]$ci,
   [switch]$collectDumps,
   [switch][Alias('a')]$runAnalyzers,
@@ -81,7 +80,6 @@ function Print-Usage() {
   Write-Host "  -deployExtensions         Deploy built vsixes (short: -d)"
   Write-Host "  -binaryLog                Create MSBuild binary log (short: -bl)"
   Write-Host "  -binaryLogName            Name of the binary log (default Build.binlog)"
-  Write-Host "  -buildServerLog           Create Roslyn build server log"
   Write-Host ""
   Write-Host "Actions:"
   Write-Host "  -restore                  Restore packages (short: -r)"
@@ -174,9 +172,6 @@ function Process-Arguments() {
 
   if ($ci) {
     $script:binaryLog = $true
-    if ($bootstrap) {
-      $script:buildServerLog = $true
-    }
   }
 
   if ($binaryLog -and ($binaryLogName -eq "")) {
@@ -231,10 +226,10 @@ function BuildSolution() {
       Write-LogIssue -Type "error" -Message "Overwriting binary log file $($binaryLogPath)"
       throw "Overwriting binary log files"
     }
-  }
 
-  if ($buildServerLog) {
     ${env:ROSLYNCOMMANDLINELOGFILE} = Join-Path $LogDir "Build.Server.log"
+    ${env:MSBUILDDEBUGCOMM} = 1
+    ${env:MSBUILDDEBUGPATH} = Join-Path $LogDir "MSbuild.Comm.log"
   }
 
   $projects = Join-Path $RepoRoot $solution
@@ -294,6 +289,8 @@ function BuildSolution() {
   }
   finally {
     ${env:ROSLYNCOMMANDLINELOGFILE} = $null
+    ${env:MSBUILDDEBUGCOMM} = 0
+    ${env:MSBUILDDEBUGPATH} = $null
   }
 }
 


### PR DESCRIPTION
Enable MSBuild COM log so that we have more information for debugging issues like node reuse.

Rather than having yet another switch for controlling build logs I decided to infer from `$ci` that we should have compiler and msbuild COMM logs. There is no case I could think of where we didn't want this behavior and it simplified this change a lot.