### PR TITLE
Fix MSBuildWorkspace report warnings as failure

### DIFF
--- a/src/Workspaces/Core/MSBuild/MSBuild/DiagnosticReporter.cs
+++ b/src/Workspaces/Core/MSBuild/MSBuild/DiagnosticReporter.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         {
             foreach (var logItem in log)
             {
-                Report(DiagnosticReportingMode.Log, GetMSBuildFailedMessage(logItem.ProjectFilePath, logItem.ToString()));
+                Report(new WorkspaceDiagnostic(logItem.Kind, GetMSBuildFailedMessage(logItem.ProjectFilePath, logItem.ToString())));
             }
         }
 

--- a/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/MsbuildError.csproj
+++ b/src/Workspaces/MSBuildTest/Resources/ProjectFiles/CSharp/MsbuildError.csproj
@@ -46,7 +46,8 @@
     <CompileDependsOn>TestError;$(CompileDependsOn)</CompileDependsOn>
   </PropertyGroup>
   <Target Name="TestError" BeforeTargets="CoreCompile">
-    <Error Text="This is a test of the msbuild error system. This is only a test." />
+    <Warning Text="This is a test of the msbuild error system. This is a warning." />
+    <Error Text="This is a test of the msbuild error system. This is an error." />
   </Target>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
+++ b/src/Workspaces/MSBuildTest/VisualStudioMSBuildWorkspaceTests.cs
@@ -3022,8 +3022,19 @@ class C { }";
             using var workspace = CreateMSBuildWorkspace(throwOnWorkspaceFailed: false);
             var proj = await workspace.OpenProjectAsync(projectFilePath);
 
-            var diagnostic = Assert.Single(workspace.Diagnostics);
-            Assert.StartsWith("Msbuild failed", diagnostic.Message);
+            Assert.Collection(workspace.Diagnostics,
+                d =>
+                {
+                    Assert.StartsWith("Msbuild failed", d.Message);
+                    Assert.Contains("This is a warning", d.Message);
+                    Assert.Equal(WorkspaceDiagnosticKind.Warning, d.Kind);
+                },
+                d =>
+                {
+                    Assert.StartsWith("Msbuild failed", d.Message);
+                    Assert.Contains("This is an error", d.Message);
+                    Assert.Equal(WorkspaceDiagnosticKind.Failure, d.Kind);
+                });
         }
 
         [ConditionalFact(typeof(VisualStudioMSBuildInstalled))]


### PR DESCRIPTION
Warnings in msbuild is reported as failures in `MSBuildWorkspace.Diagnostics`, this prevents users of `MSBuildWorkspace` to ignore these warnings and fail only on error.

https://github.com/dotnet/docfx/issues/8000 https://github.com/dotnet/docfx/issues/8118