### PR TITLE
Emit a space between lambda's return type and its open paren when normalizing syntax

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -873,12 +873,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 }
             }
 
-            // Require a separator between a lambda return type and its open paren.
-            // Current token might be 2 or 3 layers deeper than lambda expression.
-            // If the type syntax is simple, e.g. int () => ... then the token is 2 layers deeper.
-            // In more complex cases, e.g. int[] () => ..., A.B* () => ... etc. it is 3 layers deeper that the lambda.
-            if (token.Parent is { Parent: LambdaExpressionSyntax or { Parent: LambdaExpressionSyntax } } &&
-                next is { RawKind: (int)SyntaxKind.OpenParenToken, Parent.Parent: LambdaExpressionSyntax })
+            // Require a separator between a lambda return type and its open paren
+            if (next is { RawKind: (int)SyntaxKind.OpenParenToken, Parent.Parent: ParenthesizedLambdaExpressionSyntax lambda } &&
+                lambda.ReturnType?.GetLastToken() == token)
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -873,6 +873,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 }
             }
 
+            // Require a break between a lambda return type and its open paren. Current token might be:
+            // 1. Simple type (predefined or identifier): int () => ... The parent of token is Predefined/Identifier type syntax, which parent is lambda
+            // 2. Close paren of a tuple: (int, int) () => ... The parent of token is tuple type syntax, which parent is lambda
+            // 3. Close `>` of generic name: Task<int> () => ... The parent of token is type argument list, its parent is generic name syntax, and its parent is finally lambda
+            if (token.Parent is { Parent: LambdaExpressionSyntax or { Parent: LambdaExpressionSyntax } } &&
+                next is { RawKind: (int)SyntaxKind.OpenParenToken, Parent.Parent: LambdaExpressionSyntax })
+            {
+                return true;
+            }
+
             if (IsKeyword(token.Kind()))
             {
                 if (!next.IsKind(SyntaxKind.ColonToken) &&

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -873,10 +873,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 }
             }
 
-            // Require a separator between a lambda return type and its open paren. Current token might be:
-            // 1. Simple type (predefined or identifier): int () => ... The parent of token is Predefined/Identifier type syntax, which parent is lambda
-            // 2. Close paren of a tuple: (int, int) () => ... The parent of token is tuple type syntax, which parent is lambda
-            // 3. Close `>` of generic name: Task<int> () => ... The parent of token is type argument list, its parent is generic name syntax, and its parent is finally lambda
+            // Require a separator between a lambda return type and its open paren.
+            // Current token might be 2 or 3 layers deeper than lambda expression.
+            // If the type syntax is simple, e.g. int () => ... then the token is 2 layers deeper.
+            // In more complex cases, e.g. int[] () => ..., A.B* () => ... etc. it is 3 layers deeper that the lambda.
             if (token.Parent is { Parent: LambdaExpressionSyntax or { Parent: LambdaExpressionSyntax } } &&
                 next is { RawKind: (int)SyntaxKind.OpenParenToken, Parent.Parent: LambdaExpressionSyntax })
             {

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNormalizer.cs
@@ -873,7 +873,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 }
             }
 
-            // Require a break between a lambda return type and its open paren. Current token might be:
+            // Require a separator between a lambda return type and its open paren. Current token might be:
             // 1. Simple type (predefined or identifier): int () => ... The parent of token is Predefined/Identifier type syntax, which parent is lambda
             // 2. Close paren of a tuple: (int, int) () => ... The parent of token is tuple type syntax, which parent is lambda
             // 3. Close `>` of generic name: Task<int> () => ... The parent of token is type argument list, its parent is generic name syntax, and its parent is finally lambda

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -855,6 +855,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 """,
                 "static async A<int> () => x");
             TestNormalizeExpression("(A,B)()=>(new A(),new B())", "(A, B) () => (new A(), new B())");
+            TestNormalizeExpression("A.B()=>null", "A.B () => null");
+            TestNormalizeExpression("A.B.C()=>null", "A.B.C () => null");
+            TestNormalizeExpression("int[]()=>null", "int[] () => null");
+            TestNormalizeExpression("A.B[]()=>null", "A.B[] () => null");
+            TestNormalizeExpression("A.B.C[]()=>null", "A.B.C[] () => null");
+            TestNormalizeExpression("int*()=>null", "int* () => null");
+            TestNormalizeExpression("A.B*()=>null", "A.B* () => null");
+            TestNormalizeExpression("A.B.C*()=>null", "A.B.C* () => null");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -832,7 +832,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             TestNormalizeExpression(
                 "[A]B()=>{ }", """
                 [A]
-                B() =>
+                B () =>
                 {
                 }
                 """);

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNormalizerTests.cs
@@ -844,7 +844,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             TestNormalizeExpression("int( x )=>x", "int (x) => x");
             TestNormalizeExpression(
                 "A( B b )=>{}", """
-                A(B b) =>
+                A (B b) =>
                 {
                 }
                 """);
@@ -853,7 +853,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 async
                 A<int>()=>x
                 """,
-                "static async A<int>() => x");
+                "static async A<int> () => x");
+            TestNormalizeExpression("(A,B)()=>(new A(),new B())", "(A, B) () => (new A(), new B())");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/59653