### PR TITLE
Add support for collapsing case statements

### DIFF
--- a/src/EditorFeatures/CSharpTest/Structure/SwitchStatementStructureTests.cs
+++ b/src/EditorFeatures/CSharpTest/Structure/SwitchStatementStructureTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Structure;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -33,6 +31,36 @@ class C
 
             await VerifyBlockSpansAsync(code,
                 Region("textspan", "hint", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Outlining)]
+        public async Task TestSwitchStatement2()
+        {
+            const string code = @"
+class C
+{
+    void M()
+    {
+        {|hint1:$$switch (expr){|textspan1:
+        {
+            {|hint2:case 0:{|textspan2:
+                if (true)
+                {
+                }
+                break;|}|}
+            {|hint3:default:{|textspan3:
+                if (false)
+                {
+                }
+                break;|}|}
+        }|}|}
+    }
+}";
+
+            await VerifyBlockSpansAsync(code,
+                Region("textspan1", "hint1", CSharpStructureHelpers.Ellipsis, autoCollapse: false),
+                Region("textspan2", "hint2", CSharpStructureHelpers.Ellipsis, autoCollapse: false),
+                Region("textspan3", "hint3", CSharpStructureHelpers.Ellipsis, autoCollapse: false));
         }
     }
 }

--- a/src/Features/CSharp/Portable/Structure/Providers/SwitchStatementStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/SwitchStatementStructureProvider.cs
@@ -29,9 +29,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             {
                 if (section.Labels.Count > 0 && section.Statements.Count > 0)
                 {
+                    var start = section.Labels.Last().ColonToken.Span.End;
+                    var end = section.Statements.Last().Span.End;
+
                     spans.Add(new BlockSpan(
                         isCollapsible: true,
-                        textSpan: TextSpan.FromBounds(section.Labels.Last().ColonToken.Span.End, section.Statements.Last().Span.End),
+                        textSpan: TextSpan.FromBounds(start, end),
                         hintSpan: section.Span,
                         type: BlockTypes.Statement));
                 }

--- a/src/Features/CSharp/Portable/Structure/Providers/SwitchStatementStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/SwitchStatementStructureProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Shared.Collections;
@@ -23,9 +21,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
         {
             spans.Add(new BlockSpan(
                 isCollapsible: true,
-                textSpan: TextSpan.FromBounds((node.CloseParenToken != default) ? node.CloseParenToken.Span.End : node.Expression.Span.End, node.CloseBraceToken.Span.End),
+                textSpan: TextSpan.FromBounds(node.CloseParenToken != default ? node.CloseParenToken.Span.End : node.Expression.Span.End, node.CloseBraceToken.Span.End),
                 hintSpan: node.Span,
                 type: BlockTypes.Conditional));
+
+            foreach (var section in node.Sections)
+            {
+                if (section.Labels.Count > 0 && section.Statements.Count > 0)
+                {
+                    spans.Add(new BlockSpan(
+                        isCollapsible: true,
+                        textSpan: TextSpan.FromBounds(section.Labels.Last().ColonToken.Span.End, section.Statements.Last().Span.End),
+                        hintSpan: section.Span,
+                        type: BlockTypes.Statement));
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/66432

Looks like this:

![image](https://user-images.githubusercontent.com/4564579/217077105-c171c317-7a25-462b-8e25-d10dbd7330dc.png)

Sticky scroll looks like this now:

![image](https://user-images.githubusercontent.com/4564579/217077177-5eebe002-32e8-41d7-bf7e-027c6c25ac40.png)
