### PR TITLE
Update 'Prefer Language/Framework type' to support IntPtr/nint.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/PreferFrameworkType/PreferFrameworkTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/PreferFrameworkType/PreferFrameworkTypeTests.cs
@@ -213,6 +213,61 @@ class Program
         }
 
         [Fact]
+        public async Task TestNint_WithNumericIntPtr_CSharp11()
+        {
+            var code =
+@"<Workspace>
+    <Project Language=""C#"" CommonReferencesNet7=""true"" LanguageVersion=""11"">
+        <Document>using System;
+class Program
+{
+    [|nint|] _myfield;
+}</Document>
+    </Project>
+</Workspace>";
+
+            var expected =
+@"using System;
+class Program
+{
+    IntPtr _myfield;
+}";
+            await TestInRegularAndScriptAsync(code, expected, options: FrameworkTypeInDeclaration);
+        }
+
+        [Fact]
+        public async Task TestNint_WithNumericIntPtr_CSharp8()
+        {
+            var code =
+@"<Workspace>
+    <Project Language=""C#"" CommonReferencesNet7=""true"" LanguageVersion=""8"">
+        <Document>using System;
+class Program
+{
+    [|nint|] _myfield;
+}</Document>
+    </Project>
+</Workspace>";
+            await TestMissingInRegularAndScriptAsync(code, new TestParameters(options: FrameworkTypeInDeclaration));
+        }
+
+        [Fact]
+        public async Task TestNint_WithoutNumericIntPtr()
+        {
+            var code =
+@"<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" LanguageVersion=""11"">
+        <Document>using System;
+class Program
+{
+    [|nint|] _myfield;
+}</Document>
+    </Project>
+</Workspace>";
+            await TestMissingInRegularAndScriptAsync(code, new TestParameters(options: FrameworkTypeInDeclaration));
+        }
+
+        [Fact]
         public async Task FieldDeclarationWithInitializer()
         {
             var code =

--- a/src/EditorFeatures/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
+++ b/src/EditorFeatures/CSharpTest/SimplifyTypeNames/SimplifyTypeNamesTests.cs
@@ -6181,6 +6181,106 @@ public ref struct A
 }");
         }
 
+        [Fact]
+        public async Task TestNint1_NoNumericIntPtr()
+        {
+            var source =
+@"class A
+{
+    [|System.IntPtr|] i;
+}";
+            var featureOptions = PreferIntrinsicTypeEverywhere;
+            await TestMissingInRegularAndScriptAsync(source, new TestParameters(options: featureOptions));
+        }
+
+        [Fact]
+        public async Task TestNint1_WithNumericIntPtr_CSharp11()
+        {
+            var featureOptions = PreferIntrinsicTypeEverywhere;
+            await TestInRegularAndScriptAsync(
+@"
+<Workspace>
+    <Project Language=""C#"" CommonReferencesNet7=""true"">
+        <Document>class A
+{
+    [|System.IntPtr|] i;
+}</Document>
+    </Project>
+</Workspace>
+",
+@"class A
+{
+    nint i;
+}", options: featureOptions);
+        }
+
+        [Fact]
+        public async Task TestNint1_WithNumericIntPtr_CSharp8()
+        {
+            var featureOptions = PreferIntrinsicTypeEverywhere;
+            await TestMissingInRegularAndScriptAsync(
+@"
+<Workspace>
+    <Project Language=""C#"" CommonReferencesNet7=""true"" LanguageVersion=""8"">
+        <Document>class A
+{
+    [|System.IntPtr|] i;
+}</Document>
+    </Project>
+</Workspace>
+", new TestParameters(options: featureOptions));
+        }
+
+        [Fact]
+        public async Task TestNUint1_NoNumericIntPtr()
+        {
+            var source =
+@"class A
+{
+    [|System.UIntPtr|] i;
+}";
+            var featureOptions = PreferIntrinsicTypeEverywhere;
+            await TestMissingInRegularAndScriptAsync(source, new TestParameters(options: featureOptions));
+        }
+
+        [Fact]
+        public async Task TestNUint1_WithNumericIntPtr_CSharp11()
+        {
+            var featureOptions = PreferIntrinsicTypeEverywhere;
+            await TestInRegularAndScriptAsync(
+@"
+<Workspace>
+    <Project Language=""C#"" CommonReferencesNet7=""true"">
+        <Document>class A
+{
+    [|System.UIntPtr|] i;
+}</Document>
+    </Project>
+</Workspace>
+",
+@"class A
+{
+    nuint i;
+}", options: featureOptions);
+        }
+
+        [Fact]
+        public async Task TestNUint1_WithNumericIntPtr_CSharp8()
+        {
+            var featureOptions = PreferIntrinsicTypeEverywhere;
+            await TestMissingInRegularAndScriptAsync(
+@"
+<Workspace>
+    <Project Language=""C#"" CommonReferencesNet7=""true"" LanguageVersion=""8"">
+        <Document>class A
+{
+    [|System.UIntPtr|] i;
+}</Document>
+    </Project>
+</Workspace>
+", new TestParameters(options: featureOptions));
+        }
+
         private async Task TestWithPredefinedTypeOptionsAsync(string code, string expected, int index = 0)
             => await TestInRegularAndScript1Async(code, expected, index, new TestParameters(options: PreferIntrinsicTypeEverywhere));
 

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_Create.cs
@@ -53,6 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         private const string CommonReferencesPortableAttributeName = "CommonReferencesPortable";
         private const string CommonReferencesNetCoreAppName = "CommonReferencesNetCoreApp";
         private const string CommonReferencesNet6Name = "CommonReferencesNet6";
+        private const string CommonReferencesNet7Name = "CommonReferencesNet7";
         private const string CommonReferencesNetStandard20Name = "CommonReferencesNetStandard20";
         private const string ReferencesOnDiskAttributeName = "ReferencesOnDisk";
         private const string FilePathAttributeName = "FilePath";

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -1117,6 +1117,14 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
                 references = TargetFrameworkUtil.GetReferences(TargetFramework.Net60).ToList();
             }
 
+            var net7 = element.Attribute(CommonReferencesNet7Name);
+            if (net7 != null &&
+                ((bool?)net7).HasValue &&
+                ((bool?)net7).Value)
+            {
+                references = TargetFrameworkUtil.GetReferences(TargetFramework.Net70).ToList();
+            }
+
             return references;
         }
 

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpPreferFrameworkTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpPreferFrameworkTypeDiagnosticAnalyzer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -14,16 +12,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.Analyzers
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal class CSharpPreferFrameworkTypeDiagnosticAnalyzer :
-        PreferFrameworkTypeDiagnosticAnalyzerBase<SyntaxKind, ExpressionSyntax, PredefinedTypeSyntax>
+        PreferFrameworkTypeDiagnosticAnalyzerBase<
+            SyntaxKind,
+            ExpressionSyntax,
+            TypeSyntax,
+            IdentifierNameSyntax,
+            PredefinedTypeSyntax>
     {
         protected override ImmutableArray<SyntaxKind> SyntaxKindsOfInterest { get; } =
-            ImmutableArray.Create(SyntaxKind.PredefinedType);
+            ImmutableArray.Create(SyntaxKind.PredefinedType, SyntaxKind.IdentifierName);
 
         ///<remarks>
         /// every predefined type keyword except <c>void</c> can be replaced by its framework type in code.
         ///</remarks>
         protected override bool IsPredefinedTypeReplaceableWithFrameworkType(PredefinedTypeSyntax node)
             => node.Keyword.Kind() != SyntaxKind.VoidKeyword;
+
+        // Only offer to change nint->System.IntPtr when it would preserve semantics exactly.
+        protected override bool IsIdentifierNameReplaceableWithFrameworkType(SemanticModel semanticModel, IdentifierNameSyntax node)
+            => (node.IsNint || node.IsNuint) &&
+               semanticModel.SyntaxTree.Options.LanguageVersion() >= LanguageVersion.CSharp9 &&
+               semanticModel.Compilation.SupportsRuntimeCapability(RuntimeCapability.NumericIntPtr);
 
         protected override bool IsInMemberAccessOrCrefReferenceContext(ExpressionSyntax node)
             => node.IsDirectChildOfMemberAccessExpression() || node.InsideCrefReference();

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicPreferFrameworkTypeDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicPreferFrameworkTypeDiagnosticAnalyzer.vb
@@ -10,13 +10,22 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic.Diagnostics.Analyzers
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Friend Class VisualBasicPreferFrameworkTypeDiagnosticAnalyzer
-        Inherits PreferFrameworkTypeDiagnosticAnalyzerBase(Of SyntaxKind, ExpressionSyntax, PredefinedTypeSyntax)
+        Inherits PreferFrameworkTypeDiagnosticAnalyzerBase(Of
+            SyntaxKind,
+            ExpressionSyntax,
+        TypeSyntax,
+        IdentifierNameSyntax,
+        PredefinedTypeSyntax)
 
         Protected Overrides ReadOnly Property SyntaxKindsOfInterest As ImmutableArray(Of SyntaxKind) =
             ImmutableArray.Create(SyntaxKind.PredefinedType)
 
         Protected Overrides Function IsInMemberAccessOrCrefReferenceContext(node As ExpressionSyntax) As Boolean
             Return node.IsDirectChildOfMemberAccessExpression() OrElse node.InsideCrefReference()
+        End Function
+
+        Protected Overrides Function IsIdentifierNameReplaceableWithFrameworkType(semanticModel As SemanticModel, node As IdentifierNameSyntax) As Boolean
+            Return False
         End Function
 
         Protected Overrides Function IsPredefinedTypeReplaceableWithFrameworkType(node As PredefinedTypeSyntax) As Boolean

--- a/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/ExpressionSimplifier.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/ExpressionSimplifier.cs
@@ -103,14 +103,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
             // if this node is annotated as being a SpecialType, let's use this information.
             if (memberAccess.HasAnnotations(SpecialTypeAnnotation.Kind))
             {
-                replacementNode = SyntaxFactory.PredefinedType(
-                    SyntaxFactory.Token(
-                        memberAccess.GetLeadingTrivia(),
-                        GetPredefinedKeywordKind(SpecialTypeAnnotation.GetSpecialType(memberAccess.GetAnnotations(SpecialTypeAnnotation.Kind).First())),
-                        memberAccess.GetTrailingTrivia()));
-
-                issueSpan = memberAccess.Span;
-                return true;
+                var replacementToken = TryGetPredefinedKeywordToken(
+                    semanticModel, SpecialTypeAnnotation.GetSpecialType(memberAccess.GetAnnotations(SpecialTypeAnnotation.Kind).First()));
+                if (replacementToken != null)
+                {
+                    replacementNode = CreatePredefinedTypeSyntax(memberAccess, replacementToken.Value);
+                    issueSpan = memberAccess.Span;
+                    return true;
+                }
             }
 
             // See https://github.com/dotnet/roslyn/issues/40974
@@ -167,12 +167,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
                 // Check if the Expression can be replaced by Predefined Type keyword
                 if (PreferPredefinedTypeKeywordInMemberAccess(memberAccess, options, semanticModel))
                 {
-                    if (symbol != null && symbol.IsKind(SymbolKind.NamedType))
+                    if (symbol is INamedTypeSymbol namedType)
                     {
-                        var keywordKind = GetPredefinedKeywordKind(((INamedTypeSymbol)symbol).SpecialType);
-                        if (keywordKind != SyntaxKind.None)
+                        var keywordToken = TryGetPredefinedKeywordToken(semanticModel, namedType.SpecialType);
+                        if (keywordToken != null)
                         {
-                            replacementNode = CreatePredefinedTypeSyntax(memberAccess, keywordKind);
+                            replacementNode = CreatePredefinedTypeSyntax(memberAccess, keywordToken.Value);
 
                             replacementNode = replacementNode
                                 .WithAdditionalAnnotations<TypeSyntax>(new SyntaxAnnotation(

--- a/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/NameSimplifier.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/NameSimplifier.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
             replacementNode = null;
             issueSpan = default;
 
-            if (name.IsVar)
+            if (name.IsVar || name.IsNint || name.IsNuint)
             {
                 return false;
             }

--- a/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/NameSimplifier.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/NameSimplifier.cs
@@ -101,250 +101,241 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
 
             if (name.HasAnnotations(SpecialTypeAnnotation.Kind))
             {
-                replacementNode = SyntaxFactory.PredefinedType(
-                    SyntaxFactory.Token(
-                        name.GetLeadingTrivia(),
-                        GetPredefinedKeywordKind(SpecialTypeAnnotation.GetSpecialType(name.GetAnnotations(SpecialTypeAnnotation.Kind).First())),
-                        name.GetTrailingTrivia()));
-
-                issueSpan = name.Span;
-
-                return CanReplaceWithReducedNameInContext(name, replacementNode, semanticModel);
-            }
-            else
-            {
-                if (!name.IsRightSideOfDotOrColonColon())
+                var keywordToken = TryGetPredefinedKeywordToken(semanticModel, SpecialTypeAnnotation.GetSpecialType(name.GetAnnotations(SpecialTypeAnnotation.Kind).First()));
+                if (keywordToken != null)
                 {
-                    if (TryReplaceExpressionWithAlias(name, semanticModel, symbol, cancellationToken, out var aliasReplacement))
+                    replacementNode = CreatePredefinedTypeSyntax(name, keywordToken.Value);
+                    issueSpan = name.Span;
+
+                    return CanReplaceWithReducedNameInContext(name, replacementNode, semanticModel);
+                }
+            }
+
+            if (!name.IsRightSideOfDotOrColonColon())
+            {
+                if (TryReplaceExpressionWithAlias(name, semanticModel, symbol, cancellationToken, out var aliasReplacement))
+                {
+                    // get the token text as it appears in source code to preserve e.g. Unicode character escaping
+                    var text = aliasReplacement.Name;
+                    var syntaxRef = aliasReplacement.DeclaringSyntaxReferences.FirstOrDefault();
+
+                    if (syntaxRef != null)
                     {
-                        // get the token text as it appears in source code to preserve e.g. Unicode character escaping
-                        var text = aliasReplacement.Name;
-                        var syntaxRef = aliasReplacement.DeclaringSyntaxReferences.FirstOrDefault();
+                        var declIdentifier = ((UsingDirectiveSyntax)syntaxRef.GetSyntax(cancellationToken)).Alias.Name.Identifier;
+                        text = declIdentifier.IsVerbatimIdentifier() ? declIdentifier.ToString()[1..] : declIdentifier.ToString();
+                    }
 
-                        if (syntaxRef != null)
+                    var identifierToken = SyntaxFactory.Identifier(
+                            name.GetLeadingTrivia(),
+                            SyntaxKind.IdentifierToken,
+                            text,
+                            aliasReplacement.Name,
+                            name.GetTrailingTrivia());
+
+                    identifierToken = CSharpSimplificationService.TryEscapeIdentifierToken(identifierToken, name);
+                    replacementNode = SyntaxFactory.IdentifierName(identifierToken);
+
+                    // Merge annotation to new syntax node
+                    var annotatedNodesOrTokens = name.GetAnnotatedNodesAndTokens(RenameAnnotation.Kind);
+                    foreach (var annotatedNodeOrToken in annotatedNodesOrTokens)
+                    {
+                        if (annotatedNodeOrToken.IsToken)
                         {
-                            var declIdentifier = ((UsingDirectiveSyntax)syntaxRef.GetSyntax(cancellationToken)).Alias.Name.Identifier;
-                            text = declIdentifier.IsVerbatimIdentifier() ? declIdentifier.ToString()[1..] : declIdentifier.ToString();
+                            identifierToken = annotatedNodeOrToken.AsToken().CopyAnnotationsTo(identifierToken);
+                        }
+                        else
+                        {
+                            replacementNode = annotatedNodeOrToken.AsNode().CopyAnnotationsTo(replacementNode);
+                        }
+                    }
+
+                    annotatedNodesOrTokens = name.GetAnnotatedNodesAndTokens(AliasAnnotation.Kind);
+                    foreach (var annotatedNodeOrToken in annotatedNodesOrTokens)
+                    {
+                        if (annotatedNodeOrToken.IsToken)
+                        {
+                            identifierToken = annotatedNodeOrToken.AsToken().CopyAnnotationsTo(identifierToken);
+                        }
+                        else
+                        {
+                            replacementNode = annotatedNodeOrToken.AsNode().CopyAnnotationsTo(replacementNode);
+                        }
+                    }
+
+                    replacementNode = ((SimpleNameSyntax)replacementNode).WithIdentifier(identifierToken);
+                    issueSpan = name.Span;
+
+                    // In case the alias name is the same as the last name of the alias target, we only include 
+                    // the left part of the name in the unnecessary span to Not confuse uses.
+                    if (name.Kind() == SyntaxKind.QualifiedName)
+                    {
+                        var qualifiedName3 = (QualifiedNameSyntax)name;
+
+                        if (qualifiedName3.Right.Identifier.ValueText == identifierToken.ValueText)
+                        {
+                            issueSpan = qualifiedName3.Left.Span;
+                        }
+                    }
+
+                    // first check if this would be a valid reduction
+                    if (CanReplaceWithReducedNameInContext(name, replacementNode, semanticModel))
+                    {
+                        // in case this alias name ends with "Attribute", we're going to see if we can also 
+                        // remove that suffix.
+                        if (TryReduceAttributeSuffix(
+                                name,
+                                identifierToken,
+                                out var replacementNodeWithoutAttributeSuffix,
+                                out var issueSpanWithoutAttributeSuffix))
+                        {
+                            if (CanReplaceWithReducedName(name, replacementNodeWithoutAttributeSuffix, semanticModel, cancellationToken))
+                            {
+                                replacementNode = replacementNode.CopyAnnotationsTo(replacementNodeWithoutAttributeSuffix);
+                                issueSpan = issueSpanWithoutAttributeSuffix;
+                            }
                         }
 
-                        var identifierToken = SyntaxFactory.Identifier(
-                                name.GetLeadingTrivia(),
-                                SyntaxKind.IdentifierToken,
-                                text,
-                                aliasReplacement.Name,
-                                name.GetTrailingTrivia());
+                        return true;
+                    }
 
-                        identifierToken = CSharpSimplificationService.TryEscapeIdentifierToken(identifierToken, name);
-                        replacementNode = SyntaxFactory.IdentifierName(identifierToken);
+                    return false;
+                }
 
-                        // Merge annotation to new syntax node
-                        var annotatedNodesOrTokens = name.GetAnnotatedNodesAndTokens(RenameAnnotation.Kind);
-                        foreach (var annotatedNodeOrToken in annotatedNodesOrTokens)
+                var nameHasNoAlias = false;
+
+                if (name is SimpleNameSyntax simpleName)
+                {
+                    if (!simpleName.Identifier.HasAnnotations(AliasAnnotation.Kind))
+                    {
+                        nameHasNoAlias = true;
+                    }
+                }
+
+                if (name is QualifiedNameSyntax qualifiedName2)
+                {
+                    if (!qualifiedName2.Right.HasAnnotation(Simplifier.SpecialTypeAnnotation))
+                    {
+                        nameHasNoAlias = true;
+                    }
+                }
+
+                if (name is AliasQualifiedNameSyntax aliasQualifiedName)
+                {
+                    if (aliasQualifiedName.Name is SimpleNameSyntax &&
+                        !aliasQualifiedName.Name.Identifier.HasAnnotations(AliasAnnotation.Kind) &&
+                        !aliasQualifiedName.Name.HasAnnotation(Simplifier.SpecialTypeAnnotation))
+                    {
+                        nameHasNoAlias = true;
+                    }
+                }
+
+                var aliasInfo = semanticModel.GetAliasInfo(name, cancellationToken);
+                if (nameHasNoAlias && aliasInfo == null)
+                {
+                    // Don't simplify to predefined type if name is part of a QualifiedName.
+                    // QualifiedNames can't contain PredefinedTypeNames (although MemberAccessExpressions can).
+                    // In other words, the left side of a QualifiedName can't be a PredefinedTypeName.
+                    var inDeclarationContext = PreferPredefinedTypeKeywordInDeclarations(name, options, semanticModel);
+                    var inMemberAccessContext = PreferPredefinedTypeKeywordInMemberAccess(name, options, semanticModel);
+
+                    if (!name.Parent.IsKind(SyntaxKind.QualifiedName) && (inDeclarationContext || inMemberAccessContext))
+                    {
+                        // See if we can simplify this name (like System.Int32) to a built-in type (like 'int').
+                        // If not, we'll still fall through and see if we can convert it to Int32.
+
+                        var codeStyleOptionName = inDeclarationContext
+                            ? nameof(CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInDeclaration)
+                            : nameof(CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInMemberAccess);
+
+                        var type = semanticModel.GetTypeInfo(name, cancellationToken).Type;
+                        if (type != null)
                         {
-                            if (annotatedNodeOrToken.IsToken)
+                            var keywordToken = TryGetPredefinedKeywordToken(semanticModel, type.SpecialType);
+                            if (CanReplaceWithPredefinedTypeKeywordInContext(name, semanticModel, out replacementNode, ref issueSpan, keywordToken, codeStyleOptionName))
+                                return true;
+                        }
+                        else
+                        {
+                            var typeSymbol = semanticModel.GetSymbolInfo(name, cancellationToken).Symbol;
+                            if (typeSymbol is INamedTypeSymbol namedType)
                             {
-                                identifierToken = annotatedNodeOrToken.AsToken().CopyAnnotationsTo(identifierToken);
-                            }
-                            else
-                            {
-                                replacementNode = annotatedNodeOrToken.AsNode().CopyAnnotationsTo(replacementNode);
+                                var keywordToken = TryGetPredefinedKeywordToken(semanticModel, namedType.SpecialType);
+                                if (CanReplaceWithPredefinedTypeKeywordInContext(name, semanticModel, out replacementNode, ref issueSpan, keywordToken, codeStyleOptionName))
+                                    return true;
                             }
                         }
+                    }
+                }
 
-                        annotatedNodesOrTokens = name.GetAnnotatedNodesAndTokens(AliasAnnotation.Kind);
-                        foreach (var annotatedNodeOrToken in annotatedNodesOrTokens)
-                        {
-                            if (annotatedNodeOrToken.IsToken)
-                            {
-                                identifierToken = annotatedNodeOrToken.AsToken().CopyAnnotationsTo(identifierToken);
-                            }
-                            else
-                            {
-                                replacementNode = annotatedNodeOrToken.AsNode().CopyAnnotationsTo(replacementNode);
-                            }
-                        }
-
-                        replacementNode = ((SimpleNameSyntax)replacementNode).WithIdentifier(identifierToken);
-                        issueSpan = name.Span;
-
-                        // In case the alias name is the same as the last name of the alias target, we only include 
-                        // the left part of the name in the unnecessary span to Not confuse uses.
+                // Nullable rewrite: Nullable<int> -> int?
+                // Don't rewrite in the case where Nullable<int> is part of some qualified name like Nullable<int>.Something
+                if (!name.IsVar && symbol.Kind == SymbolKind.NamedType && !name.IsLeftSideOfQualifiedName())
+                {
+                    var type = (INamedTypeSymbol)symbol;
+                    if (aliasInfo == null && CanSimplifyNullable(type, name, semanticModel))
+                    {
+                        GenericNameSyntax genericName;
                         if (name.Kind() == SyntaxKind.QualifiedName)
                         {
-                            var qualifiedName3 = (QualifiedNameSyntax)name;
-
-                            if (qualifiedName3.Right.Identifier.ValueText == identifierToken.ValueText)
-                            {
-                                issueSpan = qualifiedName3.Left.Span;
-                            }
+                            genericName = (GenericNameSyntax)((QualifiedNameSyntax)name).Right;
+                        }
+                        else
+                        {
+                            genericName = (GenericNameSyntax)name;
                         }
 
-                        // first check if this would be a valid reduction
+                        var oldType = genericName.TypeArgumentList.Arguments.First();
+                        if (oldType.Kind() == SyntaxKind.OmittedTypeArgument)
+                        {
+                            return false;
+                        }
+
+                        replacementNode = SyntaxFactory.NullableType(oldType)
+                            .WithLeadingTrivia(name.GetLeadingTrivia())
+                                .WithTrailingTrivia(name.GetTrailingTrivia());
+                        issueSpan = name.Span;
+
+                        // we need to simplify the whole qualified name at once, because replacing the identifier on the left in
+                        // System.Nullable<int> alone would be illegal.
+                        // If this fails we want to continue to try at least to remove the System if possible.
                         if (CanReplaceWithReducedNameInContext(name, replacementNode, semanticModel))
                         {
-                            // in case this alias name ends with "Attribute", we're going to see if we can also 
-                            // remove that suffix.
-                            if (TryReduceAttributeSuffix(
-                                    name,
-                                    identifierToken,
-                                    out var replacementNodeWithoutAttributeSuffix,
-                                    out var issueSpanWithoutAttributeSuffix))
-                            {
-                                if (CanReplaceWithReducedName(name, replacementNodeWithoutAttributeSuffix, semanticModel, cancellationToken))
-                                {
-                                    replacementNode = replacementNode.CopyAnnotationsTo(replacementNodeWithoutAttributeSuffix);
-                                    issueSpan = issueSpanWithoutAttributeSuffix;
-                                }
-                            }
-
                             return true;
                         }
-
-                        return false;
-                    }
-
-                    var nameHasNoAlias = false;
-
-                    if (name is SimpleNameSyntax simpleName)
-                    {
-                        if (!simpleName.Identifier.HasAnnotations(AliasAnnotation.Kind))
-                        {
-                            nameHasNoAlias = true;
-                        }
-                    }
-
-                    if (name is QualifiedNameSyntax qualifiedName2)
-                    {
-                        if (!qualifiedName2.Right.HasAnnotation(Simplifier.SpecialTypeAnnotation))
-                        {
-                            nameHasNoAlias = true;
-                        }
-                    }
-
-                    if (name is AliasQualifiedNameSyntax aliasQualifiedName)
-                    {
-                        if (aliasQualifiedName.Name is SimpleNameSyntax &&
-                            !aliasQualifiedName.Name.Identifier.HasAnnotations(AliasAnnotation.Kind) &&
-                            !aliasQualifiedName.Name.HasAnnotation(Simplifier.SpecialTypeAnnotation))
-                        {
-                            nameHasNoAlias = true;
-                        }
-                    }
-
-                    var aliasInfo = semanticModel.GetAliasInfo(name, cancellationToken);
-                    if (nameHasNoAlias && aliasInfo == null)
-                    {
-                        // Don't simplify to predefined type if name is part of a QualifiedName.
-                        // QualifiedNames can't contain PredefinedTypeNames (although MemberAccessExpressions can).
-                        // In other words, the left side of a QualifiedName can't be a PredefinedTypeName.
-                        var inDeclarationContext = PreferPredefinedTypeKeywordInDeclarations(name, options, semanticModel);
-                        var inMemberAccessContext = PreferPredefinedTypeKeywordInMemberAccess(name, options, semanticModel);
-
-                        if (!name.Parent.IsKind(SyntaxKind.QualifiedName) && (inDeclarationContext || inMemberAccessContext))
-                        {
-                            // See if we can simplify this name (like System.Int32) to a built-in type (like 'int').
-                            // If not, we'll still fall through and see if we can convert it to Int32.
-
-                            var codeStyleOptionName = inDeclarationContext
-                                ? nameof(CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInDeclaration)
-                                : nameof(CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInMemberAccess);
-
-                            var type = semanticModel.GetTypeInfo(name, cancellationToken).Type;
-                            if (type != null)
-                            {
-                                var keywordKind = GetPredefinedKeywordKind(type.SpecialType);
-                                if (keywordKind != SyntaxKind.None &&
-                                    CanReplaceWithPredefinedTypeKeywordInContext(name, semanticModel, out replacementNode, ref issueSpan, keywordKind, codeStyleOptionName))
-                                {
-                                    return true;
-                                }
-                            }
-                            else
-                            {
-                                var typeSymbol = semanticModel.GetSymbolInfo(name, cancellationToken).Symbol;
-                                if (typeSymbol.IsKind(SymbolKind.NamedType))
-                                {
-                                    var keywordKind = GetPredefinedKeywordKind(((INamedTypeSymbol)typeSymbol).SpecialType);
-                                    if (keywordKind != SyntaxKind.None &&
-                                        CanReplaceWithPredefinedTypeKeywordInContext(name, semanticModel, out replacementNode, ref issueSpan, keywordKind, codeStyleOptionName))
-                                    {
-                                        return true;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // Nullable rewrite: Nullable<int> -> int?
-                    // Don't rewrite in the case where Nullable<int> is part of some qualified name like Nullable<int>.Something
-                    if (!name.IsVar && symbol.Kind == SymbolKind.NamedType && !name.IsLeftSideOfQualifiedName())
-                    {
-                        var type = (INamedTypeSymbol)symbol;
-                        if (aliasInfo == null && CanSimplifyNullable(type, name, semanticModel))
-                        {
-                            GenericNameSyntax genericName;
-                            if (name.Kind() == SyntaxKind.QualifiedName)
-                            {
-                                genericName = (GenericNameSyntax)((QualifiedNameSyntax)name).Right;
-                            }
-                            else
-                            {
-                                genericName = (GenericNameSyntax)name;
-                            }
-
-                            var oldType = genericName.TypeArgumentList.Arguments.First();
-                            if (oldType.Kind() == SyntaxKind.OmittedTypeArgument)
-                            {
-                                return false;
-                            }
-
-                            replacementNode = SyntaxFactory.NullableType(oldType)
-                                .WithLeadingTrivia(name.GetLeadingTrivia())
-                                    .WithTrailingTrivia(name.GetTrailingTrivia());
-                            issueSpan = name.Span;
-
-                            // we need to simplify the whole qualified name at once, because replacing the identifier on the left in
-                            // System.Nullable<int> alone would be illegal.
-                            // If this fails we want to continue to try at least to remove the System if possible.
-                            if (CanReplaceWithReducedNameInContext(name, replacementNode, semanticModel))
-                            {
-                                return true;
-                            }
-                        }
                     }
                 }
+            }
 
-                SyntaxToken identifier;
-                switch (name.Kind())
-                {
-                    case SyntaxKind.AliasQualifiedName:
-                        var simpleName = ((AliasQualifiedNameSyntax)name).Name
-                            .WithLeadingTrivia(name.GetLeadingTrivia());
+            SyntaxToken identifier;
+            switch (name.Kind())
+            {
+                case SyntaxKind.AliasQualifiedName:
+                    var simpleName = ((AliasQualifiedNameSyntax)name).Name
+                        .WithLeadingTrivia(name.GetLeadingTrivia());
 
-                        simpleName = simpleName.ReplaceToken(simpleName.Identifier,
-                            ((AliasQualifiedNameSyntax)name).Name.Identifier.CopyAnnotationsTo(
-                                simpleName.Identifier.WithLeadingTrivia(
-                                    ((AliasQualifiedNameSyntax)name).Alias.Identifier.LeadingTrivia)));
+                    simpleName = simpleName.ReplaceToken(simpleName.Identifier,
+                        ((AliasQualifiedNameSyntax)name).Name.Identifier.CopyAnnotationsTo(
+                            simpleName.Identifier.WithLeadingTrivia(
+                                ((AliasQualifiedNameSyntax)name).Alias.Identifier.LeadingTrivia)));
 
-                        replacementNode = simpleName;
+                    replacementNode = simpleName;
 
-                        issueSpan = ((AliasQualifiedNameSyntax)name).Alias.Span;
+                    issueSpan = ((AliasQualifiedNameSyntax)name).Alias.Span;
 
-                        break;
+                    break;
 
-                    case SyntaxKind.QualifiedName:
-                        replacementNode = ((QualifiedNameSyntax)name).Right.WithLeadingTrivia(name.GetLeadingTrivia());
-                        issueSpan = ((QualifiedNameSyntax)name).Left.Span;
+                case SyntaxKind.QualifiedName:
+                    replacementNode = ((QualifiedNameSyntax)name).Right.WithLeadingTrivia(name.GetLeadingTrivia());
+                    issueSpan = ((QualifiedNameSyntax)name).Left.Span;
 
-                        break;
+                    break;
 
-                    case SyntaxKind.IdentifierName:
-                        identifier = ((IdentifierNameSyntax)name).Identifier;
+                case SyntaxKind.IdentifierName:
+                    identifier = ((IdentifierNameSyntax)name).Identifier;
 
-                        // we can try to remove the Attribute suffix if this is the attribute name
-                        TryReduceAttributeSuffix(name, identifier, out replacementNode, out issueSpan);
-                        break;
-                }
+                    // we can try to remove the Attribute suffix if this is the attribute name
+                    TryReduceAttributeSuffix(name, identifier, out replacementNode, out issueSpan);
+                    break;
             }
 
             if (replacementNode == null)
@@ -459,10 +450,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
             SemanticModel semanticModel,
             out TypeSyntax replacementNode,
             ref TextSpan issueSpan,
-            SyntaxKind keywordKind,
+            SyntaxToken? keywordToken,
             string codeStyleOptionName)
         {
-            replacementNode = CreatePredefinedTypeSyntax(name, keywordKind);
+            replacementNode = null;
+            if (keywordToken == null)
+                return false;
+
+            replacementNode = CreatePredefinedTypeSyntax(name, keywordToken.Value);
 
             issueSpan = name.Span; // we want to show the whole name expression as unnecessary
 

--- a/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/QualifiedCrefSimplifier.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/Simplifiers/QualifiedCrefSimplifier.cs
@@ -49,11 +49,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
                 // 1. Check for Predefined Types
                 if (symbol is INamedTypeSymbol namedSymbol)
                 {
-                    var keywordKind = GetPredefinedKeywordKind(namedSymbol.SpecialType);
-
-                    if (keywordKind != SyntaxKind.None)
+                    var keywordToken = TryGetPredefinedKeywordToken(semanticModel, namedSymbol.SpecialType);
+                    if (keywordToken != null)
                     {
-                        replacementNode = CreateReplacement(crefSyntax, keywordKind);
+                        replacementNode = TypeCref(CreatePredefinedTypeSyntax(crefSyntax, keywordToken.Value))
+                            .WithAdditionalAnnotations(new SyntaxAnnotation(nameof(CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInMemberAccess)));
                         replacementNode = crefSyntax.CopyAnnotationsTo(replacementNode);
 
                         // we want to show the whole name expression as unnecessary
@@ -67,13 +67,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification.Simplifiers
             return CanSimplifyWithReplacement(
                 crefSyntax, semanticModel, memberCref,
                 out replacementNode, out issueSpan, cancellationToken);
-        }
-
-        private static TypeCrefSyntax CreateReplacement(QualifiedCrefSyntax crefSyntax, SyntaxKind keywordKind)
-        {
-            var annotation = new SyntaxAnnotation(nameof(CodeStyleOptions2.PreferIntrinsicPredefinedTypeKeywordInMemberAccess));
-            var token = Token(crefSyntax.GetLeadingTrivia(), keywordKind, crefSyntax.GetTrailingTrivia());
-            return TypeCref(PredefinedType(token)).WithAdditionalAnnotations(annotation);
         }
 
         public static bool CanSimplifyWithReplacement(


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/63421

We only offer to convert in either direction when the semantics would be identical.  That means on runtimes where [NumericIntPtr](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.runtimefeature.numericintptr?view=net-7.0) is present.