### PR TITLE
Support 'make method async' on an unbound 'await' identifier parsed as a variable declaration.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodAsynchronous/MakeMethodAsynchronousTests.cs
@@ -1382,5 +1382,34 @@ class Program
 }" + IAsyncEnumerable;
             await TestInRegularAndScriptAsync(initial, expected);
         }
+
+        [Fact, WorkItem(25446, "https://github.com/dotnet/roslyn/issues/25446")]
+        public async Task TestOnAwaitParsedAsType()
+        {
+            var initial =
+@"using System.Threading.Tasks;
+
+class C
+{
+    void M()
+    {
+        Task task = null;
+        [|await|] task;
+    }
+}";
+
+            var expected =
+@"using System.Threading.Tasks;
+
+class C
+{
+    async Task MAsync()
+    {
+        Task task = null;
+        await task;
+    }
+}";
+            await TestInRegularAndScript1Async(initial, expected);
+        }
     }
 }

--- a/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodAsynchronous/AbstractMakeMethodAsynchronousCodeFixProvider.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.MakeMethodAsynchronous
                 context.RegisterCodeFix(
                     CodeAction.Create(
                         asyncVoidTitle,
-                        c => FixNodeAsync(document, diagnostic, keepVoid: true, isEntryPoint: false, cancellationToken: c),
+                        cancellationToken => FixNodeAsync(document, diagnostic, keepVoid: true, isEntryPoint: false, cancellationToken),
                         asyncVoidTitle),
                     context.Diagnostics);
             }

--- a/src/Features/VisualBasic/Portable/MakeMethodAsynchronous/VisualBasicMakeMethodAsynchronousCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/MakeMethodAsynchronous/VisualBasicMakeMethodAsynchronousCodeFixProvider.vb
@@ -31,6 +31,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MakeMethodAsynchronous
         Public Sub New()
         End Sub
 
+        Protected Overrides Function IsSupportedDiagnostic(diagnostic As Diagnostic, cancellationToken As CancellationToken) As Boolean
+            Return True
+        End Function
+
         Public Overrides ReadOnly Property FixableDiagnosticIds As ImmutableArray(Of String)
             Get
                 Return s_diagnosticIds

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/ISymbolExtensions.cs
@@ -237,16 +237,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         public static bool IsOrdinaryMethod([NotNullWhen(returnValue: true)] this ISymbol? symbol)
             => (symbol as IMethodSymbol)?.MethodKind == MethodKind.Ordinary;
 
-        public static bool IsOrdinaryMethodOrLocalFunction([NotNullWhen(returnValue: true)] this ISymbol? symbol)
-        {
-            if (symbol is not IMethodSymbol method)
-            {
-                return false;
-            }
-
-            return method.MethodKind is MethodKind.Ordinary
-                or MethodKind.LocalFunction;
-        }
+        public static bool IsOrdinaryMethodOrLocalFunction([NotNullWhen(true)] this ISymbol? symbol)
+            => symbol is IMethodSymbol { MethodKind: MethodKind.Ordinary or MethodKind.LocalFunction };
 
         public static bool IsDelegateType([NotNullWhen(returnValue: true)] this ISymbol? symbol)
             => symbol is ITypeSymbol { TypeKind: TypeKind.Delegate };


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/25446