### PR TITLE
Wait until project/solution is fully loaded before producing semantic diagnostics in LSP

### DIFF
--- a/src/EditorFeatures/Core/Diagnostics/AbstractPushOrPullDiagnosticsTaggerProvider.SingleDiagnosticKindPullTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Diagnostics/AbstractPushOrPullDiagnosticsTaggerProvider.SingleDiagnosticKindPullTaggerProvider.cs
@@ -118,7 +118,7 @@ internal abstract partial class AbstractPushOrPullDiagnosticsTaggerProvider<TTag
                 // of loading.  We do keep compiler-syntax as that's based purely on the parse tree, and doesn't need
                 // correct project info to get reasonable results.
                 if (_diagnosticKind != DiagnosticKind.CompilerSyntax &&
-                    !await project.IsProjectReadyForSemanticDiagnosticRequestsAsync(cancellationToken).ConfigureAwait(false))
+                    !await project.IsReadyForSemanticDiagnosticRequestsAsync(cancellationToken).ConfigureAwait(false))
                 {
                     return;
                 }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -123,9 +123,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 
             var versionedCache = _categoryToVersionedCache.GetOrAdd(handlerName, static handlerName => new(handlerName));
 
+            var diagnosticMode = GetDiagnosticMode(context);
             // For this handler to be called, we must have already checked the diagnostic mode
             // and set the appropriate capabilities.
-            var diagnosticMode = GetDiagnosticMode(context);
             Contract.ThrowIfFalse(diagnosticMode == DiagnosticMode.LspPull, $"{diagnosticMode} is not pull");
 
             // The progress object we will stream reports to.

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -123,9 +123,9 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 
             var versionedCache = _categoryToVersionedCache.GetOrAdd(handlerName, static handlerName => new(handlerName));
 
-            var diagnosticMode = GetDiagnosticMode(context);
             // For this handler to be called, we must have already checked the diagnostic mode
             // and set the appropriate capabilities.
+            var diagnosticMode = GetDiagnosticMode(context);
             Contract.ThrowIfFalse(diagnosticMode == DiagnosticMode.LspPull, $"{diagnosticMode} is not pull");
 
             // The progress object we will stream reports to.

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractDocumentDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractDocumentDiagnosticSource.cs
@@ -18,7 +18,7 @@ internal abstract class AbstractDocumentDiagnosticSource<TDocument> : IDiagnosti
     public AbstractDocumentDiagnosticSource(TDocument document)
         => Document = document;
 
-    protected abstract Task<bool> IsReadyForDiagnosticRequestsAsync(RequestContext context, CancellationToken cancellationToken);
+    protected abstract ValueTask<bool> IsReadyForDiagnosticRequestsAsync(RequestContext context, CancellationToken cancellationToken);
     protected abstract Task<ImmutableArray<DiagnosticData>> GetDiagnosticsWorkerAsync(
         IDiagnosticAnalyzerService diagnosticAnalyzerService, RequestContext context, CancellationToken cancellationToken);
 

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractDocumentDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/AbstractDocumentDiagnosticSource.cs
@@ -36,9 +36,10 @@ internal abstract class AbstractDocumentDiagnosticSource<TDocument> : IDiagnosti
     public async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
         IDiagnosticAnalyzerService diagnosticAnalyzerService, RequestContext context, CancellationToken cancellationToken)
     {
-        if (!await this.IsReadyForDiagnosticRequestsAsync(context, cancellationToken).ConfigureAwait(false))
-            return ImmutableArray<DiagnosticData>.Empty;
-
-        return await this.GetDiagnosticsWorkerAsync(diagnosticAnalyzerService, context, cancellationToken).ConfigureAwait(false);
+        // If we're not ready for requests, return no results.  This ensures the user does not see a bunch of spurious
+        // errors for things like "System.Object not found".
+        return await this.IsReadyForDiagnosticRequestsAsync(context, cancellationToken).ConfigureAwait(false)
+            ? await this.GetDiagnosticsWorkerAsync(diagnosticAnalyzerService, context, cancellationToken).ConfigureAwait(false)
+            : ImmutableArray<DiagnosticData>.Empty;
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/DocumentDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/DocumentDiagnosticSource.cs
@@ -28,7 +28,7 @@ internal sealed class DocumentDiagnosticSource
             return true;
 
         // Otherwise, we need our containing project to be ready before allowing requests to go through.
-        return await this.Document.Project.IsProjectReadyForSemanticDiagnosticRequestsAsync(cancellationToken).ConfigureAwait(false);
+        return await this.Document.Project.IsReadyForSemanticDiagnosticRequestsAsync(cancellationToken).ConfigureAwait(false);
     }
 
     protected override async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsWorkerAsync(

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/DocumentDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/DocumentDiagnosticSource.cs
@@ -20,7 +20,7 @@ internal sealed class DocumentDiagnosticSource
         DiagnosticKind = diagnosticKind;
     }
 
-    protected override async Task<bool> IsReadyForDiagnosticRequestsAsync(RequestContext context, CancellationToken cancellationToken)
+    protected override async ValueTask<bool> IsReadyForDiagnosticRequestsAsync(RequestContext context, CancellationToken cancellationToken)
     {
         // Compiler syntax requests can always go through.  They just depend on syntax and don't need the
         // solution/project to be fully loaded yet.

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/TaskListDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/TaskListDiagnosticSource.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.TaskList;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 
@@ -35,7 +36,13 @@ internal sealed class TaskListDiagnosticSource : AbstractDocumentDiagnosticSourc
         _globalOptions = globalOptions;
     }
 
-    public override async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
+    protected override Task<bool> IsReadyForDiagnosticRequestsAsync(RequestContext context, CancellationToken cancellationToken)
+    {
+        // TaskList is purely syntactic.  So we're always ready to requests diagnostics for them.
+        return SpecializedTasks.True;
+    }
+
+    protected override async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsWorkerAsync(
         IDiagnosticAnalyzerService diagnosticAnalyzerService, RequestContext context, CancellationToken cancellationToken)
     {
         var service = this.Document.GetLanguageService<ITaskListService>();

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/TaskListDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/TaskListDiagnosticSource.cs
@@ -36,10 +36,10 @@ internal sealed class TaskListDiagnosticSource : AbstractDocumentDiagnosticSourc
         _globalOptions = globalOptions;
     }
 
-    protected override Task<bool> IsReadyForDiagnosticRequestsAsync(RequestContext context, CancellationToken cancellationToken)
+    protected override ValueTask<bool> IsReadyForDiagnosticRequestsAsync(RequestContext context, CancellationToken cancellationToken)
     {
         // TaskList is purely syntactic.  So we're always ready to requests diagnostics for them.
-        return SpecializedTasks.True;
+        return ValueTaskFactory.FromResult(true);
     }
 
     protected override async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsWorkerAsync(

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/WorkspaceDocumentDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/WorkspaceDocumentDiagnosticSource.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics;
 
@@ -18,7 +16,10 @@ internal sealed class WorkspaceDocumentDiagnosticSource : AbstractDocumentDiagno
     {
     }
 
-    public override async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(
+    protected override Task<bool> IsReadyForDiagnosticRequestsAsync(RequestContext context, CancellationToken cancellationToken)
+        => this.Document.Project.IsProjectReadyForSemanticDiagnosticRequestsAsync(cancellationToken);
+
+    protected override async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsWorkerAsync(
         IDiagnosticAnalyzerService diagnosticAnalyzerService,
         RequestContext context,
         CancellationToken cancellationToken)

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/WorkspaceDocumentDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/WorkspaceDocumentDiagnosticSource.cs
@@ -16,7 +16,7 @@ internal sealed class WorkspaceDocumentDiagnosticSource : AbstractDocumentDiagno
     {
     }
 
-    protected override Task<bool> IsReadyForDiagnosticRequestsAsync(RequestContext context, CancellationToken cancellationToken)
+    protected override ValueTask<bool> IsReadyForDiagnosticRequestsAsync(RequestContext context, CancellationToken cancellationToken)
         => this.Document.Project.IsReadyForSemanticDiagnosticRequestsAsync(cancellationToken);
 
     protected override async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsWorkerAsync(

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/WorkspaceDocumentDiagnosticSource.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/DiagnosticSources/WorkspaceDocumentDiagnosticSource.cs
@@ -17,7 +17,7 @@ internal sealed class WorkspaceDocumentDiagnosticSource : AbstractDocumentDiagno
     }
 
     protected override Task<bool> IsReadyForDiagnosticRequestsAsync(RequestContext context, CancellationToken cancellationToken)
-        => this.Document.Project.IsProjectReadyForSemanticDiagnosticRequestsAsync(cancellationToken);
+        => this.Document.Project.IsReadyForSemanticDiagnosticRequestsAsync(cancellationToken);
 
     protected override async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsWorkerAsync(
         IDiagnosticAnalyzerService diagnosticAnalyzerService,

--- a/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
@@ -422,7 +422,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        public static async Task<bool> IsProjectReadyForSemanticDiagnosticRequestsAsync(this Project project, CancellationToken cancellationToken)
+        public static async Task<bool> IsReadyForSemanticDiagnosticRequestsAsync(this Project project, CancellationToken cancellationToken)
         {
             var service = project.Solution.Services.GetRequiredService<IWorkspaceStatusService>();
             if (!await service.IsFullyLoadedAsync(cancellationToken).ConfigureAwait(false))

--- a/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/Extensions.cs
@@ -422,7 +422,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        public static async Task<bool> IsReadyForSemanticDiagnosticRequestsAsync(this Project project, CancellationToken cancellationToken)
+        public static async ValueTask<bool> IsReadyForSemanticDiagnosticRequestsAsync(this Project project, CancellationToken cancellationToken)
         {
             var service = project.Solution.Services.GetRequiredService<IWorkspaceStatusService>();
             if (!await service.IsFullyLoadedAsync(cancellationToken).ConfigureAwait(false))


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/66761