### PR TITLE
Support converting any language keyword to see-langword in xml doc comments

### DIFF
--- a/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
+++ b/src/EditorFeatures/CSharpTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithTag;
@@ -414,12 +412,19 @@ class C
 }");
         }
 
-        [Fact, WorkItem(22278, "https://github.com/dotnet/roslyn/issues/22278")]
-        public async Task TestNonApplicableKeyword()
+        [Fact]
+        [WorkItem(22278, "https://github.com/dotnet/roslyn/issues/22278")]
+        [WorkItem(31208, "https://github.com/dotnet/roslyn/issues/31208")]
+        public async Task TestApplicableKeyword()
         {
-            await TestMissingAsync(
+            await TestInRegularAndScript1Async(
 @"
 /// Testing keyword interfa[||]ce.
+class C<TKey>
+{
+}",
+@"
+/// Testing keyword <see langword=""interface""/>.
 class C<TKey>
 {
 }");
@@ -478,6 +483,40 @@ class C<TKey>
 
 @"
 /// Testing keyword <see langword=""this""/>.
+class C<TKey>
+{
+}");
+        }
+
+        [Fact, WorkItem(31208, "https://github.com/dotnet/roslyn/issues/31208")]
+        public async Task TestArbitraryKeyword()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// Testing keyword [||]delegate.
+class C<TKey>
+{
+}",
+
+@"
+/// Testing keyword <see langword=""delegate""/>.
+class C<TKey>
+{
+}");
+        }
+
+        [Fact, WorkItem(31208, "https://github.com/dotnet/roslyn/issues/31208")]
+        public async Task TestContextualKeyword()
+        {
+            await TestInRegularAndScriptAsync(
+@"
+/// Testing keyword [||]yield.
+class C<TKey>
+{
+}",
+
+@"
+/// Testing keyword <see langword=""yield""/>.
 class C<TKey>
 {
 }");

--- a/src/EditorFeatures/VisualBasicTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ReplaceDocCommentTextWithTag/ReplaceDocCommentTextWithTagTests.vb
@@ -319,11 +319,17 @@ interface I
 end interface")
         End Function
 
-        <Fact, WorkItem(22278, "https://github.com/dotnet/roslyn/issues/22278")>
-        Public Async Function TestNotApplicableKeyword() As Task
-            Await TestMissingAsync(
+        <Fact>
+        <WorkItem(22278, "https://github.com/dotnet/roslyn/issues/22278")>
+        <WorkItem(31208, "https://github.com/dotnet/roslyn/issues/31208")>
+        Public Async Function TestApplicableKeyword() As Task
+            Await TestInRegularAndScript1Async(
 "
 ''' Testing keyword interf[||]ace
+class C(Of TKey)
+end class",
+"
+''' Testing keyword <see langword=""interface""/>
 class C(Of TKey)
 end class")
         End Function

--- a/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ReplaceDocCommentTextWithTag/CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -2,34 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithTag
 {
-    [ExportCodeRefactoringProvider(LanguageNames.CSharp,
-        Name = PredefinedCodeRefactoringProviderNames.ReplaceDocCommentTextWithTag), Shared]
-    internal class CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider :
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = PredefinedCodeRefactoringProviderNames.ReplaceDocCommentTextWithTag), Shared]
+    internal sealed class CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider :
         AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider
     {
-        private static readonly ImmutableHashSet<string> s_triggerKeywords = ImmutableHashSet.Create(
-            SyntaxFacts.GetText(SyntaxKind.NullKeyword),
-            SyntaxFacts.GetText(SyntaxKind.StaticKeyword),
-            SyntaxFacts.GetText(SyntaxKind.VirtualKeyword),
-            SyntaxFacts.GetText(SyntaxKind.TrueKeyword),
-            SyntaxFacts.GetText(SyntaxKind.FalseKeyword),
-            SyntaxFacts.GetText(SyntaxKind.AbstractKeyword),
-            SyntaxFacts.GetText(SyntaxKind.SealedKeyword),
-            SyntaxFacts.GetText(SyntaxKind.AsyncKeyword),
-            SyntaxFacts.GetText(SyntaxKind.AwaitKeyword),
-            SyntaxFacts.GetText(SyntaxKind.BaseKeyword),
-            SyntaxFacts.GetText(SyntaxKind.ThisKeyword));
-
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
         public CSharpReplaceDocCommentTextWithTagCodeRefactoringProvider()
@@ -37,21 +22,15 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplaceDocCommentTextWithTag
         }
 
         protected override bool IsXmlTextToken(SyntaxToken token)
-            => token.Kind() is SyntaxKind.XmlTextLiteralToken or
-               SyntaxKind.XmlTextLiteralNewLineToken;
+            => token.Kind() is SyntaxKind.XmlTextLiteralToken or SyntaxKind.XmlTextLiteralNewLineToken;
 
         protected override bool IsInXMLAttribute(SyntaxToken token)
-        {
-            return (token.Parent.Kind() is SyntaxKind.XmlCrefAttribute
-                or SyntaxKind.XmlNameAttribute
-                or SyntaxKind.XmlTextAttribute);
-        }
+            => token.GetRequiredParent().Kind() is SyntaxKind.XmlCrefAttribute or SyntaxKind.XmlNameAttribute or SyntaxKind.XmlTextAttribute;
 
         protected override bool IsKeyword(string text)
-            => s_triggerKeywords.Contains(text);
+            => SyntaxFacts.IsKeywordKind(SyntaxFacts.GetKeywordKind(text)) || SyntaxFacts.IsContextualKeyword(SyntaxFacts.GetContextualKeywordKind(text));
 
         protected override SyntaxNode ParseExpression(string text)
             => SyntaxFactory.ParseExpression(text);
-
     }
 }

--- a/src/Features/Core/Portable/ReplaceDocCommentTextWithTag/AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplaceDocCommentTextWithTag/AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -27,32 +25,24 @@ namespace Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
             var (document, span, cancellationToken) = context;
-            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var token = root.FindToken(span.Start, findInsideTrivia: true);
 
             if (!IsXmlTextToken(token))
-            {
                 return;
-            }
 
             if (!token.FullSpan.Contains(span))
-            {
                 return;
-            }
 
             if (IsInXMLAttribute(token))
-            {
                 return;
-            }
 
             var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             var singleWordSpan = ExpandSpan(sourceText, span, fullyQualifiedName: false);
             var singleWordText = sourceText.ToString(singleWordSpan);
             if (singleWordText == "")
-            {
                 return;
-            }
 
             // First see if they're on an appropriate keyword. 
             if (IsKeyword(singleWordText))
@@ -62,12 +52,10 @@ namespace Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
             }
 
             // Not a keyword, see if it semantically means anything in the current context.
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var symbol = GetEnclosingSymbol(semanticModel, span.Start, cancellationToken);
             if (symbol == null)
-            {
                 return;
-            }
 
             // See if we can expand the term out to a fully qualified name. Do this
             // first in case the user has something like X.memberName.  We don't want 
@@ -86,7 +74,7 @@ namespace Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
 
             // Check if the single word could be binding to a type parameter or parameter
             // for the current symbol.
-            var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
+            var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
             var parameter = symbol.GetParameters().FirstOrDefault(p => syntaxFacts.StringComparer.Equals(p.Name, singleWordText));
             if (parameter != null)
             {
@@ -136,7 +124,7 @@ namespace Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
             return true;
         }
 
-        private static ISymbol GetEnclosingSymbol(SemanticModel semanticModel, int position, CancellationToken cancellationToken)
+        private static ISymbol? GetEnclosingSymbol(SemanticModel semanticModel, int position, CancellationToken cancellationToken)
         {
             var root = semanticModel.SyntaxTree.GetRoot(cancellationToken);
             var token = root.FindToken(position);
@@ -144,9 +132,7 @@ namespace Microsoft.CodeAnalysis.ReplaceDocCommentTextWithTag
             for (var node = token.Parent; node != null; node = node.Parent)
             {
                 if (semanticModel.GetDeclaredSymbol(node, cancellationToken) is ISymbol declaration)
-                {
                     return declaration;
-                }
             }
 
             return null;

--- a/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/ReplaceDocCommentTextWithTag/VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider.vb
@@ -13,21 +13,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ReplaceDocCommentTextWithTag
     Friend Class VisualBasicReplaceDocCommentTextWithTagCodeRefactoringProvider
         Inherits AbstractReplaceDocCommentTextWithTagCodeRefactoringProvider
 
-        Private Shared ReadOnly s_keywords As New HashSet(Of String) From
-            {
-            SyntaxFacts.GetText(SyntaxKind.NothingKeyword),
-            SyntaxFacts.GetText(SyntaxKind.SharedKeyword),
-            SyntaxFacts.GetText(SyntaxKind.OverridableKeyword),
-            SyntaxFacts.GetText(SyntaxKind.TrueKeyword),
-            SyntaxFacts.GetText(SyntaxKind.FalseKeyword),
-            SyntaxFacts.GetText(SyntaxKind.MustInheritKeyword),
-            SyntaxFacts.GetText(SyntaxKind.NotOverridableKeyword),
-            SyntaxFacts.GetText(SyntaxKind.AsyncKeyword),
-            SyntaxFacts.GetText(SyntaxKind.AwaitKeyword),
-            SyntaxFacts.GetText(SyntaxKind.MyBaseKeyword),
-            SyntaxFacts.GetText(SyntaxKind.MyClassKeyword)
-            }
-
         <ImportingConstructor>
         <SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification:="Used in test code: https://github.com/dotnet/roslyn/issues/42814")>
         Public Sub New()
@@ -43,12 +28,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ReplaceDocCommentTextWithTag
         End Function
 
         Protected Overrides Function IsKeyword(text As String) As Boolean
-            Return s_keywords.Contains(text)
+            Return SyntaxFacts.IsKeywordKind(SyntaxFacts.GetKeywordKind(text)) OrElse SyntaxFacts.IsContextualKeyword(SyntaxFacts.GetContextualKeywordKind(text))
         End Function
 
         Protected Overrides Function ParseExpression(text As String) As SyntaxNode
             Return SyntaxFactory.ParseExpression(text)
         End Function
-
     End Class
 End Namespace


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/31208.

Justifications for not doing this previously were twofold:

1. Adding all language keywords might make it difficult to find other items in the completion list
1. Adding keywords such as is or as, which are also common in English sentences, could be problematic


however, this is not a completion list (and i'm not updating that).  This is the lightbulb that you can invoke *on* a keyword to change it to the `<see langword="..."/>` form.  As such, it doesn't harm the user at all that they can now invoke this on a wider set of cases.  