### PR TITLE
 VisualBasicPackage must be constructed on the main thread

### DIFF
--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -58,6 +58,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         Public Sub New()
             MyBase.New()
 
+            ' This is a UI-affinitized operation. Currently this opeartion prevents setting AllowsBackgroundLoad for
+            ' VisualBasicPackage. The call should be removed from the constructor, and the package set back to allowing
+            ' background loads.
             _comAggregate = Implementation.Interop.ComAggregate.CreateAggregatedObject(Me)
         End Sub
 

--- a/src/VisualStudio/VisualBasic/Impl/Microsoft.VisualStudio.LanguageServices.VisualBasic.vbproj
+++ b/src/VisualStudio/VisualBasic/Impl/Microsoft.VisualStudio.LanguageServices.VisualBasic.vbproj
@@ -16,7 +16,8 @@
   </PropertyGroup>
   <ItemGroup Label="PkgDef">
     <PkgDefInstalledProduct Include="{574fc912-f74f-4b4e-92c3-f695c208a2bb}" Name="Microsoft Visual Basic" DisplayName="#113" ProductDetails="#114" />
-    <PkgDefPackageRegistration Include="{574fc912-f74f-4b4e-92c3-f695c208a2bb}" Name="VisualBasicPackage" Class="Microsoft.VisualStudio.LanguageServices.VisualBasic.VisualBasicPackage" AllowsBackgroundLoad="true" />
+    <!-- Cannot load in background until the VisualBasicPackage constructor has no more UI dependencies -->
+    <PkgDefPackageRegistration Include="{574fc912-f74f-4b4e-92c3-f695c208a2bb}" Name="VisualBasicPackage" Class="Microsoft.VisualStudio.LanguageServices.VisualBasic.VisualBasicPackage" AllowsBackgroundLoad="false" />
     <None Include="PackageRegistration.pkgdef" PkgDefEntry="FileContent" />
   </ItemGroup>
   <ItemGroup Label="Project References">


### PR DESCRIPTION
This package was incorrectly set as AllowsBackgroundLoad=true when the constructor contained a UI-affinitized operation. We attempted to moved the operation to InitializeAsync instead, but it did not work (exception in a comment below). Instead, we have marked this package as requiring the UI thread for construction.

Fixes [AB#1745017](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1745017)