### PR TITLE
Implement legacy options provider for code actions in workspace layer

### DIFF
--- a/src/EditorFeatures/Core/Options/LegacyGlobalOptionsWorkspaceService.cs
+++ b/src/EditorFeatures/Core/Options/LegacyGlobalOptionsWorkspaceService.cs
@@ -4,10 +4,8 @@
 
 using System;
 using System.Composition;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.CodeGeneration;
-using Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.InlineHints;
 
@@ -20,7 +18,6 @@ namespace Microsoft.CodeAnalysis.Options
     internal sealed class LegacyGlobalOptionsWorkspaceService : ILegacyGlobalOptionsWorkspaceService
     {
         private readonly IGlobalOptionService _globalOptions;
-        private readonly CodeActionOptionsStorage.Provider _provider;
 
         private static readonly Option2<bool> s_generateOverridesOption = new(
             "GenerateOverridesOptions_SelectAll", defaultValue: true);
@@ -46,7 +43,6 @@ namespace Microsoft.CodeAnalysis.Options
         public LegacyGlobalOptionsWorkspaceService(IGlobalOptionService globalOptions)
         {
             _globalOptions = globalOptions;
-            _provider = _globalOptions.CreateProvider();
         }
 
         public bool GenerateOverrides
@@ -67,9 +63,6 @@ namespace Microsoft.CodeAnalysis.Options
             get => _globalOptions.GetOption(InlineHintsGlobalStateOption.DisplayAllOverride);
             set => _globalOptions.SetGlobalOption(InlineHintsGlobalStateOption.DisplayAllOverride, value);
         }
-
-        public CleanCodeGenerationOptionsProvider CleanCodeGenerationOptionsProvider
-            => _provider;
 
         public bool GetGenerateEqualsAndGetHashCodeFromMembersGenerateOperators(string language)
             => _globalOptions.GetOption(s_implementIEquatable, language);

--- a/src/EditorFeatures/Core/Options/TextBufferOptionProviders.cs
+++ b/src/EditorFeatures/Core/Options/TextBufferOptionProviders.cs
@@ -50,7 +50,7 @@ internal static class TextBufferOptionProviders
     {
         var configOptions = editorOptions.ToAnalyzerConfigOptions();
         var fallbackOptions = globalOptions.GetSyntaxFormattingOptions(languageServices);
-        var options = configOptions.GetSyntaxFormattingOptions(fallbackOptions, languageServices);
+        var options = configOptions.GetSyntaxFormattingOptions(languageServices, fallbackOptions);
         var lineFormattingOptions = GetLineFormattingOptionsImpl(textBuffer, editorOptions, indentationManager, explicitFormat);
 
         return options with { LineFormatting = lineFormattingOptions };
@@ -74,7 +74,7 @@ internal static class TextBufferOptionProviders
         var editorOptions = optionsProvider.Factory.GetOptions(textBuffer);
         var configOptions = editorOptions.ToAnalyzerConfigOptions();
         var fallbackOptions = optionsProvider.GlobalOptions.GetAddImportPlacementOptions(languageServices);
-        return configOptions.GetAddImportPlacementOptions(allowInHiddenRegions, fallbackOptions, languageServices);
+        return configOptions.GetAddImportPlacementOptions(languageServices, allowInHiddenRegions, fallbackOptions);
     }
 
     public static CodeCleanupOptions GetCodeCleanupOptions(this ITextBuffer textBuffer, EditorOptionsService optionsProvider, LanguageServices languageServices, bool explicitFormat, bool allowImportsInHiddenRegions)
@@ -83,7 +83,7 @@ internal static class TextBufferOptionProviders
         var configOptions = editorOptions.ToAnalyzerConfigOptions();
         var fallbackOptions = optionsProvider.GlobalOptions.GetCodeCleanupOptions(languageServices);
 
-        var options = configOptions.GetCodeCleanupOptions(allowImportsInHiddenRegions, fallbackOptions, languageServices);
+        var options = configOptions.GetCodeCleanupOptions(languageServices, allowImportsInHiddenRegions, fallbackOptions);
         var lineFormattingOptions = GetLineFormattingOptionsImpl(textBuffer, editorOptions, optionsProvider.IndentationManager, explicitFormat);
 
         return options with { FormattingOptions = options.FormattingOptions with { LineFormatting = lineFormattingOptions } };

--- a/src/EditorFeatures/TestUtilities/Formatting/AbstractNewDocumentFormattingServiceTests.cs
+++ b/src/EditorFeatures/TestUtilities/Formatting/AbstractNewDocumentFormattingServiceTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities.Formatting
             var languageServices = document.Project.Services;
 
             var cleanupOptions =
-                options?.GetCodeCleanupOptions(allowImportsInHiddenRegions: false, fallbackOptions: null, languageServices) ??
+                options?.GetCodeCleanupOptions(languageServices, allowImportsInHiddenRegions: false, fallbackOptions: null) ??
                 CodeCleanupOptions.GetDefault(languageServices);
 
             var formattingService = document.GetRequiredLanguageService<INewDocumentFormattingService>();

--- a/src/Features/Core/Portable/Completion/Providers/AbstractMemberInsertingCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractMemberInsertingCompletionProvider.cs
@@ -38,8 +38,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         public override async Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, char? commitKey = null, CancellationToken cancellationToken = default)
         {
             // TODO: pass fallback options: https://github.com/dotnet/roslyn/issues/60786
-            var globalOptions = document.Project.Solution.Services.GetService<ILegacyGlobalOptionsWorkspaceService>();
-            var fallbackOptions = globalOptions?.CleanCodeGenerationOptionsProvider ?? CodeActionOptions.DefaultProvider;
+            var globalOptions = document.Project.Solution.Services.GetService<ILegacyGlobalCleanCodeGenerationOptionsWorkspaceService>();
+            var fallbackOptions = globalOptions?.Provider ?? CodeActionOptions.DefaultProvider;
 
             var newDocument = await DetermineNewDocumentAsync(document, item, fallbackOptions, cancellationToken).ConfigureAwait(false);
             var newText = await newDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
@@ -130,8 +130,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             var generator = document.GetRequiredLanguageService<SyntaxGenerator>();
 
             // TODO: fallback options https://github.com/dotnet/roslyn/issues/60786
-            var globalOptions = document.Project.Solution.Services.GetService<ILegacyGlobalOptionsWorkspaceService>();
-            var fallbackOptions = globalOptions?.CleanCodeGenerationOptionsProvider ?? CodeActionOptions.DefaultProvider;
+            var globalOptions = document.Project.Solution.Services.GetService<ILegacyGlobalCleanCodeGenerationOptionsWorkspaceService>();
+            var fallbackOptions = globalOptions?.Provider ?? CodeActionOptions.DefaultProvider;
 
             var addImportsOptions = await document.GetAddImportPlacementOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
             var formattingOptions = await document.GetSyntaxFormattingOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);

--- a/src/Features/LanguageServer/Protocol/Features/Options/AddImportPlacementOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/AddImportPlacementOptionsStorage.cs
@@ -15,8 +15,5 @@ internal static class AddImportPlacementOptionsStorage
         => document.GetAddImportPlacementOptionsAsync(globalOptions.GetAddImportPlacementOptions(document.Project.Services), cancellationToken);
 
     public static AddImportPlacementOptions GetAddImportPlacementOptions(this IGlobalOptionService globalOptions, LanguageServices languageServices)
-        => languageServices.GetRequiredService<IAddImportsService>().GetAddImportOptions(
-            globalOptions,
-            allowInHiddenRegions: AddImportPlacementOptions.Default.AllowInHiddenRegions, // no global option available
-            fallbackOptions: null);
+        => globalOptions.GetAddImportPlacementOptions(languageServices, allowInHiddenRegions: null, fallbackOptions: null);
 }

--- a/src/Features/LanguageServer/Protocol/Features/Options/CodeCleanupOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/CodeCleanupOptionsStorage.cs
@@ -6,10 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Simplification;
-using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.AddImport;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeCleanup;
 
@@ -18,12 +14,6 @@ internal static class CodeCleanupOptionsStorage
     public static ValueTask<CodeCleanupOptions> GetCodeCleanupOptionsAsync(this Document document, IGlobalOptionService globalOptions, CancellationToken cancellationToken)
         => document.GetCodeCleanupOptionsAsync(globalOptions.GetCodeCleanupOptions(document.Project.Services), cancellationToken);
 
-    public static CodeCleanupOptions GetCodeCleanupOptions(this IGlobalOptionService globalOptions, LanguageServices languageServices)
-        => new()
-        {
-            FormattingOptions = globalOptions.GetSyntaxFormattingOptions(languageServices),
-            SimplifierOptions = globalOptions.GetSimplifierOptions(languageServices),
-            AddImportOptions = globalOptions.GetAddImportPlacementOptions(languageServices),
-            DocumentFormattingOptions = globalOptions.GetDocumentFormattingOptions(languageServices.Language)
-        };
+    public static CodeCleanupOptions GetCodeCleanupOptions(this IOptionsReader globalOptions, LanguageServices languageServices)
+        => globalOptions.GetCodeCleanupOptions(languageServices, allowImportsInHiddenRegions: null, fallbackOptions: null);
 }

--- a/src/Features/LanguageServer/Protocol/Features/Options/CodeGenerationOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/CodeGenerationOptionsStorage.cs
@@ -4,8 +4,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.AddImport;
-using Microsoft.CodeAnalysis.CodeCleanup;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
 
@@ -20,19 +18,11 @@ internal static class CodeGenerationOptionsStorage
         => document.GetCleanCodeGenerationOptionsAsync(globalOptions.GetCleanCodeGenerationOptions(document.Project.Services), cancellationToken);
 
     public static CodeGenerationOptions GetCodeGenerationOptions(this IGlobalOptionService globalOptions, LanguageServices languageServices)
-        => languageServices.GetRequiredService<ICodeGenerationService>().GetCodeGenerationOptions(globalOptions, fallbackOptions: null);
+        => globalOptions.GetCodeGenerationOptions(languageServices, fallbackOptions: null);
 
     public static CodeAndImportGenerationOptions GetCodeAndImportGenerationOptions(this IGlobalOptionService globalOptions, LanguageServices languageServices)
-        => new()
-        {
-            GenerationOptions = globalOptions.GetCodeGenerationOptions(languageServices),
-            AddImportOptions = globalOptions.GetAddImportPlacementOptions(languageServices)
-        };
+        => globalOptions.GetCodeAndImportGenerationOptions(languageServices, allowImportsInHiddenRegions: null, fallbackOptions: null);
 
     public static CleanCodeGenerationOptions GetCleanCodeGenerationOptions(this IGlobalOptionService globalOptions, LanguageServices languageServices)
-        => new()
-        {
-            GenerationOptions = globalOptions.GetCodeGenerationOptions(languageServices),
-            CleanupOptions = globalOptions.GetCodeCleanupOptions(languageServices)
-        };
+        => globalOptions.GetCleanCodeGenerationOptions(languageServices, allowImportsInHiddenRegions: null, fallbackOptions: null);
 }

--- a/src/Features/LanguageServer/Protocol/Features/Options/DocumentFormattingOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/DocumentFormattingOptionsStorage.cs
@@ -2,13 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Formatting;
@@ -16,14 +11,9 @@ namespace Microsoft.CodeAnalysis.Formatting;
 internal static class DocumentFormattingOptionsStorage
 {
     public static ValueTask<DocumentFormattingOptions> GetDocumentFormattingOptionsAsync(this Document document, IGlobalOptionService globalOptions, CancellationToken cancellationToken)
-        => document.GetDocumentFormattingOptionsAsync(globalOptions.GetDocumentFormattingOptions(document.Project.Language), cancellationToken);
+        => document.GetDocumentFormattingOptionsAsync(globalOptions.GetDocumentFormattingOptions(), cancellationToken);
 
-#pragma warning disable IDE0060 // Unused parameters to match common pattern
-    public static DocumentFormattingOptions GetDocumentFormattingOptions(this IGlobalOptionService globalOptions, string language)
-        => new(
-           // FileHeaderTemplate not stored in global options (does not have a storage other than editorconfig)
-           // InsertFinalNewLine not stored in global options (does not have a storage other than editorconfig)
-           );
-#pragma warning restore
+    public static DocumentFormattingOptions GetDocumentFormattingOptions(this IGlobalOptionService globalOptions)
+        => globalOptions.GetDocumentFormattingOptions(fallbackOptions: null);
 }
 

--- a/src/Features/LanguageServer/Protocol/Features/Options/GlobalCodeActionOptionsProvider.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/GlobalCodeActionOptionsProvider.cs
@@ -49,7 +49,7 @@ internal static class CodeActionOptionsStorage
             => ValueTaskFactory.FromResult(_globalOptions.GetLineFormattingOptions(languageServices.Language));
 
         ValueTask<DocumentFormattingOptions> OptionsProvider<DocumentFormattingOptions>.GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
-            => ValueTaskFactory.FromResult(_globalOptions.GetDocumentFormattingOptions(languageServices.Language));
+            => ValueTaskFactory.FromResult(_globalOptions.GetDocumentFormattingOptions());
 
         ValueTask<SyntaxFormattingOptions> OptionsProvider<SyntaxFormattingOptions>.GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
             => ValueTaskFactory.FromResult(_globalOptions.GetSyntaxFormattingOptions(languageServices));

--- a/src/Features/LanguageServer/Protocol/Features/Options/LineFormattingOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/LineFormattingOptionsStorage.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Formatting;
@@ -18,12 +14,6 @@ internal static class LineFormattingOptionsStorage
         => document.GetLineFormattingOptionsAsync(globalOptions.GetLineFormattingOptions(document.Project.Language), cancellationToken);
 
     public static LineFormattingOptions GetLineFormattingOptions(this IGlobalOptionService globalOptions, string language)
-        => new()
-        {
-            UseTabs = globalOptions.GetOption(FormattingOptions2.UseTabs, language),
-            TabSize = globalOptions.GetOption(FormattingOptions2.TabSize, language),
-            IndentationSize = globalOptions.GetOption(FormattingOptions2.IndentationSize, language),
-            NewLine = globalOptions.GetOption(FormattingOptions2.NewLine, language)
-        };
+        => globalOptions.GetLineFormattingOptions(language, fallbackOptions: null);
 }
 

--- a/src/Features/LanguageServer/Protocol/Features/Options/NamingStyleOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/NamingStyleOptionsStorage.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
-using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Simplification;
 
 namespace Microsoft.CodeAnalysis.CodeStyle;
 

--- a/src/Features/LanguageServer/Protocol/Features/Options/OrganizeImportsOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/OrganizeImportsOptionsStorage.cs
@@ -4,8 +4,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.OrganizeImports;
@@ -16,10 +14,5 @@ internal static class OrganizeImportsOptionsStorage
         => document.GetOrganizeImportsOptionsAsync(globalOptions.GetOrganizeImportsOptions(document.Project.Language), cancellationToken);
 
     public static OrganizeImportsOptions GetOrganizeImportsOptions(this IGlobalOptionService globalOptions, string language)
-        => new()
-        {
-            PlaceSystemNamespaceFirst = globalOptions.GetOption(GenerationOptions.PlaceSystemNamespaceFirst, language),
-            SeparateImportDirectiveGroups = globalOptions.GetOption(GenerationOptions.SeparateImportDirectiveGroups, language),
-            NewLine = globalOptions.GetOption(FormattingOptions2.NewLine, language)
-        };
+        => globalOptions.GetOrganizeImportsOptions(language, fallbackOptions: null);
 }

--- a/src/Features/LanguageServer/Protocol/Features/Options/SimplifierOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/SimplifierOptionsStorage.cs
@@ -14,6 +14,6 @@ internal static class SimplifierOptionsStorage
     public static ValueTask<SimplifierOptions> GetSimplifierOptionsAsync(this Document document, IGlobalOptionService globalOptions, CancellationToken cancellationToken)
         => document.GetSimplifierOptionsAsync(globalOptions.GetSimplifierOptions(document.Project.Services), cancellationToken);
 
-    public static SimplifierOptions GetSimplifierOptions(this IGlobalOptionService globalOptions, LanguageServices languageServices)
-        => languageServices.GetRequiredService<ISimplificationService>().GetSimplifierOptions(globalOptions, fallbackOptions: null);
+    public static SimplifierOptions GetSimplifierOptions(this IGlobalOptionService options, LanguageServices languageServices)
+        => options.GetSimplifierOptions(languageServices, fallbackOptions: null);
 }

--- a/src/Features/LanguageServer/Protocol/Features/Options/SyntaxFormattingOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/SyntaxFormattingOptionsStorage.cs
@@ -15,6 +15,6 @@ internal static class SyntaxFormattingOptionsStorage
         => document.GetSyntaxFormattingOptionsAsync(globalOptions.GetSyntaxFormattingOptions(document.Project.Services), cancellationToken);
 
     public static SyntaxFormattingOptions GetSyntaxFormattingOptions(this IGlobalOptionService globalOptions, LanguageServices languageServices)
-        => languageServices.GetRequiredService<ISyntaxFormattingService>().GetFormattingOptions(globalOptions, fallbackOptions: null);
+        => globalOptions.GetSyntaxFormattingOptions(languageServices, fallbackOptions: null);
 }
 

--- a/src/VisualStudio/Core/Def/Venus/ContainedLanguageCodeSupport.cs
+++ b/src/VisualStudio/Core/Def/Venus/ContainedLanguageCodeSupport.cs
@@ -218,8 +218,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                 throw new InvalidOperationException(ServicesVSResources.Can_t_find_where_to_insert_member);
             }
 
-            var fallbackOptions = targetDocument.Project.Solution.Services.GetRequiredService<ILegacyGlobalOptionsWorkspaceService>().CleanCodeGenerationOptionsProvider;
-
+            var fallbackOptions = globalOptions.GetCleanCodeGenerationOptions(targetDocument.Project.Services);
             var options = targetDocument.GetCleanCodeGenerationOptionsAsync(fallbackOptions, cancellationToken).AsTask().WaitAndGetResult_Venus(cancellationToken);
 
             var info = codeGenerationService.GetInfo(new CodeGenerationContext(autoInsertionLocation: false), options.GenerationOptions, destinationType.SyntaxTree.Options);

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
@@ -332,9 +332,9 @@ namespace Microsoft.CodeAnalysis.CodeActions
         {
             if (document.SupportsSyntaxTree)
             {
-                // TODO: avoid ILegacyGlobalOptionsWorkspaceService https://github.com/dotnet/roslyn/issues/60777
-                var globalOptions = document.Project.Solution.Services.GetService<ILegacyGlobalOptionsWorkspaceService>();
-                var fallbackOptions = globalOptions?.CleanCodeGenerationOptionsProvider ?? CodeActionOptions.DefaultProvider;
+                // TODO: avoid ILegacyGlobalCodeActionOptionsWorkspaceService https://github.com/dotnet/roslyn/issues/60777
+                var globalOptions = document.Project.Solution.Services.GetService<ILegacyGlobalCleanCodeGenerationOptionsWorkspaceService>();
+                var fallbackOptions = globalOptions?.Provider ?? CodeActionOptions.DefaultProvider;
 
                 var options = await document.GetCodeCleanupOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
                 return await CleanupDocumentAsync(document, options, cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/Options/ILegacyGlobalCleanCodeGenerationOptionsWorkspaceService.cs
+++ b/src/Workspaces/Core/Portable/Options/ILegacyGlobalCleanCodeGenerationOptionsWorkspaceService.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.Options;
+
+/// <summary>
+/// Enables legacy APIs to access global options from workspace.
+/// Not available OOP. Only use in client code and when IGlobalOptionService can't be MEF imported.
+/// Removal tracked by https://github.com/dotnet/roslyn/issues/60786
+/// </summary>
+internal interface ILegacyGlobalCleanCodeGenerationOptionsWorkspaceService : IWorkspaceService
+{
+    public CleanCodeGenerationOptionsProvider Provider { get; }
+}

--- a/src/Workspaces/Core/Portable/Options/ILegacyGlobalOptionsWorkspaceService.cs
+++ b/src/Workspaces/Core/Portable/Options/ILegacyGlobalOptionsWorkspaceService.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.CodeAnalysis.CodeGeneration;
-using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.Options
@@ -28,7 +27,5 @@ namespace Microsoft.CodeAnalysis.Options
 
         public bool GetGenerateConstructorFromMembersOptionsAddNullChecks(string language);
         public void SetGenerateConstructorFromMembersOptionsAddNullChecks(string language, bool value);
-
-        public CleanCodeGenerationOptionsProvider CleanCodeGenerationOptionsProvider { get; }
     }
 }

--- a/src/Workspaces/Core/Portable/Options/LegacyGlobalCodeActionOptionsWorkspaceService.cs
+++ b/src/Workspaces/Core/Portable/Options/LegacyGlobalCodeActionOptionsWorkspaceService.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.AddImport;
+using Microsoft.CodeAnalysis.CodeCleanup;
+using Microsoft.CodeAnalysis.CodeGeneration;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Simplification;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Options;
+
+/// <summary>
+/// Enables legacy APIs to access global options from workspace.
+/// </summary>
+[ExportWorkspaceService(typeof(ILegacyGlobalCleanCodeGenerationOptionsWorkspaceService)), Shared]
+internal sealed class LegacyGlobalCleanCodeGenerationOptionsWorkspaceService : ILegacyGlobalCleanCodeGenerationOptionsWorkspaceService
+{
+    public CleanCodeGenerationOptionsProvider Provider { get; }
+
+    [ImportingConstructor]
+    [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+    public LegacyGlobalCleanCodeGenerationOptionsWorkspaceService(IGlobalOptionService globalOptions)
+    {
+        Provider = new ProviderImpl(globalOptions);
+    }
+
+    private sealed class ProviderImpl : CleanCodeGenerationOptionsProvider
+    {
+        private readonly IOptionsReader _options;
+
+        public ProviderImpl(IOptionsReader options)
+            => _options = options;
+
+        ValueTask<LineFormattingOptions> OptionsProvider<LineFormattingOptions>.GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
+            => ValueTaskFactory.FromResult(_options.GetLineFormattingOptions(languageServices.Language, fallbackOptions: null));
+
+        ValueTask<DocumentFormattingOptions> OptionsProvider<DocumentFormattingOptions>.GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
+            => ValueTaskFactory.FromResult(_options.GetDocumentFormattingOptions(fallbackOptions: null));
+
+        ValueTask<SyntaxFormattingOptions> OptionsProvider<SyntaxFormattingOptions>.GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
+            => ValueTaskFactory.FromResult(_options.GetSyntaxFormattingOptions(languageServices, fallbackOptions: null));
+
+        ValueTask<SimplifierOptions> OptionsProvider<SimplifierOptions>.GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
+            => ValueTaskFactory.FromResult(_options.GetSimplifierOptions(languageServices, fallbackOptions: null));
+
+        ValueTask<AddImportPlacementOptions> OptionsProvider<AddImportPlacementOptions>.GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
+            => ValueTaskFactory.FromResult(_options.GetAddImportPlacementOptions(languageServices, allowInHiddenRegions: null, fallbackOptions: null));
+
+        ValueTask<CodeCleanupOptions> OptionsProvider<CodeCleanupOptions>.GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
+            => ValueTaskFactory.FromResult(_options.GetCodeCleanupOptions(languageServices, allowImportsInHiddenRegions: null, fallbackOptions: null));
+
+        ValueTask<CleanCodeGenerationOptions> OptionsProvider<CleanCodeGenerationOptions>.GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
+            => ValueTaskFactory.FromResult(_options.GetCleanCodeGenerationOptions(languageServices, allowImportsInHiddenRegions: null, fallbackOptions: null));
+
+        ValueTask<CodeAndImportGenerationOptions> OptionsProvider<CodeAndImportGenerationOptions>.GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
+            => ValueTaskFactory.FromResult(_options.GetCodeAndImportGenerationOptions(languageServices, allowImportsInHiddenRegions: null, fallbackOptions: null));
+
+        ValueTask<CodeGenerationOptions> OptionsProvider<CodeGenerationOptions>.GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
+            => ValueTaskFactory.FromResult(_options.GetCodeGenerationOptions(languageServices, fallbackOptions: null));
+
+        ValueTask<NamingStylePreferences> OptionsProvider<NamingStylePreferences>.GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
+            => ValueTaskFactory.FromResult(_options.GetOption(NamingStyleOptions.NamingPreferences, languageServices.Language));
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/AddImport/AddImportPlacementOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/AddImport/AddImportPlacementOptions.cs
@@ -49,13 +49,13 @@ internal interface AddImportPlacementOptionsProvider
 internal static partial class AddImportPlacementOptionsProviders
 {
 #if !CODE_STYLE
-    public static AddImportPlacementOptions GetAddImportPlacementOptions(this IOptionsReader options, bool allowInHiddenRegions, AddImportPlacementOptions? fallbackOptions, LanguageServices languageServices)
-        => languageServices.GetRequiredService<IAddImportsService>().GetAddImportOptions(options, allowInHiddenRegions, fallbackOptions);
+    public static AddImportPlacementOptions GetAddImportPlacementOptions(this IOptionsReader options, LanguageServices languageServices, bool? allowInHiddenRegions, AddImportPlacementOptions? fallbackOptions)
+        => languageServices.GetRequiredService<IAddImportsService>().GetAddImportOptions(options, allowInHiddenRegions ?? AddImportPlacementOptions.Default.AllowInHiddenRegions, fallbackOptions);
 
     public static async ValueTask<AddImportPlacementOptions> GetAddImportPlacementOptionsAsync(this Document document, AddImportPlacementOptions? fallbackOptions, CancellationToken cancellationToken)
     {
         var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
-        return configOptions.GetAddImportPlacementOptions(document.AllowImportsInHiddenRegions(), fallbackOptions, document.Project.Services);
+        return configOptions.GetAddImportPlacementOptions(document.Project.Services, document.AllowImportsInHiddenRegions(), fallbackOptions);
     }
 
     // Normally we don't allow generation into a hidden region in the file.  However, if we have a

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeCleanup/CodeCleanupOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeCleanup/CodeCleanupOptions.cs
@@ -8,10 +8,8 @@ using System.Runtime.Serialization;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.CodeAnalysis.AddImport;
-using Microsoft.CodeAnalysis.CodeActions;
-using Roslyn.Utilities;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
+using Roslyn.Utilities;
 
 #if !CODE_STYLE
 using Microsoft.CodeAnalysis.Host;
@@ -80,24 +78,25 @@ internal abstract class AbstractCodeCleanupOptionsProvider : CodeCleanupOptionsP
     async ValueTask<AddImportPlacementOptions> OptionsProvider<AddImportPlacementOptions>.GetOptionsAsync(LanguageServices languageServices, CancellationToken cancellationToken)
         => (await GetCodeCleanupOptionsAsync(languageServices, cancellationToken).ConfigureAwait(false)).AddImportOptions;
 }
+
 #endif
 
 internal static class CodeCleanupOptionsProviders
 {
 #if !CODE_STYLE
-    public static CodeCleanupOptions GetCodeCleanupOptions(this IOptionsReader options, bool allowImportsInHiddenRegions, CodeCleanupOptions? fallbackOptions, LanguageServices languageServices)
+    public static CodeCleanupOptions GetCodeCleanupOptions(this IOptionsReader options, LanguageServices languageServices, bool? allowImportsInHiddenRegions, CodeCleanupOptions? fallbackOptions)
         => new()
         {
-            FormattingOptions = options.GetSyntaxFormattingOptions(fallbackOptions?.FormattingOptions, languageServices),
-            SimplifierOptions = options.GetSimplifierOptions(fallbackOptions?.SimplifierOptions, languageServices),
-            AddImportOptions = options.GetAddImportPlacementOptions(allowImportsInHiddenRegions, fallbackOptions?.AddImportOptions, languageServices),
+            FormattingOptions = options.GetSyntaxFormattingOptions(languageServices, fallbackOptions?.FormattingOptions),
+            SimplifierOptions = options.GetSimplifierOptions(languageServices, fallbackOptions?.SimplifierOptions),
+            AddImportOptions = options.GetAddImportPlacementOptions(languageServices, allowImportsInHiddenRegions, fallbackOptions?.AddImportOptions),
             DocumentFormattingOptions = options.GetDocumentFormattingOptions(fallbackOptions?.DocumentFormattingOptions),
         };
 
     public static async ValueTask<CodeCleanupOptions> GetCodeCleanupOptionsAsync(this Document document, CodeCleanupOptions? fallbackOptions, CancellationToken cancellationToken)
     {
         var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
-        return configOptions.GetCodeCleanupOptions(document.AllowImportsInHiddenRegions(), fallbackOptions, document.Project.Services);
+        return configOptions.GetCodeCleanupOptions(document.Project.Services, document.AllowImportsInHiddenRegions(), fallbackOptions);
     }
 
     public static async ValueTask<CodeCleanupOptions> GetCodeCleanupOptionsAsync(this Document document, CodeCleanupOptionsProvider fallbackOptionsProvider, CancellationToken cancellationToken)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeGeneration/CodeGenerationOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeGeneration/CodeGenerationOptions.cs
@@ -9,9 +9,8 @@ using Microsoft.CodeAnalysis.AddImport;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
-using System.Diagnostics;
+using Microsoft.CodeAnalysis.CodeCleanup;
 
 #if !CODE_STYLE
 using Microsoft.CodeAnalysis.Host;
@@ -110,6 +109,20 @@ internal static class CodeGenerationOptionsProviders
 #if !CODE_STYLE
     public static CodeGenerationOptions GetCodeGenerationOptions(this IOptionsReader options, LanguageServices languageServices, CodeGenerationOptions? fallbackOptions)
         => languageServices.GetRequiredService<ICodeGenerationService>().GetCodeGenerationOptions(options, fallbackOptions);
+
+    public static CodeAndImportGenerationOptions GetCodeAndImportGenerationOptions(this IOptionsReader options, LanguageServices languageServices, bool? allowImportsInHiddenRegions, CodeAndImportGenerationOptions? fallbackOptions)
+        => new()
+        {
+            GenerationOptions = options.GetCodeGenerationOptions(languageServices, fallbackOptions?.GenerationOptions),
+            AddImportOptions = options.GetAddImportPlacementOptions(languageServices, allowImportsInHiddenRegions, fallbackOptions?.AddImportOptions)
+        };
+
+    public static CleanCodeGenerationOptions GetCleanCodeGenerationOptions(this IOptionsReader options, LanguageServices languageServices, bool? allowImportsInHiddenRegions, CleanCodeGenerationOptions? fallbackOptions)
+        => new()
+        {
+            GenerationOptions = options.GetCodeGenerationOptions(languageServices, fallbackOptions?.GenerationOptions),
+            CleanupOptions = options.GetCodeCleanupOptions(languageServices, allowImportsInHiddenRegions, fallbackOptions?.CleanupOptions)
+        };
 
     public static async ValueTask<CodeGenerationOptions> GetCodeGenerationOptionsAsync(this Document document, CodeGenerationOptions? fallbackOptions, CancellationToken cancellationToken)
     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/SyntaxFormattingOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/SyntaxFormattingOptions.cs
@@ -60,13 +60,13 @@ internal interface SyntaxFormattingOptionsProvider :
 internal static partial class SyntaxFormattingOptionsProviders
 {
 #if !CODE_STYLE
-    public static SyntaxFormattingOptions GetSyntaxFormattingOptions(this IOptionsReader options, SyntaxFormattingOptions? fallbackOptions, LanguageServices languageServices)
+    public static SyntaxFormattingOptions GetSyntaxFormattingOptions(this IOptionsReader options, LanguageServices languageServices, SyntaxFormattingOptions? fallbackOptions)
         => languageServices.GetRequiredService<ISyntaxFormattingService>().GetFormattingOptions(options, fallbackOptions);
 
     public static async ValueTask<SyntaxFormattingOptions> GetSyntaxFormattingOptionsAsync(this Document document, SyntaxFormattingOptions? fallbackOptions, CancellationToken cancellationToken)
     {
         var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
-        return configOptions.GetSyntaxFormattingOptions(fallbackOptions, document.Project.Services);
+        return configOptions.GetSyntaxFormattingOptions(document.Project.Services, fallbackOptions);
     }
 
     public static async ValueTask<SyntaxFormattingOptions> GetSyntaxFormattingOptionsAsync(this Document document, SyntaxFormattingOptionsProvider fallbackOptionsProvider, CancellationToken cancellationToken)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Simplification/SimplifierOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Simplification/SimplifierOptions.cs
@@ -80,13 +80,13 @@ namespace Microsoft.CodeAnalysis.Simplification
     internal static partial class SimplifierOptionsProviders
     {
 #if !CODE_STYLE
-        public static SimplifierOptions GetSimplifierOptions(this IOptionsReader options, SimplifierOptions? fallbackOptions, LanguageServices languageServices)
+        public static SimplifierOptions GetSimplifierOptions(this IOptionsReader options, LanguageServices languageServices, SimplifierOptions? fallbackOptions)
             => languageServices.GetRequiredService<ISimplificationService>().GetSimplifierOptions(options, fallbackOptions);
 
         public static async ValueTask<SimplifierOptions> GetSimplifierOptionsAsync(this Document document, SimplifierOptions? fallbackOptions, CancellationToken cancellationToken)
         {
             var configOptions = await document.GetAnalyzerConfigOptionsAsync(cancellationToken).ConfigureAwait(false);
-            return configOptions.GetSimplifierOptions(fallbackOptions, document.Project.Services);
+            return configOptions.GetSimplifierOptions(document.Project.Services, fallbackOptions);
         }
 
         public static async ValueTask<SimplifierOptions> GetSimplifierOptionsAsync(this Document document, SimplifierOptionsProvider fallbackOptionsProvider, CancellationToken cancellationToken)


### PR DESCRIPTION
Adds a new service interface `ILegacyGlobalCleanCodeGenerationOptionsWorkspaceService` that is used in a few places in workspace layer where a provider for `CleanCodeGenerationOptions` is needed for fallback options, but the fallback options can't currently be passed to that code from a higher layer.

Previously the provider was retrieved from `ILegacyGlobalOptionsWorkspaceService`, but the implementation of that service can't be moved to Workspace layer due to additional dependencies.

Uses the recently introduced `IOptionsReader` to eliminate duplicate option reading code.

Fixes https://github.com/dotnet/roslyn/issues/66779