### PR TITLE
Remove unnecessary null suppressions in calls to `RuntimeHelpers.GetHashCode`

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDecisionDagNode.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDecisionDagNode.cs
@@ -44,8 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundTestDecisionDagNode n:
                     return Hash.Combine(n.Test.GetHashCode(), Hash.Combine(RuntimeHelpers.GetHashCode(n.WhenFalse), RuntimeHelpers.GetHashCode(n.WhenTrue)));
                 case BoundWhenDecisionDagNode n:
-                    // See https://github.com/dotnet/runtime/pull/31819 for why ! is temporarily required below.
-                    return Hash.Combine(RuntimeHelpers.GetHashCode(n.WhenExpression!), Hash.Combine(RuntimeHelpers.GetHashCode(n.WhenFalse!), RuntimeHelpers.GetHashCode(n.WhenTrue)));
+                    return Hash.Combine(RuntimeHelpers.GetHashCode(n.WhenExpression), Hash.Combine(RuntimeHelpers.GetHashCode(n.WhenFalse), RuntimeHelpers.GetHashCode(n.WhenTrue)));
                 case BoundLeafDecisionDagNode n:
                     return RuntimeHelpers.GetHashCode(n.Label);
                 default:

--- a/src/Compilers/Core/Portable/InternalUtilities/ReferenceEqualityComparer.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ReferenceEqualityComparer.cs
@@ -30,8 +30,7 @@ namespace Roslyn.Utilities
 
         public static int GetHashCode(object? a)
         {
-            // https://github.com/dotnet/roslyn/issues/41539
-            return RuntimeHelpers.GetHashCode(a!);
+            return RuntimeHelpers.GetHashCode(a);
         }
     }
 }

--- a/src/Compilers/Core/Portable/PEWriter/SymbolEquivalentEqualityComparer.cs
+++ b/src/Compilers/Core/Portable/PEWriter/SymbolEquivalentEqualityComparer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Cci
                 return objSymbol.GetHashCode();
             }
 
-            return obj is object ? RuntimeHelpers.GetHashCode(obj) : 0;
+            return RuntimeHelpers.GetHashCode(obj);
         }
 
         public bool Equals(INamespace? x, INamespace? y)
@@ -89,7 +89,7 @@ namespace Microsoft.Cci
                 return objSymbol.GetHashCode();
             }
 
-            return obj is object ? RuntimeHelpers.GetHashCode(obj) : 0;
+            return RuntimeHelpers.GetHashCode(obj);
         }
     }
 }

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxNodeCache.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxNodeCache.cs
@@ -275,9 +275,7 @@ namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
         private static int GetCacheHash(int kind, GreenNode.NodeFlags flags, GreenNode? child1)
         {
             int code = (int)(flags) ^ kind;
-            // the only child is never null
-            // https://github.com/dotnet/roslyn/issues/41539
-            code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child1!), code);
+            code = Hash.Combine(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child1), code);
 
             // ensure nonnegative hash
             return code & Int32.MaxValue;


### PR DESCRIPTION
Resolves #41539.