### PR TITLE
Remove expensive call to ApplyPolicy

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Desktop.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerAssemblyLoader.Desktop.cs
@@ -77,8 +77,7 @@ namespace Microsoft.CodeAnalysis
         {
             try
             {
-                var displayName = AppDomain.CurrentDomain.ApplyPolicy(args.Name);
-                var assemblyName = new AssemblyName(displayName);
+                var assemblyName = new AssemblyName(args.Name);
                 string? bestPath = GetBestPath(assemblyName);
                 if (bestPath is not null)
                 {


### PR DESCRIPTION
This removes the call to `ApplyPolicy` from our .NET Framework analyzer loading story. This call applies host policy to the given display name. That was likely added back in the days where we used `LoadFile` in the generator and hence needed to manually handle policy. These days though all our calls are via `LoadFrom` which has policy implicitly applied.

Further this code path is only used as a final fall back now. By the time we get here it's assumed the host does not control the reference that is being loaded, it's owned by the analyzer. That means policy shouldn't even really apply.

Removing this because it's unneeded and leads to perf issues in VS

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1742924