### PR TITLE
Add net6.0 TFM to ExternalAccess.Razor

### DIFF
--- a/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
+++ b/src/Tools/ExternalAccess/Razor/Microsoft.CodeAnalysis.ExternalAccess.Razor.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <RootNamespace>Microsoft.CodeAnalysis.ExternalAccess.Razor</RootNamespace>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
 
     <!-- NuGet -->
     <IsPackable>true</IsPackable>

--- a/src/Tools/ExternalAccess/Razor/RazorDynamicFileInfoProviderWrapper.cs
+++ b/src/Tools/ExternalAccess/Razor/RazorDynamicFileInfoProviderWrapper.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
             return _innerDynamicFileInfoProvider.Value.RemoveDynamicFileInfoAsync(projectId, projectFilePath, filePath, cancellationToken);
         }
 
-        private void InnerDynamiFileInfoProvider_Updated(object sender, string e)
+        private void InnerDynamicFileInfoProvider_Updated(object? sender, string e)
         {
             Updated?.Invoke(this, e);
         }
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.Razor
                 }
 
                 _attached = true;
-                _innerDynamicFileInfoProvider.Value.Updated += InnerDynamiFileInfoProvider_Updated;
+                _innerDynamicFileInfoProvider.Value.Updated += InnerDynamicFileInfoProvider_Updated;
 
                 return true;
             }


### PR DESCRIPTION
Fixes `MissingMethodException`s in Razor tests after updating Roslyn to a version after https://github.com/dotnet/roslyn/pull/66655. These occur because of mismatch in `IsExternalInit` attribute (credit for discovering the problem goes to @davidwengier).

<details>
<summary>Details (reference graphs):</summary>

Previously, this worked:
- `Microsoft.AspNetCore.Razor.LanguageServer.Test` net7.0
  - `MS.CA.ExternalAccess.Razor` netstandard2.0
    - `MS.CA.Workspaces` netstandard2.0
      - has its own `IsExternalInit` attribute embedded ✅
  - `MS.CA.Workspaces` netcoreapp3.1
    - has its own `IsExternalInit` attribute embedded ✅

After https://github.com/dotnet/roslyn/pull/66655, it broke:
- `Microsoft.AspNetCore.Razor.LanguageServer.Test` net7.0
  - `MS.CA.ExternalAccess.Razor` netstandard2.0
    - `MS.CA.Workspaces` netstandard2.0
      - has its own `IsExternalInit` attribute embedded ❌
  - `MS.CA.Workspaces` **net6.0** 👈 changed
    - uses `IsExternalInit` attribute from `System.Runtime` ❌

After this PR, it works again:
- `Microsoft.AspNetCore.Razor.LanguageServer.Test` net7.0
  - `MS.CA.ExternalAccess.Razor` **net6.0** 👈 changed
    - `MS.CA.Workspaces` **net6.0**
      - uses `IsExternalInit` attribute from `System.Runtime` ✅
  - `MS.CA.Workspaces` net6.0
    - uses `IsExternalInit` attribute from `System.Runtime` ✅

</details>

(Alternative would be making `Microsoft.AspNetCore.Razor.LanguageServer.Test` target `net472`. I tried that but got AppDomainUnloaded exceptions in CI.)