### PR TITLE
Don't include star when committing promoted item

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CommitManager.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CommitManager.cs
@@ -197,6 +197,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 return new AsyncCompletionData.CommitResult(isHandled: true, AsyncCompletionData.CommitBehavior.None);
             }
 
+            // This might be an item promoted by us, make sure we restore it to the original state first.
+            roslynItem = Helpers.DemoteItem(roslynItem);
             CompletionChange change;
 
             // We met an issue when external code threw an OperationCanceledException and the cancellationToken is not canceled.

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/Helpers.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/Helpers.cs
@@ -32,10 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         public static RoslynCompletionItem DemoteItem(RoslynCompletionItem item)
         {
             if (!TryGetOriginalIndexOfPromotedItem(item, out _))
-            {
-                Debug.Assert(!item.DisplayText.StartsWith(Completion.Utilities.UnicodeStarAndSpace));
                 return item;
-            }
 
             Debug.Assert(item.DisplayText.StartsWith(Completion.Utilities.UnicodeStarAndSpace));
             return item

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/Helpers.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/Helpers.cs
@@ -3,17 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
 using Microsoft.VisualStudio.Text;
-using Roslyn.Utilities;
 using EditorAsyncCompletionData = Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
 using RoslynCompletionItem = Microsoft.CodeAnalysis.Completion.CompletionItem;
 using RoslynTrigger = Microsoft.CodeAnalysis.Completion.CompletionTrigger;
-using VSCompletionItem = Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data.CompletionItem;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion
 {
@@ -29,6 +27,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         {
             return item.WithDisplayText(Completion.Utilities.UnicodeStarAndSpace + item.DisplayText)
             .AddProperty(PromotedItemOriginalIndexPropertyName, index.ToString());
+        }
+
+        public static RoslynCompletionItem DemoteItem(RoslynCompletionItem item)
+        {
+            if (!TryGetOriginalIndexOfPromotedItem(item, out _))
+            {
+                Debug.Assert(!item.DisplayText.StartsWith(Completion.Utilities.UnicodeStarAndSpace));
+                return item;
+            }
+
+            Debug.Assert(item.DisplayText.StartsWith(Completion.Utilities.UnicodeStarAndSpace));
+            return item
+                .WithDisplayText(item.DisplayText[Completion.Utilities.UnicodeStarAndSpace.Length..])
+                .WithProperties(item.Properties.Remove(PromotedItemOriginalIndexPropertyName));
         }
 
         public static bool TryGetOriginalIndexOfPromotedItem(RoslynCompletionItem item, out int originalIndex)


### PR DESCRIPTION
Fix a bug introduced in https://github.com/dotnet/roslyn/pull/66278

Original report:

Put the caret at the end of the TryParseArgs line and hit return. You should get this:
 
![image](https://user-images.githubusercontent.com/788783/218565673-df25b0b3-6235-41e1-831f-c13e4adf35cd.png)


Type ‘i' to bring up IntelliSense and you get this:
 
![image](https://user-images.githubusercontent.com/788783/218565682-f311ed6e-1828-44d7-8e82-8b20e1a66a0d.png)


Hit space (to accept the completion – IntelliCode isn’t involved: IntelliSense is handling the space) and you get this:
 
![image](https://user-images.githubusercontent.com/788783/218565696-5a907b99-f8b1-4e8a-a2ff-f9438230e73b.png)

Fixes [AB#1746726](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1746726)