### PR TITLE
Added another F# test project for external access

### DIFF
--- a/src/Tools/ExternalAccess/FSharp/Microsoft.CodeAnalysis.ExternalAccess.FSharp.csproj
+++ b/src/Tools/ExternalAccess/FSharp/Microsoft.CodeAnalysis.ExternalAccess.FSharp.csproj
@@ -22,6 +22,7 @@
     <InternalsVisibleTo Include="FSharp.Editor" Key="$(FSharpKey)" />
     <InternalsVisibleTo Include="FSharp.LanguageService" Key="$(FSharpKey)" />
     <InternalsVisibleTo Include="VisualFSharp.UnitTests" Key="$(FSharpKey)" />
+    <InternalsVisibleTo Include="FSharp.Editor.Tests" Key="$(FSharpKey)" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp.UnitTests" />
   </ItemGroup>
 


### PR DESCRIPTION
We have recently split VisualFSharp.UnitTests project into two, so updating the project list to reflect this.
Here is the link to the project: https://github.com/dotnet/fsharp/tree/main/vsintegration/tests/FSharp.Editor.Tests