### PR TITLE
Use next sibling in SyntaxNode.GetChildPosition() if available

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxListTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxListTests.cs
@@ -352,6 +352,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var source = "int[] values = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };";
 
+            CSharpSyntaxTree.ParseText(source).VerifyChildNodePositions();
+
             var builder = ArrayBuilder<SyntaxNodeOrToken>.GetInstance();
             foreach (var node in parseAndGetInitializer(source).ChildNodesAndTokens().Reverse())
             {

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxListTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxListTests.cs
@@ -305,5 +305,44 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 }
             }
         }
+
+        [Fact]
+        public void EnumerateWithManyChildren_Forward()
+        {
+            const int n = 100000;
+            var builder = new StringBuilder();
+            builder.Append("int[] values = new[] { ");
+            for (int i = 0; i < n; i++) builder.Append("0, ");
+            builder.AppendLine("};");
+
+            var tree = CSharpSyntaxTree.ParseText(builder.ToString());
+            // Do not descend into InitializerExpressionSyntax since that will populate SeparatedWithManyChildren._children.
+            var node = tree.GetRoot().DescendantNodes().OfType<InitializerExpressionSyntax>().First();
+
+            foreach (var child in node.ChildNodesAndTokens())
+            {
+                _ = child.ToString();
+            }
+        }
+
+        [WorkItem(66475, "https://github.com/dotnet/roslyn/issues/66475")]
+        [Fact]
+        public void EnumerateWithManyChildren_Reverse()
+        {
+            const int n = 100000;
+            var builder = new StringBuilder();
+            builder.Append("int[] values = new[] { ");
+            for (int i = 0; i < n; i++) builder.Append("0, ");
+            builder.AppendLine("};");
+
+            var tree = CSharpSyntaxTree.ParseText(builder.ToString());
+            // Do not descend into InitializerExpressionSyntax since that will populate SeparatedWithManyChildren._children.
+            var node = tree.GetRoot().DescendantNodes().OfType<InitializerExpressionSyntax>().First();
+
+            foreach (var child in node.ChildNodesAndTokens().Reverse())
+            {
+                _ = child.ToString();
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxListTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxListTests.cs
@@ -308,13 +308,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
         }
 
-        [Fact]
-        public void EnumerateWithManyChildren_Forward()
+        [Theory]
+        [CombinatorialData]
+        public void EnumerateWithManyChildren_Forward(bool trailingSeparator)
         {
             const int n = 100000;
             var builder = new StringBuilder();
             builder.Append("int[] values = new[] { ");
             for (int i = 0; i < n; i++) builder.Append("0, ");
+            if (!trailingSeparator) builder.Append("0 ");
             builder.AppendLine("};");
 
             var tree = CSharpSyntaxTree.ParseText(builder.ToString());
@@ -328,13 +330,15 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
         [WorkItem(66475, "https://github.com/dotnet/roslyn/issues/66475")]
-        [Fact]
-        public void EnumerateWithManyChildren_Reverse()
+        [Theory]
+        [CombinatorialData]
+        public void EnumerateWithManyChildren_Reverse(bool trailingSeparator)
         {
             const int n = 100000;
             var builder = new StringBuilder();
             builder.Append("int[] values = new[] { ");
             for (int i = 0; i < n; i++) builder.Append("0, ");
+            if (!trailingSeparator) builder.Append("0 ");
             builder.AppendLine("};");
 
             var tree = CSharpSyntaxTree.ParseText(builder.ToString());
@@ -347,11 +351,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
         }
 
-        [Fact]
-        public void EnumerateWithManyChildren_Compare()
+        [Theory]
+        [InlineData("int[] values = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };")]
+        [InlineData("int[] values = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, };")]
+        public void EnumerateWithManyChildren_Compare(string source)
         {
-            var source = "int[] values = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };";
-
             CSharpSyntaxTree.ParseText(source).VerifyChildNodePositions();
 
             var builder = ArrayBuilder<SyntaxNodeOrToken>.GetInstance();

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxListTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxListTests.cs
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [CombinatorialData]
         public void EnumerateWithManyChildren_Forward(bool trailingSeparator)
         {
-            const int n = 100000;
+            const int n = 200000;
             var builder = new StringBuilder();
             builder.Append("int[] values = new[] { ");
             for (int i = 0; i < n; i++) builder.Append("0, ");
@@ -329,12 +329,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             }
         }
 
+        // Tests should timeout when using SeparatedWithManyChildren.GetChildPosition()
+        // instead of GetChildPositionFromEnd().
         [WorkItem(66475, "https://github.com/dotnet/roslyn/issues/66475")]
         [Theory]
         [CombinatorialData]
         public void EnumerateWithManyChildren_Reverse(bool trailingSeparator)
         {
-            const int n = 100000;
+            const int n = 200000;
             var builder = new StringBuilder();
             builder.Append("int[] values = new[] { ");
             for (int i = 0; i < n; i++) builder.Append("0, ");

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.SeparatedWithManyChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.SeparatedWithManyChildren.cs
@@ -43,10 +43,6 @@ namespace Microsoft.CodeAnalysis.Syntax
                 // If the previous sibling (ignoring separator) is not cached, but the next sibling
                 // (ignoring separator) is cached, use the next sibling to determine position.
                 int valueIndex = (index & 1) != 0 ? index - 1 : index;
-                // The check for valueIndex >= Green.SlotCount - 2 ignores the last item because the last item
-                // is a separator and separators are not cached. In those cases, when the index represents
-                // the last or next to last item, we still want to calculate the position from the end of
-                // the list rather than the start.
                 if (valueIndex > 1
                     && _children[(valueIndex - 2) >> 1].Value is null
                     && (valueIndex >= Green.SlotCount - 2 || _children[(valueIndex + 2) >> 1].Value is { }))

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.SeparatedWithManyChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.SeparatedWithManyChildren.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace Microsoft.CodeAnalysis.Syntax
 {
     internal partial class SyntaxList
     {
-        internal class SeparatedWithManyChildren : SyntaxList
+        internal sealed class SeparatedWithManyChildren : SyntaxList
         {
             private readonly ArrayElement<SyntaxNode?>[] _children;
 
@@ -38,6 +36,18 @@ namespace Microsoft.CodeAnalysis.Syntax
                 }
 
                 return _children[i >> 1].Value;
+            }
+
+            internal override int GetChildPosition(int index)
+            {
+                // If the previous sibling (ignoring separator) is not cached, but the next sibling
+                // (ignoring separator) is cached, use the next sibling to determine position.
+                int valueIndex = (index & 1) != 0 ? index - 1 : index;
+                bool useNextNotPrevious = valueIndex > 1
+                    && _children[(valueIndex - 2) >> 1].Value is null
+                    && (valueIndex >= Green.SlotCount - 2 || _children[(valueIndex + 2) >> 1].Value is { });
+
+                return GetChildPosition(index, useNextNotPrevious);
             }
         }
     }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.SeparatedWithManyChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.SeparatedWithManyChildren.cs
@@ -48,8 +48,8 @@ namespace Microsoft.CodeAnalysis.Syntax
                 // the last or next to last item, we still want to calculate the position from the end of
                 // the list rather than the start.
                 if (valueIndex > 1
-                    && _children[(valueIndex - 2) >> 1].Value is null
-                    && (valueIndex >= Green.SlotCount - 2 || _children[(valueIndex + 2) >> 1].Value is { }))
+                    && GetCachedSlot(valueIndex - 2) is null
+                    && (valueIndex >= Green.SlotCount - 2 || GetCachedSlot(valueIndex + 2) is { }))
                 {
                     return GetChildPositionFromEnd(index);
                 }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.SeparatedWithManyChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.SeparatedWithManyChildren.cs
@@ -43,6 +43,10 @@ namespace Microsoft.CodeAnalysis.Syntax
                 // If the previous sibling (ignoring separator) is not cached, but the next sibling
                 // (ignoring separator) is cached, use the next sibling to determine position.
                 int valueIndex = (index & 1) != 0 ? index - 1 : index;
+                // The check for valueIndex >= Green.SlotCount - 2 ignores the last item because the last item
+                // is a separator and separators are not cached. In those cases, when the index represents
+                // the last or next to last item, we still want to calculate the position from the end of
+                // the list rather than the start.
                 if (valueIndex > 1
                     && _children[(valueIndex - 2) >> 1].Value is null
                     && (valueIndex >= Green.SlotCount - 2 || _children[(valueIndex + 2) >> 1].Value is { }))

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.SeparatedWithManyChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.SeparatedWithManyChildren.cs
@@ -43,11 +43,14 @@ namespace Microsoft.CodeAnalysis.Syntax
                 // If the previous sibling (ignoring separator) is not cached, but the next sibling
                 // (ignoring separator) is cached, use the next sibling to determine position.
                 int valueIndex = (index & 1) != 0 ? index - 1 : index;
-                bool useNextNotPrevious = valueIndex > 1
+                if (valueIndex > 1
                     && _children[(valueIndex - 2) >> 1].Value is null
-                    && (valueIndex >= Green.SlotCount - 2 || _children[(valueIndex + 2) >> 1].Value is { });
+                    && (valueIndex >= Green.SlotCount - 2 || _children[(valueIndex + 2) >> 1].Value is { }))
+                {
+                    return GetChildPositionFromEnd(index);
+                }
 
-                return GetChildPosition(index, useNextNotPrevious);
+                return base.GetChildPosition(index);
             }
         }
     }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.SeparatedWithManyWeakChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.SeparatedWithManyWeakChildren.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.Syntax
 {
     internal partial class SyntaxList
     {
-        internal class SeparatedWithManyWeakChildren : SyntaxList
+        internal sealed class SeparatedWithManyWeakChildren : SyntaxList
         {
             private readonly ArrayElement<WeakReference<SyntaxNode>?>[] _children;
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.WithManyChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.WithManyChildren.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.Syntax
 {
     internal partial class SyntaxList
     {
-        internal class WithManyChildren : SyntaxList
+        internal sealed class WithManyChildren : SyntaxList
         {
             private readonly ArrayElement<SyntaxNode?>[] _children;
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.WithManyWeakChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.WithManyWeakChildren.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.Syntax
 {
     internal partial class SyntaxList
     {
-        internal class WithManyWeakChildren : SyntaxList
+        internal sealed class WithManyWeakChildren : SyntaxList
         {
             private readonly ArrayElement<WeakReference<SyntaxNode>?>[] _children;
 

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.WithThreeChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.WithThreeChildren.cs
@@ -8,7 +8,7 @@ namespace Microsoft.CodeAnalysis.Syntax
 {
     internal partial class SyntaxList
     {
-        internal class WithThreeChildren : SyntaxList
+        internal sealed class WithThreeChildren : SyntaxList
         {
             private SyntaxNode? _child0;
             private SyntaxNode? _child1;

--- a/src/Compilers/Core/Portable/Syntax/SyntaxList.WithTwoChildren.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList.WithTwoChildren.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Syntax
 {
     internal partial class SyntaxList
     {
-        internal class WithTwoChildren : SyntaxList
+        internal sealed class WithTwoChildren : SyntaxList
         {
             private SyntaxNode? _child0;
             private SyntaxNode? _child1;

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -612,24 +612,51 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal virtual int GetChildPosition(int index)
         {
+            return GetChildPosition(index, useNextNotPrevious: false);
+        }
+
+        internal int GetChildPosition(int index, bool useNextNotPrevious)
+        {
             int offset = 0;
             var green = this.Green;
-            while (index > 0)
-            {
-                index--;
-                var prevSibling = this.GetCachedSlot(index);
-                if (prevSibling != null)
-                {
-                    return prevSibling.EndPosition + offset;
-                }
-                var greenChild = green.GetSlot(index);
-                if (greenChild != null)
-                {
-                    offset += greenChild.FullWidth;
-                }
-            }
 
-            return this.Position + offset;
+            if (!useNextNotPrevious)
+            {
+                while (index > 0)
+                {
+                    index--;
+                    var prevSibling = this.GetCachedSlot(index);
+                    if (prevSibling != null)
+                    {
+                        return prevSibling.EndPosition + offset;
+                    }
+                    var greenChild = green.GetSlot(index);
+                    if (greenChild != null)
+                    {
+                        offset += greenChild.FullWidth;
+                    }
+                }
+                return this.Position + offset;
+            }
+            else
+            {
+                int slotCount = green.SlotCount;
+                while (index < slotCount - 1)
+                {
+                    index++;
+                    var prevSibling = this.GetCachedSlot(index);
+                    if (prevSibling != null)
+                    {
+                        return prevSibling.EndPosition - offset;
+                    }
+                    var greenChild = green.GetSlot(index);
+                    if (greenChild != null)
+                    {
+                        offset += greenChild.FullWidth;
+                    }
+                }
+                return this.EndPosition - offset;
+            }
         }
 
         public Location GetLocation()

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -612,51 +612,49 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal virtual int GetChildPosition(int index)
         {
-            return GetChildPosition(index, useNextNotPrevious: false);
-        }
-
-        internal int GetChildPosition(int index, bool useNextNotPrevious)
-        {
             int offset = 0;
             var green = this.Green;
+            while (index > 0)
+            {
+                index--;
+                var prevSibling = this.GetCachedSlot(index);
+                if (prevSibling != null)
+                {
+                    return prevSibling.EndPosition + offset;
+                }
+                var greenChild = green.GetSlot(index);
+                if (greenChild != null)
+                {
+                    offset += greenChild.FullWidth;
+                }
+            }
 
-            if (!useNextNotPrevious)
+            return this.Position + offset;
+        }
+
+        // Similar to GetChildPosition() but calculating based on the positions of
+        // following siblings rather than previous siblings.
+        internal int GetChildPositionFromEnd(int index)
+        {
+            var green = this.Green;
+            int offset = green.GetSlot(index).FullWidth;
+            int slotCount = green.SlotCount;
+            while (index < slotCount - 1)
             {
-                while (index > 0)
+                index++;
+                var nextSibling = this.GetCachedSlot(index);
+                if (nextSibling != null)
                 {
-                    index--;
-                    var prevSibling = this.GetCachedSlot(index);
-                    if (prevSibling != null)
-                    {
-                        return prevSibling.EndPosition + offset;
-                    }
-                    var greenChild = green.GetSlot(index);
-                    if (greenChild != null)
-                    {
-                        offset += greenChild.FullWidth;
-                    }
+                    return nextSibling.Position - offset;
                 }
-                return this.Position + offset;
-            }
-            else
-            {
-                int slotCount = green.SlotCount;
-                while (index < slotCount - 1)
+                var greenChild = green.GetSlot(index);
+                if (greenChild != null)
                 {
-                    index++;
-                    var prevSibling = this.GetCachedSlot(index);
-                    if (prevSibling != null)
-                    {
-                        return prevSibling.EndPosition - offset;
-                    }
-                    var greenChild = green.GetSlot(index);
-                    if (greenChild != null)
-                    {
-                        offset += greenChild.FullWidth;
-                    }
+                    offset += greenChild.FullWidth;
                 }
-                return this.EndPosition - offset;
             }
+
+            return this.EndPosition - offset;
         }
 
         public Location GetLocation()

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -637,7 +637,7 @@ namespace Microsoft.CodeAnalysis
         internal int GetChildPositionFromEnd(int index)
         {
             var green = this.Green;
-            int offset = green.GetSlot(index).FullWidth;
+            int offset = green.GetSlot(index)?.FullWidth ?? 0;
             int slotCount = green.SlotCount;
             while (index < slotCount - 1)
             {

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -612,6 +612,11 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal virtual int GetChildPosition(int index)
         {
+            if (this.GetCachedSlot(index) is { } node)
+            {
+                return node.Position;
+            }
+
             int offset = 0;
             var green = this.Green;
             while (index > 0)
@@ -636,6 +641,11 @@ namespace Microsoft.CodeAnalysis
         // following siblings rather than previous siblings.
         internal int GetChildPositionFromEnd(int index)
         {
+            if (this.GetCachedSlot(index) is { } node)
+            {
+                return node.Position;
+            }
+
             var green = this.Green;
             int offset = green.GetSlot(index)?.FullWidth ?? 0;
             int slotCount = green.SlotCount;

--- a/src/Compilers/Test/Core/Compilation/CompilationExtensions.cs
+++ b/src/Compilers/Test/Core/Compilation/CompilationExtensions.cs
@@ -315,6 +315,8 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                         }
                     }
                 }
+
+                tree.VerifyChildNodePositions();
             }
 
             var explicitNodeMap = new Dictionary<SyntaxNode, IOperation>();
@@ -378,6 +380,41 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                         }
                         break;
                 }
+            }
+        }
+
+        internal static void VerifyChildNodePositions(this SyntaxTree tree)
+        {
+            var nodes = tree.GetRoot().DescendantNodesAndSelf();
+            foreach (var node in nodes)
+            {
+                var childNodesAndTokens = node.ChildNodesAndTokens();
+                if (childNodesAndTokens.Node is { } container)
+                {
+                    for (int i = 0; i < childNodesAndTokens.Count; i++)
+                    {
+                        if (container.GetNodeSlot(i) is Microsoft.CodeAnalysis.Syntax.SyntaxList.SeparatedWithManyChildren separatedList)
+                        {
+                            verifyPositions(separatedList);
+                        }
+                    }
+                }
+            }
+
+            static void verifyPositions(Microsoft.CodeAnalysis.Syntax.SyntaxList.SeparatedWithManyChildren separatedList)
+            {
+                int n = separatedList.SlotCount;
+                var positions1 = new int[n];
+                for (int i = 0; i < n; i++)
+                {
+                    positions1[i] = separatedList.GetChildPosition(i);
+                }
+                var positions2 = new int[n];
+                for (int i = n - 1; i >= 0; i--)
+                {
+                    positions2[i] = separatedList.GetChildPositionFromEnd(i);
+                }
+                AssertEx.Equal(positions1, positions2);
             }
         }
 

--- a/src/Compilers/Test/Core/Compilation/CompilationExtensions.cs
+++ b/src/Compilers/Test/Core/Compilation/CompilationExtensions.cs
@@ -406,10 +406,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             {
                 var green = (Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList)separatedList.Green;
 
-                // Calculate positions from start, using any existing cache of red nodes on separated list.
+                // Calculate positions from start, using existing cache.
                 int[] positions = getPositionsFromStart(separatedList);
 
-                // Calculate positions from end, using any existing cache of red nodes on separated list.
+                // Calculate positions from end, using existing cache.
                 AssertEx.Equal(positions, getPositionsFromEnd(separatedList));
 
                 // Avoid testing without caches if the number of children is large.
@@ -418,18 +418,18 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     return;
                 }
 
-                // Calculate positions from start, with no caching of red nodes on new separated list.
+                // Calculate positions from start, with empty cache.
                 AssertEx.Equal(positions, getPositionsFromStart(new SeparatedWithManyChildren(green, null, separatedList.Position)));
 
-                // Calculate positions from end, with no caching of red nodes on new separated list.
+                // Calculate positions from end, with empty cache.
                 AssertEx.Equal(positions, getPositionsFromEnd(new SeparatedWithManyChildren(green, null, separatedList.Position)));
             }
 
+            // Calculate positions from start, using any existing cache of red nodes on separated list.
             static int[] getPositionsFromStart(SeparatedWithManyChildren separatedList)
             {
                 int n = separatedList.SlotCount;
                 var positions = new int[n];
-                // PROTOTYPE: Add comment
                 for (int i = 0; i < n; i++)
                 {
                     positions[i] = separatedList.GetChildPosition(i);
@@ -437,10 +437,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 return positions;
             }
 
+            // Calculate positions from end, using any existing cache of red nodes on separated list.
             static int[] getPositionsFromEnd(SeparatedWithManyChildren separatedList)
             {
                 int n = separatedList.SlotCount;
-                // PROTOTYPE: Add comment
                 var positions = new int[n];
                 for (int i = n - 1; i >= 0; i--)
                 {

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxListTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxListTests.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class SyntaxListTests
@@ -238,6 +239,53 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
                     Assert.True(item.IsKind(SyntaxKind.CommaToken))
                     Assert.Equal(position, item.AsToken.Index)
                 End If
+            Next
+        End Sub
+
+        <Fact>
+        Public Sub EnumerateWithManyChildren_Forward()
+            Const n = 100000
+            Dim builder As New System.Text.StringBuilder()
+            builder.AppendLine("Module M")
+            builder.AppendLine("    Sub Main")
+            builder.Append("        Dim values As Integer() = {")
+            For i = 0 To n - 1
+                builder.Append("0, ")
+            Next
+            builder.AppendLine("}")
+            builder.AppendLine("    End Sub")
+            builder.AppendLine("End Module")
+
+            Dim tree = VisualBasicSyntaxTree.ParseText(builder.ToString())
+            ' Do not descend into CollectionInitializerSyntax since that will populate SeparatedWithManyChildren._children.
+            Dim node = tree.GetRoot().DescendantNodes().OfType(Of CollectionInitializerSyntax)().First()
+
+            For Each child In node.ChildNodesAndTokens()
+                child.ToString()
+            Next
+        End Sub
+
+        <WorkItem(66475, "https://github.com/dotnet/roslyn/issues/66475")>
+        <Fact>
+        Public Sub EnumerateWithManyChildren_Reverse()
+            Const n = 100000
+            Dim builder As New System.Text.StringBuilder()
+            builder.AppendLine("Module M")
+            builder.AppendLine("    Sub Main")
+            builder.Append("        Dim values As Integer() = {")
+            For i = 0 To n - 1
+                builder.Append("0, ")
+            Next
+            builder.AppendLine("}")
+            builder.AppendLine("    End Sub")
+            builder.AppendLine("End Module")
+
+            Dim tree = VisualBasicSyntaxTree.ParseText(builder.ToString())
+            ' Do not descend into CollectionInitializerSyntax since that will populate SeparatedWithManyChildren._children.
+            Dim node = tree.GetRoot().DescendantNodes().OfType(Of CollectionInitializerSyntax)().First()
+
+            For Each child In node.ChildNodesAndTokens()
+                child.ToString()
             Next
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxListTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxListTests.vb
@@ -284,7 +284,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             ' Do not descend into CollectionInitializerSyntax since that will populate SeparatedWithManyChildren._children.
             Dim node = tree.GetRoot().DescendantNodes().OfType(Of CollectionInitializerSyntax)().First()
 
-            For Each child In node.ChildNodesAndTokens()
+            For Each child In node.ChildNodesAndTokens().Reverse()
                 child.ToString()
             Next
         End Sub

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxListTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxListTests.vb
@@ -244,7 +244,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
 
         <Fact>
         Public Sub EnumerateWithManyChildren_Forward()
-            Const n = 100000
+            Const n = 200000
             Dim builder As New System.Text.StringBuilder()
             builder.AppendLine("Module M")
             builder.AppendLine("    Sub Main")
@@ -265,10 +265,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             Next
         End Sub
 
+        ' Tests should timeout when using SeparatedWithManyChildren.GetChildPosition()
+        ' instead of GetChildPositionFromEnd().
         <WorkItem(66475, "https://github.com/dotnet/roslyn/issues/66475")>
         <Fact>
         Public Sub EnumerateWithManyChildren_Reverse()
-            Const n = 100000
+            Const n = 200000
             Dim builder As New System.Text.StringBuilder()
             builder.AppendLine("Module M")
             builder.AppendLine("    Sub Main")


### PR DESCRIPTION
When iterating a `SyntaxList.SeparatedWithManyChildren` collection in reverse, use the next sibling to calculate the position in `SyntaxNode.GetChildPosition()` rather than relying on the previous sibling which may not be cached.

Fixes https://github.com/dotnet/roslyn/issues/66475