### PR TITLE
Fix workspace pull diagnostics

### DIFF
--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
         /// Used by public workspace pull diagnostics to allow it to keep the connection open until
         /// changes occur to avoid the client spamming the server with requests.
         /// </summary>
-        protected virtual Task WaitForChangesAsync(RequestContext context)
+        protected virtual Task WaitForChangesAsync(RequestContext context, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
             // Some implementations of the spec will re-open requests as soon as we close them, spamming the server.
             // In those cases, we wait for the implementation to indicate that changes have occurred, then we close the connection
             // so that the client asks us again.
-            await WaitForChangesAsync(context).ConfigureAwait(false);
+            await WaitForChangesAsync(context, cancellationToken).ConfigureAwait(false);
 
             // If we had a progress object, then we will have been reporting to that.  Otherwise, take what we've been
             // collecting and return that.

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/AbstractPullDiagnosticHandler.cs
@@ -113,6 +113,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
 
         protected abstract string? GetDiagnosticCategory(TDiagnosticsParams diagnosticsParams);
 
+        /// <summary>
+        /// Used by public workspace pull diagnostics to allow it to keep the connection open until
+        /// changes occur to avoid the client spamming the server with requests.
+        /// </summary>
+        protected virtual Task WaitForChangesAsync(RequestContext context)
+        {
+            return Task.CompletedTask;
+        }
+
         public async Task<TReturn?> HandleRequestAsync(
             TDiagnosticsParams diagnosticsParams, RequestContext context, CancellationToken cancellationToken)
         {
@@ -181,6 +190,11 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics
                     progress.Report(CreateUnchangedReport(previousParams.TextDocument, previousParams.PreviousResultId));
                 }
             }
+
+            // Some implementations of the spec will re-open requests as soon as we close them, spamming the server.
+            // In those cases, we wait for the implementation to indicate that changes have occurred, then we close the connection
+            // so that the client asks us again.
+            await WaitForChangesAsync(context).ConfigureAwait(false);
 
             // If we had a progress object, then we will have been reporting to that.  Otherwise, take what we've been
             // collecting and return that.

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicWorkspacePullDiagnosticsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicWorkspacePullDiagnosticsHandler.cs
@@ -174,4 +174,18 @@ internal class PublicWorkspacePullDiagnosticsHandler : AbstractPullDiagnosticHan
         _workspaceManager.LspTextChanged -= OnLspTextChanged;
         _workspaceRegistrationService.LspSolutionChanged -= OnLspSolutionChanged;
     }
+
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal readonly struct TestAccessor
+    {
+        private readonly PublicWorkspacePullDiagnosticsHandler _handler;
+
+        public TestAccessor(PublicWorkspacePullDiagnosticsHandler handler)
+        {
+            _handler = handler;
+        }
+
+        public void TriggerConnectionClose() => _handler.UpdateLspChanged();
+    }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicWorkspacePullDiagnosticsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicWorkspacePullDiagnosticsHandler.cs
@@ -153,7 +153,7 @@ internal class PublicWorkspacePullDiagnosticsHandler : AbstractPullDiagnosticHan
         Interlocked.Exchange(ref _lspChanged, 1);
     }
 
-    protected override async Task WaitForChangesAsync(RequestContext context)
+    protected override async Task WaitForChangesAsync(RequestContext context, CancellationToken cancellationToken)
     {
         // Spin waiting until our LSP change flag has been set.  When the flag is set (meaning LSP has changed),
         // we reset the flag to false and exit out of the loop allowing the request to close.
@@ -161,7 +161,7 @@ internal class PublicWorkspacePullDiagnosticsHandler : AbstractPullDiagnosticHan
         while (Interlocked.CompareExchange(ref _lspChanged, value: 0, comparand: 1) == 0)
         {
             // There have been no changes between now and when the last request finished - we will hold the connection open while we poll for changes.
-            await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken).ConfigureAwait(false);
         }
 
         context.TraceInformation("Closing workspace/diagnostics request");

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicWorkspacePullDiagnosticsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicWorkspacePullDiagnosticsHandler.cs
@@ -50,6 +50,12 @@ internal class PublicWorkspacePullDiagnosticsHandler : AbstractPullDiagnosticHan
         _workspaceManager.LspTextChanged += OnLspTextChanged;
     }
 
+    public void Dispose()
+    {
+        _workspaceManager.LspTextChanged -= OnLspTextChanged;
+        _workspaceRegistrationService.LspSolutionChanged -= OnLspSolutionChanged;
+    }
+
     /// <summary>
     /// Public API doesn't support categories (yet).
     /// </summary>
@@ -167,12 +173,6 @@ internal class PublicWorkspacePullDiagnosticsHandler : AbstractPullDiagnosticHan
         context.TraceInformation("Closing workspace/diagnostics request");
         // We've hit a change, so we close the current request to allow the client to open a new one.
         return;
-    }
-
-    public void Dispose()
-    {
-        _workspaceManager.LspTextChanged -= OnLspTextChanged;
-        _workspaceRegistrationService.LspSolutionChanged -= OnLspSolutionChanged;
     }
 
     internal TestAccessor GetTestAccessor() => new(this);

--- a/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicWorkspacePullDiagnosticsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Diagnostics/Public/PublicWorkspacePullDiagnosticsHandler.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.EditAndContinue;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics.Public;
 
@@ -21,14 +22,32 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.Diagnostics.Public;
 using WorkspaceDiagnosticPartialReport = SumType<WorkspaceDiagnosticReport, WorkspaceDiagnosticReportPartialResult>;
 
 [Method(Methods.WorkspaceDiagnosticName)]
-internal class PublicWorkspacePullDiagnosticsHandler : AbstractPullDiagnosticHandler<WorkspaceDiagnosticParams, WorkspaceDiagnosticPartialReport, WorkspaceDiagnosticReport?>
+internal class PublicWorkspacePullDiagnosticsHandler : AbstractPullDiagnosticHandler<WorkspaceDiagnosticParams, WorkspaceDiagnosticPartialReport, WorkspaceDiagnosticReport?>, IDisposable
 {
+    private readonly LspWorkspaceRegistrationService _workspaceRegistrationService;
+    private readonly LspWorkspaceManager _workspaceManager;
+
+    /// <summary>
+    /// Flag that represents whether the LSP view of the world has changed.
+    /// It is totally fine for this to somewhat over-report changes
+    /// as it is an optimization used to delay closing workspace diagnostic requests
+    /// until something has changed.
+    /// </summary>
+    private int _lspChanged = 0;
+
     public PublicWorkspacePullDiagnosticsHandler(
+        LspWorkspaceManager workspaceManager,
+        LspWorkspaceRegistrationService registrationService,
         IDiagnosticAnalyzerService analyzerService,
         EditAndContinueDiagnosticUpdateSource editAndContinueDiagnosticUpdateSource,
         IGlobalOptionService globalOptions)
         : base(analyzerService, editAndContinueDiagnosticUpdateSource, globalOptions)
     {
+        _workspaceRegistrationService = registrationService;
+        _workspaceRegistrationService.LspSolutionChanged += OnLspSolutionChanged;
+
+        _workspaceManager = workspaceManager;
+        _workspaceManager.LspTextChanged += OnLspTextChanged;
     }
 
     /// <summary>
@@ -117,5 +136,42 @@ internal class PublicWorkspacePullDiagnosticsHandler : AbstractPullDiagnosticHan
                 Uri = id.Uri
             }
         }).ToImmutableArray();
+    }
+
+    private void OnLspSolutionChanged(object? sender, WorkspaceChangeEventArgs e)
+    {
+        UpdateLspChanged();
+    }
+
+    private void OnLspTextChanged(object? sender, EventArgs e)
+    {
+        UpdateLspChanged();
+    }
+
+    private void UpdateLspChanged()
+    {
+        Interlocked.Exchange(ref _lspChanged, 1);
+    }
+
+    protected override async Task WaitForChangesAsync(RequestContext context)
+    {
+        // Spin waiting until our LSP change flag has been set.  When the flag is set (meaning LSP has changed),
+        // we reset the flag to false and exit out of the loop allowing the request to close.
+        // The client will automatically trigger a new request as soon as we close it, bringing us up to date on diagnostics.
+        while (Interlocked.CompareExchange(ref _lspChanged, value: 0, comparand: 1) == 0)
+        {
+            // There have been no changes between now and when the last request finished - we will hold the connection open while we poll for changes.
+            await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+        }
+
+        context.TraceInformation("Closing workspace/diagnostics request");
+        // We've hit a change, so we close the current request to allow the client to open a new one.
+        return;
+    }
+
+    public void Dispose()
+    {
+        _workspaceManager.LspTextChanged -= OnLspTextChanged;
+        _workspaceRegistrationService.LspSolutionChanged -= OnLspSolutionChanged;
     }
 }

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -87,6 +87,8 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, ILspService
         _lspWorkspaceRegistrationService = lspWorkspaceRegistrationService;
     }
 
+    public EventHandler<EventArgs>? LspTextChanged;
+
     #region Implementation of IDocumentChangeTracker
 
     /// <summary>
@@ -102,6 +104,8 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, ILspService
 
         // If LSP changed, we need to compare against the workspace again to get the updated solution.
         _cachedLspSolutions.Clear();
+
+        LspTextChanged?.Invoke(this, EventArgs.Empty);
     }
 
     /// <summary>
@@ -120,6 +124,8 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, ILspService
 
         // Also remove it from our loose files workspace if it is still there.
         _lspMiscellaneousFilesWorkspace.TryRemoveMiscellaneousDocument(uri);
+
+        LspTextChanged?.Invoke(this, EventArgs.Empty);
     }
 
     /// <summary>
@@ -135,6 +141,8 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, ILspService
 
         // If LSP changed, we need to compare against the workspace again to get the updated solution.
         _cachedLspSolutions.Clear();
+
+        LspTextChanged?.Invoke(this, EventArgs.Empty);
     }
 
     public ImmutableDictionary<Uri, SourceText> GetTrackedLspText() => _trackedDocuments;

--- a/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Diagnostics/PullDiagnosticTests.cs
@@ -1667,12 +1667,13 @@ class A {";
             await using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(
                 new[] { markup1, markup2 }, BackgroundAnalysisScope.FullSolution, useVSDiagnostics: false);
 
-            var resultTask = RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics: false, useProgress: true);
+            var resultTask = RunPublicGetWorkspacePullDiagnosticsAsync(testLspServer, useProgress: true, triggerConnectionClose: false);
 
             // Assert that the connection isn't closed and task doesn't complete even after some delay.
             await Task.Delay(TimeSpan.FromSeconds(5));
             Assert.False(resultTask.IsCompleted);
 
+            // Make an LSP document change that will trigger connection close.
             var uri = testLspServer.GetCurrentSolution().Projects.First().Documents.First().GetURI();
             await testLspServer.OpenDocumentAsync(uri);
 
@@ -1690,12 +1691,13 @@ class A {";
             await using var testLspServer = await CreateTestWorkspaceWithDiagnosticsAsync(
                 new[] { markup1, markup2 }, BackgroundAnalysisScope.FullSolution, useVSDiagnostics: false);
 
-            var resultTask = RunGetWorkspacePullDiagnosticsAsync(testLspServer, useVSDiagnostics: false, useProgress: true);
+            var resultTask = RunPublicGetWorkspacePullDiagnosticsAsync(testLspServer, useProgress: true, triggerConnectionClose: false);
 
             // Assert that the connection isn't closed and task doesn't complete even after some delay.
             await Task.Delay(TimeSpan.FromSeconds(5));
             Assert.False(resultTask.IsCompleted);
 
+            // Make workspace change that will trigger connection close.
             var projectInfo = testLspServer.TestWorkspace.Projects.Single().ToProjectInfo();
             testLspServer.TestWorkspace.OnProjectReloaded(projectInfo);
 


### PR DESCRIPTION
Update our public spec implementation of workspace pull diagnostics to hold the request open when nothing changes to avoid the client spamming the server with requests.