### PR TITLE
WithFrozenPartialSemantics freezing linked documents

### DIFF
--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISolutionExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISolutionExtensions.cs
@@ -59,10 +59,5 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     throw ExceptionUtilities.UnexpectedValue(documentKind);
             }
         }
-
-        public static ImmutableArray<DocumentId> FilterDocumentIdsByLanguage(this Solution solution, ImmutableArray<DocumentId> documentIds, string language)
-            => documentIds.WhereAsArray(
-                (documentId, args) => args.solution.GetDocument(documentId)?.Project.Language == args.language,
-                (solution, language));
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -453,7 +453,8 @@ namespace Microsoft.CodeAnalysis
             if (solution.PartialSemanticsEnabled &&
                 this.Project.SupportsCompilation)
             {
-                var newSolution = this.Project.Solution.WithFrozenPartialCompilationIncludingSpecificDocument(this.Id, cancellationToken);
+                var linkedDocumentIds = this.GetLinkedDocumentIds();
+                var newSolution = this.Project.Solution.WithFrozenPartialCompilationIncludingSpecificDocument(this.Id, linkedDocumentIds, cancellationToken);
                 return newSolution.GetDocument(this.Id)!;
             }
             else

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -453,8 +453,7 @@ namespace Microsoft.CodeAnalysis
             if (solution.PartialSemanticsEnabled &&
                 this.Project.SupportsCompilation)
             {
-                var linkedDocumentIds = this.GetLinkedDocumentIds();
-                var newSolution = this.Project.Solution.WithFrozenPartialCompilationIncludingSpecificDocument(this.Id, linkedDocumentIds, cancellationToken);
+                var newSolution = this.Project.Solution.WithFrozenPartialCompilationIncludingSpecificDocument(this.Id, cancellationToken);
                 return newSolution.GetDocument(this.Id)!;
             }
             else

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -430,8 +430,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public ImmutableArray<DocumentId> GetLinkedDocumentIds()
         {
-            var documentIdsWithPath = this.Project.Solution.GetDocumentIdsWithFilePath(this.FilePath);
-            var filteredDocumentIds = this.Project.Solution.FilterDocumentIdsByLanguage(documentIdsWithPath, this.Project.Language);
+            var filteredDocumentIds = this.Project.Solution.GetRelatedDocumentIds(this.Id);
             return filteredDocumentIds.Remove(this.Id);
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1696,29 +1696,7 @@ namespace Microsoft.CodeAnalysis
 
         internal ImmutableArray<DocumentId> GetRelatedDocumentIds(DocumentId documentId)
         {
-            var projectState = _state.GetProjectState(documentId.ProjectId);
-            if (projectState == null)
-            {
-                // this document no longer exist
-                return ImmutableArray<DocumentId>.Empty;
-            }
-
-            var documentState = projectState.DocumentStates.GetState(documentId);
-            if (documentState == null)
-            {
-                // this document no longer exist
-                return ImmutableArray<DocumentId>.Empty;
-            }
-
-            var filePath = documentState.FilePath;
-            if (string.IsNullOrEmpty(filePath))
-            {
-                // this document can't have any related document. only related document is itself.
-                return ImmutableArray.Create(documentId);
-            }
-
-            var documentIds = GetDocumentIdsWithFilePath(filePath);
-            return this.FilterDocumentIdsByLanguage(documentIds, projectState.ProjectInfo.Language);
+            return _state.GetRelatedDocumentIds(documentId);
         }
 
         internal Solution WithNewWorkspace(string? workspaceKind, int workspaceVersion, SolutionServices services)

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1676,9 +1676,9 @@ namespace Microsoft.CodeAnalysis
         /// 
         /// This not intended to be the public API, use Document.WithFrozenPartialSemantics() instead.
         /// </summary>
-        internal Solution WithFrozenPartialCompilationIncludingSpecificDocument(DocumentId documentId, ImmutableArray<DocumentId> linkedDocumentIds, CancellationToken cancellationToken)
+        internal Solution WithFrozenPartialCompilationIncludingSpecificDocument(DocumentId documentId, CancellationToken cancellationToken)
         {
-            var newState = _state.WithFrozenPartialCompilationIncludingSpecificDocument(documentId, linkedDocumentIds, cancellationToken);
+            var newState = _state.WithFrozenPartialCompilationIncludingSpecificDocument(documentId, cancellationToken);
             return new Solution(newState);
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1676,9 +1676,9 @@ namespace Microsoft.CodeAnalysis
         /// 
         /// This not intended to be the public API, use Document.WithFrozenPartialSemantics() instead.
         /// </summary>
-        internal Solution WithFrozenPartialCompilationIncludingSpecificDocument(DocumentId documentId, CancellationToken cancellationToken)
+        internal Solution WithFrozenPartialCompilationIncludingSpecificDocument(DocumentId documentId, ImmutableArray<DocumentId> linkedDocumentIds, CancellationToken cancellationToken)
         {
-            var newState = _state.WithFrozenPartialCompilationIncludingSpecificDocument(documentId, cancellationToken);
+            var newState = _state.WithFrozenPartialCompilationIncludingSpecificDocument(documentId, linkedDocumentIds, cancellationToken);
             return new Solution(newState);
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1724,7 +1724,7 @@ namespace Microsoft.CodeAnalysis
             return FilterDocumentIdsByLanguage(this, documentIds, projectState.ProjectInfo.Language);
         }
 
-        public static ImmutableArray<DocumentId> FilterDocumentIdsByLanguage(SolutionState solution, ImmutableArray<DocumentId> documentIds, string language)
+        private static ImmutableArray<DocumentId> FilterDocumentIdsByLanguage(SolutionState solution, ImmutableArray<DocumentId> documentIds, string language)
             => documentIds.WhereAsArray(
                 (documentId, args) =>
                 {
@@ -1735,12 +1735,6 @@ namespace Microsoft.CodeAnalysis
                         return false;
                     }
 
-                    var documentState = projectState.DocumentStates.GetState(documentId);
-                    if (documentState == null)
-                    {
-                        // this document no longer exist
-                        return false;
-                    }
                     return projectState?.ProjectInfo.Language == args.language;
                 },
                 (solution, language));

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1697,7 +1697,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal ImmutableArray<DocumentId> GetRelatedDocumentIds(DocumentId documentId)
+        public ImmutableArray<DocumentId> GetRelatedDocumentIds(DocumentId documentId)
         {
             var projectState = this.GetProjectState(documentId.ProjectId);
             if (projectState == null)
@@ -1726,7 +1726,7 @@ namespace Microsoft.CodeAnalysis
 
         private static ImmutableArray<DocumentId> FilterDocumentIdsByLanguage(SolutionState solution, ImmutableArray<DocumentId> documentIds, string language)
             => documentIds.WhereAsArray(
-                (documentId, args) =>
+                static (documentId, args) =>
                 {
                     var projectState = args.solution.GetProjectState(documentId.ProjectId);
                     if (projectState == null)
@@ -1735,7 +1735,7 @@ namespace Microsoft.CodeAnalysis
                         return false;
                     }
 
-                    return projectState?.ProjectInfo.Language == args.language;
+                    return projectState.ProjectInfo.Language == args.language;
                 },
                 (solution, language));
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs
@@ -1686,8 +1686,8 @@ namespace Microsoft.CodeAnalysis
                         var newTracker = tracker.FreezePartialStateWithTree(this, linkedDoc, linkedTree, cancellationToken);
 
                         Contract.ThrowIfFalse(_projectIdToProjectStateMap.ContainsKey(linkedDoc.Id.ProjectId));
-                        newIdToProjectStateMap = _projectIdToProjectStateMap.SetItem(linkedDoc.Id.ProjectId, newTracker.ProjectState);
-                        newIdToTrackerMap = _projectIdToTrackerMap.SetItem(linkedDoc.Id.ProjectId, newTracker);
+                        newIdToProjectStateMap = newIdToProjectStateMap.SetItem(linkedDoc.Id.ProjectId, newTracker.ProjectState);
+                        newIdToTrackerMap = newIdToTrackerMap.SetItem(linkedDoc.Id.ProjectId, newTracker);
                     }
 
                     currentPartialSolution = this.Branch(

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -773,7 +773,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             originalDocument2 = project2.GetRequiredDocument(originalDocument2.Id).WithFrozenPartialSemantics(CancellationToken.None);
             var frozenSolution = originalDocument2.Project.Solution;
             var documentIdsToTest = new[] { originalDocument1.Id, originalDocument2.Id };
-            
+
             foreach (var documentIdToTest in documentIdsToTest)
             {
                 var document = frozenSolution.GetRequiredDocument(documentIdToTest);

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -768,10 +768,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 .AddAnalyzerReference(analyzerReference)
                 .AddDocument(originalDocument1.Name, await originalDocument1.GetTextAsync().ConfigureAwait(false), filePath: originalDocument1.FilePath);
 
-            var project2 = originalDocument2.Project;
-            Assert.True(workspace.SetCurrentSolution(_ => project2.Solution, WorkspaceChangeKind.SolutionChanged));
-            originalDocument2 = project2.GetRequiredDocument(originalDocument2.Id).WithFrozenPartialSemantics(CancellationToken.None);
-            var frozenSolution = originalDocument2.Project.Solution;
+            var frozenSolution = originalDocument2.WithFrozenPartialSemantics(CancellationToken.None).Project.Solution;
             var documentIdsToTest = new[] { originalDocument1.Id, originalDocument2.Id };
 
             foreach (var documentIdToTest in documentIdsToTest)
@@ -779,9 +776,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 var document = frozenSolution.GetRequiredDocument(documentIdToTest);
                 Assert.Equal(document.GetLinkedDocumentIds().Single(), documentIdsToTest.Except(new[] { documentIdToTest }).Single());
                 document = document.WithText(SourceText.From("// Something else"));
-                var project = document.Project;
 
-                var compilation = await project.GetRequiredCompilationAsync(CancellationToken.None);
+                var compilation = await document.Project.GetRequiredCompilationAsync(CancellationToken.None);
                 Assert.Single(compilation.SyntaxTrees);
                 Assert.False(generatorRan);
             }

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionWithSourceGeneratorTests.cs
@@ -825,7 +825,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
             // SG shouldn't run
             Assert.Equal(1, compilation1.SyntaxTrees.Count());
             Assert.False(generatorRan);
-
         }
     }
 }


### PR DESCRIPTION
Fixes: [AB#1436225](https://devdiv.visualstudio.com/DevDiv/_queries/edit/1436225/?triage=true)
Previously, when calling Document's ```WithFrozenPartialSemantics``` we would only freeze that document. Changed it so we retrieve all the linked documents as well and freeze all of them.