### PR TITLE
Allow LSP code action requests to set the (new) AllowGenerateInHiddenCode option

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -5427,6 +5427,26 @@ class C
         }
 
         [Fact]
+        public async Task TestDoNotGenerateIntoHiddenRegion4()
+        {
+            // This represents a typical Razor generated document, to ensure we don't regress
+            // Razor legacy editor behavior
+            await TestMissingInRegularAndScriptAsync(
+@"#line default
+class C
+{
+#line hidden
+#line default
+    void Goo()
+    {
+        [|Bar|]();
+    }
+#line hidden
+#line default
+}");
+        }
+
+        [Fact]
         public async Task TestDoNotAddImportsIntoHiddenRegion()
         {
             await TestInRegularAndScriptAsync(

--- a/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
+++ b/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -14,9 +13,8 @@ using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.BraceMatching;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.DocumentationComments;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
@@ -164,7 +162,8 @@ public class GlobalOptionsTests
              property.DeclaringType == typeof(DocumentFormattingOptions) && property.Name == nameof(DocumentFormattingOptions.FileHeaderTemplate) ||
              property.DeclaringType == typeof(DocumentFormattingOptions) && property.Name == nameof(DocumentFormattingOptions.InsertFinalNewLine) ||
              property.DeclaringType == typeof(ClassificationOptions) && property.Name == nameof(ClassificationOptions.ForceFrozenPartialSemanticsForCrossProcessOperations) ||
-             property.DeclaringType == typeof(BlockStructureOptions) && property.Name == nameof(BlockStructureOptions.IsMetadataAsSource));
+             property.DeclaringType == typeof(BlockStructureOptions) && property.Name == nameof(BlockStructureOptions.IsMetadataAsSource) ||
+             property.DeclaringType == typeof(CodeGenerationOptions) && property.Name == nameof(CodeGenerationOptions.AllowGenerateInHiddenCode));
 
     /// <summary>
     /// Our mock <see cref="IGlobalOptionService"/> implementation returns a non-default value for each option it reads.

--- a/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
+++ b/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
@@ -163,7 +163,7 @@ public class GlobalOptionsTests
              property.DeclaringType == typeof(DocumentFormattingOptions) && property.Name == nameof(DocumentFormattingOptions.InsertFinalNewLine) ||
              property.DeclaringType == typeof(ClassificationOptions) && property.Name == nameof(ClassificationOptions.ForceFrozenPartialSemanticsForCrossProcessOperations) ||
              property.DeclaringType == typeof(BlockStructureOptions) && property.Name == nameof(BlockStructureOptions.IsMetadataAsSource) ||
-             property.DeclaringType == typeof(CodeGenerationOptions) && property.Name == nameof(CodeGenerationOptions.AllowGenerateInHiddenCode));
+             property.DeclaringType == typeof(CodeGenerationOptions) && property.Name == nameof(CodeGenerationOptions.AllowInHiddenCode));
 
     /// <summary>
     /// Our mock <see cref="IGlobalOptionService"/> implementation returns a non-default value for each option it reads.

--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -290,7 +290,7 @@ namespace Roslyn.Test.Utilities
             };
 
         private protected static CodeActionResolveData CreateCodeActionResolveData(string uniqueIdentifier, LSP.Location location, IEnumerable<string>? customTags = null)
-            => new CodeActionResolveData(uniqueIdentifier, customTags.ToImmutableArrayOrEmpty(), location.Range, CreateTextDocumentIdentifier(location.Uri));
+            => new CodeActionResolveData(uniqueIdentifier, customTags.ToImmutableArrayOrEmpty(), location.Range, CreateTextDocumentIdentifier(location.Uri), allowGenerateInHiddenCode: false);
 
         private protected Task<TestLspServer> CreateTestLspServerAsync(string markup, LSP.ClientCapabilities clientCapabilities)
             => CreateTestLspServerAsync(new string[] { markup }, LanguageNames.CSharp, new InitializationOptions { ClientCapabilities = clientCapabilities });

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.State.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                 }
 
                 Contract.ThrowIfNull(TypeToGenerateIn);
-                if (!CodeGenerator.CanAdd(_document.Project.Solution, TypeToGenerateIn, allowGenerateInHiddenCode: false, cancellationToken))
+                if (!CodeGenerator.CanAdd(_document.Project.Solution, TypeToGenerateIn, allowInHiddenCode: false, cancellationToken))
                     return false;
 
                 ParameterTypes = ParameterTypes.IsDefault ? GetParameterTypes(cancellationToken) : ParameterTypes;

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.State.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                 }
 
                 Contract.ThrowIfNull(TypeToGenerateIn);
-                if (!CodeGenerator.CanAdd(_document.Project.Solution, TypeToGenerateIn, cancellationToken))
+                if (!CodeGenerator.CanAdd(_document.Project.Solution, TypeToGenerateIn, allowGenerateInHiddenCode: false, cancellationToken))
                     return false;
 
                 ParameterTypes = ParameterTypes.IsDefault ? GetParameterTypes(cancellationToken) : ParameterTypes;

--- a/src/Features/Core/Portable/GenerateMember/GenerateEnumMember/AbstractGenerateEnumMemberService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateEnumMember/AbstractGenerateEnumMemberService.State.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateEnumMember
                     return false;
 
                 TypeToGenerateIn = sourceType;
-                return CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateIn, allowGenerateInHiddenCode: false, cancellationToken);
+                return CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateIn, allowInHiddenCode: false, cancellationToken);
             }
 
             private bool TryInitializeIdentifierName(

--- a/src/Features/Core/Portable/GenerateMember/GenerateEnumMember/AbstractGenerateEnumMemberService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateEnumMember/AbstractGenerateEnumMemberService.State.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateEnumMember
                     return false;
 
                 TypeToGenerateIn = sourceType;
-                return CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateIn, cancellationToken);
+                return CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateIn, allowGenerateInHiddenCode: false, cancellationToken);
             }
 
             private bool TryInitializeIdentifierName(

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.State.cs
@@ -28,9 +28,11 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 TService service,
                 SemanticDocument document,
                 SyntaxNode interfaceNode,
+                bool allowGenerateInHiddenCode,
                 CancellationToken cancellationToken)
             {
                 var state = new State();
+                state.AllowGenerateInHiddenCode = allowGenerateInHiddenCode;
                 if (!await state.TryInitializeMethodAsync(service, document, interfaceNode, cancellationToken).ConfigureAwait(false))
                 {
                     return null;

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.State.cs
@@ -28,11 +28,11 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 TService service,
                 SemanticDocument document,
                 SyntaxNode interfaceNode,
-                bool allowGenerateInHiddenCode,
+                bool allowInHiddenCode,
                 CancellationToken cancellationToken)
             {
                 var state = new State();
-                state.AllowGenerateInHiddenCode = allowGenerateInHiddenCode;
+                state.AllowInHiddenCode = allowInHiddenCode;
                 if (!await state.TryInitializeMethodAsync(service, document, interfaceNode, cancellationToken).ConfigureAwait(false))
                 {
                     return null;

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.cs
@@ -35,11 +35,12 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
         {
             using (Logger.LogBlock(FunctionId.Refactoring_GenerateMember_GenerateMethod, cancellationToken))
             {
-                var documentOptions = await document.GetCodeGenerationOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
-                var allowGenerateInHiddenCode = documentOptions.AllowGenerateInHiddenCode;
+                // AllowInHiddenCode is not persisted, and not per-document, so we can read it directly off the fallback options
+                var options = await ((OptionsProvider<CodeGenerationOptions>)fallbackOptions).GetOptionsAsync(document.Project.Services, cancellationToken).ConfigureAwait(false);
+                var allowInHiddenCode = options.AllowInHiddenCode;
 
                 var semanticDocument = await SemanticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-                var state = await State.GenerateMethodStateAsync((TService)this, semanticDocument, node, allowGenerateInHiddenCode, cancellationToken).ConfigureAwait(false);
+                var state = await State.GenerateMethodStateAsync((TService)this, semanticDocument, node, allowInHiddenCode, cancellationToken).ConfigureAwait(false);
                 if (state == null)
                 {
                     return ImmutableArray<CodeAction>.Empty;

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateMethodService.cs
@@ -35,8 +35,11 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
         {
             using (Logger.LogBlock(FunctionId.Refactoring_GenerateMember_GenerateMethod, cancellationToken))
             {
+                var documentOptions = await document.GetCodeGenerationOptionsAsync(fallbackOptions, cancellationToken).ConfigureAwait(false);
+                var allowGenerateInHiddenCode = documentOptions.AllowGenerateInHiddenCode;
+
                 var semanticDocument = await SemanticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-                var state = await State.GenerateMethodStateAsync((TService)this, semanticDocument, node, cancellationToken).ConfigureAwait(false);
+                var state = await State.GenerateMethodStateAsync((TService)this, semanticDocument, node, allowGenerateInHiddenCode, cancellationToken).ConfigureAwait(false);
                 if (state == null)
                 {
                     return ImmutableArray<CodeAction>.Empty;

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.State.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
             public INamedTypeSymbol TypeToGenerateIn { get; protected set; }
             public bool IsStatic { get; protected set; }
             public bool IsContainedInUnsafeType { get; protected set; }
+            public bool AllowGenerateInHiddenCode { get; protected set; }
 
             // Just the name of the method.  i.e. "Goo" in "X.Goo" or "X.Goo()"
             public SyntaxToken IdentifierToken { get; protected set; }
@@ -68,7 +69,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                     return false;
                 }
 
-                if (!CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateIn, cancellationToken))
+                if (!CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateIn, AllowGenerateInHiddenCode, cancellationToken))
                 {
                     return false;
                 }

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.State.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
             public INamedTypeSymbol TypeToGenerateIn { get; protected set; }
             public bool IsStatic { get; protected set; }
             public bool IsContainedInUnsafeType { get; protected set; }
-            public bool AllowGenerateInHiddenCode { get; protected set; }
+            public bool AllowInHiddenCode { get; protected set; }
 
             // Just the name of the method.  i.e. "Goo" in "X.Goo" or "X.Goo()"
             public SyntaxToken IdentifierToken { get; protected set; }
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                     return false;
                 }
 
-                if (!CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateIn, AllowGenerateInHiddenCode, cancellationToken))
+                if (!CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateIn, AllowInHiddenCode, cancellationToken))
                 {
                     return false;
                 }

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.State.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
 
                 IsContainedInUnsafeType = service.ContainingTypesOrSelfHasUnsafeKeyword(TypeToGenerateIn);
 
-                return CanGenerateLocal() || CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateIn, cancellationToken);
+                return CanGenerateLocal() || CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateIn, allowGenerateInHiddenCode: false, cancellationToken);
             }
 
             internal bool CanGeneratePropertyOrField()

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.State.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
 
                 IsContainedInUnsafeType = service.ContainingTypesOrSelfHasUnsafeKeyword(TypeToGenerateIn);
 
-                return CanGenerateLocal() || CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateIn, allowGenerateInHiddenCode: false, cancellationToken);
+                return CanGenerateLocal() || CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateIn, allowInHiddenCode: false, cancellationToken);
             }
 
             internal bool CanGeneratePropertyOrField()

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
 
                 using var _ = ArrayBuilder<CodeAction>.GetInstance(out var actions);
 
-                var canGenerateMember = CodeGenerator.CanAdd(document.Project.Solution, state.TypeToGenerateIn, allowGenerateInHiddenCode: false, cancellationToken);
+                var canGenerateMember = CodeGenerator.CanAdd(document.Project.Solution, state.TypeToGenerateIn, allowInHiddenCode: false, cancellationToken);
 
                 if (canGenerateMember && state.CanGeneratePropertyOrField())
                 {

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
 
                 using var _ = ArrayBuilder<CodeAction>.GetInstance(out var actions);
 
-                var canGenerateMember = CodeGenerator.CanAdd(document.Project.Solution, state.TypeToGenerateIn, cancellationToken);
+                var canGenerateMember = CodeGenerator.CanAdd(document.Project.Solution, state.TypeToGenerateIn, allowGenerateInHiddenCode: false, cancellationToken);
 
                 if (canGenerateMember && state.CanGeneratePropertyOrField())
                 {

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
 
                 if (TypeToGenerateInOpt != null)
                 {
-                    if (!CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateInOpt, allowGenerateInHiddenCode: false, cancellationToken))
+                    if (!CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateInOpt, allowInHiddenCode: false, cancellationToken))
                     {
                         TypeToGenerateInOpt = null;
                     }

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.State.cs
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
 
                 if (TypeToGenerateInOpt != null)
                 {
-                    if (!CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateInOpt, cancellationToken))
+                    if (!CodeGenerator.CanAdd(document.Project.Solution, TypeToGenerateInOpt, allowGenerateInHiddenCode: false, cancellationToken))
                     {
                         TypeToGenerateInOpt = null;
                     }

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
 
             return
                 decl != null &&
-                semanticDocument.Document.GetLanguageService<ICodeGenerationService>().CanAddTo(decl, semanticDocument.Project.Solution, allowGenerateInHiddenCode: false, cancellationToken);
+                semanticDocument.Document.GetLanguageService<ICodeGenerationService>().CanAddTo(decl, semanticDocument.Project.Solution, allowInHiddenCode: false, cancellationToken);
         }
 
         private static bool IsGeneratingIntoContainingNamespace(

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
 
             return
                 decl != null &&
-                semanticDocument.Document.GetLanguageService<ICodeGenerationService>().CanAddTo(decl, semanticDocument.Project.Solution, cancellationToken);
+                semanticDocument.Document.GetLanguageService<ICodeGenerationService>().CanAddTo(decl, semanticDocument.Project.Solution, allowGenerateInHiddenCode: false, cancellationToken);
         }
 
         private static bool IsGeneratingIntoContainingNamespace(

--- a/src/Features/Core/Portable/ImplementAbstractClass/ImplementAbstractClassData.cs
+++ b/src/Features/Core/Portable/ImplementAbstractClass/ImplementAbstractClassData.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.ImplementAbstractClass
             if (abstractClassType == null || !abstractClassType.IsAbstractClass())
                 return null;
 
-            if (!CodeGenerator.CanAdd(document.Project.Solution, classType, cancellationToken))
+            if (!CodeGenerator.CanAdd(document.Project.Solution, classType, allowGenerateInHiddenCode: false, cancellationToken))
                 return null;
 
             var unimplementedMembers = classType.GetAllUnimplementedMembers(

--- a/src/Features/Core/Portable/ImplementAbstractClass/ImplementAbstractClassData.cs
+++ b/src/Features/Core/Portable/ImplementAbstractClass/ImplementAbstractClassData.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.ImplementAbstractClass
             if (abstractClassType == null || !abstractClassType.IsAbstractClass())
                 return null;
 
-            if (!CodeGenerator.CanAdd(document.Project.Solution, classType, allowGenerateInHiddenCode: false, cancellationToken))
+            if (!CodeGenerator.CanAdd(document.Project.Solution, classType, allowInHiddenCode: false, cancellationToken))
                 return null;
 
             var unimplementedMembers = classType.GetAllUnimplementedMembers(

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.State.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.State.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                     return null;
                 }
 
-                if (!CodeGenerator.CanAdd(document.Project.Solution, classOrStructType, allowGenerateInHiddenCode: false, cancellationToken))
+                if (!CodeGenerator.CanAdd(document.Project.Solution, classOrStructType, allowInHiddenCode: false, cancellationToken))
                 {
                     return null;
                 }

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.State.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.State.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                     return null;
                 }
 
-                if (!CodeGenerator.CanAdd(document.Project.Solution, classOrStructType, cancellationToken))
+                if (!CodeGenerator.CanAdd(document.Project.Solution, classOrStructType, allowGenerateInHiddenCode: false, cancellationToken))
                 {
                     return null;
                 }

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionParamsWithOptions.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionParamsWithOptions.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler
+{
+    /// <summary>
+    /// A parameter object that indicates whether the code actions are allowed to offer generating code in
+    /// hidden regions.
+    /// </summary>
+    /// <remarks>
+    /// Code actions normal don't generate code into hidden regions (eg things protected by <c>#line hidden</c> directives
+    /// but Razor generated files are almost entirely hidden, so the Razor client relaxes this rule at will,
+    /// in order to provide better code fixes and refactorings to users. Not all code fixes necessarily support
+    /// this option.
+    /// </remarks>
+    [DataContract]
+    internal class CodeActionParamsWithOptions : CodeActionParams
+    {
+        [DataMember(Name = "allowGenerateInHiddenCode")]
+        public bool AllowGenerateInHiddenCode { get; set; }
+    }
+}

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveData.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveData.cs
@@ -30,12 +30,15 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.CodeActions
 
         public LSP.TextDocumentIdentifier TextDocument { get; }
 
-        public CodeActionResolveData(string uniqueIdentifier, ImmutableArray<string> customTags, LSP.Range range, LSP.TextDocumentIdentifier textDocument)
+        public bool AllowGenerateInHiddenCode { get; }
+
+        public CodeActionResolveData(string uniqueIdentifier, ImmutableArray<string> customTags, LSP.Range range, LSP.TextDocumentIdentifier textDocument, bool allowGenerateInHiddenCode)
         {
             UniqueIdentifier = uniqueIdentifier;
             CustomTags = customTags;
             Range = range;
             TextDocument = textDocument;
+            AllowGenerateInHiddenCode = allowGenerateInHiddenCode;
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionResolveHandler.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var data = ((JToken)codeAction.Data!).ToObject<CodeActionResolveData>();
             Assumes.Present(data);
 
-            var options = _globalOptions.GetCodeActionOptionsProvider();
+            var options = CodeActionsHandler.GetCodeActionOptionsProvider(_globalOptions, data.AllowGenerateInHiddenCode);
 
             var codeActions = await CodeActionHelpers.GetCodeActionsAsync(
                 document,

--- a/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/CodeActions/CodeActionsHandler.cs
@@ -62,12 +62,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             var options = GetCodeActionOptionsProvider(_globalOptions, request.AllowGenerateInHiddenCode);
 
             var codeActions = await CodeActionHelpers.GetVSCodeActionsAsync(
-                request, document, options, _codeFixService, _codeRefactoringService, cancellationToken).ConfigureAwait(false);
+                request, document, options, _codeFixService, _codeRefactoringService, request.AllowGenerateInHiddenCode, cancellationToken).ConfigureAwait(false);
 
             return codeActions;
         }
 
-        private static CodeActionOptionsProvider GetCodeActionOptionsProvider(IGlobalOptionService globalOptions, bool allowGenerateInHiddenCode)
+        internal static CodeActionOptionsProvider GetCodeActionOptionsProvider(IGlobalOptionService globalOptions, bool allowGenerateInHiddenCode)
         {
             var cache = ImmutableDictionary<string, CodeActionOptions>.Empty;
             return new DelegatingCodeActionOptionsProvider(languageService => ImmutableInterlocked.GetOrAdd(ref cache, languageService.Language, (_, options) => CreateCodeActionOptions(allowGenerateInHiddenCode, languageService, options), globalOptions));

--- a/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/CodeActionsTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.CodeActions
                 applicableRange: new LSP.Range { Start = new Position { Line = 4, Character = 8 }, End = new Position { Line = 4, Character = 11 } },
                 diagnostics: null);
 
-            var results = await RunGetCodeActionsAsync(testLspServer, CreateCodeActionParams(caretLocation));
+            var results = await RunGetCodeActionsAsync(testLspServer, CreateCodeActionParams(caretLocation, allowInHiddenCode: false));
             var useImplicitType = results.FirstOrDefault(r => r.Title == CSharpAnalyzersResources.Use_implicit_type);
 
             AssertJsonEquals(expected, useImplicitType);
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.CodeActions
                 applicableRange: new LSP.Range { Start = new Position { Line = 4, Character = 12 }, End = new Position { Line = 4, Character = 12 } },
                 diagnostics: null);
 
-            var results = await RunGetCodeActionsAsync(testLspServer, CreateCodeActionParams(caretLocation));
+            var results = await RunGetCodeActionsAsync(testLspServer, CreateCodeActionParams(caretLocation, allowInHiddenCode: false));
 
             var topLevelAction = Assert.Single(results.Where(action => action.Title == FeaturesResources.Introduce_constant));
             var expectedChildActionTitle = FeaturesResources.Introduce_constant + '|' + string.Format(FeaturesResources.Introduce_constant_for_0, "1");
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.CodeActions
                 applicableRange: new LSP.Range { Start = new Position { Line = 5, Character = 8 }, End = new Position { Line = 5, Character = 11 } },
                 diagnostics: null);
 
-            var results = await RunGetCodeActionsAsync(testLspServer, CreateCodeActionParams(caretLocation, allowGenerateInHiddenCode: true));
+            var results = await RunGetCodeActionsAsync(testLspServer, CreateCodeActionParams(caretLocation, allowInHiddenCode: true));
             var generateMethod = results.Single(r => r.Title == expected.Title);
 
             AssertJsonEquals(expected, generateMethod);
@@ -197,7 +197,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.CodeActions
             await using var testLspServer = await CreateTestLspServerAsync(markup);
 
             var caretLocation = testLspServer.GetLocations("caret").Single();
-            var results = await RunGetCodeActionsAsync(testLspServer, CreateCodeActionParams(caretLocation));
+            var results = await RunGetCodeActionsAsync(testLspServer, CreateCodeActionParams(caretLocation, allowInHiddenCode: false));
             Assert.False(results.Any(r => r.Title == string.Format(FeaturesResources.Generate_method_0, "Bar")));
         }
 
@@ -210,10 +210,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.CodeActions
             return result.Cast<LSP.VSInternalCodeAction>().ToArray();
         }
 
-        internal static CodeActionParamsWithOptions CreateCodeActionParams(LSP.Location caret, bool allowGenerateInHiddenCode = false)
+        internal static CodeActionParamsWithOptions CreateCodeActionParams(LSP.Location caret, bool allowInHiddenCode)
             => new CodeActionParamsWithOptions
             {
-                AllowGenerateInHiddenCode = allowGenerateInHiddenCode,
+                AllowGenerateInHiddenCode = allowInHiddenCode,
                 TextDocument = CreateTextDocumentIdentifier(caret.Uri),
                 Range = caret.Range,
                 Context = new LSP.CodeActionContext

--- a/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/RunCodeActionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/CodeActions/RunCodeActionsTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.CodeActions
             var commandArgument = new CodeActionResolveData(string.Format(FeaturesResources.Move_type_to_0, "B.cs"), customTags: ImmutableArray<string>.Empty, caretLocation.Range, new LSP.TextDocumentIdentifier
             {
                 Uri = caretLocation.Uri
-            });
+            }, allowGenerateInHiddenCode: false);
 
             var results = await ExecuteRunCodeActionCommandAsync(testLspServer, commandArgument);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeGeneration/CodeGenerationOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeGeneration/CodeGenerationOptions.cs
@@ -9,9 +9,7 @@ using Microsoft.CodeAnalysis.AddImport;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
-using System.Diagnostics;
 
 #if !CODE_STYLE
 using Microsoft.CodeAnalysis.Host;
@@ -30,6 +28,7 @@ internal record CodeGenerationOptions
     internal static readonly CodeGenerationOptions CommonDefaults = new();
 
     [DataMember] public NamingStylePreferences NamingStyle { get; init; } = NamingStylePreferences.Default;
+    [DataMember] public bool AllowGenerateInHiddenCode { get; init; } = false;
 
     private protected CodeGenerationOptions()
     {
@@ -38,6 +37,7 @@ internal record CodeGenerationOptions
     private protected CodeGenerationOptions(IOptionsReader options, CodeGenerationOptions fallbackOptions, string language)
     {
         NamingStyle = options.GetOption(NamingStyleOptions.NamingPreferences, language, fallbackOptions.NamingStyle);
+        AllowGenerateInHiddenCode = fallbackOptions.AllowGenerateInHiddenCode;
     }
 
 #if !CODE_STYLE

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeGeneration/CodeGenerationOptions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeGeneration/CodeGenerationOptions.cs
@@ -28,7 +28,7 @@ internal record CodeGenerationOptions
     internal static readonly CodeGenerationOptions CommonDefaults = new();
 
     [DataMember] public NamingStylePreferences NamingStyle { get; init; } = NamingStylePreferences.Default;
-    [DataMember] public bool AllowGenerateInHiddenCode { get; init; } = false;
+    [DataMember] public bool AllowInHiddenCode { get; init; } = false;
 
     private protected CodeGenerationOptions()
     {
@@ -37,7 +37,8 @@ internal record CodeGenerationOptions
     private protected CodeGenerationOptions(IOptionsReader options, CodeGenerationOptions fallbackOptions, string language)
     {
         NamingStyle = options.GetOption(NamingStyleOptions.NamingPreferences, language, fallbackOptions.NamingStyle);
-        AllowGenerateInHiddenCode = fallbackOptions.AllowGenerateInHiddenCode;
+        // Not read from options because this is not persisted, but rather set on the CodeGenerationOptions instance directly
+        AllowInHiddenCode = fallbackOptions.AllowInHiddenCode;
     }
 
 #if !CODE_STYLE

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/AbstractCodeGenerationService_FindDeclaration.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/AbstractCodeGenerationService_FindDeclaration.cs
@@ -21,10 +21,10 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         private IList<bool>? GetAvailableInsertionIndices<TDeclarationNode>(TDeclarationNode destination, CancellationToken cancellationToken) where TDeclarationNode : SyntaxNode
             => GetAvailableInsertionIndices((SyntaxNode)destination, cancellationToken);
 
-        public bool CanAddTo(ISymbol destination, Solution solution, bool allowGenerateInHiddenCode, CancellationToken cancellationToken)
+        public bool CanAddTo(ISymbol destination, Solution solution, bool allowInHiddenCode, CancellationToken cancellationToken)
         {
             var declarations = _symbolDeclarationService.GetDeclarations(destination);
-            return declarations.Any(static (r, arg) => arg.self.CanAddTo(r.GetSyntax(arg.cancellationToken), arg.solution, arg.allowGenerateInHiddenCode, arg.cancellationToken), (self: this, solution, allowGenerateInHiddenCode, cancellationToken));
+            return declarations.Any(static (r, arg) => arg.self.CanAddTo(r.GetSyntax(arg.cancellationToken), arg.solution, arg.allowInHiddenCode, arg.cancellationToken), (self: this, solution, allowInHiddenCode, cancellationToken));
         }
 
         protected static SyntaxToken GetEndToken(SyntaxNode node)
@@ -51,11 +51,11 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return TextSpan.FromBounds(start.SpanStart, end.Span.End);
         }
 
-        public bool CanAddTo(SyntaxNode destination, Solution solution, bool allowGenerateInHiddenCode, CancellationToken cancellationToken)
-            => CanAddTo(destination, solution, cancellationToken, out _, allowGenerateInHiddenCode: allowGenerateInHiddenCode);
+        public bool CanAddTo(SyntaxNode destination, Solution solution, bool allowInHiddenCode, CancellationToken cancellationToken)
+            => CanAddTo(destination, solution, cancellationToken, out _, allowInHiddenCode: allowInHiddenCode);
 
         private bool CanAddTo(SyntaxNode? destination, Solution solution, CancellationToken cancellationToken,
-            out IList<bool>? availableIndices, bool checkGeneratedCode = false, bool allowGenerateInHiddenCode = false)
+            out IList<bool>? availableIndices, bool checkGeneratedCode = false, bool allowInHiddenCode = false)
         {
             availableIndices = null;
             if (destination == null)
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 #endif
 
             // If we are allowed to generate into hidden code then we are done with our checks
-            if (allowGenerateInHiddenCode)
+            if (allowInHiddenCode)
             {
                 return true;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/AbstractCodeGenerationService_FindDeclaration.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/AbstractCodeGenerationService_FindDeclaration.cs
@@ -87,6 +87,12 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
 #endif
 
+            // If we are allowed to generate into hidden code then we are done with our checks
+            if (allowGenerateInHiddenCode)
+            {
+                return true;
+            }
+
             // Anything completely hidden is something you can't add to. Anything completely visible
             // is something you can add to.  Anything that is partially hidden will have to defer to
             // the underlying language to make a determination.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/AbstractCodeGenerationService_FindDeclaration.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/AbstractCodeGenerationService_FindDeclaration.cs
@@ -21,10 +21,10 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         private IList<bool>? GetAvailableInsertionIndices<TDeclarationNode>(TDeclarationNode destination, CancellationToken cancellationToken) where TDeclarationNode : SyntaxNode
             => GetAvailableInsertionIndices((SyntaxNode)destination, cancellationToken);
 
-        public bool CanAddTo(ISymbol destination, Solution solution, CancellationToken cancellationToken)
+        public bool CanAddTo(ISymbol destination, Solution solution, bool allowGenerateInHiddenCode, CancellationToken cancellationToken)
         {
             var declarations = _symbolDeclarationService.GetDeclarations(destination);
-            return declarations.Any(static (r, arg) => arg.self.CanAddTo(r.GetSyntax(arg.cancellationToken), arg.solution, arg.cancellationToken), (self: this, solution, cancellationToken));
+            return declarations.Any(static (r, arg) => arg.self.CanAddTo(r.GetSyntax(arg.cancellationToken), arg.solution, arg.allowGenerateInHiddenCode, arg.cancellationToken), (self: this, solution, allowGenerateInHiddenCode, cancellationToken));
         }
 
         protected static SyntaxToken GetEndToken(SyntaxNode node)
@@ -51,11 +51,11 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return TextSpan.FromBounds(start.SpanStart, end.Span.End);
         }
 
-        public bool CanAddTo(SyntaxNode destination, Solution solution, CancellationToken cancellationToken)
-            => CanAddTo(destination, solution, cancellationToken, out _);
+        public bool CanAddTo(SyntaxNode destination, Solution solution, bool allowGenerateInHiddenCode, CancellationToken cancellationToken)
+            => CanAddTo(destination, solution, cancellationToken, out _, allowGenerateInHiddenCode: allowGenerateInHiddenCode);
 
         private bool CanAddTo(SyntaxNode? destination, Solution solution, CancellationToken cancellationToken,
-            out IList<bool>? availableIndices, bool checkGeneratedCode = false)
+            out IList<bool>? availableIndices, bool checkGeneratedCode = false, bool allowGenerateInHiddenCode = false)
         {
             availableIndices = null;
             if (destination == null)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerator.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         /// <summary>
         /// Returns <c>true</c> if additional declarations can be added to the destination symbol's declaration.
         /// </summary>
-        public static bool CanAdd(Solution solution, ISymbol destination, bool allowGenerateInHiddenCode, CancellationToken cancellationToken)
-            => GetCodeGenerationService(solution.Services, destination.Language).CanAddTo(destination, solution, allowGenerateInHiddenCode, cancellationToken);
+        public static bool CanAdd(Solution solution, ISymbol destination, bool allowInHiddenCode, CancellationToken cancellationToken)
+            => GetCodeGenerationService(solution.Services, destination.Language).CanAddTo(destination, solution, allowInHiddenCode, cancellationToken);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerator.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/CodeGenerator.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         /// <summary>
         /// Returns <c>true</c> if additional declarations can be added to the destination symbol's declaration.
         /// </summary>
-        public static bool CanAdd(Solution solution, ISymbol destination, CancellationToken cancellationToken)
-            => GetCodeGenerationService(solution.Services, destination.Language).CanAddTo(destination, solution, cancellationToken);
+        public static bool CanAdd(Solution solution, ISymbol destination, bool allowGenerateInHiddenCode, CancellationToken cancellationToken)
+            => GetCodeGenerationService(solution.Services, destination.Language).CanAddTo(destination, solution, allowGenerateInHiddenCode, cancellationToken);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/ICodeGenerationService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/ICodeGenerationService.cs
@@ -176,12 +176,12 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         /// <summary>
         /// <c>true</c> if destination is a location where other symbols can be added to.
         /// </summary>
-        bool CanAddTo(ISymbol destination, Solution solution, bool allowGenerateInHiddenCode, CancellationToken cancellationToken);
+        bool CanAddTo(ISymbol destination, Solution solution, bool allowInHiddenCode, CancellationToken cancellationToken);
 
         /// <summary>
         /// <c>true</c> if destination is a location where other symbols can be added to.
         /// </summary>
-        bool CanAddTo(SyntaxNode destination, Solution solution, bool allowGenerateInHiddenCode, CancellationToken cancellationToken);
+        bool CanAddTo(SyntaxNode destination, Solution solution, bool allowInHiddenCode, CancellationToken cancellationToken);
 
         /// <summary>
         /// Return the most relevant declaration to namespaceOrType,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/ICodeGenerationService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/ICodeGenerationService.cs
@@ -176,12 +176,12 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         /// <summary>
         /// <c>true</c> if destination is a location where other symbols can be added to.
         /// </summary>
-        bool CanAddTo(ISymbol destination, Solution solution, CancellationToken cancellationToken);
+        bool CanAddTo(ISymbol destination, Solution solution, bool allowGenerateInHiddenCode, CancellationToken cancellationToken);
 
         /// <summary>
         /// <c>true</c> if destination is a location where other symbols can be added to.
         /// </summary>
-        bool CanAddTo(SyntaxNode destination, Solution solution, CancellationToken cancellationToken);
+        bool CanAddTo(SyntaxNode destination, Solution solution, bool allowGenerateInHiddenCode, CancellationToken cancellationToken);
 
         /// <summary>
         /// Return the most relevant declaration to namespaceOrType,


### PR DESCRIPTION
More background work for https://github.com/dotnet/razor/issues/8204

I've talked to all of you about this, so hopefully this matches your expectations.

It is intentional, for now, that only one of the actual code fixes honour the new setting. I figured going for a slow rollout makes sense, and given its triggered by LSP we don't need to worry about dual insertion nonsense to expand support on the Roslyn sign once Razor is capable enough.