### PR TITLE
Clean with authority

### DIFF
--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -333,6 +333,12 @@ function Make-BootstrapBuild([switch]$force32 = $false) {
   Write-Host "Cleaning Bootstrap compiler artifacts"
   Run-MSBuild $projectPath "/t:Clean" -logFileName "BootstrapClean"
 
+  # Work around NuGet bug that doesn't correctly re-generate our project.assets.json files.
+  # Deleting everything forces a regen
+  # https://github.com/NuGet/Home/issues/12437
+  Remove-Item -Recurse -Force (Join-Path $ArtifactsDir "bin")
+  Remove-Item -Recurse -Force (Join-Path $ArtifactsDir "obj")
+
   return $dir
 }
 


### PR DESCRIPTION
This uses `Remove-Item` to fully clean our build outputs once the build of the bootstrap compiler completes. This ensures there are no artifacts remaining that could interfere with our build using the bootstrap compiler

Work around for https://github.com/NuGet/Home/issues/12437
