### PR TITLE
Add `<SourceGeneratorProjectReference>` MSBuild item type

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -359,7 +359,7 @@
   <Target Name="TranslateSourceGeneratorProjectReferenceItems"
           BeforeTargets="ResolveProjectReferences">
     <ItemGroup>
-      <ProjectReference Include="@(SourceGeneratorProjectReference)" OutputItemType="Analyzer" ReferenceOutputAssembly="false" AdditionalProperties="IsRidAgnostic=true" />
+      <ProjectReference Include="@(SourceGeneratorProjectReference)" OutputItemType="Analyzer" ReferenceOutputAssembly="false" AdditionalProperties="%(SourceGeneratorProjectReference.AdditionalProperties);IsRidAgnostic=true" />
     </ItemGroup>
   </Target>
 

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -357,7 +357,7 @@
     ========================
   -->
   <Target Name="TranslateSourceGeneratorItems"
-          BeforeTargets="CoreCompile">
+          BeforeTargets="ResolveProjectReferences">
     <ItemGroup>
       <ProjectReference Include="@(SourceGenerator)" OutputItemType="Analyzer" ReferenceOutputAssembly="false" AdditionalProperties="IsRidAgnostic=true" />
     </ItemGroup>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -351,4 +351,16 @@
     <ProjectCapability Include="RoslynComponent" Condition="'$(IsRoslynComponent)' == 'true'"/>
   </ItemGroup>
 
+  <!--
+    ========================
+    SourceGenerator Support
+    ========================
+  -->
+  <Target Name="TranslateSourceGeneratorItems"
+          BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <ProjectReference Include="@(SourceGenerator)" OutputItemType="Analyzer" ReferenceOutputAssembly="false" AdditionalProperties="IsRidAgnostic=true" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Microsoft.Managed.Core.targets
@@ -353,13 +353,13 @@
 
   <!--
     ========================
-    SourceGenerator Support
+    SourceGeneratorProjectReference Support
     ========================
   -->
-  <Target Name="TranslateSourceGeneratorItems"
+  <Target Name="TranslateSourceGeneratorProjectReferenceItems"
           BeforeTargets="ResolveProjectReferences">
     <ItemGroup>
-      <ProjectReference Include="@(SourceGenerator)" OutputItemType="Analyzer" ReferenceOutputAssembly="false" AdditionalProperties="IsRidAgnostic=true" />
+      <ProjectReference Include="@(SourceGeneratorProjectReference)" OutputItemType="Analyzer" ReferenceOutputAssembly="false" AdditionalProperties="IsRidAgnostic=true" />
     </ItemGroup>
   </Target>
 

--- a/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
@@ -661,8 +661,8 @@ some_prop = some_val");
             VerifyValues(
                 customProps: """
                 <ItemGroup>
-                    <SourceGenerator Include="MySourceGenerator1.csproj" />
-                    <SourceGenerator Include="MySourceGenerator2.csproj" />
+                    <SourceGeneratorProjectReference Include="MySourceGenerator1.csproj" />
+                    <SourceGeneratorProjectReference Include="MySourceGenerator2.csproj" />
                 </ItemGroup>
                 """,
                 customTargets: null,

--- a/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
@@ -661,8 +661,8 @@ some_prop = some_val");
             VerifyValues(
                 customProps: """
                 <ItemGroup>
-                    <SourceGenerator Include=".\MySourceGenerator1.csproj" />
-                    <SourceGenerator Include=".\MySourceGenerator2.csproj" />
+                    <SourceGenerator Include="MySourceGenerator1.csproj" />
+                    <SourceGenerator Include="MySourceGenerator2.csproj" />
                 </ItemGroup>
                 """,
                 customTargets: null,
@@ -673,8 +673,8 @@ some_prop = some_val");
                 },
                 expectedResults: new[]
                 {
-                    @".\MySourceGenerator1.csproj Analyzer false IsRidAgnostic=true",
-                    @".\MySourceGenerator2.csproj Analyzer false IsRidAgnostic=true"
+                    @"MySourceGenerator1.csproj Analyzer false IsRidAgnostic=true",
+                    @"MySourceGenerator2.csproj Analyzer false IsRidAgnostic=true"
                 });
         }
     }

--- a/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
@@ -666,7 +666,7 @@ some_prop = some_val");
                 </ItemGroup>
                 """,
                 customTargets: null,
-                targets: new[] { "CoreCompile" },
+                targets: new[] { "ResolveProjectReferences" },
                 expressions: new[]
                 {
                     "@(ProjectReference->'%(Identity) %(OutputItemType) %(ReferenceOutputAssembly) %(AdditionalProperties)')",

--- a/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
@@ -654,5 +654,28 @@ some_prop = some_val");
                     "mycustom.config"
                 }));
         }
+
+        [Fact, WorkItem(60744, "https://github.com/dotnet/roslyn/issues/60744")]
+        public void SourceGenerators()
+        {
+            VerifyValues(
+                customProps: """
+                <ItemGroup>
+                    <SourceGenerator Include=".\MySourceGenerator1.csproj" />
+                    <SourceGenerator Include=".\MySourceGenerator2.csproj" />
+                </ItemGroup>
+                """,
+                customTargets: null,
+                targets: new[] { "CoreCompile" },
+                expressions: new[]
+                {
+                    "@(ProjectReference->'%(Identity) %(OutputItemType) %(ReferenceOutputAssembly) %(AdditionalProperties)')",
+                },
+                expectedResults: new[]
+                {
+                    @".\MySourceGenerator1.csproj Analyzer false IsRidAgnostic=true",
+                    @".\MySourceGenerator2.csproj Analyzer false IsRidAgnostic=true"
+                });
+        }
     }
 }

--- a/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/DotNetSdkTests.cs
@@ -661,20 +661,22 @@ some_prop = some_val");
             VerifyValues(
                 customProps: """
                 <ItemGroup>
-                    <SourceGeneratorProjectReference Include="MySourceGenerator1.csproj" />
-                    <SourceGeneratorProjectReference Include="MySourceGenerator2.csproj" />
+                  <SourceGeneratorProjectReference Include="MySourceGenerator1.csproj" />
+                  <SourceGeneratorProjectReference Include="MySourceGenerator2.csproj" AdditionalProperties="Configuration=Debug;TargetFramework=netstandard2.0" />
+                  <ProjectReference Include="MySourceGenerator3.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" AdditionalProperties="Configuration=Debug;TargetFramework=netstandard2.0;IsRidAgnostic=true" />
                 </ItemGroup>
                 """,
                 customTargets: null,
                 targets: new[] { "ResolveProjectReferences" },
                 expressions: new[]
                 {
-                    "@(ProjectReference->'%(Identity) %(OutputItemType) %(ReferenceOutputAssembly) %(AdditionalProperties)')",
+                    "@(ProjectReference->'%(Identity) OutputItemType=%(OutputItemType) ReferenceOutputAssembly=%(ReferenceOutputAssembly) %(AdditionalProperties)'->Replace(';',','))",
                 },
                 expectedResults: new[]
                 {
-                    @"MySourceGenerator1.csproj Analyzer false IsRidAgnostic=true",
-                    @"MySourceGenerator2.csproj Analyzer false IsRidAgnostic=true"
+                    "MySourceGenerator3.csproj OutputItemType=Analyzer ReferenceOutputAssembly=false Configuration=Debug,TargetFramework=netstandard2.0,IsRidAgnostic=true",
+                    "MySourceGenerator1.csproj OutputItemType=Analyzer ReferenceOutputAssembly=false ,IsRidAgnostic=true",
+                    "MySourceGenerator2.csproj OutputItemType=Analyzer ReferenceOutputAssembly=false Configuration=Debug,TargetFramework=netstandard2.0,IsRidAgnostic=true"
                 });
         }
     }


### PR DESCRIPTION
Instead of writing:

```csproj
<ItemGroup>
  <ProjectReference Include=".\MySourceGenerator1.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
  <ProjectReference Include=".\MySourceGenerator2.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
</ItemGroup>
```

Allows one to write:

```csproj
<ItemGroup>
  <SourceGeneratorProjectReference Include=".\MySourceGenerator1.csproj" />
  <SourceGeneratorProjectReference Include=".\MySourceGenerator2.csproj" />
</ItemGroup>
```

Automatically adding all the properties, plus `AdditionalProperties="IsRidAgnostic=true"` (fixes #60744) and maybe more in the future.