### PR TITLE
[17.6] Cache source generator node tables only if their state counts match

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -2054,7 +2054,7 @@ class C { }
         }
 
         [Fact, WorkItem(61162, "https://github.com/dotnet/roslyn/issues/61162")]
-        public void IncrementalGenerator_Collect_SyntaxProvider()
+        public void IncrementalGenerator_Collect_SyntaxProvider_01()
         {
             var generator = new IncrementalGeneratorWrapper(new PipelineCallbackGenerator(static ctx =>
             {
@@ -2107,6 +2107,68 @@ class C { }
                 generatorDiagnostics.Verify();
                 var generatedTree = driver.GetRunResult().GeneratedTrees.Single();
                 AssertEx.EqualOrDiff(generatedContent, generatedTree.ToString());
+            }
+
+            static void replace(ref Compilation compilation, CSharpParseOptions parseOptions, string source)
+            {
+                compilation = compilation.ReplaceSyntaxTree(compilation.SyntaxTrees.Single(), CSharpSyntaxTree.ParseText(source, parseOptions));
+            }
+        }
+
+        [Fact, WorkItem(61162, "https://github.com/dotnet/roslyn/issues/61162")]
+        public void IncrementalGenerator_Collect_SyntaxProvider_02()
+        {
+            var generator = new IncrementalGeneratorWrapper(new PipelineCallbackGenerator(static ctx =>
+            {
+                var invokedMethodsProvider = ctx.SyntaxProvider
+                    .CreateSyntaxProvider(
+                        static (node, _) => node is InvocationExpressionSyntax,
+                        static (ctx, ct) => ctx.SemanticModel.GetSymbolInfo(ctx.Node, ct).Symbol?.Name ?? "(method not found)")
+                    .Select((n, _) => n);
+
+                ctx.RegisterSourceOutput(invokedMethodsProvider, static (spc, invokedMethod) =>
+                {
+                    spc.AddSource(invokedMethod, "// " + invokedMethod);
+                });
+            }));
+
+            var source = """
+                System.Console.WriteLine();
+                System.Console.ReadLine();
+                """;
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugExeThrowing, parseOptions: parseOptions);
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
+            verify(ref driver, compilation, new[]
+            {
+                "// WriteLine",
+                "// ReadLine"
+            });
+
+            replace(ref compilation, parseOptions, """
+                System.Console.WriteLine();
+                """);
+
+            verify(ref driver, compilation, new[]
+            {
+                "// WriteLine"
+            });
+
+            replace(ref compilation, parseOptions, "_ = 0;");
+            verify(ref driver, compilation, Array.Empty<string>());
+
+            static void verify(ref GeneratorDriver driver, Compilation compilation, string[] generatedContent)
+            {
+                driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var generatorDiagnostics);
+                outputCompilation.VerifyDiagnostics();
+                generatorDiagnostics.Verify();
+                var trees = driver.GetRunResult().GeneratedTrees;
+                Assert.Equal(generatedContent.Length, trees.Length);
+                for (int i = 0; i < generatedContent.Length; i++)
+                {
+                    AssertEx.EqualOrDiff(generatedContent[i], trees[i].ToString());
+                }
             }
 
             static void replace(ref Compilation compilation, CSharpParseOptions parseOptions, string source)

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -2053,6 +2053,68 @@ class C { }
                 });
         }
 
+        [Fact, WorkItem(61162, "https://github.com/dotnet/roslyn/issues/61162")]
+        public void IncrementalGenerator_Collect_SyntaxProvider()
+        {
+            var generator = new IncrementalGeneratorWrapper(new PipelineCallbackGenerator(static ctx =>
+            {
+                var invokedMethodsProvider = ctx.SyntaxProvider
+                    .CreateSyntaxProvider(
+                        static (node, _) => node is InvocationExpressionSyntax,
+                        static (ctx, ct) => ctx.SemanticModel.GetSymbolInfo(ctx.Node, ct).Symbol?.Name ?? "(method not found)")
+                    .Collect();
+
+                ctx.RegisterSourceOutput(invokedMethodsProvider, static (spc, invokedMethods) =>
+                {
+                    spc.AddSource("InvokedMethods.g.cs", string.Join(Environment.NewLine,
+                        invokedMethods.Select(m => $"// {m}")));
+                });
+            }));
+
+            var source = """
+                System.Console.WriteLine();
+                System.Console.WriteLine();
+                System.Console.WriteLine();
+                System.Console.WriteLine();
+                """;
+            var parseOptions = TestOptions.RegularPreview;
+            Compilation compilation = CreateCompilation(source, options: TestOptions.DebugExeThrowing, parseOptions: parseOptions);
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create(new[] { generator }, parseOptions: parseOptions);
+            verify(ref driver, compilation, """
+                // WriteLine
+                // WriteLine
+                // WriteLine
+                // WriteLine
+                """);
+
+            replace(ref compilation, parseOptions, """
+                System.Console.WriteLine();
+                System.Console.WriteLine();
+                """);
+            verify(ref driver, compilation, """
+                // WriteLine
+                // WriteLine
+                """);
+
+            replace(ref compilation, parseOptions, "_ = 0;");
+            verify(ref driver, compilation, "");
+
+            static void verify(ref GeneratorDriver driver, Compilation compilation, string generatedContent)
+            {
+                driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var generatorDiagnostics);
+                outputCompilation.VerifyDiagnostics();
+                generatorDiagnostics.Verify();
+                var generatedTree = driver.GetRunResult().GeneratedTrees.Single();
+                AssertEx.EqualOrDiff(generatedContent, generatedTree.ToString());
+            }
+
+            static void replace(ref Compilation compilation, CSharpParseOptions parseOptions, string source)
+            {
+                compilation = compilation.ReplaceSyntaxTree(compilation.SyntaxTrees.Single(), CSharpSyntaxTree.ParseText(source, parseOptions));
+            }
+        }
+
         [Fact]
         public void IncrementalGenerator_Register_End_Node_Only_Once_Through_Combines()
         {

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -605,7 +605,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             AssertTableEntries(table1, new[] { ("A", EntryState.Added, 0), ("B", EntryState.Added, 0) });
             AssertTableEntries(table1.AsCached(), new[] { ("A", EntryState.Cached, 0), ("B", EntryState.Cached, 0) });
 
-            // batch => [[A, B]]
+            // batch => [[A], [B]]
             var batchNode = new BatchNode<string>(inputNode);
             var table2 = dstBuilder.GetLatestStateTableForNode(batchNode);
             AssertTableEntries(table2, new[] { (ImmutableArray.Create("A", "B"), EntryState.Added, 0) });

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -615,6 +615,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
             input = new[] { ("B", EntryState.Cached) };
             dstBuilder = GetBuilder(dstBuilder.ToImmutable());
             table1 = dstBuilder.GetLatestStateTableForNode(inputNode);
+            AssertTableEntries(table1, new[] { ("B", EntryState.Cached, 0) });
+            AssertTableEntries(table1.AsCached(), new[] { ("B", EntryState.Cached, 0) });
 
             // batch => [[B]]
             table2 = dstBuilder.GetLatestStateTableForNode(batchNode);

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/StateTableTests.cs
@@ -585,6 +585,43 @@ namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.SourceGeneration
                 });
         }
 
+        [Fact, WorkItem(61162, "https://github.com/dotnet/roslyn/issues/61162")]
+        public void Batch_Node_Remove_From_Beginning()
+        {
+            // [A], [B]
+            var input = new[] { ("A", EntryState.Added), ("B", EntryState.Added) };
+            var inputNode = new CallbackNode<string>((_, _) =>
+            {
+                // Simulate syntax node.
+                var builder = NodeStateTable<string>.Empty.ToBuilder(null, false);
+                foreach (var (value, state) in input)
+                {
+                    builder.AddEntry(value, state, TimeSpan.Zero, default, state);
+                }
+                return builder.ToImmutableAndFree();
+            });
+            var dstBuilder = GetBuilder(DriverStateTable.Empty);
+            var table1 = dstBuilder.GetLatestStateTableForNode(inputNode);
+            AssertTableEntries(table1, new[] { ("A", EntryState.Added, 0), ("B", EntryState.Added, 0) });
+            AssertTableEntries(table1.AsCached(), new[] { ("A", EntryState.Cached, 0), ("B", EntryState.Cached, 0) });
+
+            // batch => [[A, B]]
+            var batchNode = new BatchNode<string>(inputNode);
+            var table2 = dstBuilder.GetLatestStateTableForNode(batchNode);
+            AssertTableEntries(table2, new[] { (ImmutableArray.Create("A", "B"), EntryState.Added, 0) });
+            AssertTableEntries(table2.AsCached(), new[] { (ImmutableArray.Create("A", "B"), EntryState.Cached, 0) });
+
+            // [B]
+            input = new[] { ("B", EntryState.Cached) };
+            dstBuilder = GetBuilder(dstBuilder.ToImmutable());
+            table1 = dstBuilder.GetLatestStateTableForNode(inputNode);
+
+            // batch => [[B]]
+            table2 = dstBuilder.GetLatestStateTableForNode(batchNode);
+            AssertTableEntries(table2, new[] { (ImmutableArray.Create("B"), EntryState.Modified, 0) });
+            AssertTableEntries(table2.AsCached(), new[] { (ImmutableArray.Create("B"), EntryState.Cached, 0) });
+        }
+
         [Fact]
         [WorkItem(54832, "https://github.com/dotnet/roslyn/issues/54832")]
         public void Transform_Node_Records_NewInput_OnFirst_Run()

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchNode.cs
@@ -132,7 +132,9 @@ namespace Microsoft.CodeAnalysis
             {
                 newTable.AddEntry(sourceValues, EntryState.Added, stopwatch.Elapsed, sourceInputs, EntryState.Added);
             }
-            else if (!sourceTable.IsCached || !newTable.TryUseCachedEntries(stopwatch.Elapsed, sourceInputs))
+            else if (!sourceTable.IsCached ||
+                GetTotalValueCount(previousTable) != sourceValues.Length ||
+                !newTable.TryUseCachedEntries(stopwatch.Elapsed, sourceInputs))
             {
                 if (!newTable.TryModifyEntry(sourceValues, _comparer, stopwatch.Elapsed, sourceInputs, EntryState.Modified))
                 {
@@ -141,6 +143,16 @@ namespace Microsoft.CodeAnalysis
             }
 
             return newTable.ToImmutableAndFree();
+
+            static int GetTotalValueCount(NodeStateTable<ImmutableArray<TInput>> table)
+            {
+                var count = 0;
+                foreach (var entry in table)
+                {
+                    count += entry.Item.Length;
+                }
+                return count;
+            }
         }
 
         public void RegisterOutput(IIncrementalGeneratorOutputNode output) => _sourceNode.RegisterOutput(output);

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchNode.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis
                 newTable.AddEntry(sourceValues, EntryState.Added, stopwatch.Elapsed, sourceInputs, EntryState.Added);
             }
             else if (!sourceTable.IsCached ||
-                GetTotalValueCount(previousTable) != sourceValues.Length ||
+                getTotalValueCount(previousTable) != sourceValues.Length ||
                 !newTable.TryUseCachedEntries(stopwatch.Elapsed, sourceInputs))
             {
                 if (!newTable.TryModifyEntry(sourceValues, _comparer, stopwatch.Elapsed, sourceInputs, EntryState.Modified))
@@ -144,7 +144,7 @@ namespace Microsoft.CodeAnalysis
 
             return newTable.ToImmutableAndFree();
 
-            static int GetTotalValueCount(NodeStateTable<ImmutableArray<TInput>> table)
+            static int getTotalValueCount(NodeStateTable<ImmutableArray<TInput>> table)
             {
                 var count = 0;
                 foreach (var entry in table)

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchNode.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/BatchNode.cs
@@ -132,9 +132,7 @@ namespace Microsoft.CodeAnalysis
             {
                 newTable.AddEntry(sourceValues, EntryState.Added, stopwatch.Elapsed, sourceInputs, EntryState.Added);
             }
-            else if (!sourceTable.IsCached ||
-                getTotalValueCount(previousTable) != sourceValues.Length ||
-                !newTable.TryUseCachedEntries(stopwatch.Elapsed, sourceInputs))
+            else if (!sourceTable.IsCached || !newTable.TryUseCachedEntries(stopwatch.Elapsed, sourceInputs))
             {
                 if (!newTable.TryModifyEntry(sourceValues, _comparer, stopwatch.Elapsed, sourceInputs, EntryState.Modified))
                 {
@@ -143,16 +141,6 @@ namespace Microsoft.CodeAnalysis
             }
 
             return newTable.ToImmutableAndFree();
-
-            static int getTotalValueCount(NodeStateTable<ImmutableArray<TInput>> table)
-            {
-                var count = 0;
-                foreach (var entry in table)
-                {
-                    count += entry.Item.Length;
-                }
-                return count;
-            }
         }
 
         public void RegisterOutput(IIncrementalGeneratorOutputNode output) => _sourceNode.RegisterOutput(output);

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/NodeStateTable.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis
         public int Count => _states.Length;
 
         /// <summary>
-        /// Indicates if every entry in this table has a state of <see cref="EntryState.Cached"/>
+        /// Indicates that this table is unchanged from the previous version.
         /// </summary>
         public bool IsCached { get; }
 


### PR DESCRIPTION
Fixes #61162.
Fixes #63422.

Devdiv issue for 17.6: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1786293