### PR TITLE
Properly use 'ValueTuple' instead of native tuples in cref syntax.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
@@ -495,5 +495,37 @@ class C
 
             await VerifyItemExistsAsync(text, "MyMethod(in int)");
         }
+
+        [Fact, WorkItem(22626, "https://github.com/dotnet/roslyn/issues/22626")]
+        public async Task ValueTuple1()
+        {
+            var text = """
+                class C
+                {
+                    /// <summary>
+                    /// <seealso cref="M$$"/>
+                    /// </summary>
+                    public void M((string, int) stringAndInt) { }
+                }
+                """;
+
+            await VerifyItemExistsAsync(text, "M(ValueTuple{string, int})");
+        }
+
+        [Fact, WorkItem(22626, "https://github.com/dotnet/roslyn/issues/22626")]
+        public async Task ValueTuple2()
+        {
+            var text = """
+                class C
+                {
+                    /// <summary>
+                    /// <seealso cref="M$$"/>
+                    /// </summary>
+                    public void M((string s, int i) stringAndInt) { }
+                }
+                """;
+
+            await VerifyItemExistsAsync(text, "M(ValueTuple{string, int})");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
@@ -451,5 +451,31 @@ End Class
 
             Await VerifyNoItemsExistAsync(text)
         End Function
+
+        <Fact, WorkItem(22626, "https://github.com/dotnet/roslyn/issues/22626")>
+        Public Async Function ValueTuple1() As Task
+            Dim text = "
+Class C
+    ''' <see cref=""Goo$$""/>
+    Sub Goo(stringAndInt as (string, integer))
+    End Sub
+End Class
+"
+
+            Await VerifyItemExistsAsync(text, "Goo(ValueTuple(Of String, Integer))")
+        End Function
+
+        <Fact, WorkItem(22626, "https://github.com/dotnet/roslyn/issues/22626")>
+        Public Async Function ValueTuple2() As Task
+            Dim text = "
+Class C
+    ''' <see cref=""Goo$$""/>
+    Sub Goo(stringAndInt as (s as string, i as integer))
+    End Sub
+End Class
+"
+
+            Await VerifyItemExistsAsync(text, "Goo(ValueTuple(Of String, Integer))")
+        End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CrefCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CrefCompletionProvider.vb
@@ -31,6 +31,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                 genericsOptions:=SymbolDisplayGenericsOptions.IncludeTypeParameters,
                 miscellaneousOptions:=SymbolDisplayMiscellaneousOptions.UseSpecialTypes)
 
+        Private Shared ReadOnly s_minimalParameterTypeFormat As SymbolDisplayFormat =
+            SymbolDisplayFormat.MinimallyQualifiedFormat.AddMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.ExpandValueTuple)
+
         Private _testSpeculativeNodeCallbackOpt As Action(Of SyntaxNode)
 
         Public Overrides Function IsInsertionTrigger(text As SourceText, characterPosition As Integer, options As CompletionOptions) As Boolean
@@ -231,7 +234,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                         builder.Append("ByRef ")
                     End If
 
-                    builder.Append(parameter.Type.ToMinimalDisplayString(semanticModel, position))
+                    builder.Append(parameter.Type.ToMinimalDisplayString(semanticModel, position, s_minimalParameterTypeFormat))
                 Next
 
                 builder.Append(")"c)
@@ -259,13 +262,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
         Private Shared ReadOnly s_WithoutOpenParen As CharacterSetModificationRule = CharacterSetModificationRule.Create(CharacterSetModificationKind.Remove, "("c)
         Private Shared ReadOnly s_WithoutSpace As CharacterSetModificationRule = CharacterSetModificationRule.Create(CharacterSetModificationKind.Remove, " "c)
 
-#If False Then
-        Private Shared s_defaultRules As CompletionItemRules =
-            CompletionItemRules.Create(commitRules:=ImmutableArray.Create(
-                CommitRule.Create(CommitRuleKind.ExcludeKeysIfMatchEndOfTypedText, " ", "OF", isCaseSensitive:=False)))
-#Else
         Private Shared ReadOnly s_defaultRules As CompletionItemRules = CompletionItemRules.Default
-#End If
 
         Private Shared Function GetRules(displayText As String) As CompletionItemRules
             Dim commitRules = s_defaultRules.CommitCharacterRules
@@ -273,12 +270,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             If displayText.Contains("(") Then
                 commitRules = commitRules.Add(s_WithoutOpenParen)
             End If
-
-#If False Then
-            If displayText.Contains("(Of") Then
-                commitRules = commitRules.Add(s_WithoutSpace)
-            End If
-#End If
 
             Return s_defaultRules.WithCommitCharacterRules(commitRules)
         End Function


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/22626