### PR TITLE
Fix 'tuple can be deconstructed' issue with top level statements

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseDeconstruction/CSharpUseDeconstructionDiagnosticAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseDeconstruction/CSharpUseDeconstructionDiagnosticAnalyzer.cs
@@ -59,12 +59,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseDeconstruction
         private void AnalyzeVariableDeclaration(
             SyntaxNodeAnalysisContext context, VariableDeclarationSyntax variableDeclaration, ReportDiagnostic severity)
         {
-            if (!TryAnalyzeVariableDeclaration(
-                    context.SemanticModel, variableDeclaration, out _,
-                    out _, context.CancellationToken))
-            {
+            if (!TryAnalyzeVariableDeclaration(context.SemanticModel, variableDeclaration, out _, out _, context.CancellationToken))
                 return;
-            }
 
             context.ReportDiagnostic(DiagnosticHelper.Create(
                 Descriptor,


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/66994