### PR TITLE
Remove CheckServerState

### DIFF
--- a/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
+++ b/src/Features/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/AbstractLanguageServer.cs
@@ -184,7 +184,6 @@ public abstract class AbstractLanguageServer<TRequestContext>
 
         public async Task NotificationEntryPointAsync<TRequest>(TRequest request, CancellationToken cancellationToken) where TRequest : class
         {
-            CheckServerState();
             var queue = _target.GetRequestExecutionQueue();
             var lspServices = _target.GetLspServices();
 
@@ -193,7 +192,6 @@ public abstract class AbstractLanguageServer<TRequestContext>
 
         public async Task ParameterlessNotificationEntryPointAsync(CancellationToken cancellationToken)
         {
-            CheckServerState();
             var queue = _target.GetRequestExecutionQueue();
             var lspServices = _target.GetLspServices();
 
@@ -202,21 +200,12 @@ public abstract class AbstractLanguageServer<TRequestContext>
 
         public async Task<TResponse?> EntryPointAsync<TRequest, TResponse>(TRequest request, CancellationToken cancellationToken) where TRequest : class
         {
-            CheckServerState();
             var queue = _target.GetRequestExecutionQueue();
             var lspServices = _target.GetLspServices();
 
             var result = await queue.ExecuteAsync<TRequest, TResponse>(request, _method, lspServices, cancellationToken).ConfigureAwait(false);
 
             return result;
-        }
-
-        private void CheckServerState()
-        {
-            if (!_target.IsInitialized && _method != "initialize" && _method != "initialized")
-            {
-                throw new InvalidOperationException($"'initialized' has not been called.");
-            }
         }
     }
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/LanguageServerTargetTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
             await server.ExecuteRequestAsync<DidOpenTextDocumentParams, object>(Methods.TextDocumentDidOpenName, didOpenParams, CancellationToken.None);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/razor/issues/8311")]
         public async Task LanguageServerRejectsRequestsBeforeInitialized()
         {
             await using var server = await CreateTestLspServerAsync("", new InitializationOptions { CallInitialized = false });


### PR DESCRIPTION
- We wanted to "do the right thing" by verifying the LSP specification requirements WRT the initialized method, but our implementation was flawed. For now we're going to disable the check and come back to do the proper fix later. The check should be a no-op for well-behaved client anyway (and we've already confirmed that VS and VSCode are well-behaved.