### PR TITLE
Port to 17.5: Allow missing CommandLineArgsForDesignTimeEvaluation msbuild property (#66367)

### DIFF
--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
@@ -32,6 +32,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         private readonly IProjectCodeModelFactory _projectCodeModelFactory;
         private readonly IAsyncServiceProvider _serviceProvider;
 
+        /// <summary>
+        /// Solutions containing projects that use older compiler toolset that does not provide a checksum algorithm.
+        /// Used only for EnC issue diagnostics.
+        /// </summary>
+        private ImmutableHashSet<string> _solutionsWithMissingChecksumAlgorithm = ImmutableHashSet<string>.Empty;
+
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
         public CPSProjectFactory(
@@ -110,6 +116,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         {
             // Read all required properties from EvaluationData before we start updating anything.
 
+            // Compatibility with older SDKs:
+            // If the IDE loads a project that uses an older version of compiler targets or the SDK some msbuild properties/items might not be available
+            // (those that were added in a later version). For each property/item we read here that is defined in the compiler targets or the SDK
+            // we need to handle its absence, as long as we support that version of the compilers/SDK.
+
             var projectFilePath = data.GetRequiredPropertyAbsolutePathValue(BuildPropertyNames.MSBuildProjectFullPath);
 
             var creationInfo = new VisualStudioProjectCreationInfo
@@ -125,7 +136,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             {
                 binOutputPath = data.GetRequiredPropertyAbsolutePathValue(BuildPropertyNames.TargetPath);
                 objOutputPath = GetIntermediateAssemblyPath(data, projectFilePath);
-                commandLineArgs = data.GetRequiredPropertyValue(BuildPropertyNames.CommandLineArgsForDesignTimeEvaluation);
+
+                // Property added in VS 17.4 compiler targets capturing values of LangVersion and DefineConstants.
+                // ChecksumAlgorithm value added to the property in 17.5.
+                //
+                // Impact on Hot Reload: incorrect ChecksumAlgorithm will prevent Hot Reload in detecting changes correctly in certain scenarios.
+                // However, given that projects that explicitly set ChecksumAlgorithm to a non-default value are rare and the project system
+                // will eventually call us to update the algorithm to the correct value, Hot Reload will likely not be impacted in practice.
+                commandLineArgs = data.GetPropertyValue(BuildPropertyNames.CommandLineArgsForDesignTimeEvaluation);
+
+                // Let EnC service known the checksum might not match, in case we need to diagnose related issue.
+                if (commandLineArgs.IsEmpty())
+                {
+                    ImmutableInterlocked.Update(ref _solutionsWithMissingChecksumAlgorithm, static (set, solutionPath) => set.Add(solutionPath), _workspace.CurrentSolution.FilePath ?? "");
+                }
             }
             else
             {
@@ -161,9 +185,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             // potentially block up thread pool threads. Doing this in a batch means the global lock will be acquired asynchronously.
             project.StartBatch();
 
-            if (commandLineArgs != null)
+            if (!string.IsNullOrEmpty(commandLineArgs))
             {
-                project.SetOptions(commandLineArgs);
+                project.SetOptions(commandLineArgs!);
             }
 
             if (objOutputPath != null)


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1752151