### PR TITLE
Improve code generation for is-expressions

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -398,7 +398,7 @@ class Program
         System.Console.WriteLine(null != (x as Derived));
     }
 }";
-            var compilation = CreateCompilation(source, options: TestOptions.DebugExe);
+            var compilation = CreateCompilation(source, options: TestOptions.ReleaseExe);
             compilation.VerifyDiagnostics();
             var expectedOutput =
 @"True
@@ -407,54 +407,38 @@ True
 True";
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
             compVerifier.VerifyIL("Program.Main",
-@"{
-  // Code size       84 (0x54)
+"""
+{
+  // Code size       66 (0x42)
   .maxstack  2
-  .locals init (Base<object> V_0, //x
-                Derived V_1, //y
-                Derived V_2, //z
-                Base<object> V_3,
-                Base<object> V_4)
-  IL_0000:  nop
-  IL_0001:  newobj     ""Derived..ctor()""
-  IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  isinst     ""Derived""
-  IL_000d:  ldnull
-  IL_000e:  cgt.un
-  IL_0010:  call       ""void System.Console.WriteLine(bool)""
-  IL_0015:  nop
-  IL_0016:  ldloc.0
-  IL_0017:  isinst     ""Derived""
-  IL_001c:  stloc.1
-  IL_001d:  ldloc.1
-  IL_001e:  ldnull
-  IL_001f:  cgt.un
-  IL_0021:  call       ""void System.Console.WriteLine(bool)""
-  IL_0026:  nop
-  IL_0027:  ldloc.0
-  IL_0028:  stloc.s    V_4
-  IL_002a:  ldloc.s    V_4
-  IL_002c:  stloc.3
-  IL_002d:  ldloc.3
-  IL_002e:  isinst     ""Derived""
-  IL_0033:  stloc.2
-  IL_0034:  ldloc.2
-  IL_0035:  brtrue.s   IL_0039
-  IL_0037:  br.s       IL_0044
-  IL_0039:  br.s       IL_003b
-  IL_003b:  ldc.i4.1
-  IL_003c:  call       ""void System.Console.WriteLine(bool)""
-  IL_0041:  nop
-  IL_0042:  br.s       IL_0044
-  IL_0044:  ldloc.0
-  IL_0045:  isinst     ""Derived""
-  IL_004a:  ldnull
-  IL_004b:  cgt.un
-  IL_004d:  call       ""void System.Console.WriteLine(bool)""
-  IL_0052:  nop
-  IL_0053:  ret
-}");
+  .locals init (Base<object> V_0) //x
+  IL_0000:  newobj     "Derived..ctor()"
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  isinst     "Derived"
+  IL_000c:  ldnull
+  IL_000d:  cgt.un
+  IL_000f:  call       "void System.Console.WriteLine(bool)"
+  IL_0014:  ldloc.0
+  IL_0015:  isinst     "Derived"
+  IL_001a:  brfalse.s  IL_001f
+  IL_001c:  ldc.i4.1
+  IL_001d:  br.s       IL_0020
+  IL_001f:  ldc.i4.0
+  IL_0020:  call       "void System.Console.WriteLine(bool)"
+  IL_0025:  ldloc.0
+  IL_0026:  isinst     "Derived"
+  IL_002b:  brfalse.s  IL_0033
+  IL_002d:  ldc.i4.1
+  IL_002e:  call       "void System.Console.WriteLine(bool)"
+  IL_0033:  ldloc.0
+  IL_0034:  isinst     "Derived"
+  IL_0039:  ldnull
+  IL_003a:  cgt.un
+  IL_003c:  call       "void System.Console.WriteLine(bool)"
+  IL_0041:  ret
+}
+""");
         }
 
         [Fact]
@@ -3002,28 +2986,30 @@ True";
 @"done";
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
             compVerifier.VerifyIL("ConsoleApp1.TestHelper.IsValueTypeT<T>(ConsoleApp1.Result<T>)",
-@"{
+"""
+{
   // Code size       31 (0x1f)
-  .maxstack  2
+  .maxstack  1
   .locals init (T V_0, //v
                 bool V_1)
   IL_0000:  nop
   IL_0001:  ldarg.0
-  IL_0002:  callvirt   ""T ConsoleApp1.Result<T>.Value.get""
+  IL_0002:  callvirt   "T ConsoleApp1.Result<T>.Value.get"
   IL_0007:  stloc.0
   IL_0008:  ldloc.0
-  IL_0009:  box        ""T""
-  IL_000e:  ldnull
-  IL_000f:  cgt.un
-  IL_0011:  ldc.i4.0
-  IL_0012:  ceq
+  IL_0009:  box        "T"
+  IL_000e:  brfalse.s  IL_0013
+  IL_0010:  ldc.i4.0
+  IL_0011:  br.s       IL_0014
+  IL_0013:  ldc.i4.1
   IL_0014:  stloc.1
   IL_0015:  ldloc.1
   IL_0016:  brfalse.s  IL_001e
-  IL_0018:  newobj     ""ConsoleApp1.NotPossibleException..ctor()""
+  IL_0018:  newobj     "ConsoleApp1.NotPossibleException..ctor()"
   IL_001d:  throw
   IL_001e:  ret
-}");
+}
+""");
         }
 
         [Fact]
@@ -3636,22 +3622,24 @@ class Program
                 if (options.OptimizationLevel == OptimizationLevel.Debug)
                 {
                     compVerifier.VerifyIL("Program.P<T>",
-@"{
-  // Code size       24 (0x18)
+"""
+{
+  // Code size       26 (0x1a)
   .maxstack  1
   .locals init (object V_0) //o
   IL_0000:  ldarg.0
-  IL_0001:  box        ""T""
+  IL_0001:  box        "T"
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brtrue.s   IL_0011
-  IL_000a:  ldsfld     ""string string.Empty""
-  IL_000f:  br.s       IL_0017
-  IL_0011:  ldloc.0
-  IL_0012:  callvirt   ""string object.ToString()""
-  IL_0017:  ret
+  IL_0008:  brfalse.s  IL_000c
+  IL_000a:  br.s       IL_0013
+  IL_000c:  ldsfld     "string string.Empty"
+  IL_0011:  br.s       IL_0019
+  IL_0013:  ldloc.0
+  IL_0014:  callvirt   "string object.ToString()"
+  IL_0019:  ret
 }
-");
+""");
                 }
                 else
                 {
@@ -3784,22 +3772,24 @@ class Program
                 if (options.OptimizationLevel == OptimizationLevel.Debug)
                 {
                     compVerifier.VerifyIL("Program.P<T>",
-@"{
-  // Code size       24 (0x18)
+"""
+{
+  // Code size       26 (0x1a)
   .maxstack  1
   .locals init (System.ValueType V_0) //o
   IL_0000:  ldarg.0
-  IL_0001:  box        ""T""
+  IL_0001:  box        "T"
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
-  IL_0008:  brtrue.s   IL_0011
-  IL_000a:  ldstr      ""1""
-  IL_000f:  br.s       IL_0017
-  IL_0011:  ldloc.0
-  IL_0012:  callvirt   ""string object.ToString()""
-  IL_0017:  ret
+  IL_0008:  brfalse.s  IL_000c
+  IL_000a:  br.s       IL_0013
+  IL_000c:  ldstr      "1"
+  IL_0011:  br.s       IL_0019
+  IL_0013:  ldloc.0
+  IL_0014:  callvirt   "string object.ToString()"
+  IL_0019:  ret
 }
-");
+""");
                 }
                 else
                 {
@@ -5517,28 +5507,8 @@ class C
             compilation.VerifyDiagnostics();
             var expectedOutput = @"TrueFalseTrueFalse";
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", """
-{
-  // Code size       26 (0x1a)
-  .maxstack  1
-  .locals init (bool V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  isinst     "int"
-  IL_0006:  brtrue.s   IL_0012
-  IL_0008:  ldarg.0
-  IL_0009:  isinst     "long"
-  IL_000e:  brtrue.s   IL_0012
-  IL_0010:  br.s       IL_0016
-  IL_0012:  ldc.i4.1
-  IL_0013:  stloc.0
-  IL_0014:  br.s       IL_0018
-  IL_0016:  ldc.i4.0
-  IL_0017:  stloc.0
-  IL_0018:  ldloc.0
-  IL_0019:  ret
-}
-""");
-            compVerifier.VerifyIL("C.M2", """
+            AssertEx.Multiple(
+                () => compVerifier.VerifyIL("C.M1", """
 {
   // Code size       21 (0x15)
   .maxstack  2
@@ -5553,47 +5523,46 @@ class C
   IL_0013:  ldc.i4.1
   IL_0014:  ret
 }
-""");
+"""),
+            () => compVerifier.VerifyIL("C.M2", """
+{
+  // Code size       21 (0x15)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  isinst     "int"
+  IL_0006:  brtrue.s   IL_0013
+  IL_0008:  ldarg.0
+  IL_0009:  isinst     "long"
+  IL_000e:  ldnull
+  IL_000f:  cgt.un
+  IL_0011:  br.s       IL_0014
+  IL_0013:  ldc.i4.1
+  IL_0014:  ret
+}
+"""));
 
             compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularWithPatternCombinators);
             compilation.VerifyDiagnostics();
             compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", """
-{
-  // Code size       24 (0x18)
-  .maxstack  1
-  .locals init (bool V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  isinst     "int"
-  IL_0006:  brtrue.s   IL_0010
-  IL_0008:  ldarg.0
-  IL_0009:  isinst     "long"
-  IL_000e:  brfalse.s  IL_0014
-  IL_0010:  ldc.i4.1
-  IL_0011:  stloc.0
-  IL_0012:  br.s       IL_0016
-  IL_0014:  ldc.i4.0
-  IL_0015:  stloc.0
-  IL_0016:  ldloc.0
-  IL_0017:  ret
-}
-""");
-            compVerifier.VerifyIL("C.M2", @"
+            string expectedIl = """
 {
   // Code size       20 (0x14)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  isinst     ""int""
+  IL_0001:  isinst     "int"
   IL_0006:  brtrue.s   IL_0012
   IL_0008:  ldarg.0
-  IL_0009:  isinst     ""long""
+  IL_0009:  isinst     "long"
   IL_000e:  ldnull
   IL_000f:  cgt.un
   IL_0011:  ret
   IL_0012:  ldc.i4.1
   IL_0013:  ret
 }
-");
+""";
+            AssertEx.Multiple(
+                () => compVerifier.VerifyIL("C.M1", expectedIl),
+                () => compVerifier.VerifyIL("C.M2", expectedIl));
         }
 
         [Fact]
@@ -5617,32 +5586,7 @@ class C
             compilation.VerifyDiagnostics();
             var expectedOutput = @"TrueFalseTrueFalse";
             var compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", """
-{
-  // Code size       40 (0x28)
-  .maxstack  1
-  .locals init (bool V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  isinst     "int"
-  IL_0006:  brtrue.s   IL_0012
-  IL_0008:  ldarg.0
-  IL_0009:  isinst     "long"
-  IL_000e:  brtrue.s   IL_0012
-  IL_0010:  br.s       IL_0016
-  IL_0012:  ldc.i4.1
-  IL_0013:  stloc.0
-  IL_0014:  br.s       IL_0018
-  IL_0016:  ldc.i4.0
-  IL_0017:  stloc.0
-  IL_0018:  ldloc.0
-  IL_0019:  brtrue.s   IL_0022
-  IL_001b:  ldstr      "False"
-  IL_0020:  br.s       IL_0027
-  IL_0022:  ldstr      "True"
-  IL_0027:  ret
-}
-""");
-            compVerifier.VerifyIL("C.M2", """
+            string expectedIl = """
 {
   // Code size       29 (0x1d)
   .maxstack  1
@@ -5657,51 +5601,33 @@ class C
   IL_0017:  ldstr      "True"
   IL_001c:  ret
 }
-""");
+""";
+            AssertEx.Multiple(
+                () => compVerifier.VerifyIL("C.M1", expectedIl),
+                () => compVerifier.VerifyIL("C.M2", expectedIl));
 
             compilation = CreateCompilation(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.RegularWithPatternCombinators);
             compilation.VerifyDiagnostics();
             compVerifier = CompileAndVerify(compilation, expectedOutput: expectedOutput);
-            compVerifier.VerifyIL("C.M1", """
-{
-  // Code size       37 (0x25)
-  .maxstack  1
-  .locals init (bool V_0)
-  IL_0000:  ldarg.0
-  IL_0001:  isinst     "int"
-  IL_0006:  brtrue.s   IL_0010
-  IL_0008:  ldarg.0
-  IL_0009:  isinst     "long"
-  IL_000e:  brfalse.s  IL_0014
-  IL_0010:  ldc.i4.1
-  IL_0011:  stloc.0
-  IL_0012:  br.s       IL_0016
-  IL_0014:  ldc.i4.0
-  IL_0015:  stloc.0
-  IL_0016:  ldloc.0
-  IL_0017:  brtrue.s   IL_001f
-  IL_0019:  ldstr      "False"
-  IL_001e:  ret
-  IL_001f:  ldstr      "True"
-  IL_0024:  ret
-}
-""");
-            compVerifier.VerifyIL("C.M2", @"
+            expectedIl = """
 {
   // Code size       28 (0x1c)
   .maxstack  1
   IL_0000:  ldarg.0
-  IL_0001:  isinst     ""int""
+  IL_0001:  isinst     "int"
   IL_0006:  brtrue.s   IL_0016
   IL_0008:  ldarg.0
-  IL_0009:  isinst     ""long""
+  IL_0009:  isinst     "long"
   IL_000e:  brtrue.s   IL_0016
-  IL_0010:  ldstr      ""False""
+  IL_0010:  ldstr      "False"
   IL_0015:  ret
-  IL_0016:  ldstr      ""True""
+  IL_0016:  ldstr      "True"
   IL_001b:  ret
 }
-");
+""";
+            AssertEx.Multiple(
+                () => compVerifier.VerifyIL("C.M1", expectedIl),
+                () => compVerifier.VerifyIL("C.M2", expectedIl));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -3999,9 +3999,9 @@ class B : Node { }
 ";
             var v = CompileAndVerify(source, options: TestOptions.DebugDll);
 
-            v.VerifyIL("Program.<M>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
+            v.VerifyIL("Program.<M>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", """
     {
-      // Code size      403 (0x193)
+      // Code size      409 (0x199)
       .maxstack  3
       .locals init (int V_0,
                     bool V_1,
@@ -4014,7 +4014,7 @@ class B : Node { }
                     System.Exception V_8)
       // sequence point: <hidden>
       IL_0000:  ldarg.0
-      IL_0001:  ldfld      ""int Program.<M>d__1.<>1__state""
+      IL_0001:  ldfld      "int Program.<M>d__1.<>1__state"
       IL_0006:  stloc.0
       .try
       {
@@ -4026,188 +4026,192 @@ class B : Node { }
         IL_000d:  ldc.i4.1
         IL_000e:  beq.s      IL_0014
         IL_0010:  br.s       IL_0019
-        IL_0012:  br.s       IL_007e
-        IL_0014:  br         IL_0109
+        IL_0012:  br.s       IL_0081
+        IL_0014:  br         IL_010f
         // sequence point: {
         IL_0019:  nop
         // sequence point: <hidden>
-        IL_001a:  br         IL_0150
+        IL_001a:  br         IL_0156
         // sequence point: {
         IL_001f:  nop
         // sequence point: if (node is A a)
         IL_0020:  ldarg.0
         IL_0021:  ldarg.0
-        IL_0022:  ldfld      ""Node Program.<M>d__1.node""
-        IL_0027:  isinst     ""A""
-        IL_002c:  stfld      ""A Program.<M>d__1.<a>5__1""
+        IL_0022:  ldfld      "Node Program.<M>d__1.node"
+        IL_0027:  isinst     "A"
+        IL_002c:  stfld      "A Program.<M>d__1.<a>5__1"
         IL_0031:  ldarg.0
-        IL_0032:  ldfld      ""A Program.<M>d__1.<a>5__1""
-        IL_0037:  ldnull
-        IL_0038:  cgt.un
-        IL_003a:  stloc.1
+        IL_0032:  ldfld      "A Program.<M>d__1.<a>5__1"
+        IL_0037:  brfalse.s  IL_003c
+        IL_0039:  ldc.i4.1
+        IL_003a:  br.s       IL_003d
+        IL_003c:  ldc.i4.0
+        IL_003d:  stloc.1
         // sequence point: <hidden>
-        IL_003b:  ldloc.1
-        IL_003c:  brfalse.s  IL_00a7
+        IL_003e:  ldloc.1
+        IL_003f:  brfalse.s  IL_00aa
         // sequence point: {
-        IL_003e:  nop
+        IL_0041:  nop
         // sequence point: await Task.Yield();
-        IL_003f:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-        IL_0044:  stloc.3
-        IL_0045:  ldloca.s   V_3
-        IL_0047:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-        IL_004c:  stloc.2
+        IL_0042:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
+        IL_0047:  stloc.3
+        IL_0048:  ldloca.s   V_3
+        IL_004a:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
+        IL_004f:  stloc.2
         // sequence point: <hidden>
-        IL_004d:  ldloca.s   V_2
-        IL_004f:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-        IL_0054:  brtrue.s   IL_009a
-        IL_0056:  ldarg.0
-        IL_0057:  ldc.i4.0
-        IL_0058:  dup
-        IL_0059:  stloc.0
-        IL_005a:  stfld      ""int Program.<M>d__1.<>1__state""
+        IL_0050:  ldloca.s   V_2
+        IL_0052:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
+        IL_0057:  brtrue.s   IL_009d
+        IL_0059:  ldarg.0
+        IL_005a:  ldc.i4.0
+        IL_005b:  dup
+        IL_005c:  stloc.0
+        IL_005d:  stfld      "int Program.<M>d__1.<>1__state"
         // async: yield
-        IL_005f:  ldarg.0
-        IL_0060:  ldloc.2
-        IL_0061:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<M>d__1.<>u__1""
-        IL_0066:  ldarg.0
-        IL_0067:  stloc.s    V_4
+        IL_0062:  ldarg.0
+        IL_0063:  ldloc.2
+        IL_0064:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<M>d__1.<>u__1"
         IL_0069:  ldarg.0
-        IL_006a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<M>d__1.<>t__builder""
-        IL_006f:  ldloca.s   V_2
-        IL_0071:  ldloca.s   V_4
-        IL_0073:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<M>d__1>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<M>d__1)""
-        IL_0078:  nop
-        IL_0079:  leave      IL_0192
+        IL_006a:  stloc.s    V_4
+        IL_006c:  ldarg.0
+        IL_006d:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<M>d__1.<>t__builder"
+        IL_0072:  ldloca.s   V_2
+        IL_0074:  ldloca.s   V_4
+        IL_0076:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<M>d__1>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<M>d__1)"
+        IL_007b:  nop
+        IL_007c:  leave      IL_0198
         // async: resume
-        IL_007e:  ldarg.0
-        IL_007f:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<M>d__1.<>u__1""
-        IL_0084:  stloc.2
-        IL_0085:  ldarg.0
-        IL_0086:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<M>d__1.<>u__1""
-        IL_008b:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-        IL_0091:  ldarg.0
-        IL_0092:  ldc.i4.m1
-        IL_0093:  dup
-        IL_0094:  stloc.0
-        IL_0095:  stfld      ""int Program.<M>d__1.<>1__state""
-        IL_009a:  ldloca.s   V_2
-        IL_009c:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-        IL_00a1:  nop
+        IL_0081:  ldarg.0
+        IL_0082:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<M>d__1.<>u__1"
+        IL_0087:  stloc.2
+        IL_0088:  ldarg.0
+        IL_0089:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<M>d__1.<>u__1"
+        IL_008e:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+        IL_0094:  ldarg.0
+        IL_0095:  ldc.i4.m1
+        IL_0096:  dup
+        IL_0097:  stloc.0
+        IL_0098:  stfld      "int Program.<M>d__1.<>1__state"
+        IL_009d:  ldloca.s   V_2
+        IL_009f:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
+        IL_00a4:  nop
         // sequence point: return;
-        IL_00a2:  leave      IL_017e
+        IL_00a5:  leave      IL_0184
         // sequence point: if (node is B b)
-        IL_00a7:  ldarg.0
-        IL_00a8:  ldarg.0
-        IL_00a9:  ldfld      ""Node Program.<M>d__1.node""
-        IL_00ae:  isinst     ""B""
-        IL_00b3:  stfld      ""B Program.<M>d__1.<b>5__2""
-        IL_00b8:  ldarg.0
-        IL_00b9:  ldfld      ""B Program.<M>d__1.<b>5__2""
-        IL_00be:  ldnull
-        IL_00bf:  cgt.un
-        IL_00c1:  stloc.s    V_5
+        IL_00aa:  ldarg.0
+        IL_00ab:  ldarg.0
+        IL_00ac:  ldfld      "Node Program.<M>d__1.node"
+        IL_00b1:  isinst     "B"
+        IL_00b6:  stfld      "B Program.<M>d__1.<b>5__2"
+        IL_00bb:  ldarg.0
+        IL_00bc:  ldfld      "B Program.<M>d__1.<b>5__2"
+        IL_00c1:  brfalse.s  IL_00c6
+        IL_00c3:  ldc.i4.1
+        IL_00c4:  br.s       IL_00c7
+        IL_00c6:  ldc.i4.0
+        IL_00c7:  stloc.s    V_5
         // sequence point: <hidden>
-        IL_00c3:  ldloc.s    V_5
-        IL_00c5:  brfalse.s  IL_0130
+        IL_00c9:  ldloc.s    V_5
+        IL_00cb:  brfalse.s  IL_0136
         // sequence point: {
-        IL_00c7:  nop
+        IL_00cd:  nop
         // sequence point: await Task.Yield();
-        IL_00c8:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
-        IL_00cd:  stloc.3
-        IL_00ce:  ldloca.s   V_3
-        IL_00d0:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
-        IL_00d5:  stloc.s    V_6
+        IL_00ce:  call       "System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()"
+        IL_00d3:  stloc.3
+        IL_00d4:  ldloca.s   V_3
+        IL_00d6:  call       "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()"
+        IL_00db:  stloc.s    V_6
         // sequence point: <hidden>
-        IL_00d7:  ldloca.s   V_6
-        IL_00d9:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
-        IL_00de:  brtrue.s   IL_0126
-        IL_00e0:  ldarg.0
-        IL_00e1:  ldc.i4.1
-        IL_00e2:  dup
-        IL_00e3:  stloc.0
-        IL_00e4:  stfld      ""int Program.<M>d__1.<>1__state""
+        IL_00dd:  ldloca.s   V_6
+        IL_00df:  call       "bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get"
+        IL_00e4:  brtrue.s   IL_012c
+        IL_00e6:  ldarg.0
+        IL_00e7:  ldc.i4.1
+        IL_00e8:  dup
+        IL_00e9:  stloc.0
+        IL_00ea:  stfld      "int Program.<M>d__1.<>1__state"
         // async: yield
-        IL_00e9:  ldarg.0
-        IL_00ea:  ldloc.s    V_6
-        IL_00ec:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<M>d__1.<>u__1""
-        IL_00f1:  ldarg.0
-        IL_00f2:  stloc.s    V_4
-        IL_00f4:  ldarg.0
-        IL_00f5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<M>d__1.<>t__builder""
-        IL_00fa:  ldloca.s   V_6
-        IL_00fc:  ldloca.s   V_4
-        IL_00fe:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<M>d__1>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<M>d__1)""
-        IL_0103:  nop
-        IL_0104:  leave      IL_0192
+        IL_00ef:  ldarg.0
+        IL_00f0:  ldloc.s    V_6
+        IL_00f2:  stfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<M>d__1.<>u__1"
+        IL_00f7:  ldarg.0
+        IL_00f8:  stloc.s    V_4
+        IL_00fa:  ldarg.0
+        IL_00fb:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<M>d__1.<>t__builder"
+        IL_0100:  ldloca.s   V_6
+        IL_0102:  ldloca.s   V_4
+        IL_0104:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, Program.<M>d__1>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref Program.<M>d__1)"
+        IL_0109:  nop
+        IL_010a:  leave      IL_0198
         // async: resume
-        IL_0109:  ldarg.0
-        IL_010a:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<M>d__1.<>u__1""
-        IL_010f:  stloc.s    V_6
-        IL_0111:  ldarg.0
-        IL_0112:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<M>d__1.<>u__1""
-        IL_0117:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
-        IL_011d:  ldarg.0
-        IL_011e:  ldc.i4.m1
-        IL_011f:  dup
-        IL_0120:  stloc.0
-        IL_0121:  stfld      ""int Program.<M>d__1.<>1__state""
-        IL_0126:  ldloca.s   V_6
-        IL_0128:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
-        IL_012d:  nop
+        IL_010f:  ldarg.0
+        IL_0110:  ldfld      "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<M>d__1.<>u__1"
+        IL_0115:  stloc.s    V_6
+        IL_0117:  ldarg.0
+        IL_0118:  ldflda     "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter Program.<M>d__1.<>u__1"
+        IL_011d:  initobj    "System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter"
+        IL_0123:  ldarg.0
+        IL_0124:  ldc.i4.m1
+        IL_0125:  dup
+        IL_0126:  stloc.0
+        IL_0127:  stfld      "int Program.<M>d__1.<>1__state"
+        IL_012c:  ldloca.s   V_6
+        IL_012e:  call       "void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()"
+        IL_0133:  nop
         // sequence point: return;
-        IL_012e:  leave.s    IL_017e
+        IL_0134:  leave.s    IL_0184
         // sequence point: <hidden>
-        IL_0130:  ldarg.0
-        IL_0131:  ldnull
-        IL_0132:  stfld      ""B Program.<M>d__1.<b>5__2""
+        IL_0136:  ldarg.0
+        IL_0137:  ldnull
+        IL_0138:  stfld      "B Program.<M>d__1.<b>5__2"
         // sequence point: node = node.Parent;
-        IL_0137:  ldarg.0
-        IL_0138:  ldarg.0
-        IL_0139:  ldfld      ""Node Program.<M>d__1.node""
-        IL_013e:  ldfld      ""Node Node.Parent""
-        IL_0143:  stfld      ""Node Program.<M>d__1.node""
+        IL_013d:  ldarg.0
+        IL_013e:  ldarg.0
+        IL_013f:  ldfld      "Node Program.<M>d__1.node"
+        IL_0144:  ldfld      "Node Node.Parent"
+        IL_0149:  stfld      "Node Program.<M>d__1.node"
         // sequence point: }
-        IL_0148:  nop
-        IL_0149:  ldarg.0
-        IL_014a:  ldnull
-        IL_014b:  stfld      ""A Program.<M>d__1.<a>5__1""
+        IL_014e:  nop
+        IL_014f:  ldarg.0
+        IL_0150:  ldnull
+        IL_0151:  stfld      "A Program.<M>d__1.<a>5__1"
         // sequence point: while (node != null)
-        IL_0150:  ldarg.0
-        IL_0151:  ldfld      ""Node Program.<M>d__1.node""
-        IL_0156:  ldnull
-        IL_0157:  cgt.un
-        IL_0159:  stloc.s    V_7
+        IL_0156:  ldarg.0
+        IL_0157:  ldfld      "Node Program.<M>d__1.node"
+        IL_015c:  ldnull
+        IL_015d:  cgt.un
+        IL_015f:  stloc.s    V_7
         // sequence point: <hidden>
-        IL_015b:  ldloc.s    V_7
-        IL_015d:  brtrue     IL_001f
-        IL_0162:  leave.s    IL_017e
+        IL_0161:  ldloc.s    V_7
+        IL_0163:  brtrue     IL_001f
+        IL_0168:  leave.s    IL_0184
       }
       catch System.Exception
       {
         // sequence point: <hidden>
-        IL_0164:  stloc.s    V_8
-        IL_0166:  ldarg.0
-        IL_0167:  ldc.i4.s   -2
-        IL_0169:  stfld      ""int Program.<M>d__1.<>1__state""
-        IL_016e:  ldarg.0
-        IL_016f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<M>d__1.<>t__builder""
-        IL_0174:  ldloc.s    V_8
-        IL_0176:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)""
-        IL_017b:  nop
-        IL_017c:  leave.s    IL_0192
+        IL_016a:  stloc.s    V_8
+        IL_016c:  ldarg.0
+        IL_016d:  ldc.i4.s   -2
+        IL_016f:  stfld      "int Program.<M>d__1.<>1__state"
+        IL_0174:  ldarg.0
+        IL_0175:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<M>d__1.<>t__builder"
+        IL_017a:  ldloc.s    V_8
+        IL_017c:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetException(System.Exception)"
+        IL_0181:  nop
+        IL_0182:  leave.s    IL_0198
       }
       // sequence point: }
-      IL_017e:  ldarg.0
-      IL_017f:  ldc.i4.s   -2
-      IL_0181:  stfld      ""int Program.<M>d__1.<>1__state""
+      IL_0184:  ldarg.0
+      IL_0185:  ldc.i4.s   -2
+      IL_0187:  stfld      "int Program.<M>d__1.<>1__state"
       // sequence point: <hidden>
-      IL_0186:  ldarg.0
-      IL_0187:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<M>d__1.<>t__builder""
-      IL_018c:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()""
-      IL_0191:  nop
-      IL_0192:  ret
+      IL_018c:  ldarg.0
+      IL_018d:  ldflda     "System.Runtime.CompilerServices.AsyncTaskMethodBuilder Program.<M>d__1.<>t__builder"
+      IL_0192:  call       "void System.Runtime.CompilerServices.AsyncTaskMethodBuilder.SetResult()"
+      IL_0197:  nop
+      IL_0198:  ret
     }
-", sequencePoints: "Program+<M>d__1.MoveNext", source: source);
+    """, sequencePoints: "Program+<M>d__1.MoveNext", source: source);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests.cs
@@ -8884,55 +8884,51 @@ class C
 2.False
 3.False
 4.True")
-                .VerifyIL("C.Test", @"
+                .VerifyIL("C.Test", """
 {
-  // Code size      159 (0x9f)
+  // Code size      142 (0x8e)
   .maxstack  3
   .locals init (bool V_0)
-  IL_0000:  ldstr      ""1.""
+  IL_0000:  ldstr      "1."
   IL_0005:  ldarg.0
-  IL_0006:  ldstr      """"
-  IL_000b:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_0010:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)""
+  IL_0006:  ldstr      ""
+  IL_000b:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0010:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
   IL_0015:  stloc.0
   IL_0016:  ldloca.s   V_0
-  IL_0018:  call       ""string bool.ToString()""
-  IL_001d:  call       ""string string.Concat(string, string)""
-  IL_0022:  call       ""void System.Console.WriteLine(string)""
-  IL_0027:  ldstr      ""2.""
+  IL_0018:  call       "string bool.ToString()"
+  IL_001d:  call       "string string.Concat(string, string)"
+  IL_0022:  call       "void System.Console.WriteLine(string)"
+  IL_0027:  ldstr      "2."
   IL_002c:  ldarg.0
-  IL_002d:  ldstr      """"
-  IL_0032:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_0037:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)""
+  IL_002d:  ldstr      ""
+  IL_0032:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0037:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
   IL_003c:  stloc.0
   IL_003d:  ldloca.s   V_0
-  IL_003f:  call       ""string bool.ToString()""
-  IL_0044:  call       ""string string.Concat(string, string)""
-  IL_0049:  call       ""void System.Console.WriteLine(string)""
-  IL_004e:  ldstr      ""3.""
+  IL_003f:  call       "string bool.ToString()"
+  IL_0044:  call       "string string.Concat(string, string)"
+  IL_0049:  call       "void System.Console.WriteLine(string)"
+  IL_004e:  ldstr      "3."
   IL_0053:  ldarg.0
-  IL_0054:  ldstr      """"
-  IL_0059:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_005e:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)""
+  IL_0054:  ldstr      ""
+  IL_0059:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_005e:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)"
   IL_0063:  stloc.0
   IL_0064:  ldloca.s   V_0
-  IL_0066:  call       ""string bool.ToString()""
-  IL_006b:  call       ""string string.Concat(string, string)""
-  IL_0070:  call       ""void System.Console.WriteLine(string)""
-  IL_0075:  ldarg.0
-  IL_0076:  ldstr      """"
-  IL_007b:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_0080:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.ReadOnlySpan<char>, System.ReadOnlySpan<char>)""
-  IL_0085:  pop
-  IL_0086:  ldc.i4.1
-  IL_0087:  stloc.0
-  IL_0088:  ldstr      ""4.""
-  IL_008d:  ldloca.s   V_0
-  IL_008f:  call       ""string bool.ToString()""
-  IL_0094:  call       ""string string.Concat(string, string)""
-  IL_0099:  call       ""void System.Console.WriteLine(string)""
-  IL_009e:  ret
-}");
+  IL_0066:  call       "string bool.ToString()"
+  IL_006b:  call       "string string.Concat(string, string)"
+  IL_0070:  call       "void System.Console.WriteLine(string)"
+  IL_0075:  ldstr      "4."
+  IL_007a:  ldc.i4.1
+  IL_007b:  stloc.0
+  IL_007c:  ldloca.s   V_0
+  IL_007e:  call       "string bool.ToString()"
+  IL_0083:  call       "string string.Concat(string, string)"
+  IL_0088:  call       "void System.Console.WriteLine(string)"
+  IL_008d:  ret
+}
+""");
         }
 
         [Fact]
@@ -10486,55 +10482,51 @@ class C
 2.False
 3.False
 4.True")
-                .VerifyIL("C.Test", @"
+                .VerifyIL("C.Test", """
 {
-  // Code size      159 (0x9f)
+  // Code size      142 (0x8e)
   .maxstack  3
   .locals init (bool V_0)
-  IL_0000:  ldstr      ""1.""
+  IL_0000:  ldstr      "1."
   IL_0005:  ldarg.0
-  IL_0006:  ldstr      """"
-  IL_000b:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_0010:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)""
+  IL_0006:  ldstr      ""
+  IL_000b:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0010:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
   IL_0015:  stloc.0
   IL_0016:  ldloca.s   V_0
-  IL_0018:  call       ""string bool.ToString()""
-  IL_001d:  call       ""string string.Concat(string, string)""
-  IL_0022:  call       ""void System.Console.WriteLine(string)""
-  IL_0027:  ldstr      ""2.""
+  IL_0018:  call       "string bool.ToString()"
+  IL_001d:  call       "string string.Concat(string, string)"
+  IL_0022:  call       "void System.Console.WriteLine(string)"
+  IL_0027:  ldstr      "2."
   IL_002c:  ldarg.0
-  IL_002d:  ldstr      """"
-  IL_0032:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_0037:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)""
+  IL_002d:  ldstr      ""
+  IL_0032:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0037:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
   IL_003c:  stloc.0
   IL_003d:  ldloca.s   V_0
-  IL_003f:  call       ""string bool.ToString()""
-  IL_0044:  call       ""string string.Concat(string, string)""
-  IL_0049:  call       ""void System.Console.WriteLine(string)""
-  IL_004e:  ldstr      ""3.""
+  IL_003f:  call       "string bool.ToString()"
+  IL_0044:  call       "string string.Concat(string, string)"
+  IL_0049:  call       "void System.Console.WriteLine(string)"
+  IL_004e:  ldstr      "3."
   IL_0053:  ldarg.0
-  IL_0054:  ldstr      """"
-  IL_0059:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_005e:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)""
+  IL_0054:  ldstr      ""
+  IL_0059:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_005e:  call       "bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)"
   IL_0063:  stloc.0
   IL_0064:  ldloca.s   V_0
-  IL_0066:  call       ""string bool.ToString()""
-  IL_006b:  call       ""string string.Concat(string, string)""
-  IL_0070:  call       ""void System.Console.WriteLine(string)""
-  IL_0075:  ldarg.0
-  IL_0076:  ldstr      """"
-  IL_007b:  call       ""System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)""
-  IL_0080:  call       ""bool System.MemoryExtensions.SequenceEqual<char>(System.Span<char>, System.ReadOnlySpan<char>)""
-  IL_0085:  pop
-  IL_0086:  ldc.i4.1
-  IL_0087:  stloc.0
-  IL_0088:  ldstr      ""4.""
-  IL_008d:  ldloca.s   V_0
-  IL_008f:  call       ""string bool.ToString()""
-  IL_0094:  call       ""string string.Concat(string, string)""
-  IL_0099:  call       ""void System.Console.WriteLine(string)""
-  IL_009e:  ret
-}");
+  IL_0066:  call       "string bool.ToString()"
+  IL_006b:  call       "string string.Concat(string, string)"
+  IL_0070:  call       "void System.Console.WriteLine(string)"
+  IL_0075:  ldstr      "4."
+  IL_007a:  ldc.i4.1
+  IL_007b:  stloc.0
+  IL_007c:  ldloca.s   V_0
+  IL_007e:  call       "string bool.ToString()"
+  IL_0083:  call       "string string.Concat(string, string)"
+  IL_0088:  call       "void System.Console.WriteLine(string)"
+  IL_008d:  ret
+}
+""");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests3.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Semantics/PatternMatchingTests3.cs
@@ -6740,10 +6740,10 @@ class C
 """;
                 var v = CompileAndVerify(src);
 
-                string actualIL = v.VisualizeIL("C.Actual", false, null, src);
-                string expectedIL = v.VisualizeIL("C.Expected", false, null, src);
+                string actualIL = v.VisualizeIL("C.Actual");
+                string expectedIL = v.VisualizeIL("C.Expected");
 
-                AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedIL, actualIL, message: null);
+                AssertEx.AssertEqualToleratingWhitespaceDifferences(expectedIL, actualIL);
             }
         }
 


### PR DESCRIPTION
Close https://github.com/dotnet/roslyn/issues/59615
Close https://github.com/dotnet/roslyn/issues/55334

The basic idea is the same as https://github.com/dotnet/roslyn/pull/65845: produce `||`, `?:` as well as `&&` when lowering the is-expression, but also keep the expression deep on the left-hand-side for an optimal codegen.

Note: this does not resolve https://github.com/dotnet/roslyn/issues/44546 which applies to both non-linear is-expressions and switch-expressions, for that I think a new node e.g. `Lowered{IsPattern,Switch}Expression` is needed to avoid the result temp.