### PR TITLE
Minor source build fixes

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -204,6 +204,10 @@ function Process-Arguments() {
     $script:restore = $true
   }
 
+  if ($sourceBuild) {
+    $script:msbuildEngine = "dotnet"
+  }
+
   foreach ($property in $properties) {
     if (!$property.StartsWith("/p:", "InvariantCultureIgnoreCase")) {
       Write-Host "Invalid argument: $property"

--- a/src/Compilers/CSharp/csc/arm64/csc-arm64.csproj
+++ b/src/Compilers/CSharp/csc/arm64/csc-arm64.csproj
@@ -10,6 +10,7 @@
     <TargetFramework>net472</TargetFramework>
     <DisableNullableWarnings>true</DisableNullableWarnings>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <!-- Can't put this in shared project due to https://github.com/dotnet/project-system/issues/8157 -->

--- a/src/Compilers/Server/VBCSCompiler/arm64/VBCSCompiler-arm64.csproj
+++ b/src/Compilers/Server/VBCSCompiler/arm64/VBCSCompiler-arm64.csproj
@@ -10,6 +10,7 @@
     <TargetFramework>net472</TargetFramework>
     <DisableNullableWarnings>true</DisableNullableWarnings>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   <Import Project="..\VBCSCompilerCommandLine.projitems" Label="Shared" />
 </Project>

--- a/src/Compilers/VisualBasic/vbc/arm64/vbc-arm64.csproj
+++ b/src/Compilers/VisualBasic/vbc/arm64/vbc-arm64.csproj
@@ -10,6 +10,7 @@
     <AssemblyName>vbc</AssemblyName>
     <DisableNullableWarnings>true</DisableNullableWarnings>
     <IsSymbolPublishingPackage>true</IsSymbolPublishingPackage>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   
   <!-- Can't put this in shared project due to https://github.com/dotnet/project-system/issues/8157 -->


### PR DESCRIPTION
Couple of minor fixes to source build:

1. Force the build engine to be `dotnet` when doing a local source build. Using msbuild is not supported by arcade for source build and will lead to hard to track down errors. Force to `dotnet` to make it just work locally.
2. Exclude our .NET Framework ARM64 binaries from source build. No reason for them to be there.

related to #66930