### PR TITLE
Disable diagnostics in the preview window

### DIFF
--- a/src/EditorFeatures/Core/Diagnostics/AbstractPushOrPullDiagnosticsTaggerProvider.SingleDiagnosticKindPullTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Diagnostics/AbstractPushOrPullDiagnosticsTaggerProvider.SingleDiagnosticKindPullTaggerProvider.cs
@@ -95,6 +95,9 @@ internal abstract partial class AbstractPushOrPullDiagnosticsTaggerProvider<TTag
             if (document == null)
                 return;
 
+            if (document.Project.Solution.Workspace.Kind == WorkspaceKind.Preview)
+                return;
+
             var snapshot = documentSpanToTag.SnapshotSpan.Snapshot;
 
             var project = document.Project;

--- a/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
+++ b/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
@@ -213,7 +213,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
             var newDocument = oldDocument.WithText(oldText.WithChanges(new TextChange(new TextSpan(0, oldText.Length), "class C { }")));
 
             // create a diff view
-            WpfTestRunner.RequireWpfFact($"{nameof(TestPreviewDiagnosticTaggerInPreviewPane)} creates a {nameof(DifferenceViewerPreview)}");
+            WpfTestRunner.RequireWpfFact($"{nameof(TestPreviewDiagnosticTaggerInPreviewPaneDoesNotWork)} creates a {nameof(DifferenceViewerPreview)}");
 
             var previewFactoryService = (PreviewFactoryService)workspace.ExportProvider.GetExportedValue<IPreviewFactoryService>();
             using var diffView = await previewFactoryService.CreateChangedDocumentPreviewViewAsync(oldDocument, newDocument, CancellationToken.None);

--- a/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
+++ b/src/EditorFeatures/Test/Preview/PreviewWorkspaceTests.cs
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
         }
 
         [WpfFact]
-        public async Task TestPreviewDiagnosticTaggerInPreviewPane()
+        public async Task TestPreviewDiagnosticTaggerInPreviewPaneDoesNotWork()
         {
             // TODO: WPF required due to https://github.com/dotnet/roslyn/issues/46153
             using var workspace = TestWorkspace.CreateCSharp("class { }", composition: EditorTestCompositions.EditorFeaturesWpf);
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Preview
             // check left buffer
             var leftSnapshot = leftBuffer.CurrentSnapshot;
             var leftSpans = leftTagger.GetTags(leftSnapshot.GetSnapshotSpanCollection()).ToList();
-            Assert.Equal(1, leftSpans.Count);
+            Assert.Equal(0, leftSpans.Count);
 
             // check right buffer
             var rightSnapshot = rightBuffer.CurrentSnapshot;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/67014

Here's my general reasoning on why the simplest and cleanest thing to do here is to just disable this functionality:

First, we are moving to LSP pull-based-diagnostics.  In that world, preview-window diagnostics do not work anyways, as the preview window refers to documents that LSP knows nothing about (so it has no URI with which to even query the host about this stuff).

Second, If/when we do update LSP itself to support the concept of 'previews' it will be against the LSP workspace.  That workspace either is already running out of proc for us, or it's already the in proc workspace that already does diagnostics out of proc.  

So, having the preview workspace compute diagnostics is a point in time thing going away very soon.  And given the high amount of perf impact, and the low value (how often is it even shown that there's a squiggle in the preview pane, and how useful is that to even see?), it's best to just disable this functionality fully, and decide if we want it in the future if LSP ever moves to supporting this.

This was always a nifty system that demonstrated that roslyn is truly working on real snapshots that can speculate about the future.  But diagnostics are *extremely* expensive (forcing generators to run, and all analyzers), just to maybe populate a squiggle in a preview window that appears for a few seconds.   It's reasonable to disable this functionality for the large win we get not doing duplicate work.  And this is better than still having hte preview call to OOP to do the work, still causing the forking, source-generators and analyzers to all run (albeit in OOP instead of inproc).