### PR TITLE
Disable both solution crawlers if option is disabled

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Interactive/InteractiveEvaluator.cs
+++ b/src/EditorFeatures/Core.Wpf/Interactive/InteractiveEvaluator.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             _commandsFactory = commandsFactory;
             _commands = commands;
 
-            _workspace = new InteractiveWindowWorkspace(hostServices, editorOptionsService.GlobalOptions);
+            _workspace = new InteractiveWindowWorkspace(hostServices);
 
             _session = new InteractiveSession(
                 _workspace,

--- a/src/EditorFeatures/Core.Wpf/Interactive/InteractiveWindowWorkspace.cs
+++ b/src/EditorFeatures/Core.Wpf/Interactive/InteractiveWindowWorkspace.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.Interactive
     {
         public IInteractiveWindow? Window { get; set; }
 
-        public InteractiveWindowWorkspace(HostServices hostServices, IGlobalOptionService globalOptions)
-            : base(hostServices, globalOptions)
+        public InteractiveWindowWorkspace(HostServices hostServices)
+            : base(hostServices)
         {
         }
     }

--- a/src/EditorFeatures/Core/Interactive/InteractiveWorkspace.cs
+++ b/src/EditorFeatures/Core/Interactive/InteractiveWorkspace.cs
@@ -16,17 +16,17 @@ namespace Microsoft.CodeAnalysis.Interactive
         private SourceTextContainer? _openTextContainer;
         private DocumentId? _openDocumentId;
 
-        internal InteractiveWorkspace(HostServices hostServices, IGlobalOptionService globalOptions)
+        internal InteractiveWorkspace(HostServices hostServices)
             : base(hostServices, WorkspaceKind.Interactive)
         {
             // register work coordinator for this workspace
-            Services.GetRequiredService<ISolutionCrawlerRegistrationService>().Register(this);
+            DiagnosticProvider.Enable(this);
         }
 
         protected override void Dispose(bool finalize)
         {
             // workspace is going away. unregister this workspace from work coordinator
-            Services.GetRequiredService<ISolutionCrawlerRegistrationService>().Unregister(this, blockingShutdown: true);
+            DiagnosticProvider.Disable(this);
 
             base.Dispose(finalize);
         }

--- a/src/EditorFeatures/Core/Interactive/InteractiveWorkspace.cs
+++ b/src/EditorFeatures/Core/Interactive/InteractiveWorkspace.cs
@@ -20,10 +20,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             : base(hostServices, WorkspaceKind.Interactive)
         {
             // register work coordinator for this workspace
-            if (globalOptions.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler))
-            {
-                Services.GetRequiredService<ISolutionCrawlerRegistrationService>().Register(this);
-            }
+            Services.GetRequiredService<ISolutionCrawlerRegistrationService>().Register(this);
         }
 
         protected override void Dispose(bool finalize)

--- a/src/EditorFeatures/Core/Preview/AbstractPreviewFactoryService.cs
+++ b/src/EditorFeatures/Core/Preview/AbstractPreviewFactoryService.cs
@@ -678,11 +678,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Preview
                 rightWorkspace = null;
             };
 
-            if (_editorOptionsService.GlobalOptions.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler))
-            {
-                leftWorkspace?.EnableSolutionCrawler();
-                rightWorkspace?.EnableSolutionCrawler();
-            }
+            leftWorkspace?.EnableSolutionCrawler();
+            rightWorkspace?.EnableSolutionCrawler();
 
             return new DifferenceViewerPreview(diffViewer);
         }

--- a/src/EditorFeatures/Core/Shared/Preview/PreviewWorkspace.cs
+++ b/src/EditorFeatures/Core/Shared/Preview/PreviewWorkspace.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
 
         public void EnableSolutionCrawler()
         {
-            Services.GetRequiredService<ISolutionCrawlerRegistrationService>().Register(this);
+            DiagnosticProvider.Enable(this);
         }
 
         public override bool CanApplyChange(ApplyChangesKind feature)
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Preview
         {
             base.Dispose(finalize);
 
-            Services.GetRequiredService<ISolutionCrawlerRegistrationService>().Unregister(this);
+            DiagnosticProvider.Disable(this);
             ClearSolution();
         }
     }

--- a/src/EditorFeatures/Core/SolutionCrawler/HostSolutionCrawlerWorkspaceEventListener.cs
+++ b/src/EditorFeatures/Core/SolutionCrawler/HostSolutionCrawlerWorkspaceEventListener.cs
@@ -24,10 +24,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
         public void StartListening(Workspace workspace, object? serviceOpt)
         {
-            if (_globalOptions.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler))
-            {
-                workspace.Services.GetRequiredService<ISolutionCrawlerRegistrationService>().Register(workspace);
-            }
+            workspace.Services.GetRequiredService<ISolutionCrawlerRegistrationService>().Register(workspace);
         }
 
         public void StopListening(Workspace workspace)

--- a/src/EditorFeatures/Core/SolutionCrawler/HostSolutionCrawlerWorkspaceEventListener.cs
+++ b/src/EditorFeatures/Core/SolutionCrawler/HostSolutionCrawlerWorkspaceEventListener.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
         public void StartListening(Workspace workspace, object? serviceOpt)
         {
-            workspace.Services.GetRequiredService<ISolutionCrawlerRegistrationService>().Register(workspace);
+            DiagnosticProvider.Enable(workspace);
         }
 
         public void StopListening(Workspace workspace)
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             // we do this so that we can stop solution crawler faster and fire some telemetry. 
             // this is to reduce a case where we keep going even when VS is shutting down since we don't know about that
             var registration = workspace.Services.GetRequiredService<ISolutionCrawlerRegistrationService>();
-            registration.Unregister(workspace, blockingShutdown: true);
+            DiagnosticProvider.Disable(workspace, blockingShutdown: true);
         }
     }
 }

--- a/src/EditorFeatures/Core/SolutionCrawler/HostSolutionCrawlerWorkspaceEventListener.cs
+++ b/src/EditorFeatures/Core/SolutionCrawler/HostSolutionCrawlerWorkspaceEventListener.cs
@@ -29,9 +29,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
         public void StopListening(Workspace workspace)
         {
-            // we do this so that we can stop solution crawler faster and fire some telemetry. 
-            // this is to reduce a case where we keep going even when VS is shutting down since we don't know about that
-            var registration = workspace.Services.GetRequiredService<ISolutionCrawlerRegistrationService>();
+            // we do this so that we can stop solution crawler faster and fire some telemetry. this is to reduce a case
+            // where we keep going even when VS is shutting down since we don't know about that
             DiagnosticProvider.Disable(workspace, blockingShutdown: true);
         }
     }

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -670,7 +670,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SolutionCrawler
             // don't rely on background parser to have tree. explicitly do it here.
             await TouchEverything(workspace.CurrentSolution);
 
-            service.Reanalyze(workspace, worker, projectIds: null, documentIds: SpecializedCollections.SingletonEnumerable(info.Id), highPriority: false);
+            var testAccessor = service.GetTestAccessor();
+            testAccessor.Reanalyze(workspace, worker, projectIds: null, documentIds: SpecializedCollections.SingletonEnumerable(info.Id), highPriority: false);
 
             await TouchEverything(workspace.CurrentSolution);
 

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/LegacySolutionEvents/UnitTestingLegacySolutionEventsListener.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/LegacySolutionEvents/UnitTestingLegacySolutionEventsListener.cs
@@ -30,10 +30,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.LegacySolutionEvents
         private static IUnitTestingWorkCoordinator? GetCoordinator(Solution solution)
         {
             var service = solution.Services.GetService<IUnitTestingSolutionCrawlerRegistrationService>();
-            if (service == null)
-                return null;
-
-            return service.Register(solution);
+            return service?.Register(solution);
         }
 
         public bool ShouldReportChanges(SolutionServices services)

--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/IUnitTestingSolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/IUnitTestingSolutionCrawlerRegistrationService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
     /// </summary>
     internal interface IUnitTestingSolutionCrawlerRegistrationService : IWorkspaceService
     {
-        IUnitTestingWorkCoordinator Register(Solution solution);
+        IUnitTestingWorkCoordinator? Register(Solution solution);
 
 #if false // Not used in unit testing crawling
         void Unregister(Workspace workspace, bool blockingShutdown = false);

--- a/src/Features/LanguageServer/Protocol/Features/SolutionCrawler/MiscSolutionCrawlerWorkspaceEventListener.cs
+++ b/src/Features/LanguageServer/Protocol/Features/SolutionCrawler/MiscSolutionCrawlerWorkspaceEventListener.cs
@@ -23,10 +23,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
         }
 
         public void StartListening(Workspace workspace, object serviceOpt)
-        {
-            if (_globalOptions.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler))
-                DiagnosticProvider.Enable(workspace);
-        }
+            => DiagnosticProvider.Enable(workspace);
 
         public void StopListening(Workspace workspace)
             => DiagnosticProvider.Disable(workspace);

--- a/src/VisualStudio/Core/Def/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -317,11 +317,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                     // user might have built solution before workspace fires its first event yet (which is when solution crawler is initialized)
                     // here we give initializeLazily: false so that solution crawler is fully initialized when we do de-dup live and build errors,
                     // otherwise, we will think none of error we have here belong to live errors since diagnostic service is not initialized yet.
-                    if (_diagnosticService.GlobalOptions.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler))
-                    {
-                        var registrationService = (SolutionCrawlerRegistrationService)_workspace.Services.GetRequiredService<ISolutionCrawlerRegistrationService>();
-                        registrationService.EnsureRegistration(_workspace, initializeLazily: false);
-                    }
+                    var registrationService = (SolutionCrawlerRegistrationService)_workspace.Services.GetRequiredService<ISolutionCrawlerRegistrationService>();
+                    registrationService.EnsureRegistration(_workspace, initializeLazily: false);
 
                     // Mark the status as updated to refresh error list before we invoke 'SyncBuildErrorsAndReportAsync', which can take some time to complete.
                     OnBuildProgressChanged(inProgressState, BuildProgress.Updated);

--- a/src/VisualStudio/LiveShare/Impl/Client/RemoteLanguageServiceWorkspace.cs
+++ b/src/VisualStudio/LiveShare/Impl/Client/RemoteLanguageServiceWorkspace.cs
@@ -541,10 +541,7 @@ namespace Microsoft.VisualStudio.LanguageServices.LiveShare.Client
         }
 
         private void StartSolutionCrawler()
-        {
-            if (GlobalOptions.GetOption(SolutionCrawlerRegistrationService.EnableSolutionCrawler))
-                DiagnosticProvider.Enable(this);
-        }
+            => DiagnosticProvider.Enable(this);
 
         private void StopSolutionCrawler()
             => DiagnosticProvider.Disable(this);

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticProvider.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticProvider.cs
@@ -21,10 +21,10 @@ namespace Microsoft.CodeAnalysis
             service.Register(workspace);
         }
 
-        public static void Disable(Workspace workspace)
+        public static void Disable(Workspace workspace, bool blockingShutdown = false)
         {
             var service = workspace.Services.GetService<ISolutionCrawlerRegistrationService>();
-            service.Unregister(workspace);
+            service.Unregister(workspace, blockingShutdown);
         }
     }
 }

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Remote
         protected override void Dispose(bool finalize)
         {
             base.Dispose(finalize);
-            Services.GetRequiredService<ISolutionCrawlerRegistrationService>().Unregister(this);
+            DiagnosticProvider.Disable(this);
         }
 
         public AssetProvider CreateAssetProvider(Checksum solutionChecksum, SolutionAssetCache assetCache, IAssetSource assetSource)

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 // register solution crawler:
                 var workspace = GetWorkspace();
-                workspace.Services.GetRequiredService<ISolutionCrawlerRegistrationService>().Register(workspace);
+                DiagnosticProvider.Enable(workspace);
 
                 return ValueTaskFactory.CompletedTask;
             }, cancellationToken);


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1753274

Previously, we had an option for this, but it required all *consumers* to check it and not call into solution-crawler if it was off.  Now, the checks just go into solution-crawler (and the unit-testing version) and all the consumers don't care and just call into them.