### PR TITLE
Remove unused option

### DIFF
--- a/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingSolutionCrawlerService.cs
+++ b/src/Features/Core/Portable/ExternalAccess/UnitTesting/SolutionCrawler/UnitTestingSolutionCrawlerService.cs
@@ -13,8 +13,6 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.UnitTesting.SolutionCrawler
 {
     internal partial class UnitTestingSolutionCrawlerRegistrationService : IUnitTestingSolutionCrawlerRegistrationService
     {
-        internal static readonly Option2<bool> EnableSolutionCrawler = new("InternalSolutionCrawlerOptions_Solution Crawler", defaultValue: true);
-
         /// <summary>
         /// nested class of <see cref="UnitTestingSolutionCrawlerRegistrationService"/> since it is tightly coupled with it.
         /// 


### PR DESCRIPTION
Unit-testing-solution-crawler is already controlled by our existing solutino-crawler option. Specifically, if that option is off, we don't even register to listen to solution events.  So we never send anything over to OOP to run unit testing int he first place.  Confirmed by actual debugging and actual setting of the regkey for this option.