### PR TITLE
Fix marshalability of IWorkspaceProject.StartBatchAsync

### DIFF
--- a/src/VisualStudio/Core/Def/ProjectSystem/BrokeredService/WorkspaceProject.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/BrokeredService/WorkspaceProject.cs
@@ -159,9 +159,32 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem.BrokeredService
             return Task.CompletedTask;
         }
 
-        public Task<IAsyncDisposable> StartBatchAsync(CancellationToken cancellationToken)
+        public Task<IWorkspaceProjectBatch> StartBatchAsync(CancellationToken cancellationToken)
         {
-            return Task.FromResult(_project.CreateBatchScope());
+            return Task.FromResult<IWorkspaceProjectBatch>(new WorkspaceProjectBatch(_project.CreateBatchScope()));
+        }
+
+        private class WorkspaceProjectBatch : IWorkspaceProjectBatch
+        {
+            private IAsyncDisposable? _batch;
+
+            public WorkspaceProjectBatch(IAsyncDisposable batch)
+            {
+                _batch = batch;
+            }
+
+            public async Task ApplyAsync(CancellationToken cancellationToken)
+            {
+                if (_batch == null)
+                    throw new InvalidOperationException("The batch has already been applied.");
+
+                await _batch.DisposeAsync().ConfigureAwait(false);
+                _batch = null;
+            }
+
+            public void Dispose()
+            {
+            }
         }
     }
 }

--- a/src/Workspaces/Remote/Core/Microsoft.CodeAnalysis.Remote.Workspaces.csproj
+++ b/src/Workspaces/Remote/Core/Microsoft.CodeAnalysis.Remote.Workspaces.csproj
@@ -46,6 +46,7 @@
     <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.UnitTesting.SourceBasedTestDiscovery" Partner="UnitTesting" Key="$(UnitTestingKey)" />
     <RestrictedInternalsVisibleTo Include="Microsoft.CodeAnalysis.UnitTesting.SourceBasedTestDiscovery.Core" Partner="UnitTesting" Key="$(UnitTestingKey)" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.LanguageServer" Key="$(MicrosoftCodeAnalysisLanguageServerKey)" />
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.LanguageServer.UnitTests" Key="$(MicrosoftCodeAnalysisLanguageServerKey)" />
     <InternalsVisibleTo Include="Roslyn.VisualStudio.DiagnosticsWindow" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.CodeLens" />

--- a/src/Workspaces/Remote/Core/ProjectSystem/IWorkspaceProject.cs
+++ b/src/Workspaces/Remote/Core/ProjectSystem/IWorkspaceProject.cs
@@ -38,5 +38,5 @@ internal interface IWorkspaceProject : IDisposable
 
     Task SetProjectHasAllInformationAsync(bool hasAllInformation, CancellationToken cancellationToken);
 
-    Task<IAsyncDisposable> StartBatchAsync(CancellationToken cancellationToken);
+    Task<IWorkspaceProjectBatch> StartBatchAsync(CancellationToken cancellationToken);
 }

--- a/src/Workspaces/Remote/Core/ProjectSystem/IWorkspaceProjectBatch.cs
+++ b/src/Workspaces/Remote/Core/ProjectSystem/IWorkspaceProjectBatch.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using StreamJsonRpc;
+
+namespace Microsoft.CodeAnalysis.Remote.ProjectSystem;
+
+/// <summary>
+/// A batch returned from <see cref="IWorkspaceProject.StartBatchAsync(CancellationToken)" />. <see cref="ApplyAsync" /> must be called before disposing the batch object, which is otherwise a no-op.
+/// The dispose just releases any lifetime object tracking since this is an [RpcMarshalable] type.
+/// </summary>
+[RpcMarshalable]
+internal interface IWorkspaceProjectBatch : IDisposable
+{
+    Task ApplyAsync(CancellationToken cancellationToken);
+}


### PR DESCRIPTION
We have to make this return an interface marked with [RpcMarshalable], and since that can't really use IAsyncDisposable to say when it's done, I'm adding an explicit Apply method to make up for it.