### PR TITLE
Don't show expanded items in certain cases

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/AsyncCompletionLogger.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/AsyncCompletionLogger.cs
@@ -17,19 +17,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         {
             // # of sessions where import completion is enabled by default
             SessionWithTypeImportCompletionEnabled,
-            // # of sessions that we wait for import completion task to complete before return.
-            // Currently it's decided by "responsive completion" options
-            SessionWithImportCompletionBlocking,
-            // # of sessions where items from import completion are not included initially 
-            SessionWithImportCompletionDelayed,
+
             // # of session among SessionWithImportCompletionDelayed where import completion items
             // are later included in list update. Note this doesn't include using of expander.
             SessionWithDelayedImportCompletionIncludedInUpdate,
-            // Among sessions in SessionWithImportCompletionDelayed, how much longer it takes 
-            // for import completion task to finish after regular item task is completed.
-            // Knowing this would help us to decide whether a short wait would have ensure import completion
-            // items to be included in the initial list.
-            AdditionalTicksToCompleteDelayedImportCompletion,
+
             ExpanderUsageCount,
 
             SourceInitializationTicks,
@@ -41,25 +33,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
             ItemManagerUpdateCanceledTicks,
         }
 
-        internal static void LogImportCompletionGetContext(bool isBlocking, bool delayed)
-        {
-            s_countLogAggregator.IncreaseCount(ActionInfo.SessionWithTypeImportCompletionEnabled);
-
-            if (isBlocking)
-                s_countLogAggregator.IncreaseCount(ActionInfo.SessionWithImportCompletionBlocking);
-
-            if (delayed)
-                s_countLogAggregator.IncreaseCount(ActionInfo.SessionWithImportCompletionDelayed);
-        }
+        internal static void LogImportCompletionGetContext()
+            => s_countLogAggregator.IncreaseCount(ActionInfo.SessionWithTypeImportCompletionEnabled);
 
         internal static void LogSessionWithDelayedImportCompletionIncludedInUpdate()
             => s_countLogAggregator.IncreaseCount(ActionInfo.SessionWithDelayedImportCompletionIncludedInUpdate);
-
-        internal static void LogAdditionalTicksToCompleteDelayedImportCompletionDataPoint(TimeSpan timeSpan)
-            => s_histogramLogAggregator.LogTime(ActionInfo.AdditionalTicksToCompleteDelayedImportCompletion, timeSpan);
-
-        internal static void LogDelayedImportCompletionIncluded()
-            => s_countLogAggregator.IncreaseCount(ActionInfo.SessionWithTypeImportCompletionEnabled);
 
         internal static void LogExpanderUsage()
             => s_countLogAggregator.IncreaseCount(ActionInfo.ExpanderUsageCount);

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSessionData.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSessionData.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
 using RoslynCompletionList = Microsoft.CodeAnalysis.Completion.CompletionList;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion
@@ -27,12 +27,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
         public CompletionList<CompletionItem>? CombinedSortedList { get; set; }
         public Task<(CompletionContext, RoslynCompletionList)>? ExpandedItemsTask { get; set; }
         public bool IsExclusive { get; set; }
+        public bool NonBlockingCompletionEnabled { get; }
 
-        private CompletionSessionData()
+        private CompletionSessionData(IAsyncCompletionSession session)
         {
+            var nonBlockingCompletionEnabled = session.TextView.Options.GetOptionValue(DefaultOptions.NonBlockingCompletionOptionId);
+            var responsiveCompletionEnabled = session.TextView.Options.GetOptionValue(DefaultOptions.ResponsiveCompletionOptionId);
+            NonBlockingCompletionEnabled = nonBlockingCompletionEnabled || responsiveCompletionEnabled;
         }
 
         public static CompletionSessionData GetOrCreateSessionData(IAsyncCompletionSession session)
-            => session.Properties.GetOrCreateSingletonProperty(RoslynCompletionSessionData, static () => new CompletionSessionData());
+            => session.Properties.GetOrCreateSingletonProperty(RoslynCompletionSessionData, () => new CompletionSessionData(session));
     }
 }

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSessionData.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/CompletionSessionData.cs
@@ -31,6 +31,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
         private CompletionSessionData(IAsyncCompletionSession session)
         {
+            // Editor has to separate options control the behavior of block waiting computation of completion items.
+            // When set to true, `NonBlockingCompletionOptionId` takes precedence over `ResponsiveCompletionOptionId`
+            // and is equivalent to `ResponsiveCompletionOptionId` to true and `ResponsiveCompletionThresholdOptionId` to 0.
             var nonBlockingCompletionEnabled = session.TextView.Options.GetOptionValue(DefaultOptions.NonBlockingCompletionOptionId);
             var responsiveCompletionEnabled = session.TextView.Options.GetOptionValue(DefaultOptions.ResponsiveCompletionOptionId);
             NonBlockingCompletionEnabled = nonBlockingCompletionEnabled || responsiveCompletionEnabled;

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
@@ -234,12 +234,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
                 }
 
                 return false;
-
-                static bool IsAfterDot(ITextSnapshot snapshot, ITrackingSpan applicableToSpan)
-                {
-                    var position = applicableToSpan.GetStartPoint(snapshot).Position;
-                    return position > 0 && snapshot[position - 1] == '.';
-                }
             }
 
             private void AddCompletionItems(List<MatchResult> list, ThreadLocal<PatternMatchHelper> threadLocalPatternMatchHelper, CancellationToken cancellationToken)

--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManagerProvider.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManagerProvider.cs
@@ -22,8 +22,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncComplet
 
         [ImportingConstructor]
         [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-        public ItemManagerProvider(RecentItemsManager recentItemsManager, IGlobalOptionService globalOptions)
-            => _instance = new ItemManager(recentItemsManager, globalOptions);
+        public ItemManagerProvider(RecentItemsManager recentItemsManager, EditorOptionsService editorOptionsService)
+            => _instance = new ItemManager(recentItemsManager, editorOptionsService);
 
         public IAsyncCompletionItemManager? GetOrCreate(ITextView textView)
         {

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -6860,7 +6860,7 @@ namespace NS1
     {
         void M()
         {
-            $$
+            Un$$
         }
     }
 }
@@ -7111,7 +7111,6 @@ public class AA
 
                 Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
 
-                ' import completion is disabled, so we shouldn't have expander selected by default
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=False)
                 Await state.AssertCompletionItemsContain("DDProp1", "")
                 Await state.AssertCompletionItemsDoNotContainAny("DD")
@@ -7954,7 +7953,7 @@ namespace NS1
     {
         void M()
         {
-            $$
+            unimportedtype$$
         }
     }
 }
@@ -7973,16 +7972,7 @@ namespace  <%= containingNamespace %>
                 state.Workspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation, True)
                 state.Workspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)
 
-                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
-
-                ' make sure expander is selected
-                state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
-
-                state.SendEscape()
-                Await state.AssertNoCompletionSession()
-
-                state.SendTypeChars("unimportedtype")
-                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.SendCommitUniqueCompletionListItemAsync()
 
                 ' make sure expander is selected
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
@@ -8021,7 +8011,7 @@ namespace NS1
     {
         void M()
         {
-            $$
+            mytask$$
         }
     }
 
@@ -8042,16 +8032,7 @@ namespace NS2
                 state.Workspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ForceExpandedCompletionIndexCreation, True)
                 state.Workspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)
 
-                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
-
-                ' make sure expander is selected
-                state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
-
-                state.SendEscape()
-                Await state.AssertNoCompletionSession()
-
-                state.SendTypeChars("mytask")
-                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.SendCommitUniqueCompletionListItemAsync()
 
                 ' make sure expander is selected
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
@@ -10449,7 +10430,7 @@ class C
         Public Async Function TestNonBlockingExpandCompletionDoesNotChangeItemOrder() As Task
             Using state = TestStateFactory.CreateCSharpTestState(
                               <Document>
-                                  $$
+                                  Test$$
                               </Document>,
                               extraExportedTypes:={GetType(TestProvider)}.ToList())
 
@@ -10482,7 +10463,7 @@ class C
 
                 ' Now delayed expand item task is completed, following up by typing and delete a character to trigger
                 ' update so the list would contains all items
-                Await state.SendTypeCharsAndWaitForUiRenderAsync("t")
+                Await state.SendTypeCharsAndWaitForUiRenderAsync("U")
                 Await state.AssertCompletionItemsContain("TestUnimportedItem", "")
                 state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
 
@@ -10496,7 +10477,7 @@ class C
                 state.SendEscape()
                 Await state.AssertNoCompletionSession()
 
-                ' Now disable expand item delay, so intial trigger should contain full list
+                ' Now disable expand item delay, so initial trigger should contain full list
                 state.TextView.Options.SetOptionValue(DefaultOptions.ResponsiveCompletionOptionId, False)
 
                 state.SendInvokeCompletionList()

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests_DefaultsSource.vb
@@ -4,11 +4,16 @@
 
 Imports System.Collections.Immutable
 Imports System.Composition
+Imports System.Threading
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.AsyncCompletion
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.Shared.TestHooks
+Imports Microsoft.CodeAnalysis.PooledObjects
+Imports Microsoft.CodeAnalysis.CSharp.Completion
+Imports Microsoft.CodeAnalysis.Completion.Providers
 Imports Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion
 Imports Microsoft.VisualStudio.Text.Editor
 
@@ -469,5 +474,213 @@ class Test
                 Assert.Contains("if", committedLine, StringComparison.Ordinal)
             End Using
         End Function
+
+        <WpfTheory, CombinatorialData>
+        Public Async Function TestAutoHidingExpandedItems(afterDot As Boolean, responsiveTypingEnabled As Boolean) As Task
+            Dim text As String
+            If afterDot Then
+                text = "this."
+            Else
+                text = String.Empty
+            End If
+
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+                    <%= text %>$$
+                </Document>,
+                excludedTypes:={GetType(CSharpCompletionService.Factory)}.ToList(),
+                extraExportedTypes:={GetType(MockCompletionServiceFactory)}.ToList())
+
+                Dim workspace = state.Workspace
+                workspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)
+
+                state.TextView.Options.SetOptionValue(DefaultOptions.ResponsiveCompletionOptionId, responsiveTypingEnabled)
+
+                Dim completionService = DirectCast(workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetRequiredService(Of CompletionService)(), MockCompletionServiceFactory.Service)
+
+                If Not responsiveTypingEnabled And afterDot Then
+                    ' we'd block on expanded items when responsive completion is disabled and triggered after a dot
+                    ' so make sure the checkpoint is released first
+                    completionService.ExpandedItemsCheckpoint.Release()
+
+                    Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
+                    state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=True)
+                    Dim items = state.GetCompletionItems()
+                    Assert.Equal(completionService.RegularCount + completionService.ExpandedCount, items.Count)
+                    Assert.Equal(completionService.ExpandedCount, items.Where(Function(x) x.Flags.IsExpanded()).Count())
+                Else
+                    ' we blocked the expanded item task, so only regular items in the list
+                    ' this is true even with responsive typing disabled, since the filter text is empty.
+                    Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
+                    state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=False)
+                    Dim items = state.GetCompletionItems()
+                    Assert.Equal(completionService.RegularCount, items.Count)
+                    Assert.False(items.Any(Function(i) i.Flags.IsExpanded()))
+
+                    ' make sure expanded item task completes
+                    completionService.ExpandedItemsCheckpoint.Release()
+                    Dim session = Await state.GetCompletionSession()
+                    Dim sessionData = CompletionSessionData.GetOrCreateSessionData(session)
+                    Assert.NotNull(sessionData.ExpandedItemsTask)
+                    Await sessionData.ExpandedItemsTask
+                End If
+
+                Dim typedChars = "Item"
+                For i = 0 To typedChars.Length - 1
+                    Await state.SendTypeCharsAndWaitForUiRenderAsync(typedChars(i))
+                    Dim items = state.GetCompletionItems()
+                    Dim expandedCount As Integer
+
+                    If (Not afterDot And i < ItemManager.FilterTextLengthToExcludeExpandedItemsExclusive - 1) Then
+                        expandedCount = 0
+                    Else
+                        expandedCount = completionService.ExpandedCount
+                    End If
+
+                    Assert.True((completionService.RegularCount + expandedCount) = items.Count, $"Typed char: '{typedChars(i)}', expected: {completionService.RegularCount + expandedCount}, actual: {items.Count} ")
+                    Assert.Equal(expandedCount, items.Where(Function(x) x.Flags.IsExpanded()).Count())
+                Next
+
+                ' once we show expanded items, we will not hide it in the same session, even if filter text became shorter
+                For i = 1 To 4
+                    state.SendBackspace()
+                    Dim items = state.GetCompletionItems()
+                    Assert.True((completionService.RegularCount + completionService.ExpandedCount) = items.Count, $"Backspace number: {i}expected: {completionService.RegularCount + completionService.ExpandedCount}, actual: {items.Count} ")
+                    Assert.Equal(completionService.ExpandedCount, items.Where(Function(x) x.Flags.IsExpanded()).Count())
+                Next
+            End Using
+        End Function
+
+        <WpfFact>
+        Public Async Function TestAutoHidingExpandedItemsWithDefaults() As Task
+            Using state = TestStateFactory.CreateCSharpTestState(
+                <Document>
+$$
+                </Document>,
+                excludedTypes:={GetType(CSharpCompletionService.Factory)}.ToList(),
+                extraExportedTypes:={GetType(MockCompletionServiceFactory), GetType(MockDefaultSource)}.ToList())
+
+                Dim workspace = state.Workspace
+                workspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.ShowItemsFromUnimportedNamespaces, LanguageNames.CSharp, True)
+                state.TextView.Options.SetOptionValue(DefaultOptions.ResponsiveCompletionOptionId, True)
+
+                Dim completionService = DirectCast(workspace.Services.GetLanguageServices(LanguageNames.CSharp).GetRequiredService(Of CompletionService)(), MockCompletionServiceFactory.Service)
+                MockDefaultSource.Defaults = ImmutableArray.Create("ItemExpanded1")
+
+                ' we blocked the expanded item task, so only regular items in the list
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
+                state.AssertCompletionItemExpander(isAvailable:=True, isSelected:=False)
+                Dim items = state.GetCompletionItems()
+                Assert.Equal(completionService.RegularCount, items.Count)
+                Assert.False(items.Any(Function(i) i.Flags.IsExpanded()))
+
+                ' make sure expanded item task completes
+                completionService.ExpandedItemsCheckpoint.Release()
+                Dim session = Await state.GetCompletionSession()
+                Dim sessionData = CompletionSessionData.GetOrCreateSessionData(session)
+                Assert.NotNull(sessionData.ExpandedItemsTask)
+                Await sessionData.ExpandedItemsTask
+
+                Await state.SendInvokeCompletionListAndWaitForUiRenderAsync()
+                Await state.AssertSelectedCompletionItem("★ ItemExpanded1", isHardSelected:=False)
+            End Using
+        End Function
+
+        <ExportLanguageServiceFactory(GetType(CompletionService), LanguageNames.CSharp), [Shared], PartNotDiscoverable>
+        Private Class MockCompletionServiceFactory
+            Implements ILanguageServiceFactory
+
+            Private ReadOnly _listenerProvider As IAsynchronousOperationListenerProvider
+
+            <ImportingConstructor>
+            <Obsolete(MefConstruction.ImportingConstructorMessage, True)>
+            Public Sub New(listenerProvider As IAsynchronousOperationListenerProvider)
+                _listenerProvider = listenerProvider
+            End Sub
+
+            Public Function CreateLanguageService(languageServices As CodeAnalysis.Host.HostLanguageServices) As CodeAnalysis.Host.ILanguageService Implements ILanguageServiceFactory.CreateLanguageService
+                Return New Service(languageServices.LanguageServices.SolutionServices, _listenerProvider)
+            End Function
+
+            Public Class Service
+                Inherits CompletionService
+
+                Public Property RegularCount As Integer = 10
+                Public Property ExpandedCount As Integer = 10
+
+                Public ExpandedItemsCheckpoint As New Checkpoint()
+
+                Public Sub New(services As CodeAnalysis.Host.SolutionServices, listenerProvider As IAsynchronousOperationListenerProvider)
+                    MyBase.New(services, listenerProvider)
+                End Sub
+
+                Public Overrides ReadOnly Property Language As String
+                    Get
+                        Return LanguageNames.CSharp
+                    End Get
+                End Property
+
+                Friend Overrides Function GetRules(options As CompletionOptions) As CompletionRules
+                    Return CompletionRules.Default
+                End Function
+
+                Friend Overrides Async Function GetCompletionsAsync(document As Document,
+                    caretPosition As Integer,
+                    options As CompletionOptions,
+                    passThroughOptions As OptionSet,
+                    Optional trigger As CompletionTrigger = Nothing,
+                    Optional roles As ImmutableHashSet(Of String) = Nothing,
+                    Optional cancellationToken As CancellationToken = Nothing) As Task(Of CompletionList)
+
+                    Dim text = Await document.GetTextAsync(cancellationToken).ConfigureAwait(False)
+                    Dim defaultItemSpan = GetDefaultCompletionListSpan(text, caretPosition)
+
+                    Dim builder = ArrayBuilder(Of CompletionItem).GetInstance(RegularCount + ExpandedCount)
+                    If (options.ExpandedCompletionBehavior = ExpandedCompletionMode.AllItems) Then
+                        CreateRegularItems(builder, RegularCount)
+                        Await CreateExpandedItems(builder, ExpandedCount)
+                    ElseIf (options.ExpandedCompletionBehavior = ExpandedCompletionMode.ExpandedItemsOnly) Then
+                        Await CreateExpandedItems(builder, ExpandedCount)
+                    Else
+                        CreateRegularItems(builder, RegularCount)
+                    End If
+
+                    Return CompletionList.Create(defaultItemSpan, builder.ToImmutableAndFree())
+                End Function
+
+                Friend Overrides Function ShouldTriggerCompletion(project As Project,
+                    languageServices As CodeAnalysis.Host.LanguageServices,
+                    text As SourceText,
+                    caretPosition As Integer,
+                    trigger As CompletionTrigger,
+                    options As CompletionOptions,
+                    passThroughOptions As OptionSet,
+                    Optional roles As ImmutableHashSet(Of String) = Nothing) As Boolean
+                    Return True
+                End Function
+
+                Private Async Function CreateExpandedItems(builder As ArrayBuilder(Of CompletionItem), count As Integer) As Task
+                    Await ExpandedItemsCheckpoint.Task
+                    For i = 1 To count
+                        Dim item = ImportCompletionItem.Create(
+                        $"ItemExpanded{i}",
+                        arity:=0,
+                        containingNamespace:="NS",
+                        glyph:=Glyph.ClassPublic,
+                        genericTypeSuffix:=String.Empty,
+                        flags:=CompletionItemFlags.Expanded,
+                        extensionMethodData:=Nothing,
+                        includedInTargetTypeCompletion:=True)
+                        builder.Add(item)
+                    Next
+                End Function
+
+                Private Shared Sub CreateRegularItems(builder As ArrayBuilder(Of CompletionItem), count As Integer)
+                    For i = 1 To count
+                        builder.Add(CompletionItem.Create($"ItemRegular{i}"))
+                    Next
+                End Sub
+            End Class
+        End Class
     End Class
 End Namespace


### PR DESCRIPTION
This change hides expanded items (i.e. unimported items) in certain scenarios even if the option is enabled AND Editor's responsive completion option is also enabled. The goal is to address both usability (showing too many unimported items and cluttered the list, when we don't have enough hint to filter down the list) and perf issues.



Addressing the perf cost in matching and sorting items [AB#1749264](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1749264)

Commit-by-commit review is recommended. 
- The first commit is pure refactoring w/o behavior change. After the change, we will always have a separate task for computing expanded items, checking for responsive typing option value and combining them into the list is now handled by ItemManager.
-  The actual change as described above is in 84e59e91521f4cff72be95eb026469d4688f49f2. We only show expanded item if any of the following conditions is true:
    1. filter text length >= 2. It's common to use filter of length 2 for camel case match, e.g. `AB` for `ArrayBuiler`, but for 0 (happens quite often since we now trigger completion in argument list by default, where unimported types are rarely needed) or 1 typed char, I don't really see how including thousands of those items would be useful
    2. the completion is triggered after `.` (i.e. in the context of listing members, which usually has much fewer items and more often used for browsing purpose)
    3. defaults is not empty (it might suggest an expanded item for us to select)

In type context, only show expanded items after at least two characters are typed:

![TypeContext](https://user-images.githubusercontent.com/788783/227657262-5ae7a1d1-9ce1-40f7-88d4-37dd22e749c0.gif)

In member context, no change behavior:

![MemberContext](https://user-images.githubusercontent.com/788783/227657270-22cb6d54-9b0c-4c59-8357-8b3f8610d2a7.gif)
