### PR TITLE
Fix crash of property snippets after accessibility modifier

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpAutoPropertyCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpAutoPropertyCompletionProviderTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
 {
     public abstract class AbstractCSharpAutoPropertyCompletionProviderTests : AbstractCSharpSnippetCompletionProviderTests
     {
-        protected abstract string GetDefaultPropertyText(string propertyName);
+        protected abstract string GetDefaultPropertyBlockText();
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task MissingInNamespace()
@@ -133,6 +133,22 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
                 """);
         }
 
+        [WpfTheory, Trait(Traits.Feature, Traits.Features.Completion)]
+        [InlineData("public")]
+        [InlineData("private")]
+        [InlineData("protected")]
+        [InlineData("private protected")]
+        [InlineData("protected internal")]
+        public async Task AfterAccessibilityModifier(string modifier)
+        {
+            await VerifyPropertyAsync($$"""
+                class Program
+                {
+                    {{modifier}} $$
+                }
+                """, $"int MyProperty {GetDefaultPropertyBlockText()}");
+        }
+
         private Task VerifyPropertyAbsenceAsync(string markup) => VerifyItemIsAbsentAsync(markup, ItemToCommit);
 
         protected async Task VerifyPropertyAsync(string markup, string propertyText)
@@ -143,6 +159,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
         }
 
         protected Task VerifyDefaultPropertyAsync(string markup, string propertyName = "MyProperty")
-            => VerifyPropertyAsync(markup, GetDefaultPropertyText(propertyName));
+            => VerifyPropertyAsync(markup, $"public int {propertyName} {GetDefaultPropertyBlockText()}");
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropSnippetCompletionProviderTests.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     {
         protected override string ItemToCommit => "prop";
 
-        protected override string GetDefaultPropertyText(string propertyName)
-            => $"public int {propertyName} {{ get; set; }}";
+        protected override string GetDefaultPropertyBlockText()
+            => "{ get; set; }";
 
         public override async Task InsertSnippetInInterface()
         {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropgSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropgSnippetCompletionProviderTests.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     {
         protected override string ItemToCommit => "propg";
 
-        protected override string GetDefaultPropertyText(string propertyName)
-            => $"public int {propertyName} {{ get; private set; }}";
+        protected override string GetDefaultPropertyBlockText()
+            => "{ get; private set; }";
 
         public override async Task InsertSnippetInInterface()
         {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropiSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropiSnippetCompletionProviderTests.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     {
         protected override string ItemToCommit => "propi";
 
-        protected override string GetDefaultPropertyText(string propertyName)
-            => $"public int {propertyName} {{ get; init; }}";
+        protected override string GetDefaultPropertyBlockText()
+            => "{ get; init; }";
 
         public override async Task InsertSnippetInInterface()
         {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/67053