### PR TITLE
Up the priority of the 'fix formatting' fixer to 'high'

### DIFF
--- a/src/Analyzers/Core/CodeFixes/Formatting/FormattingCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/Formatting/FormattingCodeFixProvider.cs
@@ -23,6 +23,14 @@ namespace Microsoft.CodeAnalysis.CodeStyle
 
         protected abstract ISyntaxFormatting SyntaxFormatting { get; }
 
+        /// <summary>
+        /// Fixing formatting is high priority.  It's something the user wants to be able to fix quickly, is driven by
+        /// them acting on an error reported in code, and can be computed fast as it only uses syntax not semantics.
+        /// It's also the 8th most common fix that people use, and is picked almost all the times it is shown.
+        /// </summary>
+        private protected override CodeActionRequestPriority ComputeRequestPriority()
+            => CodeActionRequestPriority.High;
+
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
@@ -31,7 +39,8 @@ namespace Microsoft.CodeAnalysis.CodeStyle
                     CodeAction.Create(
                         AnalyzersResources.Fix_formatting,
                         c => FixOneAsync(context, diagnostic, c),
-                        nameof(AbstractFormattingCodeFixProvider)),
+                        nameof(AbstractFormattingCodeFixProvider),
+                        CodeActionPriority.High),
                     diagnostic);
             }
 

--- a/src/Analyzers/Core/CodeFixes/Formatting/FormattingCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/Formatting/FormattingCodeFixProvider.cs
@@ -23,6 +23,8 @@ namespace Microsoft.CodeAnalysis.CodeStyle
 
         protected abstract ISyntaxFormatting SyntaxFormatting { get; }
 
+#if !CODE_STYLE
+
         /// <summary>
         /// Fixing formatting is high priority.  It's something the user wants to be able to fix quickly, is driven by
         /// them acting on an error reported in code, and can be computed fast as it only uses syntax not semantics.
@@ -30,6 +32,8 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         /// </summary>
         private protected override CodeActionRequestPriority ComputeRequestPriority()
             => CodeActionRequestPriority.High;
+
+#endif
 
         public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
@@ -39,8 +43,11 @@ namespace Microsoft.CodeAnalysis.CodeStyle
                     CodeAction.Create(
                         AnalyzersResources.Fix_formatting,
                         c => FixOneAsync(context, diagnostic, c),
-                        nameof(AbstractFormattingCodeFixProvider),
-                        CodeActionPriority.High),
+                        nameof(AbstractFormattingCodeFixProvider)
+#if !CODE_STYLE
+                        , CodeActionPriority.High
+#endif
+                        ),
                     diagnostic);
             }
 

--- a/src/Analyzers/Core/CodeFixes/Formatting/FormattingCodeFixProvider.cs
+++ b/src/Analyzers/Core/CodeFixes/Formatting/FormattingCodeFixProvider.cs
@@ -39,16 +39,22 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         {
             foreach (var diagnostic in context.Diagnostics)
             {
+#if CODE_STYLE
                 context.RegisterCodeFix(
                     CodeAction.Create(
                         AnalyzersResources.Fix_formatting,
                         c => FixOneAsync(context, diagnostic, c),
-                        nameof(AbstractFormattingCodeFixProvider)
-#if !CODE_STYLE
-                        , CodeActionPriority.High
-#endif
-                        ),
+                        nameof(AbstractFormattingCodeFixProvider)),
                     diagnostic);
+#else
+                context.RegisterCodeFix(
+                    CodeAction.DocumentChangeAction.Create(
+                        AnalyzersResources.Fix_formatting,
+                        c => FixOneAsync(context, diagnostic, c),
+                        nameof(AbstractFormattingCodeFixProvider),
+                        CodeActionPriority.High),
+                    diagnostic);
+#endif
             }
 
             return Task.CompletedTask;

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
@@ -372,17 +372,18 @@ namespace Microsoft.CodeAnalysis.CodeActions
         /// <param name="equivalenceKey">Optional value used to determine the equivalence of the <see cref="CodeAction"/> with other <see cref="CodeAction"/>s. See <see cref="CodeAction.EquivalenceKey"/>.</param>
         [SuppressMessage("ApiDesign", "RS0027:Public API with optional parameter(s) should have the most parameters amongst its public overloads.", Justification = "Preserving existing public API")]
         public static CodeAction Create(string title, Func<CancellationToken, Task<Document>> createChangedDocument, string? equivalenceKey = null)
-            => Create(title, createChangedDocument, equivalenceKey, CodeActionPriority.Default);
-
-        internal static CodeAction Create(string title, Func<CancellationToken, Task<Document>> createChangedDocument, string? equivalenceKey, CodeActionPriority priority)
         {
             if (title == null)
+            {
                 throw new ArgumentNullException(nameof(title));
+            }
 
             if (createChangedDocument == null)
+            {
                 throw new ArgumentNullException(nameof(createChangedDocument));
+            }
 
-            return DocumentChangeAction.Create(title, createChangedDocument, equivalenceKey, priority);
+            return DocumentChangeAction.Create(title, createChangedDocument, equivalenceKey);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction.cs
@@ -372,18 +372,17 @@ namespace Microsoft.CodeAnalysis.CodeActions
         /// <param name="equivalenceKey">Optional value used to determine the equivalence of the <see cref="CodeAction"/> with other <see cref="CodeAction"/>s. See <see cref="CodeAction.EquivalenceKey"/>.</param>
         [SuppressMessage("ApiDesign", "RS0027:Public API with optional parameter(s) should have the most parameters amongst its public overloads.", Justification = "Preserving existing public API")]
         public static CodeAction Create(string title, Func<CancellationToken, Task<Document>> createChangedDocument, string? equivalenceKey = null)
+            => Create(title, createChangedDocument, equivalenceKey, CodeActionPriority.Default);
+
+        internal static CodeAction Create(string title, Func<CancellationToken, Task<Document>> createChangedDocument, string? equivalenceKey, CodeActionPriority priority)
         {
             if (title == null)
-            {
                 throw new ArgumentNullException(nameof(title));
-            }
 
             if (createChangedDocument == null)
-            {
                 throw new ArgumentNullException(nameof(createChangedDocument));
-            }
 
-            return DocumentChangeAction.Create(title, createChangedDocument, equivalenceKey);
+            return DocumentChangeAction.Create(title, createChangedDocument, equivalenceKey, priority);
         }
 
         /// <summary>


### PR DESCRIPTION
Telemetry shows this is one of the most used fixers (top 10), and can be done entirely with syntax.  Given  it's importance, and ability to be computed extremely quickly, it can be pulled up to the *extremely* limited set of actions that are given high-pri (currently only 'rename', 'add using', 'fix conflict markers').