### PR TITLE
Switch to frozen snapshots for design attribute checking.

### DIFF
--- a/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeDiscoveryService.cs
+++ b/src/Features/Core/Portable/DesignerAttribute/DesignerAttributeDiscoveryService.cs
@@ -225,6 +225,11 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
         public static async Task<string?> ComputeDesignerAttributeCategoryAsync(
             AsyncLazy<bool> lazyHasDesignerCategoryType, Document document, CancellationToken cancellationToken)
         {
+            // If we have computed the hasDesignerCategoryType value for a prior document, and it turned out to be
+            // false, then we can skip any further steps (like parsing the file).
+            if (lazyHasDesignerCategoryType.TryGetValue(out var hasDesignerCategoryType) && !hasDesignerCategoryType)
+                return null;
+
             var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var syntaxFacts = document.GetRequiredLanguageService<ISyntaxFactsService>();
 
@@ -236,7 +241,7 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
 
             // simple case.  If there's no DesignerCategory type in this compilation, then there's
             // definitely no designable types.
-            var hasDesignerCategoryType = await lazyHasDesignerCategoryType.GetValueAsync(cancellationToken).ConfigureAwait(false);
+            hasDesignerCategoryType = await lazyHasDesignerCategoryType.GetValueAsync(cancellationToken).ConfigureAwait(false);
             if (!hasDesignerCategoryType)
                 return null;
 

--- a/src/Features/Core/Portable/DesignerAttribute/IDesignerAttributeDiscoveryService.cs
+++ b/src/Features/Core/Portable/DesignerAttribute/IDesignerAttributeDiscoveryService.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,6 +16,7 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
             ValueTask ReportDesignerAttributeDataAsync(ImmutableArray<DesignerAttributeData> data, CancellationToken cancellationToken);
         }
 
-        ValueTask ProcessSolutionAsync(Solution solution, DocumentId? priorityDocumentId, ICallback callback, CancellationToken cancellationToken);
+        ValueTask ProcessSolutionAsync(
+            Solution solution, DocumentId? priorityDocumentId, bool useFrozenSnapshots, ICallback callback, CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/DesignerAttribute/IRemoteDesignerAttributeDiscoveryService.cs
+++ b/src/Features/Core/Portable/DesignerAttribute/IRemoteDesignerAttributeDiscoveryService.cs
@@ -23,7 +23,8 @@ namespace Microsoft.CodeAnalysis.DesignerAttribute
             ValueTask ReportDesignerAttributeDataAsync(RemoteServiceCallbackId callbackId, ImmutableArray<DesignerAttributeData> data, CancellationToken cancellationToken);
         }
 
-        ValueTask DiscoverDesignerAttributesAsync(RemoteServiceCallbackId callbackId, Checksum solutionChecksum, DocumentId? priorityDocument, CancellationToken cancellationToken);
+        ValueTask DiscoverDesignerAttributesAsync(
+            RemoteServiceCallbackId callbackId, Checksum solutionChecksum, DocumentId? priorityDocument, bool useFrozenSnapshots, CancellationToken cancellationToken);
     }
 
     [ExportRemoteServiceCallbackDispatcher(typeof(IRemoteDesignerAttributeDiscoveryService)), Shared]

--- a/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
+++ b/src/VisualStudio/Core/Def/DesignerAttribute/VisualStudioDesignerAttributeService.cs
@@ -127,7 +127,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
 
             await client.TryInvokeAsync<IRemoteDesignerAttributeDiscoveryService>(
                 solution,
-                (service, checksum, callbackId, cancellationToken) => service.DiscoverDesignerAttributesAsync(callbackId, checksum, priorityDocument, cancellationToken),
+                (service, checksum, callbackId, cancellationToken) => service.DiscoverDesignerAttributesAsync(
+                    callbackId, checksum, priorityDocument, useFrozenSnapshots: true, cancellationToken),
                 callbackTarget: this,
                 cancellationToken).ConfigureAwait(false);
         }

--- a/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Services/ServiceHubServicesTests.cs
@@ -142,7 +142,8 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
 
             var invokeTask = connection.TryInvokeAsync(
                 solution,
-                (service, checksum, callbackId, cancellationToken) => service.DiscoverDesignerAttributesAsync(callbackId, checksum, priorityDocument: null, cancellationToken),
+                (service, checksum, callbackId, cancellationToken) => service.DiscoverDesignerAttributesAsync(
+                    callbackId, checksum, priorityDocument: null, useFrozenSnapshots: true, cancellationToken),
                 cancellationTokenSource.Token);
 
             var infos = await callback.Infos;

--- a/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
+++ b/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspace.cs
@@ -51,6 +51,8 @@ namespace Microsoft.CodeAnalysis.Remote
             return new AssetProvider(solutionChecksum, assetCache, assetSource, serializerService);
         }
 
+        protected internal override bool PartialSemanticsEnabled => true;
+
         /// <summary>
         /// Syncs over the solution corresponding to <paramref name="solutionChecksum"/> and sets it as the current
         /// solution for <see langword="this"/> workspace.  This will also end up updating <see

--- a/src/Workspaces/Remote/ServiceHub/Services/DesignerAttributeDiscovery/RemoteDesignerAttributeDiscoveryService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DesignerAttributeDiscovery/RemoteDesignerAttributeDiscoveryService.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.DesignerAttribute;
-using Microsoft.CodeAnalysis.SolutionCrawler;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -47,6 +46,7 @@ namespace Microsoft.CodeAnalysis.Remote
             RemoteServiceCallbackId callbackId,
             Checksum solutionChecksum,
             DocumentId? priorityDocument,
+            bool useFrozenSnapshots,
             CancellationToken cancellationToken)
         {
             return RunServiceAsync(
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 {
                     var service = solution.Services.GetRequiredService<IDesignerAttributeDiscoveryService>();
                     return service.ProcessSolutionAsync(
-                        solution, priorityDocument, new CallbackWrapper(_callback, callbackId), cancellationToken);
+                        solution, priorityDocument, useFrozenSnapshots, new CallbackWrapper(_callback, callbackId), cancellationToken);
                 },
                 cancellationToken);
         }

--- a/src/Workspaces/Remote/ServiceHub/Services/InheritanceMargin/RemoteInheritanceMarginService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/InheritanceMargin/RemoteInheritanceMarginService.cs
@@ -35,6 +35,13 @@ namespace Microsoft.CodeAnalysis.Remote
         {
             return RunServiceAsync(solutionChecksum, async solution =>
             {
+                // Explicitly disabling frozen partial on the OOP size.  This flag was passed in, but had no actual
+                // effect (since OOP didn't support frozen partial semantics initially).  When OOP gained real support
+                // for frozen-partial, this started breaking inheritance margin.  So, until that is figured out, we just
+                // disable this to keep the pre-existing behavior.
+                //
+                // Tracked by https://github.com/dotnet/roslyn/issues/67065.
+                frozenPartialSemantics = false;
                 var document = await solution.GetRequiredDocumentAsync(documentId, includeSourceGenerated: true, cancellationToken).ConfigureAwait(false);
                 var service = document.GetRequiredLanguageService<IInheritanceMarginService>();
                 return await service.GetInheritanceMemberItemsAsync(document, spanToSearch, includeGlobalImports, frozenPartialSemantics, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
We need compilations to tell if a project contains a reference to System.ComponentModel.DesignerCategoryAttribute.  This question can be answered *without* needing the expensive work to run source generators or produce skeletons.  So we switch to frozen semantics to avoid that.
