### PR TITLE
Fix VisualStudioSettingsOptionPersister issues and increase test coverage

### DIFF
--- a/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
+++ b/src/EditorFeatures/Test/Options/GlobalOptionsTests.cs
@@ -119,7 +119,7 @@ public class GlobalOptionsTests
                     // default value for the option -- may be different then default(T):
                     var defaultValue = property.GetValue(defaultOptions);
 
-                    if (OptionsTestHelpers.IsOptionValueType(property.PropertyType))
+                    if (OptionDefinition.IsSupportedOptionType(property.PropertyType))
                     {
                         if (IsStoredInGlobalOptions(property, language))
                         {
@@ -128,7 +128,7 @@ public class GlobalOptionsTests
                     }
                     else
                     {
-                        var propertyType = OptionsTestHelpers.GetNonNullableType(property.PropertyType);
+                        var propertyType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
 
                         if (propertyType != property.PropertyType)
                         {

--- a/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioOptionStorageReadFallbacks.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioOptionStorageReadFallbacks.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.VisualStudio.LanguageServices.Options;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp;
 
@@ -60,9 +61,6 @@ internal static class CSharpVisualStudioOptionStorageReadFallbacks
             => TryReadFlags(s_storages, (int)CSharpFormattingOptions2.NewLineBeforeOpenBrace.DefaultValue, readValue, out var intValue) ? (NewLineBeforeOpenBracePlacement)intValue : default(Optional<object?>);
     }
 
-    private static readonly object s_true = true;
-    private static readonly object s_false = false;
-
     /// <summary>
     /// Returns true if an option for any flag is present in the storage. Each flag in the result will be either read from the storage 
     /// (if present) or from <paramref name="defaultValue"/> otherwise.
@@ -75,7 +73,7 @@ internal static class CSharpVisualStudioOptionStorageReadFallbacks
         foreach (var (key, flag) in storages)
         {
             var defaultFlagValue = defaultValue & flag;
-            var value = read(key, typeof(bool), (defaultFlagValue != 0) ? s_true : s_false);
+            var value = read(key, typeof(bool), (defaultFlagValue != 0) ? Boxes.BoxedTrue : Boxes.BoxedFalse);
             if (value.HasValue)
             {
                 if ((bool)value.Value!)

--- a/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioOptionStorageReadFallbacks.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/CSharpVisualStudioOptionStorageReadFallbacks.cs
@@ -73,7 +73,7 @@ internal static class CSharpVisualStudioOptionStorageReadFallbacks
         foreach (var (key, flag) in storages)
         {
             var defaultFlagValue = defaultValue & flag;
-            var value = read(key, typeof(bool), (defaultFlagValue != 0) ? Boxes.BoxedTrue : Boxes.BoxedFalse);
+            var value = read(key, typeof(bool), Boxes.Box(defaultFlagValue != 0));
             if (value.HasValue)
             {
                 if ((bool)value.Value!)

--- a/src/VisualStudio/Core/Def/Options/IVisualStudioStorageReadFallback.cs
+++ b/src/VisualStudio/Core/Def/Options/IVisualStudioStorageReadFallback.cs
@@ -3,11 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.LanguageServices.Options;
 
-internal delegate Optional<object?> TryReadValueDelegate(string storageKey, Type storageType);
+internal delegate Optional<object?> TryReadValueDelegate(string storageKey, Type storageType, object? defaultValue);
 
 /// <summary>
 /// Export an implementation of this interface to instruct <see cref="VisualStudioOptionPersister"/> to read option value

--- a/src/VisualStudio/Core/Def/Options/NamingPreferencesReadFallback.cs
+++ b/src/VisualStudio/Core/Def/Options/NamingPreferencesReadFallback.cs
@@ -24,6 +24,6 @@ internal sealed class NamingPreferencesReadFallback : IVisualStudioStorageReadFa
     public Optional<object?> TryRead(string? language, TryReadValueDelegate readValue)
     {
         Contract.ThrowIfNull(language);
-        return readValue($"TextEditor.{language}.Specific.NamingPreferences", typeof(NamingStylePreferences));
+        return readValue($"TextEditor.{language}.Specific.NamingPreferences", typeof(NamingStylePreferences), NamingStyleOptions.NamingPreferences.DefaultValue);
     }
 }

--- a/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioOptionStorage.cs
@@ -67,7 +67,7 @@ internal abstract class VisualStudioOptionStorage
             });
 
         public Task PersistAsync(VisualStudioSettingsOptionPersister persister, OptionKey2 optionKey, object? value)
-            => persister.PersistAsync(optionKey, GetKey(optionKey.Language), value);
+            => persister.PersistAsync(GetKey(optionKey.Language), value);
 
         public bool TryFetch(VisualStudioSettingsOptionPersister persister, OptionKey2 optionKey, out object? value)
             => persister.TryFetch(optionKey, GetKey(optionKey.Language), out value);

--- a/src/VisualStudio/Core/Def/Options/VisualStudioSettingsOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioSettingsOptionPersister.cs
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Options
         public Optional<object?> TryReadAndMonitorOptionValue(OptionKey2 primaryOptionKey, string primaryStorageKey, string storageKey, Type storageType, object? defaultValue)
         {
             Contract.ThrowIfNull(_settingManager);
-            ImmutableInterlocked.GetOrAdd(ref _storageKeysToMonitorForChanges, storageKey, _ => (primaryOptionKey, primaryStorageKey));
+            ImmutableInterlocked.GetOrAdd(ref _storageKeysToMonitorForChanges, storageKey, static (_, arg) => arg, factoryArgument: (primaryOptionKey, primaryStorageKey));
             return TryReadOptionValue(_settingManager, storageKey, storageType, defaultValue);
         }
 

--- a/src/VisualStudio/Core/Def/Options/VisualStudioSettingsOptionPersister.cs
+++ b/src/VisualStudio/Core/Def/Options/VisualStudioSettingsOptionPersister.cs
@@ -32,25 +32,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Options
         private class SVsSettingsPersistenceManager { };
 
         private readonly ISettingsManager? _settingManager;
-        private readonly ILegacyGlobalOptionService _legacyGlobalOptions;
+        private readonly Action<OptionKey2, object?> _refreshOption;
         private readonly ImmutableDictionary<string, Lazy<IVisualStudioStorageReadFallback, OptionNameMetadata>> _readFallbacks;
 
         /// <summary>
-        /// Options that have been been fetched from <see cref="_settingManager"/>, by key. We track this so
-        /// if a later change happens, we know to refresh that value.
+        /// Storage keys that have been been fetched from <see cref="_settingManager"/>.
+        /// We track this so if a later change happens, we know to refresh that value.
         /// </summary>
-        private ImmutableDictionary<string, (OptionKey2 optionKey, Type storageType)> _optionsToMonitorForChanges
-            = ImmutableDictionary<string, (OptionKey2 optionKey, Type storageType)>.Empty;
+        private ImmutableDictionary<string, (OptionKey2 primaryOptionKey, string primaryStorageKey)> _storageKeysToMonitorForChanges
+            = ImmutableDictionary<string, (OptionKey2, string)>.Empty;
 
         /// <remarks>
         /// We make sure this code is from the UI by asking for all <see cref="IOptionPersister"/> in <see cref="RoslynPackage.InitializeAsync"/>
         /// </remarks>
-        public VisualStudioSettingsOptionPersister(ILegacyGlobalOptionService globalOptionService, ImmutableDictionary<string, Lazy<IVisualStudioStorageReadFallback, OptionNameMetadata>> readFallbacks, ISettingsManager? settingsManager)
+        public VisualStudioSettingsOptionPersister(Action<OptionKey2, object?> refreshOption, ImmutableDictionary<string, Lazy<IVisualStudioStorageReadFallback, OptionNameMetadata>> readFallbacks, ISettingsManager? settingsManager)
         {
-            Contract.ThrowIfNull(globalOptionService);
-
             _settingManager = settingsManager;
-            _legacyGlobalOptions = globalOptionService;
+            _refreshOption = refreshOption;
             _readFallbacks = readFallbacks;
 
             // While the settings persistence service should be available in all SKUs it is possible an ISO shell author has undefined the
@@ -65,29 +63,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Options
 
         private Task OnSettingChangedAsync(object sender, PropertyChangedEventArgs args)
         {
-            var storageKey = args.PropertyName;
-            if (_optionsToMonitorForChanges.TryGetValue(storageKey, out var entry))
+            Contract.ThrowIfNull(_settingManager);
+
+            if (_storageKeysToMonitorForChanges.TryGetValue(args.PropertyName, out var entry) &&
+                TryFetch(entry.primaryOptionKey, entry.primaryStorageKey, out var newValue))
             {
-                var optionValue = TryReadOptionValue(entry.optionKey, storageKey, entry.storageType);
-                if (optionValue.HasValue && _legacyGlobalOptions.GlobalOptions.RefreshOption(entry.optionKey, optionValue.Value))
-                {
-                    // We may be updating the values of internally defined public options.
-                    // Update solution snapshots of all workspaces to reflect the new values.
-                    _legacyGlobalOptions.UpdateRegisteredWorkspaces();
-                }
+                _refreshOption(entry.primaryOptionKey, newValue);
             }
 
             return Task.CompletedTask;
         }
 
-        private void RecordObservedValueToWatchForChanges(OptionKey2 optionKey, string storageKey, Type storageType)
-        {
-            ImmutableInterlocked.GetOrAdd(ref _optionsToMonitorForChanges, storageKey, _ => (optionKey, storageType));
-        }
-
         public bool TryFetch(OptionKey2 optionKey, string storageKey, out object? value)
         {
-            var result = TryReadOptionValue(optionKey, storageKey, optionKey.Option.Type);
+            var result = TryReadAndMonitorOptionValue(optionKey, storageKey, storageKey, optionKey.Option.Type, optionKey.Option.DefaultValue);
             if (result.HasValue)
             {
                 value = result.Value;
@@ -96,7 +85,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Options
 
             if (_readFallbacks.TryGetValue(optionKey.Option.Definition.ConfigName, out var lazyReadFallback))
             {
-                var fallbackResult = lazyReadFallback.Value.TryRead(optionKey.Language, (storageKey, storageType) => TryReadOptionValue(optionKey, storageKey, storageType));
+                var fallbackResult = lazyReadFallback.Value.TryRead(
+                    optionKey.Language,
+                    (altStorageKey, altStorageType, altDefaultValue) => TryReadAndMonitorOptionValue(optionKey, storageKey, altStorageKey, altStorageType, altDefaultValue));
+
                 if (fallbackResult.HasValue)
                 {
                     value = fallbackResult.Value;
@@ -108,98 +100,135 @@ namespace Microsoft.VisualStudio.LanguageServices.Options
             return false;
         }
 
-        public Optional<object?> TryReadOptionValue(OptionKey2 optionKey, string storageKey, Type storageType)
+        public Optional<object?> TryReadAndMonitorOptionValue(OptionKey2 primaryOptionKey, string primaryStorageKey, string storageKey, Type storageType, object? defaultValue)
         {
             Contract.ThrowIfNull(_settingManager);
+            ImmutableInterlocked.GetOrAdd(ref _storageKeysToMonitorForChanges, storageKey, _ => (primaryOptionKey, primaryStorageKey));
+            return TryReadOptionValue(_settingManager, storageKey, storageType, defaultValue);
+        }
 
-            RecordObservedValueToWatchForChanges(optionKey, storageKey, storageType);
+        internal static Optional<object?> TryReadOptionValue(ISettingsManager manager, string storageKey, Type storageType, object? defaultValue)
+        {
+            if (storageType == typeof(bool))
+                return Read<bool>();
 
-            if (storageType == typeof(bool) && _settingManager.TryGetValue(storageKey, out bool boolValue) == GetValueResult.Success)
-            {
-                return boolValue;
-            }
+            if (storageType == typeof(string))
+                return Read<string>();
 
-            if (storageType == typeof(bool?) && _settingManager.TryGetValue(storageKey, out bool? nullableBoolValue) == GetValueResult.Success)
-            {
-                return nullableBoolValue;
-            }
+            if (storageType == typeof(int))
+                return Read<int>();
 
-            if (storageType == typeof(int) && _settingManager.TryGetValue(storageKey, out int intValue) == GetValueResult.Success)
-            {
-                return intValue;
-            }
+            if (storageType.IsEnum)
+                return manager.TryGetValue(storageKey, out int value) == GetValueResult.Success ? Enum.ToObject(storageType, value) : default(Optional<object?>);
 
-            if (storageType.IsEnum && _settingManager.TryGetValue(storageKey, out int enumValue) == GetValueResult.Success)
-            {
-                return Enum.ToObject(storageType, enumValue);
-            }
+            var underlyingType = Nullable.GetUnderlyingType(storageType);
+            if (underlyingType?.IsEnum == true)
+                return manager.TryGetValue(storageKey, out int? value) == GetValueResult.Success ? (value.HasValue ? Enum.ToObject(underlyingType, value.Value) : null) : default(Optional<object?>);
 
             if (storageType == typeof(NamingStylePreferences))
             {
-                if (_settingManager.TryGetValue(storageKey, out string stringValue) == GetValueResult.Success)
+                if (manager.TryGetValue(storageKey, out string value) == GetValueResult.Success)
                 {
                     try
                     {
-                        return NamingStylePreferences.FromXElement(XElement.Parse(stringValue));
+                        return NamingStylePreferences.FromXElement(XElement.Parse(value));
                     }
                     catch
                     {
                         return default;
                     }
                 }
+
+                return default;
             }
 
-            if (optionKey.Option.DefaultValue is ICodeStyleOption2 codeStyle)
+            if (defaultValue is ICodeStyleOption2 codeStyle)
             {
-                if (_settingManager.TryGetValue(storageKey, out string stringValue) == GetValueResult.Success)
+                if (manager.TryGetValue(storageKey, out string value) == GetValueResult.Success)
                 {
                     try
                     {
-                        return new Optional<object?>(codeStyle.FromXElement(XElement.Parse(stringValue)));
+                        return new Optional<object?>(codeStyle.FromXElement(XElement.Parse(value)));
                     }
                     catch
                     {
                         return default;
                     }
                 }
+
+                return default;
             }
 
-            if (storageType == typeof(ImmutableArray<string>) && _settingManager.TryGetValue(storageKey, out string[] stringArray) == GetValueResult.Success)
-            {
-                return stringArray.ToImmutableArray();
-            }
+            if (storageType == typeof(long))
+                return Read<long>();
 
-            if (_settingManager.TryGetValue(storageKey, out object? value) == GetValueResult.Success &&
-                (value is null || value.GetType() == storageType))
-            {
-                return value;
-            }
+            if (storageType == typeof(bool?))
+                return Read<bool?>();
 
-            return default;
+            if (storageType == typeof(int?))
+                return Read<int?>();
+
+            if (storageType == typeof(long?))
+                return Read<long?>();
+
+            if (storageType == typeof(ImmutableArray<bool>))
+                return ReadImmutableArray<bool>();
+
+            if (storageType == typeof(ImmutableArray<string>))
+                return ReadImmutableArray<string>();
+
+            if (storageType == typeof(ImmutableArray<int>))
+                return ReadImmutableArray<int>();
+
+            if (storageType == typeof(ImmutableArray<long>))
+                return ReadImmutableArray<long>();
+
+            throw ExceptionUtilities.UnexpectedValue(storageType);
+
+            Optional<object?> Read<T>()
+                => manager.TryGetValue(storageKey, out T value) == GetValueResult.Success ? value : default(Optional<object?>);
+
+            Optional<object?> ReadImmutableArray<T>()
+                => manager.TryGetValue(storageKey, out T[] value) == GetValueResult.Success ? (value is null ? default : value.ToImmutableArray()) : default(Optional<object?>);
         }
 
-        public Task PersistAsync(OptionKey2 optionKey, string storageKey, object? value)
+        public Task PersistAsync(string storageKey, object? value)
         {
             Contract.ThrowIfNull(_settingManager);
-
-            RecordObservedValueToWatchForChanges(optionKey, storageKey, optionKey.Option.Type);
 
             if (value is ICodeStyleOption codeStyleOption)
             {
                 // We store these as strings, so serialize
                 value = codeStyleOption.ToXElement().ToString();
             }
-            else if (optionKey.Option.Type == typeof(NamingStylePreferences))
+            else if (value is NamingStylePreferences namingStyle)
             {
                 // We store these as strings, so serialize
-                if (value is NamingStylePreferences valueToSerialize)
-                {
-                    value = valueToSerialize.CreateXElement().ToString();
-                }
+                value = namingStyle.CreateXElement().ToString();
             }
             else if (value is ImmutableArray<string> stringArray)
             {
                 value = stringArray.IsDefault ? null : stringArray.ToArray();
+            }
+            else if (value is ImmutableArray<bool> boolArray)
+            {
+                value = boolArray.IsDefault ? null : boolArray.ToArray();
+            }
+            else if (value is ImmutableArray<int> intArray)
+            {
+                value = intArray.IsDefault ? null : intArray.ToArray();
+            }
+            else if (value is ImmutableArray<long> longArray)
+            {
+                value = longArray.IsDefault ? null : longArray.ToArray();
+            }
+            else if (value != null)
+            {
+                var type = value.GetType();
+                if (type.IsEnum || Nullable.GetUnderlyingType(type)?.IsEnum == true)
+                {
+                    value = (int)value;
+                }
             }
 
             return _settingManager.SetValueAsync(storageKey, value, isMachineLocal: false);

--- a/src/VisualStudio/Core/Test.Next/Options/VisualStudioSettingsOptionPersisterTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Options/VisualStudioSettingsOptionPersisterTests.cs
@@ -1,0 +1,313 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.VisualStudio.LanguageServices.Options;
+using Microsoft.VisualStudio.LanguageServices.UnitTests;
+using Microsoft.VisualStudio.Settings;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests;
+
+[UseExportProvider]
+public class VisualStudioSettingsOptionPersisterTests
+{
+    private class MockSettingsSubset : ISettingsSubset
+    {
+        public event PropertyChangedAsyncEventHandler? SettingChangedAsync;
+
+        public void TriggerSettingChanged(string storageName)
+            => SettingChangedAsync?.Invoke(this, new PropertyChangedEventArgs(storageName));
+    }
+
+    private class MockSettingsManager : ISettingsManager
+    {
+        public Func<string, Type, (GetValueResult, object?)>? GetValueImpl;
+        public Action<string, object?>? SetValueImpl;
+
+        public readonly MockSettingsSubset Subset = new();
+
+        public ISettingsSubset GetSubset(string namePattern)
+            => Subset;
+
+        public GetValueResult TryGetValue<T>(string name, out T value)
+        {
+            var (result, objValue) = GetValueImpl!(name, typeof(T));
+            value = (result == GetValueResult.Success) ? (T)objValue! : default!;
+            return result;
+        }
+
+        public Task SetValueAsync(string name, object? value, bool isMachineLocal)
+        {
+            SetValueImpl?.Invoke(name, value);
+            return Task.CompletedTask;
+        }
+
+        public ISettingsList GetOrCreateList(string name, bool isMachineLocal)
+            => throw new NotImplementedException();
+
+        public T GetValueOrDefault<T>(string name, T defaultValue = default!)
+            => throw new NotImplementedException();
+
+        public string[] NamesStartingWith(string prefix)
+            => throw new NotImplementedException();
+
+        public void SetOnlineStore(IAsyncStringStorage store)
+            => throw new NotImplementedException();
+
+        public void SetSharedStore(IAsyncStringStorage store)
+            => throw new NotImplementedException();
+    }
+
+    public enum E
+    {
+        A,
+        B
+    }
+
+    private static readonly ImmutableDictionary<string, Lazy<IVisualStudioStorageReadFallback, OptionNameMetadata>> s_noFallbacks =
+        ImmutableDictionary<string, Lazy<IVisualStudioStorageReadFallback, OptionNameMetadata>>.Empty;
+
+    private static readonly NamingStylePreferences s_nonDefaultNamingStylePreferences = OptionsTestHelpers.GetNonDefaultNamingStylePreference();
+
+    private static (object? value, object? storageValue) GetSomeOptionValue(Type optionType)
+        => optionType == typeof(bool) ? (true, true) :
+           optionType == typeof(string) ? ("str", "str") :
+           optionType == typeof(int) ? (1, 1) :
+           optionType == typeof(long) ? (1L, 1L) :
+           optionType == typeof(bool?) ? (true, true) :
+           optionType == typeof(int?) ? (1, 1) :
+           optionType == typeof(long?) ? (1L, 1L) :
+           optionType == typeof(E) ? (E.A, (int)E.A) :
+           optionType == typeof(E?) ? (E.A, (int)E.A) :
+           optionType == typeof(NamingStylePreferences) ? (s_nonDefaultNamingStylePreferences, s_nonDefaultNamingStylePreferences.CreateXElement().ToString()) :
+           optionType == typeof(CodeStyleOption2<bool>) ? (new CodeStyleOption2<bool>(false, NotificationOption2.Warning), new CodeStyleOption2<bool>(false, NotificationOption2.Warning).ToXElement().ToString()) :
+           optionType == typeof(ImmutableArray<bool>) ? (ImmutableArray.Create(true, false), new[] { true, false }) :
+           optionType == typeof(ImmutableArray<int>) ? (ImmutableArray.Create(0, 1), new[] { 0, 1 }) :
+           optionType == typeof(ImmutableArray<long>) ? (ImmutableArray.Create(0L, 1L), new[] { 0L, 1L }) :
+           optionType == typeof(ImmutableArray<string>) ? (ImmutableArray.Create("a", "b"), new[] { "a", "b" }) :
+           throw ExceptionUtilities.UnexpectedValue(optionType);
+
+    private static Type GetStorageType(Type optionType)
+        => optionType.IsEnum ? typeof(int) :
+           (Nullable.GetUnderlyingType(optionType)?.IsEnum == true) ? typeof(int?) :
+           optionType == typeof(NamingStylePreferences) ? typeof(string) :
+           typeof(ICodeStyleOption2).IsAssignableFrom(optionType) ? typeof(string) :
+           optionType == typeof(ImmutableArray<string>) ? typeof(string[]) :
+           optionType == typeof(ImmutableArray<bool>) ? typeof(bool[]) :
+           optionType == typeof(ImmutableArray<int>) ? typeof(int[]) :
+           optionType == typeof(ImmutableArray<long>) ? typeof(long[]) :
+           optionType;
+
+    private static bool IsDefaultImmutableArray(object array)
+        => (bool)array.GetType().GetMethod("get_IsDefault").Invoke(array, Array.Empty<object>())!;
+
+    [Fact]
+    public void SettingsChangeEvent()
+    {
+        var exportProvider = VisualStudioTestCompositions.LanguageServices.ExportProviderFactory.CreateExportProvider();
+        var fallbacks = exportProvider.GetExports<IVisualStudioStorageReadFallback, OptionNameMetadata>().ToImmutableDictionary(item => item.Metadata.ConfigName, item => item);
+
+        var refreshedOptions = new List<(OptionKey2, object?)>();
+        var settingsManager = new MockSettingsManager();
+        var persister = new VisualStudioSettingsOptionPersister((optionKey, newValue) => refreshedOptions.Add((optionKey, newValue)), fallbacks, settingsManager);
+        var optionKey = new OptionKey2(CSharpFormattingOptions2.NewLineBeforeOpenBrace);
+
+        // one flag is set:
+
+        settingsManager.GetValueImpl = (name, type) => name switch
+        {
+            "TextEditor.CSharp.Specific.NewLinesForBracesInAnonymousTypes" => (GetValueResult.Success, false),
+            _ => (GetValueResult.Missing, null),
+        };
+
+        Assert.True(persister.TryFetch(optionKey, "TextEditor.CSharp.Specific.csharp_new_line_before_open_brace", out var value));
+        Assert.Equal(value, CSharpFormattingOptions2.NewLineBeforeOpenBrace.DefaultValue & ~NewLineBeforeOpenBracePlacement.AnonymousTypes);
+
+        // Settings manager receives an option update (e.g. roaming options have been retrieved from online storage) and 
+        // triggers option change event.
+
+        settingsManager.GetValueImpl = (name, type) => name switch
+        {
+            "TextEditor.CSharp.Specific.NewLinesForBracesInMethods" => (GetValueResult.Success, false),
+            _ => (GetValueResult.Missing, null),
+        };
+
+        settingsManager.Subset.TriggerSettingChanged("TextEditor.CSharp.Specific.NewLinesForBracesInMethods");
+
+        Assert.Equal((optionKey, CSharpFormattingOptions2.NewLineBeforeOpenBrace.DefaultValue & ~NewLineBeforeOpenBracePlacement.Methods), refreshedOptions.Single());
+        refreshedOptions.Clear();
+
+        // Settings manager receives another option update -- the primary option is set now
+
+        settingsManager.GetValueImpl = (name, type) => name switch
+        {
+            "TextEditor.CSharp.Specific.csharp_new_line_before_open_brace" => (GetValueResult.Success, NewLineBeforeOpenBracePlacement.Accessors | NewLineBeforeOpenBracePlacement.LambdaExpressionBody),
+            "TextEditor.CSharp.Specific.NewLinesForBracesInAnonymousTypes" => (GetValueResult.Success, false),
+            "TextEditor.CSharp.Specific.NewLinesForBracesInMethods" => (GetValueResult.Success, true),
+            _ => (GetValueResult.Missing, null),
+        };
+
+        settingsManager.Subset.TriggerSettingChanged("TextEditor.CSharp.Specific.csharp_new_line_before_open_brace");
+
+        Assert.Equal((optionKey, NewLineBeforeOpenBracePlacement.Accessors | NewLineBeforeOpenBracePlacement.LambdaExpressionBody), refreshedOptions.Single());
+        refreshedOptions.Clear();
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void SettingsManagerReadOptionValue_Success(
+        [CombinatorialValues(
+            typeof(bool),
+            typeof(string),
+            typeof(int),
+            typeof(long),
+            typeof(bool?),
+            typeof(int?),
+            typeof(long?),
+            typeof(E),
+            typeof(E?),
+            typeof(CodeStyleOption2<bool>),
+            typeof(NamingStylePreferences),
+            typeof(ImmutableArray<bool>),
+            typeof(ImmutableArray<int>),
+            typeof(ImmutableArray<long>),
+            typeof(ImmutableArray<string>))]
+        Type optionType)
+    {
+        var (optionValue, storageValue) = GetSomeOptionValue(optionType);
+        var defaultValue = OptionsTestHelpers.GetDifferentValue(optionType, optionValue);
+
+        var mockManager = new MockSettingsManager()
+        {
+            GetValueImpl = (_, _) => (GetValueResult.Success, storageValue)
+        };
+
+        var result = VisualStudioSettingsOptionPersister.TryReadOptionValue(mockManager, "key", optionType, defaultValue);
+        Assert.True(result.HasValue);
+        Assert.Equal(optionValue, result.Value);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    public void SettingsManagerReadOptionValue_Error(
+        [CombinatorialValues(
+            GetValueResult.Missing,
+            GetValueResult.IncompatibleType,
+            GetValueResult.ObsoleteFormat,
+            GetValueResult.UnknownError,
+            GetValueResult.Corrupt)]
+        GetValueResult specializedTypeResult,
+        [CombinatorialValues(
+            typeof(bool),
+            typeof(string),
+            typeof(int),
+            typeof(long),
+            typeof(bool?),
+            typeof(int?),
+            typeof(long?),
+            typeof(E),
+            typeof(E?),
+            typeof(CodeStyleOption2<bool>),
+            typeof(NamingStylePreferences),
+            typeof(ImmutableArray<bool>),
+            typeof(ImmutableArray<int>),
+            typeof(ImmutableArray<long>),
+            typeof(ImmutableArray<string>))]
+        Type optionType)
+    {
+        var (optionValue, storageValue) = GetSomeOptionValue(optionType);
+        var storageType = GetStorageType(optionType);
+
+        var mockManager = new MockSettingsManager()
+        {
+            GetValueImpl = (_, type) => (type == storageType ? specializedTypeResult : GetValueResult.Success, storageValue)
+        };
+
+        var result = VisualStudioSettingsOptionPersister.TryReadOptionValue(mockManager, "key", optionType, optionValue);
+
+        // we should not fall back to object if the manager tells us bool value is missing or invalid in any way:
+        Assert.False(result.HasValue);
+    }
+
+    [Theory]
+    [InlineData(typeof(ImmutableArray<bool>))]
+    [InlineData(typeof(ImmutableArray<int>))]
+    [InlineData(typeof(ImmutableArray<long>))]
+    [InlineData(typeof(ImmutableArray<string>))]
+    public void Roundtrip_DefaultImmutableArray(Type type)
+    {
+        var defaultArray = Activator.CreateInstance(type);
+        var serializedValue = (object?)null;
+
+        Optional<object?> newValue = default;
+
+        var mockManager = new MockSettingsManager()
+        {
+            GetValueImpl = (_, _) => (GetValueResult.Success, serializedValue),
+            SetValueImpl = (name, value) => newValue = value
+        };
+
+        // read
+        var result = VisualStudioSettingsOptionPersister.TryReadOptionValue(mockManager, "key", type, defaultValue: null);
+        Assert.True(result.HasValue);
+        Assert.True(IsDefaultImmutableArray(result.Value!));
+
+        // write
+        var persister = new VisualStudioSettingsOptionPersister((_, _) => { }, s_noFallbacks, mockManager);
+        persister.PersistAsync("key", defaultArray).Wait();
+
+        Assert.True(newValue.HasValue);
+        Assert.Equal(serializedValue, newValue.Value);
+    }
+
+    public static IEnumerable<object?[]> GetRoundtripTestCases()
+    {
+        var value1 = new CodeStyleOption2<int>(1, NotificationOption2.Warning);
+        yield return new object?[] { value1, value1.ToXElement().ToString(), new CodeStyleOption2<int>(0, NotificationOption2.None), typeof(CodeStyleOption2<int>) };
+
+        var value2 = s_nonDefaultNamingStylePreferences;
+        yield return new object?[] { value2, value2.CreateXElement().ToString(), NamingStylePreferences.Empty, typeof(NamingStylePreferences) };
+
+        yield return new object?[] { E.B, (int)E.B, E.B, typeof(E) };
+        yield return new object?[] { null, null, E.B, typeof(E?) };
+        yield return new object?[] { (E?)E.B, (int?)E.B, E.B, typeof(E?) };
+    }
+
+    [Theory]
+    [MemberData(nameof(GetRoundtripTestCases))]
+    public void Roundtrip(object? value, object? serializedValue, object defaultValue, Type type)
+    {
+        Optional<object?> newValue = default;
+
+        var mockManager = new MockSettingsManager()
+        {
+            GetValueImpl = (_, _) => (GetValueResult.Success, serializedValue),
+            SetValueImpl = (name, value) => newValue = value
+        };
+
+        // read
+        var result = VisualStudioSettingsOptionPersister.TryReadOptionValue(mockManager, "key", type, defaultValue);
+        Assert.True(result.HasValue);
+        Assert.Equal(value, result.Value);
+
+        // write
+        var persister = new VisualStudioSettingsOptionPersister((_, _) => { }, s_noFallbacks, mockManager);
+        persister.PersistAsync("key", value).Wait();
+
+        Assert.True(newValue.HasValue);
+        Assert.Equal(serializedValue, newValue.Value);
+    }
+}

--- a/src/VisualStudio/Core/Test.Next/Options/VisualStudioStorageReadFallbackTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Options/VisualStudioStorageReadFallbackTests.cs
@@ -18,27 +18,47 @@ public class VisualStudioStorageReadFallbackTests
     public void SpaceBetweenParentheses()
     {
         var exportProvider = VisualStudioTestCompositions.LanguageServices.ExportProviderFactory.CreateExportProvider();
-        var export = exportProvider.GetExports<IVisualStudioStorageReadFallback, OptionNameMetadata>().Single(export => export.Metadata.ConfigName == "csharp_space_between_parentheses");
+        var fallback = exportProvider.GetExports<IVisualStudioStorageReadFallback, OptionNameMetadata>().Single(export => export.Metadata.ConfigName == "csharp_space_between_parentheses").Value;
         string? language = null;
 
-        // if no flags are set the result should be default:
-        Assert.Equal(default(Optional<object?>), export.Value.TryRead(language, (storageKey, storageType) => default(Optional<object?>)));
+        // if no flags are set the result should be "missing":
+        Assert.Equal(default(Optional<object?>), fallback.TryRead(language, (_, _, _) => default(Optional<object?>)));
 
         // all flags set:
-        Assert.Equal(export.Value.TryRead(language, (storageKey, storageType) => true).Value, SpacePlacementWithinParentheses.All);
+        Assert.Equal(fallback.TryRead(language, (_, _, _) => true).Value, SpacePlacementWithinParentheses.All);
+
+        // one flag present in storage (false), defaults used for others:
+        Assert.Equal(
+            fallback.TryRead(language, (storageKey, _, _) => storageKey == "TextEditor.CSharp.Specific.SpaceWithinExpressionParentheses" ? false : default(Optional<object?>)).Value,
+            CSharpFormattingOptions2.SpaceBetweenParentheses.DefaultValue & ~SpacePlacementWithinParentheses.Expressions);
+
+        // one flag present in storage (true), defaults used for others:
+        Assert.Equal(
+            fallback.TryRead(language, (storageKey, _, _) => storageKey == "TextEditor.CSharp.Specific.SpaceWithinExpressionParentheses" ? true : default(Optional<object?>)).Value,
+            CSharpFormattingOptions2.SpaceBetweenParentheses.DefaultValue | SpacePlacementWithinParentheses.Expressions);
     }
 
     [Fact]
     public void NewLinesForBraces()
     {
         var exportProvider = VisualStudioTestCompositions.LanguageServices.ExportProviderFactory.CreateExportProvider();
-        var export = exportProvider.GetExports<IVisualStudioStorageReadFallback, OptionNameMetadata>().Single(export => export.Metadata.ConfigName == "csharp_new_line_before_open_brace");
+        var fallback = exportProvider.GetExports<IVisualStudioStorageReadFallback, OptionNameMetadata>().Single(export => export.Metadata.ConfigName == "csharp_new_line_before_open_brace").Value;
         string? language = null;
 
-        // if no flags are set the result should be default:
-        Assert.Equal(default(Optional<object?>), export.Value.TryRead(language, (storageKey, storageType) => default(Optional<object?>)));
+        // if no flags are set the result should be "missing":
+        Assert.Equal(default(Optional<object?>), fallback.TryRead(language, (_, _, _) => default(Optional<object?>)));
 
         // all flags set:
-        Assert.Equal(export.Value.TryRead(language, (storageKey, storageType) => true).Value, NewLineBeforeOpenBracePlacement.All);
+        Assert.Equal(fallback.TryRead(language, (_, _, _) => true).Value, NewLineBeforeOpenBracePlacement.All);
+
+        // one flag present in storage (false), defaults used for others:
+        Assert.Equal(
+            fallback.TryRead(language, (storageKey, _, _) => storageKey == "TextEditor.CSharp.Specific.NewLinesForBracesInObjectCollectionArrayInitializers" ? false : default(Optional<object?>)).Value,
+            CSharpFormattingOptions2.NewLineBeforeOpenBrace.DefaultValue & ~NewLineBeforeOpenBracePlacement.ObjectCollectionArrayInitializers);
+
+        // one flag present in storage (true), defaults used for others:
+        Assert.Equal(
+            fallback.TryRead(language, (storageKey, _, _) => storageKey == "TextEditor.CSharp.Specific.NewLinesForBracesInObjectCollectionArrayInitializers" ? true : default(Optional<object?>)).Value,
+            CSharpFormattingOptions2.NewLineBeforeOpenBrace.DefaultValue | NewLineBeforeOpenBracePlacement.ObjectCollectionArrayInitializers);
     }
 }

--- a/src/VisualStudio/IntegrationTest/New.IntegrationTests/Options/GlobalOptionsTest.cs
+++ b/src/VisualStudio/IntegrationTest/New.IntegrationTests/Options/GlobalOptionsTest.cs
@@ -6,7 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Options;
@@ -40,6 +42,8 @@ public sealed class GlobalOptionsTest : AbstractIntegrationTest
         var allLanguages = new[] { LanguageNames.CSharp, LanguageNames.VisualBasic };
         var noLanguages = new[] { (string?)null };
 
+        var vsVersion = await TestServices.Shell.GetVersionAsync(CancellationToken.None);
+
         foreach (var (configName, optionInfo) in optionsInfo)
         {
             var option = optionInfo.Option;
@@ -70,6 +74,15 @@ public sealed class GlobalOptionsTest : AbstractIntegrationTest
                 if (storage is VisualStudioOptionStorage.FeatureFlagStorage)
                 {
                     Assert.True(currentValue is bool);
+                    continue;
+                }
+
+                // TODO: Remove once test machines move to 17.6 Preview 1.
+                // Skip nullable types to avoid hitting https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1718326
+                if (vsVersion < new Version(17, 6) &&
+                    storage is VisualStudioOptionStorage.RoamingProfileStorage &&
+                    Nullable.GetUnderlyingType(option.Type) != null)
+                {
                     continue;
                 }
 

--- a/src/Workspaces/CoreTestUtilities/Options/OptionsTestHelpers.cs
+++ b/src/Workspaces/CoreTestUtilities/Options/OptionsTestHelpers.cs
@@ -123,6 +123,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 _ when type == typeof(int) => (int)value! == 0 ? 1 : 0,
                 _ when type == typeof(long) => (long)value! == 0 ? 1L : 0L,
                 _ when type.IsEnum => GetDifferentEnumValue(type, value!),
+                _ when Nullable.GetUnderlyingType(type)?.IsEnum == true => value is null ? Enum.ToObject(Nullable.GetUnderlyingType(type)!, 1) : null,
                 ICodeStyleOption codeStyle => codeStyle
                     .WithValue(GetDifferentValue(codeStyle.GetType().GetGenericArguments()[0], codeStyle.Value!)!)
                     .WithNotification((codeStyle.Notification == NotificationOption2.Error) ? NotificationOption2.Warning : NotificationOption2.Error),
@@ -144,28 +145,6 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var zero = Enum.ToObject(type, 0);
             return defaultValue.Equals(zero) ? Enum.ToObject(type, 1) : zero;
         }
-
-        /// <summary>
-        /// True if the type is a type of an option value.
-        /// </summary>
-        public static bool IsOptionValueType(Type type)
-            => type == typeof(bool) ||
-               type == typeof(string) ||
-               type == typeof(int) ||
-               type == typeof(long) ||
-               type == typeof(bool?) ||
-               type == typeof(int?) ||
-               type == typeof(long?) ||
-               type.IsEnum ||
-               typeof(ICodeStyleOption).IsAssignableFrom(type) ||
-               type == typeof(NamingStylePreferences) ||
-               type == typeof(ImmutableArray<bool>) ||
-               type == typeof(ImmutableArray<string>) ||
-               type == typeof(ImmutableArray<int>) ||
-               type == typeof(ImmutableArray<long>);
-
-        public static Type GetNonNullableType(Type type)
-            => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>) ? type.GetGenericArguments()[0] : type;
 
         public static NamingStylePreferences GetNonDefaultNamingStylePreference()
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/OptionDefinition.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Options/OptionDefinition.cs
@@ -3,9 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.CodeStyle;
-using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
 
 namespace Microsoft.CodeAnalysis.Options
 {
@@ -47,6 +48,8 @@ namespace Microsoft.CodeAnalysis.Options
             StorageMapping = storageMapping;
             IsEditorConfigOption = isEditorConfigOption;
             DefaultValue = defaultValue;
+
+            Debug.Assert(IsSupportedOptionType(Type));
         }
 
         /// <summary>
@@ -75,6 +78,23 @@ namespace Microsoft.CodeAnalysis.Options
 
         public static bool operator !=(OptionDefinition? left, OptionDefinition? right)
             => !(left == right);
+
+        public static bool IsSupportedOptionType(Type type)
+            => type == typeof(bool) ||
+               type == typeof(string) ||
+               type == typeof(int) ||
+               type == typeof(long) ||
+               type == typeof(bool?) ||
+               type == typeof(int?) ||
+               type == typeof(long?) ||
+               type.IsEnum ||
+               Nullable.GetUnderlyingType(type)?.IsEnum == true ||
+               typeof(ICodeStyleOption).IsAssignableFrom(type) ||
+               type == typeof(NamingStylePreferences) ||
+               type == typeof(ImmutableArray<bool>) ||
+               type == typeof(ImmutableArray<string>) ||
+               type == typeof(ImmutableArray<int>) ||
+               type == typeof(ImmutableArray<long>);
     }
 
     internal sealed class OptionDefinition<T> : OptionDefinition


### PR DESCRIPTION
Fixes a couple of issues, hardens the implementation and adds more test coverage.

The first [issue](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1751694) is that when reading fallback option flags we have not used the default values for flags that were not stored in the VS settings storage if there was at least one flag that was stored. As a result these flags defaulted to 0, which was incorrect for new lines after braces options.

The second [issue](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1751694) occurred when VS settings manager sync'd options from online storage and triggered option change event. We read incorrect value of the option (individual bool flag, instead of combined flag enum) and stored it in the global options, which later resulted in InvalidCastException.

Fixes [AB#1751694](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1751694).
Fixes [AB#1743163](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1743163).
