### PR TITLE
[Lightbulb Perf] Improve the caching logic in OOP DiagnosticComputer

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticAnalyzerServiceTests.cs
@@ -1064,9 +1064,8 @@ class A
             var project = workspace.CurrentSolution.Projects.Single();
             var document = documentAnalysis ? project.Documents.Single() : null;
             var ideAnalyzerOptions = IdeAnalyzerOptions.GetDefault(project.Services);
-            var checksum = await workspace.CurrentSolution.State.GetChecksumAsync(CancellationToken.None);
             var diagnosticsMapResults = await DiagnosticComputer.GetDiagnosticsAsync(
-                document, project, checksum, ideAnalyzerOptions, span: null, analyzerIdsToRequestDiagnostics,
+                document, project, Checksum.Null, ideAnalyzerOptions, span: null, analyzerIdsToRequestDiagnostics,
                 AnalysisKind.Semantic, new DiagnosticAnalyzerInfoCache(), workspace.Services,
                 reportSuppressedDiagnostics: false, logPerformanceInfo: false, getTelemetryInfo: false,
                 cancellationToken: CancellationToken.None);
@@ -1114,14 +1113,13 @@ class A
 
             var ideAnalyzerOptions = IdeAnalyzerOptions.GetDefault(project.Services);
             var kind = actionKind == AnalyzerRegisterActionKind.SyntaxTree ? AnalysisKind.Syntax : AnalysisKind.Semantic;
-            var checksum = await workspace.CurrentSolution.State.GetChecksumAsync(CancellationToken.None);
             var analyzerIds = new[] { analyzer.GetAnalyzerId() };
 
             // First invoke analysis with cancellation token, and verify canceled compilation and no reported diagnostics.
             Assert.Empty(analyzer.CanceledCompilations);
             try
             {
-                _ = await DiagnosticComputer.GetDiagnosticsAsync(document, project, checksum, ideAnalyzerOptions, span: null,
+                _ = await DiagnosticComputer.GetDiagnosticsAsync(document, project, Checksum.Null, ideAnalyzerOptions, span: null,
                     analyzerIds, kind, diagnosticAnalyzerInfoCache, workspace.Services, reportSuppressedDiagnostics: false,
                     logPerformanceInfo: false, getTelemetryInfo: false, cancellationToken: analyzer.CancellationToken);
 
@@ -1134,7 +1132,7 @@ class A
             Assert.Single(analyzer.CanceledCompilations);
 
             // Then invoke analysis without cancellation token, and verify non-cancelled diagnostic.
-            var diagnosticsMap = await DiagnosticComputer.GetDiagnosticsAsync(document, project, checksum, ideAnalyzerOptions, span: null,
+            var diagnosticsMap = await DiagnosticComputer.GetDiagnosticsAsync(document, project, Checksum.Null, ideAnalyzerOptions, span: null,
                 analyzerIds, kind, diagnosticAnalyzerInfoCache, workspace.Services, reportSuppressedDiagnostics: false,
                 logPerformanceInfo: false, getTelemetryInfo: false, cancellationToken: CancellationToken.None);
             var builder = diagnosticsMap.Diagnostics.Single().diagnosticMap;

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/DiagnosticComputer.cs
@@ -36,11 +36,12 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
         /// each project in the solution, as the CWT does not seem to drop entries until ForceGC happens, leading to significant memory
         /// pressure when there are large number of open documents across different projects to be analyzed by background analysis.
         /// </summary>
-        private static readonly WeakReference<CompilationWithAnalyzersCacheEntry?> s_compilationWithAnalyzersCache = new(null);
+        private static CompilationWithAnalyzersCacheEntry? s_compilationWithAnalyzersCache = null;
         private static readonly object s_gate = new();
 
         private readonly TextDocument? _document;
         private readonly Project _project;
+        private readonly Checksum _solutionChecksum;
         private readonly IdeAnalyzerOptions _ideOptions;
         private readonly TextSpan? _span;
         private readonly AnalysisKind? _analysisKind;
@@ -48,9 +49,10 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
         private readonly DiagnosticAnalyzerInfoCache _analyzerInfoCache;
         private readonly HostWorkspaceServices _hostWorkspaceServices;
 
-        public DiagnosticComputer(
+        private DiagnosticComputer(
             TextDocument? document,
             Project project,
+            Checksum solutionChecksum,
             IdeAnalyzerOptions ideOptions,
             TextSpan? span,
             AnalysisKind? analysisKind,
@@ -59,6 +61,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
         {
             _document = document;
             _project = project;
+            _solutionChecksum = solutionChecksum;
             _ideOptions = ideOptions;
             _span = span;
             _analysisKind = analysisKind;
@@ -67,7 +70,48 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             _performanceTracker = project.Solution.Services.GetService<IPerformanceTrackerService>();
         }
 
-        public async Task<SerializableDiagnosticAnalysisResults> GetDiagnosticsAsync(
+        public static Task<SerializableDiagnosticAnalysisResults> GetDiagnosticsAsync(
+            TextDocument? document,
+            Project project,
+            Checksum solutionChecksum,
+            IdeAnalyzerOptions ideOptions,
+            TextSpan? span,
+            IEnumerable<string> analyzerIds,
+            AnalysisKind? analysisKind,
+            DiagnosticAnalyzerInfoCache analyzerInfoCache,
+            HostWorkspaceServices hostWorkspaceServices,
+            bool reportSuppressedDiagnostics,
+            bool logPerformanceInfo,
+            bool getTelemetryInfo,
+            CancellationToken cancellationToken)
+        {
+            // PERF: Due to the concept of InFlight solution snapshots in OOP process, we might have been
+            //       handed a Project instance that does not match the Project instance corresponding to our
+            //       cached CompilationWithAnalyzers instance, while the underlying Solution checksum matches
+            //       for our cached entry and the incoming request.
+            //       We detect this case upfront here and re-use the cached CompilationWithAnalyzers and Project
+            //       instance for diagnostic computation, thus improving the performance of analyzer execution.
+            //       This is an important performance optimization for lightbulb diagnostic computation.
+            //       See https://github.com/dotnet/roslyn/issues/66968 for details.
+            lock (s_gate)
+            {
+                if (s_compilationWithAnalyzersCache != null &&
+                    s_compilationWithAnalyzersCache.SolutionChecksum == solutionChecksum &&
+                    s_compilationWithAnalyzersCache.Project.Id == project.Id &&
+                    s_compilationWithAnalyzersCache.Project != project)
+                {
+                    project = s_compilationWithAnalyzersCache.Project;
+                    if (document != null)
+                        document = project.GetTextDocument(document.Id);
+                }
+            }
+
+            var diagnosticsComputer = new DiagnosticComputer(document, project,
+                solutionChecksum, ideOptions, span, analysisKind, analyzerInfoCache, hostWorkspaceServices);
+            return diagnosticsComputer.GetDiagnosticsAsync(analyzerIds, reportSuppressedDiagnostics, logPerformanceInfo, getTelemetryInfo, cancellationToken);
+        }
+
+        private async Task<SerializableDiagnosticAnalysisResults> GetDiagnosticsAsync(
             IEnumerable<string> analyzerIds,
             bool reportSuppressedDiagnostics,
             bool logPerformanceInfo,
@@ -90,25 +134,8 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
 
             var skippedAnalyzersInfo = _project.GetSkippedAnalyzersInfo(_analyzerInfoCache);
 
-            try
-            {
-                return await AnalyzeAsync(compilationWithAnalyzers, analyzerToIdMap, analyzers, skippedAnalyzersInfo,
-                    reportSuppressedDiagnostics, logPerformanceInfo, getTelemetryInfo, cancellationToken).ConfigureAwait(false);
-            }
-            catch
-            {
-                // Do not re-use cached CompilationWithAnalyzers instance in presence of an exception, as the underlying analysis state might be corrupt.
-                lock (s_gate)
-                {
-                    if (s_compilationWithAnalyzersCache.TryGetTarget(out var target) &&
-                        target?.Project == _project)
-                    {
-                        s_compilationWithAnalyzersCache.SetTarget(null);
-                    }
-                }
-
-                throw;
-            }
+            return await AnalyzeAsync(compilationWithAnalyzers, analyzerToIdMap, analyzers, skippedAnalyzersInfo,
+                reportSuppressedDiagnostics, logPerformanceInfo, getTelemetryInfo, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<SerializableDiagnosticAnalysisResults> AnalyzeAsync(
@@ -248,10 +275,11 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
 
                 lock (s_gate)
                 {
-                    if (s_compilationWithAnalyzersCache.TryGetTarget(out var target) &&
-                        target?.Project == _project)
+                    if (s_compilationWithAnalyzersCache != null &&
+                        s_compilationWithAnalyzersCache.SolutionChecksum == _solutionChecksum &&
+                        s_compilationWithAnalyzersCache.Project == _project)
                     {
-                        return target;
+                        return s_compilationWithAnalyzersCache;
                     }
                 }
 
@@ -259,7 +287,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
 
                 lock (s_gate)
                 {
-                    s_compilationWithAnalyzersCache.SetTarget(entry);
+                    s_compilationWithAnalyzersCache = entry;
                 }
 
                 return entry;
@@ -291,7 +319,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             var compilationWithAnalyzers = await CreateCompilationWithAnalyzerAsync(analyzerBuilder.ToImmutable(), cancellationToken).ConfigureAwait(false);
             var analyzerToIdMap = new BidirectionalMap<string, DiagnosticAnalyzer>(analyzerMapBuilder);
 
-            return new CompilationWithAnalyzersCacheEntry(_project, compilationWithAnalyzers, analyzerToIdMap);
+            return new CompilationWithAnalyzersCacheEntry(_solutionChecksum, _project, compilationWithAnalyzers, analyzerToIdMap);
         }
 
         private async Task<CompilationWithAnalyzers> CreateCompilationWithAnalyzerAsync(ImmutableArray<DiagnosticAnalyzer> analyzers, CancellationToken cancellationToken)
@@ -324,12 +352,14 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
 
         private sealed class CompilationWithAnalyzersCacheEntry
         {
+            public Checksum SolutionChecksum { get; }
             public Project Project { get; }
             public CompilationWithAnalyzers CompilationWithAnalyzers { get; }
             public BidirectionalMap<string, DiagnosticAnalyzer> AnalyzerToIdMap { get; }
 
-            public CompilationWithAnalyzersCacheEntry(Project project, CompilationWithAnalyzers compilationWithAnalyzers, BidirectionalMap<string, DiagnosticAnalyzer> analyzerToIdMap)
+            public CompilationWithAnalyzersCacheEntry(Checksum solutionChecksum, Project project, CompilationWithAnalyzers compilationWithAnalyzers, BidirectionalMap<string, DiagnosticAnalyzer> analyzerToIdMap)
             {
+                SolutionChecksum = solutionChecksum;
                 Project = project;
                 CompilationWithAnalyzers = compilationWithAnalyzers;
                 AnalyzerToIdMap = analyzerToIdMap;

--- a/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/DiagnosticAnalyzer/RemoteDiagnosticAnalyzerService.cs
@@ -73,10 +73,12 @@ namespace Microsoft.CodeAnalysis.Remote
                         var documentSpan = arguments.DocumentSpan;
                         var documentAnalysisKind = arguments.DocumentAnalysisKind;
                         var hostWorkspaceServices = this.GetWorkspace().Services;
-                        var diagnosticComputer = new DiagnosticComputer(document, project, arguments.IdeOptions, documentSpan, documentAnalysisKind, _analyzerInfoCache, hostWorkspaceServices);
 
-                        var result = await diagnosticComputer.GetDiagnosticsAsync(
-                            arguments.AnalyzerIds,
+                        var result = await DiagnosticComputer.GetDiagnosticsAsync(
+                            document, project, solutionChecksum,
+                            arguments.IdeOptions, documentSpan,
+                            arguments.AnalyzerIds, documentAnalysisKind,
+                            _analyzerInfoCache, hostWorkspaceServices,
                             reportSuppressedDiagnostics: arguments.ReportSuppressedDiagnostics,
                             logPerformanceInfo: arguments.LogPerformanceInfo,
                             getTelemetryInfo: arguments.GetTelemetryInfo,


### PR DESCRIPTION
Addresses part of #66968

Due to the concept of InFlight solution snapshots in OOP process, the DiagnosticComputer might be handed a Project instance that does not match the Project instance corresponding to the cached CompilationWithAnalyzers instance in the computer, while the underlying Solution checksum matches for the cached entry and the incoming request. We now detect this case upfront in the OOP DiagnosticComputer and re-use the cached CompilationWithAnalyzers and Project for this case, thus improving the performance of analyzer execution in OOP. This change seems to give a noticeable performance improvement for lightbulb diagnostic computation in OOP.

# Performance measurements

## OutOfProc

### Current PR Branch

**0.25-0.5 progress bar cycles**

![OutOfProc_Latest_PRBranch_LightBulb_Perf](https://user-images.githubusercontent.com/10605811/221554862-31493305-c267-4dcf-b432-b3b1cb5472f2.gif)

### Main Branch

**1-1.5 progress bar cycles**

![OutOfProc_Latest_MainBranch_LightBulb_Perf](https://user-images.githubusercontent.com/10605811/221555042-7cfd48e1-5491-4294-a4d9-ae3978161135.gif)

### 17.5 GA

**3-4 progress bar cycles**

![17_5_GA_LightBulb_Perf](https://user-images.githubusercontent.com/10605811/221555140-39d0224d-d48d-40f9-ad5b-e0cbfd88d675.gif)

## InProc

### Current PR Branch

**Almost instantaneous (this our final target experience with OutOfProc)**

![InProc_Latest_PRBranch_LightBulb_Perf](https://user-images.githubusercontent.com/10605811/221555284-2c5c64cd-0636-44e7-8cd5-9325a860fac1.gif)

