### PR TITLE
Exclude CSharp.EditorFeature from vs_perf_designtime_ide_searchtest

### DIFF
--- a/eng/config/OptProf.json
+++ b/eng/config/OptProf.json
@@ -182,7 +182,7 @@
             },
             {
               "filename": "/Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll",
-              "testCases":[ "VSPE.OptProfTests.vs_asl_cs_scenario", "VSPE.OptProfTests.vs_perf_designtime_editor_intellisense_globalcompletionlist_cs", "VSPE.OptProfTests.vs_perf_designtime_ide_searchtest", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Typing", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
+              "testCases":[ "VSPE.OptProfTests.vs_asl_cs_scenario", "VSPE.OptProfTests.vs_perf_designtime_editor_intellisense_globalcompletionlist_cs", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Typing", "VSPE.OptProfTests.DDRIT_RPS_ManagedLangs_Debug" ]
             },
             {
               "filename": "/Microsoft.CodeAnalysis.Features.dll",


### PR DESCRIPTION
Fixes [AB#1717263](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1717263)
Probably caused by options related changes in #66069. This assembly should still have sufficient coverage from other tests