### PR TITLE
Bump up priority for formatting analyzer

### DIFF
--- a/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer_Core.cs
+++ b/src/Analyzers/Core/Analyzers/AbstractBuiltInCodeStyleDiagnosticAnalyzer_Core.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             Debug.Assert(!supportedDiagnostics.Any(descriptor => descriptor.CustomTags.Any(t => t == WellKnownDiagnosticTags.Unnecessary)) || this is AbstractBuiltInUnnecessaryCodeStyleDiagnosticAnalyzer);
         }
 
-        public CodeActionRequestPriority RequestPriority => CodeActionRequestPriority.Normal;
+        public virtual CodeActionRequestPriority RequestPriority => CodeActionRequestPriority.Normal;
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
 
         protected static DiagnosticDescriptor CreateDescriptorWithId(

--- a/src/Analyzers/Core/Analyzers/Formatting/AbstractFormattingAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/Formatting/AbstractFormattingAnalyzer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
 
@@ -28,6 +29,13 @@ namespace Microsoft.CodeAnalysis.CodeStyle
 
         protected sealed override void InitializeWorker(AnalysisContext context)
             => context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
+
+        /// <summary>
+        /// Fixing formatting is high priority.  It's something the user wants to be able to fix quickly, is driven by
+        /// them acting on an error reported in code, and can be computed fast as it only uses syntax not semantics.
+        /// It's also the 8th most common fix that people use, and is picked almost all the times it is shown.
+        /// </summary>
+        public override CodeActionRequestPriority RequestPriority => CodeActionRequestPriority.High;
 
         private void AnalyzeSyntaxTree(SyntaxTreeAnalysisContext context)
         {


### PR DESCRIPTION
Follow-up change to #67058. We also trim down the analyzers to run for each code action priority bucket, so the analyzer priority needs to match the fixer priority. I'll add a unit test in a follow-up PR to verify that all our analyzer/fixer pairs have matching priority.

https://github.com/dotnet/roslyn/blob/6c98e5cb10876d820d74c3eca9a43ef5592b0251/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs#L404-L424