### PR TITLE
Fix utf8 classification

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -355,7 +355,7 @@ partial interface T3
         {
             await TestInMethodAsync(@"@""goo""u8",
                 testHost,
-                Verbatim(@"@""goo""u8"),
+                Verbatim(@"@""goo"""),
                 Keyword("u8"));
         }
 
@@ -365,7 +365,7 @@ partial interface T3
         {
             await TestInMethodAsync(@"@""goo""U8",
                 testHost,
-                Verbatim(@"@""goo""U8"),
+                Verbatim(@"@""goo"""),
                 Keyword("U8"));
         }
 
@@ -446,7 +446,7 @@ more stuff";
                 testHost,
                 Verbatim(@"@"" goo bar
 and 
-on a new line ""u8"),
+on a new line """),
                 Keyword("u8"),
                 Identifier("more"),
                 Local("stuff"));
@@ -466,7 +466,7 @@ more stuff";
                 testHost,
                 Verbatim(@"@"" goo bar
 and 
-on a new line ""U8"),
+on a new line """),
                 Keyword("U8"),
                 Identifier("more"),
                 Local("stuff"));
@@ -508,7 +508,7 @@ on a new line ""U8"),
                 Keyword("string"),
                 script ? Field("s") : Local("s"),
                 Operators.Equals,
-                Verbatim(@"@""""""/*""u8"),
+                Verbatim(@"@""""""/*"""),
                 Keyword("u8"),
                 Punctuation.Semicolon);
         }
@@ -529,7 +529,7 @@ on a new line ""U8"),
                 Keyword("string"),
                 script ? Field("s") : Local("s"),
                 Operators.Equals,
-                Verbatim(@"@""""""/*""u8"),
+                Verbatim(@"@""""""/*"""),
                 Keyword("u8"),
                 Punctuation.Semicolon);
         }
@@ -549,7 +549,7 @@ on a new line ""U8"),
         {
             await TestAsync(@"""goo""u8",
                 testHost,
-                String(@"""goo""u8"),
+                String(@"""goo"""),
                 Keyword("u8"));
         }
 
@@ -559,7 +559,7 @@ on a new line ""U8"),
         {
             await TestAsync(@"""goo""U8",
                 testHost,
-                String(@"""goo""U8"),
+                String(@"""goo"""),
                 Keyword("U8"));
         }
 
@@ -578,7 +578,7 @@ on a new line ""U8"),
         {
             await TestAsync(@"""""u8",
                 testHost,
-                String(@"""""u8"),
+                String(@""""""),
                 Keyword("u8"));
         }
 
@@ -588,7 +588,7 @@ on a new line ""U8"),
         {
             await TestAsync(@"""""U8",
                 testHost,
-                String(@"""""U8"),
+                String(@""""""),
                 Keyword("U8"));
         }
 
@@ -6005,7 +6005,7 @@ class C
                 Keyword("var"),
                 Local("s"),
                 Operators.Equals,
-                String("\"\"\"Hello world\"\"\"u8"),
+                String("\"\"\"Hello world\"\"\""),
                 Keyword("u8"),
                 Punctuation.Semicolon,
                 Punctuation.CloseCurly,
@@ -6043,7 +6043,7 @@ class C
                 Keyword("var"),
                 Local("s"),
                 Operators.Equals,
-                String("\"\"\"Hello world\"\"\"U8"),
+                String("\"\"\"Hello world\"\"\""),
                 Keyword("U8"),
                 Punctuation.Semicolon,
                 Punctuation.CloseCurly,
@@ -6126,7 +6126,7 @@ class C
                 Operators.Equals,
                 String(@"""""""
       Hello world
-   """"""u8"),
+   """""""),
                 Keyword("u8"),
                 Punctuation.Semicolon,
                 Punctuation.CloseCurly,
@@ -6168,7 +6168,7 @@ class C
                 Operators.Equals,
                 String(@"""""""
       Hello world
-   """"""U8"),
+   """""""),
                 Keyword("U8"),
                 Punctuation.Semicolon,
                 Punctuation.CloseCurly,

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -98,17 +98,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
 
                 if (type != null)
                 {
-                    // Additionally classify static symbols
-                    if (token.Kind() == SyntaxKind.IdentifierToken
-                        && ClassificationHelpers.IsStaticallyDeclared(token))
-                    {
-                        AddClassification(span, ClassificationTypeNames.StaticSymbol);
-                    }
-                    else if (token.Kind() is
-                                SyntaxKind.Utf8StringLiteralToken or
-                                SyntaxKind.Utf8SingleLineRawStringLiteralToken or
-                                SyntaxKind.Utf8MultiLineRawStringLiteralToken &&
-                             token.Text.EndsWith("u8", StringComparison.OrdinalIgnoreCase))
+                    if (token.Kind() is
+                            SyntaxKind.Utf8StringLiteralToken or
+                            SyntaxKind.Utf8SingleLineRawStringLiteralToken or
+                            SyntaxKind.Utf8MultiLineRawStringLiteralToken &&
+                        token.Text.EndsWith("u8", StringComparison.OrdinalIgnoreCase))
                     {
                         AddClassification(TextSpan.FromBounds(token.Span.Start, token.Span.End - "u8".Length), type);
                         AddClassification(TextSpan.FromBounds(token.Span.End - "u8".Length, token.Span.End), ClassificationTypeNames.Keyword);
@@ -116,6 +110,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                     else
                     {
                         AddClassification(span, type);
+                    }
+
+                    // Additionally classify static symbols
+                    if (token.Kind() == SyntaxKind.IdentifierToken &&
+                        ClassificationHelpers.IsStaticallyDeclared(token))
+                    {
+                        AddClassification(span, ClassificationTypeNames.StaticSymbol);
                     }
                 }
             }

--- a/src/Workspaces/CSharp/Portable/Classification/Worker.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Worker.cs
@@ -98,8 +98,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
 
                 if (type != null)
                 {
-                    AddClassification(span, type);
-
                     // Additionally classify static symbols
                     if (token.Kind() == SyntaxKind.IdentifierToken
                         && ClassificationHelpers.IsStaticallyDeclared(token))
@@ -110,9 +108,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
                                 SyntaxKind.Utf8StringLiteralToken or
                                 SyntaxKind.Utf8SingleLineRawStringLiteralToken or
                                 SyntaxKind.Utf8MultiLineRawStringLiteralToken &&
-                            token.Text.EndsWith("u8", StringComparison.OrdinalIgnoreCase))
+                             token.Text.EndsWith("u8", StringComparison.OrdinalIgnoreCase))
                     {
-                        AddClassification(new TextSpan(token.Span.End - "u8".Length, "u8".Length), ClassificationTypeNames.Keyword);
+                        AddClassification(TextSpan.FromBounds(token.Span.Start, token.Span.End - "u8".Length), type);
+                        AddClassification(TextSpan.FromBounds(token.Span.End - "u8".Length, token.Span.End), ClassificationTypeNames.Keyword);
+                    }
+                    else
+                    {
+                        AddClassification(span, type);
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/66507

Core problem here is that we were generating two classifications over the same region of text (i.e. the `u8` portion was classified both as a string and a keyword).  However, editor defines no ordering for these two classifications, so it was possible for keyword to sometimes override string, or vice versa.  

test coming.