### PR TITLE
Do not offer `string` (or other type-keywords) after `ref/readonly` inside namespace member declaration

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/BoolKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/BoolKeywordRecommenderTests.cs
@@ -799,5 +799,114 @@ class C
     required $$
 }");
         }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [CombinatorialData]
+        public async Task TestAfterReadonlyAtTopLevel1(bool script)
+        {
+            if (script)
+            {
+                // A legal top level script field.
+                await VerifyKeywordAsync(
+@"readonly $$", Options.Script);
+            }
+            else
+            {
+                // no legal top level statement can start with `readonly string`
+                await VerifyAbsenceAsync(
+@"readonly $$", CSharp9ParseOptions, CSharp9ParseOptions);
+            }
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefReadonlyAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    readonly $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref readonly $$
+}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    readonly $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref readonly $$
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ByteKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ByteKeywordRecommenderTests.cs
@@ -800,5 +800,114 @@ class C
     required $$
 }");
         }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [CombinatorialData]
+        public async Task TestAfterReadonlyAtTopLevel1(bool script)
+        {
+            if (script)
+            {
+                // A legal top level script field.
+                await VerifyKeywordAsync(
+@"readonly $$", Options.Script);
+            }
+            else
+            {
+                // no legal top level statement can start with `readonly string`
+                await VerifyAbsenceAsync(
+@"readonly $$", CSharp9ParseOptions, CSharp9ParseOptions);
+            }
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefReadonlyAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    readonly $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref readonly $$
+}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    readonly $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref readonly $$
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/CharKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/CharKeywordRecommenderTests.cs
@@ -839,5 +839,114 @@ class C
     required $$
 }");
         }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [CombinatorialData]
+        public async Task TestAfterReadonlyAtTopLevel1(bool script)
+        {
+            if (script)
+            {
+                // A legal top level script field.
+                await VerifyKeywordAsync(
+@"readonly $$", Options.Script);
+            }
+            else
+            {
+                // no legal top level statement can start with `readonly string`
+                await VerifyAbsenceAsync(
+@"readonly $$", CSharp9ParseOptions, CSharp9ParseOptions);
+            }
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefReadonlyAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    readonly $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref readonly $$
+}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    readonly $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref readonly $$
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/DecimalKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/DecimalKeywordRecommenderTests.cs
@@ -791,5 +791,114 @@ class C
     required $$
 }");
         }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [CombinatorialData]
+        public async Task TestAfterReadonlyAtTopLevel1(bool script)
+        {
+            if (script)
+            {
+                // A legal top level script field.
+                await VerifyKeywordAsync(
+@"readonly $$", Options.Script);
+            }
+            else
+            {
+                // no legal top level statement can start with `readonly string`
+                await VerifyAbsenceAsync(
+@"readonly $$", CSharp9ParseOptions, CSharp9ParseOptions);
+            }
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefReadonlyAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    readonly $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref readonly $$
+}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    readonly $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref readonly $$
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/DoubleKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/DoubleKeywordRecommenderTests.cs
@@ -777,5 +777,114 @@ class C
     required $$
 }");
         }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [CombinatorialData]
+        public async Task TestAfterReadonlyAtTopLevel1(bool script)
+        {
+            if (script)
+            {
+                // A legal top level script field.
+                await VerifyKeywordAsync(
+@"readonly $$", Options.Script);
+            }
+            else
+            {
+                // no legal top level statement can start with `readonly string`
+                await VerifyAbsenceAsync(
+@"readonly $$", CSharp9ParseOptions, CSharp9ParseOptions);
+            }
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefReadonlyAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    readonly $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref readonly $$
+}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    readonly $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref readonly $$
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/FloatKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/FloatKeywordRecommenderTests.cs
@@ -750,5 +750,114 @@ class C
     required $$
 }");
         }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [CombinatorialData]
+        public async Task TestAfterReadonlyAtTopLevel1(bool script)
+        {
+            if (script)
+            {
+                // A legal top level script field.
+                await VerifyKeywordAsync(
+@"readonly $$", Options.Script);
+            }
+            else
+            {
+                // no legal top level statement can start with `readonly string`
+                await VerifyAbsenceAsync(
+@"readonly $$", CSharp9ParseOptions, CSharp9ParseOptions);
+            }
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefReadonlyAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    readonly $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref readonly $$
+}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    readonly $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref readonly $$
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/IntKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/IntKeywordRecommenderTests.cs
@@ -864,5 +864,114 @@ class C
     required $$
 }");
         }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [CombinatorialData]
+        public async Task TestAfterReadonlyAtTopLevel1(bool script)
+        {
+            if (script)
+            {
+                // A legal top level script field.
+                await VerifyKeywordAsync(
+@"readonly $$", Options.Script);
+            }
+            else
+            {
+                // no legal top level statement can start with `readonly string`
+                await VerifyAbsenceAsync(
+@"readonly $$", CSharp9ParseOptions, CSharp9ParseOptions);
+            }
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefReadonlyAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    readonly $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref readonly $$
+}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    readonly $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref readonly $$
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/LongKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/LongKeywordRecommenderTests.cs
@@ -777,5 +777,114 @@ class C
     required $$
 }");
         }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [CombinatorialData]
+        public async Task TestAfterReadonlyAtTopLevel1(bool script)
+        {
+            if (script)
+            {
+                // A legal top level script field.
+                await VerifyKeywordAsync(
+@"readonly $$", Options.Script);
+            }
+            else
+            {
+                // no legal top level statement can start with `readonly string`
+                await VerifyAbsenceAsync(
+@"readonly $$", CSharp9ParseOptions, CSharp9ParseOptions);
+            }
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefReadonlyAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    readonly $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref readonly $$
+}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    readonly $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref readonly $$
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ObjectKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ObjectKeywordRecommenderTests.cs
@@ -798,5 +798,114 @@ class C
     required $$
 }");
         }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [CombinatorialData]
+        public async Task TestAfterReadonlyAtTopLevel1(bool script)
+        {
+            if (script)
+            {
+                // A legal top level script field.
+                await VerifyKeywordAsync(
+@"readonly $$", Options.Script);
+            }
+            else
+            {
+                // no legal top level statement can start with `readonly string`
+                await VerifyAbsenceAsync(
+@"readonly $$", CSharp9ParseOptions, CSharp9ParseOptions);
+            }
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefReadonlyAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    readonly $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref readonly $$
+}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    readonly $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref readonly $$
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/SByteKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/SByteKeywordRecommenderTests.cs
@@ -777,5 +777,114 @@ class C
     required $$
 }");
         }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [CombinatorialData]
+        public async Task TestAfterReadonlyAtTopLevel1(bool script)
+        {
+            if (script)
+            {
+                // A legal top level script field.
+                await VerifyKeywordAsync(
+@"readonly $$", Options.Script);
+            }
+            else
+            {
+                // no legal top level statement can start with `readonly string`
+                await VerifyAbsenceAsync(
+@"readonly $$", CSharp9ParseOptions, CSharp9ParseOptions);
+            }
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefReadonlyAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    readonly $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref readonly $$
+}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    readonly $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref readonly $$
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ShortKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ShortKeywordRecommenderTests.cs
@@ -777,5 +777,114 @@ class C
     required $$
 }");
         }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [CombinatorialData]
+        public async Task TestAfterReadonlyAtTopLevel1(bool script)
+        {
+            if (script)
+            {
+                // A legal top level script field.
+                await VerifyKeywordAsync(
+@"readonly $$", Options.Script);
+            }
+            else
+            {
+                // no legal top level statement can start with `readonly string`
+                await VerifyAbsenceAsync(
+@"readonly $$", CSharp9ParseOptions, CSharp9ParseOptions);
+            }
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefReadonlyAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    readonly $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref readonly $$
+}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    readonly $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref readonly $$
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/StringKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/StringKeywordRecommenderTests.cs
@@ -837,7 +837,7 @@ class C
             {
                 // no legal top level statement can start with `readonly string`
                 await VerifyAbsenceAsync(
-@"readonly $$", CSharp9ParseOptions);
+@"readonly $$", CSharp9ParseOptions, CSharp9ParseOptions);
             }
         }
 

--- a/src/EditorFeatures/CSharpTest2/Recommendations/StringKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/StringKeywordRecommenderTests.cs
@@ -813,5 +813,103 @@ class C
     required $$
 }");
         }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyAtTopLevel1()
+        {
+            await VerifyAbsenceAsync(
+@"readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefReadonlyAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyKeywordAsync(
+@"namespace N
+{
+    ref $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    readonly $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyKeywordAsync(
+@"namespace N
+{
+    ref readonly $$
+}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    readonly $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref readonly $$
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/UIntKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/UIntKeywordRecommenderTests.cs
@@ -777,5 +777,114 @@ class C
     required $$
 }");
         }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [CombinatorialData]
+        public async Task TestAfterReadonlyAtTopLevel1(bool script)
+        {
+            if (script)
+            {
+                // A legal top level script field.
+                await VerifyKeywordAsync(
+@"readonly $$", Options.Script);
+            }
+            else
+            {
+                // no legal top level statement can start with `readonly string`
+                await VerifyAbsenceAsync(
+@"readonly $$", CSharp9ParseOptions, CSharp9ParseOptions);
+            }
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefReadonlyAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    readonly $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref readonly $$
+}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    readonly $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref readonly $$
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ULongKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ULongKeywordRecommenderTests.cs
@@ -777,5 +777,114 @@ class C
     required $$
 }");
         }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [CombinatorialData]
+        public async Task TestAfterReadonlyAtTopLevel1(bool script)
+        {
+            if (script)
+            {
+                // A legal top level script field.
+                await VerifyKeywordAsync(
+@"readonly $$", Options.Script);
+            }
+            else
+            {
+                // no legal top level statement can start with `readonly string`
+                await VerifyAbsenceAsync(
+@"readonly $$", CSharp9ParseOptions, CSharp9ParseOptions);
+            }
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefReadonlyAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    readonly $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref readonly $$
+}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    readonly $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref readonly $$
+}}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/UShortKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/UShortKeywordRecommenderTests.cs
@@ -777,5 +777,114 @@ class C
     required $$
 }");
         }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref $$");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [CombinatorialData]
+        public async Task TestAfterReadonlyAtTopLevel1(bool script)
+        {
+            if (script)
+            {
+                // A legal top level script field.
+                await VerifyKeywordAsync(
+@"readonly $$", Options.Script);
+            }
+            else
+            {
+                // no legal top level statement can start with `readonly string`
+                await VerifyAbsenceAsync(
+@"readonly $$", CSharp9ParseOptions, CSharp9ParseOptions);
+            }
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestAfterRefReadonlyAtTopLevel1()
+        {
+            // Could be defining a ref-local in top-level-code
+            await VerifyKeywordAsync(
+@"ref readonly $$");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    readonly $$
+}");
+        }
+
+        [Fact, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        public async Task TestNotAfterRefReadonlyInNamespace()
+        {
+            // This is only legal for a struct declaration
+            await VerifyAbsenceAsync(
+@"namespace N
+{
+    ref readonly $$
+}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    readonly $$
+}}");
+        }
+
+        [Theory, WorkItem(67061, "https://github.com/dotnet/roslyn/issues/67061")]
+        [InlineData("class")]
+        [InlineData("interface")]
+        [InlineData("struct")]
+        [InlineData("record")]
+        public async Task TestAfterRefReadonlyInClassInterfaceStructRecord(string type)
+        {
+            await VerifyKeywordAsync(
+$@"{type} N
+{{
+    ref readonly $$
+}}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
@@ -62,12 +62,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             if (token.Kind() != SyntaxKind.RefKeyword)
                 return false;
 
-            // If we're inside a type, this is always to have a ref/readonly string.
+            // If we're inside a type, this is always to have a ref/readonly type name.
             var containingType = token.GetAncestor<TypeDeclarationSyntax>();
             if (containingType != null)
                 return true;
 
-            // If not in a type, but in a namespace, this is not ok to have a ref/readonly string.
+            // If not in a type, but in a namespace, this is not ok to have a ref/readonly type name.
             var containingNamespace = token.GetAncestor<BaseNamespaceDeclarationSyntax>();
             if (containingNamespace != null)
                 return false;

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             if (token.Kind() is SyntaxKind.ReadOnlyKeyword)
                 token = syntaxTree.FindTokenOnLeftOfPosition(token.SpanStart, cancellationToken);
 
-            // if we're not after `ref` or `ref readonly` then don't offer `string` here.
+            // if we're not after `ref` or `ref readonly` then don't offer a type-keyword here.
             if (token.Kind() != SyntaxKind.RefKeyword)
                 return false;
 

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Completion.Providers;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
@@ -36,7 +38,42 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
             if (context.IsTaskLikeTypeContext)
                 return false;
 
-            return IsValidContextWorker(position, context, cancellationToken);
+            return IsValidContextWorker(position, context, cancellationToken) ||
+                IsAfterRefOrReadonlyInTopLevelOrMemberDeclaration(context, position, cancellationToken);
+        }
+
+        private static bool IsAfterRefOrReadonlyInTopLevelOrMemberDeclaration(CSharpSyntaxContext context, int position, CancellationToken cancellationToken)
+        {
+            var syntaxTree = context.SyntaxTree;
+            if (!syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) &&
+                !syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken))
+            {
+                return false;
+            }
+
+            var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
+            token = token.GetPreviousTokenIfTouchingWord(position);
+
+            // if we have `readonly` move backwards to see if we have `ref readonly`.
+            if (token.Kind() is SyntaxKind.ReadOnlyKeyword)
+                token = syntaxTree.FindTokenOnLeftOfPosition(token.SpanStart, cancellationToken);
+
+            // if we're not after `ref` or `ref readonly` then don't offer `string` here.
+            if (token.Kind() != SyntaxKind.RefKeyword)
+                return false;
+
+            // If we're inside a type, this is always to have a ref/readonly string.
+            var containingType = token.GetAncestor<TypeDeclarationSyntax>();
+            if (containingType != null)
+                return true;
+
+            // If not in a type, but in a namespace, this is not ok to have a ref/readonly string.
+            var containingNamespace = token.GetAncestor<BaseNamespaceDeclarationSyntax>();
+            if (containingNamespace != null)
+                return false;
+
+            // otherwise, we're at top level.  Can have a ref/readonly top-level local/function.
+            return true;
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/BoolKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/BoolKeywordRecommender.cs
@@ -39,8 +39,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 context.IsPrimaryFunctionExpressionContext ||
                 context.IsCrefContext ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.ConstKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken) ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.StackAllocKeyword, cancellationToken) ||
                 context.IsDelegateReturnTypeContext ||
                 syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ByteKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ByteKeywordRecommender.cs
@@ -40,8 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 context.IsPrimaryFunctionExpressionContext ||
                 context.IsCrefContext ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.ConstKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken) ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.StackAllocKeyword, cancellationToken) ||
                 context.IsDelegateReturnTypeContext ||
                 syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/CharKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/CharKeywordRecommender.cs
@@ -39,8 +39,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 context.IsPrimaryFunctionExpressionContext ||
                 context.IsCrefContext ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.ConstKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken) ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.StackAllocKeyword, cancellationToken) ||
                 context.IsDelegateReturnTypeContext ||
                 syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DecimalKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DecimalKeywordRecommender.cs
@@ -39,8 +39,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 context.IsPrimaryFunctionExpressionContext ||
                 context.IsCrefContext ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.ConstKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken) ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.StackAllocKeyword, cancellationToken) ||
                 context.IsDelegateReturnTypeContext ||
                 syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DoubleKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DoubleKeywordRecommender.cs
@@ -39,8 +39,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 context.IsPrimaryFunctionExpressionContext ||
                 context.IsCrefContext ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.ConstKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken) ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.StackAllocKeyword, cancellationToken) ||
                 context.IsDelegateReturnTypeContext ||
                 syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/FloatKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/FloatKeywordRecommender.cs
@@ -39,8 +39,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 context.IsPrimaryFunctionExpressionContext ||
                 context.IsCrefContext ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.ConstKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken) ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.StackAllocKeyword, cancellationToken) ||
                 context.IsDelegateReturnTypeContext ||
                 syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/IntKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/IntKeywordRecommender.cs
@@ -40,8 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 context.IsPrimaryFunctionExpressionContext ||
                 context.IsCrefContext ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.ConstKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken) ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.StackAllocKeyword, cancellationToken) ||
                 context.IsDelegateReturnTypeContext ||
                 syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/LongKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/LongKeywordRecommender.cs
@@ -40,8 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 context.IsPrimaryFunctionExpressionContext ||
                 context.IsCrefContext ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.ConstKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken) ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.StackAllocKeyword, cancellationToken) ||
                 context.IsDelegateReturnTypeContext ||
                 syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ObjectKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ObjectKeywordRecommender.cs
@@ -39,8 +39,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 context.IsCrefContext ||
                 syntaxTree.IsDefaultExpressionContext(position, context.LeftToken) ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.ConstKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken) ||
                 context.IsDelegateReturnTypeContext ||
                 syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||
                 context.IsPossibleTupleContext ||

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/SByteKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/SByteKeywordRecommender.cs
@@ -40,8 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 context.IsPrimaryFunctionExpressionContext ||
                 context.IsCrefContext ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.ConstKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken) ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.StackAllocKeyword, cancellationToken) ||
                 context.IsDelegateReturnTypeContext ||
                 syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ShortKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ShortKeywordRecommender.cs
@@ -40,8 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 context.IsPrimaryFunctionExpressionContext ||
                 context.IsCrefContext ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.ConstKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken) ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.StackAllocKeyword, cancellationToken) ||
                 context.IsDelegateReturnTypeContext ||
                 syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StringKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StringKeywordRecommender.cs
@@ -50,42 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     validModifiers: SyntaxKindSet.AllMemberModifiers,
                     validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations,
                     canBePartial: false,
-                    cancellationToken) ||
-                IsAfterRefOrReadonlyInTopLevelOrMemberDeclaration(context, position, cancellationToken);
-        }
-
-        private static bool IsAfterRefOrReadonlyInTopLevelOrMemberDeclaration(CSharpSyntaxContext context, int position, CancellationToken cancellationToken)
-        {
-            var syntaxTree = context.SyntaxTree;
-            if (!syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) &&
-                !syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken))
-            {
-                return false;
-            }
-
-            var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
-            token = token.GetPreviousTokenIfTouchingWord(position);
-
-            // if we have `readonly` move backwards to see if we have `ref readonly`.
-            if (token.Kind() is SyntaxKind.ReadOnlyKeyword)
-                token = syntaxTree.FindTokenOnLeftOfPosition(token.SpanStart, cancellationToken);
-
-            // if we're not after `ref` or `ref readonly` then don't offer `string` here.
-            if (token.Kind() != SyntaxKind.RefKeyword)
-                return false;
-
-            // If we're inside a type, this is always to have a ref/readonly string.
-            var containingType = token.GetAncestor<TypeDeclarationSyntax>();
-            if (containingType != null)
-                return true;
-
-            // If not in a type, but in a namespace, this is not ok to have a ref/readonly string.
-            var containingNamespace = token.GetAncestor<BaseNamespaceDeclarationSyntax>();
-            if (containingNamespace != null)
-                return false;
-
-            // otherwise, we're at top level.  Can have a ref/readonly top-level local/function.
-            return true;
+                    cancellationToken);
         }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UIntKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UIntKeywordRecommender.cs
@@ -40,8 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 context.IsPrimaryFunctionExpressionContext ||
                 context.IsCrefContext ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.ConstKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken) ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.StackAllocKeyword, cancellationToken) ||
                 context.IsDelegateReturnTypeContext ||
                 syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ULongKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ULongKeywordRecommender.cs
@@ -40,8 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 context.IsPrimaryFunctionExpressionContext ||
                 context.IsCrefContext ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.ConstKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken) ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.StackAllocKeyword, cancellationToken) ||
                 context.IsDelegateReturnTypeContext ||
                 syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UShortKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UShortKeywordRecommender.cs
@@ -47,8 +47,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 context.IsPrimaryFunctionExpressionContext ||
                 context.IsCrefContext ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.ConstKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.RefKeyword, cancellationToken) ||
-                syntaxTree.IsAfterKeyword(position, SyntaxKind.ReadOnlyKeyword, cancellationToken) ||
                 syntaxTree.IsAfterKeyword(position, SyntaxKind.StackAllocKeyword, cancellationToken) ||
                 context.IsDelegateReturnTypeContext ||
                 syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/67061

This is both not legal, and interferes with typing `ref struct` since `string` sorts above `struct`.