### PR TITLE
Avoid large object heap allocations in classification

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Editor.Implementation.Classification;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -33,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
     [Trait(Traits.Feature, Traits.Features.Classification)]
     public class SemanticClassifierTests : AbstractCSharpClassifierTests
     {
-        protected override async Task<ImmutableArray<ClassifiedSpan>> GetClassificationSpansAsync(string code, TextSpan span, ParseOptions? options, TestHost testHost)
+        private protected override async Task<ImmutableSegmentedList<ClassifiedSpan>> GetClassificationSpansAsync(string code, TextSpan span, ParseOptions? options, TestHost testHost)
         {
             using var workspace = CreateWorkspace(code, options, testHost);
             var document = workspace.CurrentSolution.GetRequiredDocument(workspace.Documents.First().Id);

--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Remote.Testing;
@@ -18,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
 {
     public partial class SyntacticClassifierTests : AbstractCSharpClassifierTests
     {
-        protected override async Task<ImmutableArray<ClassifiedSpan>> GetClassificationSpansAsync(string code, TextSpan span, ParseOptions? options, TestHost testHost)
+        private protected override async Task<ImmutableSegmentedList<ClassifiedSpan>> GetClassificationSpansAsync(string code, TextSpan span, ParseOptions? options, TestHost testHost)
         {
             using var workspace = CreateWorkspace(code, options, testHost);
             var document = workspace.CurrentSolution.Projects.First().Documents.First();

--- a/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Remote.Testing;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -20,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
     [Trait(Traits.Feature, Traits.Features.Classification)]
     public partial class TotalClassifierTests : AbstractCSharpClassifierTests
     {
-        protected override async Task<ImmutableArray<ClassifiedSpan>> GetClassificationSpansAsync(string code, TextSpan span, ParseOptions? options, TestHost testHost)
+        private protected override async Task<ImmutableSegmentedList<ClassifiedSpan>> GetClassificationSpansAsync(string code, TextSpan span, ParseOptions? options, TestHost testHost)
         {
             using var workspace = CreateWorkspace(code, options, testHost);
             var document = workspace.CurrentSolution.GetRequiredDocument(workspace.Documents.First().Id);

--- a/src/EditorFeatures/Core/Classification/Semantic/ClassificationUtilities.cs
+++ b/src/EditorFeatures/Core/Classification/Semantic/ClassificationUtilities.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
@@ -162,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Classification
             {
                 using (Logger.LogBlock(FunctionId.Tagger_SemanticClassification_TagProducer_ProduceTags, cancellationToken))
                 {
-                    using var _ = ArrayBuilder<ClassifiedSpan>.GetInstance(out var classifiedSpans);
+                    var classifiedSpans = ImmutableSegmentedList.CreateBuilder<ClassifiedSpan>();
 
                     await AddClassificationsAsync(
                         classificationService, options, document, snapshotSpan, classifiedSpans, type, cancellationToken).ConfigureAwait(false);
@@ -188,7 +189,7 @@ namespace Microsoft.CodeAnalysis.Classification
             ClassificationOptions options,
             Document document,
             SnapshotSpan snapshotSpan,
-            ArrayBuilder<ClassifiedSpan> classifiedSpans,
+            ImmutableSegmentedList<ClassifiedSpan>.Builder classifiedSpans,
             ClassificationType type,
             CancellationToken cancellationToken)
         {

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Shared.Collections;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
@@ -56,10 +57,10 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
             var intersectingIntervals = _tree.GetIntervalsThatIntersectWith(
                 snapshotSpan.Start, snapshotSpan.Length, new IntervalIntrospector(snapshot));
 
-            List<ITagSpan<TTag>>? result = null;
+            SegmentedList<ITagSpan<TTag>>? result = null;
             foreach (var tagNode in intersectingIntervals)
             {
-                result ??= new List<ITagSpan<TTag>>();
+                result ??= new SegmentedList<ITagSpan<TTag>>();
                 result.Add(new TagSpan<TTag>(tagNode.Span.GetSpan(snapshot), tagNode.Tag));
             }
 

--- a/src/EditorFeatures/Core/Tagging/TaggerContext.cs
+++ b/src/EditorFeatures/Core/Tagging/TaggerContext.cs
@@ -4,17 +4,14 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Tagging
 {
@@ -23,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
         private readonly ImmutableDictionary<ITextBuffer, TagSpanIntervalTree<TTag>> _existingTags;
 
         internal ImmutableArray<SnapshotSpan> _spansTagged;
-        internal ImmutableArray<ITagSpan<TTag>>.Builder tagSpans = ImmutableArray.CreateBuilder<ITagSpan<TTag>>();
+        internal ImmutableSegmentedList<ITagSpan<TTag>>.Builder tagSpans = ImmutableSegmentedList.CreateBuilder<ITagSpan<TTag>>();
 
         public ImmutableArray<DocumentSnapshotSpan> SpansToTag { get; }
         public SnapshotPoint? CaretPosition { get; }

--- a/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
+++ b/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
@@ -5,7 +5,7 @@
 Imports System.Composition
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Classification
-Imports Microsoft.CodeAnalysis.Editor.Implementation.Classification
+Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.Editor.Shared.Extensions
 Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
@@ -295,8 +295,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
 
                 ' make sure we don't crash with wrong document
                 Dim result = New ArrayBuilder(Of ClassifiedSpan)()
+                Dim result2 = ImmutableSegmentedList.CreateBuilder(Of ClassifiedSpan)()
                 Await classificationService.AddSyntacticClassificationsAsync(wrongDocument, New TextSpan(0, text.Length), result, CancellationToken.None)
-                Await classificationService.AddSemanticClassificationsAsync(wrongDocument, New TextSpan(0, text.Length), options:=Nothing, result, CancellationToken.None)
+                Await classificationService.AddSemanticClassificationsAsync(wrongDocument, New TextSpan(0, text.Length), options:=Nothing, result2, CancellationToken.None)
             End Using
         End Function
 
@@ -315,7 +316,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
             Public Sub AddSyntacticClassifications(services As SolutionServices, root As SyntaxNode, textSpan As TextSpan, result As ArrayBuilder(Of ClassifiedSpan), cancellationToken As CancellationToken) Implements IClassificationService.AddSyntacticClassifications
             End Sub
 
-            Public Function AddSemanticClassificationsAsync(document As Document, textSpan As TextSpan, options As ClassificationOptions, result As ArrayBuilder(Of ClassifiedSpan), cancellationToken As CancellationToken) As Task Implements IClassificationService.AddSemanticClassificationsAsync
+            Public Function AddSemanticClassificationsAsync(document As Document, textSpan As TextSpan, options As ClassificationOptions, result As ImmutableSegmentedList(Of ClassifiedSpan).Builder, cancellationToken As CancellationToken) As Task Implements IClassificationService.AddSemanticClassificationsAsync
                 Return Task.CompletedTask
             End Function
 
@@ -334,7 +335,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
                 Return Nothing
             End Function
 
-            Public Function AddEmbeddedLanguageClassificationsAsync(document As Document, textSpan As TextSpan, options As ClassificationOptions, result As ArrayBuilder(Of ClassifiedSpan), cancellationToken As CancellationToken) As Task Implements IClassificationService.AddEmbeddedLanguageClassificationsAsync
+            Public Function AddEmbeddedLanguageClassificationsAsync(document As Document, textSpan As TextSpan, options As ClassificationOptions, result As ImmutableSegmentedList(Of ClassifiedSpan).Builder, cancellationToken As CancellationToken) As Task Implements IClassificationService.AddEmbeddedLanguageClassificationsAsync
                 Return Task.CompletedTask
             End Function
         End Class

--- a/src/EditorFeatures/VisualBasicTest/Classification/SemanticClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/SemanticClassifierTests.vb
@@ -4,6 +4,7 @@
 
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.Classification
+Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Classification.FormattedClassifications
 Imports Microsoft.CodeAnalysis.Remote.Testing
 Imports Microsoft.CodeAnalysis.Test.Utilities.EmbeddedLanguages
@@ -14,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Classification
     Public Class SemanticClassifierTests
         Inherits AbstractVisualBasicClassifierTests
 
-        Protected Overrides Async Function GetClassificationSpansAsync(code As String, span As TextSpan, parseOptions As ParseOptions, testHost As TestHost) As Task(Of ImmutableArray(Of ClassifiedSpan))
+        Private Protected Overrides Async Function GetClassificationSpansAsync(code As String, span As TextSpan, parseOptions As ParseOptions, testHost As TestHost) As Task(Of ImmutableSegmentedList(Of ClassifiedSpan))
             Using workspace = CreateWorkspace(code, testHost)
                 Dim document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id)
 

--- a/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/SyntacticClassifierTests.vb
@@ -4,6 +4,7 @@
 
 Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.Classification
+Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Classification.FormattedClassifications
 Imports Microsoft.CodeAnalysis.Remote.Testing
 Imports Microsoft.CodeAnalysis.Text
@@ -13,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Classification
     Public Class SyntacticClassifierTests
         Inherits AbstractVisualBasicClassifierTests
 
-        Protected Overrides Async Function GetClassificationSpansAsync(code As String, span As TextSpan, parseOptions As ParseOptions, testHost As TestHost) As Task(Of ImmutableArray(Of ClassifiedSpan))
+        Private Protected Overrides Async Function GetClassificationSpansAsync(code As String, span As TextSpan, parseOptions As ParseOptions, testHost As TestHost) As Task(Of ImmutableSegmentedList(Of ClassifiedSpan))
             Using workspace = CreateWorkspace(code, testHost)
                 Dim document = workspace.CurrentSolution.Projects.First().Documents.First()
                 Return Await GetSyntacticClassificationsAsync(document, span)

--- a/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractEmbeddedLanguageClassificationService.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Classification/AbstractEmbeddedLanguageClassificationService.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.EmbeddedLanguages;
 using Microsoft.CodeAnalysis.LanguageService;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -35,14 +36,14 @@ namespace Microsoft.CodeAnalysis.Classification
         }
 
         public async Task AddEmbeddedLanguageClassificationsAsync(
-            Document document, TextSpan textSpan, ClassificationOptions options, ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken)
+            Document document, TextSpan textSpan, ClassificationOptions options, ImmutableSegmentedList<ClassifiedSpan>.Builder result, CancellationToken cancellationToken)
         {
             var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             AddEmbeddedLanguageClassifications(document.Project, semanticModel, textSpan, options, result, cancellationToken);
         }
 
         public void AddEmbeddedLanguageClassifications(
-            Project? project, SemanticModel semanticModel, TextSpan textSpan, ClassificationOptions options, ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken)
+            Project? project, SemanticModel semanticModel, TextSpan textSpan, ClassificationOptions options, ImmutableSegmentedList<ClassifiedSpan>.Builder result, CancellationToken cancellationToken)
         {
             if (project is null)
                 return;
@@ -59,7 +60,7 @@ namespace Microsoft.CodeAnalysis.Classification
             private readonly SemanticModel _semanticModel;
             private readonly TextSpan _textSpan;
             private readonly ClassificationOptions _options;
-            private readonly ArrayBuilder<ClassifiedSpan> _result;
+            private readonly ImmutableSegmentedList<ClassifiedSpan>.Builder _result;
             private readonly CancellationToken _cancellationToken;
 
             public Worker(
@@ -68,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Classification
                 SemanticModel semanticModel,
                 TextSpan textSpan,
                 ClassificationOptions options,
-                ArrayBuilder<ClassifiedSpan> result,
+                ImmutableSegmentedList<ClassifiedSpan>.Builder result,
                 CancellationToken cancellationToken)
             {
                 _owner = service;

--- a/src/Features/Core/Portable/EmbeddedLanguages/Classification/EmbeddedLanguageClassifierContext.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Classification/EmbeddedLanguageClassifierContext.cs
@@ -3,16 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
-using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Classification
 {
     internal readonly struct EmbeddedLanguageClassificationContext
     {
-        private readonly ArrayBuilder<ClassifiedSpan> _result;
+        private readonly ImmutableSegmentedList<ClassifiedSpan>.Builder _result;
 
         public Project Project { get; }
 
@@ -37,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Classification
             SyntaxToken syntaxToken,
             ClassificationOptions options,
             IVirtualCharService virtualCharService,
-            ArrayBuilder<ClassifiedSpan> result,
+            ImmutableSegmentedList<ClassifiedSpan>.Builder result,
             CancellationToken cancellationToken)
         {
             Project = project;

--- a/src/Tools/ExternalAccess/FSharp/Internal/Classification/FSharpClassificationService.cs
+++ b/src/Tools/ExternalAccess/FSharp/Internal/Classification/FSharpClassificationService.cs
@@ -8,6 +8,7 @@ using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Classification;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
@@ -37,7 +38,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Classification
             result.AddRange(list);
         }
 
-        public async Task AddSemanticClassificationsAsync(Document document, TextSpan textSpan, ClassificationOptions options, ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken)
+        public async Task AddSemanticClassificationsAsync(Document document, TextSpan textSpan, ClassificationOptions options, ImmutableSegmentedList<ClassifiedSpan>.Builder result, CancellationToken cancellationToken)
         {
             using var _ = s_listPool.GetPooledObject(out var list);
             await _service.AddSemanticClassificationsAsync(document, textSpan, list, cancellationToken).ConfigureAwait(false);
@@ -73,7 +74,7 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Classification
             return new();
         }
 
-        public Task AddEmbeddedLanguageClassificationsAsync(Document document, TextSpan textSpan, ClassificationOptions options, ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken)
+        public Task AddEmbeddedLanguageClassificationsAsync(Document document, TextSpan textSpan, ClassificationOptions options, ImmutableSegmentedList<ClassifiedSpan>.Builder result, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/src/Tools/IdeBenchmarks/RegexClassifierBenchmarks.cs
+++ b/src/Tools/IdeBenchmarks/RegexClassifierBenchmarks.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -66,7 +67,7 @@ class Program
 ";
         }
 
-        protected Task<ImmutableArray<ClassifiedSpan>> GetClassificationSpansAsync(string code, TextSpan span, ParseOptions parseOptions)
+        private protected Task<ImmutableSegmentedList<ClassifiedSpan>> GetClassificationSpansAsync(string code, TextSpan span, ParseOptions parseOptions)
         {
             using (var workspace = TestWorkspace.CreateCSharp(code, parseOptions))
             {
@@ -75,7 +76,7 @@ class Program
             }
         }
 
-        protected static async Task<ImmutableArray<ClassifiedSpan>> GetSemanticClassificationsAsync(Document document, TextSpan span)
+        private protected static async Task<ImmutableSegmentedList<ClassifiedSpan>> GetSemanticClassificationsAsync(Document document, TextSpan span)
         {
             var tree = await document.GetSyntaxTreeAsync();
 
@@ -83,7 +84,7 @@ class Program
             var classifiers = service.GetDefaultSyntaxClassifiers();
             var extensionManager = document.Project.Solution.Services.GetService<IExtensionManager>();
 
-            var results = ArrayBuilder<ClassifiedSpan>.GetInstance();
+            var results = ImmutableSegmentedList.CreateBuilder<ClassifiedSpan>();
 
             await service.AddSemanticClassificationsAsync(
                 document,
@@ -94,7 +95,7 @@ class Program
                 results,
                 CancellationToken.None);
 
-            return results.ToImmutableAndFree();
+            return results.ToImmutable();
         }
     }
 }

--- a/src/Tools/IdeCoreBenchmarks/ClassificationBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/ClassificationBenchmarks.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -17,11 +16,10 @@ using BenchmarkDotNet.Attributes;
 using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.MSBuild;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
-using Microsoft.CodeAnalysis.Storage;
 using Microsoft.CodeAnalysis.Text;
 
 namespace IdeCoreBenchmarks
@@ -93,10 +91,10 @@ namespace IdeCoreBenchmarks
             Console.WriteLine("Finished opening roslyn: " + (DateTime.Now - start));
         }
 
-        protected static async Task<ImmutableArray<ClassifiedSpan>> GetSemanticClassificationsAsync(Document document, TextSpan span)
+        private protected static async Task<ImmutableSegmentedList<ClassifiedSpan>> GetSemanticClassificationsAsync(Document document, TextSpan span)
         {
             var service = document.GetRequiredLanguageService<IClassificationService>();
-            using var _ = ArrayBuilder<ClassifiedSpan>.GetInstance(out var result);
+            var result = ImmutableSegmentedList.CreateBuilder<ClassifiedSpan>();
             await service.AddSemanticClassificationsAsync(document, span, ClassificationOptions.Default, result, CancellationToken.None);
             return result.ToImmutable();
         }

--- a/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/AbstractClassificationService.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -24,13 +25,13 @@ namespace Microsoft.CodeAnalysis.Classification
         public abstract ClassifiedSpan AdjustStaleClassification(SourceText text, ClassifiedSpan classifiedSpan);
 
         public Task AddSemanticClassificationsAsync(
-            Document document, TextSpan textSpan, ClassificationOptions options, ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken)
+            Document document, TextSpan textSpan, ClassificationOptions options, ImmutableSegmentedList<ClassifiedSpan>.Builder result, CancellationToken cancellationToken)
         {
             return AddClassificationsAsync(document, textSpan, options, ClassificationType.Semantic, result, cancellationToken);
         }
 
         public Task AddEmbeddedLanguageClassificationsAsync(
-            Document document, TextSpan textSpan, ClassificationOptions options, ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken)
+            Document document, TextSpan textSpan, ClassificationOptions options, ImmutableSegmentedList<ClassifiedSpan>.Builder result, CancellationToken cancellationToken)
         {
             return AddClassificationsAsync(document, textSpan, options, ClassificationType.EmbeddedLanguage, result, cancellationToken);
         }
@@ -40,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Classification
             TextSpan textSpan,
             ClassificationOptions options,
             ClassificationType type,
-            ArrayBuilder<ClassifiedSpan> result,
+            ImmutableSegmentedList<ClassifiedSpan>.Builder result,
             CancellationToken cancellationToken)
         {
             var classificationService = document.GetLanguageService<ISyntaxClassificationService>();
@@ -114,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Classification
             ClassificationType type,
             RemoteHostClient client,
             bool isFullyLoaded,
-            ArrayBuilder<ClassifiedSpan> result,
+            ImmutableSegmentedList<ClassifiedSpan>.Builder result,
             CancellationToken cancellationToken)
         {
             // Only try to get cached classifications if we're not fully loaded yet.
@@ -143,7 +144,7 @@ namespace Microsoft.CodeAnalysis.Classification
             TextSpan textSpan,
             ClassificationType type,
             ClassificationOptions options,
-            ArrayBuilder<ClassifiedSpan> result,
+            ImmutableSegmentedList<ClassifiedSpan>.Builder result,
             CancellationToken cancellationToken)
         {
             if (type == ClassificationType.Semantic)

--- a/src/Workspaces/Core/Portable/Classification/Classifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/Classifier.cs
@@ -8,7 +8,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Classification.Classifiers;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Classification
             var getTokenClassifiers = extensionManager.CreateTokenExtensionGetter(syntaxClassifiers, c => c.SyntaxTokenKinds);
 
             using var _1 = ArrayBuilder<ClassifiedSpan>.GetInstance(out var syntacticClassifications);
-            using var _2 = ArrayBuilder<ClassifiedSpan>.GetInstance(out var semanticClassifications);
+            var semanticClassifications = ImmutableSegmentedList.CreateBuilder<ClassifiedSpan>();
 
             var root = semanticModel.SyntaxTree.GetRoot(cancellationToken);
 

--- a/src/Workspaces/Core/Portable/Classification/IClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IClassificationService.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
@@ -50,13 +51,13 @@ namespace Microsoft.CodeAnalysis.Classification
         /// This will not include classifications for embedded language constructs in string literals.  For that use
         /// <see cref="AddEmbeddedLanguageClassificationsAsync"/>.
         /// </remarks>
-        Task AddSemanticClassificationsAsync(Document document, TextSpan textSpan, ClassificationOptions options, ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken);
+        Task AddSemanticClassificationsAsync(Document document, TextSpan textSpan, ClassificationOptions options, ImmutableSegmentedList<ClassifiedSpan>.Builder result, CancellationToken cancellationToken);
 
         /// <summary>
         /// Produce the classifications for embedded language string literals (e.g. Regex/Json strings) in the span of
         /// text specified.
         /// </summary>
-        Task AddEmbeddedLanguageClassificationsAsync(Document document, TextSpan textSpan, ClassificationOptions options, ArrayBuilder<ClassifiedSpan> result, CancellationToken cancellationToken);
+        Task AddEmbeddedLanguageClassificationsAsync(Document document, TextSpan textSpan, ClassificationOptions options, ImmutableSegmentedList<ClassifiedSpan>.Builder result, CancellationToken cancellationToken);
 
         /// <summary>
         /// Adjust a classification from a previous version of text accordingly based on the current

--- a/src/Workspaces/Core/Portable/Classification/IEmbeddedLanguageClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IEmbeddedLanguageClassificationService.cs
@@ -4,8 +4,8 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Classification
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Classification
             Document document,
             TextSpan textSpan,
             ClassificationOptions options,
-            ArrayBuilder<ClassifiedSpan> result,
+            ImmutableSegmentedList<ClassifiedSpan>.Builder result,
             CancellationToken cancellationToken);
 
         void AddEmbeddedLanguageClassifications(
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Classification
             SemanticModel semanticModel,
             TextSpan textSpan,
             ClassificationOptions options,
-            ArrayBuilder<ClassifiedSpan> result,
+            ImmutableSegmentedList<ClassifiedSpan>.Builder result,
             CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/IRemoteSemanticClassificationService.cs
@@ -3,12 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
-using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Serialization;
 using Microsoft.CodeAnalysis.Storage;
 using Microsoft.CodeAnalysis.Text;
@@ -55,16 +54,16 @@ namespace Microsoft.CodeAnalysis.Classification
         [DataMember(Order = 1)]
         public List<int>? ClassificationTriples;
 
-        internal static SerializableClassifiedSpans Dehydrate(ImmutableArray<ClassifiedSpan> classifiedSpans)
+        internal static SerializableClassifiedSpans Dehydrate(ImmutableSegmentedList<ClassifiedSpan> classifiedSpans)
         {
             using var _ = PooledDictionary<string, int>.GetInstance(out var classificationTypeToId);
             return Dehydrate(classifiedSpans, classificationTypeToId);
         }
 
-        private static SerializableClassifiedSpans Dehydrate(ImmutableArray<ClassifiedSpan> classifiedSpans, Dictionary<string, int> classificationTypeToId)
+        private static SerializableClassifiedSpans Dehydrate(ImmutableSegmentedList<ClassifiedSpan> classifiedSpans, Dictionary<string, int> classificationTypeToId)
         {
             var classificationTypes = new List<string>();
-            var classificationTriples = new List<int>(capacity: classifiedSpans.Length * 3);
+            var classificationTriples = new List<int>(capacity: classifiedSpans.Count * 3);
 
             foreach (var classifiedSpan in classifiedSpans)
             {
@@ -89,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Classification
             };
         }
 
-        internal void Rehydrate(ArrayBuilder<ClassifiedSpan> classifiedSpans)
+        internal void Rehydrate(ImmutableSegmentedList<ClassifiedSpan>.Builder classifiedSpans)
         {
             Contract.ThrowIfNull(ClassificationTypes);
             Contract.ThrowIfNull(ClassificationTriples);

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/AbstractSyntaxClassificationService.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification.Classifiers;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -34,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Classification
             ClassificationOptions options,
             Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>> getNodeClassifiers,
             Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>> getTokenClassifiers,
-            ArrayBuilder<ClassifiedSpan> result,
+            ImmutableSegmentedList<ClassifiedSpan>.Builder result,
             CancellationToken cancellationToken)
         {
             try
@@ -53,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Classification
             TextSpan textSpan,
             Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>> getNodeClassifiers,
             Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>> getTokenClassifiers,
-            ArrayBuilder<ClassifiedSpan> result,
+            ImmutableSegmentedList<ClassifiedSpan>.Builder result,
             ClassificationOptions options,
             CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/Classification/SyntaxClassification/ISyntaxClassificationService.cs
+++ b/src/Workspaces/Core/Portable/Classification/SyntaxClassification/ISyntaxClassificationService.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification.Classifiers;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
@@ -37,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Classification
             ClassificationOptions options,
             Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>> getNodeClassifiers,
             Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>> getTokenClassifiers,
-            ArrayBuilder<ClassifiedSpan> result,
+            ImmutableSegmentedList<ClassifiedSpan>.Builder result,
             CancellationToken cancellationToken);
 
         /// <inheritdoc cref="AddSemanticClassificationsAsync"/>
@@ -46,7 +47,7 @@ namespace Microsoft.CodeAnalysis.Classification
             TextSpan textSpan,
             Func<SyntaxNode, ImmutableArray<ISyntaxClassifier>> getNodeClassifiers,
             Func<SyntaxToken, ImmutableArray<ISyntaxClassifier>> getTokenClassifiers,
-            ArrayBuilder<ClassifiedSpan> result,
+            ImmutableSegmentedList<ClassifiedSpan>.Builder result,
             ClassificationOptions options,
             CancellationToken cancellationToken);
 

--- a/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SemanticClassification/RemoteSemanticClassificationService.cs
@@ -5,6 +5,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Storage;
 using Microsoft.CodeAnalysis.Text;
@@ -40,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Remote
                     document = document.WithFrozenPartialSemantics(cancellationToken);
                 }
 
-                using var _ = ArrayBuilder<ClassifiedSpan>.GetInstance(out var temp);
+                var temp = ImmutableSegmentedList.CreateBuilder<ClassifiedSpan>();
                 await AbstractClassificationService.AddClassificationsInCurrentProcessAsync(
                     document, span, type, options, temp, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
Redirects 750MB (about 50%) of the large object heap allocations seen in AB#1746674 to the normal object allocator.