### PR TITLE
link isexternalinit to avoid errors in O# about missing reference

### DIFF
--- a/src/Tools/ExternalAccess/OmniSharp/Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.csproj
+++ b/src/Tools/ExternalAccess/OmniSharp/Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.csproj
@@ -10,6 +10,10 @@
       https://github.com/OmniSharp/omnisharp-roslyn
     </PackageDescription>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\IsExternalInit.cs" Link="IsExternalInit.cs" />
+  </ItemGroup>
   
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp" />


### PR DESCRIPTION
O# build fails when upgrading to newer roslyn packages with
```
OmniSharpLineFormattingOptionsProvider.cs(27,17): error CS7069: Reference to type 'IsExternalInit' claims it is defined in 'Microsoft.CodeAnalysis.Workspaces', but it could not be found
```

This change appears to fix the problem