### PR TITLE
Use CallStackWindow icon for StackTrace Explorer menu button

### DIFF
--- a/src/VisualStudio/Core/Def/Commands.vsct
+++ b/src/VisualStudio/Core/Def/Commands.vsct
@@ -498,7 +498,10 @@
 
       <Button guid="guidStackTraceExplorer" id="cmdIdShowStackTraceExplorer" priority="0x0100" type="Button">
         <Parent guid="guidSHLMainMenu" id="IDG_VS_WNDO_OTRWNDWS1"/>
+        <Icon guid="ImageCatalogGuid" id="CallStackWindow" />
         <CommandFlag>DefaultDisabled</CommandFlag>
+        <CommandFlag>IconAndText</CommandFlag>
+        <CommandFlag>IconIsMoniker</CommandFlag>
         <Strings>
           <ButtonText>Stack Trace Explorer</ButtonText>
           <CommandName>ShowStackTraceExplorerCommandName</CommandName>


### PR DESCRIPTION
I can't upload images to GH today :( but... trust that it's a cool icon I guess