### PR TITLE
Compute TextChange based on syntax instead of text

### DIFF
--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
@@ -3,16 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.CodeAnalysis.BraceCompletion;
 using Microsoft.CodeAnalysis.CSharp.Formatting;
 using Microsoft.CodeAnalysis.Editor.UnitTests.AutomaticCompletion;
 using Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Test.Utilities;
-using Microsoft.VisualStudio.Text.Editor;
 using Roslyn.Test.Utilities;
 using Xunit;
 using static Microsoft.CodeAnalysis.BraceCompletion.AbstractBraceCompletionService;
@@ -1663,6 +1659,35 @@ class C
 
             CheckStart(session.Session);
             CheckReturn(session.Session, 12, expected);
+        }
+
+        [WpfFact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1758005")]
+        public void NoFormattingAfterNewlineIfOptionsDisabled()
+        {
+            var code = @"namespace NS1
+$$";
+
+            var expected = @"namespace NS1
+{}";
+
+            var expectedAfterReturn = @"namespace NS1
+{
+
+}";
+
+            var globalOptions = new OptionsCollection(LanguageNames.CSharp)
+            {
+                { FormattingOptions2.SmartIndent, FormattingOptions2.IndentStyle.None },
+                { AutoFormattingOptionsStorage.FormatOnCloseBrace, false },
+            };
+
+            using var session = CreateSession(code, globalOptions);
+            Assert.NotNull(session);
+
+            CheckStart(session.Session);
+            Assert.Equal(expected, session.Session.SubjectBuffer.CurrentSnapshot.GetText());
+
+            CheckReturn(session.Session, 0, expectedAfterReturn);
         }
 
         internal static Holder CreateSession(string code, OptionsCollection? globalOptions = null)

--- a/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
+++ b/src/EditorFeatures/CSharpTest/AutomaticCompletion/AutomaticBraceCompletionTests.cs
@@ -1675,6 +1675,7 @@ $$";
 
 }";
 
+            // Those option ensures no additional formatting would happen around added braces, including indention of added newline
             var globalOptions = new OptionsCollection(LanguageNames.CSharp)
             {
                 { FormattingOptions2.SmartIndent, FormattingOptions2.IndentStyle.None },

--- a/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/AbstractCurlyBraceOrBracketCompletionService.cs
@@ -115,15 +115,13 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
             {
                 // Handling syntax tree directly to avoid parsing in potentially UI blocking code-path
                 var closingToken = document.Root.FindToken(closingPoint - 1);
-                Debug.Assert(IsValidClosingBraceToken(closingToken));
 
                 var newClosingToken = closingToken.WithPrependedLeadingTrivia(
                     SpecializedCollections.SingletonEnumerable(SyntaxFactory.EndOfLine(options.FormattingOptions.NewLine)));
 
                 var rootToFormat = document.Root.ReplaceToken(closingToken, newClosingToken);
 
-                newClosingToken = rootToFormat.FindToken(closingPoint - 1, findInsideTrivia: true);
-                Debug.Assert(IsValidClosingBraceToken(newClosingToken));
+                newClosingToken = rootToFormat.FindToken(closingPoint - 1);
 
                 // Modify the closing point location to adjust for the newly inserted line.
                 closingPoint = newClosingToken.Span.End;


### PR DESCRIPTION
and check for empty change range before merge.

An attempt to fix the error reported by @jasonmalinowski 
``` 
    <description>System.ArgumentException: newChanges&#x000D;&#x000A;
    at Roslyn.Utilities.TextChangeRangeExtensions.Merge(ImmutableArray`1 oldChanges, ImmutableArray`1 newChanges)&#x000D;&#x000A;
    at Microsoft.CodeAnalysis.CSharp.BraceCompletion.AbstractCurlyBraceOrBracketCompletionService.&lt;GetTextChangeAfterReturn&gt;g__GetMergedChanges|5_2(TextChange newLineEdit, ImmutableArray`1 formattingChanges, SourceText formattedText)&#x000D;&#x000A;
    at Microsoft.CodeAnalysis.CSharp.BraceCompletion.AbstractCurlyBraceOrBracketCompletionService.GetTextChangeAfterReturn(BraceCompletionContext context, IndentationOptions options, CancellationToken cancellationToken)&#x000D;&#x000A;
    at Microsoft.CodeAnalysis.AutomaticCompletion.BraceCompletionSessionProvider.BraceCompletionSession.PostReturn()&#x000D;&#x000A;
    at Microsoft.VisualStudio.Text.Utilities.GuardedOperations.CallExtensionPoint(Object errorSource, Action call)</description>
```

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1758005