### PR TITLE
Make the go-to search result preview-window editable.

### DIFF
--- a/src/VisualStudio/Core/Def/NavigateTo/RoslynSearchResultPreviewPanel.cs
+++ b/src/VisualStudio/Core/Def/NavigateTo/RoslynSearchResultPreviewPanel.cs
@@ -36,7 +36,7 @@ internal sealed partial class RoslynSearchItemsSourceProvider
                 new VisualStudio.Threading.AsyncLazy<TextDocumentLocation>(() =>
                     Task.FromResult(new TextDocumentLocation(uri, projectGuid, span)),
                     provider._threadingContext.JoinableTaskFactory),
-                isEditable: false);
+                isEditable: true);
         }
     }
 }


### PR DESCRIPTION
This is a request from the AIOSP team to bring parity to C# documents to what is already teh case for normal file-search.