### PR TITLE
Revert "Fix extraction inside anonymous function"

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractLocalFunctionTests.cs
@@ -372,14 +372,14 @@ class C
         {
             goto label2;
             return {|Rename:NewMethod|}(x);
-
-            static int NewMethod(int x)
-            {
-                return x * x;
-            }
         };
     label2:
         return;
+
+        static int NewMethod(int x)
+        {
+            return x * x;
+        }
     }
 }", CodeActionIndex);
         }
@@ -653,15 +653,12 @@ static class C
 
     static void Main()
     {
-        Outer(y => Inner(x =>
-        {
-            {|Rename:GetX|}(x).Ex();
+        Outer(y => Inner(x => {|Rename:GetX|}(x).Ex(), y), (object)- -1);
 
-            static string GetX(string x)
-            {
-                return x;
-            }
-        }, y), (object)- -1);
+        static string GetX(string x)
+        {
+            return x;
+        }
     }
 }
 
@@ -754,15 +751,12 @@ static class C
 
     static void Main()
     {
-        Outer(y => Inner(x =>
-        {
-            {|Rename:GetX|}(x).Ex<int>();
+        Outer(y => Inner(x => {|Rename:GetX|}(x).Ex<int>(), y), (object)- -1);
 
-            static string GetX(string x)
-            {
-                return x;
-            }
-        }, y), (object)- -1);
+        static string GetX(string x)
+        {
+            return x;
+        }
     }
 }
 
@@ -5247,21 +5241,21 @@ public class Class
             await TestMissingAsync(code, codeActionIndex: CodeActionIndex);
         }
 
-        [Fact]
-        public async Task TestExtractLocalFunction_LambdaBlockInitializer()
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/65222")]
+        public async Task TestExtractLocalFunction_LambdaInitializer()
         {
             var code = """
                 class C
                 {
                     public C(int y)
-                        : this(y, (x) =>
-                        {
-                            return [|x + 1|];
-                        })
+                        : this(y, (x) => 
+                            {
+                                return [|y + 1|];
+                            })
                     {
                     }
                 
-                    public C(int x, System.Func<int, int> modX)
+                    public C(int x, Func<int, int> modX)
                     {
                     }
                 }
@@ -5271,19 +5265,19 @@ public class Class
                 class C
                 {
                     public C(int y)
-                        : this(y, (x) =>
-                        {
-                            return {|Rename:NewMethod|}(x);
-
-                            static int NewMethod(int x)
+                        : this(y, (x) => 
                             {
-                                return x + 1;
-                            }
-                        })
+                                return NewMethod(x);
+
+                                int NewMethod(int x)
+                                {
+                                    return x + 1;
+                                }
+                            })
                     {
                     }
                 
-                    public C(int x, System.Func<int, int> modX)
+                    public C(int x, Func<int, int> modX)
                     {
                     }
                 }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.cs
@@ -46,53 +46,11 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             {
                 // If we are extracting a local function and are within a local function, then we want the new function to be created within the
                 // existing local function instead of the overarching method.
-                SyntaxNode functionNode = null;
-
-                var currentNode = basePosition.Parent;
-                while (currentNode is not null)
+                var localFunctionNode = basePosition.GetAncestor<LocalFunctionStatementSyntax>(node => (node.Body != null && node.Body.Span.Contains(OriginalSelectionResult.OriginalSpan)) ||
+                                                                                                       (node.ExpressionBody != null && node.ExpressionBody.Span.Contains(OriginalSelectionResult.OriginalSpan)));
+                if (localFunctionNode is object)
                 {
-                    if (currentNode is AnonymousFunctionExpressionSyntax anonymousFunction)
-                    {
-                        if (OriginalSelectionWithin(anonymousFunction.Body) || OriginalSelectionWithin(anonymousFunction.ExpressionBody))
-                        {
-                            functionNode = currentNode;
-                            break;
-                        }
-
-                        if (!OriginalSelectionResult.OriginalSpan.Contains(anonymousFunction.Span))
-                        {
-                            // If we encountered a function but the selection isn't within the body, it's likely the user
-                            // is attempting to move the function (which is behavior that is supported). Stop looking up the 
-                            // tree and assume the encapsulating member is the right place to put the local function. This is to help
-                            // maintain the behavior introduced with https://github.com/dotnet/roslyn/pull/41377
-                            break;
-                        }
-                    }
-
-                    if (currentNode is LocalFunctionStatementSyntax localFunction)
-                    {
-                        if (OriginalSelectionWithin(localFunction.ExpressionBody) || OriginalSelectionWithin(localFunction.Body))
-                        {
-                            functionNode = currentNode;
-                            break;
-                        }
-
-                        if (!OriginalSelectionResult.OriginalSpan.Contains(localFunction.Span))
-                        {
-                            // If we encountered a function but the selection isn't within the body, it's likely the user
-                            // is attempting to move the function (which is behavior that is supported). Stop looking up the 
-                            // tree and assume the encapsulating member is the right place to put the local function. This is to help
-                            // maintain the behavior introduced with https://github.com/dotnet/roslyn/pull/41377
-                            break;
-                        }
-                    }
-
-                    currentNode = currentNode.Parent;
-                }
-
-                if (functionNode is not null)
-                {
-                    return await InsertionPoint.CreateAsync(document, functionNode, cancellationToken).ConfigureAwait(false);
+                    return await InsertionPoint.CreateAsync(document, localFunctionNode, cancellationToken).ConfigureAwait(false);
                 }
             }
 
@@ -128,16 +86,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             }
 
             return await InsertionPoint.CreateAsync(document, memberNode, cancellationToken).ConfigureAwait(false);
-        }
-
-        private bool OriginalSelectionWithin(SyntaxNode node)
-        {
-            if (node is null)
-            {
-                return false;
-            }
-
-            return node.Span.Contains(OriginalSelectionResult.OriginalSpan);
         }
 
         protected override async Task<TriviaResult> PreserveTriviaAsync(SelectionResult selectionResult, CancellationToken cancellationToken)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/CSharpCodeGenerationService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/CodeGeneration/CSharpCodeGenerationService.cs
@@ -493,10 +493,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             {
                 return AddStatementsToLocalFunctionStatement(destinationMember, statements, localFunctionStatement);
             }
-            else if (destinationMember is AnonymousFunctionExpressionSyntax anonymousFunctionSyntax)
-            {
-                return AddStatementsToAnonymousFunctions(destinationMember, statements, anonymousFunctionSyntax);
-            }
             else if (destinationMember is AccessorDeclarationSyntax accessorDeclaration)
             {
                 return (accessorDeclaration.Body == null) ? destinationMember : Cast<TDeclarationNode>(accessorDeclaration.AddBodyStatements(StatementGenerator.GenerateStatements(statements).ToArray()));
@@ -603,31 +599,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             var finalMember = localFunctionStatement
                 .WithExpressionBody(null)
                 .WithSemicolonToken(default)
-                .WithBody(body.WithStatements(body.Statements.AddRange(StatementGenerator.GenerateStatements(statements))));
-
-            return Cast<TDeclarationNode>(finalMember);
-        }
-
-        private static TDeclarationNode AddStatementsToAnonymousFunctions<TDeclarationNode>(
-            TDeclarationNode destinationMember, IEnumerable<SyntaxNode> statements, AnonymousFunctionExpressionSyntax anonymousFunctionSyntax) where TDeclarationNode : SyntaxNode
-        {
-            if (anonymousFunctionSyntax.ExpressionBody is ExpressionSyntax expressionBody)
-            {
-                var semicolonToken = SyntaxFactory.Token(SyntaxKind.SemicolonToken);
-                if (expressionBody.TryConvertToStatement(semicolonToken, createReturnStatementForExpression: false, out var statement))
-                {
-                    var block = SyntaxFactory.Block(statement);
-                    anonymousFunctionSyntax = anonymousFunctionSyntax.WithBlock(block).WithExpressionBody(null);
-                }
-            }
-
-            var body = anonymousFunctionSyntax.Block;
-
-            if (body is null)
-                return destinationMember;
-
-            var finalMember = anonymousFunctionSyntax
-                .WithExpressionBody(null)
                 .WithBody(body.WithStatements(body.Statements.AddRange(StatementGenerator.GenerateStatements(statements))));
 
             return Cast<TDeclarationNode>(finalMember);


### PR DESCRIPTION
#66158 is suspected of introducing RPS regressions.

Last known good: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/455096#view=discussion
First known bad: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/455137#view=discussion
Revert validation: https://dev.azure.com/dnceng/internal/_build/results?buildId=2125950&view=results

Regressed counters:

ManagedLangsVS64.AddNewProject - RegressedBeyondThreshold / 0100.Add New Project / RefSet_Image_Delta_devenv / Regressed: 1296384.00 Bytes (5.93%)

Please advise whether the failures are plausibly connected with this PR, and if so, whether we should revert, or take a follow-up PR to fix, or seek an exception. @genlu @ryzngard @allisonchou 