### PR TITLE
Update find-refs to find references to nint/nuint

### DIFF
--- a/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
@@ -951,6 +951,122 @@ namespace X
         Public Async Function TestNintNUint1(testHost As TestHost) As Task
             Dim input =
             <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+using System;
+class Test
+{
+    void M()
+    {
+        $${|Reference:nint|} n1 = 1;
+        nuint n2 = 1;
+        {|Reference:nint|} n3 = 1;
+        nuint n4 = 1;
+        IntPtr n5 = 1;
+        UIntPtr n6 = 1;
+        IntPtr n7 = 1;
+        UIntPtr n8 = 1;
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyHighlightsAsync(input, testHost)
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        <WorkItem(42988, "https://github.com/dotnet/roslyn/issues/42988")>
+        Public Async Function TestNintNUint2(testHost As TestHost) As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+using System;
+class Test
+{
+    void M()
+    {
+        nint n1 = 1;
+        nuint n2 = 1;
+        nint n3 = 1;
+        nuint n4 = 1;
+        $${|Reference:IntPtr|} n5 = 1;
+        UIntPtr n6 = 1;
+        {|Reference:IntPtr|} n7 = 1;
+        UIntPtr n8 = 1;
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyHighlightsAsync(input, testHost)
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        <WorkItem(42988, "https://github.com/dotnet/roslyn/issues/42988")>
+        Public Async Function TestNintNUint3(testHost As TestHost) As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+using System;
+class Test
+{
+    void M()
+    {
+        nint n1 = 1;
+        $${|Reference:nuint|} n2 = 1;
+        nint n3 = 1;
+        {|Reference:nuint|} n4 = 1;
+        IntPtr n5 = 1;
+        UIntPtr n6 = 1;
+        IntPtr n7 = 1;
+        UIntPtr n8 = 1;
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyHighlightsAsync(input, testHost)
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        <WorkItem(42988, "https://github.com/dotnet/roslyn/issues/42988")>
+        Public Async Function TestNintNUint4(testHost As TestHost) As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+using System;
+class Test
+{
+    void M()
+    {
+        nint n1 = 1;
+        nuint n2 = 1;
+        nint n3 = 1;
+        nuint n4 = 1;
+        IntPtr n5 = 1;
+        $${|Reference:UIntPtr|} n6 = 1;
+        IntPtr n7 = 1;
+        {|Reference:UIntPtr|} n8 = 1;
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyHighlightsAsync(input, testHost)
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        <WorkItem(42988, "https://github.com/dotnet/roslyn/issues/42988")>
+        Public Async Function TestNintNUint1_Net7(testHost As TestHost) As Task
+            Dim input =
+            <Workspace>
                 <Project Language="C#" CommonReferencesNet7="true">
                     <Document>
 using System;
@@ -977,7 +1093,7 @@ class Test
 
         <WpfTheory, CombinatorialData>
         <WorkItem(42988, "https://github.com/dotnet/roslyn/issues/42988")>
-        Public Async Function TestNintNUint2(testHost As TestHost) As Task
+        Public Async Function TestNintNUint2_Net7(testHost As TestHost) As Task
             Dim input =
             <Workspace>
                 <Project Language="C#" CommonReferencesNet7="true">
@@ -1006,7 +1122,7 @@ class Test
 
         <WpfTheory, CombinatorialData>
         <WorkItem(42988, "https://github.com/dotnet/roslyn/issues/42988")>
-        Public Async Function TestNintNUint3(testHost As TestHost) As Task
+        Public Async Function TestNintNUint3_Net7(testHost As TestHost) As Task
             Dim input =
             <Workspace>
                 <Project Language="C#" CommonReferencesNet7="true">
@@ -1035,7 +1151,7 @@ class Test
 
         <WpfTheory, CombinatorialData>
         <WorkItem(42988, "https://github.com/dotnet/roslyn/issues/42988")>
-        Public Async Function TestNintNUint4(testHost As TestHost) As Task
+        Public Async Function TestNintNUint4_Net7(testHost As TestHost) As Task
             Dim input =
             <Workspace>
                 <Project Language="C#" CommonReferencesNet7="true">

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
@@ -1177,5 +1177,30 @@ class Test
 
             Await VerifyHighlightsAsync(input, testHost)
         End Function
+
+        <WpfTheory, CombinatorialData>
+        <WorkItem(42988, "https://github.com/dotnet/roslyn/issues/42988")>
+        Public Async Function TestNintNUint(testHost As TestHost) As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+using System;
+class Test
+{
+    void M()
+    {
+        $${|Reference:nint|} n1 = 1;
+        int nint;
+    }
+
+    void nint() { }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyHighlightsAsync(input, testHost)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
+++ b/src/EditorFeatures/Test2/ReferenceHighlighting/CSharpReferenceHighlightingTests.vb
@@ -945,5 +945,121 @@ namespace X
 
             Await VerifyHighlightsAsync(input, testHost)
         End Function
+
+        <WpfTheory, CombinatorialData>
+        <WorkItem(42988, "https://github.com/dotnet/roslyn/issues/42988")>
+        Public Async Function TestNintNUint1(testHost As TestHost) As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferencesNet7="true">
+                    <Document>
+using System;
+class Test
+{
+    void M()
+    {
+        $${|Reference:nint|} n1 = 1;
+        nuint n2 = 1;
+        {|Reference:nint|} n3 = 1;
+        nuint n4 = 1;
+        {|Reference:IntPtr|} n5 = 1;
+        UIntPtr n6 = 1;
+        {|Reference:IntPtr|} n7 = 1;
+        UIntPtr n8 = 1;
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyHighlightsAsync(input, testHost)
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        <WorkItem(42988, "https://github.com/dotnet/roslyn/issues/42988")>
+        Public Async Function TestNintNUint2(testHost As TestHost) As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferencesNet7="true">
+                    <Document>
+using System;
+class Test
+{
+    void M()
+    {
+        {|Reference:nint|} n1 = 1;
+        nuint n2 = 1;
+        {|Reference:nint|} n3 = 1;
+        nuint n4 = 1;
+        $${|Reference:IntPtr|} n5 = 1;
+        UIntPtr n6 = 1;
+        {|Reference:IntPtr|} n7 = 1;
+        UIntPtr n8 = 1;
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyHighlightsAsync(input, testHost)
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        <WorkItem(42988, "https://github.com/dotnet/roslyn/issues/42988")>
+        Public Async Function TestNintNUint3(testHost As TestHost) As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferencesNet7="true">
+                    <Document>
+using System;
+class Test
+{
+    void M()
+    {
+        nint n1 = 1;
+        $${|Reference:nuint|} n2 = 1;
+        nint n3 = 1;
+        {|Reference:nuint|} n4 = 1;
+        IntPtr n5 = 1;
+        {|Reference:UIntPtr|} n6 = 1;
+        IntPtr n7 = 1;
+        {|Reference:UIntPtr|} n8 = 1;
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyHighlightsAsync(input, testHost)
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        <WorkItem(42988, "https://github.com/dotnet/roslyn/issues/42988")>
+        Public Async Function TestNintNUint4(testHost As TestHost) As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferencesNet7="true">
+                    <Document>
+using System;
+class Test
+{
+    void M()
+    {
+        nint n1 = 1;
+        {|Reference:nuint|} n2 = 1;
+        nint n3 = 1;
+        {|Reference:nuint|} n4 = 1;
+        IntPtr n5 = 1;
+        $${|Reference:UIntPtr|} n6 = 1;
+        IntPtr n7 = 1;
+        {|Reference:UIntPtr|} n8 = 1;
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyHighlightsAsync(input, testHost)
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/Shared/AbstractSyntaxIndex_Persistence.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
     internal partial class AbstractSyntaxIndex<TIndex> : IObjectWritable
     {
         private static readonly string s_persistenceName = typeof(TIndex).Name;
-        private static readonly Checksum s_serializationFormatChecksum = Checksum.Create("36");
+        private static readonly Checksum s_serializationFormatChecksum = Checksum.Create("37");
 
         /// <summary>
         /// Cache of ParseOptions to a checksum for the <see cref="ParseOptions.PreprocessorSymbolNames"/> contained

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -326,8 +326,7 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageService
         }
 
         private static PredefinedType GetPredefinedType(SyntaxToken token)
-        {
-            return (SyntaxKind)token.RawKind switch
+            => token.Kind() switch
             {
                 SyntaxKind.BoolKeyword => PredefinedType.Boolean,
                 SyntaxKind.ByteKeyword => PredefinedType.Byte,
@@ -345,9 +344,14 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageService
                 SyntaxKind.CharKeyword => PredefinedType.Char,
                 SyntaxKind.ObjectKeyword => PredefinedType.Object,
                 SyntaxKind.VoidKeyword => PredefinedType.Void,
+                SyntaxKind.IdentifierToken => token.Text switch
+                {
+                    "nint" => PredefinedType.IntPtr,
+                    "nuint" => PredefinedType.UIntPtr,
+                    _ => PredefinedType.None,
+                },
                 _ => PredefinedType.None,
             };
-        }
 
         public bool IsPredefinedOperator(SyntaxToken token)
             => TryGetPredefinedOperator(token, out var actualOperator) && actualOperator != PredefinedOperator.None;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/PredefinedTypeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/PredefinedTypeExtensions.cs
@@ -9,46 +9,28 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
     internal static class PredefinedTypeExtensions
     {
         public static SpecialType ToSpecialType(this PredefinedType predefinedType)
-        {
-            switch (predefinedType)
+            => predefinedType switch
             {
-                case PredefinedType.Object:
-                    return SpecialType.System_Object;
-                case PredefinedType.Void:
-                    return SpecialType.System_Void;
-                case PredefinedType.Boolean:
-                    return SpecialType.System_Boolean;
-                case PredefinedType.Char:
-                    return SpecialType.System_Char;
-                case PredefinedType.SByte:
-                    return SpecialType.System_SByte;
-                case PredefinedType.Byte:
-                    return SpecialType.System_Byte;
-                case PredefinedType.Int16:
-                    return SpecialType.System_Int16;
-                case PredefinedType.UInt16:
-                    return SpecialType.System_UInt16;
-                case PredefinedType.Int32:
-                    return SpecialType.System_Int32;
-                case PredefinedType.UInt32:
-                    return SpecialType.System_UInt32;
-                case PredefinedType.Int64:
-                    return SpecialType.System_Int64;
-                case PredefinedType.UInt64:
-                    return SpecialType.System_UInt64;
-                case PredefinedType.Decimal:
-                    return SpecialType.System_Decimal;
-                case PredefinedType.Single:
-                    return SpecialType.System_Single;
-                case PredefinedType.Double:
-                    return SpecialType.System_Double;
-                case PredefinedType.String:
-                    return SpecialType.System_String;
-                case PredefinedType.DateTime:
-                    return SpecialType.System_DateTime;
-                default:
-                    return SpecialType.None;
-            }
-        }
+                PredefinedType.Object => SpecialType.System_Object,
+                PredefinedType.Void => SpecialType.System_Void,
+                PredefinedType.Boolean => SpecialType.System_Boolean,
+                PredefinedType.Char => SpecialType.System_Char,
+                PredefinedType.SByte => SpecialType.System_SByte,
+                PredefinedType.Byte => SpecialType.System_Byte,
+                PredefinedType.Int16 => SpecialType.System_Int16,
+                PredefinedType.UInt16 => SpecialType.System_UInt16,
+                PredefinedType.Int32 => SpecialType.System_Int32,
+                PredefinedType.UInt32 => SpecialType.System_UInt32,
+                PredefinedType.Int64 => SpecialType.System_Int64,
+                PredefinedType.UInt64 => SpecialType.System_UInt64,
+                PredefinedType.Decimal => SpecialType.System_Decimal,
+                PredefinedType.Single => SpecialType.System_Single,
+                PredefinedType.Double => SpecialType.System_Double,
+                PredefinedType.String => SpecialType.System_String,
+                PredefinedType.DateTime => SpecialType.System_DateTime,
+                PredefinedType.IntPtr => SpecialType.System_IntPtr,
+                PredefinedType.UIntPtr => SpecialType.System_UIntPtr,
+                _ => SpecialType.None,
+            };
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SpecialTypeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Extensions/SpecialTypeExtensions.cs
@@ -28,6 +28,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 SpecialType.System_Double => PredefinedType.Double,
                 SpecialType.System_String => PredefinedType.String,
                 SpecialType.System_DateTime => PredefinedType.DateTime,
+                SpecialType.System_IntPtr => PredefinedType.IntPtr,
+                SpecialType.System_UIntPtr => PredefinedType.UIntPtr,
                 _ => PredefinedType.None,
             };
     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/PredefinedType.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Utilities/PredefinedType.cs
@@ -24,5 +24,7 @@ namespace Microsoft.CodeAnalysis.LanguageService
         UInt32 = 1 << 14,
         UInt64 = 1 << 15,
         Void = 1 << 16,
+        IntPtr = 1 << 17,
+        UIntPtr = 1 << 18,
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/42988

Properly understands if nint/nuint are true aliases to IntPtr/UIntPtr or not depending on underlying framework.