### PR TITLE
Force solution-asset system to fail if it can't find an asset for a checksum

### DIFF
--- a/src/Workspaces/Remote/Core/SolutionAsset.cs
+++ b/src/Workspaces/Remote/Core/SolutionAsset.cs
@@ -12,13 +12,13 @@ namespace Microsoft.CodeAnalysis.Remote
     /// </summary>
     internal sealed class SolutionAsset
     {
-        public static readonly SolutionAsset Null = new SolutionAsset(value: null, Checksum.Null, WellKnownSynchronizationKind.Null);
+        public static readonly SolutionAsset Null = new(value: null, Checksum.Null, WellKnownSynchronizationKind.Null);
 
         /// <summary>
         /// Indicates what kind of object it.
         /// 
-        /// Used in tranportation framework and deserialization service
-        /// to hand shake how to send over data and deserialize serialized data.
+        /// Used in transportation framework and deserialization service to hand shake how to send over data and
+        /// deserialize serialized data.
         /// </summary>
         public readonly WellKnownSynchronizationKind Kind;
 

--- a/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetProvider.cs
@@ -65,7 +65,6 @@ namespace Microsoft.CodeAnalysis.Remote
             if (checksums.Length == 1)
             {
                 singleAsset = await scope.GetAssetAsync(checksums[0], cancellationToken).ConfigureAwait(false);
-                singleAsset ??= SolutionAsset.Null;
             }
             else
             {

--- a/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
+++ b/src/Workspaces/Remote/Core/SolutionAssetStorage.Scope.cs
@@ -68,6 +68,8 @@ internal partial class SolutionAssetStorage
         public async ValueTask<IReadOnlyDictionary<Checksum, SolutionAsset>> GetAssetsAsync(
             Checksum[] checksums, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             using var checksumsToFind = Creator.CreateChecksumSet(checksums);
 
             var numberOfChecksumsToSearch = checksumsToFind.Object.Count;
@@ -91,6 +93,8 @@ internal partial class SolutionAssetStorage
         /// </summary>
         private async ValueTask<SolutionAsset> FindAssetAsync(Checksum checksum, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             using var checksumPool = Creator.CreateChecksumSet(SpecializedCollections.SingletonEnumerable(checksum));
             using var resultPool = Creator.CreateResultSet();
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/47013

This code was non-sensical.  We could only get to the point where we would be trying to find an asset for a checksum once all the checksums/assets were already stored in the storage-scope.  So if we had taht, but then can't find an asset for a checksum later, then that indicates a very very bad invariant problem.  And definitely not something we want to paper over.  It's unclear how this wouldn't just crash higher layers anyways as trying to get an asset, and returning null, would just break anything expecting a normally non-null asset (the common case for everything in the workspace).