### PR TITLE
Ensure placeholders and locals are registered in RefSafetyAnalysis before escape analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1709,6 +1709,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var data = expression.GetInterpolatedStringHandlerData();
 #if DEBUG
+            // VisitArgumentsAndGetArgumentPlaceholders() does not visit data.Construction
+            // since that expression does not introduce locals or placeholders that are needed
+            // by GetValEscape() or CheckValEscape(), so we disable tracking here.
             bool previousTrackVisited = _trackVisited;
             _trackVisited = false;
 #endif
@@ -2092,7 +2095,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                         stackLocalsOpt: null))
                     {
 #if DEBUG
-                        CheckVisited(receiver);
+                        AssertVisited(receiver);
 #endif
                         // Equivalent to a non-ref local with the underlying receiver as an initializer provided at declaration 
                         receiver = new BoundCapturedReceiverPlaceholder(receiver.Syntax, receiver, _localScopeDepth, receiver.Type).MakeCompilerGenerated();
@@ -2924,7 +2927,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal uint GetRefEscape(BoundExpression expr, uint scopeOfTheContainingExpression)
         {
 #if DEBUG
-            CheckVisited(expr);
+            AssertVisited(expr);
 #endif
 
             // cannot infer anything from errors
@@ -3164,7 +3167,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal bool CheckRefEscape(SyntaxNode node, BoundExpression expr, uint escapeFrom, uint escapeTo, bool checkingReceiver, BindingDiagnosticBag diagnostics)
         {
 #if DEBUG
-            CheckVisited(expr);
+            AssertVisited(expr);
 #endif
 
             Debug.Assert(!checkingReceiver || expr.Type.IsValueType || expr.Type.IsTypeParameter());
@@ -3490,7 +3493,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal uint GetValEscape(BoundExpression expr, uint scopeOfTheContainingExpression)
         {
 #if DEBUG
-            CheckVisited(expr);
+            AssertVisited(expr);
 #endif
 
             // cannot infer anything from errors
@@ -3893,7 +3896,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal bool CheckValEscape(SyntaxNode node, BoundExpression expr, uint escapeFrom, uint escapeTo, bool checkingReceiver, BindingDiagnosticBag diagnostics)
         {
 #if DEBUG
-            CheckVisited(expr);
+            AssertVisited(expr);
 #endif
 
             Debug.Assert(!checkingReceiver || expr.Type.IsValueType || expr.Type.IsTypeParameter());
@@ -4514,7 +4517,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Consider the case where a ref-struct handler saves off the result of one call to AppendFormatted,
             // and then on a subsequent call it either assigns that saved value to another ref struct with a larger
             // escape, or does the opposite. In either case, we need to check.
+
 #if DEBUG
+            // VisitArgumentsAndGetArgumentPlaceholders() does not visit data.Construction
+            // since that expression does not introduce locals or placeholders that are needed
+            // by GetValEscape() or CheckValEscape(), so we disable tracking here.
             bool previousTrackVisited = _trackVisited;
             _trackVisited = false;
 #endif

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -2084,8 +2084,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                                         _compilation.IsPeVerifyCompatEnabled,
                                         stackLocalsOpt: null))
                     {
+#if DEBUG
+                        Debug.Assert(IsVisited(receiver));
+#endif
                         // Equivalent to a non-ref local with the underlying receiver as an initializer provided at declaration 
                         receiver = new BoundCapturedReceiverPlaceholder(receiver.Syntax, receiver, _localScopeDepth, receiver.Type).MakeCompilerGenerated();
+#if DEBUG
+                        MarkedVisited(receiver);
+#endif
                     }
                 }
 
@@ -2910,6 +2916,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         internal uint GetRefEscape(BoundExpression expr, uint scopeOfTheContainingExpression)
         {
+#if DEBUG
+            Debug.Assert(IsVisited(expr));
+#endif
+
             // cannot infer anything from errors
             if (expr.HasAnyErrors)
             {
@@ -3146,6 +3156,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         internal bool CheckRefEscape(SyntaxNode node, BoundExpression expr, uint escapeFrom, uint escapeTo, bool checkingReceiver, BindingDiagnosticBag diagnostics)
         {
+#if DEBUG
+            Debug.Assert(IsVisited(expr));
+#endif
+
             Debug.Assert(!checkingReceiver || expr.Type.IsValueType || expr.Type.IsTypeParameter());
 
             if (escapeTo >= escapeFrom)
@@ -3468,6 +3482,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         internal uint GetValEscape(BoundExpression expr, uint scopeOfTheContainingExpression)
         {
+#if DEBUG
+            Debug.Assert(IsVisited(expr));
+#endif
+
             // cannot infer anything from errors
             if (expr.HasAnyErrors)
             {
@@ -3867,6 +3885,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         internal bool CheckValEscape(SyntaxNode node, BoundExpression expr, uint escapeFrom, uint escapeTo, bool checkingReceiver, BindingDiagnosticBag diagnostics)
         {
+#if DEBUG
+            Debug.Assert(IsVisited(expr));
+#endif
+
             Debug.Assert(!checkingReceiver || expr.Type.IsValueType || expr.Type.IsTypeParameter());
 
             if (escapeTo >= escapeFrom)

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -2099,9 +2099,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 #endif
                         // Equivalent to a non-ref local with the underlying receiver as an initializer provided at declaration 
                         receiver = new BoundCapturedReceiverPlaceholder(receiver.Syntax, receiver, _localScopeDepth, receiver.Type).MakeCompilerGenerated();
-#if DEBUG
-                        MarkVisited(receiver);
-#endif
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1712,12 +1712,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             // VisitArgumentsAndGetArgumentPlaceholders() does not visit data.Construction
             // since that expression does not introduce locals or placeholders that are needed
             // by GetValEscape() or CheckValEscape(), so we disable tracking here.
-            bool previousTrackVisited = _trackVisited;
-            _trackVisited = false;
+            var previousVisited = _visited;
+            _visited = null;
 #endif
             uint escapeScope = GetValEscape(data.Construction, scopeOfTheContainingExpression);
 #if DEBUG
-            _trackVisited = previousTrackVisited;
+            _visited = previousVisited;
 #endif
 
             var arguments = ArrayBuilder<BoundExpression>.GetInstance();
@@ -4519,12 +4519,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             // VisitArgumentsAndGetArgumentPlaceholders() does not visit data.Construction
             // since that expression does not introduce locals or placeholders that are needed
             // by GetValEscape() or CheckValEscape(), so we disable tracking here.
-            bool previousTrackVisited = _trackVisited;
-            _trackVisited = false;
+            var previousVisited = _visited;
+            _visited = null;
 #endif
             CheckValEscape(expression.Syntax, data.Construction, escapeFrom, escapeTo, checkingReceiver: false, diagnostics);
 #if DEBUG
-            _trackVisited = previousTrackVisited;
+            _visited = previousVisited;
 #endif
 
             var arguments = ArrayBuilder<BoundExpression>.GetInstance();

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -192,14 +192,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private (uint RefEscapeScope, uint ValEscapeScope) GetLocalScopes(LocalSymbol local)
         {
-            Debug.Assert(_localEscapeScopes is { });
-            return _localEscapeScopes[local];
+            Debug.Assert(_localEscapeScopes?.ContainsKey(local) == true);
+
+            return _localEscapeScopes?.TryGetValue(local, out var scopes) == true
+                ? scopes
+                : (CallingMethodScope, CallingMethodScope);
         }
 
         private void SetLocalScopes(LocalSymbol local, uint refEscapeScope, uint valEscapeScope)
         {
-            Debug.Assert(_localEscapeScopes is { });
-            _localEscapeScopes[local] = (refEscapeScope, valEscapeScope);
+            Debug.Assert(_localEscapeScopes?.ContainsKey(local) == true);
+
+            AddOrSetLocalScopes(local, refEscapeScope, valEscapeScope);
         }
 
         private void AddPlaceholderScope(BoundValuePlaceholderBase placeholder, uint valEscapeScope)
@@ -211,7 +215,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 #pragma warning disable IDE0060
         private void RemovePlaceholderScope(BoundValuePlaceholderBase placeholder)
         {
-            Debug.Assert(_placeholderScopes is { });
+            Debug.Assert(_placeholderScopes?.ContainsKey(placeholder) == true);
+
             // https://github.com/dotnet/roslyn/issues/65961: Currently, analysis may require subsequent calls
             // to GetRefEscape(), etc. for the same expression so we cannot remove placeholders eagerly.
             //_placeholderScopes.Remove(placeholder);
@@ -220,8 +225,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private uint GetPlaceholderScope(BoundValuePlaceholderBase placeholder)
         {
-            Debug.Assert(_placeholderScopes is { });
-            return _placeholderScopes[placeholder];
+            // https://github.com/dotnet/roslyn/issues/67070: Assert should be re-enabled when placeholders are included.
+            //Debug.Assert(_placeholderScopes?.ContainsKey(placeholder) == true);
+
+            return _placeholderScopes?.TryGetValue(placeholder, out var scope) == true
+                ? scope
+                : CallingMethodScope;
         }
 
         public override BoundNode? VisitBlock(BoundBlock node)
@@ -405,8 +414,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                     CallingMethodScope;
             }
 
+            Debug.Assert(_localEscapeScopes?.ContainsKey(local) != true);
+
+            AddOrSetLocalScopes(local, refEscapeScope, valEscapeScope);
+        }
+
+        private void AddOrSetLocalScopes(LocalSymbol local, uint refEscapeScope, uint valEscapeScope)
+        {
             _localEscapeScopes ??= new Dictionary<LocalSymbol, (uint RefEscapeScope, uint ValEscapeScope)>();
-            _localEscapeScopes.Add(local, (refEscapeScope, valEscapeScope));
+            _localEscapeScopes[local] = (refEscapeScope, valEscapeScope);
         }
 
 #pragma warning disable IDE0060

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -86,8 +86,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         private uint _patternInputValEscape;
 #if DEBUG
         private const int MaxTrackVisited = 100; // Avoid tracking if too many expressions.
-        private readonly HashSet<BoundExpression> _visited;
-        private bool _trackVisited;
+        private readonly HashSet<BoundExpression> _visited = new HashSet<BoundExpression>();
+        private bool _trackVisited = true;
 #endif
 
         private RefSafetyAnalysis(
@@ -108,9 +108,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // the same depth as parameters, _localScopeDepth is initialized to one less.
             _localScopeDepth = CurrentMethodScope - 1;
             _localEscapeScopes = localEscapeScopes;
-#if DEBUG
-            _visited = new HashSet<BoundExpression>();
-#endif
         }
 
         private ref struct LocalScope
@@ -255,6 +252,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return true;
             }
 
+            // _placeholderScopes should contain all placeholders that may be used by GetValEscape() or CheckValEscape().
+            // The following placeholders are not needed by those methods and can be ignored, however.
             switch (placeholder)
             {
                 case BoundObjectOrCollectionValuePlaceholder:
@@ -296,7 +295,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
 #if DEBUG
-        private void CheckVisited(BoundExpression expr)
+        private void AssertVisited(BoundExpression expr)
         {
             if (expr is BoundValuePlaceholderBase placeholder
                 && placeholder is not BoundCapturedReceiverPlaceholder)

--- a/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
+++ b/src/Compilers/CSharp/Portable/Binder/RefSafetyAnalysis.cs
@@ -86,8 +86,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private uint _patternInputValEscape;
 #if DEBUG
         private const int MaxTrackVisited = 100; // Avoid tracking if too many expressions.
-        private readonly HashSet<BoundExpression> _visited = new HashSet<BoundExpression>();
-        private bool _trackVisited = true;
+        private HashSet<BoundExpression>? _visited = new HashSet<BoundExpression>();
 #endif
 
         private RefSafetyAnalysis(
@@ -286,7 +285,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if (node is BoundExpression expr)
             {
-                if (_trackVisited && _visited.Count <= MaxTrackVisited)
+                if (_visited is { } && _visited.Count <= MaxTrackVisited)
                 {
                     bool added = _visited.Add(expr);
                     Debug.Assert(added);
@@ -303,7 +302,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert(ContainsPlaceholderScope(placeholder));
             }
-            else if (_trackVisited && _visited.Count <= MaxTrackVisited)
+            else if (_visited is { } && _visited.Count <= MaxTrackVisited)
             {
                 Debug.Assert(_visited.Contains(expr));
             }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/IndexAndRangeTests.cs
@@ -3891,5 +3891,23 @@ class S
 }
 ");
         }
+
+        [ConditionalFact(typeof(CoreClrOnly))]
+        public void SpanSlice()
+        {
+            string source = """
+                using System;
+                class Program
+                {
+                    static void M(Span<int> s)
+                    {
+                        var x = s[1..^1];
+                        var y = s[^1];
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InterpolationTests.cs
@@ -15078,6 +15078,410 @@ class Program
                 Diagnostic(ErrorCode.ERR_EscapeCall, @"$""{1}""").WithArguments("CustomHandler.CustomHandler(int, int, ref R)", "r").WithLocation(18, 28));
         }
 
+        [Fact]
+        public void RefEscape_18()
+        {
+            string source = """
+                using System.Runtime.CompilerServices;
+                [InterpolatedStringHandler]
+                ref struct CustomHandler
+                {
+                    private ref readonly int _i;
+                    public CustomHandler(int literalLength, int formattedCount, in int i = 0) { _i = ref i; }
+                    public void AppendFormatted(int i) { } 
+                }
+                class Program
+                {
+                    static CustomHandler F1()
+                    {
+                        return $"{1}";
+                    }
+                    static CustomHandler F2()
+                    {
+                        CustomHandler h2 = $"{2}";
+                        return h2;
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics(
+                // (13,16): error CS8156: An expression cannot be used in this context because it may not be passed or returned by reference
+                //         return $"{1}";
+                Diagnostic(ErrorCode.ERR_RefReturnLvalueExpected, @"$""{1}""").WithLocation(13, 16),
+                // (13,16): error CS8347: Cannot use a result of 'CustomHandler.CustomHandler(int, int, in int)' in this context because it may expose variables referenced by parameter 'i' outside of their declaration scope
+                //         return $"{1}";
+                Diagnostic(ErrorCode.ERR_EscapeCall, @"$""{1}""").WithArguments("CustomHandler.CustomHandler(int, int, in int)", "i").WithLocation(13, 16),
+                // (18,16): error CS8352: Cannot use variable 'h2' in this context because it may expose referenced variables outside of their declaration scope
+                //         return h2;
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "h2").WithArguments("h2").WithLocation(18, 16));
+        }
+
+        [WorkItem(63306, "https://github.com/dotnet/roslyn/issues/63306")]
+        [Fact]
+        public void RefEscape_19()
+        {
+            string source = """
+                using System.Diagnostics.CodeAnalysis;
+                using System.Runtime.CompilerServices;
+                [InterpolatedStringHandler]
+                ref struct CustomHandler
+                {
+                    private ref readonly int _i;
+                    public CustomHandler(int literalLength, int formattedCount) { }
+                    public void AppendFormatted(int x, [UnscopedRef] in int y = 0) { _i = ref y; } 
+                }
+                class Program
+                {
+                    static CustomHandler F1()
+                    {
+                        return $"{1}";
+                    }
+                    static CustomHandler F2()
+                    {
+                        CustomHandler h2 = $"{2}";
+                        return h2;
+                    }
+                }
+                """;
+            // https://github.com/dotnet/roslyn/issues/63306: Should report an error that a reference to y will escape F1() and F2().
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics();
+        }
+
+        [WorkItem(67070, "https://github.com/dotnet/roslyn/issues/67070")]
+        [ConditionalFact(typeof(CoreClrOnly))]
+        public void RefEscape_NestedCalls_01()
+        {
+            string source = """
+                using System;
+                using System.Runtime.CompilerServices;
+                static class Program
+                {
+                    static void Main()
+                    {
+                        var r = new R();
+                        r
+                           .F($"[{42}]")
+                           .F($"[{"str".AsSpan()}]");
+                    }
+                }
+                readonly ref struct R
+                {
+                    public R F([InterpolatedStringHandlerArgument("")] CustomHandler handler)
+                        => this;
+                }
+                [InterpolatedStringHandler]
+                readonly ref struct CustomHandler
+                {
+                    public CustomHandler(int literalLength, int formattedCount, R r)
+                    {
+                    }
+                    public void AppendLiteral(string value)
+                    {
+                    }
+                    public void AppendFormatted<T>(T value)
+                    {
+                    }
+                    public void AppendFormatted(ReadOnlySpan<char> value)
+                    {
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics();
+        }
+
+        [WorkItem(67070, "https://github.com/dotnet/roslyn/issues/67070")]
+        [ConditionalFact(typeof(CoreClrOnly))]
+        public void RefEscape_NestedCalls_02()
+        {
+            string source = """
+                using System.Runtime.CompilerServices;
+                static class Program
+                {
+                    static void Main()
+                    {
+                        var r = new R();
+                        r
+                           .F($"{42}")
+                           .F($"{42}");
+                    }
+                }
+                readonly ref struct R
+                {
+                    public R F([InterpolatedStringHandlerArgument("")] CustomHandler handler)
+                        => this;
+                }
+                [InterpolatedStringHandler]
+                readonly ref struct CustomHandler
+                {
+                    public CustomHandler(int literalLength, int formattedCount, R r)
+                    {
+                    }
+                    public void AppendLiteral(string value)
+                    {
+                    }
+                    public void AppendFormatted<T>(T value)
+                    {
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics();
+        }
+
+        [WorkItem(67070, "https://github.com/dotnet/roslyn/issues/67070")]
+        [ConditionalFact(typeof(CoreClrOnly))]
+        public void RefEscape_NestedCalls_03()
+        {
+            string source = """
+                using System.Runtime.CompilerServices;
+                static class Program
+                {
+                    static void Main()
+                    {
+                        var r = new R();
+                        F(
+                            F(r, $"{42}"),
+                            $"{42}");
+                    }
+                    static R F(R r, [InterpolatedStringHandlerArgument("r")] CustomHandler handler)
+                        => r;
+                }
+                readonly ref struct R
+                {
+                }
+                [InterpolatedStringHandler]
+                readonly ref struct CustomHandler
+                {
+                    public CustomHandler(int literalLength, int formattedCount, R r)
+                    {
+                    }
+                    public void AppendLiteral(string value)
+                    {
+                    }
+                    public void AppendFormatted<T>(T value)
+                    {
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics();
+        }
+
+        [WorkItem(67070, "https://github.com/dotnet/roslyn/issues/67070")]
+        [ConditionalFact(typeof(CoreClrOnly))]
+        public void RefEscape_NestedCalls_04()
+        {
+            string source = """
+                using System.Runtime.CompilerServices;
+                static class Program
+                {
+                    static void Main()
+                    {
+                        var r = new R();
+                        r = new R(
+                            new R(r, $"{42}"),
+                            $"{42}");
+                    }
+                }
+                readonly ref struct R
+                {
+                    public R(R r, [InterpolatedStringHandlerArgument("r")] CustomHandler handler)
+                    {
+                    }
+                }
+                [InterpolatedStringHandler]
+                readonly ref struct CustomHandler
+                {
+                    public CustomHandler(int literalLength, int formattedCount, R r)
+                    {
+                    }
+                    public void AppendLiteral(string value)
+                    {
+                    }
+                    public void AppendFormatted<T>(T value)
+                    {
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics();
+        }
+
+        [WorkItem(67070, "https://github.com/dotnet/roslyn/issues/67070")]
+        [ConditionalFact(typeof(CoreClrOnly))]
+        public void RefEscape_NestedCalls_05()
+        {
+            string source = """
+                using System.Runtime.CompilerServices;
+                static class Program
+                {
+                    static void Main()
+                    {
+                        var r = new R();
+                        r = r
+                            [$"{42}"]
+                            [$"{42}"];
+                    }
+                }
+                readonly ref struct R
+                {
+                    public R this[[InterpolatedStringHandlerArgument("")] CustomHandler handler]
+                        => this;
+                }
+                [InterpolatedStringHandler]
+                readonly ref struct CustomHandler
+                {
+                    public CustomHandler(int literalLength, int formattedCount, R r)
+                    {
+                    }
+                    public void AppendLiteral(string value)
+                    {
+                    }
+                    public void AppendFormatted<T>(T value)
+                    {
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics();
+        }
+
+        [WorkItem(67070, "https://github.com/dotnet/roslyn/issues/67070")]
+        [ConditionalFact(typeof(CoreClrOnly))]
+        public void RefEscape_NestedCalls_06()
+        {
+            string source = """
+                using System;
+                using System.Runtime.CompilerServices;
+                static class Program
+                {
+                    static R M()
+                    {
+                        R r = default;
+                        Span<byte> span = stackalloc byte[42];
+                        return r
+                            .F($"{span}")
+                            .F($"{span}");
+                    }
+                }
+                readonly ref struct R
+                {
+                    public R F([InterpolatedStringHandlerArgument("")] CustomHandler handler)
+                        => this;
+                }
+                [InterpolatedStringHandler]
+                readonly ref struct CustomHandler
+                {
+                    public CustomHandler(int literalLength, int formattedCount, R r)
+                    {
+                    }
+                    public void AppendLiteral(string value)
+                    {
+                    }
+                    public void AppendFormatted<T>(T value)
+                    {
+                    }
+                    public void AppendFormatted(Span<byte> span)
+                    {
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics(
+                // (9,16): error CS8347: Cannot use a result of 'R.F(CustomHandler)' in this context because it may expose variables referenced by parameter 'handler' outside of their declaration scope
+                //         return r
+                Diagnostic(ErrorCode.ERR_EscapeCall, @"r
+            .F($""{span}"")").WithArguments("R.F(CustomHandler)", "handler").WithLocation(9, 16),
+                // (10,19): error CS8352: Cannot use variable 'span' in this context because it may expose referenced variables outside of their declaration scope
+                //             .F($"{span}")
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "span").WithArguments("span").WithLocation(10, 19));
+        }
+
+        [ConditionalFact(typeof(CoreClrOnly))]
+        public void RefEscape_NestedCalls_07()
+        {
+            string source = """
+                using System.Runtime.CompilerServices;
+                static class Program
+                {
+                    static R M()
+                    {
+                        int i = 0;
+                        var r = new R(ref i);
+                        return r
+                           .F($"{i}")
+                           .F($"{i}");
+                    }
+                }
+                readonly ref struct R
+                {
+                    private readonly ref int _i;
+                    public R(ref int i) { _i = i; }
+                    public R F([InterpolatedStringHandlerArgument("")] CustomHandler handler)
+                        => this;
+                }
+                [InterpolatedStringHandler]
+                readonly ref struct CustomHandler
+                {
+                    public CustomHandler(int literalLength, int formattedCount, R r)
+                    {
+                    }
+                    public void AppendLiteral(string value)
+                    {
+                    }
+                    public void AppendFormatted<T>(T value)
+                    {
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics(
+                // (8,16): error CS8352: Cannot use variable 'r' in this context because it may expose referenced variables outside of their declaration scope
+                //         return r
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "r").WithArguments("r").WithLocation(8, 16));
+        }
+
+        [WorkItem(67070, "https://github.com/dotnet/roslyn/issues/67070")]
+        [ConditionalFact(typeof(CoreClrOnly))]
+        public void RefEscape_NestedCalls_08()
+        {
+            string source = """
+                using System.Runtime.CompilerServices;
+                static class Program
+                {
+                    static void Main()
+                    {
+                        var r = new R();
+                        r
+                           .F($"{1}", $"{2}")
+                           .F($"{3}", $"{4}");
+                    }
+                }
+                readonly ref struct R
+                {
+                    public R F([InterpolatedStringHandlerArgument("")] CustomHandler h1, [InterpolatedStringHandlerArgument("")] CustomHandler h2)
+                        => this;
+                }
+                [InterpolatedStringHandler]
+                readonly ref struct CustomHandler
+                {
+                    public CustomHandler(int literalLength, int formattedCount, R r)
+                    {
+                    }
+                    public void AppendLiteral(string value)
+                    {
+                    }
+                    public void AppendFormatted<T>(T value)
+                    {
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics();
+        }
+
         [Theory, WorkItem(54703, "https://github.com/dotnet/roslyn/issues/54703")]
         [InlineData(@"$""{{ {i} }}""")]
         [InlineData(@"$""{{ "" + $""{i}"" + $"" }}""")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -7092,6 +7092,7 @@ public struct Vec4
             comp.VerifyDiagnostics();
         }
 
+        [WorkItem(67493, "https://github.com/dotnet/roslyn/issues/67493")]
         [Fact]
         public void Local_SwitchStatementExpression()
         {
@@ -7127,6 +7128,7 @@ public struct Vec4
                 Diagnostic(ErrorCode.ERR_EscapeVariable, "z").WithArguments("z").WithLocation(20, 24));
         }
 
+        [WorkItem(67493, "https://github.com/dotnet/roslyn/issues/67493")]
         [Fact]
         public void Local_ForEachExpression()
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -7061,6 +7061,113 @@ public struct Vec4
             comp.VerifyDiagnostics();
         }
 
+        [Fact]
+        public void Local_UsingStatementExpression()
+        {
+            string source = """
+                using System;
+                struct S : IDisposable
+                {
+                    public void Dispose() { }
+                }
+                ref struct R
+                {
+                    public ref int F;
+                    public R(ref int i) { F = ref i; }
+                    public static implicit operator S(R r) => default;
+                }
+                class Program
+                {
+                    static void Main()
+                    {
+                        int i = 0;
+                        var x = new R(ref i);
+                        using (x switch { R y => (S)y })
+                        {
+                        }
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void Local_SwitchStatementExpression()
+        {
+            string source = """
+                ref struct R1
+                {
+                    public R2 F;
+                    public R1(ref int i) { F = new R2(ref i); }
+                }
+                ref struct R2
+                {
+                    ref int _i;
+                    public R2(ref int i) { _i = ref i; }
+                }
+                class Program
+                {
+                    static R2 F()
+                    {
+                        int i = 0;
+                        var x = new R1(ref i);
+                        switch (x switch { { F: R2 y } => y })
+                        {
+                            case R2 z:
+                                return z;
+                        }
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics(
+                // (20,24): error CS8352: Cannot use variable 'z' in this context because it may expose referenced variables outside of their declaration scope
+                //                 return z;
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "z").WithArguments("z").WithLocation(20, 24));
+        }
+
+        [Fact]
+        public void Local_ForEachExpression()
+        {
+            string source = """
+                ref struct R
+                {
+                    public ref int F;
+                    public R(ref int i) { F = ref i; }
+                }
+                ref struct Enumerable
+                {
+                    public ref int F;
+                    public Enumerable(ref int i) { F = ref i; }
+                    public Enumerator GetEnumerator() => new Enumerator(ref F);
+                }
+                ref struct Enumerator
+                {
+                    public ref int F;
+                    public Enumerator(ref int i) { F = ref i; }
+                    public R Current => new R(ref F);
+                    public bool MoveNext() => false;
+                }
+                class Program
+                {
+                    static R F()
+                    {
+                        foreach (var y in 1 switch { int x => new Enumerable(ref x) })
+                        {
+                            return y;
+                        }
+                        return default;
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics(
+                // (25,20): error CS8352: Cannot use variable 'y' in this context because it may expose referenced variables outside of their declaration scope
+                //             return y;
+                Diagnostic(ErrorCode.ERR_EscapeVariable, "y").WithArguments("y").WithLocation(25, 20));
+        }
+
         [ConditionalFact(typeof(CoreClrOnly))]
         public void ParameterEscape()
         {


### PR DESCRIPTION
Updates `RefSafetyAnalysis` to ensure that expressions are visited before calling `GetValEscape()`, `GetRefEscape()`, `CheckValEscape()`, or `CheckRefEscape()`, so that the escape scopes of placeholders and locals are registered with the visitor for those calls.

Fixes #67070
Fixes #67493

_The first commit is a port of https://github.com/dotnet/roslyn/commit/bcbb2d7e056217b17afce0a2fabcd6f9a907380c from `release/dev17.5-vs-deps` since that branch has not flowed into `main` yet._