### PR TITLE
[Lightbulb Perf] Execute symbol start analyzers concurrently

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisScope.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisScope.cs
@@ -92,7 +92,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private AnalysisScope(ImmutableArray<SyntaxTree> trees, ImmutableArray<AdditionalText> additionalFiles, ImmutableArray<DiagnosticAnalyzer> analyzers, bool isPartialAnalysis, SourceOrAdditionalFile? filterFile, TextSpan? filterSpanOpt, bool isSyntacticSingleFileAnalysis, bool isEntireCompilationAnalysis, bool concurrentAnalysis, bool categorizeDiagnostics)
         {
-            Debug.Assert(trees.Any() || additionalFiles.Any());
             Debug.Assert(isPartialAnalysis || FilterFileOpt == null);
             Debug.Assert(isPartialAnalysis || FilterSpanOpt == null);
             Debug.Assert(isPartialAnalysis || !isSyntacticSingleFileAnalysis);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -730,7 +730,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private void ExecuteSyntaxTreeActions(AnalysisScope analysisScope, CancellationToken cancellationToken)
         {
-            if (analysisScope.IsSingleFileAnalysis && !analysisScope.IsSyntacticSingleFileAnalysis)
+            if (!analysisScope.IsEntireCompilationAnalysis && !analysisScope.IsSyntacticSingleFileAnalysis)
             {
                 // For partial analysis, only execute syntax tree actions if performing syntax analysis.
                 return;
@@ -762,7 +762,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private void ExecuteAdditionalFileActions(AnalysisScope analysisScope, CancellationToken cancellationToken)
         {
-            if (analysisScope.IsSingleFileAnalysis && !analysisScope.IsSyntacticSingleFileAnalysis)
+            if (!analysisScope.IsEntireCompilationAnalysis && !analysisScope.IsSyntacticSingleFileAnalysis)
             {
                 // For partial analysis, only execute additional file actions if performing syntactic single file analysis.
                 return;
@@ -2418,7 +2418,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    if (analysisScope.FilterFileOpt != null && analysisScope.FilterFileOpt?.SourceTree != decl.SyntaxTree)
+                    if (!analysisScope.ShouldAnalyze(decl.SyntaxTree))
                     {
                         continue;
                     }


### PR DESCRIPTION
Addresses part of #66968
Work identified as part of #66970

NOTE: This change only affects IDE analyzer execution code path.

SymbolStart/End analyzers require analyzer callbacks to be made for all the code within the containing type symbol, including it's partial definitions. This can span across multiple source files, and can be expensive. Currently, we execute the symbol start analyzers sequentially for the files corresponding to the partial definition. This PR changes this model to now execute them concurrently. We now generate the compilation events for all the partial decl trees in parallel and subsequently process all the generated compilation events across all these files concurrently in the driver. The primary changes are to enhance `AnalysisScope` and `AnalyzerDriver` types to support analyzing multiple files - prior to this change we only supported analyzing a single file or entire compilation.