### PR TITLE
Multitarget O# external access projects to fix issues accessing prope…

### DIFF
--- a/src/Tools/ExternalAccess/OmniSharp.CSharp/Completion/OmniSharpCompletionProviderNames.cs
+++ b/src/Tools/ExternalAccess/OmniSharp.CSharp/Completion/OmniSharpCompletionProviderNames.cs
@@ -8,11 +8,11 @@ namespace Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp.Completion
 {
     internal static class OmniSharpCompletionProviderNames
     {
-        internal static string ObjectCreationCompletionProvider = typeof(ObjectCreationCompletionProvider).FullName;
-        internal static string OverrideCompletionProvider = typeof(OverrideCompletionProvider).FullName;
-        internal static string PartialMethodCompletionProvider = typeof(PartialMethodCompletionProvider).FullName;
-        internal static string InternalsVisibleToCompletionProvider = typeof(InternalsVisibleToCompletionProvider).FullName;
-        internal static string TypeImportCompletionProvider = typeof(TypeImportCompletionProvider).FullName;
-        internal static string ExtensionMethodImportCompletionProvider = typeof(ExtensionMethodImportCompletionProvider).FullName;
+        internal static string ObjectCreationCompletionProvider = typeof(ObjectCreationCompletionProvider).FullName!;
+        internal static string OverrideCompletionProvider = typeof(OverrideCompletionProvider).FullName!;
+        internal static string PartialMethodCompletionProvider = typeof(PartialMethodCompletionProvider).FullName!;
+        internal static string InternalsVisibleToCompletionProvider = typeof(InternalsVisibleToCompletionProvider).FullName!;
+        internal static string TypeImportCompletionProvider = typeof(TypeImportCompletionProvider).FullName!;
+        internal static string ExtensionMethodImportCompletionProvider = typeof(ExtensionMethodImportCompletionProvider).FullName!;
     }
 }

--- a/src/Tools/ExternalAccess/OmniSharp.CSharp/Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp.csproj
+++ b/src/Tools/ExternalAccess/OmniSharp.CSharp/Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
 
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp</PackageId>

--- a/src/Tools/ExternalAccess/OmniSharp/Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.csproj
+++ b/src/Tools/ExternalAccess/OmniSharp/Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
 
     <IsPackable>true</IsPackable>
     <PackageId>Microsoft.CodeAnalysis.ExternalAccess.OmniSharp</PackageId>
@@ -10,10 +10,6 @@
       https://github.com/OmniSharp/omnisharp-roslyn
     </PackageDescription>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\IsExternalInit.cs" Link="IsExternalInit.cs" />
-  </ItemGroup>
   
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp" />


### PR DESCRIPTION
…rties on records

The last PR - https://github.com/dotnet/roslyn/pull/67106 was slightly incorrect - it fixed the build, but caused a bunch of test failures trying to call methods on records

```
System.MissingMethodException : Method not found: 'Void Microsoft.CodeAnalysis.Completion.CompletionOptions.set_ShowItemsFromUnimportedNamespaces(System.Nullable`1<Boolean>)'.[xUnit.net 00:00:19.95]       Stack Trace:[xUnit.net 00:00:19.95]            at Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Completion.OmniSharpCompletionOptions.ToCompletionOptions()[xUnit.net 00:00:19.95]            at Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.Completion.OmniSharpCompletionService.GetCompletionsAsync(CompletionService completionService, Document document, Int32 caretPosition, CompletionTrigger trigger, ImmutableHashSet`1 roles, OmniSharpCompletionOptions options, CancellationToken cancellationToken)[xUnit.net 00:00:19.95]         /home/runner/work/omnisharp-roslyn/omnisharp-roslyn/src/OmniSharp.Roslyn.CSharp/Services/Completion/CompletionService.cs(95,0): at OmniSharp.Roslyn.CSharp.Services.Completion.CompletionService.Handle(CompletionRequest request, Boolean forceExpandedCompletionIndexCreation)[xUnit.net 00:00:19.95]         /home/runner/work/omnisharp-roslyn/omnisharp-roslyn/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs(2281,0): at OmniSharp.Roslyn.CSharp.Tests.CompletionFacts.FindCompletionsAsync(String filename, String source, OmniSharpTestHost testHost, Nullable`1 triggerChar, TestFile[] additionalFiles, Boolean forceExpandedCompletionIndexCreation)[xUnit.net 00:00:19.95]         /home/runner/work/omnisharp-roslyn/omnisharp-roslyn/tests/OmniSharp.Roslyn.CSharp.Tests/CompletionFacts.cs(301,0): at OmniSharp.Roslyn.CSharp.Tests.CompletionFacts.ImportCompletion_OnLine0(String filename, Boolean useAsyncCompletion)[xUnit.net 00:00:19.95]         --- End of stack trace from previous location ---
```

The root cause of that failure appeared to be a mismatch in the method signatures caused by the workspace version of IsExternalInit
```
.method public hidebysig specialname         instance void modreq([System.Runtime]System.Runtime.CompilerServices.IsExternalInit) set_ShowItemsFromUnimportedNamespaces (            valuetype [System.Runtime]System.Nullable`1<bool> 'value'        ) cil managed
```
vs the caller
```
IL_0016: callvirt instance void modreq([Microsoft.CodeAnalysis.Workspaces]System.Runtime.CompilerServices.IsExternalInit) [Microsoft.CodeAnalysis.Features]Microsoft.CodeAnalysis.Completion.CompletionOptions::set_ShowItemsFromUnimportedNamespaces(valuetype [netstandard]System.Nullable`1<bool>)
```

Switching over to appropriately multi-target the external access project appears to have fixed the issue in build and in the tests (so far).