### PR TITLE
[Lightbulb Perf] Execute symbol start analyzers concurrently - Approach #2

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisScope.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisScope.cs
@@ -92,7 +92,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private AnalysisScope(ImmutableArray<SyntaxTree> trees, ImmutableArray<AdditionalText> additionalFiles, ImmutableArray<DiagnosticAnalyzer> analyzers, bool isPartialAnalysis, SourceOrAdditionalFile? filterFile, TextSpan? filterSpanOpt, bool isSyntacticSingleFileAnalysis, bool isEntireCompilationAnalysis, bool concurrentAnalysis, bool categorizeDiagnostics)
         {
-            Debug.Assert(trees.Any() || additionalFiles.Any());
             Debug.Assert(isPartialAnalysis || FilterFileOpt == null);
             Debug.Assert(isPartialAnalysis || FilterSpanOpt == null);
             Debug.Assert(isPartialAnalysis || !isSyntacticSingleFileAnalysis);

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -730,7 +730,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private void ExecuteSyntaxTreeActions(AnalysisScope analysisScope, CancellationToken cancellationToken)
         {
-            if (analysisScope.IsSingleFileAnalysis && !analysisScope.IsSyntacticSingleFileAnalysis)
+            if (!analysisScope.IsEntireCompilationAnalysis && !analysisScope.IsSyntacticSingleFileAnalysis)
             {
                 // For partial analysis, only execute syntax tree actions if performing syntax analysis.
                 return;
@@ -762,7 +762,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         private void ExecuteAdditionalFileActions(AnalysisScope analysisScope, CancellationToken cancellationToken)
         {
-            if (analysisScope.IsSingleFileAnalysis && !analysisScope.IsSyntacticSingleFileAnalysis)
+            if (!analysisScope.IsEntireCompilationAnalysis && !analysisScope.IsSyntacticSingleFileAnalysis)
             {
                 // For partial analysis, only execute additional file actions if performing syntactic single file analysis.
                 return;
@@ -2418,7 +2418,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    if (analysisScope.FilterFileOpt != null && analysisScope.FilterFileOpt?.SourceTree != decl.SyntaxTree)
+                    if (!analysisScope.ShouldAnalyze(decl.SyntaxTree))
                     {
                         continue;
                     }


### PR DESCRIPTION
This is an alternate approach from #67159. Instead of using `SemanticModel.GetDiagnostics()` to generate compilation events, we synthesize the compilation events by walking the syntax nodes in the tree and using `SemanticModel.GetDeclaredSymbol()` at appropriate declaration nodes to get symbols and synthesize `SymbolDeclaredCompilationEvents`.