### PR TITLE
Fix failure to expose IsExternalInit in net6.0 binaries

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/IsExternalInit.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/IsExternalInit.cs
@@ -21,4 +21,12 @@ namespace System.Runtime.CompilerServices
     }
 }
 
+#else
+
+using System.Runtime.CompilerServices;
+
+#pragma warning disable RS0016 // Add public types and members to the declared API (this is a supporting fowarder for an internal polyfill API)
+[assembly: TypeForwardedTo(typeof(IsExternalInit))]
+#pragma warning restore RS0016 // Add public types and members to the declared API
+
 #endif

--- a/src/Tools/ExternalAccess/OmniSharp/Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.csproj
+++ b/src/Tools/ExternalAccess/OmniSharp/Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.csproj
@@ -10,10 +10,6 @@
       https://github.com/OmniSharp/omnisharp-roslyn
     </PackageDescription>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include="..\..\..\Compilers\Core\Portable\InternalUtilities\IsExternalInit.cs" Link="IsExternalInit.cs" />
-  </ItemGroup>
   
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp" />


### PR DESCRIPTION
Allows a netstandard2.0 binary to be replaced with a net6.0 binary at runtime without breaking binary references (via IVT) to `IsExternalInit`.