### PR TITLE
Add azdo marker for bootstrap failure message

### DIFF
--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -65,7 +65,7 @@ try {
 catch [exception] {
   Write-Host $_
   Write-Host $_.Exception
-  Write-Host "How to investigate bootstrap failures: https://github.com/dotnet/roslyn/blob/main/docs/compilers/Bootstrap%20Builds.md#Investigating"
+  Write-Host "##vso[task.logissue type=error]How to investigate bootstrap failures: https://github.com/dotnet/roslyn/blob/main/docs/compilers/Bootstrap%20Builds.md#Investigating"
   exit 1
 }
 finally {


### PR DESCRIPTION
Might need to push the branch to dotnet/roslyn repo to actually see if the job runs. Or insert an error in the correctness script?

Example of the log we want to change: https://dev.azure.com/dnceng-public/public/_build/results?buildId=190601&view=logs&j=89d3da57-d43f-50a1-f922-23d6fe844e96&t=e1f2962e-b5c2-538c-8f54-dec3f1555db2&l=6358

We want the doc link to be bright red and visible. Currently it is a bit subtle.