### PR TITLE
Allow generating local variable in expression body

### DIFF
--- a/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/GenerateVariable/GenerateVariableTests.cs
@@ -9740,5 +9740,121 @@ class C
     }
 }", index: 4);
         }
+
+        [Fact, WorkItem(28762, "https://github.com/dotnet/roslyn/issues/28762")]
+        public async Task TestGenerateLocalForArrowExpressionBody1()
+        {
+            await TestInRegularAndScriptAsync("""
+                using System;
+
+                class C
+                {
+                    void M() => Console.WriteLine([|bar|]);
+                }
+                """, """
+                using System;
+                
+                class C
+                {
+                    void M()
+                    {
+                        bool bar = false;
+                        Console.WriteLine(bar);
+                    }
+                }
+                """, index: 3);
+        }
+
+        [Fact, WorkItem(28762, "https://github.com/dotnet/roslyn/issues/28762")]
+        public async Task TestGenerateLocalForArrowExpressionBody2()
+        {
+            await TestInRegularAndScriptAsync("""
+                using System;
+
+                class C
+                {
+                    void M()
+                    {
+                        void LocalFunction() => Console.WriteLine([|bar|]);
+                    }
+                }
+                """, """
+                using System;
+                
+                class C
+                {
+                    void M()
+                    {
+                        void LocalFunction()
+                        {
+                            bool bar = false;
+                            Console.WriteLine([|bar|]);
+                        }
+                    }
+                }
+                """, index: 3);
+        }
+
+        [Fact, WorkItem(28762, "https://github.com/dotnet/roslyn/issues/28762")]
+        public async Task TestGenerateLocalForArrowExpressionBody3()
+        {
+            await TestInRegularAndScriptAsync("""
+                using System;
+
+                class C
+                {
+                    void M()
+                    {
+                        void LocalFunction()
+                        {
+                            void NestedLocalFunction() => Console.WriteLine([|bar|]);
+                        }
+                    }
+                }
+                """, """
+                using System;
+                
+                class C
+                {
+                    void M()
+                    {
+                        void LocalFunction()
+                        {
+                            void NestedLocalFunction()
+                            {
+                                bool bar = false;
+                                Console.WriteLine([|bar|]);
+                            }
+                        }
+                    }
+                }
+                """, index: 3);
+        }
+
+        [Fact, WorkItem(28762, "https://github.com/dotnet/roslyn/issues/28762")]
+        public async Task TestGenerateLocalForArrowExpressionBody4()
+        {
+            await TestInRegularAndScriptAsync("""
+                using System;
+
+                class C
+                {
+                    void M()
+                    {
+                        var action = () => Console.WriteLine([|bar|]);
+                    }
+                }
+                """, """
+                using System;
+                
+                class C
+                {
+                    void M()
+                    {
+                        var action = () => { bool bar = false; Console.WriteLine([|bar|]); };
+                    }
+                }
+                """, index: 3);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateVariable/CSharpGenerateVariableService.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateVariable
 
         protected override bool TryInitializeIdentifierNameState(
             SemanticDocument document, SimpleNameSyntax identifierName, CancellationToken cancellationToken,
-            out SyntaxToken identifierToken, out ExpressionSyntax simpleNameOrMemberAccessExpression, out bool isInExecutableBlock, out bool isConditionalAccessExpression)
+            out SyntaxToken identifierToken, out ExpressionSyntax simpleNameOrMemberAccessExpression, out bool isInExecutableSyntax, out bool isConditionalAccessExpression)
         {
             identifierToken = identifierName.Identifier;
             if (identifierToken.ValueText != string.Empty &&
@@ -111,20 +111,20 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateVariable
                 // very esoteric and probably not what most users want.
                 if (!IsLegal(document, simpleNameOrMemberAccessExpression, cancellationToken))
                 {
-                    isInExecutableBlock = false;
+                    isInExecutableSyntax = false;
                     isConditionalAccessExpression = false;
                     return false;
                 }
 
-                var block = identifierName.GetAncestor<BlockSyntax>();
-                isInExecutableBlock = block != null && !block.OverlapsHiddenPosition(cancellationToken);
+                var executableSyntax = identifierName.GetAncestorsOrThis(n => n is BlockSyntax or ArrowExpressionClauseSyntax or LambdaExpressionSyntax).FirstOrDefault();
+                isInExecutableSyntax = executableSyntax is not null && !executableSyntax.OverlapsHiddenPosition(cancellationToken);
                 isConditionalAccessExpression = conditionalMemberAccess != null;
                 return true;
             }
 
             identifierToken = default;
             simpleNameOrMemberAccessExpression = null;
-            isInExecutableBlock = false;
+            isInExecutableSyntax = false;
             isConditionalAccessExpression = false;
             return false;
         }

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.State.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.State.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
             public bool IsInMemberContext { get; private set; }
 
             public bool IsInSourceGeneratedDocument { get; private set; }
-            public bool IsInExecutableBlock { get; private set; }
+            public bool IsInExecutableSyntax { get; private set; }
             public bool IsInConditionalAccessExpression { get; private set; }
 
             public Location AfterThisLocation { get; private set; }
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
             internal bool CanGenerateLocal()
             {
                 // !this.IsInMemberContext prevents us offering this fix for `x.goo` where `goo` does not exist
-                return !IsInMemberContext && IsInExecutableBlock && !IsInSourceGeneratedDocument;
+                return !IsInMemberContext && IsInExecutableSyntax && !IsInSourceGeneratedDocument;
             }
 
             internal bool CanGenerateParameter()
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
             {
                 if (!service.TryInitializeIdentifierNameState(
                         semanticDocument, simpleName, cancellationToken,
-                        out var identifierToken, out var simpleNameOrMemberAccessExpression, out var isInExecutableBlock, out var isInConditionalAccessExpression))
+                        out var identifierToken, out var simpleNameOrMemberAccessExpression, out var isInExecutableSyntax, out var isInConditionalAccessExpression))
                 {
                     return false;
                 }
@@ -243,7 +243,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
 
                 IdentifierToken = identifierToken;
                 SimpleNameOrMemberAccessExpressionOpt = simpleNameOrMemberAccessExpression;
-                IsInExecutableBlock = isInExecutableBlock;
+                IsInExecutableSyntax = isInExecutableSyntax;
                 IsInConditionalAccessExpression = isInConditionalAccessExpression;
 
                 // If we're in a type context then we shouldn't offer to generate a field or


### PR DESCRIPTION
Closes: https://github.com/dotnet/roslyn/issues/28762

I am a bit sceptical about implementation. There is no common ancestor for lambda, local function and method syntax, so I had to make several ugly switches. LMK if you have any idea on how to implement it without such workarounds.