### PR TITLE
Walk green tree in SyntaxFacts.HasYieldOperations to avoid excessive allocations in reported trace

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
@@ -544,7 +544,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             });
         }
 
-        internal static bool IsNestedFunction(SyntaxNode child)
+        private static bool IsNestedFunction(SyntaxNode child)
             => IsNestedFunction(child.Kind());
 
         private static bool IsNestedFunction(SyntaxKind kind)

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
@@ -578,7 +578,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 if (current is Syntax.InternalSyntax.YieldStatementSyntax)
+                {
+                    stack.Free();
                     return true;
+                }
 
                 foreach (var child in current.ChildNodesAndTokens())
                 {

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
@@ -559,7 +559,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (node is null)
                 return false;
 
-            // Intentionally walk green tree to avoid allocations.  This accounted for
             var stack = ArrayBuilder<GreenNode>.GetInstance();
             stack.Push(node.Green);
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
@@ -553,7 +553,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or SyntaxKind.SimpleLambdaExpression
                 or SyntaxKind.ParenthesizedLambdaExpression;
 
-        [PerformanceSensitive("", Constraint = "Use Green nodes for walking to avoid heavy allocations.")]
+        [PerformanceSensitive("https://github.com/dotnet/roslyn/pull/66970", Constraint = "Use Green nodes for walking to avoid heavy allocations.")]
         internal static bool HasYieldOperations(SyntaxNode? node)
         {
             if (node is null)

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxKind;
 
@@ -544,28 +545,51 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         internal static bool IsNestedFunction(SyntaxNode child)
-        {
-            switch (child.Kind())
-            {
-                case SyntaxKind.LocalFunctionStatement:
-                case SyntaxKind.AnonymousMethodExpression:
-                case SyntaxKind.SimpleLambdaExpression:
-                case SyntaxKind.ParenthesizedLambdaExpression:
-                    return true;
-                default:
-                    return false;
-            }
-        }
+            => IsNestedFunction(child.Kind());
 
+        private static bool IsNestedFunction(SyntaxKind kind)
+            => kind is SyntaxKind.LocalFunctionStatement
+                or SyntaxKind.AnonymousMethodExpression
+                or SyntaxKind.SimpleLambdaExpression
+                or SyntaxKind.ParenthesizedLambdaExpression;
+
+        [PerformanceSensitive("", Constraint = "Use Green nodes for walking to avoid heavy allocations.")]
         internal static bool HasYieldOperations(SyntaxNode? node)
         {
-            // Do not descend into functions and expressions
-            return node is object &&
-                   node.DescendantNodesAndSelf(child =>
-                   {
-                       Debug.Assert(ReferenceEquals(node, child) || child is not (MemberDeclarationSyntax or TypeDeclarationSyntax));
-                       return !IsNestedFunction(child) && !(node is ExpressionSyntax);
-                   }).Any(n => n is YieldStatementSyntax);
+            if (node is null)
+                return false;
+
+            // Intentionally walk green tree to avoid allocations.  This accounted for
+            var stack = ArrayBuilder<GreenNode>.GetInstance();
+            stack.Push(node.Green);
+
+            while (stack.Count > 0)
+            {
+                var current = stack.Pop();
+                Debug.Assert(node.Green == current || current is not Syntax.InternalSyntax.MemberDeclarationSyntax and not Syntax.InternalSyntax.TypeDeclarationSyntax);
+
+                if (current is null)
+                    continue;
+
+                // Do not descend into functions and expressions
+                if (IsNestedFunction((SyntaxKind)current.RawKind) ||
+                    current is Syntax.InternalSyntax.ExpressionSyntax)
+                {
+                    continue;
+                }
+
+                if (current is Syntax.InternalSyntax.YieldStatementSyntax)
+                    return true;
+
+                foreach (var child in current.ChildNodesAndTokens())
+                {
+                    if (!child.IsToken)
+                        stack.Push(child);
+                }
+            }
+
+            stack.Free();
+            return false;
         }
 
         internal static bool HasReturnWithExpression(SyntaxNode? node)


### PR DESCRIPTION
This is called for every method (from SourceOrdinaryMethodSymbol) and accounts for 10% of allocations in traces we are looking at. Continuation of https://github.com/dotnet/roslyn/pull/67198.