### PR TITLE
Infra fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -208,7 +208,7 @@ stages:
           - src/Compilers/*
           - src/Dependencies/*
           - src/NuGet/Microsoft.Net.Compilers.Toolset/*
-          - eng/*`
+          - eng/*
           - src/Tools/Source/CompilerGeneratorTools/*
 
   - job: Correctness_Build_Artifacts

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -207,7 +207,8 @@ stages:
           include:
           - src/Compilers/*
           - src/Dependencies/*
-          - eng/*
+          - src/NuGet/Microsoft.Net.Compilers.Toolset/*
+          - eng/*`
           - src/Tools/Source/CompilerGeneratorTools/*
 
   - job: Correctness_Build_Artifacts

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -273,7 +273,7 @@ function Make-BootstrapBuild([switch]$force32 = $false) {
     # that we do not reuse MSBuild nodes from other jobs/builds on the machine. Otherwise,
     # we'll run into issues such as https://github.com/dotnet/roslyn/issues/6211.
     # MSBuildAdditionalCommandLineArgs=
-    $args = "/p:TreatWarningsAsErrors=true /nologo /nodeReuse:false /p:Configuration=$configuration ";
+    $args = "/p:TreatWarningsAsErrors=true /nologo /nodeReuse:false /p:Configuration=$configuration /v:m ";
 
     if ($warnAsError) {
       $args += " /warnaserror"


### PR DESCRIPTION
- Set bootstrap build verbosity to minimal. That will clean up our log files _significantly_
- Include Compiler NuPkg in the compiler file subset