### PR TITLE
Include containing type for nested types when showing goto-impl results

### DIFF
--- a/src/Features/Core/Portable/FindUsages/FindUsagesHelpers.cs
+++ b/src/Features/Core/Portable/FindUsages/FindUsagesHelpers.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.FindUsages
 
         private static readonly SymbolDisplayFormat s_definitionFormat =
             new(
-                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameOnly,
+                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
                 genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
                 parameterOptions: SymbolDisplayParameterOptions.IncludeType,
                 propertyStyle: SymbolDisplayPropertyStyle.ShowReadWriteDescriptor,


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/47447.  

Looks like:

![image](https://user-images.githubusercontent.com/4564579/223538583-d05b9b25-5d03-4e42-ab7e-d1053c421823.png)

so you can distinguish the similar values.