### PR TITLE
Make the import of IPasteTrackingService optional

### DIFF
--- a/src/Features/CSharp/Portable/CodeRefactorings/AddMissingImports/CSharpAddMissingImportsRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/CodeRefactorings/AddMissingImports/CSharpAddMissingImportsRefactoringProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Composition;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.AddMissingImports;
@@ -19,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.AddMissingImports
 
         [ImportingConstructor]
         [SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification = "Used in test code: https://github.com/dotnet/roslyn/issues/42814")]
-        public CSharpAddMissingImportsRefactoringProvider(IPasteTrackingService pasteTrackingService)
+        public CSharpAddMissingImportsRefactoringProvider([Import(AllowDefault = true)] IPasteTrackingService? pasteTrackingService)
             : base(pasteTrackingService)
         {
         }

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsRefactoringProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsRefactoringProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,14 +16,19 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
 {
     internal abstract class AbstractAddMissingImportsRefactoringProvider : CodeRefactoringProvider
     {
-        private readonly IPasteTrackingService _pasteTrackingService;
+        private readonly IPasteTrackingService? _pasteTrackingService;
         protected abstract string CodeActionTitle { get; }
 
-        public AbstractAddMissingImportsRefactoringProvider(IPasteTrackingService pasteTrackingService)
+        public AbstractAddMissingImportsRefactoringProvider(IPasteTrackingService? pasteTrackingService)
             => _pasteTrackingService = pasteTrackingService;
 
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {
+            // If we aren't in a host that supports paste tracking, we can't do anything. This is just to avoid creating MEF part rejections for
+            // things composing the Features layer.
+            if (_pasteTrackingService == null)
+                return;
+
             var (document, _, cancellationToken) = context;
             // Currently this refactoring requires the SourceTextContainer to have a pasted text span.
             var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
@@ -35,7 +38,7 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             }
 
             // Check pasted text span for missing imports
-            var addMissingImportsService = document.GetLanguageService<IAddMissingImportsFeatureService>();
+            var addMissingImportsService = document.GetRequiredLanguageService<IAddMissingImportsFeatureService>();
 
             var cleanupOptions = await document.GetCodeCleanupOptionsAsync(context.Options, cancellationToken).ConfigureAwait(false);
             var options = new AddMissingImportsOptions(

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AddMissingImportsAnalysisResult.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AddMissingImportsAnalysisResult.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.AddImport;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.AddMissingImports
 {

--- a/src/Features/VisualBasic/Portable/CodeRefactorings/AddMissingImports/VisualBasicAddMissingImportsRefactoringProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeRefactorings/AddMissingImports/VisualBasicAddMissingImportsRefactoringProvider.vb
@@ -18,7 +18,7 @@ Friend Class VisualBasicAddMissingImportsRefactoringProvider
 
     <ImportingConstructor>
     <SuppressMessage("RoslynDiagnosticsReliability", "RS0033:Importing constructor should be [Obsolete]", Justification:="Used in test code: https://github.com/dotnet/roslyn/issues/42814")>
-    Public Sub New(pasteTrackingService As IPasteTrackingService)
+    Public Sub New(<Import(AllowDefault:=True)> pasteTrackingService As IPasteTrackingService)
         MyBase.New(pasteTrackingService)
     End Sub
 End Class


### PR DESCRIPTION
If somebody composes our features layer and tries to assert there is no composition issues, this will get flagged.

Fixes https://github.com/dotnet/roslyn/issues/66157