### PR TITLE
[Lightbulb Perf] Analyzer driver fixes for span-based analysis

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisScope.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisScope.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 //       We are basically analyzing the entire tree, and clearing out the filter span
                 //       avoids span intersection checks for each symbol/node/operation in the tree
                 //       to determine if it falls in the analysis scope.
-                if (filterSpanOpt.Value.Start == 0 && filterSpanOpt.Value.Length == filterFile.Value.SourceTree.Length)
+                if (filterSpanOpt.GetValueOrDefault().Start == 0 && filterSpanOpt.GetValueOrDefault().Length == filterFile.GetValueOrDefault().SourceTree.Length)
                 {
                     filterSpanOpt = null;
                 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisScope.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisScope.cs
@@ -90,13 +90,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 Debug.Assert(filterFile.HasValue);
                 Debug.Assert(filterFile.Value.SourceTree != null);
-                Debug.Assert(filterSpanOpt.Value.Length <= filterFile.Value.SourceTree.Length);
 
-                // PERF: Clear out filter span if the span length is equal to the entire tree span.
+                // PERF: Clear out filter span if the span length is equal to the entire tree span, and the filter span starts at 0.
                 //       We are basically analyzing the entire tree, and clearing out the filter span
                 //       avoids span intersection checks for each symbol/node/operation in the tree
                 //       to determine if it falls in the analysis scope.
-                if (filterSpanOpt.Value.Length == filterFile.Value.SourceTree.Length)
+                if (filterSpanOpt.Value.Start == 0 && filterSpanOpt.Value.Length == filterFile.Value.SourceTree.Length)
                 {
                     filterSpanOpt = null;
                 }
@@ -135,7 +134,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         }
 
         public AnalysisScope WithFilterSpan(TextSpan? filterSpan)
-            => new(SyntaxTrees, AdditionalFiles, Analyzers, IsPartialAnalysis, FilterFileOpt, filterSpan, IsSyntacticSingleFileAnalysis, ConcurrentAnalysis, CategorizeDiagnostics);
+            => new AnalysisScope(SyntaxTrees, AdditionalFiles, Analyzers, IsPartialAnalysis, FilterFileOpt, filterSpan, IsSyntacticSingleFileAnalysis, ConcurrentAnalysis, CategorizeDiagnostics);
 
         public static bool ShouldSkipSymbolAnalysis(SymbolDeclaredCompilationEvent symbolEvent)
         {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GroupedAnalyzerActionsForAnalyzer.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.GroupedAnalyzerActionsForAnalyzer.cs
@@ -132,6 +132,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             private ImmutableArray<OperationBlockAnalyzerAction> OperationBlockActions
                 => GetExecutableCodeActions(ref _lazyOperationBlockActions, AnalyzerActions.OperationBlockActions, _analyzer, _analyzerActionsNeedFiltering);
 
+            public bool HasCodeBlockStartActions => !CodeBlockStartActions.IsEmpty;
+            public bool HasOperationBlockStartActions => !OperationBlockStartActions.IsEmpty;
+
             private static ImmutableArray<ActionType> GetExecutableCodeActions<ActionType>(
                 ref ImmutableArray<ActionType> lazyCodeBlockActions,
                 ImmutableArray<ActionType> codeBlockActions,

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1673,7 +1673,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
             if (!skipSymbolAnalysis)
             {
-                ExecuteSymbolActions(symbolEvent, analysisScope, isGeneratedCodeSymbol);
+                ExecuteSymbolActions(symbolEvent, analysisScope, isGeneratedCodeSymbol, cancellationToken);
             }
 
             if (!skipDeclarationAnalysis)
@@ -1682,7 +1682,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             if (hasPerSymbolActions &&
-                !TryExecuteSymbolEndActions(perSymbolActions.AnalyzerActions, symbolEvent, analysisScope, isGeneratedCodeSymbol, out var subsetProcessedAnalyzers))
+                !TryExecuteSymbolEndActions(perSymbolActions.AnalyzerActions, symbolEvent, analysisScope, isGeneratedCodeSymbol, cancellationToken, out var subsetProcessedAnalyzers))
             {
                 Debug.Assert(!subsetProcessedAnalyzers.IsDefault);
                 return subsetProcessedAnalyzers.IsEmpty ? EventProcessedState.NotProcessed : EventProcessedState.CreatePartiallyProcessed(subsetProcessedAnalyzers);
@@ -1691,10 +1691,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return EventProcessedState.Processed;
         }
 
-        private void ExecuteSymbolActions(SymbolDeclaredCompilationEvent symbolEvent, AnalysisScope analysisScope, bool isGeneratedCodeSymbol)
+        private void ExecuteSymbolActions(SymbolDeclaredCompilationEvent symbolEvent, AnalysisScope analysisScope, bool isGeneratedCodeSymbol, CancellationToken cancellationToken)
         {
             var symbol = symbolEvent.Symbol;
-            if (!analysisScope.ShouldAnalyze(symbol))
+            if (!analysisScope.ShouldAnalyze(symbolEvent, s_getTopmostNodeForAnalysis, cancellationToken))
             {
                 return;
             }
@@ -1719,13 +1719,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SymbolDeclaredCompilationEvent symbolEvent,
             AnalysisScope analysisScope,
             bool isGeneratedCodeSymbol,
+            CancellationToken cancellationToken,
             out ImmutableArray<DiagnosticAnalyzer> subsetProcessedAnalyzers)
         {
             Debug.Assert(AnalyzerActions.SymbolStartActionsCount > 0);
 
             var symbol = symbolEvent.Symbol;
             var symbolEndActions = perSymbolActions.SymbolEndActions;
-            if (!analysisScope.ShouldAnalyze(symbol) || symbolEndActions.IsEmpty)
+            if (symbolEndActions.IsEmpty || !analysisScope.ShouldAnalyze(symbolEvent, s_getTopmostNodeForAnalysis, cancellationToken))
             {
                 subsetProcessedAnalyzers = ImmutableArray<DiagnosticAnalyzer>.Empty;
                 return true;
@@ -1827,14 +1828,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     continue;
                 }
 
-                // Only compiler analyzer supports span-based semantic model action callbacks.
-                if (completedEvent.FilterSpan.HasValue && !IsCompilerAnalyzer(analyzer))
-                {
-                    continue;
-                }
-
                 // Execute actions for a given analyzer sequentially.
-                AnalyzerExecutor.ExecuteSemanticModelActions(semanticModelActions, analyzer, semanticModel, completedEvent, analysisScope, isGeneratedCode);
+                AnalyzerExecutor.ExecuteSemanticModelActions(semanticModelActions, analyzer, semanticModel, analysisScope, isGeneratedCode);
             }
         }
 
@@ -2451,7 +2446,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableArray<DeclarationInfo> declarationInfos = builder.ToImmutableAndFree();
 
             bool isPartialDeclAnalysis = analysisScope.FilterSpanOpt.HasValue && !analysisScope.ContainsSpan(topmostNodeForAnalysis.FullSpan);
-            ImmutableArray<SyntaxNode> nodesToAnalyze = GetSyntaxNodesToAnalyze(topmostNodeForAnalysis, symbol, declarationInfos, analysisScope, isPartialDeclAnalysis, semanticModel, AnalyzerExecutor);
+            ImmutableArray<SyntaxNode> nodesToAnalyze = GetSyntaxNodesToAnalyze(topmostNodeForAnalysis, symbol, declarationInfos, semanticModel, AnalyzerExecutor);
             return new DeclarationAnalysisData(declaringReferenceSyntax, topmostNodeForAnalysis, declarationInfos, nodesToAnalyze, isPartialDeclAnalysis);
         }
 
@@ -2521,7 +2516,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         continue;
                     }
 
-                    AnalyzerExecutor.ExecuteSyntaxNodeActions(nodesToAnalyze, nodeActionsByKind,
+                    // We further filter out the nodes to analyze based on analysis scope if we are performing
+                    // partial analysis of the declaration, i.e. analyzing a sub-span within the declaration span,
+                    // and additionally the analyzer has not registered any code block start actions. In case
+                    // the analyzer has registered code block start actions, we need to make callbacks for all nodes
+                    // in the code block to ensure the analyzer can correctly report code block end diagnostics.
+                    var filteredNodesToAnalyze = declarationAnalysisData.IsPartialAnalysis && !groupedActionsForAnalyzer.HasCodeBlockStartActions
+                        ? nodesToAnalyze.WhereAsArray(analysisScope.ShouldAnalyze)
+                        : nodesToAnalyze;
+
+                    AnalyzerExecutor.ExecuteSyntaxNodeActions(filteredNodesToAnalyze, nodeActionsByKind,
                         analyzer, semanticModel, _getKind, declarationAnalysisData.TopmostNodeForAnalysis.FullSpan,
                         symbol, isInGeneratedCode);
                 }
@@ -2620,7 +2624,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         continue;
                     }
 
-                    AnalyzerExecutor.ExecuteOperationActions(operationsToAnalyze, operationActionsByKind,
+                    // We further filter out the operation to analyze based on analysis scope if we are performing
+                    // partial analysis of the declaration, i.e. analyzing a sub-span within the declaration span,
+                    // and additionally the analyzer has not registered any operation block start actions. In case the
+                    // analyzer has registered operation block start actions, we need to make callbacks for all operations
+                    // in the operation block to ensure the analyzer can correctly report operation block end diagnostics.
+                    var filteredOperationsToAnalyze = declarationAnalysisData.IsPartialAnalysis && !groupedActionsForAnalyzer.HasOperationBlockStartActions
+                        ? operationsToAnalyze.WhereAsArray(operation => analysisScope.ShouldAnalyze(operation.Syntax))
+                        : operationsToAnalyze;
+
+                    AnalyzerExecutor.ExecuteOperationActions(filteredOperationsToAnalyze, operationActionsByKind,
                         analyzer, semanticModel, declarationAnalysisData.TopmostNodeForAnalysis.FullSpan,
                         symbol, isInGeneratedCode);
                 }
@@ -2702,8 +2715,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             SyntaxNode declaredNode,
             ISymbol declaredSymbol,
             ImmutableArray<DeclarationInfo> declarationsInNode,
-            AnalysisScope analysisScope,
-            bool isPartialDeclAnalysis,
             SemanticModel semanticModel,
             AnalyzerExecutor analyzerExecutor)
         {
@@ -2753,8 +2764,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             foreach (var node in declaredNode.DescendantNodesAndSelf(descendIntoChildren: shouldAddNode, descendIntoTrivia: true))
             {
                 if (shouldAddNode(node) &&
-                    !semanticModel.ShouldSkipSyntaxNodeAnalysis(node, declaredSymbol) &&
-                    (!isPartialDeclAnalysis || analysisScope.ShouldAnalyze(node)))
+                    !semanticModel.ShouldSkipSyntaxNodeAnalysis(node, declaredSymbol))
                 {
                     nodeBuilder.Add(node);
                 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -554,12 +554,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             ImmutableArray<SemanticModelAnalyzerAction> semanticModelActions,
             DiagnosticAnalyzer analyzer,
             SemanticModel semanticModel,
-            CompilationUnitCompletedEvent compilationUnitCompletedEvent,
             AnalysisScope analysisScope,
             bool isGeneratedCode)
         {
-            Debug.Assert(!compilationUnitCompletedEvent.FilterSpan.HasValue || _isCompilerAnalyzer!(analyzer), "Only compiler analyzer supports span-based semantic model action callbacks");
-
             if (isGeneratedCode && _shouldSkipAnalysisOnGeneratedCode(analyzer) ||
                 IsAnalyzerSuppressedForTree(analyzer, semanticModel.SyntaxTree))
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerExecutor.cs
@@ -547,7 +547,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// <param name="semanticModelActions">Semantic model actions to be executed.</param>
         /// <param name="analyzer">Analyzer whose actions are to be executed.</param>
         /// <param name="semanticModel">Semantic model to analyze.</param>
-        /// <param name="compilationUnitCompletedEvent">Compilation event for semantic model analysis.</param>
         /// <param name="analysisScope">Scope for analyzer execution.</param>
         /// <param name="isGeneratedCode">Flag indicating if the syntax tree being analyzed is generated code.</param>
         public void ExecuteSemanticModelActions(

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -904,6 +904,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     {
                         compilationEvents = compilationEventsForTree.AddRange(compilationEvents);
 
+                        // Filter out synthesized compilation unit completed event that was generated for span analysis
+                        // as we are now doing full tree analysis, GetCompilationEventsForSingleFileAnalysis call above should
+                        // have already generated a CompilationUnitCompletedEvent without any filter span.
+                        compilationEvents = compilationEvents.WhereAsArray(e => e is not CompilationUnitCompletedEvent c || !c.FilterSpan.HasValue);
+                        Debug.Assert(compilationEvents.Count(e => e is CompilationUnitCompletedEvent c && !c.FilterSpan.HasValue) == 1);
+
                         // We shouldn't have any duplicate events.
                         Debug.Assert(compilationEvents.Distinct().Length == compilationEvents.Length);
                     }

--- a/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
+++ b/src/Compilers/Test/Core/Diagnostics/CommonDiagnosticAnalyzers.cs
@@ -2642,5 +2642,92 @@ namespace Microsoft.CodeAnalysis
                 reportDiagnostic(Diagnostic.Create(s_descriptor, analysisLocation));
             }
         }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp)]
+        public sealed class AllActionsAnalyzer : DiagnosticAnalyzer
+        {
+            private static readonly DiagnosticDescriptor s_descriptor = new("ID0001", "Title", "Message", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+            private readonly bool _testSyntaxTreeAction;
+            private readonly bool _testSemanticModelAction;
+            private readonly bool _testSymbolStartAction;
+            private readonly bool _testBlockActions;
+
+            public readonly List<SyntaxTree> AnalyzedTrees = new();
+            public readonly List<SemanticModel> AnalyzedSemanticModels = new();
+            public readonly List<ISymbol> AnalyzedSymbols = new();
+            public readonly List<ISymbol> AnalyzedSymbolStartSymbols = new();
+            public readonly List<ISymbol> AnalyzedSymbolEndSymbols = new();
+            public readonly List<IOperation> AnalyzedOperations = new();
+            public readonly List<ISymbol> AnalyzedOperationBlockSymbols = new();
+            public readonly List<IOperation> AnalyzedOperationsInsideOperationBlock = new();
+            public readonly List<ISymbol> AnalyzedOperationBlockStartSymbols = new();
+            public readonly List<ISymbol> AnalyzedOperationBlockEndSymbols = new();
+            public readonly List<SyntaxNode> AnalyzedSyntaxNodes = new();
+            public readonly List<ISymbol> AnalyzedCodeBlockSymbols = new();
+            public readonly List<SyntaxNode> AnalyzedSyntaxNodesInsideCodeBlock = new();
+            public readonly List<ISymbol> AnalyzedCodeBlockStartSymbols = new();
+            public readonly List<ISymbol> AnalyzedCodeBlockEndSymbols = new();
+
+            public AllActionsAnalyzer(bool testSyntaxTreeAction, bool testSemanticModelAction, bool testSymbolStartAction, bool testBlockActions)
+            {
+                _testSyntaxTreeAction = testSyntaxTreeAction;
+                _testSemanticModelAction = testSemanticModelAction;
+                _testSymbolStartAction = testSymbolStartAction;
+                _testBlockActions = testBlockActions;
+            }
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_descriptor);
+
+            public override void Initialize(AnalysisContext context)
+            {
+                context.RegisterCompilationStartAction(AnalyzeCompilation);
+            }
+
+            private void AnalyzeCompilation(CompilationStartAnalysisContext context)
+            {
+                // Unconditionally test symbol/operation/node actions.
+                context.RegisterSymbolAction(symbolContext => AnalyzedSymbols.Add(symbolContext.Symbol), SymbolKind.NamedType, SymbolKind.Method);
+                context.RegisterOperationAction(operationContext => AnalyzedOperations.Add(operationContext.Operation), OperationKind.VariableDeclaration);
+                context.RegisterSyntaxNodeAction(syntaxNodeContext => AnalyzedSyntaxNodes.Add(syntaxNodeContext.Node), SyntaxKind.LocalDeclarationStatement);
+
+                if (_testSyntaxTreeAction)
+                {
+                    context.RegisterSyntaxTreeAction(treeContext => AnalyzedTrees.Add(treeContext.Tree));
+                }
+
+                if (_testSemanticModelAction)
+                {
+                    context.RegisterSemanticModelAction(semanticModelContext => AnalyzedSemanticModels.Add(semanticModelContext.SemanticModel));
+                }
+
+                if (_testSymbolStartAction)
+                {
+                    context.RegisterSymbolStartAction(symbolStartContext =>
+                    {
+                        AnalyzedSymbolStartSymbols.Add(symbolStartContext.Symbol);
+                        symbolStartContext.RegisterSymbolEndAction(symbolEndContext => AnalyzedSymbolEndSymbols.Add(symbolEndContext.Symbol));
+                    }, SymbolKind.NamedType);
+                }
+
+                if (_testBlockActions)
+                {
+                    context.RegisterOperationBlockAction(operationBlockContext => AnalyzedOperationBlockSymbols.Add(operationBlockContext.OwningSymbol));
+                    context.RegisterOperationBlockStartAction(operationBlockStartContext =>
+                    {
+                        AnalyzedOperationBlockStartSymbols.Add(operationBlockStartContext.OwningSymbol);
+                        operationBlockStartContext.RegisterOperationAction(operationContext => AnalyzedOperationsInsideOperationBlock.Add(operationContext.Operation), OperationKind.VariableDeclaration);
+                        operationBlockStartContext.RegisterOperationBlockEndAction(operationBlockEndContext => AnalyzedOperationBlockEndSymbols.Add(operationBlockEndContext.OwningSymbol));
+                    });
+                    context.RegisterCodeBlockAction(codeBlockContext => AnalyzedCodeBlockSymbols.Add(codeBlockContext.OwningSymbol));
+                    context.RegisterCodeBlockStartAction<SyntaxKind>(codeBlockStartContext =>
+                    {
+                        AnalyzedCodeBlockStartSymbols.Add(codeBlockStartContext.OwningSymbol);
+                        codeBlockStartContext.RegisterSyntaxNodeAction(syntaxNodeContext => AnalyzedSyntaxNodesInsideCodeBlock.Add(syntaxNodeContext.Node), SyntaxKind.LocalDeclarationStatement);
+                        codeBlockStartContext.RegisterCodeBlockEndAction(codeBlockEndContext => AnalyzedCodeBlockEndSymbols.Add(codeBlockEndContext.OwningSymbol));
+                    });
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Work towards #66968

**NOTE:** None of the changes in this PR affects analyzer execution in batch compile scenarios.

While investigating the lightbulb performance as part of #66968, we have identified that currently IDE executes majority of analyzers on the entire file span, even when we only want to compute diagnostics for a single line span. This is a big overhead when populating the lightbulb, and hence we are working towards minimizing the scope for which the analyzers are executed for lightbulb. #67236 is a draft PR towards moving the IDE to try to execute the analyzers on the minimal possible span. This work requires the analyzer driver to identify the scope for which each analyzer needs to receive callbacks based on the actions registered by the analyzer:

1. Symbol/SyntaxNode/Operation analyzer - execute callbacks only on symbols/nodes/operations whose span intersects with the input filter span. The driver already did this prior to this PR, but needed a small bug fix for symbol action callbacks to consider the entire symbol declaration span, not just the symbol's location span (which only contains the span for the symbol header).

2. SymbolStart/End analyzer - execute callbacks for all symbols/operations/syntax nodes defined in the containing type declaration, including partial declarations spanning across files. This is required to ensure that SymbolEnd actions reports the correct diagnostics. The driver already did this prior to this PR.

3. OperationBlockStart/End and CodeBlockStart/End analyzer - execute callbacks on all the operations/syntax nodes in the operation block/code block that intersects the input filter span. Driver already did this for operations in operation blocks, but not for syntax nodes in the code block. This PR has a fix for the latter.

4. SemanticModel analyzer- execute semantic model action callback on the input file. The driver was only doing so for compiler analyzer, but after this PR we do so for all semantic model analyzers. Note that the public API for semantic model action callbacks does not take a filter span for analysis, though we have this span available in the driver. We should consider exposing a new public API for an optional FilterSpan on SemanticModelAnalysisContext, which should allow SmanticModel analyzers to optimize the diagnostic computation and reporting for just the span, instead of entire file. ~~I'll file a tracking issue for this.~~ Filed #67257.

5. SyntaxTree based syntax-only analyzer - execute callback on input tree. Driver already did this correctly. Note that the public API for SyntaxTreeAction on the DiagnosticAnalyzer does not take any filter span, so there is no further optimization possible here - we have to request full tree syntax diagnostics. ~~I'll file a tracking issue for exposing an optional FilterSpan on SyntaxTreeAnalysisContext to help analyzers optimize the diagnostic computation and reporting to just the span.~~ Filed #67257.

**Test:** I have added a unit test to verify callbacks with a matrix of different combinations of registered action kinds, and all the product changes in this PR are corresponding to one or more failing combination for this unit test.