### PR TITLE
[Infra] Take insertion PRs to main out of draft mode

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -153,7 +153,7 @@
       ],
       "vsBranch": "main",
       "vsMajorVersion": 17,
-      "insertionCreateDraftPR": true,
+      "insertionCreateDraftPR": false,
       "insertionTitlePrefix": "[d17.6P3]"
     },
     "dev/jorobich/fix-pr-val": {


### PR DESCRIPTION
Makes it so required checks run by default and will speed up the insertion process