### PR TITLE
Fix unimported completions show in places where they should not be

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
@@ -1733,7 +1733,7 @@ $$";
             await VerifyTypeImportItemIsAbsentAsync(markup, "Task", inlineDescription: "System.Threading.Tasks");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/59088")]
+        [Fact]
         [WorkItem("https://github.com/dotnet/roslyn/issues/58473")]
         public async Task TestGlobalUsingsInUserDocument()
         {

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ImportCompletion/ImportCompletionProviderHelper.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ImportCompletion/ImportCompletionProviderHelper.cs
@@ -25,6 +25,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         public static async Task<ImmutableArray<string>> GetImportedNamespacesAsync(SyntaxContext context, CancellationToken cancellationToken)
         {
+            var scopes = context.SemanticModel.GetImportScopes(context.Position, cancellationToken);
+
+            var usingsBuilder = ImmutableArray.CreateBuilder<string>();
+
+            foreach (var scope in scopes)
+            {
+                foreach (var import in scope.Imports)
+                {
+                    if (import.NamespaceOrType is INamespaceSymbol @namespace)
+                    {
+                        usingsBuilder.Add(GetNamespaceName(@namespace));
+                    }
+                }
+            }
+
+            return usingsBuilder.ToImmutable();
+
             // The location is the containing node of the LeftToken, or the compilation unit itself if LeftToken
             // indicates the beginning of the document (i.e. no parent).
             var location = context.LeftToken.Parent ?? context.SyntaxTree.GetRoot(cancellationToken);


### PR DESCRIPTION
Will eventually fix https://github.com/dotnet/roslyn/issues/58473

This PR is in a very early prototype state and is published to help to find and debug one particular problem. This description will be updated when the PR is ready to review

To reproduce problem:
1. Place a breakpoint at line 43 of `ImportCompletionProviderHelper.cs` (line content: `return usingsBuilder.ToImmutable()`)
2. Start debugging test https://github.com/dotnet/roslyn/blob/92a989539e51a89627a487a6a664202624efef83/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs#L1698-L1719
3. When hit the breakpoint observer that `usingsBuilder` and returned `scopes` from compiler API don't include all 7 usings from the global usings test content