### PR TITLE
Do not use the Lsp-Misc workspace in VS scenarios

### DIFF
--- a/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/EditorFeatures/TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -516,8 +516,7 @@ namespace Roslyn.Test.Utilities
                 };
 
                 // Workspace listener events do not run in tests, so we manually register the lsp misc workspace.
-                var miscWorkspace = GetManagerAccessor().GetLspMiscellaneousFilesWorkspace();
-                TestWorkspace.GetService<LspWorkspaceRegistrationService>().Register(miscWorkspace);
+                TestWorkspace.GetService<LspWorkspaceRegistrationService>().Register(GetManagerAccessor().GetLspMiscellaneousFilesWorkspace());
 
                 InitializeClientRpc();
             }

--- a/src/Features/LanguageServer/Protocol/LspServices/LspServices.cs
+++ b/src/Features/LanguageServer/Protocol/LspServices/LspServices.cs
@@ -54,20 +54,18 @@ internal class LspServices : ILspServices
 
     public T GetRequiredService<T>() where T : notnull
     {
-        T? service;
-
-        // Check the base services first
-        service = GetBaseServices<T>().SingleOrDefault();
-        service ??= GetService<T>();
-
+        var service = GetService<T>();
         Contract.ThrowIfNull(service, $"Missing required LSP service {typeof(T).FullName}");
         return service;
     }
 
     public T? GetService<T>()
     {
-        var type = typeof(T);
-        var service = (T?)TryGetService(type);
+        T? service;
+
+        // Check the base services first
+        service = GetBaseServices<T>().SingleOrDefault();
+        service ??= (T?)TryGetService(typeof(T));
 
         return service;
     }
@@ -106,7 +104,8 @@ internal class LspServices : ILspServices
         return lspService;
     }
 
-    public ImmutableArray<Type> GetRegisteredServices() => _lazyMefLspServices.Keys.ToImmutableArray();
+    public ImmutableArray<Type> GetRegisteredServices()
+        => _lazyMefLspServices.Keys.ToImmutableArray();
 
     public bool SupportsGetRegisteredServices()
     {
@@ -114,14 +113,9 @@ internal class LspServices : ILspServices
     }
 
     private IEnumerable<T> GetBaseServices<T>()
-    {
-        if (_baseServices.TryGetValue(typeof(T), out var baseServices))
-        {
-            return baseServices.Select(creatorFunc => (T)creatorFunc(this)).ToImmutableArray();
-        }
-
-        return ImmutableArray<T>.Empty;
-    }
+        => _baseServices.TryGetValue(typeof(T), out var baseServices)
+            ? baseServices.Select(creatorFunc => (T)creatorFunc(this)).ToImmutableArray()
+            : (IEnumerable<T>)ImmutableArray<T>.Empty;
 
     private IEnumerable<T> GetMefServices<T>()
     {

--- a/src/Features/LanguageServer/Protocol/RoslynLanguageServer.cs
+++ b/src/Features/LanguageServer/Protocol/RoslynLanguageServer.cs
@@ -67,7 +67,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             var clientLanguageServerManager = new ClientLanguageServerManager(jsonRpc);
             var lifeCycleManager = new LspServiceLifeCycleManager(clientLanguageServerManager);
 
-            AddBaseService<LspMiscellaneousFilesWorkspace>(new LspMiscellaneousFilesWorkspace(hostServices));
             AddBaseService<IClientLanguageServerManager>(clientLanguageServerManager);
             AddBaseService<ILspLogger>(logger);
             AddBaseService<ILspServiceLogger>(logger);
@@ -81,6 +80,13 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             AddBaseService<IMethodHandler>(new InitializeHandler());
             AddBaseService<IMethodHandler>(new InitializedHandler());
             AddBaseService<IOnInitialized>(this);
+
+            // In all VS cases, we already have a misc workspace.  Specifically
+            // Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.MiscellaneousFilesWorkspace.  In
+            // those cases, we do not need to add an additional workspace to manage new files we hear about.  So only
+            // add the LspMiscellaneousFilesWorkspace for hosts that have not already brought their own.
+            if (serverKind != WellKnownLspServerKinds.CSharpVisualBasicLspServer)
+                AddBaseService<LspMiscellaneousFilesWorkspace>(new LspMiscellaneousFilesWorkspace(hostServices));
 
             return baseServices.ToImmutableDictionary();
 

--- a/src/Features/LanguageServer/Protocol/RoslynLanguageServer.cs
+++ b/src/Features/LanguageServer/Protocol/RoslynLanguageServer.cs
@@ -85,7 +85,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             // Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.MiscellaneousFilesWorkspace.  In
             // those cases, we do not need to add an additional workspace to manage new files we hear about.  So only
             // add the LspMiscellaneousFilesWorkspace for hosts that have not already brought their own.
-            if (serverKind != WellKnownLspServerKinds.CSharpVisualBasicLspServer)
+            if (serverKind == WellKnownLspServerKinds.CSharpVisualBasicLspServer)
                 AddBaseService<LspMiscellaneousFilesWorkspace>(new LspMiscellaneousFilesWorkspace(hostServices));
 
             return baseServices.ToImmutableDictionary();

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -208,9 +208,9 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, ILspService
         _requestTelemetryLogger.UpdateFindDocumentTelemetryData(success: false, workspaceKind: null);
 
         // Add the document to our loose files workspace (if we have one) if it iss open.
-        if (_trackedDocuments.ContainsKey(uri) && _lspMiscellaneousFilesWorkspace != null)
+        if (_trackedDocuments.TryGetValue(uri, out var trackedText))
         {
-            var miscDocument = _lspMiscellaneousFilesWorkspace.AddMiscellaneousDocument(uri, _trackedDocuments[uri], _logger);
+            var miscDocument = _lspMiscellaneousFilesWorkspace?.AddMiscellaneousDocument(uri, trackedText, _logger);
             if (miscDocument is not null)
                 return (_lspMiscellaneousFilesWorkspace, miscDocument.Project.Solution, miscDocument);
         }

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -207,7 +207,6 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, ILspService
         _logger.LogError($"Could not find '{textDocumentIdentifier.Uri}'.  Searched {searchedWorkspaceKinds}");
         _requestTelemetryLogger.UpdateFindDocumentTelemetryData(success: false, workspaceKind: null);
 
-
         // Add the document to our loose files workspace (if we have one) if it iss open.
         if (_trackedDocuments.ContainsKey(uri) && _lspMiscellaneousFilesWorkspace != null)
         {

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -199,7 +199,7 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, ILspService
                 // As we found the document in a non-misc workspace, also attempt to remove it from the misc workspace
                 // if it happens to be in there as well.
                 if (workspace != _lspMiscellaneousFilesWorkspace)
-                    _lspMiscellaneousFilesWorkspace.TryRemoveMiscellaneousDocument(uri);
+                    _lspMiscellaneousFilesWorkspace?.TryRemoveMiscellaneousDocument(uri);
 
                 return (workspace, document.Project.Solution, document);
             }

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -46,23 +46,20 @@ internal class LspWorkspaceManager : IDocumentChangeTracker, ILspService
 {
     /// <summary>
     /// A cache from workspace to the last solution we returned for LSP.
-    /// 
-    /// The forkedFromVersion is not null when the solution was created from a fork of the workspace with LSP text applied on top.
-    /// It is null when LSP reuses the workspace solution (the LSP text matches the contents of the workspace).
-    /// 
-    /// Access to this is gauranteed to be serial by the <see cref="RequestExecutionQueue{RequestContextType}"/>
+    /// <para/> The forkedFromVersion is not null when the solution was created from a fork of the workspace with LSP
+    /// text applied on top. It is null when LSP reuses the workspace solution (the LSP text matches the contents of the
+    /// workspace).
+    /// <para/> Access to this is guaranteed to be serial by the <see cref="RequestExecutionQueue{RequestContextType}"/>
     /// </summary>
     private readonly Dictionary<Workspace, (int? forkedFromVersion, Solution solution)> _cachedLspSolutions = new();
 
     /// <summary>
-    /// Stores the current source text for each URI that is being tracked by LSP.
-    /// Each time an LSP text sync notification comes in, this source text is updated to match.
-    /// Used as the backing implementation for the <see cref="IDocumentChangeTracker"/>.
-    /// 
-    /// Note that the text here is tracked regardless of whether or not we found a matching roslyn document
-    /// for the URI.
-    /// 
-    /// Access to this is gauranteed to be serial by the <see cref="RequestExecutionQueue{RequestContextType}"/>
+    /// Stores the current source text for each URI that is being tracked by LSP. Each time an LSP text sync
+    /// notification comes in, this source text is updated to match. Used as the backing implementation for the <see
+    /// cref="IDocumentChangeTracker"/>.
+    /// <para/> Note that the text here is tracked regardless of whether or not we found a matching roslyn document for
+    /// the URI.
+    /// <para/> Access to this is guaranteed to be serial by the <see cref="RequestExecutionQueue{RequestContextType}"/>
     /// </summary>
     private ImmutableDictionary<Uri, SourceText> _trackedDocuments = ImmutableDictionary<Uri, SourceText>.Empty;
 

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManagerFactory.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManagerFactory.cs
@@ -26,7 +26,7 @@ internal class LspWorkspaceManagerFactory : ILspServiceFactory
     {
         var logger = lspServices.GetRequiredService<ILspServiceLogger>();
         var telemetryLogger = lspServices.GetRequiredService<RequestTelemetryLogger>();
-        var miscFilesWorkspace = lspServices.GetRequiredService<LspMiscellaneousFilesWorkspace>();
+        var miscFilesWorkspace = lspServices.GetService<LspMiscellaneousFilesWorkspace>();
         return new LspWorkspaceManager(logger, miscFilesWorkspace, _workspaceRegistrationService, telemetryLogger);
     }
 }

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationEventListener.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationEventListener.cs
@@ -9,8 +9,16 @@ using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.CodeAnalysis.LanguageServer;
 
-// Specify the VS workspaces we know we need (host, misc, metadata as source) and MSBuild for VSCode.
-[ExportEventListener(WellKnownEventListeners.Workspace, WorkspaceKind.Host, WorkspaceKind.MiscellaneousFiles, WorkspaceKind.MetadataAsSource, WorkspaceKind.MSBuild, WorkspaceKind.Interactive), Shared]
+[ExportEventListener(
+    WellKnownEventListeners.Workspace,
+    WorkspaceKind.Host,
+    WorkspaceKind.MiscellaneousFiles,
+    WorkspaceKind.MetadataAsSource,
+    // TODO(cyrusn): Why does LSP need to know about the msbuild workspace?  It's a workspace that is used in console
+    // apps, not rich server scenarios.
+    WorkspaceKind.MSBuild,
+    // TODO(cyrusn): Why does LSP need to know about the interactive workspace? Does LSP work in interactive buffers?
+    WorkspaceKind.Interactive), Shared]
 internal class LspWorkspaceRegistrationEventListener : IEventListener<object>, IEventListenerStoppable
 {
     private readonly LspWorkspaceRegistrationService _lspWorkspaceRegistrationService;

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationEventListener.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationEventListener.cs
@@ -14,10 +14,6 @@ namespace Microsoft.CodeAnalysis.LanguageServer;
     WorkspaceKind.Host,
     WorkspaceKind.MiscellaneousFiles,
     WorkspaceKind.MetadataAsSource,
-    // TODO(cyrusn): Why does LSP need to know about the msbuild workspace?  It's a workspace that is used in console
-    // apps, not rich server scenarios.
-    WorkspaceKind.MSBuild,
-    // TODO(cyrusn): Why does LSP need to know about the interactive workspace? Does LSP work in interactive buffers?
     WorkspaceKind.Interactive), Shared]
 internal class LspWorkspaceRegistrationEventListener : IEventListener<object>, IEventListenerStoppable
 {

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationService.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationService.cs
@@ -24,8 +24,11 @@ internal abstract class LspWorkspaceRegistrationService : IDisposable
         }
     }
 
-    public virtual void Register(Workspace workspace)
+    public virtual void Register(Workspace? workspace)
     {
+        if (workspace is null)
+            return;
+
         Logger.Log(FunctionId.RegisterWorkspace, KeyValueLogMessage.Create(LogType.Trace, m =>
         {
             m["WorkspaceKind"] = workspace.Kind;
@@ -45,6 +48,9 @@ internal abstract class LspWorkspaceRegistrationService : IDisposable
 
     public void Deregister(Workspace workspace)
     {
+        if (workspace is null)
+            return;
+
         workspace.WorkspaceChanged -= OnLspWorkspaceChanged;
         lock (_gate)
         {

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationService.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceRegistrationService.cs
@@ -46,7 +46,7 @@ internal abstract class LspWorkspaceRegistrationService : IDisposable
         workspace.WorkspaceChanged += OnLspWorkspaceChanged;
     }
 
-    public void Deregister(Workspace workspace)
+    public void Deregister(Workspace? workspace)
     {
         if (workspace is null)
             return;

--- a/src/VisualStudio/Core/Def/LanguageClient/VisualStudioLspWorkspaceRegistrationService.cs
+++ b/src/VisualStudio/Core/Def/LanguageClient/VisualStudioLspWorkspaceRegistrationService.cs
@@ -20,7 +20,7 @@ internal class VisualStudioLspWorkspaceRegistrationService : LspWorkspaceRegistr
 
     public override string GetHostWorkspaceKind() => WorkspaceKind.Host;
 
-    public override void Register(Workspace workspace)
+    public override void Register(Workspace? workspace)
     {
         // The lsp misc files workspace has the MiscellaneousFiles workspace kind,
         // but we don't actually want to mark it as a registered workspace in VS since we


### PR DESCRIPTION
Tracking down why we're seeing some flakeyness in LSP pull diagnostic scenarios.  The misc workspace is showing up unepectedly, so this tries to beef things up to make things better.

This is slightly more aggressive than https://github.com/dotnet/roslyn/pull/67289 in terms of teh change.