### PR TITLE
Disable IDE0090 (use target typed new) in compiler layer

### DIFF
--- a/src/Compilers/.editorconfig
+++ b/src/Compilers/.editorconfig
@@ -15,6 +15,9 @@ dotnet_diagnostic.RS0102.severity = none
 # IDE0170: Prefer extended property pattern
 dotnet_diagnostic.IDE0170.severity = suggestion
 
+# IDE0090: Simplify new expression
+dotnet_diagnostic.IDE0090.severity = none
+
 # CSharp code style settings:
 [*.cs]
 csharp_style_var_for_built_in_types = false:none


### PR DESCRIPTION
Suppress IDE0090 suggestion in compiler layer as per the team's style preferences.

Based on the feedback in https://github.com/dotnet/roslyn/pull/67255#discussion_r1136234399