### PR TITLE
Disable analyzer telemetry for all but lightbulb invocation path

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 {
                     // calculate regular diagnostic analyzers diagnostics
                     var resultMap = await _diagnosticAnalyzerRunner.AnalyzeProjectAsync(project, compilationWithAnalyzers,
-                        forcedAnalysis, logPerformanceInfo: true, getTelemetryInfo: true, cancellationToken).ConfigureAwait(false);
+                        forcedAnalysis, logPerformanceInfo: false, getTelemetryInfo: true, cancellationToken).ConfigureAwait(false);
 
                     result = resultMap.AnalysisResult;
 

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -109,7 +109,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 // We log performance info when we are computing diagnostics for a span
                 // and also blocking for data, i.e. for lightbulb code path for "Ctrl + Dot" user command.
-                var logPerformanceInfo = range.HasValue && blockForData;
+                // Note that some callers, such as diagnostic tagger, might pass in a range equal to the entire document span,
+                // so we also check that the range length is lesser then the document text length.
+                var logPerformanceInfo = range.HasValue && blockForData && range.Value.Length < text.Length;
                 var compilationWithAnalyzers = await GetOrCreateCompilationWithAnalyzersAsync(document.Project, ideOptions, stateSets, includeSuppressedDiagnostics, cancellationToken).ConfigureAwait(false);
 
                 return new LatestDiagnosticsForSpanGetter(

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 if (nonCachedStateSets.Count > 0)
                 {
                     var analysisScope = new DocumentAnalysisScope(document, span: null, nonCachedStateSets.SelectAsArray(s => s.Analyzer), kind);
-                    var executor = new DocumentAnalysisExecutor(analysisScope, compilationWithAnalyzers, _diagnosticAnalyzerRunner, logPerformanceInfo: true, onAnalysisException: OnAnalysisException);
+                    var executor = new DocumentAnalysisExecutor(analysisScope, compilationWithAnalyzers, _diagnosticAnalyzerRunner, logPerformanceInfo: false, onAnalysisException: OnAnalysisException);
                     var logTelemetry = GlobalOptions.GetOption(DiagnosticOptionsStorage.LogTelemetryForBackgroundAnalyzerExecution);
                     foreach (var stateSet in nonCachedStateSets)
                     {

--- a/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.PerformanceReporter.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/ProcessTelemetry/RemoteProcessTelemetryService.PerformanceReporter.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Remote
                         foreach (var analyzerInfo in pooledObject.Object)
                         {
                             // this will report telemetry under VS. this will let us see how accurate our performance tracking is
-                            RoslynLogger.Log(FunctionId.Diagnostics_AnalyzerPerformanceInfo, KeyValueLogMessage.Create(m =>
+                            RoslynLogger.Log(FunctionId.Diagnostics_AnalyzerPerformanceInfo2, KeyValueLogMessage.Create(m =>
                             {
                                 // since it is telemetry, we hash analyzer name if it is not builtin analyzer
                                 m[nameof(analyzerInfo.AnalyzerId)] = isInternalUser ? analyzerInfo.AnalyzerId : analyzerInfo.PIISafeAnalyzerId;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Log/FunctionId.cs
@@ -582,7 +582,8 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         SQLite_StorageDisabled = 631,
 
         // 650-660 for diagnostic/fix related ids.
-        Diagnostics_AnalyzerPerformanceInfo = 651,
+        //Diagnostics_AnalyzerPerformanceInfo = 651, - Deprecated due to high volume of events.
+        Diagnostics_AnalyzerPerformanceInfo2 = 652,
 
         // 660-670 for semantic model reuse service.
         SemanticModelReuseLanguageService_TryGetSpeculativeSemanticModelAsync_Equivalent = 660,


### PR DESCRIPTION
We enabled this analyer telemetry for all diagnostic computation code paths in 17.5, but this ended up generating a lot of traffic and we had to suppress the telemetry event. This change makes a targeted fix to disable the telemetry event for all paths except the lightbulb path. We want to collect this telemetry to help identify slow analyzers affecting lightbulb perf.

In future, we plan to revert this PR and re-enable the telemetry on all diagnostic computation paths using the new telemetry aggregation APIs exposed by the telemetry team.