### PR TITLE
Improve perf of resolving local symbol keys

### DIFF
--- a/src/Workspaces/CoreTest/SymbolKeyTests.cs
+++ b/src/Workspaces/CoreTest/SymbolKeyTests.cs
@@ -1296,6 +1296,8 @@ public class C
             end: goto start;
             end: ; // duplicate label
 
+            DeepLocalFunction();
+
             void DeepLocalFunction()
             {
                 int[] xs = new int[] { 1, 2, 3, 4 };
@@ -1319,6 +1321,8 @@ public class C
                 {
                     var q2 = from x in xs where x < 4 select x;
                 }
+
+                InteriorMethod();
             }
         }
     }
@@ -1332,6 +1336,8 @@ public class C
 
             var syntaxTree = compilation.SyntaxTrees.Single();
             var text = syntaxTree.GetText();
+
+            // replace all spaces with double spaces.  So nothing is in the same location anymore.
             var newTree = syntaxTree.WithChangedText(text.WithChanges(new TextChange(new TextSpan(0, text.Length), text.ToString().Replace(" ", "  "))));
             var newCompilation = compilation.ReplaceSyntaxTree(syntaxTree, newTree);
 
@@ -1345,7 +1351,8 @@ public class C
                 Assert.Equal(resolved.Symbol.Name, symbol.Name);
                 Assert.Equal(resolved.Symbol.Kind, symbol.Kind);
 
-                Assert.NotEqual(resolved.Symbol.Locations[0].SourceSpan, symbol.Locations[0].SourceSpan);
+                // Ensure that the local moved later in the file.
+                Assert.True(resolved.Symbol.Locations[0].SourceSpan.Start > symbol.Locations[0].SourceSpan.Start);
             }
         }
 

--- a/src/Workspaces/CoreTest/SymbolKeyTests.cs
+++ b/src/Workspaces/CoreTest/SymbolKeyTests.cs
@@ -1332,6 +1332,13 @@ public class C
             var methods = GetDeclaredSymbols(compilation).OfType<IMethodSymbol>();
             var symbols = methods.SelectMany(ms => GetInteriorSymbols(ms, compilation)).Where(s => SymbolKey.IsBodyLevelSymbol(s)).ToList();
             Assert.Equal(25, symbols.Count);
+
+            // Ensure we have coverage for all our body symbols.
+            Assert.True(symbols.Any(s => s is ILocalSymbol));
+            Assert.True(symbols.Any(s => s is ILabelSymbol));
+            Assert.True(symbols.Any(s => s is IRangeVariableSymbol));
+            Assert.True(symbols.Any(s => s.IsLocalFunction()));
+
             TestRoundTrip(symbols, compilation);
 
             var syntaxTree = compilation.SyntaxTrees.Single();

--- a/src/Workspaces/CoreTest/SymbolKeyTests.cs
+++ b/src/Workspaces/CoreTest/SymbolKeyTests.cs
@@ -1250,6 +1250,105 @@ public class C
             Assert.True(SymbolKey.GetComparer(ignoreCase: true, ignoreAssemblyKeys: true).Equals(symbolKey1, symbolKey2));
         }
 
+        [Fact]
+        public void TestBodySymbolsWithEdits()
+        {
+            var source = @"
+using System.Collections.Generic;
+using System.Linq;
+
+public class C
+{
+    public void M()
+    {
+        void InteriorMethod()
+        {
+            int a, b;
+            if (a > b) {
+               int c = a + b;
+            }
+
+            {
+                string d = "";
+            }
+
+            {
+                double d = 0.0;
+            }
+
+            {
+                bool d = false;
+            }
+
+            var q = new { };
+
+            int[] xs = new int[] { 1, 2, 3, 4 };
+
+            {
+                var q = from x in xs where x > 2 select x;
+            }
+
+            {
+                var q2 = from x in xs where x < 4 select x;
+            }
+
+            start: goto end;
+            end: goto start;
+            end: ; // duplicate label
+
+            void DeepLocalFunction()
+            {
+                int[] xs = new int[] { 1, 2, 3, 4 };
+
+                {
+                    string d = "";
+                }
+
+                {
+                    double d = 0.0;
+                }
+
+                {
+                    bool d = false;
+                }
+
+                {
+                    var q = from x in xs where x > 2 select x;
+                }
+
+                {
+                    var q2 = from x in xs where x < 4 select x;
+                }
+            }
+        }
+    }
+}
+";
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
+            var methods = GetDeclaredSymbols(compilation).OfType<IMethodSymbol>();
+            var symbols = methods.SelectMany(ms => GetInteriorSymbols(ms, compilation)).Where(s => SymbolKey.IsBodyLevelSymbol(s)).ToList();
+            Assert.Equal(25, symbols.Count);
+            TestRoundTrip(symbols, compilation);
+
+            var syntaxTree = compilation.SyntaxTrees.Single();
+            var text = syntaxTree.GetText();
+            var newTree = syntaxTree.WithChangedText(text.WithChanges(new TextChange(new TextSpan(0, text.Length), text.ToString().Replace(" ", "  "))));
+            var newCompilation = compilation.ReplaceSyntaxTree(syntaxTree, newTree);
+
+            foreach (var symbol in symbols)
+            {
+                var key = SymbolKey.Create(symbol);
+                var resolved = key.Resolve(newCompilation);
+
+                Assert.NotNull(resolved.Symbol);
+
+                Assert.Equal(resolved.Symbol.Name, symbol.Name);
+                Assert.Equal(resolved.Symbol.Kind, symbol.Kind);
+
+                Assert.NotEqual(resolved.Symbol.Locations[0].SourceSpan, symbol.Locations[0].SourceSpan);
+            }
+        }
+
         private static void TestRoundTrip(IEnumerable<ISymbol> symbols, Compilation compilation, Func<ISymbol, object> fnId = null)
         {
             foreach (var symbol in symbols)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -37,6 +38,8 @@ namespace Microsoft.CodeAnalysis
 
             public static void Create(ISymbol symbol, SymbolKeyWriter visitor)
             {
+                var cancellationToken = visitor.CancellationToken;
+
                 // Store the body level symbol in two forms.  The first, a highly precise form that should find explicit
                 // symbols for the case of resolving a symbol key back in the *same* solution snapshot it was created
                 // from. The second, in a more query-oriented form that can allow the symbol to be found in some cases
@@ -58,12 +61,14 @@ namespace Microsoft.CodeAnalysis
                 // write out the locations for precision
                 Contract.ThrowIfTrue(symbol.DeclaringSyntaxReferences.IsEmpty && symbol.Locations.IsEmpty);
 
-                var locations = GetBodyLevelSourceLocations(symbol, visitor.CancellationToken);
+                var locations = GetBodyLevelSourceLocations(symbol, cancellationToken);
 
                 Contract.ThrowIfFalse(locations.All(loc => loc.IsInSource));
                 visitor.WriteLocationArray(locations.Distinct());
 
-                // and the ordinal for resilience
+                // and the containingSymbol/ordinal for resilience
+                var container = symbol.ContainingSymbol;
+                visitor.WriteSymbolKey(container);
                 visitor.WriteInteger(GetOrdinal());
 
                 return;
@@ -73,11 +78,16 @@ namespace Microsoft.CodeAnalysis
                     var syntaxTree = locations[0].SourceTree;
                     var compilation = ((ISourceAssemblySymbol)symbol.ContainingAssembly).Compilation;
 
+                    // See if we can find an appropriate container for this local and attempt to find this local's index
+                    // within it.
+                    var containerDeclaration = TryGetContainerDeclaration(container, syntaxTree, cancellationToken);
+
                     // Ensure that the tree we're looking at is actually in this compilation.  It may not be in the
                     // compilation in the case of work done with a speculative model.
-                    if (TryGetSemanticModel(compilation, syntaxTree, out var semanticModel))
+                    if (containerDeclaration != null &&
+                        TryGetSemanticModel(compilation, syntaxTree, out var semanticModel))
                     {
-                        foreach (var possibleSymbol in EnumerateSymbols(semanticModel, kind, localName, visitor.CancellationToken))
+                        foreach (var possibleSymbol in EnumerateSymbols(semanticModel, containerDeclaration, kind, localName, cancellationToken))
                         {
                             if (possibleSymbol.symbol.Equals(symbol))
                                 return possibleSymbol.ordinal;
@@ -86,6 +96,20 @@ namespace Microsoft.CodeAnalysis
 
                     return int.MaxValue;
                 }
+            }
+
+            private static SyntaxNode? TryGetContainerDeclaration(ISymbol container, SyntaxTree? syntaxTree, CancellationToken cancellationToken)
+            {
+                if (syntaxTree != null)
+                {
+                    foreach (var reference in container.DeclaringSyntaxReferences)
+                    {
+                        if (reference.SyntaxTree == syntaxTree)
+                            return reference.GetSyntax(cancellationToken);
+                    }
+                }
+
+                return null;
             }
 
             private static bool TryGetSemanticModel(
@@ -110,9 +134,9 @@ namespace Microsoft.CodeAnalysis
 
                 var name = reader.ReadRequiredString();
                 var kind = (SymbolKind)reader.ReadInteger();
-#pragma warning disable IDE0007 // Use implicit type
-                PooledArrayBuilder<Location> locations = reader.ReadLocationArray(out var locationsFailureReason)!;
-#pragma warning restore IDE0007 // Use implicit type
+                using var locations = reader.ReadLocationArray(out var locationsFailureReason);
+
+                var containingSymbol = reader.ReadSymbolKey(contextualSymbol: null, out var containingSymbolFailureReason);
                 var ordinal = reader.ReadInteger();
 
                 if (locationsFailureReason != null)
@@ -127,6 +151,8 @@ namespace Microsoft.CodeAnalysis
                 for (var i = 0; i < locations.Count; i++)
                 {
                     var loc = locations[i];
+                    if (loc is null)
+                        continue;
 
                     if (!TryResolveLocation(loc, i, out var resolution, out var reason))
                     {
@@ -141,21 +167,55 @@ namespace Microsoft.CodeAnalysis
                 }
 
                 // Couldn't recover.  See if we can still find a match across the textual drift.
-                if (ordinal != int.MaxValue &&
-                    TryGetSemanticModel(reader.Compilation, locations[0].SourceTree, out var semanticModel))
+                if (ordinal != int.MaxValue)
                 {
-                    foreach (var symbol in EnumerateSymbols(semanticModel, kind, name, cancellationToken))
+                    if (containingSymbolFailureReason != null)
                     {
-                        if (symbol.ordinal == ordinal)
+                        var reason = $"({nameof(BodyLevelSymbolKey)} {nameof(containingSymbol)} failed -> {containingSymbolFailureReason})";
+
+                        totalFailureReason = totalFailureReason == null
+                            ? $"({reason})"
+                            : $"({totalFailureReason} -> {reason})";
+                    }
+                    else
+                    {
+                        var firstSourceTree = locations[0]?.SourceTree;
+                        var containerDeclaration = GetContainerDeclaration(firstSourceTree);
+
+                        if (containerDeclaration != null &&
+                            TryGetSemanticModel(reader.Compilation, firstSourceTree, out var semanticModel))
                         {
-                            failureReason = null;
-                            return new SymbolKeyResolution(symbol.symbol);
+                            foreach (var symbol in EnumerateSymbols(semanticModel, containerDeclaration, kind, name, cancellationToken))
+                            {
+                                if (symbol.ordinal == ordinal)
+                                {
+                                    failureReason = null;
+                                    return new SymbolKeyResolution(symbol.symbol);
+                                }
+                            }
                         }
                     }
                 }
 
                 failureReason = $"({nameof(BodyLevelSymbolKey)} '{name}' not found -> {totalFailureReason})";
                 return default;
+
+                SyntaxNode? GetContainerDeclaration(SyntaxTree? syntaxTree)
+                {
+                    if (syntaxTree != null)
+                    {
+                        foreach (var container in containingSymbol)
+                        {
+                            foreach (var reference in container.DeclaringSyntaxReferences)
+                            {
+                                if (reference.SyntaxTree == syntaxTree)
+                                    return reference.GetSyntax(cancellationToken);
+                            }
+                        }
+                    }
+
+                    return null;
+                }
 
                 bool TryResolveLocation(Location loc, int index, out SymbolKeyResolution resolution, out string? reason)
                 {
@@ -193,12 +253,11 @@ namespace Microsoft.CodeAnalysis
             }
 
             private static IEnumerable<(ISymbol symbol, int ordinal)> EnumerateSymbols(
-                SemanticModel semanticModel, SymbolKind kind, string localName, CancellationToken cancellationToken)
+                SemanticModel semanticModel, SyntaxNode containerDeclaration, SymbolKind kind, string localName, CancellationToken cancellationToken)
             {
                 var ordinal = 0;
-                var root = semanticModel.SyntaxTree.GetRoot(cancellationToken);
 
-                foreach (var node in root.DescendantNodes())
+                foreach (var node in containerDeclaration.DescendantNodes())
                 {
                     var symbol = semanticModel.GetDeclaredSymbol(node, cancellationToken);
 
@@ -215,9 +274,7 @@ namespace Microsoft.CodeAnalysis
                 foreach (var current in trees)
                 {
                     if (current == tree)
-                    {
                         return true;
-                    }
                 }
 
                 return false;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/SymbolKey/SymbolKey.BodyLevelSymbolKey.cs
@@ -255,6 +255,8 @@ namespace Microsoft.CodeAnalysis
             private static IEnumerable<(ISymbol symbol, int ordinal)> EnumerateSymbols(
                 SemanticModel semanticModel, SyntaxNode containerDeclaration, SymbolKind kind, string localName, CancellationToken cancellationToken)
             {
+                Contract.ThrowIfTrue(semanticModel.SyntaxTree != containerDeclaration.SyntaxTree);
+
                 var ordinal = 0;
 
                 foreach (var node in containerDeclaration.DescendantNodes())


### PR DESCRIPTION
SymbolKey supports a mode where it tries to be resilient to edits in a file, allowing you to try to find a symbol from a prior compilation in a later compilation.  For local symbols, this currently works by walking all declared symbols in the file of the same type and same name, and recording the ordinal of that symbol in that list.

This works, and is resilient to many types of edits.  However, it can be quite slow, having to walk the entire file, binding everything to see if there's a match.

This change updates things so that instead of doing that logic across the whole file, we instead use the "containing symbol's declaration node" to scope down the set of nodes we actually have to examine, instead of looking at the whole file.

The upside of htis is much less to look at.  The downside is that we are now dependent on being able to find the container.  However, that matches the logic of how 'resilient resolution' has worked for all other symbols.  So this seems fine.