### PR TITLE
Rename codefix predefined name

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/MakeTypePartial/CSharpMakeTypePartialCodeFixProvider.cs
+++ b/src/Analyzers/CSharp/CodeFixes/MakeTypePartial/CSharpMakeTypePartialCodeFixProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.MakeTypePartial;
 
 namespace Microsoft.CodeAnalysis.CSharp.MakeTypePartial
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.MakeDeclarationsPartial), Shared]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.MakeTypePartial), Shared]
     internal sealed class CSharpMakeTypePartialCodeFixProvider : AbstractMakeTypePartialCodeFixProvider
     {
         private const string CS0260 = nameof(CS0260); // Missing partial modifier on declaration of type 'C'; another partial declaration of this type exists

--- a/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
+++ b/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string InlineDeclaration = nameof(InlineDeclaration);
         public const string InvokeDelegateWithConditionalAccess = nameof(InvokeDelegateWithConditionalAccess);
         public const string JsonDetection = nameof(JsonDetection);
-        public const string MakeDeclarationsPartial = nameof(MakeDeclarationsPartial);
+        public const string MakeTypePartial = nameof(MakeTypePartial);
         public const string MakeFieldReadonly = nameof(MakeFieldReadonly);
         public const string MakeLocalFunctionStatic = nameof(MakeLocalFunctionStatic);
         public const string MakeMemberRequired = nameof(MakeMemberRequired);

--- a/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
+++ b/src/Analyzers/Core/CodeFixes/PredefinedCodeFixProviderNames.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string AddBraces = nameof(AddBraces);
         public const string AddDocCommentNodes = nameof(AddDocCommentNodes);
         public const string AddExplicitCast = nameof(AddExplicitCast);
-        public const string AddInheritdoc = nameof(AddInheritdoc);
         public const string AddImport = nameof(AddImport);
+        public const string AddInheritdoc = nameof(AddInheritdoc);
         public const string AddMissingReference = nameof(AddMissingReference);
         public const string AddNew = nameof(AddNew);
         public const string AddObsoleteAttribute = nameof(AddObsoleteAttribute);
@@ -36,10 +36,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string ConsecutiveStatementPlacement = nameof(ConsecutiveStatementPlacement);
         public const string ConstructorInitializerPlacement = nameof(ConstructorInitializerPlacement);
         public const string ConvertNamespace = nameof(ConvertNamespace);
-        public const string ConvertToProgramMain = nameof(ConvertToProgramMain);
         public const string ConvertSwitchStatementToExpression = nameof(ConvertSwitchStatementToExpression);
         public const string ConvertToAsync = nameof(ConvertToAsync);
         public const string ConvertToIterator = nameof(ConvertToIterator);
+        public const string ConvertToProgramMain = nameof(ConvertToProgramMain);
         public const string ConvertToRecord = nameof(ConvertToRecord);
         public const string ConvertToTopLevelStatements = nameof(ConvertToTopLevelStatements);
         public const string ConvertTypeOfToNameOf = nameof(ConvertTypeOfToNameOf);
@@ -70,7 +70,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string InlineDeclaration = nameof(InlineDeclaration);
         public const string InvokeDelegateWithConditionalAccess = nameof(InvokeDelegateWithConditionalAccess);
         public const string JsonDetection = nameof(JsonDetection);
-        public const string MakeTypePartial = nameof(MakeTypePartial);
         public const string MakeFieldReadonly = nameof(MakeFieldReadonly);
         public const string MakeLocalFunctionStatic = nameof(MakeLocalFunctionStatic);
         public const string MakeMemberRequired = nameof(MakeMemberRequired);
@@ -79,9 +78,10 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string MakeRefStruct = nameof(MakeRefStruct);
         public const string MakeStatementAsynchronous = nameof(MakeStatementAsynchronous);
         public const string MakeStructFieldsWritable = nameof(MakeStructFieldsWritable);
-        public const string MakeStructReadOnly = nameof(MakeStructReadOnly);
         public const string MakeStructMemberReadOnly = nameof(MakeStructMemberReadOnly);
+        public const string MakeStructReadOnly = nameof(MakeStructReadOnly);
         public const string MakeTypeAbstract = nameof(MakeTypeAbstract);
+        public const string MakeTypePartial = nameof(MakeTypePartial);
         public const string MoveMisplacedUsingDirectives = nameof(MoveMisplacedUsingDirectives);
         public const string MoveToTopOfFile = nameof(MoveToTopOfFile);
         public const string OrderModifiers = nameof(OrderModifiers);
@@ -128,8 +128,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string UpgradeProject = nameof(UpgradeProject);
         public const string UseAutoProperty = nameof(UseAutoProperty);
         public const string UseCoalesceExpressionForIfNullStatementCheck = nameof(UseCoalesceExpressionForIfNullStatementCheck);
-        public const string UseCoalesceExpressionForTernaryConditionalCheck = nameof(UseCoalesceExpressionForTernaryConditionalCheck);
         public const string UseCoalesceExpressionForNullableTernaryConditionalCheck = nameof(UseCoalesceExpressionForNullableTernaryConditionalCheck);
+        public const string UseCoalesceExpressionForTernaryConditionalCheck = nameof(UseCoalesceExpressionForTernaryConditionalCheck);
         public const string UseCollectionInitializer = nameof(UseCollectionInitializer);
         public const string UseCompoundAssignment = nameof(UseCompoundAssignment);
         public const string UseCompoundCoalesceAssignment = nameof(UseCompoundCoalesceAssignment);

--- a/src/Analyzers/VisualBasic/CodeFixes/MakeTypePartial/VisualBasicMakeTypePartialCodeFixProvider.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/MakeTypePartial/VisualBasicMakeTypePartialCodeFixProvider.vb
@@ -9,7 +9,7 @@ Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.MakeTypePartial
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.MakeTypePartial
-    <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=PredefinedCodeFixProviderNames.MakeDeclarationsPartial), [Shared]>
+    <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=PredefinedCodeFixProviderNames.MakeTypePartial), [Shared]>
     Friend Class VisualBasicMakeTypePartialCodeFixProvider
         Inherits AbstractMakeTypePartialCodeFixProvider
 


### PR DESCRIPTION
When implementing `Make type partial` codefix I forgot to rename predefined codefix name. This little PR fixes that. But since I'm modifying the file anyway, I also sorted its content