### PR TITLE
Fix CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer to report local diagnostic

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/MakeStructMemberReadOnly/CSharpMakeStructMemberReadOnlyAnalyzer.cs
@@ -94,8 +94,6 @@ internal sealed class CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer : Abstrac
         }
 
         var declaration = methodReference.GetSyntax(cancellationToken);
-        if (declaration is ArrowExpressionClauseSyntax)
-            declaration = declaration.GetRequiredParent();
 
         var nameToken = declaration switch
         {
@@ -103,8 +101,12 @@ internal sealed class CSharpMakeStructMemberReadOnlyDiagnosticAnalyzer : Abstrac
             AccessorDeclarationSyntax accessorDeclaration => accessorDeclaration.Keyword,
             PropertyDeclarationSyntax propertyDeclaration => propertyDeclaration.Identifier,
             IndexerDeclarationSyntax indexerDeclaration => indexerDeclaration.ThisKeyword,
+            ArrowExpressionClauseSyntax arrowExpression => arrowExpression.ArrowToken,
             _ => (SyntaxToken?)null
         };
+
+        if (declaration is ArrowExpressionClauseSyntax)
+            declaration = declaration.GetRequiredParent();
 
         if (nameToken is null)
             return;

--- a/src/Analyzers/CSharp/Tests/MakeStructMemberReadOnly/MakeStructMemberReadOnlyTests.cs
+++ b/src/Analyzers/CSharp/Tests/MakeStructMemberReadOnly/MakeStructMemberReadOnlyTests.cs
@@ -478,11 +478,10 @@ public sealed class MakeStructMemberReadOnlyTests
     {
         await new VerifyCS.Test
         {
-            CodeFixTestBehaviors = CodeFixTestBehaviors.SkipLocalDiagnosticCheck,
             TestCode = """
             struct S
             {
-                int [|P|] => 0;
+                int P [|=>|] 0;
             }
             """,
             FixedCode = """


### PR DESCRIPTION
Follow-up to #67298