### PR TITLE
Update 'use auto property' to be a symbol-start/end analyzer instead of a semantic-model analyzer.

### DIFF
--- a/src/Analyzers/CSharp/Analyzers/UseAutoProperty/CSharpUseAutoPropertyAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseAutoProperty/CSharpUseAutoPropertyAnalyzer.cs
@@ -43,13 +43,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UseAutoProperty
             => variable.Initializer?.Value;
 
         protected override void RegisterNonConstructorFieldWrites(
-            ISet<string> fieldNames, ConcurrentDictionary<IFieldSymbol, ConcurrentSet<SyntaxNode>> fieldWrites, SemanticModel semanticModel, SyntaxNode codeBlock, CancellationToken cancellationToken)
+            HashSet<string> fieldNames, ConcurrentDictionary<IFieldSymbol, ConcurrentSet<SyntaxNode>> fieldWrites, SemanticModel semanticModel, SyntaxNode codeBlock, CancellationToken cancellationToken)
         {
             // nothing to do here for C#.  This is for VB only situations.
         }
 
         protected override void RegisterIneligibleFieldsAction(
-            ISet<string> fieldNames,
+            HashSet<string> fieldNames,
             ConcurrentSet<IFieldSymbol> ineligibleFields,
             SemanticModel semanticModel,
             SyntaxNode codeBlock,

--- a/src/Analyzers/CSharp/Analyzers/UseAutoProperty/CSharpUseAutoPropertyAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseAutoProperty/CSharpUseAutoPropertyAnalyzer.cs
@@ -22,6 +22,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseAutoProperty
         VariableDeclaratorSyntax,
         ExpressionSyntax>
     {
+        protected override SyntaxKind PropertyDeclarationKind => SyntaxKind.PropertyDeclaration;
+
         protected override bool SupportsReadOnlyProperties(Compilation compilation)
             => compilation.LanguageVersion() >= LanguageVersion.CSharp6;
 
@@ -30,9 +32,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UseAutoProperty
 
         protected override bool CanExplicitInterfaceImplementationsBeFixed()
             => false;
-
-        protected override PropertyDeclarationSyntax? GetPropertyDeclaration(SyntaxNode node)
-            => node as PropertyDeclarationSyntax;
 
         protected override void RegisterIneligibleFieldsAction(
             ConcurrentSet<IFieldSymbol> ineligibleFields, SemanticModel semanticModel, SyntaxNode codeBlock, CancellationToken cancellationToken)

--- a/src/Analyzers/CSharp/Analyzers/UseAutoProperty/CSharpUseAutoPropertyAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseAutoProperty/CSharpUseAutoPropertyAnalyzer.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
@@ -32,83 +31,33 @@ namespace Microsoft.CodeAnalysis.CSharp.UseAutoProperty
         protected override bool CanExplicitInterfaceImplementationsBeFixed()
             => false;
 
-        protected override void AnalyzeCompilationUnit(
-            SemanticModelAnalysisContext context, SyntaxNode root, List<AnalysisResult> analysisResults)
-            => AnalyzeMembers(context, ((CompilationUnitSyntax)root).Members, analysisResults);
-
-        private void AnalyzeMembers(
-            SemanticModelAnalysisContext context,
-            SyntaxList<MemberDeclarationSyntax> members,
-            List<AnalysisResult> analysisResults)
-        {
-            foreach (var memberDeclaration in members)
-            {
-                AnalyzeMemberDeclaration(context, memberDeclaration, analysisResults);
-            }
-        }
-
-        private void AnalyzeMemberDeclaration(
-            SemanticModelAnalysisContext context,
-            MemberDeclarationSyntax member,
-            List<AnalysisResult> analysisResults)
-        {
-            if (member is BaseNamespaceDeclarationSyntax namespaceDeclaration)
-            {
-                AnalyzeMembers(context, namespaceDeclaration.Members, analysisResults);
-            }
-            else if (member is TypeDeclarationSyntax(
-                SyntaxKind.ClassDeclaration or
-                SyntaxKind.StructDeclaration or
-                SyntaxKind.RecordDeclaration or
-                SyntaxKind.RecordStructDeclaration) typeDeclaration)
-            {
-                // If we have a class or struct, recurse inwards.
-                AnalyzeMembers(context, typeDeclaration.Members, analysisResults);
-            }
-            else if (member is PropertyDeclarationSyntax propertyDeclaration)
-            {
-                AnalyzeProperty(context, propertyDeclaration, analysisResults);
-            }
-        }
-
         protected override void RegisterIneligibleFieldsAction(
-            List<AnalysisResult> analysisResults, HashSet<IFieldSymbol> ineligibleFields,
-            Compilation compilation, CancellationToken cancellationToken)
+            ConcurrentSet<IFieldSymbol> ineligibleFields, SemanticModel semanticModel, SyntaxNode codeBlock, CancellationToken cancellationToken)
         {
-            var groups = analysisResults.Select(r => (typeDeclaration: (TypeDeclarationSyntax)r.PropertyDeclaration.Parent!, r.SemanticModel))
-                                        .Distinct()
-                                        .GroupBy(n => n.typeDeclaration.SyntaxTree);
-
-            foreach (var (tree, typeDeclarations) in groups)
+            foreach (var argument in codeBlock.DescendantNodesAndSelf().OfType<ArgumentSyntax>())
             {
-                foreach (var (typeDeclaration, semanticModel) in typeDeclarations)
-                {
-                    foreach (var argument in typeDeclaration.DescendantNodesAndSelf().OfType<ArgumentSyntax>())
-                    {
-                        // An argument will disqualify a field if that field is used in a ref/out position.  
-                        // We can't change such field references to be property references in C#.
-                        if (argument.RefKindKeyword.Kind() != SyntaxKind.None)
-                            AddIneligibleFields(semanticModel, argument.Expression, ineligibleFields, cancellationToken);
-                    }
-
-                    foreach (var refExpression in typeDeclaration.DescendantNodesAndSelf().OfType<RefExpressionSyntax>())
-                        AddIneligibleFields(semanticModel, refExpression.Expression, ineligibleFields, cancellationToken);
-
-                    // Can't take the address of an auto-prop.  So disallow for fields that we do `&x` on.
-                    foreach (var addressOfExpression in typeDeclaration.DescendantNodesAndSelf().OfType<PrefixUnaryExpressionSyntax>())
-                    {
-                        if (addressOfExpression.Kind() == SyntaxKind.AddressOfExpression)
-                            AddIneligibleFields(semanticModel, addressOfExpression.Operand, ineligibleFields, cancellationToken);
-                    }
-
-                    foreach (var memberAccess in typeDeclaration.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
-                        AddIneligibleFieldsIfAccessedOffNotDefinitelyAssignedValue(semanticModel, memberAccess, ineligibleFields, cancellationToken);
-                }
+                // An argument will disqualify a field if that field is used in a ref/out position.  
+                // We can't change such field references to be property references in C#.
+                if (argument.RefKindKeyword.Kind() != SyntaxKind.None)
+                    AddIneligibleFields(semanticModel, argument.Expression, ineligibleFields, cancellationToken);
             }
+
+            foreach (var refExpression in codeBlock.DescendantNodesAndSelf().OfType<RefExpressionSyntax>())
+                AddIneligibleFields(semanticModel, refExpression.Expression, ineligibleFields, cancellationToken);
+
+            // Can't take the address of an auto-prop.  So disallow for fields that we do `&x` on.
+            foreach (var addressOfExpression in codeBlock.DescendantNodesAndSelf().OfType<PrefixUnaryExpressionSyntax>())
+            {
+                if (addressOfExpression.Kind() == SyntaxKind.AddressOfExpression)
+                    AddIneligibleFields(semanticModel, addressOfExpression.Operand, ineligibleFields, cancellationToken);
+            }
+
+            foreach (var memberAccess in codeBlock.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>())
+                AddIneligibleFieldsIfAccessedOffNotDefinitelyAssignedValue(semanticModel, memberAccess, ineligibleFields, cancellationToken);
         }
 
         private static void AddIneligibleFieldsIfAccessedOffNotDefinitelyAssignedValue(
-            SemanticModel semanticModel, MemberAccessExpressionSyntax memberAccess, HashSet<IFieldSymbol> ineligibleFields, CancellationToken cancellationToken)
+            SemanticModel semanticModel, MemberAccessExpressionSyntax memberAccess, ConcurrentSet<IFieldSymbol> ineligibleFields, CancellationToken cancellationToken)
         {
             // `c.x = ...` can't be converted to `c.X = ...` if `c` is a struct and isn't definitely assigned as that point.
 
@@ -138,13 +87,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UseAutoProperty
         }
 
         private static void AddIneligibleFields(
-            SemanticModel semanticModel, ExpressionSyntax expression, HashSet<IFieldSymbol> ineligibleFields, CancellationToken cancellationToken)
+            SemanticModel semanticModel, ExpressionSyntax expression, ConcurrentSet<IFieldSymbol> ineligibleFields, CancellationToken cancellationToken)
         {
             var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
             AddIneligibleFields(ineligibleFields, symbolInfo);
         }
 
-        private static void AddIneligibleFields(HashSet<IFieldSymbol> ineligibleFields, SymbolInfo symbolInfo)
+        private static void AddIneligibleFields(ConcurrentSet<IFieldSymbol> ineligibleFields, SymbolInfo symbolInfo)
         {
             AddIneligibleField(symbolInfo.Symbol);
             foreach (var symbol in symbolInfo.CandidateSymbols)
@@ -194,16 +143,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UseAutoProperty
         private static ExpressionSyntax? GetGetterExpressionFromSymbol(IMethodSymbol getMethod, CancellationToken cancellationToken)
         {
             var declaration = getMethod.DeclaringSyntaxReferences[0].GetSyntax(cancellationToken);
-            switch (declaration)
+            return declaration switch
             {
-                case AccessorDeclarationSyntax accessorDeclaration:
-                    return accessorDeclaration.ExpressionBody?.Expression ??
-                           GetSingleStatementFromAccessor<ReturnStatementSyntax>(accessorDeclaration)?.Expression;
-                case ArrowExpressionClauseSyntax arrowExpression:
-                    return arrowExpression.Expression;
-                case null: return null;
-                default: throw ExceptionUtilities.Unreachable();
-            }
+                AccessorDeclarationSyntax accessorDeclaration =>
+                    accessorDeclaration.ExpressionBody?.Expression ?? GetSingleStatementFromAccessor<ReturnStatementSyntax>(accessorDeclaration)?.Expression,
+                ArrowExpressionClauseSyntax arrowExpression => arrowExpression.Expression,
+                null => null,
+                _ => throw ExceptionUtilities.Unreachable(),
+            };
         }
 
         private static T? GetSingleStatementFromAccessor<T>(AccessorDeclarationSyntax? accessorDeclaration) where T : StatementSyntax

--- a/src/Analyzers/CSharp/Analyzers/UseAutoProperty/CSharpUseAutoPropertyAnalyzer.cs
+++ b/src/Analyzers/CSharp/Analyzers/UseAutoProperty/CSharpUseAutoPropertyAnalyzer.cs
@@ -17,7 +17,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UseAutoProperty
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal sealed class CSharpUseAutoPropertyAnalyzer : AbstractUseAutoPropertyAnalyzer<
-        PropertyDeclarationSyntax, FieldDeclarationSyntax, VariableDeclaratorSyntax, ExpressionSyntax>
+        SyntaxKind,
+        PropertyDeclarationSyntax,
+        FieldDeclarationSyntax,
+        VariableDeclaratorSyntax,
+        ExpressionSyntax>
     {
         protected override bool SupportsReadOnlyProperties(Compilation compilation)
             => compilation.LanguageVersion() >= LanguageVersion.CSharp6;

--- a/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
@@ -30,6 +30,9 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
         where TVariableDeclarator : SyntaxNode
         where TExpression : SyntaxNode
     {
+        /// <summary>
+        /// ConcurrentStack as that's the only concurrent collection that supports 'Clear' in netstandard2.
+        /// </summary>
         private static readonly ObjectPool<ConcurrentStack<AnalysisResult>> s_analysisResultPool = new(() => new());
         private static readonly ObjectPool<ConcurrentSet<IFieldSymbol>> s_fieldSetPool = new(() => new());
         private static readonly ObjectPool<ConcurrentSet<SyntaxNode>> s_nodeSetPool = new(() => new());

--- a/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
@@ -44,6 +44,7 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
         protected abstract bool SupportsReadOnlyProperties(Compilation compilation);
         protected abstract bool SupportsPropertyInitializer(Compilation compilation);
         protected abstract bool CanExplicitInterfaceImplementationsBeFixed();
+        protected abstract TPropertyDeclaration? GetPropertyDeclaration(SyntaxNode syntaxNode);
         protected abstract TExpression? GetFieldInitializer(TVariableDeclarator variable, CancellationToken cancellationToken);
         protected abstract TExpression? GetGetterExpression(IMethodSymbol getMethod, CancellationToken cancellationToken);
         protected abstract TExpression? GetSetterExpression(IMethodSymbol setMethod, SemanticModel semanticModel, CancellationToken cancellationToken);
@@ -114,7 +115,8 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
             if (property.DeclaringSyntaxReferences is not [var propertyReference])
                 return;
 
-            if (propertyReference.GetSyntax(cancellationToken) is not TPropertyDeclaration propertyDeclaration)
+            var propertyDeclaration = GetPropertyDeclaration(propertyReference.GetSyntax(cancellationToken));
+            if (propertyDeclaration is null)
                 return;
 
             var preferAutoProps = options.GetAnalyzerOptions(propertyDeclaration.SyntaxTree).PreferAutoProperties;

--- a/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
@@ -95,6 +95,9 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
             if (semanticModel.GetDeclaredSymbol(propertyDeclaration, cancellationToken) is not IPropertySymbol property)
                 return;
 
+            if (!containingType.Equals(property.ContainingType))
+                return;
+
             if (property.IsIndexer)
                 return;
 

--- a/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
@@ -25,12 +25,12 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
         where TVariableDeclarator : SyntaxNode
         where TExpression : SyntaxNode
     {
-        private static readonly LocalizableString s_title =
-            new LocalizableResourceString(nameof(AnalyzersResources.Use_auto_property),
-                AnalyzersResources.ResourceManager, typeof(AnalyzersResources));
-
         protected AbstractUseAutoPropertyAnalyzer()
-            : base(IDEDiagnosticIds.UseAutoPropertyDiagnosticId, EnforceOnBuildValues.UseAutoProperty, CodeStyleOptions2.PreferAutoProperties, s_title, s_title)
+            : base(IDEDiagnosticIds.UseAutoPropertyDiagnosticId,
+                   EnforceOnBuildValues.UseAutoProperty,
+                   CodeStyleOptions2.PreferAutoProperties,
+                   new LocalizableResourceString(nameof(AnalyzersResources.Use_auto_property), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)),
+                   new LocalizableResourceString(nameof(AnalyzersResources.Use_auto_property), AnalyzersResources.ResourceManager, typeof(AnalyzersResources)))
         {
         }
 

--- a/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/UseAutoProperty/AbstractUseAutoPropertyAnalyzer.cs
@@ -169,10 +169,7 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
                 return;
 
             var fieldReference = getterField.DeclaringSyntaxReferences[0];
-            if (fieldReference.GetSyntax(cancellationToken) is not TVariableDeclarator variableDeclarator)
-                return;
-
-            if (variableDeclarator.Parent?.Parent is not TFieldDeclaration fieldDeclaration)
+            if (fieldReference.GetSyntax(cancellationToken) is not TVariableDeclarator { Parent.Parent: TFieldDeclaration fieldDeclaration } variableDeclarator)
                 return;
 
             // A setter is optional though.
@@ -200,11 +197,6 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
             }
 
             if (!CanConvert(property))
-                return;
-
-            // Check if there are additional, language specific, reasons we think this field might be ineligible for 
-            // replacing with an auto prop.
-            if (!IsEligibleHeuristic(getterField, propertyDeclaration, semanticModel, cancellationToken))
                 return;
 
             // Looks like a viable property/field to convert into an auto property.
@@ -290,12 +282,6 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
 
             context.ReportDiagnostic(diagnostic1);
             context.ReportDiagnostic(diagnostic2);
-        }
-
-        protected virtual bool IsEligibleHeuristic(
-            IFieldSymbol field, TPropertyDeclaration propertyDeclaration, SemanticModel semanticModel, CancellationToken cancellationToken)
-        {
-            return true;
         }
 
         private sealed record AnalysisResult(

--- a/src/Analyzers/VisualBasic/Analyzers/UseAutoProperty/VisualBasicUseAutoPropertyAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseAutoProperty/VisualBasicUseAutoPropertyAnalyzer.vb
@@ -20,8 +20,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty
             ModifiedIdentifierSyntax,
             ExpressionSyntax)
 
-        Private Shared ReadOnly s_createSet As Func(Of IFieldSymbol, ConcurrentSet(Of SyntaxNode)) = Function(unused) New ConcurrentSet(Of SyntaxNode)
-
         Protected Overrides ReadOnly Property PropertyDeclarationKind As SyntaxKind = SyntaxKind.PropertyBlock
 
         Protected Overrides ReadOnly Property SyntaxFacts As ISyntaxFacts = VisualBasicSyntaxFacts.Instance
@@ -162,7 +160,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty
                 If field IsNot Nothing AndAlso
                    node.IsWrittenTo(semanticModel, cancellationToken) Then
 
-                    fieldWrites.GetOrAdd(field, s_createSet).Add(node)
+                    AddFieldWrite(fieldWrites, field, node)
                 End If
             Next
         End Sub

--- a/src/Analyzers/VisualBasic/Analyzers/UseAutoProperty/VisualBasicUseAutoPropertyAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseAutoProperty/VisualBasicUseAutoPropertyAnalyzer.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty
             Return True
         End Function
 
-        Protected Overrides Sub RegisterIneligibleFieldsAction(fieldNames As ISet(Of String), ineligibleFields As ConcurrentSet(Of IFieldSymbol), semanticModel As SemanticModel, codeBlock As SyntaxNode, cancellationToken As CancellationToken)
+        Protected Overrides Sub RegisterIneligibleFieldsAction(fieldNames As HashSet(Of String), ineligibleFields As ConcurrentSet(Of IFieldSymbol), semanticModel As SemanticModel, codeBlock As SyntaxNode, cancellationToken As CancellationToken)
             ' There are no syntactic constructs that make a field ineligible to be replaced with 
             ' a property.  In C# you can't use a property in a ref/out position.  But that restriction
             ' doesn't apply to VB.
@@ -134,7 +134,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty
         End Function
 
         Protected Overrides Sub RegisterNonConstructorFieldWrites(
-                fieldNames As ISet(Of String),
+                fieldNames As HashSet(Of String),
                 fieldWrites As ConcurrentDictionary(Of IFieldSymbol, ConcurrentSet(Of SyntaxNode)),
                 semanticModel As SemanticModel,
                 codeBlock As SyntaxNode,

--- a/src/Analyzers/VisualBasic/Analyzers/UseAutoProperty/VisualBasicUseAutoPropertyAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseAutoProperty/VisualBasicUseAutoPropertyAnalyzer.vb
@@ -29,6 +29,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty
             Return True
         End Function
 
+        Protected Overrides Function GetPropertyDeclaration(node As SyntaxNode) As PropertyBlockSyntax
+            Return TryCast(TryCast(node, PropertyStatementSyntax).Parent, PropertyBlockSyntax)
+        End Function
+
         Protected Overrides Sub RegisterIneligibleFieldsAction(ineligibleFields As ConcurrentSet(Of IFieldSymbol), semanticModel As SemanticModel, codeBlock As SyntaxNode, cancellationToken As CancellationToken)
             ' There are no syntactic constructs that make a field ineligible to be replaced with 
             ' a property.  In C# you can't use a property in a ref/out position.  But that restriction

--- a/src/Analyzers/VisualBasic/Analyzers/UseAutoProperty/VisualBasicUseAutoPropertyAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseAutoProperty/VisualBasicUseAutoPropertyAnalyzer.vb
@@ -17,6 +17,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty
             ModifiedIdentifierSyntax,
             ExpressionSyntax)
 
+        Protected Overrides ReadOnly Property PropertyDeclarationKind As SyntaxKind = SyntaxKind.PropertyBlock
+
         Protected Overrides Function SupportsReadOnlyProperties(compilation As Compilation) As Boolean
             Return DirectCast(compilation, VisualBasicCompilation).LanguageVersion >= LanguageVersion.VisualBasic14
         End Function
@@ -27,10 +29,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty
 
         Protected Overrides Function CanExplicitInterfaceImplementationsBeFixed() As Boolean
             Return True
-        End Function
-
-        Protected Overrides Function GetPropertyDeclaration(node As SyntaxNode) As PropertyBlockSyntax
-            Return TryCast(TryCast(node, PropertyStatementSyntax).Parent, PropertyBlockSyntax)
         End Function
 
         Protected Overrides Sub RegisterIneligibleFieldsAction(ineligibleFields As ConcurrentSet(Of IFieldSymbol), semanticModel As SemanticModel, codeBlock As SyntaxNode, cancellationToken As CancellationToken)

--- a/src/Analyzers/VisualBasic/Analyzers/UseAutoProperty/VisualBasicUseAutoPropertyAnalyzer.vb
+++ b/src/Analyzers/VisualBasic/Analyzers/UseAutoProperty/VisualBasicUseAutoPropertyAnalyzer.vb
@@ -29,43 +29,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseAutoProperty
             Return True
         End Function
 
-        Protected Overrides Sub AnalyzeCompilationUnit(context As SemanticModelAnalysisContext, root As SyntaxNode, analysisResults As List(Of AnalysisResult))
-            AnalyzeMembers(context, DirectCast(root, CompilationUnitSyntax).Members, analysisResults)
-        End Sub
-
-        Private Sub AnalyzeMembers(context As SemanticModelAnalysisContext,
-                                   members As SyntaxList(Of StatementSyntax),
-                                   analysisResults As List(Of AnalysisResult))
-            For Each member In members
-                AnalyzeMember(context, member, analysisResults)
-            Next
-        End Sub
-
-        Private Sub AnalyzeMember(context As SemanticModelAnalysisContext,
-                                  member As StatementSyntax,
-                                  analysisResults As List(Of AnalysisResult))
-
-            If member.Kind() = SyntaxKind.NamespaceBlock Then
-                Dim namespaceBlock = DirectCast(member, NamespaceBlockSyntax)
-                AnalyzeMembers(context, namespaceBlock.Members, analysisResults)
-            End If
-
-            ' If we have a class or struct or module, recurse inwards.
-            If member.IsKind(SyntaxKind.ClassBlock) OrElse
-               member.IsKind(SyntaxKind.StructureBlock) OrElse
-               member.IsKind(SyntaxKind.ModuleBlock) Then
-
-                Dim typeBlock = DirectCast(member, TypeBlockSyntax)
-                AnalyzeMembers(context, typeBlock.Members, analysisResults)
-            End If
-
-            Dim propertyDeclaration = TryCast(member, PropertyBlockSyntax)
-            If propertyDeclaration IsNot Nothing Then
-                AnalyzeProperty(context, propertyDeclaration, analysisResults)
-            End If
-        End Sub
-
-        Protected Overrides Sub RegisterIneligibleFieldsAction(analysisResults As List(Of AnalysisResult), ineligibleFields As HashSet(Of IFieldSymbol), compilation As Compilation, cancellationToken As CancellationToken)
+        Protected Overrides Sub RegisterIneligibleFieldsAction(ineligibleFields As ConcurrentSet(Of IFieldSymbol), semanticModel As SemanticModel, codeBlock As SyntaxNode, cancellationToken As CancellationToken)
             ' There are no syntactic constructs that make a field ineligible to be replaced with 
             ' a property.  In C# you can't use a property in a ref/out position.  But that restriction
             ' doesn't apply to VB.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/ObjectPools/Extensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -160,6 +161,22 @@ namespace Microsoft.CodeAnalysis
             pool.Free(set);
         }
 
+        public static void ClearAndFree<T>(this ObjectPool<ConcurrentStack<T>> pool, ConcurrentStack<T> stack)
+        {
+            if (stack == null)
+                return;
+
+            // if stack grew too big, don't put it back to pool
+            if (stack.Count > Threshold)
+            {
+                pool.ForgetTrackedObject(stack);
+                return;
+            }
+
+            stack.Clear();
+            pool.Free(stack);
+        }
+
         public static void ClearAndFree<T>(this ObjectPool<Queue<T>> pool, Queue<T> set)
         {
             if (set == null)
@@ -185,6 +202,23 @@ namespace Microsoft.CodeAnalysis
             {
                 return;
             }
+
+            // if map grew too big, don't put it back to pool
+            if (map.Count > Threshold)
+            {
+                pool.ForgetTrackedObject(map);
+                return;
+            }
+
+            map.Clear();
+            pool.Free(map);
+        }
+
+        public static void ClearAndFree<TKey, TValue>(this ObjectPool<ConcurrentDictionary<TKey, TValue>> pool, ConcurrentDictionary<TKey, TValue> map)
+            where TKey : notnull
+        {
+            if (map == null)
+                return;
 
             // if map grew too big, don't put it back to pool
             if (map.Count > Threshold)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/67350