### PR TITLE
Move to new binary logger NuGet

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -203,7 +203,7 @@
     <MicrosoftVisualStudioWorkspaceVSIntegrationVersion>17.1.11-preview-0002</MicrosoftVisualStudioWorkspaceVSIntegrationVersion>
     <MicrosoftWin32PrimitivesVersion>4.3.0</MicrosoftWin32PrimitivesVersion>
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
-    <MSBuildStructuredLoggerVersion>2.1.787</MSBuildStructuredLoggerVersion>
+    <MSBuildStructuredLoggerVersion>2.1.790</MSBuildStructuredLoggerVersion>
     <MDbgVersion>0.1.0</MDbgVersion>
     <MonoOptionsVersion>6.6.0.161</MonoOptionsVersion>
     <MoqVersion>4.10.1</MoqVersion>


### PR DESCRIPTION
Based on a few reports seems like the VS queues got updated last night. That seems to have brought in a new version of MSBuild that incremented the binary log version number. Need to get our consumption updated so our tools can function in CI