### PR TITLE
Improve props in readonly struct

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpAutoPropertyCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/AbstractCSharpAutoPropertyCompletionProviderTests.cs
@@ -77,6 +77,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
                 """);
         }
 
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public abstract Task InsertSnippetInReadonlyStruct();
+
         // This case might produce non-default results for different snippets (e.g. no `set` accessor in 'propg' snippet),
         // so it is tested separately for all of them
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropSnippetCompletionProviderTests.cs
@@ -13,6 +13,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
         protected override string GetDefaultPropertyBlockText()
             => "{ get; set; }";
 
+        public override async Task InsertSnippetInReadonlyStruct()
+        {
+            // Ensure we don't generate redundant `set` accessor when executed in readonly struct
+            await VerifyPropertyAsync("""
+                readonly struct MyStruct
+                {
+                    $$
+                }
+                """, "public int MyProperty { get; }");
+        }
+
         public override async Task InsertSnippetInInterface()
         {
             await VerifyDefaultPropertyAsync("""

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropgSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropgSnippetCompletionProviderTests.cs
@@ -13,6 +13,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
         protected override string GetDefaultPropertyBlockText()
             => "{ get; private set; }";
 
+        public override async Task InsertSnippetInReadonlyStruct()
+        {
+            // Ensure we don't generate redundant `set` accessor when executed in readonly struct
+            await VerifyPropertyAsync("""
+                readonly struct MyStruct
+                {
+                    $$
+                }
+                """, "public int MyProperty { get; }");
+        }
+
         public override async Task InsertSnippetInInterface()
         {
             // Ensure we don't generate redundant `set` accessor when executed in interface

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropiSnippetCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/Snippets/CSharpPropiSnippetCompletionProviderTests.cs
@@ -13,6 +13,16 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
         protected override string GetDefaultPropertyBlockText()
             => "{ get; init; }";
 
+        public override async Task InsertSnippetInReadonlyStruct()
+        {
+            await VerifyDefaultPropertyAsync("""
+                readonly struct MyStruct
+                {
+                    $$
+                }
+                """);
+        }
+
         public override async Task InsertSnippetInInterface()
         {
             await VerifyDefaultPropertyAsync("""

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         {
             var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
 
-            return syntaxTree.IsMemberDeclarationContext(position, contextOpt: null, SyntaxKindSet.AllMemberModifiers, SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations, canBePartial: true, cancellationToken) ||
+            return syntaxTree.IsMemberDeclarationContext(position, context: null, SyntaxKindSet.AllMemberModifiers, SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations, canBePartial: true, cancellationToken) ||
                    syntaxTree.IsStatementContext(position, token, cancellationToken) ||
                    syntaxTree.IsGlobalMemberDeclarationContext(position, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||
                    syntaxTree.IsGlobalStatementContext(position, cancellationToken) ||

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             Contract.ThrowIfNull(syntaxTree);
 
-            return syntaxTree.IsMemberDeclarationContext(position, contextOpt: null,
+            return syntaxTree.IsMemberDeclarationContext(position, context: null,
                 SyntaxKindSet.AllMemberModifiers, SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations, canBePartial: true, cancellationToken);
         }
 

--- a/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/AbstractCSharpAutoPropertySnippetProvider.cs
@@ -19,7 +19,6 @@ using Microsoft.CodeAnalysis.Shared.Utilities;
 using Microsoft.CodeAnalysis.Snippets;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
 using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Snippets
 {
@@ -33,8 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
 
         protected override async Task<bool> IsValidSnippetLocationAsync(Document document, int position, CancellationToken cancellationToken)
         {
-            var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            Contract.ThrowIfNull(syntaxTree);
+            var syntaxTree = await document.GetRequiredSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
 
             return syntaxTree.IsMemberDeclarationContext(position, context: null,
                 SyntaxKindSet.AllMemberModifiers, SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations, canBePartial: true, cancellationToken);

--- a/src/Features/CSharp/Portable/Snippets/CSharpPropSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpPropSnippetProvider.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Composition;
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
@@ -32,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             // Having a property with `set` accessor in a readonly struct leads to a compiler error.
             // So if user executes snippet inside a readonly struct the right thing to do is to not generate `set` accessor at all
             if (syntaxContext.ContainingTypeDeclaration is StructDeclarationSyntax structDeclaration &&
-                structDeclaration.Modifiers.Any(m => m.IsKind(SyntaxKind.ReadOnlyKeyword)))
+                structDeclaration.Modifiers.Any(SyntaxKind.ReadOnlyKeyword))
             {
                 return null;
             }

--- a/src/Features/CSharp/Portable/Snippets/CSharpPropSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpPropSnippetProvider.cs
@@ -4,6 +4,10 @@
 
 using System;
 using System.Composition;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Snippets;
 using Microsoft.CodeAnalysis.Snippets.SnippetProviders;
@@ -22,5 +26,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
         public override string Identifier => "prop";
 
         public override string Description => FeaturesResources.property_;
+
+        protected override AccessorDeclarationSyntax? GenerateSetAccessorDeclaration(CSharpSyntaxContext syntaxContext, SyntaxGenerator generator)
+        {
+            // Having a property with `set` accessor in a readonly struct leads to a compiler error.
+            // So if user executes snippet inside a readonly struct the right thing to do is to not generate `set` accessor at all
+            if (syntaxContext.ContainingTypeDeclaration is StructDeclarationSyntax structDeclaration &&
+                structDeclaration.Modifiers.Any(m => m.IsKind(SyntaxKind.ReadOnlyKeyword)))
+            {
+                return null;
+            }
+
+            return base.GenerateSetAccessorDeclaration(syntaxContext, generator);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Snippets/CSharpPropgSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpPropgSnippetProvider.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Composition;
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
@@ -40,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             // Having a property with `set` accessor in a readonly struct leads to a compiler error.
             // So if user executes snippet inside a readonly struct the right thing to do is to not generate `set` accessor at all
             if (syntaxContext.ContainingTypeDeclaration is StructDeclarationSyntax structDeclaration &&
-                structDeclaration.Modifiers.Any(m => m.IsKind(SyntaxKind.ReadOnlyKeyword)))
+                structDeclaration.Modifiers.Any(SyntaxKind.ReadOnlyKeyword))
             {
                 return null;
             }

--- a/src/Features/CSharp/Portable/Snippets/CSharpPropgSnippetProvider.cs
+++ b/src/Features/CSharp/Portable/Snippets/CSharpPropgSnippetProvider.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Composition;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
@@ -32,6 +33,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Snippets
             // So if we are inside an interface, we just return null here.
             // This causes the caller to just skip this `set` accessor
             if (syntaxContext.ContainingTypeDeclaration is InterfaceDeclarationSyntax)
+            {
+                return null;
+            }
+
+            // Having a property with `set` accessor in a readonly struct leads to a compiler error.
+            // So if user executes snippet inside a readonly struct the right thing to do is to not generate `set` accessor at all
+            if (syntaxContext.ContainingTypeDeclaration is StructDeclarationSyntax structDeclaration &&
+                structDeclaration.Modifiers.Any(m => m.IsKind(SyntaxKind.ReadOnlyKeyword)))
             {
                 return null;
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -369,7 +369,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 }
 
                 if (SyntaxTree.IsMemberDeclarationContext(
-                    token.SpanStart, contextOpt: null, validModifiers: null, validTypeDeclarations: validTypeDeclarations, canBePartial: false, cancellationToken: cancellationToken))
+                    token.SpanStart, context: null, validModifiers: null, validTypeDeclarations: validTypeDeclarations, canBePartial: false, cancellationToken: cancellationToken))
                 {
                     return true;
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -238,14 +238,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         public static bool IsMemberDeclarationContext(
             this SyntaxTree syntaxTree,
             int position,
-            CSharpSyntaxContext? contextOpt,
+            CSharpSyntaxContext? context,
             ISet<SyntaxKind>? validModifiers,
             ISet<SyntaxKind>? validTypeDeclarations,
             bool canBePartial,
             CancellationToken cancellationToken)
         {
-            var typeDecl = contextOpt != null
-                ? contextOpt.ContainingTypeOrEnumDeclaration
+            var typeDecl = context != null
+                ? context.ContainingTypeOrEnumDeclaration
                 : syntaxTree.GetContainingTypeOrEnumDeclaration(position, cancellationToken);
 
             if (typeDecl == null)
@@ -261,12 +261,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             // Check many of the simple cases first.
-            var leftToken = contextOpt != null
-                ? contextOpt.LeftToken
+            var leftToken = context != null
+                ? context.LeftToken
                 : syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
 
-            var token = contextOpt != null
-                ? contextOpt.TargetToken
+            var token = context != null
+                ? context.TargetToken
                 : leftToken.GetPreviousTokenIfTouchingWord(position);
 
             if (token.IsAnyAccessorDeclarationContext(position))
@@ -286,7 +286,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 return true;
             }
 
-            var modifierTokens = contextOpt?.PrecedingModifiers ?? syntaxTree.GetPrecedingModifiers(position, cancellationToken);
+            var modifierTokens = context?.PrecedingModifiers ?? syntaxTree.GetPrecedingModifiers(position, cancellationToken);
             if (modifierTokens.IsEmpty())
                 return false;
 
@@ -755,7 +755,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 syntaxTree.IsPossibleTupleContext(tokenOnLeftOfPosition, position) ||
                 syntaxTree.IsMemberDeclarationContext(
                     position,
-                    contextOpt: null,
+                    context: null,
                     validModifiers: SyntaxKindSet.AllMemberModifiers,
                     validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructRecordTypeDeclarations,
                     canBePartial: false,


### PR DESCRIPTION
Made `prop` and `propg` snippets not generate `set` accessor when executed inside readonly struct, so they don't create compiler error immideatelly after being invoked. Originally wanted to disable `prop` snippet entirely, but the first candidate after it was `propa`, so it could break muscle memory in the worst possible way. The tradeoff is that now `prop` and `propg` in such cases behave the same. This is relatively small change, so I didn't create an issue upfront.