### PR TITLE
Reduce allocations in diagnostic analyzer management system.

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/LiveDiagnosticUpdateArgsId.cs
+++ b/src/Features/Core/Portable/Diagnostics/LiveDiagnosticUpdateArgsId.cs
@@ -2,29 +2,35 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
     internal class LiveDiagnosticUpdateArgsId : AnalyzerUpdateArgsId
     {
-        private readonly string _analyzerPackageName;
+        private string? _buildTool;
 
         public readonly object ProjectOrDocumentId;
         public readonly AnalysisKind Kind;
 
-        public LiveDiagnosticUpdateArgsId(DiagnosticAnalyzer analyzer, object projectOrDocumentId, AnalysisKind kind, string analyzerPackageName)
+        public LiveDiagnosticUpdateArgsId(DiagnosticAnalyzer analyzer, object projectOrDocumentId, AnalysisKind kind)
             : base(analyzer)
         {
             Contract.ThrowIfNull(projectOrDocumentId);
 
             ProjectOrDocumentId = projectOrDocumentId;
             Kind = kind;
-
-            _analyzerPackageName = analyzerPackageName;
         }
 
-        public override string BuildTool => _analyzerPackageName;
+        public override string BuildTool => _buildTool ??= ComputeBuildTool();
+
+        private string ComputeBuildTool()
+        {
+            return Analyzer.IsBuiltInAnalyzer() || Analyzer == FileContentLoadAnalyzer.Instance || Analyzer == GeneratorDiagnosticsPlaceholderAnalyzer.Instance
+                ? PredefinedBuildTools.Live
+                : Analyzer.GetAnalyzerAssemblyName();
+        }
 
         public override bool Equals(object? obj)
         {

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InMemoryStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InMemoryStorage.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using Roslyn.Utilities;

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InMemoryStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.InMemoryStorage.cs
@@ -14,10 +14,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         private static class InMemoryStorage
         {
             // the reason using nested map rather than having tuple as key is so that I dont have a gigantic map
-            private static readonly ConcurrentDictionary<DiagnosticAnalyzer, ConcurrentDictionary<(object key, (Type, string) stateKey), CacheEntry>> s_map =
+            private static readonly ConcurrentDictionary<DiagnosticAnalyzer, ConcurrentDictionary<(object key, string stateKey), CacheEntry>> s_map =
                 new(concurrencyLevel: 2, capacity: 10);
 
-            public static bool TryGetValue(DiagnosticAnalyzer analyzer, (object key, (Type, string) stateKey) key, out CacheEntry entry)
+            public static bool TryGetValue(DiagnosticAnalyzer analyzer, (object key, string stateKey) key, out CacheEntry entry)
             {
                 AssertKey(key);
 
@@ -31,16 +31,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return true;
             }
 
-            public static void Cache(DiagnosticAnalyzer analyzer, (object key, (Type, string) stateKey) key, CacheEntry entry)
+            public static void Cache(DiagnosticAnalyzer analyzer, (object key, string stateKey) key, CacheEntry entry)
             {
                 AssertKey(key);
 
                 // add new cache entry
-                var analyzerMap = s_map.GetOrAdd(analyzer, _ => new ConcurrentDictionary<(object key, (Type, string) stateKey), CacheEntry>(concurrencyLevel: 2, capacity: 10));
+                var analyzerMap = s_map.GetOrAdd(analyzer, _ => new ConcurrentDictionary<(object key, string stateKey), CacheEntry>(concurrencyLevel: 2, capacity: 10));
                 analyzerMap[key] = entry;
             }
 
-            public static void Remove(DiagnosticAnalyzer analyzer, (object key, (Type, string) stateKey) key)
+            public static void Remove(DiagnosticAnalyzer analyzer, (object key, string stateKey) key)
             {
                 AssertKey(key);
                 // remove the entry
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             }
 
             // make sure key is either documentId or projectId
-            private static void AssertKey((object key, (Type, string) stateKey) key)
+            private static void AssertKey((object key, string stateKey) key)
                 => Contract.ThrowIfFalse(key.key is DocumentId or ProjectId);
         }
 

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -19,15 +19,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 {
     internal partial class DiagnosticIncrementalAnalyzer
     {
-        private const string SyntaxStateName = nameof(SyntaxStateName);
-        private const string SemanticStateName = nameof(SemanticStateName);
-        private const string NonLocalStateName = nameof(NonLocalStateName);
-
         /// <summary>
         /// State for diagnostics that belong to a project at given time.
         /// </summary>
         private sealed class ProjectState
         {
+            private const string SyntaxStateName = nameof(SyntaxStateName);
+            private const string SemanticStateName = nameof(SemanticStateName);
+            private const string NonLocalStateName = nameof(NonLocalStateName);
+
             // project id of this state
             private readonly StateSet _owner;
 

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
@@ -347,7 +348,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return builder.ToResult();
             }
 
-            private ValueTask AddToInMemoryStorageAsync(VersionStamp serializerVersion, Project project, TextDocument? document, object key, string stateKey, ImmutableArray<DiagnosticData> diagnostics)
+            private ValueTask AddToInMemoryStorageAsync(
+                VersionStamp serializerVersion, Project project, TextDocument? document, object key, (Type, string) stateKey, ImmutableArray<DiagnosticData> diagnostics)
             {
                 Contract.ThrowIfFalse(document == null || document.Project == project);
 
@@ -408,7 +410,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             }
 
             private ValueTask<ImmutableArray<DiagnosticData>> GetDiagnosticsFromInMemoryStorageAsync(
-                VersionStamp serializerVersion, Project project, TextDocument? document, object key, string stateKey, CancellationToken _)
+                VersionStamp serializerVersion, Project project, TextDocument? document, object key, (Type, string) stateKey, CancellationToken _)
             {
                 Contract.ThrowIfFalse(document == null || document.Project == project);
 
@@ -433,7 +435,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 RemoveInMemoryCacheEntry(id, _owner.NonLocalStateName);
             }
 
-            private void RemoveInMemoryCacheEntry(object key, string stateKey)
+            private void RemoveInMemoryCacheEntry(object key, (Type, string) stateKey)
             {
                 // remove in memory cache if entry exist
                 InMemoryStorage.Remove(_owner.Analyzer, (key, stateKey));

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -19,6 +19,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 {
     internal partial class DiagnosticIncrementalAnalyzer
     {
+        private const string SyntaxStateName = nameof(SyntaxStateName);
+        private const string SemanticStateName = nameof(SemanticStateName);
+        private const string NonLocalStateName = nameof(NonLocalStateName);
+
         /// <summary>
         /// State for diagnostics that belong to a project at given time.
         /// </summary>
@@ -224,12 +228,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         continue;
                     }
 
-                    await AddToInMemoryStorageAsync(serializerVersion, project, document, document.Id, _owner.SyntaxStateName, result.GetDocumentDiagnostics(document.Id, AnalysisKind.Syntax)).ConfigureAwait(false);
-                    await AddToInMemoryStorageAsync(serializerVersion, project, document, document.Id, _owner.SemanticStateName, result.GetDocumentDiagnostics(document.Id, AnalysisKind.Semantic)).ConfigureAwait(false);
-                    await AddToInMemoryStorageAsync(serializerVersion, project, document, document.Id, _owner.NonLocalStateName, result.GetDocumentDiagnostics(document.Id, AnalysisKind.NonLocal)).ConfigureAwait(false);
+                    await AddToInMemoryStorageAsync(serializerVersion, project, document, document.Id, SyntaxStateName, result.GetDocumentDiagnostics(document.Id, AnalysisKind.Syntax)).ConfigureAwait(false);
+                    await AddToInMemoryStorageAsync(serializerVersion, project, document, document.Id, SemanticStateName, result.GetDocumentDiagnostics(document.Id, AnalysisKind.Semantic)).ConfigureAwait(false);
+                    await AddToInMemoryStorageAsync(serializerVersion, project, document, document.Id, NonLocalStateName, result.GetDocumentDiagnostics(document.Id, AnalysisKind.NonLocal)).ConfigureAwait(false);
                 }
 
-                await AddToInMemoryStorageAsync(serializerVersion, project, document: null, result.ProjectId, _owner.NonLocalStateName, result.GetOtherDiagnostics()).ConfigureAwait(false);
+                await AddToInMemoryStorageAsync(serializerVersion, project, document: null, result.ProjectId, NonLocalStateName, result.GetOtherDiagnostics()).ConfigureAwait(false);
             }
 
             public void ResetVersion()
@@ -278,8 +282,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var serializerVersion = version;
 
                 // save active file diagnostics back to project state
-                await AddToInMemoryStorageAsync(serializerVersion, project, document, document.Id, _owner.SyntaxStateName, syntax.Items).ConfigureAwait(false);
-                await AddToInMemoryStorageAsync(serializerVersion, project, document, document.Id, _owner.SemanticStateName, semantic.Items).ConfigureAwait(false);
+                await AddToInMemoryStorageAsync(serializerVersion, project, document, document.Id, SyntaxStateName, syntax.Items).ConfigureAwait(false);
+                await AddToInMemoryStorageAsync(serializerVersion, project, document, document.Id, SemanticStateName, semantic.Items).ConfigureAwait(false);
 
                 // save last aggregated form of analysis result
                 _lastResult = _lastResult.UpdateAggregatedResult(version, state.DocumentId, fromBuild);
@@ -293,7 +297,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             public bool OnProjectRemoved(ProjectId id)
             {
-                RemoveInMemoryCacheEntry(id, _owner.NonLocalStateName);
+                RemoveInMemoryCacheEntry(id, NonLocalStateName);
                 return !IsEmpty();
             }
 
@@ -349,7 +353,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             }
 
             private ValueTask AddToInMemoryStorageAsync(
-                VersionStamp serializerVersion, Project project, TextDocument? document, object key, (Type, string) stateKey, ImmutableArray<DiagnosticData> diagnostics)
+                VersionStamp serializerVersion, Project project, TextDocument? document, object key, string stateKey, ImmutableArray<DiagnosticData> diagnostics)
             {
                 Contract.ThrowIfFalse(document == null || document.Project == project);
 
@@ -364,7 +368,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var project = document.Project;
                 var documentId = document.Id;
 
-                var diagnostics = await GetDiagnosticsFromInMemoryStorageAsync(serializerVersion, project, document, documentId, _owner.SyntaxStateName, cancellationToken).ConfigureAwait(false);
+                var diagnostics = await GetDiagnosticsFromInMemoryStorageAsync(serializerVersion, project, document, documentId, SyntaxStateName, cancellationToken).ConfigureAwait(false);
                 if (!diagnostics.IsDefault)
                 {
                     builder.AddSyntaxLocals(documentId, diagnostics);
@@ -374,7 +378,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     success = false;
                 }
 
-                diagnostics = await GetDiagnosticsFromInMemoryStorageAsync(serializerVersion, project, document, documentId, _owner.SemanticStateName, cancellationToken).ConfigureAwait(false);
+                diagnostics = await GetDiagnosticsFromInMemoryStorageAsync(serializerVersion, project, document, documentId, SemanticStateName, cancellationToken).ConfigureAwait(false);
                 if (!diagnostics.IsDefault)
                 {
                     builder.AddSemanticLocals(documentId, diagnostics);
@@ -384,7 +388,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     success = false;
                 }
 
-                diagnostics = await GetDiagnosticsFromInMemoryStorageAsync(serializerVersion, project, document, documentId, _owner.NonLocalStateName, cancellationToken).ConfigureAwait(false);
+                diagnostics = await GetDiagnosticsFromInMemoryStorageAsync(serializerVersion, project, document, documentId, NonLocalStateName, cancellationToken).ConfigureAwait(false);
                 if (!diagnostics.IsDefault)
                 {
                     builder.AddNonLocals(documentId, diagnostics);
@@ -399,7 +403,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private async ValueTask<bool> TryGetProjectDiagnosticsFromInMemoryStorageAsync(VersionStamp serializerVersion, Project project, Builder builder, CancellationToken cancellationToken)
             {
-                var diagnostics = await GetDiagnosticsFromInMemoryStorageAsync(serializerVersion, project, document: null, project.Id, _owner.NonLocalStateName, cancellationToken).ConfigureAwait(false);
+                var diagnostics = await GetDiagnosticsFromInMemoryStorageAsync(serializerVersion, project, document: null, project.Id, NonLocalStateName, cancellationToken).ConfigureAwait(false);
                 if (!diagnostics.IsDefault)
                 {
                     builder.AddOthers(diagnostics);
@@ -410,7 +414,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             }
 
             private ValueTask<ImmutableArray<DiagnosticData>> GetDiagnosticsFromInMemoryStorageAsync(
-                VersionStamp serializerVersion, Project project, TextDocument? document, object key, (Type, string) stateKey, CancellationToken _)
+                VersionStamp serializerVersion, Project project, TextDocument? document, object key, string stateKey, CancellationToken _)
             {
                 Contract.ThrowIfFalse(document == null || document.Project == project);
 
@@ -430,12 +434,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private void RemoveInMemoryCacheEntries(DocumentId id)
             {
-                RemoveInMemoryCacheEntry(id, _owner.SyntaxStateName);
-                RemoveInMemoryCacheEntry(id, _owner.SemanticStateName);
-                RemoveInMemoryCacheEntry(id, _owner.NonLocalStateName);
+                RemoveInMemoryCacheEntry(id, SyntaxStateName);
+                RemoveInMemoryCacheEntry(id, SemanticStateName);
+                RemoveInMemoryCacheEntry(id, NonLocalStateName);
             }
 
-            private void RemoveInMemoryCacheEntry(object key, (Type, string) stateKey)
+            private void RemoveInMemoryCacheEntry(object key, string stateKey)
             {
                 // remove in memory cache if entry exist
                 InMemoryStorage.Remove(_owner.Analyzer, (key, stateKey));

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.HostStates.cs
@@ -41,7 +41,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     var analyzersPerReference = hostAnalyzers.GetOrCreateHostDiagnosticAnalyzersPerReference(language);
 
                     var analyzerMap = CreateStateSetMap(language, analyzersPerReference.Values, includeWorkspacePlaceholderAnalyzers: true);
-                    VerifyUniqueStateNames(analyzerMap.Values);
 
                     return new HostAnalyzerStateSets(analyzerMap);
                 }

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.ProjectStates.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.ProjectStates.cs
@@ -107,8 +107,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 // update cache. 
                 _projectAnalyzerStateMap[project.Id] = projectStateSets;
 
-                VerifyProjectDiagnosticStates(projectStateSets.StateSetMap.Values);
-
                 return projectStateSets;
             }
 

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -287,27 +287,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return builder.ToImmutable();
             }
 
-            [Conditional("DEBUG")]
-            private static void VerifyUniqueStateNames(IEnumerable<StateSet> stateSets)
-            {
-                // Ensure diagnostic state name is indeed unique.
-                var set = new HashSet<(string, (Type, string))>();
-
-                foreach (var stateSet in stateSets)
-                    Contract.ThrowIfFalse(set.Add((stateSet.Language, stateSet.StateName)));
-            }
-
-            [Conditional("DEBUG")]
-            private void VerifyProjectDiagnosticStates(IEnumerable<StateSet> stateSets)
-            {
-                // We do not de-duplicate analyzer instances across host and project analyzers.
-                var projectAnalyzers = stateSets.Select(state => state.Analyzer).ToImmutableHashSet();
-
-                var hostStates = GetAllHostStateSets().Where(state => !projectAnalyzers.Contains(state.Analyzer));
-
-                VerifyUniqueStateNames(hostStates.Concat(stateSets));
-            }
-
             private readonly struct HostAnalyzerStateSetKey : IEquatable<HostAnalyzerStateSetKey>
             {
                 public HostAnalyzerStateSetKey(string language, IReadOnlyList<AnalyzerReference> analyzerReferences)

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -291,12 +291,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             private static void VerifyUniqueStateNames(IEnumerable<StateSet> stateSets)
             {
                 // Ensure diagnostic state name is indeed unique.
-                var set = new HashSet<ValueTuple<string, string>>();
+                var set = new HashSet<(string, (Type, string))>();
 
                 foreach (var stateSet in stateSets)
-                {
                     Contract.ThrowIfFalse(set.Add((stateSet.Language, stateSet.StateName)));
-                }
             }
 
             [Conditional("DEBUG")]

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -261,8 +261,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 if (includeWorkspacePlaceholderAnalyzers)
                 {
-                    builder.Add(FileContentLoadAnalyzer.Instance, new StateSet(language, FileContentLoadAnalyzer.Instance, PredefinedBuildTools.Live));
-                    builder.Add(GeneratorDiagnosticsPlaceholderAnalyzer.Instance, new StateSet(language, GeneratorDiagnosticsPlaceholderAnalyzer.Instance, PredefinedBuildTools.Live));
+                    builder.Add(FileContentLoadAnalyzer.Instance, new StateSet(language, FileContentLoadAnalyzer.Instance));
+                    builder.Add(GeneratorDiagnosticsPlaceholderAnalyzer.Instance, new StateSet(language, GeneratorDiagnosticsPlaceholderAnalyzer.Instance));
                 }
 
                 foreach (var analyzers in analyzerCollection)
@@ -280,10 +280,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                             continue;
                         }
 
-                        var buildToolName = analyzer.IsBuiltInAnalyzer() ?
-                            PredefinedBuildTools.Live : analyzer.GetAnalyzerAssemblyName();
-
-                        builder.Add(analyzer, new StateSet(language, analyzer, buildToolName));
+                        builder.Add(analyzer, new StateSet(language, analyzer));
                     }
                 }
 

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
@@ -37,7 +37,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 _projectStates = new ConcurrentDictionary<ProjectId, ProjectState>(concurrencyLevel: 2, capacity: 1);
             }
 
-            public (Type, string) StateName => (Analyzer.GetType(), nameof(StateName));
             public (Type, string) SyntaxStateName => (Analyzer.GetType(), nameof(SyntaxStateName));
             public (Type, string) SemanticStateName => (Analyzer.GetType(), nameof(SemanticStateName));
             public (Type, string) NonLocalStateName => (Analyzer.GetType(), nameof(NonLocalStateName));

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateSet.cs
@@ -37,10 +37,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 _projectStates = new ConcurrentDictionary<ProjectId, ProjectState>(concurrencyLevel: 2, capacity: 1);
             }
 
-            public (Type, string) SyntaxStateName => (Analyzer.GetType(), nameof(SyntaxStateName));
-            public (Type, string) SemanticStateName => (Analyzer.GetType(), nameof(SemanticStateName));
-            public (Type, string) NonLocalStateName => (Analyzer.GetType(), nameof(NonLocalStateName));
-
             [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/34761", AllowCaptures = false, AllowGenericEnumeration = false)]
             public bool ContainsAnyDocumentOrProjectDiagnostics(ProjectId projectId)
             {

--- a/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -216,10 +216,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
         }
 
         private static object CreateId(StateSet stateSet, DocumentId documentId, AnalysisKind kind)
-            => new LiveDiagnosticUpdateArgsId(stateSet.Analyzer, documentId, kind, stateSet.ErrorSourceName);
+            => new LiveDiagnosticUpdateArgsId(stateSet.Analyzer, documentId, kind);
 
         private static object CreateId(StateSet stateSet, ProjectId projectId, AnalysisKind kind)
-            => new LiveDiagnosticUpdateArgsId(stateSet.Analyzer, projectId, kind, stateSet.ErrorSourceName);
+            => new LiveDiagnosticUpdateArgsId(stateSet.Analyzer, projectId, kind);
 
         public static Task<VersionStamp> GetDiagnosticVersionAsync(Project project, CancellationToken cancellationToken)
             => project.GetDependentVersionAsync(cancellationToken);


### PR DESCRIPTION
Removes rougly 30 MB of allocations on a call to get diagnostics in LSP.

![image](https://user-images.githubusercontent.com/4564579/226464367-2c62a153-0d25-4e35-b015-628dc57b2af7.png)
