### PR TITLE
Change CheckBoxOptionViewModel to AbstractCheckBoxViewModel

### DIFF
--- a/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/OptionPreviewControl.xaml.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             if (e.Key == Key.Space && e.KeyboardDevice.Modifiers == ModifierKeys.None)
             {
                 var listView = (AutomationDelegatingListView)sender;
-                if (listView.SelectedItem is CheckBoxOptionViewModel checkBox)
+                if (listView.SelectedItem is AbstractCheckBoxViewModel checkBox)
                 {
                     checkBox.IsChecked = !checkBox.IsChecked;
                     e.Handled = true;


### PR DESCRIPTION
Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1760903/

`AbstractCheckBoxViewModel` derives `CheckBoxEnumFlagsOptionViewModel` and `CheckBoxOptionViewModel`

`CheckBoxEnumFlagsOptionViewModel` is used for OpenBraceRelated options, so it can't be set/unset use space key.