### PR TITLE
Fix 17.5 CI build

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -240,6 +240,11 @@ function BuildSolution() {
   $generateDocumentationFile = if ($skipDocumentation) { "/p:GenerateDocumentationFile=false" } else { "" }
   $roslynUseHardLinks = if ($ci) { "/p:ROSLYNUSEHARDLINKS=true" } else { "" }
 
+ # Temporarily disable RestoreUseStaticGraphEvaluation to work around this NuGet issue 
+  # in our CI builds
+  # https://github.com/NuGet/Home/issues/12373
+  $restoreUseStaticGraphEvaluation = if ($ci) { $false } else { $true }
+  
   try {
     MSBuild $toolsetBuildProj `
       $bl `
@@ -259,7 +264,7 @@ function BuildSolution() {
       /p:TreatWarningsAsErrors=$warnAsError `
       /p:EnableNgenOptimization=$applyOptimizationData `
       /p:IbcOptimizationDataDir=$ibcDir `
-      /p:RestoreUseStaticGraphEvaluation=true `
+      /p:RestoreUseStaticGraphEvaluation=$restoreUseStaticGraphEvaluation `
       /p:VisualStudioIbcDrop=$ibcDropName `
       /p:VisualStudioDropAccessToken=$officialVisualStudioDropAccessToken `
       $suppressExtensionDeployment `

--- a/src/Tools/BuildBoss/BuildBoss.csproj
+++ b/src/Tools/BuildBoss/BuildBoss.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />

--- a/src/Tools/BuildBoss/BuildBoss.csproj
+++ b/src/Tools/BuildBoss/BuildBoss.csproj
@@ -7,6 +7,13 @@
     <SignAssembly>false</SignAssembly>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <IsShipping>false</IsShipping>
+
+    <!-- 
+      Bumping MSBuildStructuredLoggerVersion for entire repo would move us to newer version of MSBuild Pacakge,
+      which no longer support netcoreapp3.1. Therefore we only change the version referenced here to get the binlog 
+      checker to work for logs produced by newer MSBuild in CI without requiring product change.
+     -->
+    <MSBuildStructuredLoggerVersion>2.1.787</MSBuildStructuredLoggerVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -18,12 +25,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-    <!-- 
-      Bumping MSBuildStructuredLoggerVersion would move us to newer version of MSBuild Pacakge,
-      which no longer support netcoreapp3.1. Therefore we only change the version referenced here
-      to get our CI to work without requiring product change.
-     -->
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.787" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="$(MSBuildStructuredLoggerVersion)" />
     <PackageReference Include="Mono.Options" Version="$(MonoOptionsVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Tools/BuildBoss/BuildBoss.csproj
+++ b/src/Tools/BuildBoss/BuildBoss.csproj
@@ -17,7 +17,12 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="$(MSBuildStructuredLoggerVersion)" />
+    <!-- 
+      Bumping MSBuildStructuredLoggerVersion would move us to newer version of MSBuild Pacakge,
+      which no longer support netcoreapp3.1. Therefore we only change the version referenced here
+      to get our CI to work without requiring product change.
+     -->
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.787" />
     <PackageReference Include="Mono.Options" Version="$(MonoOptionsVersion)" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Port the change from 17.6 https://github.com/dotnet/roslyn/pull/66559

[val build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2139782&view=results)