### PR TITLE
Display exception filters by `BoundNode.DumpSource()`

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode_Source.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode_Source.cs
@@ -37,6 +37,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 {
                                     append("catch (");
                                     append(catchBlock.ExceptionTypeOpt?.Name);
+                                    append(" ");
+                                    appendSource(catchBlock.ExceptionSourceOpt);
                                     append(")");
                                     if (catchBlock.ExceptionFilterOpt is { } exceptionFilter)
                                     {

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode_Source.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode_Source.cs
@@ -317,6 +317,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                             appendSource(unary.Operand);
                             break;
                         }
+                    case BoundConversion conversion:
+                        {
+                            append($" {conversion.Conversion} ");
+                            appendSource(conversion.Operand);
+                            break;
+                        }
                     case BoundStatementList list:
                         {
                             foreach (var statement in list.Statements)

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode_Source.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode_Source.cs
@@ -37,10 +37,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 {
                                     append("catch (");
                                     append(catchBlock.ExceptionTypeOpt?.Name);
-                                    append(") ");
-                                    if (catchBlock.ExceptionFilterOpt != null)
+                                    append(")");
+                                    if (catchBlock.ExceptionFilterOpt is { } exceptionFilter)
                                     {
-                                        append("... exception filter omitted ...");
+                                        if (catchBlock.ExceptionFilterPrologueOpt is { } exceptionFilterPrologue)
+                                        {
+                                            appendLine("");
+                                            appendLine("{");
+                                            appendSource(exceptionFilterPrologue);
+                                            appendLine("}");
+                                        }
+                                        else
+                                        {
+                                            append(" ");
+                                        }
+                                        append("when (");
+                                        appendSource(exceptionFilter);
+                                        append(")");
                                     }
                                     appendLine("");
 


### PR DESCRIPTION
For example:

```diff
 {
     {
         object temp1;
         int temp2;
         (Local System.Exception ex);
         System.Exception temp3;
         temp2 = default;
         try
         {
             throw ObjectCreationExpression
             ;
         }
-        catch (Exception) ... exception filter omitted ...
+        catch (Exception temp4)
+        {
+            temp1 =  ImplicitReference temp4;
+            (Local System.Exception ex) =  ExplicitReference temp1;
+        }
+        when ({ temp5 = this.F((Local System.Exception ex)); temp5 })
         {
             temp2 = 1;
         }
-        catch (Exception) ... exception filter omitted ...
+        catch (Exception temp6)
+        {
+            temp1 =  ImplicitReference temp6;
+            temp3 =  ExplicitReference temp1;
+        }
+        when ({ temp7 = this.F(temp3); temp7 })
         {
             temp2 = 2;
         }
         {
             SwitchDispatch
             <case 1-13>: ;
             {
                 {
                     {
                         await this.M2((Local System.Exception ex));
                     }
                 }
                 goto <handled-11>;
             }
             <case 2-14>: ;
             {
                 goto <handled-11>;
             }
             <break-12>: ;
         }
         <handled-11>: ;
     }
     return;
 }
```

is displayed after `AsyncExceptionHandlerRewriter` on:

```cs
async Task M1()
{
    try
    {
        throw new Exception("M1");
    }
    catch (Exception ex) when (F(ex))
    {
        await M2(ex);
    }
    catch (Exception ex) when (F(ex))
    {
    }
}
```