### PR TITLE
Enum base list completions

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -12316,7 +12316,6 @@ public static class Extension
         {
             yield return new object[] { "Byte" };
             yield return new object[] { "SByte" };
-            yield return new object[] { "SByte" };
             yield return new object[] { "Int16" };
             yield return new object[] { "UInt16" };
             yield return new object[] { "Int32" };

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -12023,26 +12023,21 @@ public static class Extension
             await VerifyItemIsAbsentAsync(MakeMarkup(source), "ExtMethod");
         }
 
-        [Fact]
-        public async Task EnumBaseList1()
+        [Theory]
+        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        public async Task EnumBaseList1(string underlyingType)
         {
             var source = "enum E : $$";
 
             await VerifyItemExistsAsync(source, "System");
 
             // Not accessible in the given context
-            await VerifyItemIsAbsentAsync(source, "Byte");
-            await VerifyItemIsAbsentAsync(source, "SByte");
-            await VerifyItemIsAbsentAsync(source, "Int16");
-            await VerifyItemIsAbsentAsync(source, "UInt16");
-            await VerifyItemIsAbsentAsync(source, "Int32");
-            await VerifyItemIsAbsentAsync(source, "UInt32");
-            await VerifyItemIsAbsentAsync(source, "Int64");
-            await VerifyItemIsAbsentAsync(source, "UInt64");
+            await VerifyItemIsAbsentAsync(source, underlyingType);
         }
 
-        [Fact]
-        public async Task EnumBaseList2()
+        [Theory]
+        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        public async Task EnumBaseList2(string underlyingType)
         {
             var source = """
                 enum E : $$
@@ -12056,18 +12051,12 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, "System", sourceCodeKind: SourceCodeKind.Regular);
 
             // Not accessible in the given context
-            await VerifyItemIsAbsentAsync(source, "Byte");
-            await VerifyItemIsAbsentAsync(source, "SByte");
-            await VerifyItemIsAbsentAsync(source, "Int16");
-            await VerifyItemIsAbsentAsync(source, "UInt16");
-            await VerifyItemIsAbsentAsync(source, "Int32");
-            await VerifyItemIsAbsentAsync(source, "UInt32");
-            await VerifyItemIsAbsentAsync(source, "Int64");
-            await VerifyItemIsAbsentAsync(source, "UInt64");
+            await VerifyItemIsAbsentAsync(source, underlyingType);
         }
 
-        [Fact]
-        public async Task EnumBaseList3()
+        [Theory]
+        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        public async Task EnumBaseList3(string underlyingType)
         {
             var source = """
                 using System;
@@ -12076,14 +12065,7 @@ public static class Extension
                 """;
 
             await VerifyItemExistsAsync(source, "System");
-            await VerifyItemExistsAsync(source, "Byte");
-            await VerifyItemExistsAsync(source, "SByte");
-            await VerifyItemExistsAsync(source, "Int16");
-            await VerifyItemExistsAsync(source, "UInt16");
-            await VerifyItemExistsAsync(source, "Int32");
-            await VerifyItemExistsAsync(source, "UInt32");
-            await VerifyItemExistsAsync(source, "Int64");
-            await VerifyItemExistsAsync(source, "UInt64");
+            await VerifyItemExistsAsync(source, underlyingType);
 
             // Verify that other things from `System` namespace are not present
             await VerifyItemIsAbsentAsync(source, "Console");
@@ -12091,8 +12073,9 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, "DateTime");
         }
 
-        [Fact]
-        public async Task EnumBaseList4()
+        [Theory]
+        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        public async Task EnumBaseList4(string underlyingType)
         {
             var source = """
                 namespace MyNamespace
@@ -12108,31 +12091,18 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, "MyNamespace");
 
             // Not accessible in the given context
-            await VerifyItemIsAbsentAsync(source, "Byte");
-            await VerifyItemIsAbsentAsync(source, "SByte");
-            await VerifyItemIsAbsentAsync(source, "Int16");
-            await VerifyItemIsAbsentAsync(source, "UInt16");
-            await VerifyItemIsAbsentAsync(source, "Int32");
-            await VerifyItemIsAbsentAsync(source, "UInt32");
-            await VerifyItemIsAbsentAsync(source, "Int64");
-            await VerifyItemIsAbsentAsync(source, "UInt64");
+            await VerifyItemIsAbsentAsync(source, underlyingType);
         }
 
-        [Fact]
-        public async Task EnumBaseList5()
+        [Theory]
+        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        public async Task EnumBaseList5(string underlyingType)
         {
             var source = "enum E : System.$$";
 
             await VerifyItemIsAbsentAsync(source, "System");
 
-            await VerifyItemExistsAsync(source, "Byte");
-            await VerifyItemExistsAsync(source, "SByte");
-            await VerifyItemExistsAsync(source, "Int16");
-            await VerifyItemExistsAsync(source, "UInt16");
-            await VerifyItemExistsAsync(source, "Int32");
-            await VerifyItemExistsAsync(source, "UInt32");
-            await VerifyItemExistsAsync(source, "Int64");
-            await VerifyItemExistsAsync(source, "UInt64");
+            await VerifyItemExistsAsync(source, underlyingType);
 
             // Verify that other things from `System` namespace are not present
             await VerifyItemIsAbsentAsync(source, "Console");
@@ -12140,21 +12110,15 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, "DateTime");
         }
 
-        [Fact]
-        public async Task EnumBaseList6()
+        [Theory]
+        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        public async Task EnumBaseList6(string underlyingType)
         {
             var source = "enum E : global::System.$$";
 
             await VerifyItemIsAbsentAsync(source, "System");
 
-            await VerifyItemExistsAsync(source, "Byte");
-            await VerifyItemExistsAsync(source, "SByte");
-            await VerifyItemExistsAsync(source, "Int16");
-            await VerifyItemExistsAsync(source, "UInt16");
-            await VerifyItemExistsAsync(source, "Int32");
-            await VerifyItemExistsAsync(source, "UInt32");
-            await VerifyItemExistsAsync(source, "Int64");
-            await VerifyItemExistsAsync(source, "UInt64");
+            await VerifyItemExistsAsync(source, underlyingType);
 
             // Verify that other things from `System` namespace are not present
             await VerifyItemIsAbsentAsync(source, "Console");
@@ -12217,8 +12181,9 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, "MySystem");
         }
 
-        [Fact]
-        public async Task EnumBaseList11()
+        [Theory]
+        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        public async Task EnumBaseList11(string underlyingType)
         {
             var source = """
                 using MySystem = System;
@@ -12229,14 +12194,7 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, "System");
             await VerifyItemIsAbsentAsync(source, "MySystem");
 
-            await VerifyItemExistsAsync(source, "Byte");
-            await VerifyItemExistsAsync(source, "SByte");
-            await VerifyItemExistsAsync(source, "Int16");
-            await VerifyItemExistsAsync(source, "UInt16");
-            await VerifyItemExistsAsync(source, "Int32");
-            await VerifyItemExistsAsync(source, "UInt32");
-            await VerifyItemExistsAsync(source, "Int64");
-            await VerifyItemExistsAsync(source, "UInt64");
+            await VerifyItemExistsAsync(source, underlyingType);
 
             // Verify that other things from `System` namespace are not present
             await VerifyItemIsAbsentAsync(source, "Console");
@@ -12256,109 +12214,58 @@ public static class Extension
             await VerifyNoItemsExistAsync(source);
         }
 
-        [Fact]
-        public async Task EnumBaseList13()
+        [Theory]
+        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        public async Task EnumBaseList13(string underlyingType)
         {
-            var source = """
-                using MyByte = System.Byte;
-                using MySByte = System.SByte;
-                using MyInt16 = System.Int16;
-                using MyUInt16 = System.UInt16;
-                using MyInt32 = System.Int32;
-                using MyUInt32 = System.UInt32;
-                using MyInt64 = System.Int64;
-                using MyUInt64 = System.UInt64;
+            var source = $"""
+                using My{underlyingType} = System.{underlyingType};
 
                 enum E : $$
                 """;
 
-            await VerifyItemExistsAsync(source, "MyByte");
-            await VerifyItemExistsAsync(source, "MySByte");
-            await VerifyItemExistsAsync(source, "MyInt16");
-            await VerifyItemExistsAsync(source, "MyUInt16");
-            await VerifyItemExistsAsync(source, "MyInt32");
-            await VerifyItemExistsAsync(source, "MyUInt32");
-            await VerifyItemExistsAsync(source, "MyInt64");
-            await VerifyItemExistsAsync(source, "MyUInt64");
+            await VerifyItemExistsAsync(source, $"My{underlyingType}");
         }
 
-        [Fact]
-        public async Task EnumBaseList14()
+        [Theory]
+        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        public async Task EnumBaseList14(string underlyingType)
         {
-            var source = """
-                using MyByte = System.Byte;
-                using MySByte = System.SByte;
-                using MyInt16 = System.Int16;
-                using MyUInt16 = System.UInt16;
-                using MyInt32 = System.Int32;
-                using MyUInt32 = System.UInt32;
-                using MyInt64 = System.Int64;
-                using MyUInt64 = System.UInt64;
+            var source = $"""
+                using My{underlyingType} = System.{underlyingType};
 
                 enum E : global::$$
                 """;
 
-            await VerifyItemIsAbsentAsync(source, "MyByte");
-            await VerifyItemIsAbsentAsync(source, "MySByte");
-            await VerifyItemIsAbsentAsync(source, "MyInt16");
-            await VerifyItemIsAbsentAsync(source, "MyUInt16");
-            await VerifyItemIsAbsentAsync(source, "MyInt32");
-            await VerifyItemIsAbsentAsync(source, "MyUInt32");
-            await VerifyItemIsAbsentAsync(source, "MyInt64");
-            await VerifyItemIsAbsentAsync(source, "MyUInt64");
+            await VerifyItemIsAbsentAsync(source, $"My{underlyingType}");
         }
 
-        [Fact]
-        public async Task EnumBaseList15()
+        [Theory]
+        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        public async Task EnumBaseList15(string underlyingType)
         {
-            var source = """
-                using MyByte = System.Byte;
-                using MySByte = System.SByte;
-                using MyInt16 = System.Int16;
-                using MyUInt16 = System.UInt16;
-                using MyInt32 = System.Int32;
-                using MyUInt32 = System.UInt32;
-                using MyInt64 = System.Int64;
-                using MyUInt64 = System.UInt64;
+            var source = $"""
+                using My{underlyingType} = System.{underlyingType};
 
                 enum E : System.$$
                 """;
 
-            await VerifyItemIsAbsentAsync(source, "MyByte");
-            await VerifyItemIsAbsentAsync(source, "MySByte");
-            await VerifyItemIsAbsentAsync(source, "MyInt16");
-            await VerifyItemIsAbsentAsync(source, "MyUInt16");
-            await VerifyItemIsAbsentAsync(source, "MyInt32");
-            await VerifyItemIsAbsentAsync(source, "MyUInt32");
-            await VerifyItemIsAbsentAsync(source, "MyInt64");
-            await VerifyItemIsAbsentAsync(source, "MyUInt64");
+            await VerifyItemIsAbsentAsync(source, $"My{underlyingType}");
+
         }
 
-        [Fact]
-        public async Task EnumBaseList16()
+        [Theory]
+        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        public async Task EnumBaseList16(string underlyingType)
         {
-            var source = """
+            var source = $"""
                 using MySystem = System;
-                using MyByte = System.Byte;
-                using MySByte = System.SByte;
-                using MyInt16 = System.Int16;
-                using MyUInt16 = System.UInt16;
-                using MyInt32 = System.Int32;
-                using MyUInt32 = System.UInt32;
-                using MyInt64 = System.Int64;
-                using MyUInt64 = System.UInt64;
+                using My{underlyingType} = System.{underlyingType};
 
                 enum E : MySystem.$$
                 """;
 
-            await VerifyItemIsAbsentAsync(source, "MyByte");
-            await VerifyItemIsAbsentAsync(source, "MySByte");
-            await VerifyItemIsAbsentAsync(source, "MyInt16");
-            await VerifyItemIsAbsentAsync(source, "MyUInt16");
-            await VerifyItemIsAbsentAsync(source, "MyInt32");
-            await VerifyItemIsAbsentAsync(source, "MyUInt32");
-            await VerifyItemIsAbsentAsync(source, "MyInt64");
-            await VerifyItemIsAbsentAsync(source, "MyUInt64");
+            await VerifyItemIsAbsentAsync(source, $"My{underlyingType}");
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66903")]
@@ -12414,6 +12321,19 @@ public static class Extension
     </Project>
 </Workspace>
 """;
+        }
+
+        public static IEnumerable<object[]> ValidEnumUnderlyingTypeNames()
+        {
+            yield return new object[] { "Byte" };
+            yield return new object[] { "SByte" };
+            yield return new object[] { "SByte" };
+            yield return new object[] { "Int16" };
+            yield return new object[] { "UInt16" };
+            yield return new object[] { "Int32" };
+            yield return new object[] { "UInt32" };
+            yield return new object[] { "Int64" };
+            yield return new object[] { "UInt64" };
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -12143,13 +12143,35 @@ public static class Extension
         [Fact]
         public async Task EnumBaseList6()
         {
+            var source = "enum E : global::System.$$";
+
+            await VerifyItemIsAbsentAsync(source, "System");
+
+            await VerifyItemExistsAsync(source, "Byte");
+            await VerifyItemExistsAsync(source, "SByte");
+            await VerifyItemExistsAsync(source, "Int16");
+            await VerifyItemExistsAsync(source, "UInt16");
+            await VerifyItemExistsAsync(source, "Int32");
+            await VerifyItemExistsAsync(source, "UInt32");
+            await VerifyItemExistsAsync(source, "Int64");
+            await VerifyItemExistsAsync(source, "UInt64");
+
+            // Verify that other things from `System` namespace are not present
+            await VerifyItemIsAbsentAsync(source, "Console");
+            await VerifyItemIsAbsentAsync(source, "Action");
+            await VerifyItemIsAbsentAsync(source, "DateTime");
+        }
+
+        [Fact]
+        public async Task EnumBaseList7()
+        {
             var source = "enum E : System.Collections.Generic.$$";
 
             await VerifyNoItemsExistAsync(source);
         }
 
         [Fact]
-        public async Task EnumBaseList7()
+        public async Task EnumBaseList8()
         {
             var source = """
                 namespace MyNamespace
@@ -12169,6 +12191,174 @@ public static class Extension
                 """;
 
             await VerifyNoItemsExistAsync(source);
+        }
+
+        [Fact]
+        public async Task EnumBaseList9()
+        {
+            var source = """
+                using MySystem = System;
+
+                enum E : $$
+                """;
+
+            await VerifyItemExistsAsync(source, "MySystem");
+        }
+
+        [Fact]
+        public async Task EnumBaseList10()
+        {
+            var source = """
+                using MySystem = System;
+
+                enum E : global::$$
+                """;
+
+            await VerifyItemIsAbsentAsync(source, "MySystem");
+        }
+
+        [Fact]
+        public async Task EnumBaseList11()
+        {
+            var source = """
+                using MySystem = System;
+
+                enum E : MySystem.$$
+                """;
+
+            await VerifyItemIsAbsentAsync(source, "System");
+            await VerifyItemIsAbsentAsync(source, "MySystem");
+
+            await VerifyItemExistsAsync(source, "Byte");
+            await VerifyItemExistsAsync(source, "SByte");
+            await VerifyItemExistsAsync(source, "Int16");
+            await VerifyItemExistsAsync(source, "UInt16");
+            await VerifyItemExistsAsync(source, "Int32");
+            await VerifyItemExistsAsync(source, "UInt32");
+            await VerifyItemExistsAsync(source, "Int64");
+            await VerifyItemExistsAsync(source, "UInt64");
+
+            // Verify that other things from `System` namespace are not present
+            await VerifyItemIsAbsentAsync(source, "Console");
+            await VerifyItemIsAbsentAsync(source, "Action");
+            await VerifyItemIsAbsentAsync(source, "DateTime");
+        }
+
+        [Fact]
+        public async Task EnumBaseList12()
+        {
+            var source = """
+                using MySystem = System;
+
+                enum E : global::MySystem.$$
+                """;
+
+            await VerifyNoItemsExistAsync(source);
+        }
+
+        [Fact]
+        public async Task EnumBaseList13()
+        {
+            var source = """
+                using MyByte = System.Byte;
+                using MySByte = System.SByte;
+                using MyInt16 = System.Int16;
+                using MyUInt16 = System.UInt16;
+                using MyInt32 = System.Int32;
+                using MyUInt32 = System.UInt32;
+                using MyInt64 = System.Int64;
+                using MyUInt64 = System.UInt64;
+
+                enum E : $$
+                """;
+
+            await VerifyItemExistsAsync(source, "MyByte");
+            await VerifyItemExistsAsync(source, "MySByte");
+            await VerifyItemExistsAsync(source, "MyInt16");
+            await VerifyItemExistsAsync(source, "MyUInt16");
+            await VerifyItemExistsAsync(source, "MyInt32");
+            await VerifyItemExistsAsync(source, "MyUInt32");
+            await VerifyItemExistsAsync(source, "MyInt64");
+            await VerifyItemExistsAsync(source, "MyUInt64");
+        }
+
+        [Fact]
+        public async Task EnumBaseList14()
+        {
+            var source = """
+                using MyByte = System.Byte;
+                using MySByte = System.SByte;
+                using MyInt16 = System.Int16;
+                using MyUInt16 = System.UInt16;
+                using MyInt32 = System.Int32;
+                using MyUInt32 = System.UInt32;
+                using MyInt64 = System.Int64;
+                using MyUInt64 = System.UInt64;
+
+                enum E : global::$$
+                """;
+
+            await VerifyItemIsAbsentAsync(source, "MyByte");
+            await VerifyItemIsAbsentAsync(source, "MySByte");
+            await VerifyItemIsAbsentAsync(source, "MyInt16");
+            await VerifyItemIsAbsentAsync(source, "MyUInt16");
+            await VerifyItemIsAbsentAsync(source, "MyInt32");
+            await VerifyItemIsAbsentAsync(source, "MyUInt32");
+            await VerifyItemIsAbsentAsync(source, "MyInt64");
+            await VerifyItemIsAbsentAsync(source, "MyUInt64");
+        }
+
+        [Fact]
+        public async Task EnumBaseList15()
+        {
+            var source = """
+                using MyByte = System.Byte;
+                using MySByte = System.SByte;
+                using MyInt16 = System.Int16;
+                using MyUInt16 = System.UInt16;
+                using MyInt32 = System.Int32;
+                using MyUInt32 = System.UInt32;
+                using MyInt64 = System.Int64;
+                using MyUInt64 = System.UInt64;
+
+                enum E : System.$$
+                """;
+
+            await VerifyItemIsAbsentAsync(source, "MyByte");
+            await VerifyItemIsAbsentAsync(source, "MySByte");
+            await VerifyItemIsAbsentAsync(source, "MyInt16");
+            await VerifyItemIsAbsentAsync(source, "MyUInt16");
+            await VerifyItemIsAbsentAsync(source, "MyInt32");
+            await VerifyItemIsAbsentAsync(source, "MyUInt32");
+            await VerifyItemIsAbsentAsync(source, "MyInt64");
+            await VerifyItemIsAbsentAsync(source, "MyUInt64");
+        }
+
+        [Fact]
+        public async Task EnumBaseList16()
+        {
+            var source = """
+                using MySystem = System;
+                using MyByte = System.Byte;
+                using MySByte = System.SByte;
+                using MyInt16 = System.Int16;
+                using MyUInt16 = System.UInt16;
+                using MyInt32 = System.Int32;
+                using MyUInt32 = System.UInt32;
+                using MyInt64 = System.Int64;
+                using MyUInt64 = System.UInt64;
+
+                enum E : MySystem.$$
+                """;
+
+            await VerifyItemIsAbsentAsync(source, "MyByte");
+            await VerifyItemIsAbsentAsync(source, "MySByte");
+            await VerifyItemIsAbsentAsync(source, "MyInt16");
+            await VerifyItemIsAbsentAsync(source, "MyUInt16");
+            await VerifyItemIsAbsentAsync(source, "MyInt32");
+            await VerifyItemIsAbsentAsync(source, "MyUInt32");
+            await VerifyItemIsAbsentAsync(source, "MyInt64");
+            await VerifyItemIsAbsentAsync(source, "MyUInt64");
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66903")]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -12024,11 +12024,71 @@ public static class Extension
         }
 
         [Fact]
-        public async Task NoSymbolCompletionsInEnumBaseList()
+        public async Task EnumBaseList1()
         {
             var source = "enum E : $$";
 
-            await VerifyNoItemsExistAsync(source);
+            await VerifyItemExistsAsync(source, "System");
+
+            // Not accessible in the given context
+            await VerifyItemIsAbsentAsync(source, "Byte");
+            await VerifyItemIsAbsentAsync(source, "SByte");
+            await VerifyItemIsAbsentAsync(source, "Int16");
+            await VerifyItemIsAbsentAsync(source, "UInt16");
+            await VerifyItemIsAbsentAsync(source, "Int32");
+            await VerifyItemIsAbsentAsync(source, "UInt32");
+            await VerifyItemIsAbsentAsync(source, "Int64");
+            await VerifyItemIsAbsentAsync(source, "UInt64");
+        }
+
+        [Fact]
+        public async Task EnumBaseList2()
+        {
+            var source = """
+                enum E : $$
+
+                class System
+                {
+                }
+                """;
+
+            // class `System` shadows the namespace in regular source
+            await VerifyItemIsAbsentAsync(source, "System", sourceCodeKind: SourceCodeKind.Regular);
+
+            // Not accessible in the given context
+            await VerifyItemIsAbsentAsync(source, "Byte");
+            await VerifyItemIsAbsentAsync(source, "SByte");
+            await VerifyItemIsAbsentAsync(source, "Int16");
+            await VerifyItemIsAbsentAsync(source, "UInt16");
+            await VerifyItemIsAbsentAsync(source, "Int32");
+            await VerifyItemIsAbsentAsync(source, "UInt32");
+            await VerifyItemIsAbsentAsync(source, "Int64");
+            await VerifyItemIsAbsentAsync(source, "UInt64");
+        }
+
+        [Fact]
+        public async Task EnumBaseList3()
+        {
+            var source = """
+                using System;
+
+                enum E : $$
+                """;
+
+            await VerifyItemExistsAsync(source, "System");
+            await VerifyItemExistsAsync(source, "Byte");
+            await VerifyItemExistsAsync(source, "SByte");
+            await VerifyItemExistsAsync(source, "Int16");
+            await VerifyItemExistsAsync(source, "UInt16");
+            await VerifyItemExistsAsync(source, "Int32");
+            await VerifyItemExistsAsync(source, "UInt32");
+            await VerifyItemExistsAsync(source, "Int64");
+            await VerifyItemExistsAsync(source, "UInt64");
+
+            // Verify that other things from `System` namespace are not present
+            await VerifyItemIsAbsentAsync(source, "Console");
+            await VerifyItemIsAbsentAsync(source, "Action");
+            await VerifyItemIsAbsentAsync(source, "DateTime");
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66903")]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -12023,8 +12023,7 @@ public static class Extension
             await VerifyItemIsAbsentAsync(MakeMarkup(source), "ExtMethod");
         }
 
-        [Theory]
-        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        [Theory, MemberData(nameof(ValidEnumUnderlyingTypeNames))]
         public async Task EnumBaseList1(string underlyingType)
         {
             var source = "enum E : $$";
@@ -12035,8 +12034,7 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, underlyingType);
         }
 
-        [Theory]
-        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        [Theory, MemberData(nameof(ValidEnumUnderlyingTypeNames))]
         public async Task EnumBaseList2(string underlyingType)
         {
             var source = """
@@ -12054,8 +12052,7 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, underlyingType);
         }
 
-        [Theory]
-        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        [Theory, MemberData(nameof(ValidEnumUnderlyingTypeNames))]
         public async Task EnumBaseList3(string underlyingType)
         {
             var source = """
@@ -12073,8 +12070,7 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, "DateTime");
         }
 
-        [Theory]
-        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        [Theory, MemberData(nameof(ValidEnumUnderlyingTypeNames))]
         public async Task EnumBaseList4(string underlyingType)
         {
             var source = """
@@ -12094,8 +12090,7 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, underlyingType);
         }
 
-        [Theory]
-        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        [Theory, MemberData(nameof(ValidEnumUnderlyingTypeNames))]
         public async Task EnumBaseList5(string underlyingType)
         {
             var source = "enum E : System.$$";
@@ -12110,8 +12105,7 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, "DateTime");
         }
 
-        [Theory]
-        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        [Theory, MemberData(nameof(ValidEnumUnderlyingTypeNames))]
         public async Task EnumBaseList6(string underlyingType)
         {
             var source = "enum E : global::System.$$";
@@ -12181,8 +12175,7 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, "MySystem");
         }
 
-        [Theory]
-        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        [Theory, MemberData(nameof(ValidEnumUnderlyingTypeNames))]
         public async Task EnumBaseList11(string underlyingType)
         {
             var source = """
@@ -12214,8 +12207,7 @@ public static class Extension
             await VerifyNoItemsExistAsync(source);
         }
 
-        [Theory]
-        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        [Theory, MemberData(nameof(ValidEnumUnderlyingTypeNames))]
         public async Task EnumBaseList13(string underlyingType)
         {
             var source = $"""
@@ -12227,8 +12219,7 @@ public static class Extension
             await VerifyItemExistsAsync(source, $"My{underlyingType}");
         }
 
-        [Theory]
-        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        [Theory, MemberData(nameof(ValidEnumUnderlyingTypeNames))]
         public async Task EnumBaseList14(string underlyingType)
         {
             var source = $"""
@@ -12240,8 +12231,7 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, $"My{underlyingType}");
         }
 
-        [Theory]
-        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        [Theory, MemberData(nameof(ValidEnumUnderlyingTypeNames))]
         public async Task EnumBaseList15(string underlyingType)
         {
             var source = $"""
@@ -12254,8 +12244,7 @@ public static class Extension
 
         }
 
-        [Theory]
-        [MemberData(nameof(ValidEnumUnderlyingTypeNames))]
+        [Theory, MemberData(nameof(ValidEnumUnderlyingTypeNames))]
         public async Task EnumBaseList16(string underlyingType)
         {
             var source = $"""

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -12091,6 +12091,33 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, "DateTime");
         }
 
+        [Fact]
+        public async Task EnumBaseList4()
+        {
+            var source = """
+                namespace MyNamespace
+                {
+                }
+
+                enum E : global::$$
+                """;
+
+            await VerifyItemIsAbsentAsync(source, "E");
+
+            await VerifyItemExistsAsync(source, "System");
+            await VerifyItemIsAbsentAsync(source, "MyNamespace");
+
+            // Not accessible in the given context
+            await VerifyItemIsAbsentAsync(source, "Byte");
+            await VerifyItemIsAbsentAsync(source, "SByte");
+            await VerifyItemIsAbsentAsync(source, "Int16");
+            await VerifyItemIsAbsentAsync(source, "UInt16");
+            await VerifyItemIsAbsentAsync(source, "Int32");
+            await VerifyItemIsAbsentAsync(source, "UInt32");
+            await VerifyItemIsAbsentAsync(source, "Int64");
+            await VerifyItemIsAbsentAsync(source, "UInt64");
+        }
+
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66903")]
         public async Task InRangeExpression()
         {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -12148,6 +12148,29 @@ public static class Extension
             await VerifyNoItemsExistAsync(source);
         }
 
+        [Fact]
+        public async Task EnumBaseList7()
+        {
+            var source = """
+                namespace MyNamespace
+                {
+                    namespace System {}
+                    public struct Byte {}
+                    public struct SByte {}
+                    public struct Int16 {}
+                    public struct UInt16 {}
+                    public struct Int32 {}
+                    public struct UInt32 {}
+                    public struct Int64 {}
+                    public struct UInt64 {}
+                }
+
+                enum E : MyNamespace.$$
+                """;
+
+            await VerifyNoItemsExistAsync(source);
+        }
+
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66903")]
         public async Task InRangeExpression()
         {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -12118,6 +12118,36 @@ public static class Extension
             await VerifyItemIsAbsentAsync(source, "UInt64");
         }
 
+        [Fact]
+        public async Task EnumBaseList5()
+        {
+            var source = "enum E : System.$$";
+
+            await VerifyItemIsAbsentAsync(source, "System");
+
+            await VerifyItemExistsAsync(source, "Byte");
+            await VerifyItemExistsAsync(source, "SByte");
+            await VerifyItemExistsAsync(source, "Int16");
+            await VerifyItemExistsAsync(source, "UInt16");
+            await VerifyItemExistsAsync(source, "Int32");
+            await VerifyItemExistsAsync(source, "UInt32");
+            await VerifyItemExistsAsync(source, "Int64");
+            await VerifyItemExistsAsync(source, "UInt64");
+
+            // Verify that other things from `System` namespace are not present
+            await VerifyItemIsAbsentAsync(source, "Console");
+            await VerifyItemIsAbsentAsync(source, "Action");
+            await VerifyItemIsAbsentAsync(source, "DateTime");
+        }
+
+        [Fact]
+        public async Task EnumBaseList6()
+        {
+            var source = "enum E : System.Collections.Generic.$$";
+
+            await VerifyNoItemsExistAsync(source);
+        }
+
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/66903")]
         public async Task InRangeExpression()
         {

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.cs
@@ -1798,6 +1798,46 @@ namespace Foo
                     inlineDescription: "Foo");
         }
 
+        [Fact]
+        public async Task TestEnumBaseList1()
+        {
+            var source = """
+                enum E : $$
+                """;
+
+            await VerifyTypeImportItemExistsAsync(source, "Byte", glyph: (int)Glyph.StructurePublic, inlineDescription: "System");
+            await VerifyTypeImportItemExistsAsync(source, "SByte", glyph: (int)Glyph.StructurePublic, inlineDescription: "System");
+            await VerifyTypeImportItemExistsAsync(source, "Int16", glyph: (int)Glyph.StructurePublic, inlineDescription: "System");
+            await VerifyTypeImportItemExistsAsync(source, "UInt16", glyph: (int)Glyph.StructurePublic, inlineDescription: "System");
+            await VerifyTypeImportItemExistsAsync(source, "Int32", glyph: (int)Glyph.StructurePublic, inlineDescription: "System");
+            await VerifyTypeImportItemExistsAsync(source, "UInt32", glyph: (int)Glyph.StructurePublic, inlineDescription: "System");
+            await VerifyTypeImportItemExistsAsync(source, "Int64", glyph: (int)Glyph.StructurePublic, inlineDescription: "System");
+            await VerifyTypeImportItemExistsAsync(source, "UInt64", glyph: (int)Glyph.StructurePublic, inlineDescription: "System");
+
+            // Verify that other things from `System` namespace are not present
+            await VerifyTypeImportItemIsAbsentAsync(source, "Console", inlineDescription: "System");
+            await VerifyTypeImportItemIsAbsentAsync(source, "Action", inlineDescription: "System");
+            await VerifyTypeImportItemIsAbsentAsync(source, "DateTime", inlineDescription: "System");
+
+            // Verify that things from other namespaces are not present
+            await VerifyTypeImportItemIsAbsentAsync(source, "IEnumerable", inlineDescription: "System.Collections");
+            await VerifyTypeImportItemIsAbsentAsync(source, "Task", inlineDescription: "System.Threading.Tasks");
+            await VerifyTypeImportItemIsAbsentAsync(source, "AssemblyName", inlineDescription: "System.Reflection");
+        }
+
+        [Fact]
+        public async Task TestEnumBaseList2()
+        {
+            var source = """
+                using System;
+
+                enum E : $$
+                """;
+
+            // Everything valid is already in the scope
+            await VerifyNoItemsExistAsync(source);
+        }
+
         private Task VerifyTypeImportItemExistsAsync(string markup, string expectedItem, int glyph, string inlineDescription, string displayTextSuffix = null, string expectedDescriptionOrNull = null, CompletionItemFlags? flags = null)
             => VerifyItemExistsAsync(markup, expectedItem, displayTextSuffix: displayTextSuffix, glyph: glyph, inlineDescription: inlineDescription, expectedDescriptionOrNull: expectedDescriptionOrNull, isComplexTextEdit: true, flags: flags);
 

--- a/src/EditorFeatures/CSharpTest2/Recommendations/GlobalKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/GlobalKeywordRecommenderTests.cs
@@ -356,5 +356,11 @@ Call();");
             await VerifyKeywordAsync("scoped $$");
             await VerifyKeywordAsync(AddInsideMethod("scoped $$"));
         }
+
+        [Fact]
+        public async Task TestInEnumBaseList()
+        {
+            await VerifyKeywordAsync("enum E : $$");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/KeywordCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/KeywordCompletionProviderTests.vb
@@ -214,12 +214,5 @@ End Class
 
             Await VerifyItemExistsAsync(code, "Implements")
         End Function
-
-        <Fact>
-        Public Async Function GlobalKeywordInEnumBaseList() As Task
-            Dim code = "Enum MyEnum As $$"
-
-            Await VerifyItemExistsAsync(code, "Global")
-        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/KeywordCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/KeywordCompletionProviderTests.vb
@@ -214,5 +214,12 @@ End Class
 
             Await VerifyItemExistsAsync(code, "Implements")
         End Function
+
+        <Fact>
+        Public Async Function GlobalKeywordInEnumBaseList() As Task
+            Dim code = "Enum MyEnum As $$"
+
+            Await VerifyItemExistsAsync(code, "Global")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -8290,7 +8290,7 @@ End Class"
                 matchingFilters:=New List(Of CompletionFilter) From {FilterSet.FieldFilter})
         End Function
 
-        <Fact, Trait(Traits.Feature, Traits.Features.TargetTypedCompletion)>
+        <Fact>
         Public Async Function TestTargetTypeFilter_NotOnObjectMembers() As Task
             ShowTargetTypedCompletionFilter = True
             Dim markup =
@@ -8303,6 +8303,68 @@ End Class"
             Await VerifyItemExistsAsync(
                 markup, "GetHashCode",
                 matchingFilters:=New List(Of CompletionFilter) From {FilterSet.MethodFilter})
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList1() As Task
+            Dim markup = "Enum MyEnum As $$"
+
+            Await VerifyItemExistsAsync(markup, "System")
+
+            ' Not accessible in the given context
+            Await VerifyItemIsAbsentAsync(markup, "Byte")
+            Await VerifyItemIsAbsentAsync(markup, "SByte")
+            Await VerifyItemIsAbsentAsync(markup, "Int16")
+            Await VerifyItemIsAbsentAsync(markup, "UInt16")
+            Await VerifyItemIsAbsentAsync(markup, "Int32")
+            Await VerifyItemIsAbsentAsync(markup, "UInt32")
+            Await VerifyItemIsAbsentAsync(markup, "Int64")
+            Await VerifyItemIsAbsentAsync(markup, "UInt64")
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList2() As Task
+            Dim markup =
+"Enum MyEnum As $$
+
+Class System
+End Class"
+
+            ' class `System` shadows the namespace in regular source
+            Await VerifyItemIsAbsentAsync(markup, "System", sourceCodeKind:=SourceCodeKind.Regular)
+
+            ' Not accessible in the given context
+            Await VerifyItemIsAbsentAsync(markup, "Byte")
+            Await VerifyItemIsAbsentAsync(markup, "SByte")
+            Await VerifyItemIsAbsentAsync(markup, "Int16")
+            Await VerifyItemIsAbsentAsync(markup, "UInt16")
+            Await VerifyItemIsAbsentAsync(markup, "Int32")
+            Await VerifyItemIsAbsentAsync(markup, "UInt32")
+            Await VerifyItemIsAbsentAsync(markup, "Int64")
+            Await VerifyItemIsAbsentAsync(markup, "UInt64")
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList3() As Task
+            Dim markup =
+"Imports System;
+
+Enum MyEnum As $$"
+
+            Await VerifyItemExistsAsync(markup, "System")
+            Await VerifyItemExistsAsync(markup, "Byte")
+            Await VerifyItemExistsAsync(markup, "SByte")
+            Await VerifyItemExistsAsync(markup, "Int16")
+            Await VerifyItemExistsAsync(markup, "UInt16")
+            Await VerifyItemExistsAsync(markup, "Int32")
+            Await VerifyItemExistsAsync(markup, "UInt32")
+            Await VerifyItemExistsAsync(markup, "Int64")
+            Await VerifyItemExistsAsync(markup, "UInt64")
+
+            ' Verify that other things from `System` namespace are not present
+            Await VerifyItemIsAbsentAsync(markup, "Console")
+            Await VerifyItemIsAbsentAsync(markup, "Action")
+            Await VerifyItemIsAbsentAsync(markup, "DateTime")
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -8305,25 +8305,18 @@ End Class"
                 matchingFilters:=New List(Of CompletionFilter) From {FilterSet.MethodFilter})
         End Function
 
-        <Fact>
-        Public Async Function TestEnumBaseList1() As Task
+        <Theory, MemberData(NameOf(ValidEnumUnderlyingTypeNames))>
+        Public Async Function TestEnumBaseList1(underlyingType As String) As Task
             Dim markup = "Enum MyEnum As $$"
 
             Await VerifyItemExistsAsync(markup, "System")
 
             ' Not accessible in the given context
-            Await VerifyItemIsAbsentAsync(markup, "Byte")
-            Await VerifyItemIsAbsentAsync(markup, "SByte")
-            Await VerifyItemIsAbsentAsync(markup, "Int16")
-            Await VerifyItemIsAbsentAsync(markup, "UInt16")
-            Await VerifyItemIsAbsentAsync(markup, "Int32")
-            Await VerifyItemIsAbsentAsync(markup, "UInt32")
-            Await VerifyItemIsAbsentAsync(markup, "Int64")
-            Await VerifyItemIsAbsentAsync(markup, "UInt64")
+            Await VerifyItemIsAbsentAsync(markup, underlyingType)
         End Function
 
-        <Fact>
-        Public Async Function TestEnumBaseList2() As Task
+        <Theory, MemberData(NameOf(ValidEnumUnderlyingTypeNames))>
+        Public Async Function TestEnumBaseList2(underlyingType As String) As Task
             Dim markup =
 "Enum MyEnum As $$
 
@@ -8334,18 +8327,11 @@ End Class"
             Await VerifyItemIsAbsentAsync(markup, "System", sourceCodeKind:=SourceCodeKind.Regular)
 
             ' Not accessible in the given context
-            Await VerifyItemIsAbsentAsync(markup, "Byte")
-            Await VerifyItemIsAbsentAsync(markup, "SByte")
-            Await VerifyItemIsAbsentAsync(markup, "Int16")
-            Await VerifyItemIsAbsentAsync(markup, "UInt16")
-            Await VerifyItemIsAbsentAsync(markup, "Int32")
-            Await VerifyItemIsAbsentAsync(markup, "UInt32")
-            Await VerifyItemIsAbsentAsync(markup, "Int64")
-            Await VerifyItemIsAbsentAsync(markup, "UInt64")
+            Await VerifyItemIsAbsentAsync(markup, underlyingType)
         End Function
 
-        <Fact>
-        Public Async Function TestEnumBaseList3() As Task
+        <Theory, MemberData(NameOf(ValidEnumUnderlyingTypeNames))>
+        Public Async Function TestEnumBaseList3(underlyingType As String) As Task
             Dim markup =
 "Imports System;
 
@@ -8353,14 +8339,7 @@ Enum MyEnum As $$"
 
             Await VerifyItemExistsAsync(markup, "System")
 
-            Await VerifyItemExistsAsync(markup, "Byte")
-            Await VerifyItemExistsAsync(markup, "SByte")
-            Await VerifyItemExistsAsync(markup, "Int16")
-            Await VerifyItemExistsAsync(markup, "UInt16")
-            Await VerifyItemExistsAsync(markup, "Int32")
-            Await VerifyItemExistsAsync(markup, "UInt32")
-            Await VerifyItemExistsAsync(markup, "Int64")
-            Await VerifyItemExistsAsync(markup, "UInt64")
+            Await VerifyItemExistsAsync(markup, underlyingType)
 
             ' Verify that other things from `System` namespace are not present
             Await VerifyItemIsAbsentAsync(markup, "Console")
@@ -8368,8 +8347,8 @@ Enum MyEnum As $$"
             Await VerifyItemIsAbsentAsync(markup, "DateTime")
         End Function
 
-        <Fact>
-        Public Async Function TestEnumBaseList4() As Task
+        <Theory, MemberData(NameOf(ValidEnumUnderlyingTypeNames))>
+        Public Async Function TestEnumBaseList4(underlyingType As String) As Task
             Dim markup =
 "Namespace MyNamespace
 End Namespace
@@ -8382,30 +8361,16 @@ Enum MyEnum As Global.$$"
             Await VerifyItemIsAbsentAsync(markup, "MyNamespace")
 
             ' Not accessible in the given context
-            Await VerifyItemIsAbsentAsync(markup, "Byte")
-            Await VerifyItemIsAbsentAsync(markup, "SByte")
-            Await VerifyItemIsAbsentAsync(markup, "Int16")
-            Await VerifyItemIsAbsentAsync(markup, "UInt16")
-            Await VerifyItemIsAbsentAsync(markup, "Int32")
-            Await VerifyItemIsAbsentAsync(markup, "UInt32")
-            Await VerifyItemIsAbsentAsync(markup, "Int64")
-            Await VerifyItemIsAbsentAsync(markup, "UInt64")
+            Await VerifyItemIsAbsentAsync(markup, underlyingType)
         End Function
 
-        <Fact>
-        Public Async Function TestEnumBaseList5() As Task
+        <Theory, MemberData(NameOf(ValidEnumUnderlyingTypeNames))>
+        Public Async Function TestEnumBaseList5(underlyingType As String) As Task
             Dim markup = "Enum MyEnum As System.$$"
 
             Await VerifyItemIsAbsentAsync(markup, "System")
 
-            Await VerifyItemExistsAsync(markup, "Byte")
-            Await VerifyItemExistsAsync(markup, "SByte")
-            Await VerifyItemExistsAsync(markup, "Int16")
-            Await VerifyItemExistsAsync(markup, "UInt16")
-            Await VerifyItemExistsAsync(markup, "Int32")
-            Await VerifyItemExistsAsync(markup, "UInt32")
-            Await VerifyItemExistsAsync(markup, "Int64")
-            Await VerifyItemExistsAsync(markup, "UInt64")
+            Await VerifyItemExistsAsync(markup, underlyingType)
 
             ' Verify that other things from `System` namespace are not present
             Await VerifyItemIsAbsentAsync(markup, "Console")
@@ -8413,20 +8378,13 @@ Enum MyEnum As Global.$$"
             Await VerifyItemIsAbsentAsync(markup, "DateTime")
         End Function
 
-        <Fact>
-        Public Async Function TestEnumBaseList6() As Task
+        <Theory, MemberData(NameOf(ValidEnumUnderlyingTypeNames))>
+        Public Async Function TestEnumBaseList6(underlyingType As String) As Task
             Dim markup = "Enum MyEnum As Global.System.$$"
 
             Await VerifyItemIsAbsentAsync(markup, "System")
 
-            Await VerifyItemExistsAsync(markup, "Byte")
-            Await VerifyItemExistsAsync(markup, "SByte")
-            Await VerifyItemExistsAsync(markup, "Int16")
-            Await VerifyItemExistsAsync(markup, "UInt16")
-            Await VerifyItemExistsAsync(markup, "Int32")
-            Await VerifyItemExistsAsync(markup, "UInt32")
-            Await VerifyItemExistsAsync(markup, "Int64")
-            Await VerifyItemExistsAsync(markup, "UInt64")
+            Await VerifyItemExistsAsync(markup, underlyingType)
 
             ' Verify that other things from `System` namespace are not present
             Await VerifyItemIsAbsentAsync(markup, "Console")
@@ -8490,8 +8448,8 @@ Enum MyEnum As Global.$$"
             Await VerifyItemIsAbsentAsync(markup, "MySystem")
         End Function
 
-        <Fact>
-        Public Async Function TestEnumBaseList11() As Task
+        <Theory, MemberData(NameOf(ValidEnumUnderlyingTypeNames))>
+        Public Async Function TestEnumBaseList11(underlyingType As String) As Task
             Dim markup =
 "Imports MySystem = System
 
@@ -8500,14 +8458,7 @@ Enum MyEnum As MySystem.$$"
             Await VerifyItemIsAbsentAsync(markup, "System")
             Await VerifyItemIsAbsentAsync(markup, "MySystem")
 
-            Await VerifyItemExistsAsync(markup, "Byte")
-            Await VerifyItemExistsAsync(markup, "SByte")
-            Await VerifyItemExistsAsync(markup, "Int16")
-            Await VerifyItemExistsAsync(markup, "UInt16")
-            Await VerifyItemExistsAsync(markup, "Int32")
-            Await VerifyItemExistsAsync(markup, "UInt32")
-            Await VerifyItemExistsAsync(markup, "Int64")
-            Await VerifyItemExistsAsync(markup, "UInt64")
+            Await VerifyItemExistsAsync(markup, underlyingType)
 
             ' Verify that other things from `System` namespace are not present
             Await VerifyItemIsAbsentAsync(markup, "Console")
@@ -8525,101 +8476,56 @@ Enum MyEnum As Global.MySystem.$$"
             Await VerifyNoItemsExistAsync(markup)
         End Function
 
-        <Fact>
-        Public Async Function TestEnumBaseList13() As Task
+        <Theory, MemberData(NameOf(ValidEnumUnderlyingTypeNames))>
+        Public Async Function TestEnumBaseList13(underlyingType As String) As Task
             Dim markup =
-"Imports MyByte = System.Byte
-Imports MySByte = System.SByte
-Imports MyInt16 = System.Int16
-Imports MyUInt16 = System.UInt16
-Imports MyInt32 = System.Int32
-Imports MyUInt32 = System.UInt32
-Imports MyInt64 = System.Int64
-Imports MyUInt64 = System.UInt64
+$"Imports My{underlyingType} = System.{underlyingType}
 
 Enum MyEnum As $$"
 
-            Await VerifyItemExistsAsync(markup, "MyByte")
-            Await VerifyItemExistsAsync(markup, "MySByte")
-            Await VerifyItemExistsAsync(markup, "MyInt16")
-            Await VerifyItemExistsAsync(markup, "MyUInt16")
-            Await VerifyItemExistsAsync(markup, "MyInt32")
-            Await VerifyItemExistsAsync(markup, "MyUInt32")
-            Await VerifyItemExistsAsync(markup, "MyInt64")
-            Await VerifyItemExistsAsync(markup, "MyUInt64")
+            Await VerifyItemExistsAsync(markup, $"My{underlyingType}")
         End Function
 
-        <Fact>
-        Public Async Function TestEnumBaseList14() As Task
+        <Theory, MemberData(NameOf(ValidEnumUnderlyingTypeNames))>
+        Public Async Function TestEnumBaseList14(underlyingType As String) As Task
             Dim markup =
-"Imports MyByte = System.Byte
-Imports MySByte = System.SByte
-Imports MyInt16 = System.Int16
-Imports MyUInt16 = System.UInt16
-Imports MyInt32 = System.Int32
-Imports MyUInt32 = System.UInt32
-Imports MyInt64 = System.Int64
-Imports MyUInt64 = System.UInt64
+$"Imports My{underlyingType} = System.{underlyingType}
 
 Enum MyEnum As Global.$$"
 
-            Await VerifyItemIsAbsentAsync(markup, "MyByte")
-            Await VerifyItemIsAbsentAsync(markup, "MySByte")
-            Await VerifyItemIsAbsentAsync(markup, "MyInt16")
-            Await VerifyItemIsAbsentAsync(markup, "MyUInt16")
-            Await VerifyItemIsAbsentAsync(markup, "MyInt32")
-            Await VerifyItemIsAbsentAsync(markup, "MyUInt32")
-            Await VerifyItemIsAbsentAsync(markup, "MyInt64")
-            Await VerifyItemIsAbsentAsync(markup, "MyUInt64")
+            Await VerifyItemIsAbsentAsync(markup, $"My{underlyingType}")
         End Function
 
-        <Fact>
-        Public Async Function TestEnumBaseList15() As Task
+        <Theory, MemberData(NameOf(ValidEnumUnderlyingTypeNames))>
+        Public Async Function TestEnumBaseList15(underlyingType As String) As Task
             Dim markup =
-"Imports MyByte = System.Byte
-Imports MySByte = System.SByte
-Imports MyInt16 = System.Int16
-Imports MyUInt16 = System.UInt16
-Imports MyInt32 = System.Int32
-Imports MyUInt32 = System.UInt32
-Imports MyInt64 = System.Int64
-Imports MyUInt64 = System.UInt64
+$"Imports My{underlyingType} = System.{underlyingType}
 
 Enum MyEnum As System.$$"
 
-            Await VerifyItemIsAbsentAsync(markup, "MyByte")
-            Await VerifyItemIsAbsentAsync(markup, "MySByte")
-            Await VerifyItemIsAbsentAsync(markup, "MyInt16")
-            Await VerifyItemIsAbsentAsync(markup, "MyUInt16")
-            Await VerifyItemIsAbsentAsync(markup, "MyInt32")
-            Await VerifyItemIsAbsentAsync(markup, "MyUInt32")
-            Await VerifyItemIsAbsentAsync(markup, "MyInt64")
-            Await VerifyItemIsAbsentAsync(markup, "MyUInt64")
+            Await VerifyItemIsAbsentAsync(markup, $"My{underlyingType}")
         End Function
 
-        <Fact>
-        Public Async Function TestEnumBaseList16() As Task
+        <Theory, MemberData(NameOf(ValidEnumUnderlyingTypeNames))>
+        Public Async Function TestEnumBaseList16(underlyingType As String) As Task
             Dim markup =
-"Imports MySystem = System
-Imports MyByte = System.Byte
-Imports MySByte = System.SByte
-Imports MyInt16 = System.Int16
-Imports MyUInt16 = System.UInt16
-Imports MyInt32 = System.Int32
-Imports MyUInt32 = System.UInt32
-Imports MyInt64 = System.Int64
-Imports MyUInt64 = System.UInt64
+$"Imports MySystem = System
+Imports My{underlyingType} = System.{underlyingType}
 
 Enum MyEnum As MySystem.$$"
 
-            Await VerifyItemIsAbsentAsync(markup, "MyByte")
-            Await VerifyItemIsAbsentAsync(markup, "MySByte")
-            Await VerifyItemIsAbsentAsync(markup, "MyInt16")
-            Await VerifyItemIsAbsentAsync(markup, "MyUInt16")
-            Await VerifyItemIsAbsentAsync(markup, "MyInt32")
-            Await VerifyItemIsAbsentAsync(markup, "MyUInt32")
-            Await VerifyItemIsAbsentAsync(markup, "MyInt64")
-            Await VerifyItemIsAbsentAsync(markup, "MyUInt64")
+            Await VerifyItemIsAbsentAsync(markup, $"My{underlyingType}")
+        End Function
+
+        Public Shared Iterator Function ValidEnumUnderlyingTypeNames() As IEnumerable(Of Object())
+            Yield {"Byte"}
+            Yield {"SByte"}
+            Yield {"Int16"}
+            Yield {"UInt16"}
+            Yield {"Int32"}
+            Yield {"UInt32"}
+            Yield {"Int64"}
+            Yield {"UInt64"}
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -8352,6 +8352,7 @@ End Class"
 Enum MyEnum As $$"
 
             Await VerifyItemExistsAsync(markup, "System")
+
             Await VerifyItemExistsAsync(markup, "Byte")
             Await VerifyItemExistsAsync(markup, "SByte")
             Await VerifyItemExistsAsync(markup, "Int16")
@@ -8365,6 +8366,260 @@ Enum MyEnum As $$"
             Await VerifyItemIsAbsentAsync(markup, "Console")
             Await VerifyItemIsAbsentAsync(markup, "Action")
             Await VerifyItemIsAbsentAsync(markup, "DateTime")
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList4() As Task
+            Dim markup =
+"Namespace MyNamespace
+End Namespace
+
+Enum MyEnum As Global.$$"
+
+            Await VerifyItemIsAbsentAsync(markup, "MyEnum")
+
+            Await VerifyItemExistsAsync(markup, "System")
+            Await VerifyItemIsAbsentAsync(markup, "MyNamespace")
+
+            ' Not accessible in the given context
+            Await VerifyItemIsAbsentAsync(markup, "Byte")
+            Await VerifyItemIsAbsentAsync(markup, "SByte")
+            Await VerifyItemIsAbsentAsync(markup, "Int16")
+            Await VerifyItemIsAbsentAsync(markup, "UInt16")
+            Await VerifyItemIsAbsentAsync(markup, "Int32")
+            Await VerifyItemIsAbsentAsync(markup, "UInt32")
+            Await VerifyItemIsAbsentAsync(markup, "Int64")
+            Await VerifyItemIsAbsentAsync(markup, "UInt64")
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList5() As Task
+            Dim markup = "Enum MyEnum As System.$$"
+
+            Await VerifyItemIsAbsentAsync(markup, "System")
+
+            Await VerifyItemExistsAsync(markup, "Byte")
+            Await VerifyItemExistsAsync(markup, "SByte")
+            Await VerifyItemExistsAsync(markup, "Int16")
+            Await VerifyItemExistsAsync(markup, "UInt16")
+            Await VerifyItemExistsAsync(markup, "Int32")
+            Await VerifyItemExistsAsync(markup, "UInt32")
+            Await VerifyItemExistsAsync(markup, "Int64")
+            Await VerifyItemExistsAsync(markup, "UInt64")
+
+            ' Verify that other things from `System` namespace are not present
+            Await VerifyItemIsAbsentAsync(markup, "Console")
+            Await VerifyItemIsAbsentAsync(markup, "Action")
+            Await VerifyItemIsAbsentAsync(markup, "DateTime")
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList6() As Task
+            Dim markup = "Enum MyEnum As Global.System.$$"
+
+            Await VerifyItemIsAbsentAsync(markup, "System")
+
+            Await VerifyItemExistsAsync(markup, "Byte")
+            Await VerifyItemExistsAsync(markup, "SByte")
+            Await VerifyItemExistsAsync(markup, "Int16")
+            Await VerifyItemExistsAsync(markup, "UInt16")
+            Await VerifyItemExistsAsync(markup, "Int32")
+            Await VerifyItemExistsAsync(markup, "UInt32")
+            Await VerifyItemExistsAsync(markup, "Int64")
+            Await VerifyItemExistsAsync(markup, "UInt64")
+
+            ' Verify that other things from `System` namespace are not present
+            Await VerifyItemIsAbsentAsync(markup, "Console")
+            Await VerifyItemIsAbsentAsync(markup, "Action")
+            Await VerifyItemIsAbsentAsync(markup, "DateTime")
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList7() As Task
+            Dim markup = "Enum MyEnum As System.Collections.Generic.$$"
+
+            Await VerifyNoItemsExistAsync(markup)
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList8() As Task
+            Dim markup =
+"Namespace MyNamespace
+    Namespace System
+    End Namespace
+    Public Structure Byte
+    End Structure
+    Public Structure SByte
+    End Structure
+    Public Structure Int16
+    End Structure
+    Public Structure UInt16
+    End Structure
+    Public Structure Int32
+    End Structure
+    Public Structure UInt32
+    End Structure
+    Public Structure Int64
+    End Structure
+    Public Structure UInt64
+    End Structure
+End Namespace
+
+Enum MyEnum As MyNamespace.$$"
+
+            Await VerifyNoItemsExistAsync(markup)
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList9() As Task
+            Dim markup =
+"Imports MySystem = System
+
+Enum MyEnum As $$"
+
+            Await VerifyItemExistsAsync(markup, "MySystem")
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList10() As Task
+            Dim markup =
+"Imports MySystem = System
+
+Enum MyEnum As Global.$$"
+
+            Await VerifyItemIsAbsentAsync(markup, "MySystem")
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList11() As Task
+            Dim markup =
+"Imports MySystem = System
+
+Enum MyEnum As MySystem.$$"
+
+            Await VerifyItemIsAbsentAsync(markup, "System")
+            Await VerifyItemIsAbsentAsync(markup, "MySystem")
+
+            Await VerifyItemExistsAsync(markup, "Byte")
+            Await VerifyItemExistsAsync(markup, "SByte")
+            Await VerifyItemExistsAsync(markup, "Int16")
+            Await VerifyItemExistsAsync(markup, "UInt16")
+            Await VerifyItemExistsAsync(markup, "Int32")
+            Await VerifyItemExistsAsync(markup, "UInt32")
+            Await VerifyItemExistsAsync(markup, "Int64")
+            Await VerifyItemExistsAsync(markup, "UInt64")
+
+            ' Verify that other things from `System` namespace are not present
+            Await VerifyItemIsAbsentAsync(markup, "Console")
+            Await VerifyItemIsAbsentAsync(markup, "Action")
+            Await VerifyItemIsAbsentAsync(markup, "DateTime")
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList12() As Task
+            Dim markup =
+"Imports MySystem = System
+
+Enum MyEnum As Global.MySystem.$$"
+
+            Await VerifyNoItemsExistAsync(markup)
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList13() As Task
+            Dim markup =
+"Imports MyByte = System.Byte
+Imports MySByte = System.SByte
+Imports MyInt16 = System.Int16
+Imports MyUInt16 = System.UInt16
+Imports MyInt32 = System.Int32
+Imports MyUInt32 = System.UInt32
+Imports MyInt64 = System.Int64
+Imports MyUInt64 = System.UInt64
+
+Enum MyEnum As $$"
+
+            Await VerifyItemExistsAsync(markup, "MyByte")
+            Await VerifyItemExistsAsync(markup, "MySByte")
+            Await VerifyItemExistsAsync(markup, "MyInt16")
+            Await VerifyItemExistsAsync(markup, "MyUInt16")
+            Await VerifyItemExistsAsync(markup, "MyInt32")
+            Await VerifyItemExistsAsync(markup, "MyUInt32")
+            Await VerifyItemExistsAsync(markup, "MyInt64")
+            Await VerifyItemExistsAsync(markup, "MyUInt64")
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList14() As Task
+            Dim markup =
+"Imports MyByte = System.Byte
+Imports MySByte = System.SByte
+Imports MyInt16 = System.Int16
+Imports MyUInt16 = System.UInt16
+Imports MyInt32 = System.Int32
+Imports MyUInt32 = System.UInt32
+Imports MyInt64 = System.Int64
+Imports MyUInt64 = System.UInt64
+
+Enum MyEnum As Global.$$"
+
+            Await VerifyItemIsAbsentAsync(markup, "MyByte")
+            Await VerifyItemIsAbsentAsync(markup, "MySByte")
+            Await VerifyItemIsAbsentAsync(markup, "MyInt16")
+            Await VerifyItemIsAbsentAsync(markup, "MyUInt16")
+            Await VerifyItemIsAbsentAsync(markup, "MyInt32")
+            Await VerifyItemIsAbsentAsync(markup, "MyUInt32")
+            Await VerifyItemIsAbsentAsync(markup, "MyInt64")
+            Await VerifyItemIsAbsentAsync(markup, "MyUInt64")
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList15() As Task
+            Dim markup =
+"Imports MyByte = System.Byte
+Imports MySByte = System.SByte
+Imports MyInt16 = System.Int16
+Imports MyUInt16 = System.UInt16
+Imports MyInt32 = System.Int32
+Imports MyUInt32 = System.UInt32
+Imports MyInt64 = System.Int64
+Imports MyUInt64 = System.UInt64
+
+Enum MyEnum As System.$$"
+
+            Await VerifyItemIsAbsentAsync(markup, "MyByte")
+            Await VerifyItemIsAbsentAsync(markup, "MySByte")
+            Await VerifyItemIsAbsentAsync(markup, "MyInt16")
+            Await VerifyItemIsAbsentAsync(markup, "MyUInt16")
+            Await VerifyItemIsAbsentAsync(markup, "MyInt32")
+            Await VerifyItemIsAbsentAsync(markup, "MyUInt32")
+            Await VerifyItemIsAbsentAsync(markup, "MyInt64")
+            Await VerifyItemIsAbsentAsync(markup, "MyUInt64")
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList16() As Task
+            Dim markup =
+"Imports MySystem = System
+Imports MyByte = System.Byte
+Imports MySByte = System.SByte
+Imports MyInt16 = System.Int16
+Imports MyUInt16 = System.UInt16
+Imports MyInt32 = System.Int32
+Imports MyUInt32 = System.UInt32
+Imports MyInt64 = System.Int64
+Imports MyUInt64 = System.UInt64
+
+Enum MyEnum As MySystem.$$"
+
+            Await VerifyItemIsAbsentAsync(markup, "MyByte")
+            Await VerifyItemIsAbsentAsync(markup, "MySByte")
+            Await VerifyItemIsAbsentAsync(markup, "MyInt16")
+            Await VerifyItemIsAbsentAsync(markup, "MyUInt16")
+            Await VerifyItemIsAbsentAsync(markup, "MyInt32")
+            Await VerifyItemIsAbsentAsync(markup, "MyUInt32")
+            Await VerifyItemIsAbsentAsync(markup, "MyInt64")
+            Await VerifyItemIsAbsentAsync(markup, "MyUInt64")
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/TypeImportCompletionProviderTests.vb
@@ -2,8 +2,6 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 ' See the LICENSE file in the project root for more information.
 
-Imports Microsoft.CodeAnalysis.Completion
-Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.CompletionProviders
@@ -244,6 +242,41 @@ End Namespace"
 
             Dim markup = CreateMarkupForSingleProject(file1, file2, LanguageNames.VisualBasic)
             Await VerifyItemExistsAsync(markup, "Foo4", glyph:=Glyph.ClassPublic, inlineDescription:="Foo1.Foo2.Foo3", displayTextSuffix:="(Of ...)", isComplexTextEdit:=True)
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList1() As Task
+            Dim source As String = "Enum MyEnum As $$"
+
+            Await VerifyItemExistsAsync(source, "Byte", glyph:=Glyph.StructurePublic, inlineDescription:="System")
+            Await VerifyItemExistsAsync(source, "SByte", glyph:=Glyph.StructurePublic, inlineDescription:="System")
+            Await VerifyItemExistsAsync(source, "Int16", glyph:=Glyph.StructurePublic, inlineDescription:="System")
+            Await VerifyItemExistsAsync(source, "UInt16", glyph:=Glyph.StructurePublic, inlineDescription:="System")
+            Await VerifyItemExistsAsync(source, "Int32", glyph:=Glyph.StructurePublic, inlineDescription:="System")
+            Await VerifyItemExistsAsync(source, "UInt32", glyph:=Glyph.StructurePublic, inlineDescription:="System")
+            Await VerifyItemExistsAsync(source, "Int64", glyph:=Glyph.StructurePublic, inlineDescription:="System")
+            Await VerifyItemExistsAsync(source, "UInt64", glyph:=Glyph.StructurePublic, inlineDescription:="System")
+
+            ' Verify that other things from `System` namespace are not present
+            Await VerifyItemIsAbsentAsync(source, "Console", inlineDescription:="System")
+            Await VerifyItemIsAbsentAsync(source, "Action", inlineDescription:="System")
+            Await VerifyItemIsAbsentAsync(source, "DateTime", inlineDescription:="System")
+
+            ' Verify that things from other namespaces are not present
+            Await VerifyItemIsAbsentAsync(source, "IEnumerable", inlineDescription:="System.Collections")
+            Await VerifyItemIsAbsentAsync(source, "Task", inlineDescription:="System.Threading.Tasks")
+            Await VerifyItemIsAbsentAsync(source, "AssemblyName", inlineDescription:="System.Reflection")
+        End Function
+
+        <Fact>
+        Public Async Function TestEnumBaseList2() As Task
+            Dim source As String =
+"Imports System
+
+Enum MyEnum As $$"
+
+            ' Everything valid is already in the scope
+            Await VerifyNoItemsExistAsync(source)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Types/BuiltInTypesKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Types/BuiltInTypesKeywordRecommenderTests.vb
@@ -29,8 +29,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.Ty
         }
 
         <Fact>
-        Public Sub NumericTypesAfterEnumAs()
-            VerifyRecommendationsAreExactly(<File>Enum Goo As |</File>, "Byte",
+        Public Sub NumericTypesAndGlobalAfterEnumAs()
+            VerifyRecommendationsAreExactly(<File>Enum Goo As |</File>, "Global",
+                                                                        "Byte",
                                                                         "SByte",
                                                                         "Short",
                                                                         "UShort",

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/GlobalKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/GlobalKeywordRecommender.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 
             return
                 context.IsTypeContext ||
+                context.IsEnumBaseListContext ||
                 UsingKeywordRecommender.IsUsingDirectiveContext(context, forGlobalKeyword: true, cancellationToken);
         }
     }

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -20,7 +19,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         where AliasDeclarationTypeNode : SyntaxNode
     {
         protected override bool ShouldProvideCompletion(CompletionContext completionContext, SyntaxContext syntaxContext)
-            => syntaxContext.IsTypeContext;
+            => syntaxContext.IsTypeContext || syntaxContext.IsEnumBaseListContext;
 
         protected override void LogCommit()
             => CompletionProvidersLogger.LogCommitOfTypeImportCompletionItem();

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractTypeImportCompletionService.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Roslyn.Utilities;
 
 using static Microsoft.CodeAnalysis.Shared.Utilities.EditorBrowsableHelpers;
@@ -60,6 +59,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     Language,
                     GenericTypeSuffix,
                     syntaxContext.IsAttributeNameContext,
+                    syntaxContext.IsEnumBaseListContext,
                     IsCaseSensitive,
                     options.HideAdvancedMembers);
         }

--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/TypeImportCompletionCacheEntry.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/TypeImportCompletionCacheEntry.cs
@@ -28,12 +28,20 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         /// </summary>
         private int PublicItemCount { get; }
 
+        /// <summary>
+        /// Only 1 entry (which corresponds to `System` namespace) can have items,
+        /// suitable for enum's base list. This flag allows to fast-skip other entries
+        /// without need to enumerate their items
+        /// </summary>
+        private bool HasItemsSuitableForEnumBaseList { get; }
+
         private TypeImportCompletionCacheEntry(
             SymbolKey assemblySymbolKey,
             Checksum checksum,
             string language,
             ImmutableArray<TypeImportCompletionItemInfo> items,
-            int publicItemCount)
+            int publicItemCount,
+            bool hasItemsSuitableForEnumBaseList)
         {
             AssemblySymbolKey = assemblySymbolKey;
             Checksum = checksum;
@@ -41,6 +49,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             ItemInfos = items;
             PublicItemCount = publicItemCount;
+            HasItemsSuitableForEnumBaseList = hasItemsSuitableForEnumBaseList;
         }
 
         public ImmutableArray<CompletionItem> GetItemsForContext(
@@ -48,10 +57,14 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             string language,
             string genericTypeSuffix,
             bool isAttributeContext,
+            bool isEnumBaseListContext,
             bool isCaseSensitive,
             bool hideAdvancedMembers)
         {
             if (AssemblySymbolKey.Resolve(originCompilation).Symbol is not IAssemblySymbol assemblySymbol)
+                return ImmutableArray<CompletionItem>.Empty;
+
+            if (isEnumBaseListContext && !HasItemsSuitableForEnumBaseList)
                 return ImmutableArray<CompletionItem>.Empty;
 
             var isSameLanguage = Language == language;
@@ -59,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             using var _ = ArrayBuilder<CompletionItem>.GetInstance(out var builder);
 
             // PERF: try set the capacity upfront to avoid allocation from Resize
-            if (!isAttributeContext)
+            if (!isAttributeContext && !isEnumBaseListContext)
             {
                 if (isInternalsVisible)
                 {
@@ -98,7 +111,13 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     item = GetAppropriateAttributeItem(info.Item, isCaseSensitive);
                 }
 
-                // C# and VB the display text is different for generics, i.e. <T> and (Of T). For simpllicity, we only cache for one language.
+                // Skip item if not suitable for enum base list
+                if (isEnumBaseListContext && !info.IsSuitableForEnumBaseList)
+                {
+                    continue;
+                }
+
+                // C# and VB the display text is different for generics, i.e. <T> and (Of T). For simplicity, we only cache for one language.
                 // But when we trigger in a project with different language than when the cache entry was created for, we will need to
                 // change the generic suffix accordingly.
                 if (!isSameLanguage && info.IsGeneric)
@@ -133,6 +152,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             private readonly EditorBrowsableInfo _editorBrowsableInfo;
 
             private int _publicItemCount;
+            private bool _hasItemsSuitableForEnumBaseList;
 
             private readonly ArrayBuilder<TypeImportCompletionItemInfo> _itemsBuilder;
 
@@ -154,7 +174,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                     _checksum,
                     _language,
                     _itemsBuilder.ToImmutable(),
-                    _publicItemCount);
+                    _publicItemCount,
+                    _hasItemsSuitableForEnumBaseList);
             }
 
             public void AddItem(INamedTypeSymbol symbol, string containingNamespace, bool isPublic)
@@ -181,6 +202,9 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 // attribute types that don't have "Attribute" suffix would be filtered out when in attribute context.
                 var isAttribute = symbol.Name.HasAttributeSuffix(isCaseSensitive: false) && symbol.IsAttribute();
 
+                var isSuitableForEnumBaseList = symbol.SpecialType is >= SpecialType.System_SByte and <= SpecialType.System_UInt64;
+                _hasItemsSuitableForEnumBaseList |= isSuitableForEnumBaseList;
+
                 var item = ImportCompletionItem.Create(
                     symbol.Name,
                     symbol.Arity,
@@ -193,7 +217,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 if (isPublic)
                     _publicItemCount++;
 
-                _itemsBuilder.Add(new TypeImportCompletionItemInfo(item, isPublic, isGeneric, isAttribute, isEditorBrowsableStateAdvanced));
+                _itemsBuilder.Add(new TypeImportCompletionItemInfo(item, isPublic, isGeneric, isAttribute, isEditorBrowsableStateAdvanced, isSuitableForEnumBaseList));
             }
 
             public void Dispose()
@@ -204,12 +228,13 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         {
             private readonly ItemPropertyKind _properties;
 
-            public TypeImportCompletionItemInfo(CompletionItem item, bool isPublic, bool isGeneric, bool isAttribute, bool isEditorBrowsableStateAdvanced)
+            public TypeImportCompletionItemInfo(CompletionItem item, bool isPublic, bool isGeneric, bool isAttribute, bool isEditorBrowsableStateAdvanced, bool isSuitableForEnumBaseList)
             {
                 Item = item;
                 _properties = (isPublic ? ItemPropertyKind.IsPublic : 0)
                             | (isGeneric ? ItemPropertyKind.IsGeneric : 0)
                             | (isAttribute ? ItemPropertyKind.IsAttribute : 0)
+                            | (isSuitableForEnumBaseList ? ItemPropertyKind.IsSuitableForEnumBaseList : 0)
                             | (isEditorBrowsableStateAdvanced ? ItemPropertyKind.IsEditorBrowsableStateAdvanced : 0);
             }
 
@@ -224,19 +249,20 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             public bool IsAttribute
                 => (_properties & ItemPropertyKind.IsAttribute) != 0;
 
+            public bool IsSuitableForEnumBaseList
+                => (_properties & ItemPropertyKind.IsSuitableForEnumBaseList) != 0;
+
             public bool IsEditorBrowsableStateAdvanced
                 => (_properties & ItemPropertyKind.IsEditorBrowsableStateAdvanced) != 0;
-
-            public TypeImportCompletionItemInfo WithItem(CompletionItem item)
-                => new(item, IsPublic, IsGeneric, IsAttribute, IsEditorBrowsableStateAdvanced);
 
             [Flags]
             private enum ItemPropertyKind : byte
             {
-                IsPublic = 0x1,
-                IsGeneric = 0x2,
-                IsAttribute = 0x4,
-                IsEditorBrowsableStateAdvanced = 0x8,
+                IsPublic = 1,
+                IsGeneric = 2,
+                IsAttribute = 4,
+                IsSuitableForEnumBaseList = 8,
+                IsEditorBrowsableStateAdvanced = 16
             }
         }
     }

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/GlobalKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/GlobalKeywordRecommender.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Expr
 
         Protected Overrides Function RecommendKeywords(context As VisualBasicSyntaxContext, cancellationToken As CancellationToken) As ImmutableArray(Of RecommendedKeyword)
             Dim targetToken = context.TargetToken
-            Return If(context.IsNamespaceContext AndAlso Not context.IsInImportsDirective, s_keywords, ImmutableArray(Of RecommendedKeyword).Empty)
+            Return If(context.IsNamespaceContext AndAlso Not context.IsInImportsDirective OrElse context.IsEnumBaseListContext, s_keywords, ImmutableArray(Of RecommendedKeyword).Empty)
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Types/BuiltInTypesKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Types/BuiltInTypesKeywordRecommender.vb
@@ -24,10 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Type
             Dim targetToken = context.TargetToken
 
             ' Are we right after an As in an Enum declaration?
-            Dim enumDeclaration = targetToken.GetAncestor(Of EnumStatementSyntax)()
-            If enumDeclaration IsNot Nothing AndAlso
-               enumDeclaration.UnderlyingType IsNot Nothing AndAlso
-               targetToken = enumDeclaration.UnderlyingType.AsKeyword Then
+            If context.IsEnumBaseListContext Then
 
                 Dim keywordList = GetIntrinsicTypeKeywords(context)
 

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -244,14 +244,7 @@ internal partial class CSharpRecommendationService
 
             // If we are in case like `enum E : global::$$` we need to show only `System` namespace
             if (alias.GetAncestor<BaseListSyntax>().Parent is EnumDeclarationSyntax)
-            {
-                if (aliasSymbol.Target is not INamespaceSymbol { IsGlobalNamespace: true } globalNamespace)
-                {
-                    return default;
-                }
-
-                return new(GetSymbolsForEnumBaseList(globalNamespace));
-            }
+                return new(GetSymbolsForEnumBaseList(aliasSymbol.Target));
 
             return new RecommendedSymbols(_context.SemanticModel.LookupNamespacesAndTypes(
                 alias.SpanStart,

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -124,7 +124,7 @@ internal partial class CSharpRecommendationService
             // Ensure that we have the correct token in A.B| case
             var node = _context.TargetToken.GetRequiredParent();
 
-            if (node.GetAncestor<BaseListSyntax>().Parent is EnumDeclarationSyntax)
+            if (node.GetAncestor<BaseListSyntax>()?.Parent is EnumDeclarationSyntax)
             {
                 // We are in enum's base list. Valid nodes here are:
                 // 1) QualifiedNameSyntax, e.g. `enum E : System.$$`
@@ -243,7 +243,7 @@ internal partial class CSharpRecommendationService
                 return default;
 
             // If we are in case like `enum E : global::$$` we need to show only `System` namespace
-            if (alias.GetAncestor<BaseListSyntax>().Parent is EnumDeclarationSyntax)
+            if (alias.GetAncestor<BaseListSyntax>()?.Parent is EnumDeclarationSyntax)
                 return new(GetSymbolsForEnumBaseList(aliasSymbol.Target));
 
             return new RecommendedSymbols(_context.SemanticModel.LookupNamespacesAndTypes(
@@ -348,7 +348,7 @@ internal partial class CSharpRecommendationService
             if (_context.IsNameOfContext)
                 return new RecommendedSymbols(_context.SemanticModel.LookupSymbols(position: name.SpanStart, container: symbol));
 
-            if (name.GetAncestor<BaseListSyntax>().Parent is EnumDeclarationSyntax)
+            if (name.GetAncestor<BaseListSyntax>()?.Parent is EnumDeclarationSyntax)
                 return new(GetSymbolsForEnumBaseList(symbol));
 
             var symbols = _context.SemanticModel.LookupNamespacesAndTypes(

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -113,7 +113,7 @@ internal partial class CSharpRecommendationService
             }
             else if (_context.IsEnumBaseListContext)
             {
-                return GetSymbolsForEnumBaseList();
+                return GetSymbolsForEnumBaseList(container: null);
             }
 
             return ImmutableArray<ISymbol>.Empty;

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -111,6 +111,10 @@ internal partial class CSharpRecommendationService
             {
                 return GetSymbolsForNamespaceDeclarationNameContext<BaseNamespaceDeclarationSyntax>();
             }
+            else if (_context.IsEnumBaseListContext)
+            {
+                return GetSymbolsForEnumBaseListContext();
+            }
 
             return ImmutableArray<ISymbol>.Empty;
         }

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -290,7 +290,7 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
                 container: semanticModel.Compilation.GlobalNamespace,
                 name: nameof(System)).FirstOrDefault(s => s is INamespaceSymbol);
 
-            var builder = ArrayBuilder<ISymbol>.GetInstance(capacity: 9);
+            using var builder = ArrayBuilder<ISymbol>.GetInstance();
 
             if (systemNamespace is not null)
             {

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -288,19 +288,19 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
             var systemNamespace = container is not (null or INamespaceSymbol { IsGlobalNamespace: true }) ? null : (INamespaceSymbol?)semanticModel.LookupNamespacesAndTypes(
                 _context.Position,
                 container: container,
-                name: "System").FirstOrDefault(s => s is INamespaceSymbol);
+                name: nameof(System)).FirstOrDefault(s => s is INamespaceSymbol);
 
             var builder = ArrayBuilder<ISymbol>.GetInstance(capacity: 9);
 
             builder.AddIfNotNull(systemNamespace);
-            builder.AddIfNotNull(GetSpecialTypeSymbol("Byte", SpecialType.System_Byte));
-            builder.AddIfNotNull(GetSpecialTypeSymbol("SByte", SpecialType.System_SByte));
-            builder.AddIfNotNull(GetSpecialTypeSymbol("Int16", SpecialType.System_Int16));
-            builder.AddIfNotNull(GetSpecialTypeSymbol("UInt16", SpecialType.System_UInt16));
-            builder.AddIfNotNull(GetSpecialTypeSymbol("Int32", SpecialType.System_Int32));
-            builder.AddIfNotNull(GetSpecialTypeSymbol("UInt32", SpecialType.System_UInt32));
-            builder.AddIfNotNull(GetSpecialTypeSymbol("Int64", SpecialType.System_Int64));
-            builder.AddIfNotNull(GetSpecialTypeSymbol("UInt64", SpecialType.System_UInt64));
+            builder.AddIfNotNull(GetSpecialTypeSymbol(nameof(Byte), SpecialType.System_Byte));
+            builder.AddIfNotNull(GetSpecialTypeSymbol(nameof(SByte), SpecialType.System_SByte));
+            builder.AddIfNotNull(GetSpecialTypeSymbol(nameof(Int16), SpecialType.System_Int16));
+            builder.AddIfNotNull(GetSpecialTypeSymbol(nameof(UInt16), SpecialType.System_UInt16));
+            builder.AddIfNotNull(GetSpecialTypeSymbol(nameof(Int32), SpecialType.System_Int32));
+            builder.AddIfNotNull(GetSpecialTypeSymbol(nameof(UInt32), SpecialType.System_UInt32));
+            builder.AddIfNotNull(GetSpecialTypeSymbol(nameof(Int64), SpecialType.System_Int64));
+            builder.AddIfNotNull(GetSpecialTypeSymbol(nameof(UInt64), SpecialType.System_UInt64));
 
             return builder.ToImmutableAndFree();
 

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -285,10 +285,10 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
         protected ImmutableArray<ISymbol> GetSymbolsForEnumBaseList(INamespaceOrTypeSymbol container)
         {
             var semanticModel = _context.SemanticModel;
-            var systemNamespace = container is not (null or INamespaceSymbol { IsGlobalNamespace: true }) ? null : (INamespaceSymbol)semanticModel.LookupNamespacesAndTypes(
-                _context.Position,
-                container: semanticModel.Compilation.GlobalNamespace,
-                name: nameof(System)).FirstOrDefault(s => s is INamespaceSymbol);
+            var systemNamespace = container is not (null or INamespaceSymbol { IsGlobalNamespace: true })
+                ? null
+                 : semanticModel.LookupNamespacesAndTypes(_context.Position, semanticModel.Compilation.GlobalNamespace, nameof(System))
+                     .OfType<INamespaceSymbol>().FirstOrDefault();
 
             using var _ = ArrayBuilder<ISymbol>.GetInstance(out var builder);
 

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -315,7 +315,7 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
             {
                 var specialTypeSymbol = _context.SemanticModel
                     .LookupNamespacesAndTypes(_context.Position, container, name)
-                    .SingleOrDefault(s => s is INamedTypeSymbol namedType && namedType.SpecialType == specialType);
+                    .FirstOrDefault(s => s is INamedTypeSymbol namedType && namedType.SpecialType == specialType);
 
                 builder.AddIfNotNull(specialTypeSymbol);
 

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -282,23 +282,17 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
             return symbols;
         }
 
-        protected ImmutableArray<ISymbol> GetSymbolsForEnumBaseListContext()
+        protected ImmutableArray<ISymbol> GetSymbolsForEnumBaseList(INamespaceOrTypeSymbol? container = null)
         {
             var semanticModel = _context.SemanticModel;
             var systemNamespace = (INamespaceSymbol?)semanticModel.LookupNamespacesAndTypes(
                 _context.Position,
-                container: semanticModel.Compilation.GlobalNamespace,
+                container: container is null ? semanticModel.Compilation.GlobalNamespace : container,
                 name: "System").FirstOrDefault(s => s is INamespaceSymbol);
-
-            if (systemNamespace is null)
-            {
-                return ImmutableArray<ISymbol>.Empty;
-            }
 
             var builder = ArrayBuilder<ISymbol>.GetInstance(capacity: 9);
 
-            builder.Add(systemNamespace);
-
+            builder.AddIfNotNull(systemNamespace);
             builder.AddIfNotNull(GetSpecialTypeSymbol("Byte", SpecialType.System_Byte));
             builder.AddIfNotNull(GetSpecialTypeSymbol("SByte", SpecialType.System_SByte));
             builder.AddIfNotNull(GetSpecialTypeSymbol("Int16", SpecialType.System_Int16));
@@ -314,6 +308,7 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
             {
                 return _context.SemanticModel.LookupNamespacesAndTypes(
                     _context.Position,
+                    container: container,
                     name: name).SingleOrDefault(s => s is INamedTypeSymbol namedType && namedType.SpecialType == specialType);
             }
         }

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -309,7 +309,7 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
             AddSpecialTypeSymbolAndItsAliases(nameof(Int64), SpecialType.System_Int64);
             AddSpecialTypeSymbolAndItsAliases(nameof(UInt64), SpecialType.System_UInt64);
 
-            return builder.ToImmutableAndFree();
+            return builder.ToImmutableAndClear();
 
             void AddSpecialTypeSymbolAndItsAliases(string name, SpecialType specialType)
             {

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -296,7 +296,7 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
             {
                 builder.Add(systemNamespace);
 
-                var aliases = semanticModel.LookupSymbols(_context.Position, container).Where(s => s is IAliasSymbol alias && alias.Target.Equals(systemNamespace));
+                var aliases = semanticModel.LookupSymbols(_context.Position, container).OfType<IAliasSymbol>().Where(a => systemNamespace.Equals(a.Target));
                 builder.AddRange(aliases);
             }
 

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -282,10 +282,10 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
             return symbols;
         }
 
-        protected ImmutableArray<ISymbol> GetSymbolsForEnumBaseList(INamespaceOrTypeSymbol? container = null)
+        protected ImmutableArray<ISymbol> GetSymbolsForEnumBaseList(INamespaceOrTypeSymbol container = null)
         {
             var semanticModel = _context.SemanticModel;
-            var systemNamespace = container is not (null or INamespaceSymbol { IsGlobalNamespace: true }) ? null : (INamespaceSymbol?)semanticModel.LookupNamespacesAndTypes(
+            var systemNamespace = container is not (null or INamespaceSymbol { IsGlobalNamespace: true }) ? null : (INamespaceSymbol)semanticModel.LookupNamespacesAndTypes(
                 _context.Position,
                 container: semanticModel.Compilation.GlobalNamespace,
                 name: nameof(System)).FirstOrDefault(s => s is INamespaceSymbol);

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -285,9 +285,9 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
         protected ImmutableArray<ISymbol> GetSymbolsForEnumBaseList(INamespaceOrTypeSymbol? container = null)
         {
             var semanticModel = _context.SemanticModel;
-            var systemNamespace = (INamespaceSymbol?)semanticModel.LookupNamespacesAndTypes(
+            var systemNamespace = container is not (null or INamespaceSymbol { IsGlobalNamespace: true }) ? null : (INamespaceSymbol?)semanticModel.LookupNamespacesAndTypes(
                 _context.Position,
-                container: container is null ? semanticModel.Compilation.GlobalNamespace : container,
+                container: container,
                 name: "System").FirstOrDefault(s => s is INamespaceSymbol);
 
             var builder = ArrayBuilder<ISymbol>.GetInstance(capacity: 9);

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -322,7 +322,7 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
 
                 specialTypeSymbol ??= _context.SemanticModel.Compilation.GetSpecialType(specialType);
 
-                var aliases = semanticModel.LookupSymbols(_context.Position, container).Where(s => s is IAliasSymbol alias && alias.Target.Equals(specialTypeSymbol));
+                var aliases = _context.SemanticModel.LookupSymbols(_context.Position, container).Where(s => s is IAliasSymbol alias && alias.Target.Equals(specialTypeSymbol));
                 builder.AddRange(aliases);
             }
         }

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -290,7 +290,7 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
                 container: semanticModel.Compilation.GlobalNamespace,
                 name: nameof(System)).FirstOrDefault(s => s is INamespaceSymbol);
 
-            using var builder = ArrayBuilder<ISymbol>.GetInstance();
+            using var _ = ArrayBuilder<ISymbol>.GetInstance(out var builder);
 
             if (systemNamespace is not null)
             {

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -321,7 +321,7 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
 
                 specialTypeSymbol ??= _context.SemanticModel.Compilation.GetSpecialType(specialType);
 
-                var aliases = _context.SemanticModel.LookupSymbols(_context.Position, container).Where(s => s is IAliasSymbol alias && alias.Target.Equals(specialTypeSymbol));
+                var aliases = _context.SemanticModel.LookupSymbols(_context.Position, container).OfType<IAliasSymbol>().Where(a => specialTypeSymbol.Equals(a.Target));
                 builder.AddRange(aliases);
             }
         }

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -282,7 +282,7 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
             return symbols;
         }
 
-        protected ImmutableArray<ISymbol> GetSymbolsForEnumBaseList(INamespaceOrTypeSymbol container = null)
+        protected ImmutableArray<ISymbol> GetSymbolsForEnumBaseList(INamespaceOrTypeSymbol container)
         {
             var semanticModel = _context.SemanticModel;
             var systemNamespace = container is not (null or INamespaceSymbol { IsGlobalNamespace: true }) ? null : (INamespaceSymbol)semanticModel.LookupNamespacesAndTypes(

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationServiceRunner.cs
@@ -313,10 +313,9 @@ internal abstract partial class AbstractRecommendationService<TSyntaxContext, TA
 
             void AddSpecialTypeSymbolAndItsAliases(string name, SpecialType specialType)
             {
-                var specialTypeSymbol = _context.SemanticModel.LookupNamespacesAndTypes(
-                    _context.Position,
-                    container: container,
-                    name: name).SingleOrDefault(s => s is INamedTypeSymbol namedType && namedType.SpecialType == specialType);
+                var specialTypeSymbol = _context.SemanticModel
+                    .LookupNamespacesAndTypes(_context.Position, container, name)
+                    .SingleOrDefault(s => s is INamedTypeSymbol namedType && namedType.SpecialType == specialType);
 
                 builder.AddIfNotNull(specialTypeSymbol);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -22,7 +22,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         public readonly bool IsDefiniteCastTypeContext;
         public readonly bool IsDelegateReturnTypeContext;
         public readonly bool IsDestructorTypeContext;
-        public readonly bool IsEnumBaseListContext;
         public readonly bool IsFixedVariableDeclarationContext;
         public readonly bool IsFunctionPointerTypeArgumentContext;
         public readonly bool IsGenericTypeArgumentContext;
@@ -119,6 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                   isAtStartOfPattern: isAtStartOfPattern,
                   isAttributeNameContext: isAttributeNameContext,
                   isAwaitKeywordContext: isAwaitKeywordContext,
+                  isEnumBaseListContext: isEnumBaseListContext,
                   isEnumTypeMemberAccessContext: isEnumTypeMemberAccessContext,
                   isGenericConstraintContext: isGenericConstraintContext,
                   isGlobalStatementContext: isGlobalStatementContext,
@@ -148,7 +148,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             this.IsDefiniteCastTypeContext = isDefiniteCastTypeContext;
             this.IsDelegateReturnTypeContext = isDelegateReturnTypeContext;
             this.IsDestructorTypeContext = isDestructorTypeContext;
-            this.IsEnumBaseListContext = isEnumBaseListContext;
             this.IsFixedVariableDeclarationContext = isFixedVariableDeclarationContext;
             this.IsFunctionPointerTypeArgumentContext = isFunctionPointerTypeArgumentContext;
             this.IsGenericTypeArgumentContext = isGenericTypeArgumentContext;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -259,7 +259,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 isDefiniteCastTypeContext: syntaxTree.IsDefiniteCastTypeContext(position, leftToken),
                 isDelegateReturnTypeContext: syntaxTree.IsDelegateReturnTypeContext(position, leftToken),
                 isDestructorTypeContext: isDestructorTypeContext,
-                isEnumBaseListContext: syntaxTree.IsEnumBaseListContext(position, leftToken),
+                isEnumBaseListContext: syntaxTree.IsEnumBaseListContext(targetToken),
                 isEnumTypeMemberAccessContext: syntaxTree.IsEnumTypeMemberAccessContext(semanticModel, position, cancellationToken),
                 isFixedVariableDeclarationContext: syntaxTree.IsFixedVariableDeclarationContext(position, leftToken),
                 isFunctionPointerTypeArgumentContext: syntaxTree.IsFunctionPointerTypeArgumentContext(position, leftToken, cancellationToken),

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -2985,19 +2985,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             return false;
         }
 
-        public static bool IsEnumBaseListContext(this SyntaxTree syntaxTree, int position, SyntaxToken tokenOnLeftOfPosition)
+        public static bool IsEnumBaseListContext(this SyntaxTree syntaxTree, SyntaxToken targetToken)
         {
-            var token = tokenOnLeftOfPosition;
-            token = token.GetPreviousTokenIfTouchingWord(position);
-
             // Options:
             //  enum E : |
             //  enum E : i|
 
             return
-                token.IsKind(SyntaxKind.ColonToken) &&
-                token.Parent.IsKind(SyntaxKind.BaseList) &&
-                token.Parent.IsParentKind(SyntaxKind.EnumDeclaration);
+                targetToken.IsKind(SyntaxKind.ColonToken) &&
+                targetToken.Parent.IsKind(SyntaxKind.BaseList) &&
+                targetToken.Parent.IsParentKind(SyntaxKind.EnumDeclaration);
         }
 
         public static bool IsEnumTypeMemberAccessContext(this SyntaxTree syntaxTree, SemanticModel semanticModel, int position, CancellationToken cancellationToken)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/ContextQuery/SyntaxContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/ContextQuery/SyntaxContext.cs
@@ -32,6 +32,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
         public bool IsAtStartOfPattern { get; }
         public bool IsAttributeNameContext { get; }
         public bool IsAwaitKeywordContext { get; }
+        public bool IsEnumBaseListContext { get; }
         public bool IsEnumTypeMemberAccessContext { get; }
         public bool IsGenericConstraintContext { get; }
         public bool IsGlobalStatementContext { get; }
@@ -64,6 +65,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
             bool isAtStartOfPattern,
             bool isAttributeNameContext,
             bool isAwaitKeywordContext,
+            bool isEnumBaseListContext,
             bool isEnumTypeMemberAccessContext,
             bool isGenericConstraintContext,
             bool isGlobalStatementContext,
@@ -96,6 +98,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
             this.IsAtStartOfPattern = isAtStartOfPattern;
             this.IsAttributeNameContext = isAttributeNameContext;
             this.IsAwaitKeywordContext = isAwaitKeywordContext;
+            this.IsEnumBaseListContext = isEnumBaseListContext;
             this.IsEnumTypeMemberAccessContext = isEnumTypeMemberAccessContext;
             this.IsGenericConstraintContext = isGenericConstraintContext;
             this.IsGlobalStatementContext = isGlobalStatementContext;

--- a/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
+++ b/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
@@ -172,7 +172,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
                     Return ImmutableArray(Of ISymbol).Empty
                 End If
 
-                If TypeOf node.GetAncestor(Of AsClauseSyntax)().Parent Is EnumStatementSyntax Then
+                If TypeOf node.GetAncestor(Of AsClauseSyntax)()?.Parent Is EnumStatementSyntax Then
                     Return GetSymbolsForEnumBaseList(leftHandSymbol)
                 End If
 

--- a/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
+++ b/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
@@ -59,6 +59,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
                     Return symbols
                 ElseIf _context.IsNamespaceDeclarationNameContext Then
                     Return GetSymbolsForNamespaceDeclarationNameContext(Of NamespaceBlockSyntax)()
+                ElseIf _context.IsEnumBaseListContext Then
+                    Return GetSymbolsForEnumBaseListContext()
                 End If
 
                 Return ImmutableArray(Of ISymbol).Empty

--- a/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
+++ b/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
@@ -172,6 +172,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
                     Return ImmutableArray(Of ISymbol).Empty
                 End If
 
+                If TypeOf node.GetAncestor(Of AsClauseSyntax)().Parent Is EnumStatementSyntax Then
+                    Return GetSymbolsForEnumBaseList(leftHandSymbol)
+                End If
+
                 Dim symbols As ImmutableArray(Of ISymbol)
                 If couldBeMergedNamespace Then
                     symbols = leftHandSymbolInfo.CandidateSymbols.OfType(Of INamespaceSymbol)() _

--- a/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
+++ b/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
                 ElseIf _context.IsNamespaceDeclarationNameContext Then
                     Return GetSymbolsForNamespaceDeclarationNameContext(Of NamespaceBlockSyntax)()
                 ElseIf _context.IsEnumBaseListContext Then
-                    Return GetSymbolsForEnumBaseListContext()
+                    Return GetSymbolsForEnumBaseList()
                 End If
 
                 Return ImmutableArray(Of ISymbol).Empty

--- a/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
+++ b/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationServiceRunner.vb
@@ -60,7 +60,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
                 ElseIf _context.IsNamespaceDeclarationNameContext Then
                     Return GetSymbolsForNamespaceDeclarationNameContext(Of NamespaceBlockSyntax)()
                 ElseIf _context.IsEnumBaseListContext Then
-                    Return GetSymbolsForEnumBaseList()
+                    Return GetSymbolsForEnumBaseList(container:=Nothing)
                 End If
 
                 Return ImmutableArray(Of ISymbol).Empty


### PR DESCRIPTION
Addresses feedback from https://github.com/dotnet/roslyn/pull/66119

Now completions in enum's base list include valid symbols:
![devenv_qVtTFu85F0](https://user-images.githubusercontent.com/70431552/226648263-76f02ba3-23d9-4201-90ce-0f6d7d810ab9.gif)

@CyrusNajmabadi @Youssef1313 PTAL