### PR TITLE
Do not use VS specific completion kinds in core LSP protocol layer

### DIFF
--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -38,9 +38,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer
 
         private static readonly Regex s_markdownEscapeRegex = new(@"([\\`\*_\{\}\[\]\(\)#+\-\.!])", RegexOptions.Compiled);
 
-        // NOTE: While the spec allows it, don't use Function and Method, as both VS and VS Code display them the same way
-        // which can confuse users
-        public static readonly Dictionary<string, LSP.CompletionItemKind> RoslynTagToCompletionItemKind = new Dictionary<string, LSP.CompletionItemKind>()
+        // NOTE: While the spec allows it, don't use Function and Method, as both VS and VS Code display them the same
+        // way which can confuse users
+
+        /// <summary>
+        /// Mapping from tags to lsp completion item kinds.  This mapping allows values including extensions to the
+        /// kinds defined by VS (but not in the core LSP spec).
+        /// </summary>
+        public static readonly ImmutableDictionary<string, LSP.CompletionItemKind> RoslynTagToVSCompletionItemKind = new Dictionary<string, LSP.CompletionItemKind>()
         {
             { WellKnownTags.Public, LSP.CompletionItemKind.Keyword },
             { WellKnownTags.Protected, LSP.CompletionItemKind.Keyword },
@@ -79,7 +84,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer
             { WellKnownTags.StatusInformation, LSP.CompletionItemKind.Text },
             { WellKnownTags.AddReference, LSP.CompletionItemKind.Text },
             { WellKnownTags.NuGet, LSP.CompletionItemKind.Text }
-        };
+        }.ToImmutableDictionary();
+
+        /// <summary>
+        /// Same as <see cref="RoslynTagToVSCompletionItemKind"/> except that the values are only from the safe set of
+        /// kinds defined directly by the core LSP protocol.
+        /// </summary>
+        public static readonly ImmutableDictionary<string, LSP.CompletionItemKind> RoslynTagToDefaultCompletionItemKind = RoslynTagToVSCompletionItemKind
+            .SetItem(WellKnownTags.Delegate, LSP.CompletionItemKind.Class)
+            .SetItem(WellKnownTags.ExtensionMethod, LSP.CompletionItemKind.Method)
+            .SetItem(WellKnownTags.Namespace, LSP.CompletionItemKind.Module);
 
         // TO-DO: More LSP.CompletionTriggerKind mappings are required to properly map to Roslyn CompletionTriggerKinds.
         // https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1178726

--- a/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/Features/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -42,58 +42,51 @@ namespace Microsoft.CodeAnalysis.LanguageServer
         // way which can confuse users
 
         /// <summary>
-        /// Mapping from tags to lsp completion item kinds.  This mapping allows values including extensions to the
-        /// kinds defined by VS (but not in the core LSP spec).
+        /// Mapping from tags to lsp completion item kinds.  The value lists the potential lsp kinds from
+        /// least-preferred to most preferred.  More preferred kinds will be chosen if the client states they support
+        /// it.  This mapping allows values including extensions to the kinds defined by VS (but not in the core LSP
+        /// spec).
         /// </summary>
-        public static readonly ImmutableDictionary<string, LSP.CompletionItemKind> RoslynTagToVSCompletionItemKind = new Dictionary<string, LSP.CompletionItemKind>()
+        public static readonly ImmutableDictionary<string, ImmutableArray<LSP.CompletionItemKind>> RoslynTagToCompletionItemKinds = new Dictionary<string, ImmutableArray<LSP.CompletionItemKind>>()
         {
-            { WellKnownTags.Public, LSP.CompletionItemKind.Keyword },
-            { WellKnownTags.Protected, LSP.CompletionItemKind.Keyword },
-            { WellKnownTags.Private, LSP.CompletionItemKind.Keyword },
-            { WellKnownTags.Internal, LSP.CompletionItemKind.Keyword },
-            { WellKnownTags.File, LSP.CompletionItemKind.File },
-            { WellKnownTags.Project, LSP.CompletionItemKind.File },
-            { WellKnownTags.Folder, LSP.CompletionItemKind.Folder },
-            { WellKnownTags.Assembly, LSP.CompletionItemKind.File },
-            { WellKnownTags.Class, LSP.CompletionItemKind.Class },
-            { WellKnownTags.Constant, LSP.CompletionItemKind.Constant },
-            { WellKnownTags.Delegate, LSP.CompletionItemKind.Delegate },
-            { WellKnownTags.Enum, LSP.CompletionItemKind.Enum },
-            { WellKnownTags.EnumMember, LSP.CompletionItemKind.EnumMember },
-            { WellKnownTags.Event, LSP.CompletionItemKind.Event },
-            { WellKnownTags.ExtensionMethod, LSP.CompletionItemKind.ExtensionMethod },
-            { WellKnownTags.Field, LSP.CompletionItemKind.Field },
-            { WellKnownTags.Interface, LSP.CompletionItemKind.Interface },
-            { WellKnownTags.Intrinsic, LSP.CompletionItemKind.Text },
-            { WellKnownTags.Keyword, LSP.CompletionItemKind.Keyword },
-            { WellKnownTags.Label, LSP.CompletionItemKind.Text },
-            { WellKnownTags.Local, LSP.CompletionItemKind.Variable },
-            { WellKnownTags.Namespace, LSP.CompletionItemKind.Namespace },
-            { WellKnownTags.Method, LSP.CompletionItemKind.Method },
-            { WellKnownTags.Module, LSP.CompletionItemKind.Module },
-            { WellKnownTags.Operator, LSP.CompletionItemKind.Operator },
-            { WellKnownTags.Parameter, LSP.CompletionItemKind.Value },
-            { WellKnownTags.Property, LSP.CompletionItemKind.Property },
-            { WellKnownTags.RangeVariable, LSP.CompletionItemKind.Variable },
-            { WellKnownTags.Reference, LSP.CompletionItemKind.Reference },
-            { WellKnownTags.Structure, LSP.CompletionItemKind.Struct },
-            { WellKnownTags.TypeParameter, LSP.CompletionItemKind.TypeParameter },
-            { WellKnownTags.Snippet, LSP.CompletionItemKind.Snippet },
-            { WellKnownTags.Error, LSP.CompletionItemKind.Text },
-            { WellKnownTags.Warning, LSP.CompletionItemKind.Text },
-            { WellKnownTags.StatusInformation, LSP.CompletionItemKind.Text },
-            { WellKnownTags.AddReference, LSP.CompletionItemKind.Text },
-            { WellKnownTags.NuGet, LSP.CompletionItemKind.Text }
+            { WellKnownTags.Public, ImmutableArray.Create(LSP.CompletionItemKind.Keyword) },
+            { WellKnownTags.Protected, ImmutableArray.Create(LSP.CompletionItemKind.Keyword) },
+            { WellKnownTags.Private, ImmutableArray.Create(LSP.CompletionItemKind.Keyword) },
+            { WellKnownTags.Internal, ImmutableArray.Create(LSP.CompletionItemKind.Keyword) },
+            { WellKnownTags.File, ImmutableArray.Create(LSP.CompletionItemKind.File) },
+            { WellKnownTags.Project, ImmutableArray.Create(LSP.CompletionItemKind.File) },
+            { WellKnownTags.Folder, ImmutableArray.Create(LSP.CompletionItemKind.Folder) },
+            { WellKnownTags.Assembly, ImmutableArray.Create(LSP.CompletionItemKind.File) },
+            { WellKnownTags.Class, ImmutableArray.Create(LSP.CompletionItemKind.Class) },
+            { WellKnownTags.Constant, ImmutableArray.Create(LSP.CompletionItemKind.Constant) },
+            { WellKnownTags.Delegate, ImmutableArray.Create(LSP.CompletionItemKind.Class, LSP.CompletionItemKind.Delegate) },
+            { WellKnownTags.Enum, ImmutableArray.Create(LSP.CompletionItemKind.Enum) },
+            { WellKnownTags.EnumMember, ImmutableArray.Create(LSP.CompletionItemKind.EnumMember) },
+            { WellKnownTags.Event, ImmutableArray.Create(LSP.CompletionItemKind.Event) },
+            { WellKnownTags.ExtensionMethod, ImmutableArray.Create(LSP.CompletionItemKind.Method, LSP.CompletionItemKind.ExtensionMethod) },
+            { WellKnownTags.Field, ImmutableArray.Create(LSP.CompletionItemKind.Field) },
+            { WellKnownTags.Interface, ImmutableArray.Create(LSP.CompletionItemKind.Interface) },
+            { WellKnownTags.Intrinsic, ImmutableArray.Create(LSP.CompletionItemKind.Text) },
+            { WellKnownTags.Keyword, ImmutableArray.Create(LSP.CompletionItemKind.Keyword) },
+            { WellKnownTags.Label, ImmutableArray.Create(LSP.CompletionItemKind.Text) },
+            { WellKnownTags.Local, ImmutableArray.Create(LSP.CompletionItemKind.Variable) },
+            { WellKnownTags.Namespace, ImmutableArray.Create(LSP.CompletionItemKind.Module, LSP.CompletionItemKind.Namespace) },
+            { WellKnownTags.Method, ImmutableArray.Create(LSP.CompletionItemKind.Method) },
+            { WellKnownTags.Module, ImmutableArray.Create(LSP.CompletionItemKind.Module) },
+            { WellKnownTags.Operator, ImmutableArray.Create(LSP.CompletionItemKind.Operator) },
+            { WellKnownTags.Parameter, ImmutableArray.Create(LSP.CompletionItemKind.Value) },
+            { WellKnownTags.Property, ImmutableArray.Create(LSP.CompletionItemKind.Property) },
+            { WellKnownTags.RangeVariable, ImmutableArray.Create(LSP.CompletionItemKind.Variable) },
+            { WellKnownTags.Reference, ImmutableArray.Create(LSP.CompletionItemKind.Reference) },
+            { WellKnownTags.Structure, ImmutableArray.Create(LSP.CompletionItemKind.Struct) },
+            { WellKnownTags.TypeParameter, ImmutableArray.Create(LSP.CompletionItemKind.TypeParameter) },
+            { WellKnownTags.Snippet, ImmutableArray.Create(LSP.CompletionItemKind.Snippet) },
+            { WellKnownTags.Error, ImmutableArray.Create(LSP.CompletionItemKind.Text) },
+            { WellKnownTags.Warning, ImmutableArray.Create(LSP.CompletionItemKind.Text) },
+            { WellKnownTags.StatusInformation, ImmutableArray.Create(LSP.CompletionItemKind.Text) },
+            { WellKnownTags.AddReference, ImmutableArray.Create(LSP.CompletionItemKind.Text) },
+            { WellKnownTags.NuGet, ImmutableArray.Create(LSP.CompletionItemKind.Text) }
         }.ToImmutableDictionary();
-
-        /// <summary>
-        /// Same as <see cref="RoslynTagToVSCompletionItemKind"/> except that the values are only from the safe set of
-        /// kinds defined directly by the core LSP protocol.
-        /// </summary>
-        public static readonly ImmutableDictionary<string, LSP.CompletionItemKind> RoslynTagToDefaultCompletionItemKind = RoslynTagToVSCompletionItemKind
-            .SetItem(WellKnownTags.Delegate, LSP.CompletionItemKind.Class)
-            .SetItem(WellKnownTags.ExtensionMethod, LSP.CompletionItemKind.Method)
-            .SetItem(WellKnownTags.Namespace, LSP.CompletionItemKind.Module);
 
         // TO-DO: More LSP.CompletionTriggerKind mappings are required to properly map to Roslyn CompletionTriggerKinds.
         // https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1178726

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -207,7 +207,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                         // If better kinds are preferred, return them if the client supports them.
                         for (var i = 1; i < completionItemKinds.Length; i++)
                         {
-                            var preferredKind = completionItemKinds[1];
+                            var preferredKind = completionItemKinds[i];
                             if (supportedClientKinds.Contains(preferredKind))
                                 kind = preferredKind;
                         }

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 lspItem.SortText = item.SortText;
                 lspItem.FilterText = item.FilterText;
 
-                lspItem.Kind = GetCompletionKind(item.Tags);
+                lspItem.Kind = GetCompletionKind(item.Tags, lspVSClientCapability);
                 lspItem.Preselect = ShouldItemBePreselected(item);
 
                 lspItem.CommitCharacters = GetCommitCharacters(item, commitCharactersRuleCache, lspVSClientCapability);
@@ -190,11 +190,16 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 return lspItem;
             }
 
-            static LSP.CompletionItemKind GetCompletionKind(ImmutableArray<string> tags)
+            static LSP.CompletionItemKind GetCompletionKind(
+                ImmutableArray<string> tags, bool lspVSClientCapability)
             {
+                var dictionary = lspVSClientCapability
+                    ? ProtocolConversions.RoslynTagToVSCompletionItemKind
+                    : ProtocolConversions.RoslynTagToDefaultCompletionItemKind;
+
                 foreach (var tag in tags)
                 {
-                    if (ProtocolConversions.RoslynTagToCompletionItemKind.TryGetValue(tag, out var completionItemKind))
+                    if (dictionary.TryGetValue(tag, out var completionItemKind))
                         return completionItemKind;
                 }
 

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -209,10 +209,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                         {
                             var preferredKind = completionItemKinds[1];
                             if (supportedClientKinds.Contains(preferredKind))
-                            {
                                 kind = preferredKind;
-                                break;
-                            }
                         }
 
                         return kind;

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -214,6 +214,8 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                                 break;
                             }
                         }
+
+                        return kind;
                     }
                 }
 

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
     {
         private static readonly LSP.VSInternalClientCapabilities s_vsCompletionCapabilities = CreateCoreCompletionCapabilities();
 
-        private static LSP.VSInternalClientCapabilities CreateCoreCompletionCapabilities ()
+        private static LSP.VSInternalClientCapabilities CreateCoreCompletionCapabilities()
             => new LSP.VSInternalClientCapabilities
             {
                 SupportsVisualStudioExtensions = true,

--- a/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.Completion
             Assert.NotNull(results.ItemDefaults.EditRange);
         }
 
-        [Fact]
+        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1777096")]
         public async Task TestGetExtensionMethodCoreLsp()
         {
             var markup =
@@ -206,7 +206,7 @@ static class Extensions
             Assert.NotNull(results.ItemDefaults.EditRange);
         }
 
-        [Fact]
+        [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1777096")]
         public async Task TestGetExtensionMethodCoreVSLsp()
         {
             var markup =

--- a/src/Features/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Linq;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Xunit;
@@ -12,10 +10,10 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
 {
     public class ProtocolConversionsTests
     {
-        [Fact]
-        public void CompletionItemKind_DontUseMethodAndFunction()
+        [Theory, CombinatorialData]
+        public void CompletionItemKind_DoNotUseMethodAndFunction(bool vsKinds)
         {
-            var map = ProtocolConversions.RoslynTagToCompletionItemKind;
+            var map = vsKinds? ProtocolConversions.RoslynTagToVSCompletionItemKind : ProtocolConversions.RoslynTagToDefaultCompletionItemKind;
 
             var containsMethod = map.Values.Any(c => c == CompletionItemKind.Method);
             var containsFunction = map.Values.Any(c => c == CompletionItemKind.Function);

--- a/src/Features/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
@@ -10,13 +10,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests
 {
     public class ProtocolConversionsTests
     {
-        [Theory, CombinatorialData]
-        public void CompletionItemKind_DoNotUseMethodAndFunction(bool vsKinds)
+        [Fact]
+        public void CompletionItemKind_DoNotUseMethodAndFunction()
         {
-            var map = vsKinds? ProtocolConversions.RoslynTagToVSCompletionItemKind : ProtocolConversions.RoslynTagToDefaultCompletionItemKind;
-
-            var containsMethod = map.Values.Any(c => c == CompletionItemKind.Method);
-            var containsFunction = map.Values.Any(c => c == CompletionItemKind.Function);
+            var map = ProtocolConversions.RoslynTagToCompletionItemKinds;
+            var containsMethod = map.Values.Any(c => c.Contains(CompletionItemKind.Method));
+            var containsFunction = map.Values.Any(c => c.Contains(CompletionItemKind.Function));
 
             Assert.False(containsFunction && containsMethod, "Don't use Method and Function completion item kinds as it causes user confusion.");
         }


### PR DESCRIPTION
Fixes [AB#1777096](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1777096)