### PR TITLE
Remove assert in CheckParameterValEscape()

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -1050,7 +1050,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private bool CheckParameterValEscape(SyntaxNode node, ParameterSymbol parameter, uint escapeTo, BindingDiagnosticBag diagnostics)
         {
-            Debug.Assert(escapeTo is CallingMethodScope or ReturnOnlyScope);
             if (_useUpdatedEscapeRules)
             {
                 if (GetParameterValEscape(parameter) > escapeTo)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefEscapingTests.cs
@@ -7060,5 +7060,32 @@ public struct Vec4
             var comp = CreateCompilationWithSpan(source);
             comp.VerifyDiagnostics();
         }
+
+        [ConditionalFact(typeof(CoreClrOnly))]
+        public void ParameterEscape()
+        {
+            var source = """
+                using System;
+                ref struct R
+                {
+                    public R(Span<int> s) { }
+                    public void F(ReadOnlySpan<int> s) { }
+                }
+                class Program
+                {
+                    static void M(ReadOnlySpan<int> s)
+                    {
+                        R r = new R(stackalloc int[2]);
+                        while (true)
+                        {
+                            r.F(s);
+                            r.F(s.Slice(0, 1));
+                        }
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net70);
+            comp.VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
The `escapeTo` value passed to `CheckParameterValEscape()` may be a local scope `> 0`.

Assert failed compiling dotnet/runtime.