### PR TITLE
Checking escape characters when classification virtual character sequence 

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -5474,5 +5474,60 @@ int m(Delegate d) { }",
                 Method("staticLocalFunction"),
                 Static("staticLocalFunction"));
         }
+
+        [Theory, CombinatorialData]
+        public async Task TestEscapeFourBytesCharacter(TestHost testHost)
+        {
+            await TestAsync(@"
+class C
+{
+        void M()
+        {
+            var x = ""𠀀𠀁𠣶𤆐𥽠𪛕"";
+        }
+}", testHost,
+Keyword("var"));
+        }
+
+        [Theory, CombinatorialData]
+        public async Task TestEscapeCharacter(TestHost testHost)
+        {
+            await TestAsync(@"
+class C
+{
+    string x1 = ""\xabcd"";
+    string x2 = ""\uabcd"";
+    string x3 = ""\U00009F99"";
+    string x4 = ""\'"";
+    string x5 = ""\"""";
+    string x6 = ""\\"";
+    string x7 = ""\0"";
+    string x8 = ""\a"";
+    string x9 = ""\b"";
+    string x10 = ""\f"";
+    string x11 = ""\n"";
+    string x12 = ""\r"";
+    string x13 = ""\t"";
+    string x14 = ""\v"";
+    string x15 = @"""""""";
+}", testHost,
+Escape("\\xabcd"),
+Escape("\\uabcd"),
+Escape("\\U00009F99"),
+Escape("\\\'"),
+Escape("\\\""),
+Escape("\\\\"),
+Escape("\\0"),
+Escape("\\a"),
+Escape("\\b"),
+Escape("\\f"),
+Escape("\\n"),
+Escape("\\r"),
+Escape("\\t"),
+Escape("\\v"),
+Escape("\"\"")
+);
+
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Classification/SemanticClassifierTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Classification/SemanticClassifierTests.vb
@@ -1211,5 +1211,33 @@ End Try"
                 [Class]("Exception"),
                 Local("ex"))
         End Function
+
+        <Theory, CombinatorialData>
+        Public Async Function TestEscapeFourBytesCharacter(testHost As TestHost) As Task
+            Dim code =
+"
+Public Class C
+    Private x As String = ""𠀀𠀁𠣶𤆐𥽠𪛕""
+End Class
+"
+
+            Await TestInMethodAsync(code,
+                testHost)
+        End Function
+
+        <Theory, CombinatorialData>
+        Public Async Function TestEscapeCharacter(testHost As TestHost) As Task
+            Dim code =
+"
+Public Class C
+    Private x As String = """"""""
+End Class
+"
+
+            Await TestInMethodAsync(code,
+                testHost,
+                Escape(""""""))
+        End Function
+
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/EmbeddedLanguages/Classification/CSharpFallbackEmbeddedLanguageClassifier.cs
+++ b/src/Features/CSharp/Portable/EmbeddedLanguages/Classification/CSharpFallbackEmbeddedLanguageClassifier.cs
@@ -2,8 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.CSharp.EmbeddedLanguages.LanguageServices;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Classification
 {
@@ -11,9 +16,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification
     {
         public static readonly CSharpFallbackEmbeddedLanguageClassifier Instance = new();
 
+        // https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/lexical-structure.md#6456-string-literals
+        // Regular String Literal Character can have these escape character
+        // 1. Simple_Escape_Sequence ('\\\'' | '\\"' | '\\\\' | '\\0' | '\\a' | '\\b' | '\\f' | '\\n' | '\\r' | '\\t' | '\\v')
+        // 2. Hexadecimal_Escape_Sequence ('\\x' hex_digit)
+        // 3. Unicode_Escape_Sequence ('\\u' or '\\U' )
+        //  Verbatim string can only escape double quote
+        private static readonly ImmutableArray<string> s_regularStringLiteralEscapeStrings = ImmutableArray.Create(
+            "\\x", "\\u", "\\U", "\\\'", "\\\"", "\\\\", "\\0", "\\a", "\\b", "\\f", "\\n", "\\r", "\\t", "\\v",
+            "\"\"");
+
         private CSharpFallbackEmbeddedLanguageClassifier()
             : base(CSharpEmbeddedLanguagesProvider.Info)
         {
         }
+
+        protected override bool TextStartWithEscapeCharacter(string text)
+            => s_regularStringLiteralEscapeStrings.Any(s => text.StartsWith(s, StringComparison.InvariantCulture));
     }
 }

--- a/src/Features/Core/Portable/EmbeddedLanguages/Classification/EmbeddedLanguageClassifierContext.cs
+++ b/src/Features/Core/Portable/EmbeddedLanguages/Classification/EmbeddedLanguageClassifierContext.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading;
-using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.EmbeddedLanguages.VirtualChars;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Text;

--- a/src/Features/VisualBasic/Portable/EmbeddedLanguages/Classification/VisualBasicFallbackEmbeddedLanguageClassifier.vb
+++ b/src/Features/VisualBasic/Portable/EmbeddedLanguages/Classification/VisualBasicFallbackEmbeddedLanguageClassifier.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Classification
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.EmbeddedLanguages.LanguageServices
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
@@ -14,5 +15,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Classification
         Private Sub New()
             MyBase.New(VisualBasicEmbeddedLanguagesProvider.Info)
         End Sub
+
+        Protected Overrides Function TextStartWithEscapeCharacter(text As String) As Boolean
+            ' https://github.com/dotnet/vblang/blob/main/spec/lexical-grammar.md#string-literals
+            ' VB only escape double quote
+            Return text.StartsWith("""""", StringComparison.InvariantCulture)
+        End Function
     End Class
 End Namespace

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -19,7 +18,6 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
-using Microsoft.CodeAnalysis.CSharp.Shared.Extensions;
 
 #if CODE_STYLE
 using Microsoft.CodeAnalysis.Internal.Editing;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Services/SyntaxFacts/ISyntaxFacts.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis.Text;


### PR DESCRIPTION
Fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1407272/

From https://en.wikipedia.org/wiki/UTF-16
>  In the UTF-16 encoding, code points less than 216 are encoded with a single 16-bit code unit equal to the numerical value of the code point, as in the older UCS-2. The newer code points greater than or equal to 216 are encoded by a compound value using two 16-bit code units.

In the existing implementation, if the text span's length is larger then one it is classified as escape characters. This would cause us always escape two 16-bits Unicode (their text span length is 2).

The fix I found is when the length is larger than one, check if the string prefix is the reserved escape character. (A more comprehensive way might be to write a regex to match the lang spec of C# and VB, but since we are using virtual character sequence to check the character one by one, it feels like not needed)