### PR TITLE
Update assert in EmitConversion to allow for pointer subtraction

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitConversion.cs
@@ -156,7 +156,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                             Debug.Assert(
                                 (toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.IntPtr || toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.UIntPtr) && !toType.IsNativeIntegerWrapperType ||
                                 toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.Pointer ||
-                                toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.FunctionPointer);
+                                toPredefTypeKind == Microsoft.Cci.PrimitiveTypeCode.FunctionPointer ||
+                                (fromPredefTypeKind == Cci.PrimitiveTypeCode.IntPtr && conversion.Operand is BoundBinaryOperator { OperatorKind: BinaryOperatorKind.Division })); // pointer subtraction: see LocalRewriter.RewritePointerSubtraction()
                             break;
                     }
 #endif

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -11757,6 +11757,29 @@ class Program
             }
         }
 
+        [WorkItem(67041, "https://github.com/dotnet/roslyn/issues/67041")]
+        [Theory]
+        [CombinatorialData]
+        public void Conversion_ExplicitPointerToInteger(bool useNumericIntPtr)
+        {
+            var source = """
+                class Program
+                {
+                    static unsafe long F(int* p1)
+                    {
+                        byte* p2 = (byte*)p1;
+                        p2++;
+                        return p2 - (byte*)p1;
+                    }
+                }
+                """;
+            var comp = CreateCompilation(
+                source,
+                options: TestOptions.UnsafeReleaseDll,
+                targetFramework: useNumericIntPtr ? TargetFramework.Net60 : TargetFramework.Net70);
+            comp.VerifyEmitDiagnostics();
+        }
+
         private void VerifyNoNativeIntegerAttributeEmitted(CSharpCompilation comp)
         {
             // PEVerify is skipped because it reports "Type load failed" because of the above corlib,

--- a/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/Emit/NumericIntPtrTests.cs
@@ -11760,7 +11760,7 @@ class Program
         [WorkItem(67041, "https://github.com/dotnet/roslyn/issues/67041")]
         [Theory]
         [CombinatorialData]
-        public void Conversion_ExplicitPointerToInteger(bool useNumericIntPtr)
+        public void PointerSubtraction(bool useNumericIntPtr)
         {
             var source = """
                 class Program


### PR DESCRIPTION
See [`LocalRewriter.RewritePointerSubtraction()`](https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperator.cs#L2382).

Fixes #67041