### PR TITLE
Update Building, Debugging, Testing instructions for VS

### DIFF
--- a/docs/contributing/Building, Debugging, and Testing on Windows.md
+++ b/docs/contributing/Building, Debugging, and Testing on Windows.md
@@ -16,7 +16,8 @@ The minimal required version of .NET Framework is 4.7.2.
 ## Developing with Visual Studio 2022
 
 1. Use latest [Visual Studio 2022 Preview](https://visualstudio.microsoft.com/vs/preview/vs2022/)
-    - Ensure C#, VB, MSBuild, .NET Core and Visual Studio Extensibility are included in the selected work loads
+    - Ensure Visual Studio extension development is included in the selected workloads
+    - Ensure C# and Visual Basic, MSBuild, and .NET Core are included in the selected individual components
     - Ensure "Use previews of the .NET Core SDK" is checked in Tools -> Options -> Environment -> Preview Features
     - Restart Visual Studio
 1. Install the latest [.NET 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)


### PR DESCRIPTION
If I've interpreted the instructions correctly, VS is required to have the extensibility workload installed. These other requirements are **individual components**. Updating the instructions to make it more clear what specifically needs to be installed. 

![image](https://user-images.githubusercontent.com/9122518/227059304-5f1fa79e-a603-49a0-bebf-6c0da8c41a0d.png)
