### PR TITLE
Gracefully handle unexpected NullableWalker state

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -11522,15 +11522,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     return NullableFlowState.NotNull;
                 }
+
                 Debug.Assert(index < Capacity);
                 index *= 2;
+                Debug.Assert((_state[index], _state[index + 1]) != (false, false));
+
                 var result = (_state[index], _state[index + 1]) switch
                 {
-                    (false, false) => throw ExceptionUtilities.Unreachable(),
+                    (false, false) => NullableFlowState.NotNull, // Should not be reachable
                     (true, false) => NullableFlowState.MaybeNull,
                     (false, true) => NullableFlowState.MaybeDefault,
                     (true, true) => NullableFlowState.NotNull
                 };
+
                 return result;
             }
 


### PR DESCRIPTION
I'm now able to repro issue https://github.com/dotnet/roslyn/issues/66960 locally, but didn't have much time to investigate since then.
Given this is a regression in 17.6 (unreachable exception throw was added in PR https://github.com/dotnet/roslyn/pull/66174), this fix is to handle this situation more gracefully. This will provide more time for a full fix.