### PR TITLE
Don't trigger completion in argument list

### DIFF
--- a/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/ImportCompletionProvider/AbstractImportCompletionProvider.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
 
             if (!ShouldProvideCompletion(completionContext, syntaxContext))
             {
-                // Queue a backgound task to warm up cache and return immediately if this is not the context to trigger this provider.
+                // Queue a background task to warm up cache and return immediately if this is not the context to trigger this provider.
                 // `ForceExpandedCompletionIndexCreation` and `UpdateImportCompletionCacheInBackground` are both test only options to
                 // make test behavior deterministic.
                 var options = completionContext.CompletionOptions;

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
                 return null;
             }
 
-            var completionOptions = GetCompletionOptions(document) with { UpdateImportCompletionCacheInBackground = true };
+            var completionOptions = GetCompletionOptions(document);
             var completionService = document.GetRequiredLanguageService<CompletionService>();
             var documentText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
@@ -469,6 +469,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             {
                 ShowItemsFromUnimportedNamespaces = false,
                 ExpandedCompletionBehavior = ExpandedCompletionMode.NonExpandedItemsOnly,
+                UpdateImportCompletionCacheInBackground = false,
                 TriggerInArgumentLists = false
             };
         }

--- a/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/Completion/CompletionHandler.cs
@@ -462,10 +462,14 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler
             // 2.  We need to figure out how to provide the text edits along with the completion item or provide them in the resolve request.
             //     https://devdiv.visualstudio.com/DevDiv/_workitems/edit/985860/
             // 3.  LSP client should support completion filters / expanders
+            //
+            // Also don't trigger completion in argument list automatically, since LSP currently has no concept of soft selection.
+            // We want to avoid committing selected item with commit chars like `"` and `)`.
             return _globalOptions.GetCompletionOptions(document.Project.Language) with
             {
                 ShowItemsFromUnimportedNamespaces = false,
-                ExpandedCompletionBehavior = ExpandedCompletionMode.NonExpandedItemsOnly
+                ExpandedCompletionBehavior = ExpandedCompletionMode.NonExpandedItemsOnly,
+                TriggerInArgumentLists = false
             };
         }
 


### PR DESCRIPTION
Since LSP has no concept of soft-selection at the moment, we want to avoid accidental commit when user typed any commit char after an open parenthesis, e.g. `Method(`  then typed `"`
A temporary fix for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1755955