### PR TITLE
Change inline hint to inline hints

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/Options/InlineHintsOptionsStorage.cs
+++ b/src/Features/LanguageServer/Protocol/Features/Options/InlineHintsOptionsStorage.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.InlineHints
               ForImplicitObjectCreation = globalOptions.GetOption(ForImplicitObjectCreation, language),
           };
 
-        private static readonly OptionGroup s_inlineHintOptionGroup = new(name: "inline_hint", description: "");
+        private static readonly OptionGroup s_inlineHintOptionGroup = new(name: "inline_hints", description: "");
 
         //  Parameter hints
 


### PR DESCRIPTION
Found this when add options to the client.
This will match to our VS options page 
<img width="365" alt="image" src="https://user-images.githubusercontent.com/24360909/227388705-165b7681-4548-4a03-8c0f-f511eb9915a9.png">
