### PR TITLE
Update ExtractInterface to use IRefactoringHelpersService

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractInterface
                 }$$
                 """;
 
-            await TestExtractInterfaceCommandCSharpAsync(markup, expectedSuccess: false);
+            await TestExtractInterfaceCommandCSharpAsync(markup, expectedSuccess: true);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]

--- a/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractInterface
                 }$$
                 """;
 
-            await TestExtractInterfaceCommandCSharpAsync(markup, expectedSuccess: true);
+            await TestExtractInterfaceCommandCSharpAsync(markup, expectedSuccess: false);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]
@@ -1360,6 +1360,21 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractInterface
                 class Program $$: ISomeInterface<object>
                 {
                     public void Goo() { }
+                }
+                """;
+
+            await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable: true);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]
+        public async Task ExtractInterface_TypeDiscovery_NameOnly11()
+        {
+            var markup = """
+                namespace N
+                {
+                $$    class Program
+                    {
+                    }
                 }
                 """;
 

--- a/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
@@ -1374,6 +1374,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractInterface
                 {
                 $$    class Program
                     {
+                        public void Goo() { }
                     }
                 }
                 """;

--- a/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractInterface/ExtractInterfaceTests.cs
@@ -1251,7 +1251,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractInterface
                 }
                 """;
 
-            await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable: false);
+            await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable: true);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]
@@ -1265,7 +1265,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractInterface
                 }
                 """;
 
-            await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable: false);
+            await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable: true);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]
@@ -1349,7 +1349,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractInterface
                 }
                 """;
 
-            await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable: false);
+            await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable: true);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ExtractInterface)]
@@ -1363,7 +1363,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractInterface
                 }
                 """;
 
-            await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable: false);
+            await TestTypeDiscoveryAsync(markup, TypeDiscoveryRule.TypeNameOnly, expectedExtractable: true);
         }
 
         private static async Task TestTypeDiscoveryAsync(

--- a/src/Features/CSharp/Portable/ExtractInterface/CSharpExtractInterfaceService.cs
+++ b/src/Features/CSharp/Portable/ExtractInterface/CSharpExtractInterfaceService.cs
@@ -35,21 +35,19 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractInterface
         protected override async Task<SyntaxNode> GetTypeDeclarationAsync(Document document, int position, TypeDiscoveryRule typeDiscoveryRule, CancellationToken cancellationToken)
         {
             var span = new TextSpan(position, 0);
-            var relevantNode = await document.TryGetRelevantNodeAsync<SyntaxNode>(span, cancellationToken).ConfigureAwait(false);
-
-            if (relevantNode is TypeDeclarationSyntax)
-            {
-                return relevantNode;
-            }
+            var typeDeclarationNode = await document.TryGetRelevantNodeAsync<TypeDeclarationSyntax>(span, cancellationToken).ConfigureAwait(false);
 
             // If TypeDiscoverRule is set to TypeDeclaration, a position anywhere inside of the
-            // declaration is valid. In this case check to see if there is a type declaration ancestor.
-            if (relevantNode != null && typeDiscoveryRule == TypeDiscoveryRule.TypeDeclaration)
+            // declaration enclosure is valid. In this case check to see if there is a type declaration ancestor
+            // of the focused node.
+            if (typeDeclarationNode == null && typeDiscoveryRule == TypeDiscoveryRule.TypeDeclaration)
             {
+                var relevantNode = await document.TryGetRelevantNodeAsync<SyntaxNode>(span, cancellationToken).ConfigureAwait(false);
                 return relevantNode.GetAncestor<TypeDeclarationSyntax>();
             }
 
-            return relevantNode;
+            return typeDeclarationNode;
+
         }
 
         internal override string GetContainingNamespaceDisplay(INamedTypeSymbol typeSymbol, CompilationOptions compilationOptions)

--- a/src/Features/CSharp/Portable/ExtractInterface/CSharpExtractInterfaceService.cs
+++ b/src/Features/CSharp/Portable/ExtractInterface/CSharpExtractInterfaceService.cs
@@ -35,21 +35,21 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractInterface
         protected override async Task<SyntaxNode> GetTypeDeclarationAsync(Document document, int position, TypeDiscoveryRule typeDiscoveryRule, CancellationToken cancellationToken)
         {
             var span = new TextSpan(position, 0);
-            var typeDeclaration = await document.TryGetRelevantNodeAsync<SyntaxNode>(span, cancellationToken).ConfigureAwait(false);
+            var relevantNode = await document.TryGetRelevantNodeAsync<SyntaxNode>(span, cancellationToken).ConfigureAwait(false);
 
-            //var typeDeclaration = nodes.Where(n => n is TypeDeclarationSyntax).FirstOrDefault() ?? nodes.FirstOrDefault();
-
-            if (typeDeclaration == null)
+            if (relevantNode is TypeDeclarationSyntax)
             {
-                return typeDeclaration;
+                return relevantNode;
             }
 
-            if (typeDiscoveryRule == TypeDiscoveryRule.TypeNameOnly)
+            // If TypeDiscoverRule is set to TypeDeclaration, a position anywhere inside of the
+            // declaration is valid. In this case check to see if there is a type declaration ancestor.
+            if (relevantNode != null && typeDiscoveryRule == TypeDiscoveryRule.TypeDeclaration)
             {
-                return typeDeclaration.Span.IntersectsWith(position) ? typeDeclaration : null;
+                return relevantNode.GetAncestor<TypeDeclarationSyntax>();
             }
 
-            return typeDeclaration is TypeDeclarationSyntax ? typeDeclaration : typeDeclaration.GetAncestor<TypeDeclarationSyntax>();
+            return relevantNode;
         }
 
         internal override string GetContainingNamespaceDisplay(INamedTypeSymbol typeSymbol, CompilationOptions compilationOptions)

--- a/src/Features/CSharp/Portable/ExtractInterface/CSharpExtractInterfaceService.cs
+++ b/src/Features/CSharp/Portable/ExtractInterface/CSharpExtractInterfaceService.cs
@@ -31,12 +31,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractInterface
         public CSharpExtractInterfaceService()
         {
         }
+
         protected override async Task<SyntaxNode> GetTypeDeclarationAsync(Document document, int position, TypeDiscoveryRule typeDiscoveryRule, CancellationToken cancellationToken)
         {
             var span = new TextSpan(position, 0);
-            var nodes = await document.GetRelevantNodesAsync<SyntaxNode>(span, cancellationToken).ConfigureAwait(false);
+            var typeDeclaration = await document.TryGetRelevantNodeAsync<SyntaxNode>(span, cancellationToken).ConfigureAwait(false);
 
-            var typeDeclaration = nodes.Where(n => n is TypeDeclarationSyntax).FirstOrDefault() ?? nodes.FirstOrDefault();
+            //var typeDeclaration = nodes.Where(n => n is TypeDeclarationSyntax).FirstOrDefault() ?? nodes.FirstOrDefault();
 
             if (typeDeclaration == null)
             {


### PR DESCRIPTION
Edit the Extract Interface action to trigger more easily. Remove the code to FindToken and replace with GetRelevantNodeAsync. This enables the action when the user focus ($$) is in the middle of the declaration. 

```
class Program $$: ISomeInterface
{
  public void Goo() { }
}
```

Here is the behavior. Notice that the lightbulb action is available anywhere in line 9. The lightbulb action isn't available in lines 11-19, but the Extract Interface command still works if it is triggered from another source. 
![ExtractInterface](https://user-images.githubusercontent.com/9122518/228308977-bce6956f-fdd9-4301-8c38-c8f834436834.gif)


Definitely not familiar with all of the intricacies here. Feedback would be great! 

Fixes https://github.com/dotnet/roslyn/issues/13503