### PR TITLE
Don't look to the global.json when we're loading a binlog

### DIFF
--- a/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
+++ b/src/Features/Lsif/Generator/Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj
@@ -45,6 +45,7 @@
                               Condition="'%(ReferenceCopyLocalPaths.DestinationSubDirectory)' == '' and '%(Extension)' != '.pdb' and '%(Extension)' != '.xml'" />
 
       <TfmSpecificPackageFile Include="@(BuiltProjectOutputGroupOutput)" PackagePath="tools\$(TargetFramework)\any" />
+      <TfmSpecificPackageFile Include="$(ProjectDepsFilePath)" PackagePath="tools\$(TargetFramework)\any" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
     </ItemGroup>
   </Target>
 

--- a/src/Features/Lsif/Generator/Program.cs
+++ b/src/Features/Lsif/Generator/Program.cs
@@ -105,7 +105,12 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
                 else
                 {
                     Contract.ThrowIfNull(binLog);
-                    await LocateAndRegisterMSBuild(logFile, binLog.Directory);
+
+                    // If we're loading a binlog, we don't need to discover an MSBuild that matches the SDK or source that we're processing, since we're not running
+                    // any MSBuild builds or tasks/targets in our process. Since we're reading a binlog, simply none of the SDK will be loaded. We might load analyzers
+                    // or source generators from the SDK or user-built, but those must generally target netstandard2.0 so we don't really expect them to have problems loading
+                    // on one version of the runtime versus another.
+                    await LocateAndRegisterMSBuild(logFile, sourceDirectory: null);
                     await GenerateFromBinaryLogAsync(binLog, lsifWriter, logFile, cancellationToken);
                 }
             }
@@ -122,13 +127,13 @@ namespace Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator
             await logFile.WriteLineAsync("Generation complete.");
         }
 
-        private static async Task LocateAndRegisterMSBuild(TextWriter logFile, DirectoryInfo? workingDirectory)
+        private static async Task LocateAndRegisterMSBuild(TextWriter logFile, DirectoryInfo? sourceDirectory)
         {
             // Make sure we pick the highest version
             var options = VisualStudioInstanceQueryOptions.Default;
 
-            if (workingDirectory != null)
-                options.WorkingDirectory = workingDirectory.FullName;
+            if (sourceDirectory != null)
+                options.WorkingDirectory = sourceDirectory.FullName;
 
             var msBuildInstance = MSBuildLocator.QueryVisualStudioInstances(options).OrderByDescending(i => i.Version).FirstOrDefault();
             if (msBuildInstance == null)


### PR DESCRIPTION
If we're loading a binlog, we don't need to discover an MSBuild that matches the SDK or source that we're processing, since we're not running any MSBuild builds or tasks/targets in our process. Since we're reading a binlog, simply none of the SDK will be loaded. We might load analyzers or source generators from the SDK or user-built, but those must generally target netstandard2.0 so we don't really expect them to have problems loading on one version of the runtime versus another.