### PR TITLE
Add '@' prefix when inline hint value is a reserved keyword in C#

### DIFF
--- a/src/EditorFeatures/Test2/InlineHints/CSharpInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineHints/CSharpInlineParameterNameHintsTests.vb
@@ -1179,5 +1179,91 @@ class Program
 
             Await VerifyParamHints(input, output)
         End Function
+
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/66817")>
+        Public Async Function TestParameterNameIsReservedKeyword() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+class C
+{
+    void M()
+    {
+        N({|int:|}0);
+    }
+
+    void N(int @int)
+    {
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Dim output =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+class C
+{
+    void M()
+    {
+        N(@int: 0);
+    }
+
+    void N(int @int)
+    {
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyParamHints(input, output)
+        End Function
+
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/66817")>
+        Public Async Function TestParameterNameIsContextualKeyword() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+class C
+{
+    void M()
+    {
+        N({|async:|}true);
+    }
+
+    void N(bool async)
+    {
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Dim output =
+            <Workspace>
+                <Project Language="C#" CommonReferences="true">
+                    <Document>
+class C
+{
+    void M()
+    {
+        N(async: true);
+    }
+
+    void N(bool async)
+    {
+    }
+}
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyParamHints(input, output)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/InlineHints/VisualBasicInlineParameterNameHintsTests.vb
+++ b/src/EditorFeatures/Test2/InlineHints/VisualBasicInlineParameterNameHintsTests.vb
@@ -885,5 +885,79 @@ end class
 
             Await VerifyParamHints(input, output)
         End Function
+
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/66817")>
+        Public Async Function TestParameterNameIsReservedKeyword() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="Visual Basic" CommonReferences="true">
+                    <Document>
+Class C
+    Sub M()
+        N({|Integer:|}1)
+    End Sub
+
+    Sub N([Integer] As Integer)
+    End Sub
+End Class
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Dim output =
+            <Workspace>
+                <Project Language="Visual Basic" CommonReferences="true">
+                    <Document>
+Class C
+    Sub M()
+        N(Integer:=1)
+    End Sub
+
+    Sub N([Integer] As Integer)
+    End Sub
+End Class
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyParamHints(input, output)
+        End Function
+
+        <WpfFact, WorkItem("https://github.com/dotnet/roslyn/issues/66817")>
+        Public Async Function TestParameterNameIsContextualKeyword() As Task
+            Dim input =
+            <Workspace>
+                <Project Language="Visual Basic" CommonReferences="true">
+                    <Document>
+Class C
+    Sub M()
+        N({|Async:|}True)
+    End Sub
+
+    Sub N(Async As Boolean)
+    End Sub
+End Class
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Dim output =
+            <Workspace>
+                <Project Language="Visual Basic" CommonReferences="true">
+                    <Document>
+Class C
+    Sub M()
+        N(Async:=True)
+    End Sub
+
+    Sub N(Async As Boolean)
+    End Sub
+End Class
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Await VerifyParamHints(input, output)
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/InlineHints/CSharpInlineParameterNameHintsService.cs
+++ b/src/Features/CSharp/Portable/InlineHints/CSharpInlineParameterNameHintsService.cs
@@ -4,14 +4,12 @@
 
 using System;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.InlineHints;
 using Microsoft.CodeAnalysis.LanguageService;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp.InlineHints
@@ -102,7 +100,9 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineHints
 
         protected override string GetReplacementText(string parameterName)
         {
-            return parameterName + ": ";
+            var keywordKind = SyntaxFacts.GetKeywordKind(parameterName);
+            var isReservedKeyword = SyntaxFacts.IsReservedKeyword(keywordKind);
+            return (isReservedKeyword ? "@" : string.Empty) + parameterName + ": ";
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/66817

Also added tests for VB, even though it doesn't seem to be the problem there: [reserved keyword](https://sharplab.io/#v2:EYLgtghglgdgNAGxAN2HALigpgJygMwE84ATEAagB8BhBCAZ3oAJqBYAKCa6YGUBXYEwCyACgCUHblKYA5EQEkY6LAHNcIALwBGCZ24BRGCV4COk7v0FyA2ouVqcAXSYBBZndW5dUw8csdfFjpGIA===), [contextual keyword](https://sharplab.io/#v2:EYLgtghglgdgNAGxAN2HALigpgJygMwE84ATEAagB8BhBCAZ3oAJqBYAKCa6YGUBXYEwCyACgCUHblKYA5EQEF6hGAGMQAXgAqOPlgmduAURgleAjpO79BcxcpVNFTAEIB7VwiwQY+qcdPWHP4sdIxAA)