### PR TITLE
Fix crash in `NullableWalker.LocalState.Join`

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -11406,7 +11406,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             private void EnsureCapacity(int capacity)
             {
-                _state.EnsureCapacity(capacity * 2);
+                int previousCapacity = _state.Capacity;
+                int newCapacity = capacity * 2;
+                _state.EnsureCapacity(newCapacity);
+
+                for (int i = previousCapacity; i < newCapacity; i++)
+                {
+                    _state[i] = true; // (true, true) means NotNull
+                }
             }
 
             public bool HasVariable(int slot)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/66960
Follow-up on https://github.com/dotnet/roslyn/pull/67453

Here's what happens in the repro scenario:
We create an unreachable state (bit vector 00), either with a `throw` or a crafted invocation with a nullability attribute.
We use this as the starting state for lambda analysis. We enter the lambda parameter `EnterParameter` and call `GetOrCreateSlot`, which calls `Normalize` and `EnsureCapacity` (on the state and its containers). This results in bit vector 0000.
Later on, in `VisitTryBlockWithAnyTransferFunction` we join to states (and their containers): 1101 and 0000. This results in state 0001, which crashes `GetValue()` later on.

~~The fix is for `EnsureCapacity` to create fully/explicitly formed state by filling with the default value.~~
From discussion with Rikki and Chuck, we don't want `EnsureCapacity` to use NotNull values as fillers, because that defeats the point of avoiding reliance on default values. The PR was updated to instead patch the `Join` logic to be aware of a frankenstate like `0001` (ie. reachable but invalid values) during the join.