### PR TITLE
Issue with VBCSCompiler directory on linux

### DIFF
--- a/src/Compilers/Server/VBCSCompiler/CompilerRequestHandler.cs
+++ b/src/Compilers/Server/VBCSCompiler/CompilerRequestHandler.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
     internal sealed class CompilerServerHost : ICompilerServerHost
     {
-        public IAnalyzerAssemblyLoader AnalyzerAssemblyLoader { get; } = new ShadowCopyAnalyzerAssemblyLoader(baseDirectory: Path.Combine(Path.GetTempPath(), "VBCSCompiler", "AnalyzerAssemblyLoader"));
+        public IAnalyzerAssemblyLoader AnalyzerAssemblyLoader { get; } = new ShadowCopyAnalyzerAssemblyLoader(baseDirectory: Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "VBCSCompiler", "AnalyzerAssemblyLoader"));
 
         public static Func<string, MetadataReferenceProperties, PortableExecutableReference> SharedAssemblyReferenceProvider { get; } = (path, properties) => new CachingMetadataReference(path, properties);
 


### PR DESCRIPTION
`Path.GetTempPath()` returns the shared `/tmp/` on Linux as a fallback.. If the `TMPDIR` environment variable isn´t set, which it isn´t by default.
see: https://github.com/dotnet/runtime/blob/79e1abfda1078aaf6b869915121777d5418299b3/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs#L81

and: https://github.com/dotnet/runtime/blob/591e96bff186330d35887815faddc9c1a71f05cd/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.NoniOS.cs

When building a project Rosly writes the analyzers .dlls into `/tmp/VBCSCompiler/AnalyzerAssemblyLoader` as the current user performing the build.

When a second user is trying to build the same project he get´s cryptic error messages with "Access Denied" when loading the Analyzers dlls, as Roslyn tries to load them from the tmp folder but the current user does not have permissions to read them.

This does not usally happen on windows, as `Path.GetTempPath()` internally calss `GetTempPath2W` from the Win32 API, which looks at the environment variables TMP and TEMP. They are pointing pointing to `C:\Users\[USERNAME]\AppData\Local\Temp` in 99% of cases as they are set by default in a fresh windows install.

On Linux `TMPDIR` however is not usally specified by default. At least not in commonly used Distros like Ubuntu and such.

My patch is probably not the best idea on how to fix this.. There are multiple places in roslyn where `Path.GetTempPath()`  is used which might lead to permission problems, if the TempDir is shared between users.. Maybe this should be solved in a more generalized way like having these roslyn based temporary files in `$HOME/.dotnet/tmp` or so by default if `TMPDIR` is not specified. This would involve having a custom static helper function in roslyn just for that purpose.. Not sure if i like that either...