### PR TITLE
Pass through document open/close information to the workspace in LSP scenarios.

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -11522,15 +11522,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     return NullableFlowState.NotNull;
                 }
+
                 Debug.Assert(index < Capacity);
                 index *= 2;
+                Debug.Assert((_state[index], _state[index + 1]) != (false, false));
+
                 var result = (_state[index], _state[index + 1]) switch
                 {
-                    (false, false) => throw ExceptionUtilities.Unreachable(),
+                    (false, false) => NullableFlowState.NotNull, // Should not be reachable
                     (true, false) => NullableFlowState.MaybeNull,
                     (false, true) => NullableFlowState.MaybeDefault,
                     (true, true) => NullableFlowState.NotNull
                 };
+
                 return result;
             }
 

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -671,7 +671,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         /// workspace was loaded, throwing away any changes made to the open version.
         /// </summary>
         internal override void TryOnDocumentClosed(DocumentId documentId)
-            => CloseDocument(documentId);
+        {
+            Contract.ThrowIfFalse(this._supportsLspMutation);
+            CloseDocument(documentId);
+        }
 
         public override void CloseDocument(DocumentId documentId)
         {

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -673,7 +673,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         internal override void TryOnDocumentClosed(DocumentId documentId)
         {
             Contract.ThrowIfFalse(this._supportsLspMutation);
-            CloseDocument(documentId);
+
+            var testDocument = this.GetTestDocument(documentId);
+            Contract.ThrowIfTrue(testDocument.IsSourceGenerated);
+
+            this.OnDocumentClosedEx(documentId, testDocument.Loader, requireDocumentPresentAndOpen: false);
         }
 
         public override void CloseDocument(DocumentId documentId)

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -666,6 +666,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             testDocument.GetOpenTextContainer();
         }
 
+        /// <summary>
+        /// Overriding base impl so that when we close a document it goes back to the initial state when the test
+        /// workspace was loaded, throwing away any changes made to the open version.
+        /// </summary>
+        internal override void TryOnDocumentClosed(DocumentId documentId)
+            => CloseDocument(documentId);
+
         public override void CloseDocument(DocumentId documentId)
         {
             var testDocument = this.GetTestDocument(documentId);

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_ILspWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_ILspWorkspace.cs
@@ -2,36 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.ServiceModel.Syndication;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer;
-using Microsoft.CodeAnalysis.MetadataAsSource;
-using Microsoft.CodeAnalysis.Notification;
-using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis.Text.Shared.Extensions;
-using Microsoft.CodeAnalysis.UnitTests;
-using Microsoft.VisualStudio.Composition;
-using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.Text.Projection;
-using Microsoft.VisualStudio.Utilities;
-using Roslyn.Test.EditorUtilities;
-using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces

--- a/src/Features/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.WithFindAllReferences.cs
+++ b/src/Features/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.WithFindAllReferences.cs
@@ -75,20 +75,13 @@ class B
                 Assert.Equal("M", findResults[1].ContainingMember);
                 Assert.Equal("M2", findResults[3].ContainingMember);
 
-                {
-                    // NOTE: This is not a real world scenario.
-                    //
-                    // By closing the document we revert back to the original state, but in the real world the original
-                    // state will have been updated by back channels (text buffer sync, file changed on disk, etc.) This
-                    // is validating that the above didn't succeed by any means except the FAR handler being passed the
-                    // updated document, so if we regress and get lucky, we still know about it.
-                    await DidClose(testLspServer, locationTyped.Uri);
-
-                    // In the mutating scenario, simulate this by rolling back to the text we had when the workspace was
-                    // created.
-                    if (mutatingLspWorkspace)
-                        ((ILspWorkspace)testLspServer.TestWorkspace).UpdateTextIfPresent(originalDocument.Id, await originalDocument.GetTextAsync());
-                }
+                // NOTE: This is not a real world scenario.
+                //
+                // By closing the document we revert back to the original state, but in the real world the original
+                // state will have been updated by back channels (text buffer sync, file changed on disk, etc.) This
+                // is validating that the above didn't succeed by any means except the FAR handler being passed the
+                // updated document, so if we regress and get lucky, we still know about it.
+                await DidClose(testLspServer, locationTyped.Uri);
 
                 findResults = await FindAllReferencesHandlerTests.RunFindAllReferencesAsync<VSInternalReferenceItem>(testLspServer, locationTyped);
                 Assert.Single(findResults);

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1047,7 +1047,7 @@ namespace Microsoft.CodeAnalysis
                     // Ensure this closure data is always clean if we had to restart the the operation.
                     var updatedDocumentIds = data.updatedDocumentIds;
                     updatedDocumentIds.Clear();
-                    
+
                     var @this = data.@this;
                     var documentId = data.documentId;
 

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -1047,15 +1047,18 @@ namespace Microsoft.CodeAnalysis
                     // Ensure this closure data is always clean if we had to restart the the operation.
                     var updatedDocumentIds = data.updatedDocumentIds;
                     updatedDocumentIds.Clear();
+                    
+                    var @this = data.@this;
+                    var documentId = data.documentId;
 
-                    var document = data.getDocumentInSolution(oldSolution, data.documentId);
+                    var document = data.getDocumentInSolution(oldSolution, documentId);
                     if (document is null)
                     {
                         if (data.requireDocumentPresent)
                         {
                             throw new ArgumentException(string.Format(
                                 WorkspacesResources._0_is_not_part_of_the_workspace,
-                                oldSolution.Workspace.GetDocumentName(data.documentId)));
+                                data.@this.GetDocumentName(documentId)));
                         }
                         else
                         {
@@ -1066,14 +1069,14 @@ namespace Microsoft.CodeAnalysis
                     // First, just update the text for the document passed in.
                     var newSolution = oldSolution;
                     var previousSolution = newSolution;
-                    newSolution = data.updateSolutionWithText(newSolution, data.documentId, data.arg);
+                    newSolution = data.updateSolutionWithText(newSolution, documentId, data.arg);
 
                     if (previousSolution != newSolution)
                     {
-                        updatedDocumentIds.Add(data.documentId);
+                        updatedDocumentIds.Add(documentId);
 
                         // Now go update the linked docs to have the same doc contents.
-                        var linkedDocumentIds = oldSolution.GetRelatedDocumentIds(data.documentId);
+                        var linkedDocumentIds = oldSolution.GetRelatedDocumentIds(documentId);
                         if (linkedDocumentIds.Length > 0)
                         {
                             // Two options for updating linked docs (legacy and new).
@@ -1088,7 +1091,7 @@ namespace Microsoft.CodeAnalysis
                             var options = oldSolution.Services.GetRequiredService<IWorkspaceConfigurationService>().Options;
                             var shareSyntaxTrees = !options.DisableSharedSyntaxTrees;
 
-                            var newDocument = newSolution.GetRequiredDocument(data.documentId);
+                            var newDocument = newSolution.GetRequiredDocument(documentId);
                             foreach (var linkedDocumentId in linkedDocumentIds)
                             {
                                 previousSolution = newSolution;

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -366,7 +366,7 @@ namespace Microsoft.CodeAnalysis
             SetCurrentSolution(
                 static (oldSolution, data) =>
                 {
-                    var (@this, documentId, _, _, requireDocumentPresentAndClosed) = data;
+                    var (@this, documentId, textContainer, _, requireDocumentPresentAndClosed) = data;
 
                     var oldDocument = oldSolution.GetRequiredDocument(documentId);
                     if (oldDocument is null)
@@ -395,7 +395,7 @@ namespace Microsoft.CodeAnalysis
 
                     var oldDocumentState = oldDocument.State;
 
-                    var newText = data.textContainer.CurrentText;
+                    var newText = textContainer.CurrentText;
                     if (oldDocument.TryGetText(out var oldText) &&
                         oldDocument.TryGetTextVersion(out var version))
                     {

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -370,16 +370,22 @@ namespace Microsoft.CodeAnalysis
 
                     var oldDocument = oldSolution.GetRequiredDocument(documentId);
 
-                    if (requireDocumentPresentAndClosed)
+                    if (oldDocument is null)
                     {
-                        CheckDocumentIsInSolution(oldSolution, documentId);
-                        @this.CheckDocumentIsClosed(documentId);
-                    }
-                    else
-                    {
-                        if (oldDocument is null)
+                        if (requireDocumentPresentAndClosed)
+                        {
+                            throw new ArgumentException(string.Format(
+                                WorkspacesResources._0_is_not_part_of_the_workspace,
+                                oldSolution.Workspace.GetDocumentName(documentId)));
+                        }
+                        else
+                        {
                             return oldSolution;
+                        }
                     }
+
+                    if (requireDocumentPresentAndClosed)
+                        @this.CheckDocumentIsClosed(documentId);
 
                     var oldDocumentState = oldDocument.State;
 
@@ -638,17 +644,22 @@ namespace Microsoft.CodeAnalysis
                         var documentId = data.documentId;
 
                         var document = oldSolution.GetDocument(documentId);
-                        if (data.requireDocumentPresentAndOpen)
+                        if (document is null)
                         {
-                            CheckDocumentIsInSolution(oldSolution, documentId);
-                            data.@this.CheckDocumentIsOpen(documentId);
-                        }
-                        else
-                        {
-                            // if the document isn't even here, nothing to do.
-                            if (document is null)
+                            if (data.requireDocumentPresentAndOpen)
+                            {
+                                throw new ArgumentException(string.Format(
+                                    WorkspacesResources._0_is_not_part_of_the_workspace,
+                                    oldSolution.Workspace.GetDocumentName(documentId)));
+                            }
+                            else
+                            {
                                 return oldSolution;
+                            }
                         }
+
+                        if (data.requireDocumentPresentAndOpen)
+                            data.@this.CheckDocumentIsOpen(documentId);
 
                         return oldSolution.WithDocumentTextLoader(documentId, data.reloader, PreservationMode.PreserveValue);
                     },

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -376,7 +376,7 @@ namespace Microsoft.CodeAnalysis
                         {
                             throw new ArgumentException(string.Format(
                                 WorkspacesResources._0_is_not_part_of_the_workspace,
-                                oldSolution.Workspace.GetDocumentName(documentId)));
+                                @this.GetDocumentName(documentId)));
                         }
                         else
                         {
@@ -640,7 +640,7 @@ namespace Microsoft.CodeAnalysis
                             {
                                 throw new ArgumentException(string.Format(
                                     WorkspacesResources._0_is_not_part_of_the_workspace,
-                                    oldSolution.Workspace.GetDocumentName(documentId)));
+                                    @this.GetDocumentName(documentId)));
                             }
                             else
                             {

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -605,22 +605,16 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
-        /// Tries to close the document identified by <paramref name="documentId"/>.  The contents of the closed
-        /// document will be set to whatever the contents of the document are in <see cref="CurrentSolution"/>.
-        /// Subclasses should override this if they want to have different behavior here (for example, reloading the
-        /// contents from disk).
+        /// Tries to close the document identified by <paramref name="documentId"/>.  This is only needed by
+        /// implementations of ILspWorkspace to indicate that the workspace should try to transition to the closed state
+        /// for this document, but can bail out gracefully if they don't know about it (for example if they haven't
+        /// heard about the file from the project system).  Subclasses should determine what file contents they should
+        /// transition to if the file is within the workspace.
         /// </summary>
         /// <param name="documentId"></param>
         internal virtual void TryOnDocumentClosed(DocumentId documentId)
         {
-            var doc = this.CurrentSolution.GetDocument(documentId);
-            if (doc != null)
-            {
-                var text = doc.GetTextSynchronously(CancellationToken.None);
-                var version = doc.GetTextVersionSynchronously(CancellationToken.None);
-                var loader = TextLoader.From(TextAndVersion.Create(text, version, doc.FilePath));
-                this.OnDocumentClosedEx(documentId, loader, requireDocumentPresentAndOpen: false);
-            }
+            throw new NotImplementedException();
         }
 
 #pragma warning disable IDE0060 // Remove unused parameter 'updateActiveContext' - shipped public API.

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -121,28 +121,11 @@ namespace Microsoft.CodeAnalysis
         public virtual void OpenDocument(DocumentId documentId, bool activate = true)
             => this.CheckCanOpenDocuments();
 
-        //internal void TryOpenDocument(DocumentId documentId)
-        //{
-        //    using var _ = _serializationLock.DisposableWait();
-        //    if (this.CurrentSolution.GetDocument(documentId) != null &&
-        //        !this.IsDocumentOpen(documentId))
-        //    {
-
-        //    }
-        //}
-
         /// <summary>
         /// Close the specified document in the host environment.
         /// </summary>
         public virtual void CloseDocument(DocumentId documentId)
             => this.CheckCanOpenDocuments();
-
-        //internal void TryCloseDocument(DocumentId documentId)
-        //{
-        //    using var _ = _serializationLock.DisposableWait();
-        //    if (this.IsDocumentOpen(documentId))
-        //        this.CloseDocument(documentId);
-        //}
 
         /// <summary>
         /// Open the specified additional document in the host environment.


### PR DESCRIPTION
This is done on a best-effort basis as fundamentally a project system might itself may or may have not changed the solution structure wrt to that document's existence.