### PR TITLE
Convert string.Split call into corresponding IndexOf calls

### DIFF
--- a/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
+++ b/src/Compilers/Core/Portable/Collections/ImmutableArrayExtensions.cs
@@ -778,7 +778,7 @@ namespace Microsoft.CodeAnalysis
             return builder.ToImmutableAndFree();
         }
 
-        internal static bool HasDuplicates<T>(this ImmutableArray<T> array, IEqualityComparer<T> comparer)
+        internal static bool HasDuplicates<T>(this ImmutableArray<T> array, IEqualityComparer<T>? comparer = null)
         {
             switch (array.Length)
             {
@@ -787,6 +787,7 @@ namespace Microsoft.CodeAnalysis
                     return false;
 
                 case 2:
+                    comparer ??= EqualityComparer<T>.Default;
                     return comparer.Equals(array[0], array[1]);
 
                 default:

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/CompilationWithAnalyzers.cs
@@ -148,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 throw new ArgumentException(CodeAnalysisResources.ArgumentElementCannotBeNull, nameof(analyzers));
             }
 
-            if (analyzers.Distinct().Length != analyzers.Length)
+            if (analyzers.HasDuplicates())
             {
                 // Has duplicate analyzer instances.
                 throw new ArgumentException(CodeAnalysisResources.DuplicateAnalyzerInstances, nameof(analyzers));
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 throw new ArgumentException(CodeAnalysisResources.UnsupportedAnalyzerInstance, nameof(_analyzers));
             }
 
-            if (analyzers.Distinct().Length != analyzers.Length)
+            if (analyzers.HasDuplicates())
             {
                 // Has duplicate analyzer instances.
                 throw new ArgumentException(CodeAnalysisResources.DuplicateAnalyzerInstances, nameof(analyzers));
@@ -911,7 +911,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                         Debug.Assert(compilationEvents.Count(e => e is CompilationUnitCompletedEvent c && !c.FilterSpan.HasValue) == 1);
 
                         // We shouldn't have any duplicate events.
-                        Debug.Assert(compilationEvents.Distinct().Length == compilationEvents.Length);
+                        Debug.Assert(!compilationEvents.HasDuplicates());
                     }
 
                     scopeAndEvents = (analysisScope, compilationEvents);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/CodeStyle/CodeStyleHelpers.cs
@@ -62,24 +62,26 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         public static bool TryGetCodeStyleValueAndOptionalNotification(
             string arg, NotificationOption2 defaultNotification, [NotNullWhen(true)] out string? value, [NotNullWhen(true)] out NotificationOption2 notification)
         {
-            var args = arg.Split(':');
-            Debug.Assert(args.Length > 0);
+            var firstColonIndex = arg.IndexOf(':');
 
             // We allow a single value to be provided without an explicit notification.
-            if (args.Length == 1)
+            if (firstColonIndex == -1)
             {
-                value = args[0].Trim();
+                value = arg.Trim();
                 notification = defaultNotification;
                 return true;
             }
 
-            if (args.Length == 2)
+            int secondColonIndex = arg.IndexOf(':', firstColonIndex + 1);
+            if (secondColonIndex == -1)
             {
                 // If we have two args, then the second must be a notification option.  If 
                 // it isn't, then this isn't a valid code style option at all.
-                if (TryParseNotification(args[1], out var localNotification))
+                string secondValue = arg.Substring(firstColonIndex + 1);
+                if (TryParseNotification(secondValue, out var localNotification))
                 {
-                    value = args[0].Trim();
+                    var firstValue = arg.Substring(0, firstColonIndex);
+                    value = firstValue.Trim();
                     notification = localNotification;
                     return true;
                 }


### PR DESCRIPTION
This yields a small reduction in Int32[] allocations.

Additional small change to change some ImmutableArray.Distinct calls that were verifying non-duplicates to just call the existing HasDuplicates extension method. (It's slightly more efficient and better describes the check being invoked).

Collected the following traces when typing a line and bringing up a lightbulb in a large file.

*** old ***
![image](https://user-images.githubusercontent.com/6785178/228098641-7b0fd07b-5676-4e19-bb14-2701c5e50c0b.png)

*** new ***
![image](https://user-images.githubusercontent.com/6785178/228098778-0af8744a-9beb-476c-8fe8-a9fe5833ca3a.png)
