### PR TITLE
Update lsp doc operation to be async.

### DIFF
--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace.cs
@@ -670,7 +670,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         /// Overriding base impl so that when we close a document it goes back to the initial state when the test
         /// workspace was loaded, throwing away any changes made to the open version.
         /// </summary>
-        internal override void TryOnDocumentClosed(DocumentId documentId)
+        internal override ValueTask TryOnDocumentClosedAsync(DocumentId documentId, CancellationToken cancellationToken)
         {
             Contract.ThrowIfFalse(this._supportsLspMutation);
 
@@ -678,6 +678,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             Contract.ThrowIfTrue(testDocument.IsSourceGenerated);
 
             this.OnDocumentClosedEx(documentId, testDocument.Loader, requireDocumentPresentAndOpen: false);
+            return ValueTaskFactory.CompletedTask;
         }
 
         public override void CloseDocument(DocumentId documentId)

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_ILspWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_ILspWorkspace.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -12,16 +13,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
     {
         bool ILspWorkspace.SupportsMutation => _supportsLspMutation;
 
-        void ILspWorkspace.UpdateTextIfPresent(DocumentId documentId, SourceText sourceText)
+        ValueTask ILspWorkspace.UpdateTextIfPresentAsync(DocumentId documentId, SourceText sourceText)
         {
             Contract.ThrowIfFalse(_supportsLspMutation);
             OnDocumentTextChanged(documentId, sourceText, PreservationMode.PreserveIdentity, requireDocumentPresent: false);
-        }
-
-        void ILspWorkspace.UpdateTextIfPresent(DocumentId documentId, TextLoader textLoader)
-        {
-            Contract.ThrowIfFalse(_supportsLspMutation);
-            OnDocumentTextLoaderChanged(documentId, textLoader, requireDocumentPresent: false);
+            return ValueTaskFactory.CompletedTask;
         }
     }
 }

--- a/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_ILspWorkspace.cs
+++ b/src/EditorFeatures/TestUtilities/Workspaces/TestWorkspace_ILspWorkspace.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Text;
@@ -13,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
     {
         bool ILspWorkspace.SupportsMutation => _supportsLspMutation;
 
-        ValueTask ILspWorkspace.UpdateTextIfPresentAsync(DocumentId documentId, SourceText sourceText)
+        ValueTask ILspWorkspace.UpdateTextIfPresentAsync(DocumentId documentId, SourceText sourceText, CancellationToken cancellationToken)
         {
             Contract.ThrowIfFalse(_supportsLspMutation);
             OnDocumentTextChanged(documentId, sourceText, PreservationMode.PreserveIdentity, requireDocumentPresent: false);

--- a/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidCloseHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidCloseHandler.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges
             // GetTextDocumentIdentifier returns null to avoid creating the solution, so the queue is not able to log the uri.
             context.TraceInformation($"didClose for {request.TextDocument.Uri}");
 
-            await context.StopTrackingAsync(request.TextDocument.Uri).ConfigureAwait(false);
+            await context.StopTrackingAsync(request.TextDocument.Uri, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidCloseHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidCloseHandler.cs
@@ -28,14 +28,12 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges
 
         public TextDocumentIdentifier GetTextDocumentIdentifier(LSP.DidCloseTextDocumentParams request) => request.TextDocument;
 
-        public Task HandleNotificationAsync(LSP.DidCloseTextDocumentParams request, RequestContext context, CancellationToken cancellationToken)
+        public async Task HandleNotificationAsync(LSP.DidCloseTextDocumentParams request, RequestContext context, CancellationToken cancellationToken)
         {
             // GetTextDocumentIdentifier returns null to avoid creating the solution, so the queue is not able to log the uri.
             context.TraceInformation($"didClose for {request.TextDocument.Uri}");
 
-            context.StopTracking(request.TextDocument.Uri);
-
-            return Task.CompletedTask;
+            await context.StopTrackingAsync(request.TextDocument.Uri).ConfigureAwait(false);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges
 
         public Uri GetTextDocumentIdentifier(LSP.DidOpenTextDocumentParams request) => request.TextDocument.Uri;
 
-        public Task HandleNotificationAsync(LSP.DidOpenTextDocumentParams request, RequestContext context, CancellationToken cancellationToken)
+        public async Task HandleNotificationAsync(LSP.DidOpenTextDocumentParams request, RequestContext context, CancellationToken cancellationToken)
         {
             // GetTextDocumentIdentifier returns null to avoid creating the solution, so the queue is not able to log the uri.
             context.TraceInformation($"didOpen for {request.TextDocument.Uri}");
@@ -39,9 +39,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges
             // Create SourceText from binary representation of the document, retrieve encoding from the request and checksum algorithm from the project.
             var sourceText = SourceText.From(request.TextDocument.Text, System.Text.Encoding.UTF8, SourceHashAlgorithms.OpenDocumentChecksumAlgorithm);
 
-            context.StartTracking(request.TextDocument.Uri, sourceText);
-
-            return Task.CompletedTask;
+            await context.StartTrackingAsync(request.TextDocument.Uri, sourceText).ConfigureAwait(false);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/DocumentChanges/DidOpenHandler.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges
             // Create SourceText from binary representation of the document, retrieve encoding from the request and checksum algorithm from the project.
             var sourceText = SourceText.From(request.TextDocument.Text, System.Text.Encoding.UTF8, SourceHashAlgorithms.OpenDocumentChecksumAlgorithm);
 
-            await context.StartTrackingAsync(request.TextDocument.Uri, sourceText).ConfigureAwait(false);
+            await context.StartTrackingAsync(request.TextDocument.Uri, sourceText, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Features/LanguageServer/Protocol/Handler/IDocumentChangeTracker.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/IDocumentChangeTracker.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges;
 using Microsoft.CodeAnalysis.Text;
 
@@ -14,19 +15,19 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 /// </summary>
 internal interface IDocumentChangeTracker
 {
-    void StartTracking(Uri documentUri, SourceText initialText);
+    ValueTask StartTrackingAsync(Uri documentUri, SourceText initialText);
     void UpdateTrackedDocument(Uri documentUri, SourceText text);
-    void StopTracking(Uri documentUri);
+    ValueTask StopTrackingAsync(Uri documentUri);
 }
 
 internal class NonMutatingDocumentChangeTracker : IDocumentChangeTracker
 {
-    public void StartTracking(Uri documentUri, SourceText initialText)
+    public ValueTask StartTrackingAsync(Uri documentUri, SourceText initialText)
     {
         throw new InvalidOperationException("Mutating documents not allowed in a non-mutating request handler");
     }
 
-    public void StopTracking(Uri documentUri)
+    public ValueTask StopTrackingAsync(Uri documentUri)
     {
         throw new InvalidOperationException("Mutating documents not allowed in a non-mutating request handler");
     }

--- a/src/Features/LanguageServer/Protocol/Handler/IDocumentChangeTracker.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/IDocumentChangeTracker.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentChanges;
 using Microsoft.CodeAnalysis.Text;
@@ -15,19 +16,19 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 /// </summary>
 internal interface IDocumentChangeTracker
 {
-    ValueTask StartTrackingAsync(Uri documentUri, SourceText initialText);
+    ValueTask StartTrackingAsync(Uri documentUri, SourceText initialText, CancellationToken cancellationToken);
     void UpdateTrackedDocument(Uri documentUri, SourceText text);
-    ValueTask StopTrackingAsync(Uri documentUri);
+    ValueTask StopTrackingAsync(Uri documentUri, CancellationToken cancellationToken);
 }
 
 internal class NonMutatingDocumentChangeTracker : IDocumentChangeTracker
 {
-    public ValueTask StartTrackingAsync(Uri documentUri, SourceText initialText)
+    public ValueTask StartTrackingAsync(Uri documentUri, SourceText initialText, CancellationToken cancellationToken)
     {
         throw new InvalidOperationException("Mutating documents not allowed in a non-mutating request handler");
     }
 
-    public ValueTask StopTrackingAsync(Uri documentUri)
+    public ValueTask StopTrackingAsync(Uri documentUri, CancellationToken cancellationToken)
     {
         throw new InvalidOperationException("Mutating documents not allowed in a non-mutating request handler");
     }

--- a/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
@@ -202,8 +202,8 @@ internal readonly struct RequestContext
     /// Allows a mutating request to open a document and start it being tracked.
     /// Mutating requests are serialized by the execution queue in order to prevent concurrent access.
     /// </summary>
-    public void StartTracking(Uri uri, SourceText initialText)
-        => _documentChangeTracker.StartTracking(uri, initialText);
+    public ValueTask StartTrackingAsync(Uri uri, SourceText initialText)
+        => _documentChangeTracker.StartTrackingAsync(uri, initialText);
 
     /// <summary>
     /// Allows a mutating request to update the contents of a tracked document.
@@ -222,8 +222,8 @@ internal readonly struct RequestContext
     /// Allows a mutating request to close a document and stop it being tracked.
     /// Mutating requests are serialized by the execution queue in order to prevent concurrent access.
     /// </summary>
-    public void StopTracking(Uri uri)
-        => _documentChangeTracker.StopTracking(uri);
+    public ValueTask StopTrackingAsync(Uri uri)
+        => _documentChangeTracker.StopTrackingAsync(uri);
 
     public bool IsTracking(Uri documentUri)
         => _trackedDocuments.ContainsKey(documentUri);

--- a/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
+++ b/src/Features/LanguageServer/Protocol/Handler/RequestContext.cs
@@ -202,8 +202,8 @@ internal readonly struct RequestContext
     /// Allows a mutating request to open a document and start it being tracked.
     /// Mutating requests are serialized by the execution queue in order to prevent concurrent access.
     /// </summary>
-    public ValueTask StartTrackingAsync(Uri uri, SourceText initialText)
-        => _documentChangeTracker.StartTrackingAsync(uri, initialText);
+    public ValueTask StartTrackingAsync(Uri uri, SourceText initialText, CancellationToken cancellationToken)
+        => _documentChangeTracker.StartTrackingAsync(uri, initialText, cancellationToken);
 
     /// <summary>
     /// Allows a mutating request to update the contents of a tracked document.
@@ -222,8 +222,8 @@ internal readonly struct RequestContext
     /// Allows a mutating request to close a document and stop it being tracked.
     /// Mutating requests are serialized by the execution queue in order to prevent concurrent access.
     /// </summary>
-    public ValueTask StopTrackingAsync(Uri uri)
-        => _documentChangeTracker.StopTrackingAsync(uri);
+    public ValueTask StopTrackingAsync(Uri uri, CancellationToken cancellationToken)
+        => _documentChangeTracker.StopTrackingAsync(uri, cancellationToken);
 
     public bool IsTracking(Uri documentUri)
         => _trackedDocuments.ContainsKey(documentUri);

--- a/src/Features/LanguageServer/Protocol/Workspaces/ILspWorkspace.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/ILspWorkspace.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -36,5 +37,5 @@ internal interface ILspWorkspace
     /// name="sourceText"/>.  Does nothing if the document is not present in the workspace (for example if something
     /// else removed it).
     /// </summary>
-    ValueTask UpdateTextIfPresentAsync(DocumentId documentId, SourceText sourceText);
+    ValueTask UpdateTextIfPresentAsync(DocumentId documentId, SourceText sourceText, CancellationToken cancellationToken);
 }

--- a/src/Features/LanguageServer/Protocol/Workspaces/ILspWorkspace.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/ILspWorkspace.cs
@@ -37,10 +37,4 @@ internal interface ILspWorkspace
     /// else removed it).
     /// </summary>
     ValueTask UpdateTextIfPresentAsync(DocumentId documentId, SourceText sourceText);
-    ///// <summary>
-    ///// If <paramref name="documentId"/> is currently within this workspace, then its text is updated to <paramref
-    ///// name="textLoader"/>.  Does nothing if the document is not present in the workspace (for example if something
-    ///// else removed it).
-    ///// </summary>
-    //Task UpdateTextIfPresentAsync(DocumentId documentId, TextLoader textLoader);
 }

--- a/src/Features/LanguageServer/Protocol/Workspaces/ILspWorkspace.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/ILspWorkspace.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis.Text;
+using System.Threading.Tasks;
 using LSP = Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer;
@@ -35,11 +36,11 @@ internal interface ILspWorkspace
     /// name="sourceText"/>.  Does nothing if the document is not present in the workspace (for example if something
     /// else removed it).
     /// </summary>
-    void UpdateTextIfPresent(DocumentId documentId, SourceText sourceText);
-    /// <summary>
-    /// If <paramref name="documentId"/> is currently within this workspace, then its text is updated to <paramref
-    /// name="textLoader"/>.  Does nothing if the document is not present in the workspace (for example if something
-    /// else removed it).
-    /// </summary>
-    void UpdateTextIfPresent(DocumentId documentId, TextLoader textLoader);
+    ValueTask UpdateTextIfPresentAsync(DocumentId documentId, SourceText sourceText);
+    ///// <summary>
+    ///// If <paramref name="documentId"/> is currently within this workspace, then its text is updated to <paramref
+    ///// name="textLoader"/>.  Does nothing if the document is not present in the workspace (for example if something
+    ///// else removed it).
+    ///// </summary>
+    //Task UpdateTextIfPresentAsync(DocumentId documentId, TextLoader textLoader);
 }

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -99,7 +99,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
     /// 
     /// <see cref="DidOpenHandler.MutatesSolutionState"/> is true which means this runs serially in the <see cref="RequestExecutionQueue{RequestContextType}"/>
     /// </summary>
-    public async ValueTask StartTrackingAsync(Uri uri, SourceText documentText)
+    public async ValueTask StartTrackingAsync(Uri uri, SourceText documentText, CancellationToken cancellationToken)
     {
         // First, store the LSP view of the text as the uri is now owned by the LSP client.
         Contract.ThrowIfTrue(_trackedDocuments.ContainsKey(uri), $"didOpen received for {uri} which is already open.");
@@ -123,10 +123,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
             foreach (var workspace in registeredWorkspaces)
             {
                 await ApplyChangeToMutatingWorkspaceAsync(workspace, uri, (_, documentId) =>
-                {
-                    workspace.TryOnDocumentOpened(documentId, documentText.Container, isCurrentContext: false);
-                    return ValueTaskFactory.CompletedTask;
-                }).ConfigureAwait(false);
+                    workspace.TryOnDocumentOpenedAsync(documentId, documentText.Container, isCurrentContext: false, cancellationToken)).ConfigureAwait(false);
             }
         }
     }
@@ -136,7 +133,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
     /// 
     /// <see cref="DidCloseHandler.MutatesSolutionState"/> is true which means this runs serially in the <see cref="RequestExecutionQueue{RequestContextType}"/>
     /// </summary>
-    public async ValueTask StopTrackingAsync(Uri uri)
+    public async ValueTask StopTrackingAsync(Uri uri, CancellationToken cancellationToken)
     {
         // First, stop tracking this URI and source text as it is no longer owned by LSP.
         Contract.ThrowIfFalse(_trackedDocuments.ContainsKey(uri), $"didClose received for {uri} which is not open.");
@@ -161,10 +158,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
             foreach (var workspace in registeredWorkspaces)
             {
                 await ApplyChangeToMutatingWorkspaceAsync(workspace, uri, (_, documentId) =>
-                {
-                    workspace.TryOnDocumentClosed(documentId);
-                    return ValueTaskFactory.CompletedTask;
-                }).ConfigureAwait(false);
+                    workspace.TryOnDocumentClosedAsync(documentId, cancellationToken)).ConfigureAwait(false);
             }
         }
     }
@@ -363,7 +357,8 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
                     //
                     // TODO(cyrusn): Do we need to pass a correct value for isCurrentContext?  Or will that fall out from
                     // something else in lsp.
-                    workspace.TryOnDocumentOpened(documentId, sourceText.Container, isCurrentContext: false);
+                    await workspace.TryOnDocumentOpenedAsync(
+                        documentId, sourceText.Container, isCurrentContext: false, cancellationToken).ConfigureAwait(false);
 
                     // Note: there is a race here in that we might see/change/return here based on the
                     // relationship of 'sourceText' and 'currentSolution' while some other entity outside of the
@@ -371,7 +366,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
                     // though.  The caller will always grab the 'current solution' again off of the workspace
                     // and check the checksums of all documents against the ones this workspace manager is
                     // tracking.  If there are any differences, it will fork and use that fork.
-                    await mutatingWorkspace.UpdateTextIfPresentAsync(documentId, sourceText).ConfigureAwait(false);
+                    await mutatingWorkspace.UpdateTextIfPresentAsync(documentId, sourceText, cancellationToken).ConfigureAwait(false);
                 }).ConfigureAwait(false);
             }
         }

--- a/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -85,13 +85,13 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
 
     #region Implementation of IDocumentChangeTracker
 
-    private static void ApplyChangeToMutatingWorkspace(Workspace workspace, Uri uri, Action<ILspWorkspace, DocumentId> change)
+    private static async ValueTask ApplyChangeToMutatingWorkspaceAsync(Workspace workspace, Uri uri, Func<ILspWorkspace, DocumentId, ValueTask> change)
     {
         if (workspace is not ILspWorkspace { SupportsMutation: true } mutatingWorkspace)
             return;
 
         foreach (var documentId in workspace.CurrentSolution.GetDocumentIds(uri))
-            change(mutatingWorkspace, documentId);
+            await change(mutatingWorkspace, documentId).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -99,7 +99,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
     /// 
     /// <see cref="DidOpenHandler.MutatesSolutionState"/> is true which means this runs serially in the <see cref="RequestExecutionQueue{RequestContextType}"/>
     /// </summary>
-    public void StartTracking(Uri uri, SourceText documentText)
+    public async ValueTask StartTrackingAsync(Uri uri, SourceText documentText)
     {
         // First, store the LSP view of the text as the uri is now owned by the LSP client.
         Contract.ThrowIfTrue(_trackedDocuments.ContainsKey(uri), $"didOpen received for {uri} which is already open.");
@@ -113,17 +113,20 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
         // Attempt to open the doc if we find it in a workspace.  Note: if we don't (because we've heard from lsp about
         // the doc before we've heard from the project system), that's ok.  We'll still attempt to open it later in
         // GetLspSolutionForWorkspaceAsync
-        TryOpenDocumentsInMutatingWorkspace(uri);
+        await TryOpenDocumentsInMutatingWorkspaceAsync(uri).ConfigureAwait(false);
 
         return;
 
-        void TryOpenDocumentsInMutatingWorkspace(Uri uri)
+        async ValueTask TryOpenDocumentsInMutatingWorkspaceAsync(Uri uri)
         {
             var registeredWorkspaces = _lspWorkspaceRegistrationService.GetAllRegistrations();
             foreach (var workspace in registeredWorkspaces)
             {
-                ApplyChangeToMutatingWorkspace(workspace, uri, (_, documentId) =>
-                    workspace.TryOnDocumentOpened(documentId, documentText.Container, isCurrentContext: false));
+                await ApplyChangeToMutatingWorkspaceAsync(workspace, uri, (_, documentId) =>
+                {
+                    workspace.TryOnDocumentOpened(documentId, documentText.Container, isCurrentContext: false);
+                    return ValueTaskFactory.CompletedTask;
+                }).ConfigureAwait(false);
             }
         }
     }
@@ -133,7 +136,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
     /// 
     /// <see cref="DidCloseHandler.MutatesSolutionState"/> is true which means this runs serially in the <see cref="RequestExecutionQueue{RequestContextType}"/>
     /// </summary>
-    public void StopTracking(Uri uri)
+    public async ValueTask StopTrackingAsync(Uri uri)
     {
         // First, stop tracking this URI and source text as it is no longer owned by LSP.
         Contract.ThrowIfFalse(_trackedDocuments.ContainsKey(uri), $"didClose received for {uri} which is not open.");
@@ -148,17 +151,20 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
         LspTextChanged?.Invoke(this, EventArgs.Empty);
 
         // Attempt to close the doc, if it is currently open in a workspace.
-        TryCloseDocumentsInMutatingWorkspace(uri);
+        await TryCloseDocumentsInMutatingWorkspaceAsync(uri).ConfigureAwait(false);
 
         return;
 
-        void TryCloseDocumentsInMutatingWorkspace(Uri uri)
+        async ValueTask TryCloseDocumentsInMutatingWorkspaceAsync(Uri uri)
         {
             var registeredWorkspaces = _lspWorkspaceRegistrationService.GetAllRegistrations();
             foreach (var workspace in registeredWorkspaces)
             {
-                ApplyChangeToMutatingWorkspace(workspace, uri, (_, documentId) =>
-                    workspace.TryOnDocumentClosed(documentId));
+                await ApplyChangeToMutatingWorkspaceAsync(workspace, uri, (_, documentId) =>
+                {
+                    workspace.TryOnDocumentClosed(documentId);
+                    return ValueTaskFactory.CompletedTask;
+                }).ConfigureAwait(false);
             }
         }
     }
@@ -317,7 +323,7 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
                 return (workspaceCurrentSolution, IsForked: false);
 
             // Step 2: Push through any changes to the underlying workspace if it's a mutating workspace.
-            TryOpenAndEditDocumentsInMutatingWorkspace(workspace);
+            await TryOpenAndEditDocumentsInMutatingWorkspaceAsync(workspace).ConfigureAwait(false);
 
             // Because the workspace may have been mutated, go back and retrieve its current snapshot so we're operating
             // against that view.
@@ -346,11 +352,11 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
             return (lspSolution, IsForked: true);
         }
 
-        void TryOpenAndEditDocumentsInMutatingWorkspace(Workspace workspace)
+        async ValueTask TryOpenAndEditDocumentsInMutatingWorkspaceAsync(Workspace workspace)
         {
             foreach (var (uri, sourceText) in _trackedDocuments)
             {
-                ApplyChangeToMutatingWorkspace(workspace, uri, (mutatingWorkspace, documentId) =>
+                await ApplyChangeToMutatingWorkspaceAsync(workspace, uri, async (mutatingWorkspace, documentId) =>
                 {
                     // This may be the first time this workspace is hearing that this document is open from LSP's
                     // perspective. Attempt to open it there.
@@ -365,8 +371,8 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
                     // though.  The caller will always grab the 'current solution' again off of the workspace
                     // and check the checksums of all documents against the ones this workspace manager is
                     // tracking.  If there are any differences, it will fork and use that fork.
-                    mutatingWorkspace.UpdateTextIfPresent(documentId, sourceText);
-                });
+                    await mutatingWorkspace.UpdateTextIfPresentAsync(documentId, sourceText).ConfigureAwait(false);
+                }).ConfigureAwait(false);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -358,8 +358,11 @@ namespace Microsoft.CodeAnalysis
         protected internal void OnDocumentOpened(DocumentId documentId, SourceTextContainer textContainer, bool isCurrentContext = true)
             => OnDocumentOpened(documentId, textContainer, isCurrentContext, requireDocumentPresentAndClosed: true);
 
-        internal void TryOnDocumentOpened(DocumentId documentId, SourceTextContainer textContainer, bool isCurrentContext)
-            => OnDocumentOpened(documentId, textContainer, isCurrentContext, requireDocumentPresentAndClosed: false);
+        internal virtual ValueTask TryOnDocumentOpenedAsync(DocumentId documentId, SourceTextContainer textContainer, bool isCurrentContext, CancellationToken cancellationToken)
+        {
+            OnDocumentOpened(documentId, textContainer, isCurrentContext, requireDocumentPresentAndClosed: false);
+            return ValueTaskFactory.CompletedTask;
+        }
 
         internal void OnDocumentOpened(DocumentId documentId, SourceTextContainer textContainer, bool isCurrentContext, bool requireDocumentPresentAndClosed)
         {
@@ -606,7 +609,7 @@ namespace Microsoft.CodeAnalysis
         /// transition to if the file is within the workspace.
         /// </summary>
         /// <param name="documentId"></param>
-        internal virtual void TryOnDocumentClosed(DocumentId documentId)
+        internal virtual ValueTask TryOnDocumentClosedAsync(DocumentId documentId, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
This will allow a hypothetical impl to be able to be lock-based, without having to block a calling thread.