### PR TITLE
Minor memory optimizations in SourceText.ToString

### DIFF
--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -612,22 +612,30 @@ namespace Microsoft.CodeAnalysis.Text
             CheckSubSpan(span);
 
             // default implementation constructs text using CopyTo
-            var builder = new StringBuilder();
-            var buffer = new char[Math.Min(span.Length, 1024)];
+            var builder = PooledStringBuilder.GetInstance();
+            var buffer = s_charArrayPool.Allocate();
 
-            int position = Math.Max(Math.Min(span.Start, this.Length), 0);
-            int length = Math.Min(span.End, this.Length) - position;
-
-            while (position < this.Length && length > 0)
+            try
             {
-                int copyLength = Math.Min(buffer.Length, length);
-                this.CopyTo(position, buffer, 0, copyLength);
-                builder.Append(buffer, 0, copyLength);
-                length -= copyLength;
-                position += copyLength;
+                int position = Math.Max(Math.Min(span.Start, this.Length), 0);
+                int length = Math.Min(span.End, this.Length) - position;
+                builder.Builder.EnsureCapacity(length);
+
+                while (position < this.Length && length > 0)
+                {
+                    int copyLength = Math.Min(buffer.Length, length);
+                    this.CopyTo(position, buffer, 0, copyLength);
+                    builder.Builder.Append(buffer, 0, copyLength);
+                    length -= copyLength;
+                    position += copyLength;
+                }
+            }
+            finally
+            {
+                s_charArrayPool.Free(buffer);
             }
 
-            return builder.ToString();
+            return builder.ToStringAndFree();
         }
 
         #region Changes

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -615,25 +615,20 @@ namespace Microsoft.CodeAnalysis.Text
             var builder = PooledStringBuilder.GetInstance();
             var buffer = s_charArrayPool.Allocate();
 
-            try
-            {
-                int position = Math.Max(Math.Min(span.Start, this.Length), 0);
-                int length = Math.Min(span.End, this.Length) - position;
-                builder.Builder.EnsureCapacity(length);
+            int position = Math.Max(Math.Min(span.Start, this.Length), 0);
+            int length = Math.Min(span.End, this.Length) - position;
+            builder.Builder.EnsureCapacity(length);
 
-                while (position < this.Length && length > 0)
-                {
-                    int copyLength = Math.Min(buffer.Length, length);
-                    this.CopyTo(position, buffer, 0, copyLength);
-                    builder.Builder.Append(buffer, 0, copyLength);
-                    length -= copyLength;
-                    position += copyLength;
-                }
-            }
-            finally
+            while (position < this.Length && length > 0)
             {
-                s_charArrayPool.Free(buffer);
+                int copyLength = Math.Min(buffer.Length, length);
+                this.CopyTo(position, buffer, 0, copyLength);
+                builder.Builder.Append(buffer, 0, copyLength);
+                length -= copyLength;
+                position += copyLength;
             }
+
+            s_charArrayPool.Free(buffer);
 
             return builder.ToStringAndFree();
         }


### PR DESCRIPTION
This modifies the ToString(span) implementation to better match existing optimizations done in the Write method.

Measured > 50% reduction in memory allocations and CPU time accounted to SourceText.ToString when opening a large file, typing "var a = "test";" near the EOF, and bringing up a lightbulb.

*** without changes ***

![image](https://user-images.githubusercontent.com/6785178/228306081-4681c133-f8fd-4e8a-a743-433f2e0d53f8.png)

![image](https://user-images.githubusercontent.com/6785178/228307396-dbb03205-b8b1-474c-821a-68257f5f7dc0.png)

*** with changes ***

![image](https://user-images.githubusercontent.com/6785178/228306922-414c7dd4-335a-484f-8e41-41be2020f529.png)

![image](https://user-images.githubusercontent.com/6785178/228307231-e51c672a-fc32-46f8-b0a5-298df18b0058.png)
