### PR TITLE
Work to unify threading concepts between Workspace and ProjectSystemProjectFactory

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProjectFactory.cs
@@ -329,9 +329,9 @@ namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
             Contract.ThrowIfFalse(_projectToMaxSupportedLangVersionMap.Count == 0);
             Contract.ThrowIfFalse(_projectToDependencyNodeTargetIdentifier.Count == 0);
 
-            // Create a new empty solution and set this; we will reuse the same SolutionId and path since components still may have persistence information they still need
-            // to look up by that location; we also keep the existing analyzer references around since those are host-level analyzers that were loaded asynchronously.
-            Workspace.ClearOpenDocuments();
+            // Create a new empty solution and set this; we will reuse the same SolutionId and path since components
+            // still may have persistence information they still need to look up by that location; we also keep the
+            // existing analyzer references around since those are host-level analyzers that were loaded asynchronously.
 
             Workspace.SetCurrentSolution(
                 solution => Workspace.CreateSolution(
@@ -339,7 +339,11 @@ namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
                         SolutionId.CreateNewId(),
                         VersionStamp.Create(),
                         analyzerReferences: solution.AnalyzerReferences)),
-                WorkspaceChangeKind.SolutionRemoved);
+                WorkspaceChangeKind.SolutionRemoved,
+                onBeforeUpdate: (_, _) =>
+                {
+                    Workspace.ClearOpenDocuments();
+                });
         }
 
         [PerformanceSensitive("https://github.com/dotnet/roslyn/issues/54137", AllowLocks = false)]

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/SolutionChangeAccumulator.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/SolutionChangeAccumulator.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Workspaces.ProjectSystem
     /// A little helper type to hold onto the <see cref="Solution"/> being updated in a batch, which also
     /// keeps track of the right <see cref="CodeAnalysis.WorkspaceChangeKind"/> to raise when we are done.
     /// </summary>
-    internal class SolutionChangeAccumulator
+    internal sealed class SolutionChangeAccumulator
     {
         /// <summary>
         /// The kind that encompasses all the changes we've made. It's null if no changes have been made,

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -90,6 +90,16 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
+        /// Helper only for the purpose of writing asserts.  Useful when code wants to assert that it is being run while
+        /// the serialization lock is being held.  Note: this function is both racey (could change immediately after
+        /// calling), and ambiguous (it just says that some thread of execution is holding the lock, not that the
+        /// current one is).  So, having this return an expected value is not a guarantee that things are working
+        /// properly.  However, if it returns an unexpected value (for example, 'false' when some thread expects to be
+        /// holding the lock) then it definitely indicates a bug.
+        /// </summary>
+        internal bool IsCurrentlyHoldingSerializationLock => _serializationLock.CurrentCount == 0;
+
+        /// <summary>
         /// Services provider by the host for implementing workspace features.
         /// </summary>
         public HostWorkspaceServices Services => _services;


### PR DESCRIPTION
This is some preliminary work to help fix https://github.com/dotnet/roslyn/issues/67510.  There is a lot more work to be done, but this creates an initial foundation to safely and incrementally move ProjectSystemProjectFactory and workspace off of having two separate locks that have to be coordinated, to just using a single lock that ensures consistent atomic changes to the workspace across all clients.

The core problem we want to solve is that currently it is possible to corrupt the workspace if it is within a host that both uses ProjectSystemProjectFactory to manipulate the workspace *and* which attempts to mutate the workspace through any other means.  This can happen as the ProjectSystemProjectFactory expects all workspace edits to be done while a particular lock it owns is held.  But the host can directly interact with the workspace, changing it out from underneath ProjectSystemProjectFactory while it is in the middle of making a series of changes.

Moving to a consistent change-application mechanism ensures that the workspace changes from the host and ProjectSystemProjectFactory happen atomically, and either mutator only ever sees complete changes from the other.

