### PR TITLE
Remove existing sync lightbulb code

### DIFF
--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource.cs
@@ -8,19 +8,15 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Editor.Shared;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Options;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
@@ -120,170 +116,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 ISuggestedActionCategorySet requestedActionCategories,
                 SnapshotSpan range,
                 CancellationToken cancellationToken)
-                => GetSuggestedActions(requestedActionCategories, range, operationContext: null, cancellationToken);
+                => null;
 
             public IEnumerable<SuggestedActionSet>? GetSuggestedActions(
                 ISuggestedActionCategorySet requestedActionCategories,
                 SnapshotSpan range,
                 IUIThreadOperationContext operationContext)
-            {
-                return GetSuggestedActions(
-                    requestedActionCategories,
-                    range,
-                    operationContext,
-                    operationContext.UserCancellationToken);
-            }
-
-            private ImmutableArray<SuggestedActionSet>? GetSuggestedActions(
-                ISuggestedActionCategorySet requestedActionCategories,
-                SnapshotSpan range,
-                IUIThreadOperationContext? operationContext,
-                CancellationToken cancellationToken)
-            {
-                AssertIsForeground();
-
-                using var state = _state.TryAddReference();
-                if (state is null)
-                    return null;
-
-                if (state.Target.Workspace == null)
-                    return null;
-
-                using (operationContext?.AddScope(allowCancellation: true, description: EditorFeaturesResources.Gathering_Suggestions_Waiting_for_the_solution_to_fully_load))
-                {
-                    // This needs to run under threading context otherwise, we can deadlock on VS
-                    var statusService = state.Target.Workspace.Services.GetRequiredService<IWorkspaceStatusService>();
-                    ThreadingContext.JoinableTaskFactory.Run(() => statusService.WaitUntilFullyLoadedAsync(cancellationToken));
-                }
-
-                using (Logger.LogBlock(FunctionId.SuggestedActions_GetSuggestedActions, cancellationToken))
-                {
-                    var document = range.Snapshot.GetOpenTextDocumentInCurrentContextWithChanges();
-                    if (document == null)
-                    {
-                        // this is here to fail test and see why it is failed.
-                        Trace.WriteLine("given range is not current");
-                        return null;
-                    }
-
-                    var workspace = document.Project.Solution.Workspace;
-                    var supportsFeatureService = workspace.Services.GetRequiredService<ITextBufferSupportsFeatureService>();
-
-                    var selection = TryGetCodeRefactoringSelection(state, range);
-
-                    Func<string, IDisposable?> addOperationScope =
-                        description => operationContext?.AddScope(allowCancellation: true, string.Format(EditorFeaturesResources.Gathering_Suggestions_0, description));
-
-                    var options = GlobalOptions.GetCodeActionOptionsProvider();
-
-                    // We convert the code fixes and refactorings to UnifiedSuggestedActionSets instead of
-                    // SuggestedActionSets so that we can share logic between local Roslyn and LSP.
-                    var fixesTask = GetCodeFixesAsync(
-                        state, supportsFeatureService, requestedActionCategories, workspace, document, range,
-                        addOperationScope, CodeActionRequestPriority.None,
-                        options, isBlocking: true, cancellationToken);
-
-                    var refactoringsTask = GetRefactoringsAsync(
-                        state, supportsFeatureService, requestedActionCategories, GlobalOptions, workspace, document, selection,
-                        addOperationScope, CodeActionRequestPriority.None, options, isBlocking: true, cancellationToken);
-
-                    Task.WhenAll(fixesTask, refactoringsTask).WaitAndGetResult(cancellationToken);
-
-                    return ConvertToSuggestedActionSets(
-                        state, selection,
-                        fixesTask.WaitAndGetResult(cancellationToken),
-                        refactoringsTask.WaitAndGetResult(cancellationToken),
-                        currentActionCount: 0);
-                }
-            }
-
-            private ImmutableArray<SuggestedActionSet> ConvertToSuggestedActionSets(
-                ReferenceCountedDisposable<State> state,
-                TextSpan? selection,
-                ImmutableArray<UnifiedSuggestedActionSet> fixes,
-                ImmutableArray<UnifiedSuggestedActionSet> refactorings,
-                int currentActionCount)
-            {
-                var filteredSets = UnifiedSuggestedActionsSource.FilterAndOrderActionSets(fixes, refactorings, selection, currentActionCount);
-                return filteredSets.Select(s => ConvertToSuggestedActionSet(s, state.Target.Owner, state.Target.SubjectBuffer)).WhereNotNull().ToImmutableArray();
-            }
-
-            [return: NotNullIfNotNull(nameof(unifiedSuggestedActionSet))]
-            private SuggestedActionSet? ConvertToSuggestedActionSet(UnifiedSuggestedActionSet? unifiedSuggestedActionSet, SuggestedActionsSourceProvider owner, ITextBuffer subjectBuffer)
-            {
-                // May be null in cases involving CodeFixSuggestedActions since FixAllFlavors may be null.
-                if (unifiedSuggestedActionSet == null)
-                    return null;
-
-                var originalSolution = unifiedSuggestedActionSet.OriginalSolution;
-
-                return new SuggestedActionSet(
-                    unifiedSuggestedActionSet.CategoryName,
-                    unifiedSuggestedActionSet.Actions.SelectAsArray(set => ConvertToSuggestedAction(set)),
-                    unifiedSuggestedActionSet.Title,
-                    ConvertToSuggestedActionSetPriority(unifiedSuggestedActionSet.Priority),
-                    unifiedSuggestedActionSet.ApplicableToSpan?.ToSpan());
-
-                // Local functions
-                ISuggestedAction ConvertToSuggestedAction(IUnifiedSuggestedAction unifiedSuggestedAction)
-                    => unifiedSuggestedAction switch
-                    {
-                        UnifiedCodeFixSuggestedAction codeFixAction => new CodeFixSuggestedAction(
-                            ThreadingContext, owner, codeFixAction.Workspace, originalSolution, subjectBuffer,
-                            codeFixAction.CodeFix, codeFixAction.Provider, codeFixAction.OriginalCodeAction,
-                            ConvertToSuggestedActionSet(codeFixAction.FixAllFlavors, owner, subjectBuffer)),
-                        UnifiedCodeRefactoringSuggestedAction codeRefactoringAction => new CodeRefactoringSuggestedAction(
-                            ThreadingContext, owner, codeRefactoringAction.Workspace, originalSolution, subjectBuffer,
-                            codeRefactoringAction.CodeRefactoringProvider, codeRefactoringAction.OriginalCodeAction,
-                            ConvertToSuggestedActionSet(codeRefactoringAction.FixAllFlavors, owner, subjectBuffer)),
-                        UnifiedFixAllCodeFixSuggestedAction fixAllAction => new FixAllCodeFixSuggestedAction(
-                            ThreadingContext, owner, fixAllAction.Workspace, originalSolution, subjectBuffer,
-                            fixAllAction.FixAllState, fixAllAction.Diagnostic, fixAllAction.OriginalCodeAction),
-                        UnifiedFixAllCodeRefactoringSuggestedAction fixAllCodeRefactoringAction => new FixAllCodeRefactoringSuggestedAction(
-                            ThreadingContext, owner, fixAllCodeRefactoringAction.Workspace, originalSolution, subjectBuffer,
-                            fixAllCodeRefactoringAction.FixAllState, fixAllCodeRefactoringAction.OriginalCodeAction),
-                        UnifiedSuggestedActionWithNestedActions nestedAction => new SuggestedActionWithNestedActions(
-                            ThreadingContext, owner, nestedAction.Workspace, originalSolution, subjectBuffer,
-                            nestedAction.Provider ?? this, nestedAction.OriginalCodeAction,
-                            nestedAction.NestedActionSets.SelectAsArray((s, arg) => ConvertToSuggestedActionSet(s, arg.owner, arg.subjectBuffer), (owner, subjectBuffer))),
-                        _ => throw ExceptionUtilities.Unreachable()
-                    };
-
-                static SuggestedActionSetPriority ConvertToSuggestedActionSetPriority(CodeActionPriority priority)
-                    => priority switch
-                    {
-                        CodeActionPriority.Lowest => SuggestedActionSetPriority.None,
-                        CodeActionPriority.Low => SuggestedActionSetPriority.Low,
-                        CodeActionPriority.Medium => SuggestedActionSetPriority.Medium,
-                        CodeActionPriority.High => SuggestedActionSetPriority.High,
-                        _ => throw ExceptionUtilities.Unreachable(),
-                    };
-            }
-
-            private static Task<ImmutableArray<UnifiedSuggestedActionSet>> GetCodeFixesAsync(
-                ReferenceCountedDisposable<State> state,
-                ITextBufferSupportsFeatureService supportsFeatureService,
-                ISuggestedActionCategorySet requestedActionCategories,
-                Workspace workspace,
-                TextDocument document,
-                SnapshotSpan range,
-                Func<string, IDisposable?> addOperationScope,
-                CodeActionRequestPriority priority,
-                CodeActionOptionsProvider fallbackOptions,
-                bool isBlocking,
-                CancellationToken cancellationToken)
-            {
-                if (state.Target.Owner._codeFixService == null ||
-                    !supportsFeatureService.SupportsCodeFixes(state.Target.SubjectBuffer) ||
-                    !requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.CodeFix))
-                {
-                    return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
-                }
-
-                return UnifiedSuggestedActionsSource.GetFilterAndOrderCodeFixesAsync(
-                    workspace, state.Target.Owner._codeFixService, document, range.Span.ToTextSpan(),
-                    priority, fallbackOptions, isBlocking, addOperationScope, cancellationToken).AsTask();
-            }
+                => null;
 
             private static string GetFixCategory(DiagnosticSeverity severity)
             {
@@ -298,50 +137,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     default:
                         throw ExceptionUtilities.Unreachable();
                 }
-            }
-
-            private static Task<ImmutableArray<UnifiedSuggestedActionSet>> GetRefactoringsAsync(
-                ReferenceCountedDisposable<State> state,
-                ITextBufferSupportsFeatureService supportsFeatureService,
-                ISuggestedActionCategorySet requestedActionCategories,
-                IGlobalOptionService globalOptions,
-                Workspace workspace,
-                TextDocument document,
-                TextSpan? selection,
-                Func<string, IDisposable?> addOperationScope,
-                CodeActionRequestPriority priority,
-                CodeActionOptionsProvider fallbackOptions,
-                bool isBlocking,
-                CancellationToken cancellationToken)
-            {
-                if (!selection.HasValue)
-                {
-                    // this is here to fail test and see why it is failed.
-                    Trace.WriteLine("given range is not current");
-                    return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
-                }
-
-                if (!globalOptions.GetOption(EditorComponentOnOffOptions.CodeRefactorings) ||
-                    state.Target.Owner._codeRefactoringService == null ||
-                    !supportsFeatureService.SupportsRefactorings(state.Target.SubjectBuffer))
-                {
-                    return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
-                }
-
-                // 'CodeActionRequestPriority.Lowest' is reserved for suppression/configuration code fixes.
-                // No code refactoring should have this request priority.
-                if (priority == CodeActionRequestPriority.Lowest)
-                {
-                    return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
-                }
-
-                // If we are computing refactorings outside the 'Refactoring' context, i.e. for example, from the lightbulb under a squiggle or selection,
-                // then we want to filter out refactorings outside the selection span.
-                var filterOutsideSelection = !requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring);
-
-                return UnifiedSuggestedActionsSource.GetFilterAndOrderCodeRefactoringsAsync(
-                    workspace, state.Target.Owner._codeRefactoringService, document, selection.Value, priority, fallbackOptions, isBlocking,
-                    addOperationScope, filterOutsideSelection, cancellationToken);
             }
 
             public Task<bool> HasSuggestedActionsAsync(

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource_Async.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource_Async.cs
@@ -174,7 +174,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 
                 var fixes = await fixesTask.ConfigureAwait(false);
                 var refactorings = await refactoringsTask.ConfigureAwait(false);
-                foreach (var set in ConvertToSuggestedActionSets())
+
+                var filteredSets = UnifiedSuggestedActionsSource.FilterAndOrderActionSets(fixes, refactorings, selection, currentActionCount);
+                var convertedSets = filteredSets.Select(s => ConvertToSuggestedActionSet(s)).WhereNotNull().ToImmutableArray();
+
+                foreach (var set in convertedSets)
                     yield return set;
 
                 yield break;
@@ -221,12 +225,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                     return UnifiedSuggestedActionsSource.GetFilterAndOrderCodeRefactoringsAsync(
                         workspace, owner._codeRefactoringService, document, selection.Value, priority, options, isBlocking: false,
                         addOperationScope, filterOutsideSelection, cancellationToken);
-                }
-
-                ImmutableArray<SuggestedActionSet> ConvertToSuggestedActionSets()
-                {
-                    var filteredSets = UnifiedSuggestedActionsSource.FilterAndOrderActionSets(fixes, refactorings, selection, currentActionCount);
-                    return filteredSets.Select(s => ConvertToSuggestedActionSet(s)).WhereNotNull().ToImmutableArray();
                 }
 
                 [return: NotNullIfNotNull(nameof(unifiedSuggestedActionSet))]

--- a/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource_Async.cs
+++ b/src/EditorFeatures/Core.Wpf/Suggestions/SuggestedActionsSource_Async.cs
@@ -5,24 +5,25 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Editor.Shared;
-using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
+using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Internal.Log;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.CodeAnalysis.UnifiedSuggestions;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
@@ -158,24 +159,126 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 int currentActionCount,
                 [EnumeratorCancellation] CancellationToken cancellationToken)
             {
+                var target = state.Target;
+                var owner = target.Owner;
+                var subjectBuffer = target.SubjectBuffer;
                 var workspace = document.Project.Solution.Workspace;
                 var supportsFeatureService = workspace.Services.GetRequiredService<ITextBufferSupportsFeatureService>();
 
                 var options = GlobalOptions.GetCodeActionOptionsProvider();
 
-                var fixesTask = GetCodeFixesAsync(
-                    state, supportsFeatureService, requestedActionCategories, workspace, document, range,
-                    addOperationScope, priority, options, isBlocking: false, cancellationToken);
-                var refactoringsTask = GetRefactoringsAsync(
-                    state, supportsFeatureService, requestedActionCategories, GlobalOptions, workspace, document, selection,
-                    addOperationScope, priority, options, isBlocking: false, cancellationToken);
+                var fixesTask = GetCodeFixesAsync();
+                var refactoringsTask = GetRefactoringsAsync();
 
                 await Task.WhenAll(fixesTask, refactoringsTask).ConfigureAwait(false);
 
                 var fixes = await fixesTask.ConfigureAwait(false);
                 var refactorings = await refactoringsTask.ConfigureAwait(false);
-                foreach (var set in ConvertToSuggestedActionSets(state, selection, fixes, refactorings, currentActionCount))
+                foreach (var set in ConvertToSuggestedActionSets())
                     yield return set;
+
+                yield break;
+
+                Task<ImmutableArray<UnifiedSuggestedActionSet>> GetCodeFixesAsync()
+                {
+                    if (owner._codeFixService == null ||
+                        !supportsFeatureService.SupportsCodeFixes(target.SubjectBuffer) ||
+                        !requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.CodeFix))
+                    {
+                        return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
+                    }
+
+                    return UnifiedSuggestedActionsSource.GetFilterAndOrderCodeFixesAsync(
+                        workspace, owner._codeFixService, document, range.Span.ToTextSpan(),
+                        priority, options, isBlocking: false, addOperationScope, cancellationToken).AsTask();
+                }
+
+                Task<ImmutableArray<UnifiedSuggestedActionSet>> GetRefactoringsAsync()
+                {
+                    if (!selection.HasValue)
+                    {
+                        // this is here to fail test and see why it is failed.
+                        Trace.WriteLine("given range is not current");
+                        return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
+                    }
+
+                    if (!this.GlobalOptions.GetOption(EditorComponentOnOffOptions.CodeRefactorings) ||
+                        owner._codeRefactoringService == null ||
+                        !supportsFeatureService.SupportsRefactorings(subjectBuffer))
+                    {
+                        return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
+                    }
+
+                    // 'CodeActionRequestPriority.Lowest' is reserved for suppression/configuration code fixes.
+                    // No code refactoring should have this request priority.
+                    if (priority == CodeActionRequestPriority.Lowest)
+                        return SpecializedTasks.EmptyImmutableArray<UnifiedSuggestedActionSet>();
+
+                    // If we are computing refactorings outside the 'Refactoring' context, i.e. for example, from the lightbulb under a squiggle or selection,
+                    // then we want to filter out refactorings outside the selection span.
+                    var filterOutsideSelection = !requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring);
+
+                    return UnifiedSuggestedActionsSource.GetFilterAndOrderCodeRefactoringsAsync(
+                        workspace, owner._codeRefactoringService, document, selection.Value, priority, options, isBlocking: false,
+                        addOperationScope, filterOutsideSelection, cancellationToken);
+                }
+
+                ImmutableArray<SuggestedActionSet> ConvertToSuggestedActionSets()
+                {
+                    var filteredSets = UnifiedSuggestedActionsSource.FilterAndOrderActionSets(fixes, refactorings, selection, currentActionCount);
+                    return filteredSets.Select(s => ConvertToSuggestedActionSet(s)).WhereNotNull().ToImmutableArray();
+                }
+
+                [return: NotNullIfNotNull(nameof(unifiedSuggestedActionSet))]
+                SuggestedActionSet? ConvertToSuggestedActionSet(UnifiedSuggestedActionSet? unifiedSuggestedActionSet)
+                {
+                    // May be null in cases involving CodeFixSuggestedActions since FixAllFlavors may be null.
+                    if (unifiedSuggestedActionSet == null)
+                        return null;
+
+                    var originalSolution = unifiedSuggestedActionSet.OriginalSolution;
+
+                    return new SuggestedActionSet(
+                        unifiedSuggestedActionSet.CategoryName,
+                        unifiedSuggestedActionSet.Actions.SelectAsArray(set => ConvertToSuggestedAction(set)),
+                        unifiedSuggestedActionSet.Title,
+                        ConvertToSuggestedActionSetPriority(unifiedSuggestedActionSet.Priority),
+                        unifiedSuggestedActionSet.ApplicableToSpan?.ToSpan());
+
+                    ISuggestedAction ConvertToSuggestedAction(IUnifiedSuggestedAction unifiedSuggestedAction)
+                        => unifiedSuggestedAction switch
+                        {
+                            UnifiedCodeFixSuggestedAction codeFixAction => new CodeFixSuggestedAction(
+                                ThreadingContext, owner, codeFixAction.Workspace, originalSolution, subjectBuffer,
+                                codeFixAction.CodeFix, codeFixAction.Provider, codeFixAction.OriginalCodeAction,
+                                ConvertToSuggestedActionSet(codeFixAction.FixAllFlavors)),
+                            UnifiedCodeRefactoringSuggestedAction codeRefactoringAction => new CodeRefactoringSuggestedAction(
+                                ThreadingContext, owner, codeRefactoringAction.Workspace, originalSolution, subjectBuffer,
+                                codeRefactoringAction.CodeRefactoringProvider, codeRefactoringAction.OriginalCodeAction,
+                                ConvertToSuggestedActionSet(codeRefactoringAction.FixAllFlavors)),
+                            UnifiedFixAllCodeFixSuggestedAction fixAllAction => new FixAllCodeFixSuggestedAction(
+                                ThreadingContext, owner, fixAllAction.Workspace, originalSolution, subjectBuffer,
+                                fixAllAction.FixAllState, fixAllAction.Diagnostic, fixAllAction.OriginalCodeAction),
+                            UnifiedFixAllCodeRefactoringSuggestedAction fixAllCodeRefactoringAction => new FixAllCodeRefactoringSuggestedAction(
+                                ThreadingContext, owner, fixAllCodeRefactoringAction.Workspace, originalSolution, subjectBuffer,
+                                fixAllCodeRefactoringAction.FixAllState, fixAllCodeRefactoringAction.OriginalCodeAction),
+                            UnifiedSuggestedActionWithNestedActions nestedAction => new SuggestedActionWithNestedActions(
+                                ThreadingContext, owner, nestedAction.Workspace, originalSolution, subjectBuffer,
+                                nestedAction.Provider ?? this, nestedAction.OriginalCodeAction,
+                                nestedAction.NestedActionSets.SelectAsArray(s => ConvertToSuggestedActionSet(s))),
+                            _ => throw ExceptionUtilities.Unreachable()
+                        };
+                }
+
+                static SuggestedActionSetPriority ConvertToSuggestedActionSetPriority(CodeActionPriority priority)
+                    => priority switch
+                    {
+                        CodeActionPriority.Lowest => SuggestedActionSetPriority.None,
+                        CodeActionPriority.Low => SuggestedActionSetPriority.Low,
+                        CodeActionPriority.Medium => SuggestedActionSetPriority.Medium,
+                        CodeActionPriority.High => SuggestedActionSetPriority.High,
+                        _ => throw ExceptionUtilities.Unreachable(),
+                    };
             }
         }
     }


### PR DESCRIPTION
This helps the work to add lightbulb telemetry, but reducing hte layers of indirections and the need to pass huge numbers of parameters around.