### PR TITLE
Fix incorrect 'isExplicit' value in CodeFixService

### DIFF
--- a/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
+++ b/src/Features/LanguageServer/Protocol/Features/CodeFixes/CodeFixService.cs
@@ -175,12 +175,12 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             // this design's weakness is that each side don't have enough information to narrow down works to do. it
             // will most likely always do more works than needed. sometimes way more than it is needed. (compilation)
 
-            // We mark blocking requests to GetDiagnosticsForSpanAsync as 'isExplicit = true' to indicate
+            // We mark requests to GetDiagnosticsForSpanAsync as 'isExplicit = true' to indicate
             // user-invoked diagnostic requests, for example, user invoked Ctrl + Dot operation for lightbulb.
             var diagnostics = await _diagnosticService.GetDiagnosticsForSpanAsync(
                 document, range, GetShouldIncludeDiagnosticPredicate(document, priority),
                 includeCompilerDiagnostics: true, includeSuppressedDiagnostics: includeSuppressionFixes, priority: priority,
-                addOperationScope: addOperationScope, isExplicit: isBlocking, cancellationToken: cancellationToken).ConfigureAwait(false);
+                addOperationScope: addOperationScope, isExplicit: true, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             var buildOnlyDiagnosticsService = document.Project.Solution.Services.GetRequiredService<IBuildOnlyDiagnosticsService>();
             var buildOnlyDiagnostics = buildOnlyDiagnosticsService.GetBuildOnlyDiagnostics(document.Id);


### PR DESCRIPTION
`isExplicit` flag was added in #67392 to indicate explicit user-invoked diagnostic request. However, I incorrectly set this value to `isExplicit: isBlocking` in CodeFixService. `isBlocking` flag indicates if we are executing sync lightbulb or async lightbulb, and this flag is always false for the current default async lightbulb.

- This PR adjusts `isExplicit` argument to be always true for `GetDiagnosticsForSpanAsync` call from `CodeFixService.StreamFixesAsync` in release/dev17.6 branch.
- ~~I will create a separate PR targeting main branch that builds on top of #67536 and completely removes the `isBlocking` flag as we no longer support sync lightbulb source in main branch.~~ We can't remove the `isBlocking` flag as it is still being used by TS. See https://github.com/dotnet/roslyn/pull/67540/files#r1151914766